### PR TITLE
docs: fix design docs HTML rendering on Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -23,6 +23,10 @@ for md in "$ROOT_DIR"/docs/design/*.md; do
   if command -v pandoc >/dev/null 2>&1; then
     pandoc "$md" -f gfm -t html5 -o "$html" --standalone
   else
+    if [ "${CI:-}" = "true" ]; then
+      echo "pandoc is required in CI to render docs/design/*.md as HTML."
+      exit 1
+    fi
     {
       printf '<!doctype html><html><head><meta charset="utf-8"><title>%s</title></head><body><pre>\n' "$base"
       sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' "$md"


### PR DESCRIPTION
## Summary
- install pandoc in docs workflow before site generation
- make CI fail if pandoc is missing to avoid publishing raw markdown pages

## Validation
- bash -n scripts/build_docs_site.sh

Generated with [Claude Code](https://claude.com/claude-code)