### PR TITLE
feat: add forward-over-reverse HVP API skeleton

### DIFF
--- a/docs/design/tenferro_autodiff_design.md
+++ b/docs/design/tenferro_autodiff_design.md
@@ -36,29 +36,33 @@ Current POC scope (in `tenferro-autodiff`):
 - Public API skeleton for reverse-mode and forward-mode
 - `TrackedTensor`, `DualTensor`, `backward`, `Gradients`, `BackwardPlan`
 - Trait extension points: `VjpRule`, `JvpRule`
+- Forward-over-reverse HVP: `HvpResult`, `hvp()`,
+  `VjpRule::backward_with_tangents()`, `TrackedTensor::leaf_with_tangent()`
 
 Current POC scope (in `tenferro-einsum`):
 
 - `tracked_einsum`, `dual_einsum` — AD-aware einsum frontends
 - `einsum_vjp`, `einsum_jvp` — local derivative kernels for FFI/manual AD
+- `einsum_hvp` — local HVP kernel for FFI/manual AD
 
 Planned scope (not yet implemented):
 
 - Reverse-mode tape runtime and node execution
 - Rule registry and decomposition rules for all primitives
-- Higher-order APIs (HVP, forward-on-reverse)
 - Device-aware execution paths for GPU backends
 
 ## API Layers
 
 1. AD framework (`tenferro-autodiff`)
 
-- `TrackedTensor<T>` — reverse-mode wrapper
+- `TrackedTensor<T>` — reverse-mode wrapper (with optional tangent for HVP)
 - `DualTensor<T>` — forward-mode wrapper
 - `backward(loss)` — reverse-mode execution
+- `hvp(loss)` — forward-over-reverse HVP execution
 - `clear_tape<T>()` — tape management
-- `Gradients<T>`, `BackwardPlan<T>` — result and plan types
+- `Gradients<T>`, `BackwardPlan<T>`, `HvpResult<T>` — result and plan types
 - `VjpRule<T>`, `JvpRule<T>` — rule extension traits
+  (`VjpRule` includes `backward_with_tangents` for HVP support)
 
 2. Operation-specific AD rules (in each operation's crate)
 
@@ -68,6 +72,7 @@ Einsum AD rules (in `tenferro-einsum`):
 - `dual_einsum(subscripts, operands)` — forward-mode einsum
 - `einsum_vjp(subscripts, operands, cotangent)` — local VJP for FFI/manual AD
 - `einsum_jvp(subscripts, primals, tangents)` — local JVP for FFI/manual AD
+- `einsum_hvp(subscripts, primals, tangents, cotangent, cotangent_tangent)` — local HVP for FFI/manual AD
 
 Future operations define their own AD rules in their own crates using the
 `VjpRule` and `JvpRule` traits.
@@ -101,4 +106,5 @@ runtime implementation is not complete in current POC.
 
 - Full runtime implementation of graph scheduling
 - End-to-end optimized GPU backward kernels
-- Full second-order differentiation API
+- Full second-order differentiation API beyond HVP
+  (HVP API skeleton is defined; full Hessian computation is deferred)

--- a/docs/plans/2026-02-15-autodiff-api-skeleton-design.md
+++ b/docs/plans/2026-02-15-autodiff-api-skeleton-design.md
@@ -58,21 +58,24 @@ Core types:
 
 - `AutodiffError`, `AdResult<T>`
 - `NodeId`
-- `TrackedTensor<T>`
+- `TrackedTensor<T>` (with optional tangent for HVP)
 - `DualTensor<T>`
 - `Gradients<T>`
 - `BackwardPlan<T>`
+- `HvpResult<T>`
 - `SavePolicy`
 
 Core traits:
 
-- `VjpRule<T>`: `backward(cotangent) -> [(NodeId, Tensor<T>)]`
+- `VjpRule<T>`: `backward(cotangent) -> [(NodeId, Tensor<T>)]`,
+  `backward_with_tangents(cotangent, cotangent_tangent) -> [(NodeId, Tensor<T>, Tensor<T>)]`
 - `JvpRule<T>`: `forward(input_tangents) -> Tensor<T>`
 
 Core functions:
 
 - `clear_tape<T>()`
 - `backward(loss: &TrackedTensor<T>) -> AdResult<Gradients<T>>`
+- `hvp(loss: &TrackedTensor<T>) -> AdResult<HvpResult<T>>`
 
 ### tenferro-einsum (AD additions)
 
@@ -82,6 +85,7 @@ Einsum AD functions added to `tenferro-einsum`:
 - `dual_einsum(subscripts, operands)` — forward-mode einsum
 - `einsum_vjp(subscripts, operands, cotangent)` — local VJP for FFI/manual AD
 - `einsum_jvp(subscripts, primals, tangents)` — local JVP for FFI/manual AD
+- `einsum_hvp(subscripts, primals, tangents, cotangent, cotangent_tangent)` — local HVP for FFI/manual AD
 
 ## Design Decisions
 
@@ -96,4 +100,4 @@ Einsum AD functions added to `tenferro-einsum`:
 
 - No runtime implementation of tape/graph execution.
 - No decomposition AD rules yet for every `TensorPrims` operation.
-- No HVP/second-order API yet (can be layered on `DualTensor` + `backward` later).
+- No full second-order API beyond HVP (HVP API skeleton is now defined).

--- a/tenferro-autodiff/src/lib.rs
+++ b/tenferro-autodiff/src/lib.rs
@@ -53,6 +53,25 @@
 //! let c_dual = dual_einsum("ij,jk->ik", &[&a_dual, &b_dual]).unwrap();
 //! let _jvp = c_dual.tangent();
 //! ```
+//!
+//! Forward-over-reverse HVP (Hessian-vector product):
+//!
+//! ```ignore
+//! use tenferro_autodiff::{TrackedTensor, hvp, clear_tape};
+//! use tenferro_einsum::tracked_einsum;
+//! use tenferro_tensor::{MemoryOrder, Tensor};
+//! use tenferro_device::LogicalMemorySpace;
+//!
+//! clear_tape::<f64>();
+//! let x = TrackedTensor::leaf_with_tangent(
+//!     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),
+//!     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),  // direction v
+//! ).unwrap();
+//! let loss = tracked_einsum("i,i->", &[&x, &x]).unwrap();  // f(x) = x·x
+//! let result = hvp(&loss).unwrap();
+//! let _grad = result.gradients;  // ∇f(x) = 2x
+//! let _hv = result.hvp;          // H·v = 2v
+//! ```
 
 use strided_traits::ScalarBase;
 use tenferro_algebra::HasAlgebra;
@@ -88,6 +107,9 @@ pub enum AutodiffError {
         /// Actual shape.
         got: Vec<usize>,
     },
+    /// A VjpRule does not support HVP (backward_with_tangents).
+    #[error("HVP not supported by this VjpRule implementation")]
+    HvpNotSupported,
     /// Generic AD argument error.
     #[error("invalid autodiff argument: {0}")]
     InvalidArgument(String),
@@ -185,6 +207,7 @@ pub struct TrackedTensor<T: ScalarBase> {
     tensor: Tensor<T>,
     node_id: Option<NodeId>,
     requires_grad: bool,
+    tangent: Option<Tensor<T>>,
 }
 
 impl<T: ScalarBase> TrackedTensor<T> {
@@ -202,6 +225,7 @@ impl<T: ScalarBase> TrackedTensor<T> {
             tensor,
             node_id: None,
             requires_grad: false,
+            tangent: None,
         }
     }
 
@@ -274,6 +298,51 @@ impl<T: ScalarBase> TrackedTensor<T> {
     /// ```
     pub fn node_id(&self) -> Option<NodeId> {
         self.node_id
+    }
+
+    /// Creates a leaf tensor requiring gradient, with a tangent for HVP.
+    ///
+    /// The tangent defines the perturbation direction *v* used in
+    /// forward-over-reverse Hessian-vector product computation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AutodiffError::TangentShapeMismatch`] if shapes differ.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_autodiff::TrackedTensor;
+    /// let x = TrackedTensor::leaf_with_tangent(tensor, tangent).unwrap();
+    /// assert!(x.requires_grad());
+    /// assert!(x.has_tangent());
+    /// ```
+    pub fn leaf_with_tangent(_tensor: Tensor<T>, _tangent: Tensor<T>) -> AdResult<Self> {
+        todo!()
+    }
+
+    /// Returns the tangent tensor for HVP, or `None` if not set.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// if let Some(t) = tracked.tangent() {
+    ///     println!("tangent shape: {:?}", t.dims());
+    /// }
+    /// ```
+    pub fn tangent(&self) -> Option<&Tensor<T>> {
+        self.tangent.as_ref()
+    }
+
+    /// Returns whether this tracked tensor has a tangent for HVP.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// assert!(tracked.has_tangent());
+    /// ```
+    pub fn has_tangent(&self) -> bool {
+        self.tangent.is_some()
     }
 
     /// Returns a detached tensor that does not require gradients.
@@ -483,6 +552,33 @@ pub trait VjpRule<T: ScalarBase + HasAlgebra> {
 
     /// Returns input node IDs this rule depends on.
     fn inputs(&self) -> Vec<NodeId>;
+
+    /// Computes backward pass with tangent propagation for HVP.
+    ///
+    /// Given an output cotangent ḡ and its tangent dḡ, returns
+    /// `(node_id, input_cotangent, input_cotangent_tangent)` triples.
+    ///
+    /// The default implementation returns [`AutodiffError::HvpNotSupported`].
+    /// Operations that support forward-over-reverse HVP override this method.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Called internally by hvp(); users rarely call this directly.
+    /// let results = rule.backward_with_tangents(&cotangent, &cotangent_tangent)?;
+    /// for (node_id, grad, grad_tangent) in results {
+    ///     // grad: standard cotangent for this input
+    ///     // grad_tangent: cotangent tangent for HVP
+    /// }
+    /// ```
+    fn backward_with_tangents(
+        &self,
+        cotangent: &Tensor<T>,
+        cotangent_tangent: &Tensor<T>,
+    ) -> AdResult<Vec<(NodeId, Tensor<T>, Tensor<T>)>> {
+        let _ = (cotangent, cotangent_tangent);
+        Err(AutodiffError::HvpNotSupported)
+    }
 }
 
 /// Forward rule interface for JVP propagation.
@@ -576,5 +672,65 @@ pub fn clear_tape<T: ScalarBase>() {
 /// let grads = tenferro_autodiff::backward(&loss).unwrap();
 /// ```
 pub fn backward<T: ScalarBase + HasAlgebra>(_loss: &TrackedTensor<T>) -> AdResult<Gradients<T>> {
+    todo!()
+}
+
+/// Result of a forward-over-reverse HVP computation.
+///
+/// Contains both the standard gradient ∇f(x) and the Hessian-vector
+/// product H·v, where v is the tangent direction set on leaf tensors
+/// via [`TrackedTensor::leaf_with_tangent`].
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_autodiff::{TrackedTensor, hvp, HvpResult};
+/// use tenferro_einsum::tracked_einsum;
+///
+/// let result: HvpResult<f64> = hvp(&loss).unwrap();
+/// let _grad = result.gradients.get(x.node_id().unwrap());  // ∇f(x)
+/// let _hv = result.hvp.get(x.node_id().unwrap());          // H·v
+/// ```
+pub struct HvpResult<T: ScalarBase> {
+    /// Gradients: ∇f(x).
+    pub gradients: Gradients<T>,
+    /// Hessian-vector product: H·v.
+    pub hvp: Gradients<T>,
+}
+
+/// Computes gradient and Hessian-vector product via forward-over-reverse.
+///
+/// Leaf tensors with tangents (created via [`TrackedTensor::leaf_with_tangent`])
+/// define the direction *v*. The function runs backward through the tape,
+/// propagating both cotangents (ḡ) and cotangent-tangents (dḡ) at each node.
+///
+/// Returns both ∇f(x) (in [`HvpResult::gradients`]) and H·v (in
+/// [`HvpResult::hvp`]).
+///
+/// # Errors
+///
+/// Returns [`AutodiffError::NonScalarLoss`] for non-scalar losses.
+/// Returns [`AutodiffError::HvpNotSupported`] if any VjpRule on the tape
+/// does not implement `backward_with_tangents`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_autodiff::{TrackedTensor, hvp, clear_tape};
+/// use tenferro_einsum::tracked_einsum;
+/// use tenferro_tensor::{MemoryOrder, Tensor};
+/// use tenferro_device::LogicalMemorySpace;
+///
+/// clear_tape::<f64>();
+/// let x = TrackedTensor::leaf_with_tangent(
+///     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),
+///     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),
+/// ).unwrap();
+/// let loss = tracked_einsum("i,i->", &[&x, &x]).unwrap();  // f(x) = x·x
+/// let result = hvp(&loss).unwrap();
+/// let _grad = result.gradients;  // ∇f(x) = 2x
+/// let _hv = result.hvp;          // H·v = 2v
+/// ```
+pub fn hvp<T: ScalarBase + HasAlgebra>(_loss: &TrackedTensor<T>) -> AdResult<HvpResult<T>> {
     todo!()
 }

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -753,3 +753,54 @@ pub fn einsum_jvp<T: ScalarBase + HasAlgebra>(
 ) -> Result<Tensor<T>> {
     todo!()
 }
+
+/// Local HVP rule for einsum without building a global tape.
+///
+/// Computes the forward-over-reverse Hessian-vector product for an einsum
+/// operation. Given primals, their tangents (direction v), an output
+/// cotangent ḡ, and its tangent dḡ, returns `(gradient, hvp)` pairs
+/// for each input operand.
+///
+/// For C = einsum(subscripts, [A, B]):
+/// - gradient: standard VJP (e.g., ḡ_A = einsum(ḡ_C, B))
+/// - hvp: tangent of VJP (e.g., dḡ_A = einsum(dḡ_C, B) + einsum(ḡ_C, dB))
+///
+/// This API is intended for language interop (`custom_vjp` with HVP)
+/// and manual AD.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_einsum::einsum_hvp;
+/// use tenferro_tensor::{MemoryOrder, Tensor};
+/// use tenferro_device::LogicalMemorySpace;
+///
+/// let col = MemoryOrder::ColumnMajor;
+/// let mem = LogicalMemorySpace::MainMemory;
+/// let a = Tensor::<f64>::ones(&[2, 3], mem, col);
+/// let b = Tensor::<f64>::ones(&[3, 4], mem, col);
+/// let da = Tensor::<f64>::ones(&[2, 3], mem, col);
+///
+/// let grad_c = Tensor::<f64>::ones(&[2, 4], mem, col);
+/// let dgrad_c = Tensor::<f64>::ones(&[2, 4], mem, col);
+///
+/// let results = einsum_hvp(
+///     "ij,jk->ik",
+///     &[&a, &b],
+///     &[Some(&da), None],
+///     &grad_c,
+///     &dgrad_c,
+/// ).unwrap();
+/// assert_eq!(results.len(), 2);
+/// let (_grad_a, _hvp_a) = &results[0];
+/// let (_grad_b, _hvp_b) = &results[1];
+/// ```
+pub fn einsum_hvp<T: ScalarBase + HasAlgebra>(
+    _subscripts: &str,
+    _primals: &[&Tensor<T>],
+    _tangents: &[Option<&Tensor<T>>],
+    _cotangent: &Tensor<T>,
+    _cotangent_tangent: &Tensor<T>,
+) -> Result<Vec<(Tensor<T>, Tensor<T>)>> {
+    todo!()
+}


### PR DESCRIPTION
## Summary

- Add forward-over-reverse Hessian-vector product (HVP) API skeleton to both `tenferro-autodiff` and `tenferro-einsum`
- `tenferro-autodiff`: `TrackedTensor` tangent field, `VjpRule::backward_with_tangents`, `HvpResult`, `hvp()`, `AutodiffError::HvpNotSupported`
- `tenferro-einsum`: `einsum_hvp()` tape-free HVP function for FFI/manual AD
- Update design docs and plan docs to reflect HVP additions

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes
- [ ] Review API surface for forward-over-reverse HVP correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)