### PR TITLE
refactor: rename AD traits to ChainRules.jl convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ RUSTFLAGS="-C target-cpu=native" cargo bench
 
 ```
 Layer 5: tenferro-einsum       — High-level einsum on Tensor<T>, N-ary tree, algebra dispatch, einsum AD rules
-Layer 4: tenferro-autodiff     — AD framework: TrackedTensor, DualTensor, VjpRule/JvpRule, backward, tape
+Layer 4: tenferro-autodiff     — AD framework: TrackedTensor, DualTensor, ReverseRule/ForwardRule, backward, tape
 Layer 3: tenferro-tensor       — Tensor<T> = DataBuffer + shape + strides, zero-copy view ops
 Layer 2: tenferro-prims        — "Tensor BLAS": TensorPrims<A> trait (algebra-parameterized), plan-based execution
 Shared:  tenferro-algebra      — HasAlgebra trait, Semiring trait, Standard type
@@ -108,7 +108,7 @@ Foundation: strided-rs    — Independent workspace (strided-traits → strided-
 
 Operation-specific AD rules live with their operations, not in the AD framework.
 `tenferro-autodiff` is a pure AD framework; `tenferro-einsum` owns einsum AD functions
-(`tracked_einsum`, `dual_einsum`, `einsum_vjp`, `einsum_jvp`).
+(`tracked_einsum`, `dual_einsum`, `einsum_rrule`, `einsum_frule`).
 
 ### Dependency Graph (POC)
 

--- a/docs/design/tenferro_autodiff_design.md
+++ b/docs/design/tenferro_autodiff_design.md
@@ -17,8 +17,8 @@ and rule traits, but does **not** contain operation-specific AD rules.
 - `tenferro-autodiff` depends on `tenferro-tensor`, `tenferro-algebra`,
   `tenferro-device` (no dependency on `tenferro-einsum` or `tenferro-prims`).
 - Operation-specific AD rules live with their operations:
-  - Einsum AD functions (`tracked_einsum`, `dual_einsum`, `einsum_vjp`,
-    `einsum_jvp`) are in `tenferro-einsum`.
+  - Einsum AD functions (`tracked_einsum`, `dual_einsum`, `einsum_rrule`,
+    `einsum_frule`) are in `tenferro-einsum`.
   - Future operations (e.g., block-sparse matmul) define their own AD rules
     in their own crates.
 - `tenferro-einsum` depends on `tenferro-autodiff` to use the AD framework.
@@ -35,14 +35,14 @@ Current POC scope (in `tenferro-autodiff`):
 
 - Public API skeleton for reverse-mode and forward-mode
 - `TrackedTensor`, `DualTensor`, `backward`, `Gradients`, `BackwardPlan`
-- Trait extension points: `VjpRule`, `JvpRule`
+- Trait extension points: `ReverseRule`, `ForwardRule`
 - Forward-over-reverse HVP: `HvpResult`, `hvp()`,
-  `VjpRule::backward_with_tangents()`, `TrackedTensor::leaf_with_tangent()`
+  `ReverseRule::pullback_with_tangents()`, `TrackedTensor::leaf_with_tangent()`
 
 Current POC scope (in `tenferro-einsum`):
 
 - `tracked_einsum`, `dual_einsum` — AD-aware einsum frontends
-- `einsum_vjp`, `einsum_jvp` — local derivative kernels for FFI/manual AD
+- `einsum_rrule`, `einsum_frule` — local derivative kernels for FFI/manual AD
 - `einsum_hvp` — local HVP kernel for FFI/manual AD
 
 Planned scope (not yet implemented):
@@ -61,8 +61,9 @@ Planned scope (not yet implemented):
 - `hvp(loss)` — forward-over-reverse HVP execution
 - `clear_tape<T>()` — tape management
 - `Gradients<T>`, `BackwardPlan<T>`, `HvpResult<T>` — result and plan types
-- `VjpRule<T>`, `JvpRule<T>` — rule extension traits
-  (`VjpRule` includes `backward_with_tangents` for HVP support)
+- `ReverseRule<T>`, `ForwardRule<T>` — rule extension traits
+  (named after Julia's ChainRules.jl: rrule/frule)
+  (`ReverseRule` includes `pullback_with_tangents` for HVP support)
 
 2. Operation-specific AD rules (in each operation's crate)
 
@@ -70,18 +71,18 @@ Einsum AD rules (in `tenferro-einsum`):
 
 - `tracked_einsum(subscripts, operands)` — reverse-mode einsum
 - `dual_einsum(subscripts, operands)` — forward-mode einsum
-- `einsum_vjp(subscripts, operands, cotangent)` — local VJP for FFI/manual AD
-- `einsum_jvp(subscripts, primals, tangents)` — local JVP for FFI/manual AD
+- `einsum_rrule(subscripts, operands, cotangent)` — local pullback for FFI/manual AD
+- `einsum_frule(subscripts, primals, tangents)` — local pushforward for FFI/manual AD
 - `einsum_hvp(subscripts, primals, tangents, cotangent, cotangent_tangent)` — local HVP for FFI/manual AD
 
 Future operations define their own AD rules in their own crates using the
-`VjpRule` and `JvpRule` traits.
+`ReverseRule` and `ForwardRule` traits.
 
 ## Algebra and Tropical Support
 
 Autodiff must remain algebra-aware.
 
-- Standard arithmetic: direct VJP/JVP formulas over `+/*`.
+- Standard arithmetic: direct rrule/frule formulas over `+/*`.
 - Tropical algebra (`tenferro-tropical`): formulas may need algebra-specific
   state (for example, argmax path information for max-plus variants).
 - API design keeps this extensible by relying on `HasAlgebra` and
@@ -93,7 +94,7 @@ runtime implementation is not complete in current POC.
 ## Design Decisions
 
 1. Separate reverse and forward wrappers (`TrackedTensor` vs `DualTensor`).
-2. Keep local VJP/JVP callable without constructing a tape.
+2. Keep local rrule/frule callable without constructing a tape.
 3. Keep public APIs backend-neutral; backend-specific execution stays in
    `tenferro-prims` / device layer.
 4. Use doc examples on all public items to make API review possible before

--- a/docs/plans/2026-02-15-autodiff-api-skeleton-design.md
+++ b/docs/plans/2026-02-15-autodiff-api-skeleton-design.md
@@ -7,8 +7,8 @@ Date: 2026-02-15
 Define a reviewable public API for automatic differentiation in tenferro-rs without adding implementations.
 
 - Reverse-mode: tape/graph based API (`TrackedTensor`, `backward`)
-- Forward-mode: tangent propagation API (`DualTensor`, JVP)
-- Rule extension traits (`VjpRule`, `JvpRule`) for backend-agnostic AD
+- Forward-mode: tangent propagation API (`DualTensor`, frule)
+- Rule extension traits (`ReverseRule`, `ForwardRule`) for backend-agnostic AD
 
 All function bodies remain `todo!()` in POC phase.
 
@@ -17,14 +17,14 @@ All function bodies remain `todo!()` in POC phase.
 `ndtensors-rs` was referenced for API shape and separation of concerns:
 
 - split user-facing wrappers: `TrackedTensor` (reverse) and `DualTensor` (forward)
-- expose local primitive derivatives (`contract_vjp`, `contract_jvp`)
-- keep op-level backward/JVP rules independent from high-level graph execution
+- expose local primitive derivatives (`contract_rrule`, `contract_frule`)
+- keep op-level rrule/frule independent from high-level graph execution
 
 Applied to tenferro as:
 
 - `tracked_einsum` and `dual_einsum` as AD-aware frontends (in `tenferro-einsum`)
-- `einsum_vjp` and `einsum_jvp` as local derivative kernels (in `tenferro-einsum`)
-- rule traits (`VjpRule`, `JvpRule`) for backend-agnostic extension (in `tenferro-autodiff`)
+- `einsum_rrule` and `einsum_frule` as local derivative kernels (in `tenferro-einsum`)
+- rule traits (`ReverseRule`, `ForwardRule`) for backend-agnostic extension (in `tenferro-autodiff`)
 
 ## Architecture: AD Framework vs Operation AD Rules
 
@@ -33,9 +33,9 @@ depend on any operation crate. Operation-specific AD rules live with their
 operations:
 
 - `tenferro-autodiff` — framework: `TrackedTensor`, `DualTensor`, `backward()`,
-  `VjpRule`, `JvpRule`, tape management
+  `ReverseRule`, `ForwardRule`, tape management
 - `tenferro-einsum` — einsum AD rules: `tracked_einsum`, `dual_einsum`,
-  `einsum_vjp`, `einsum_jvp`
+  `einsum_rrule`, `einsum_frule`
 
 Dependency direction: `tenferro-einsum → tenferro-autodiff` (not the reverse).
 
@@ -67,9 +67,9 @@ Core types:
 
 Core traits:
 
-- `VjpRule<T>`: `backward(cotangent) -> [(NodeId, Tensor<T>)]`,
-  `backward_with_tangents(cotangent, cotangent_tangent) -> [(NodeId, Tensor<T>, Tensor<T>)]`
-- `JvpRule<T>`: `forward(input_tangents) -> Tensor<T>`
+- `ReverseRule<T>`: `pullback(cotangent) -> [(NodeId, Tensor<T>)]`,
+  `pullback_with_tangents(cotangent, cotangent_tangent) -> [(NodeId, Tensor<T>, Tensor<T>)]`
+- `ForwardRule<T>`: `pushforward(input_tangents) -> Tensor<T>`
 
 Core functions:
 
@@ -83,15 +83,15 @@ Einsum AD functions added to `tenferro-einsum`:
 
 - `tracked_einsum(subscripts, operands)` — reverse-mode einsum
 - `dual_einsum(subscripts, operands)` — forward-mode einsum
-- `einsum_vjp(subscripts, operands, cotangent)` — local VJP for FFI/manual AD
-- `einsum_jvp(subscripts, primals, tangents)` — local JVP for FFI/manual AD
+- `einsum_rrule(subscripts, operands, cotangent)` — local pullback for FFI/manual AD
+- `einsum_frule(subscripts, primals, tangents)` — local pushforward for FFI/manual AD
 - `einsum_hvp(subscripts, primals, tangents, cotangent, cotangent_tangent)` — local HVP for FFI/manual AD
 
 ## Design Decisions
 
 1. Keep reverse and forward APIs separate.
 2. Do not force a specific graph runtime strategy in the public interface.
-3. Keep local VJP/JVP callable without tape construction.
+3. Keep local rrule/frule callable without tape construction.
 4. Reuse `tenferro_device::Result` for primitive derivative helpers where AD-specific errors are not required.
 5. Require minimal but sufficient doc examples for each public item, matching repository doc policy.
 6. AD framework does not depend on operation crates. Each operation crate owns its AD rules.

--- a/tenferro-autodiff/src/lib.rs
+++ b/tenferro-autodiff/src/lib.rs
@@ -1,11 +1,11 @@
 //! Automatic differentiation framework for tenferro.
 //!
 //! This crate provides the core AD infrastructure:
-//! - reverse-mode AD (VJP/backward) via [`TrackedTensor`]
-//! - forward-mode AD (JVP) via [`DualTensor`]
-//! - rule extension traits ([`VjpRule`], [`JvpRule`])
+//! - reverse-mode AD (rrule/pullback) via [`TrackedTensor`]
+//! - forward-mode AD (frule/pushforward) via [`DualTensor`]
+//! - rule extension traits ([`ReverseRule`], [`ForwardRule`])
 //!
-//! Operation-specific AD rules (e.g., einsum VJP/JVP) live in the crate
+//! Operation-specific AD rules (e.g., einsum rrule/frule) live in the crate
 //! that defines the operation. See `tenferro-einsum` for einsum AD functions.
 //!
 //! Bodies are intentionally `todo!()` in the current POC phase.
@@ -107,8 +107,8 @@ pub enum AutodiffError {
         /// Actual shape.
         got: Vec<usize>,
     },
-    /// A VjpRule does not support HVP (backward_with_tangents).
-    #[error("HVP not supported by this VjpRule implementation")]
+    /// A ReverseRule does not support HVP (pullback_with_tangents).
+    #[error("HVP not supported by this ReverseRule implementation")]
     HvpNotSupported,
     /// Generic AD argument error.
     #[error("invalid autodiff argument: {0}")]
@@ -530,30 +530,31 @@ impl<T: ScalarBase> Default for Gradients<T> {
     }
 }
 
-/// Backward rule interface for reverse-mode AD.
+/// Reverse-mode AD rule interface (rrule).
 ///
 /// Implemented by operation-specific nodes (einsum, reduce, permute, ...).
+/// Named after Julia's ChainRules.jl convention: `rrule` returns a pullback.
 ///
 /// # Examples
 ///
 /// ```ignore
 /// struct MyRule;
-/// impl tenferro_autodiff::VjpRule<f64> for MyRule {
-///     fn backward(&self, cotangent: &tenferro_tensor::Tensor<f64>)
+/// impl tenferro_autodiff::ReverseRule<f64> for MyRule {
+///     fn pullback(&self, cotangent: &tenferro_tensor::Tensor<f64>)
 ///         -> tenferro_autodiff::AdResult<Vec<(tenferro_autodiff::NodeId, tenferro_tensor::Tensor<f64>)>> {
 ///         todo!()
 ///     }
 ///     fn inputs(&self) -> Vec<tenferro_autodiff::NodeId> { vec![] }
 /// }
 /// ```
-pub trait VjpRule<T: ScalarBase + HasAlgebra> {
-    /// Computes input cotangents from an output cotangent.
-    fn backward(&self, cotangent: &Tensor<T>) -> AdResult<Vec<(NodeId, Tensor<T>)>>;
+pub trait ReverseRule<T: ScalarBase + HasAlgebra> {
+    /// Computes input cotangents from an output cotangent (pullback).
+    fn pullback(&self, cotangent: &Tensor<T>) -> AdResult<Vec<(NodeId, Tensor<T>)>>;
 
     /// Returns input node IDs this rule depends on.
     fn inputs(&self) -> Vec<NodeId>;
 
-    /// Computes backward pass with tangent propagation for HVP.
+    /// Computes pullback with tangent propagation for HVP.
     ///
     /// Given an output cotangent ḡ and its tangent dḡ, returns
     /// `(node_id, input_cotangent, input_cotangent_tangent)` triples.
@@ -565,13 +566,13 @@ pub trait VjpRule<T: ScalarBase + HasAlgebra> {
     ///
     /// ```ignore
     /// // Called internally by hvp(); users rarely call this directly.
-    /// let results = rule.backward_with_tangents(&cotangent, &cotangent_tangent)?;
+    /// let results = rule.pullback_with_tangents(&cotangent, &cotangent_tangent)?;
     /// for (node_id, grad, grad_tangent) in results {
     ///     // grad: standard cotangent for this input
     ///     // grad_tangent: cotangent tangent for HVP
     /// }
     /// ```
-    fn backward_with_tangents(
+    fn pullback_with_tangents(
         &self,
         cotangent: &Tensor<T>,
         cotangent_tangent: &Tensor<T>,
@@ -581,22 +582,24 @@ pub trait VjpRule<T: ScalarBase + HasAlgebra> {
     }
 }
 
-/// Forward rule interface for JVP propagation.
+/// Forward-mode AD rule interface (frule).
+///
+/// Named after Julia's ChainRules.jl convention: `frule` computes pushforward.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// struct MyJvp;
-/// impl tenferro_autodiff::JvpRule<f64> for MyJvp {
-///     fn forward(&self, tangents: &[Option<&tenferro_tensor::Tensor<f64>>])
+/// struct MyFrule;
+/// impl tenferro_autodiff::ForwardRule<f64> for MyFrule {
+///     fn pushforward(&self, tangents: &[Option<&tenferro_tensor::Tensor<f64>>])
 ///         -> tenferro_autodiff::AdResult<tenferro_tensor::Tensor<f64>> {
 ///         todo!()
 ///     }
 /// }
 /// ```
-pub trait JvpRule<T: ScalarBase + HasAlgebra> {
-    /// Computes output tangent from input tangents.
-    fn forward(&self, tangents: &[Option<&Tensor<T>>]) -> AdResult<Tensor<T>>;
+pub trait ForwardRule<T: ScalarBase + HasAlgebra> {
+    /// Computes output tangent from input tangents (pushforward).
+    fn pushforward(&self, tangents: &[Option<&Tensor<T>>]) -> AdResult<Tensor<T>>;
 }
 
 /// Compiled backward execution plan.
@@ -710,8 +713,8 @@ pub struct HvpResult<T: ScalarBase> {
 /// # Errors
 ///
 /// Returns [`AutodiffError::NonScalarLoss`] for non-scalar losses.
-/// Returns [`AutodiffError::HvpNotSupported`] if any VjpRule on the tape
-/// does not implement `backward_with_tangents`.
+/// Returns [`AutodiffError::HvpNotSupported`] if any ReverseRule on the tape
+/// does not implement `pullback_with_tangents`.
 ///
 /// # Examples
 ///

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -693,17 +693,18 @@ pub fn dual_einsum<T: ScalarBase + HasAlgebra>(
     todo!()
 }
 
-/// Local VJP rule for einsum without building a global tape.
+/// Reverse-mode rule (rrule) for einsum without building a global tape.
 ///
-/// Computes the vector-Jacobian product for an einsum operation.
+/// Computes the pullback (vector-Jacobian product) for an einsum operation.
 /// Returns one gradient tensor per input operand.
 ///
-/// This API is intended for language interop (`custom_vjp`) and manual AD.
+/// Named after Julia's ChainRules.jl convention.
+/// This API is intended for language interop and manual AD.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use tenferro_einsum::einsum_vjp;
+/// use tenferro_einsum::einsum_rrule;
 /// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_device::LogicalMemorySpace;
 ///
@@ -713,10 +714,10 @@ pub fn dual_einsum<T: ScalarBase + HasAlgebra>(
 /// let b = Tensor::<f64>::ones(&[3, 4], mem, col);
 /// let grad_c = Tensor::<f64>::ones(&[2, 4], mem, col);
 ///
-/// let grads = einsum_vjp("ij,jk->ik", &[&a, &b], &grad_c).unwrap();
+/// let grads = einsum_rrule("ij,jk->ik", &[&a, &b], &grad_c).unwrap();
 /// assert_eq!(grads.len(), 2);
 /// ```
-pub fn einsum_vjp<T: ScalarBase + HasAlgebra>(
+pub fn einsum_rrule<T: ScalarBase + HasAlgebra>(
     _subscripts: &str,
     _operands: &[&Tensor<T>],
     _cotangent: &Tensor<T>,
@@ -724,17 +725,18 @@ pub fn einsum_vjp<T: ScalarBase + HasAlgebra>(
     todo!()
 }
 
-/// Local JVP rule for einsum without building a global tape.
+/// Forward-mode rule (frule) for einsum without building a global tape.
 ///
-/// Computes the Jacobian-vector product for an einsum operation.
+/// Computes the pushforward (Jacobian-vector product) for an einsum operation.
 /// Inputs without tangent should use `None`.
 ///
-/// This API is intended for language interop (`custom_jvp`) and manual AD.
+/// Named after Julia's ChainRules.jl convention.
+/// This API is intended for language interop and manual AD.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use tenferro_einsum::einsum_jvp;
+/// use tenferro_einsum::einsum_frule;
 /// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_device::LogicalMemorySpace;
 ///
@@ -744,9 +746,9 @@ pub fn einsum_vjp<T: ScalarBase + HasAlgebra>(
 /// let b = Tensor::<f64>::ones(&[3, 4], mem, col);
 /// let da = Tensor::<f64>::ones(&[2, 3], mem, col);
 ///
-/// let dc = einsum_jvp("ij,jk->ik", &[&a, &b], &[Some(&da), None]).unwrap();
+/// let dc = einsum_frule("ij,jk->ik", &[&a, &b], &[Some(&da), None]).unwrap();
 /// ```
-pub fn einsum_jvp<T: ScalarBase + HasAlgebra>(
+pub fn einsum_frule<T: ScalarBase + HasAlgebra>(
     _subscripts: &str,
     _primals: &[&Tensor<T>],
     _tangents: &[Option<&Tensor<T>>],
@@ -762,11 +764,10 @@ pub fn einsum_jvp<T: ScalarBase + HasAlgebra>(
 /// for each input operand.
 ///
 /// For C = einsum(subscripts, [A, B]):
-/// - gradient: standard VJP (e.g., ḡ_A = einsum(ḡ_C, B))
-/// - hvp: tangent of VJP (e.g., dḡ_A = einsum(dḡ_C, B) + einsum(ḡ_C, dB))
+/// - gradient: standard pullback (e.g., ḡ_A = einsum(ḡ_C, B))
+/// - hvp: tangent of pullback (e.g., dḡ_A = einsum(dḡ_C, B) + einsum(ḡ_C, dB))
 ///
-/// This API is intended for language interop (`custom_vjp` with HVP)
-/// and manual AD.
+/// This API is intended for language interop and manual AD.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary

- Rename `VjpRule` → `ReverseRule`, `JvpRule` → `ForwardRule` (Julia ChainRules.jl convention)
- Rename methods: `backward` → `pullback`, `forward` → `pushforward`
- Rename einsum functions: `einsum_vjp` → `einsum_rrule`, `einsum_jvp` → `einsum_frule`
- Update all docs (design, plan, AGENTS.md) to use new names

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes
- [x] No old names (VjpRule, JvpRule, einsum_vjp, einsum_jvp) remain in .rs or .md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)