### PR TITLE
refactor: rename backward to pullback (ChainRules.jl)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ RUSTFLAGS="-C target-cpu=native" cargo bench
 
 ```
 Layer 5: tenferro-einsum       — High-level einsum on Tensor<T>, N-ary tree, algebra dispatch, einsum AD rules
-Layer 4: tenferro-autodiff     — AD framework: TrackedTensor, DualTensor, ReverseRule/ForwardRule, backward, tape
+Layer 4: tenferro-autodiff     — AD framework: TrackedTensor, DualTensor, ReverseRule/ForwardRule, pullback, tape
 Layer 3: tenferro-tensor       — Tensor<T> = DataBuffer + shape + strides, zero-copy view ops
 Layer 2: tenferro-prims        — "Tensor BLAS": TensorPrims<A> trait (algebra-parameterized), plan-based execution
 Shared:  tenferro-algebra      — HasAlgebra trait, Semiring trait, Standard type

--- a/docs/design/tenferro_autodiff_design.md
+++ b/docs/design/tenferro_autodiff_design.md
@@ -34,7 +34,7 @@ tenferro-einsum            ← Einsum + einsum AD rules
 Current POC scope (in `tenferro-autodiff`):
 
 - Public API skeleton for reverse-mode and forward-mode
-- `TrackedTensor`, `DualTensor`, `backward`, `Gradients`, `BackwardPlan`
+- `TrackedTensor`, `DualTensor`, `pullback`, `Gradients`, `PullbackPlan`
 - Trait extension points: `ReverseRule`, `ForwardRule`
 - Forward-over-reverse HVP: `HvpResult`, `hvp()`,
   `ReverseRule::pullback_with_tangents()`, `TrackedTensor::leaf_with_tangent()`
@@ -57,10 +57,10 @@ Planned scope (not yet implemented):
 
 - `TrackedTensor<T>` — reverse-mode wrapper (with optional tangent for HVP)
 - `DualTensor<T>` — forward-mode wrapper
-- `backward(loss)` — reverse-mode execution
+- `pullback(loss)` — reverse-mode execution
 - `hvp(loss)` — forward-over-reverse HVP execution
 - `clear_tape<T>()` — tape management
-- `Gradients<T>`, `BackwardPlan<T>`, `HvpResult<T>` — result and plan types
+- `Gradients<T>`, `PullbackPlan<T>`, `HvpResult<T>` — result and plan types
 - `ReverseRule<T>`, `ForwardRule<T>` — rule extension traits
   (named after Julia's ChainRules.jl: rrule/frule)
   (`ReverseRule` includes `pullback_with_tangents` for HVP support)
@@ -106,6 +106,6 @@ runtime implementation is not complete in current POC.
 ## Out of Scope in This Phase
 
 - Full runtime implementation of graph scheduling
-- End-to-end optimized GPU backward kernels
+- End-to-end optimized GPU pullback kernels
 - Full second-order differentiation API beyond HVP
   (HVP API skeleton is defined; full Hessian computation is deferred)

--- a/docs/plans/2026-02-15-autodiff-api-skeleton-design.md
+++ b/docs/plans/2026-02-15-autodiff-api-skeleton-design.md
@@ -6,7 +6,7 @@ Date: 2026-02-15
 
 Define a reviewable public API for automatic differentiation in tenferro-rs without adding implementations.
 
-- Reverse-mode: tape/graph based API (`TrackedTensor`, `backward`)
+- Reverse-mode: tape/graph based API (`TrackedTensor`, `pullback`)
 - Forward-mode: tangent propagation API (`DualTensor`, frule)
 - Rule extension traits (`ReverseRule`, `ForwardRule`) for backend-agnostic AD
 
@@ -32,7 +32,7 @@ The AD framework (`tenferro-autodiff`) is a **pure framework** that does not
 depend on any operation crate. Operation-specific AD rules live with their
 operations:
 
-- `tenferro-autodiff` — framework: `TrackedTensor`, `DualTensor`, `backward()`,
+- `tenferro-autodiff` — framework: `TrackedTensor`, `DualTensor`, `pullback()`,
   `ReverseRule`, `ForwardRule`, tape management
 - `tenferro-einsum` — einsum AD rules: `tracked_einsum`, `dual_einsum`,
   `einsum_rrule`, `einsum_frule`
@@ -61,7 +61,7 @@ Core types:
 - `TrackedTensor<T>` (with optional tangent for HVP)
 - `DualTensor<T>`
 - `Gradients<T>`
-- `BackwardPlan<T>`
+- `PullbackPlan<T>`
 - `HvpResult<T>`
 - `SavePolicy`
 
@@ -74,7 +74,7 @@ Core traits:
 Core functions:
 
 - `clear_tape<T>()`
-- `backward(loss: &TrackedTensor<T>) -> AdResult<Gradients<T>>`
+- `pullback(loss: &TrackedTensor<T>) -> AdResult<Gradients<T>>`
 - `hvp(loss: &TrackedTensor<T>) -> AdResult<HvpResult<T>>`
 
 ### tenferro-einsum (AD additions)

--- a/tenferro-autodiff/src/lib.rs
+++ b/tenferro-autodiff/src/lib.rs
@@ -15,7 +15,7 @@
 //! Reverse-mode usage (with operation-specific AD functions from other crates):
 //!
 //! ```ignore
-//! use tenferro_autodiff::{TrackedTensor, backward, clear_tape};
+//! use tenferro_autodiff::{TrackedTensor, pullback, clear_tape};
 //! use tenferro_einsum::tracked_einsum;
 //! use tenferro_tensor::{MemoryOrder, Tensor};
 //! use tenferro_device::LogicalMemorySpace;
@@ -33,7 +33,7 @@
 //! ));
 //! let c = tracked_einsum("ij,jk->ik", &[&a, &b]).unwrap();
 //! let loss = tracked_einsum("ij,ij->", &[&c, &c]).unwrap();
-//! let grads = backward(&loss).unwrap();
+//! let grads = pullback(&loss).unwrap();
 //! let _ga = grads.get(a.node_id().unwrap()).unwrap();
 //! ```
 //!
@@ -93,10 +93,10 @@ pub enum AutodiffError {
     /// Wrapped error from tenferro shared device/result layer.
     #[error(transparent)]
     Device(#[from] DeviceError),
-    /// Loss tensor for backward pass must contain exactly one element.
-    #[error("backward() requires scalar loss, got {num_elements} elements")]
+    /// Loss tensor for pullback must contain exactly one element.
+    #[error("pullback() requires scalar loss, got {num_elements} elements")]
     NonScalarLoss { num_elements: usize },
-    /// Attempted backward on a tensor not connected to AD tape.
+    /// Attempted pullback on a tensor not connected to AD tape.
     #[error("tensor is not connected to AD tape")]
     MissingNode,
     /// Tangent shape must match primal shape.
@@ -176,15 +176,15 @@ impl NodeId {
 /// ```
 /// use tenferro_autodiff::SavePolicy;
 ///
-/// let p = SavePolicy::SaveForBackward;
-/// assert_eq!(p, SavePolicy::SaveForBackward);
+/// let p = SavePolicy::SaveForPullback;
+/// assert_eq!(p, SavePolicy::SaveForPullback);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SavePolicy {
-    /// Keep forward tensors for exact backward formulas.
-    SaveForBackward,
+    /// Keep forward tensors for exact pullback formulas.
+    SaveForPullback,
     /// Discard forward tensors and require recomputation/checkpointing later.
-    RecomputeOnBackward,
+    RecomputeOnPullback,
 }
 
 /// Tensor wrapper for reverse-mode AD.
@@ -602,32 +602,32 @@ pub trait ForwardRule<T: ScalarBase + HasAlgebra> {
     fn pushforward(&self, tangents: &[Option<&Tensor<T>>]) -> AdResult<Tensor<T>>;
 }
 
-/// Compiled backward execution plan.
+/// Compiled pullback execution plan.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// let plan = tenferro_autodiff::BackwardPlan::<f64>::build(&loss).unwrap();
+/// let plan = tenferro_autodiff::PullbackPlan::<f64>::build(&loss).unwrap();
 /// ```
 #[derive(Debug, Clone)]
-pub struct BackwardPlan<T: ScalarBase + HasAlgebra> {
+pub struct PullbackPlan<T: ScalarBase + HasAlgebra> {
     loss: NodeId,
     _marker: std::marker::PhantomData<T>,
 }
 
-impl<T: ScalarBase + HasAlgebra> BackwardPlan<T> {
-    /// Builds a backward plan from a loss tensor.
+impl<T: ScalarBase + HasAlgebra> PullbackPlan<T> {
+    /// Builds a pullback plan from a loss tensor.
     ///
     /// # Examples
     ///
     /// ```ignore
-    /// let plan = tenferro_autodiff::BackwardPlan::<f64>::build(&loss).unwrap();
+    /// let plan = tenferro_autodiff::PullbackPlan::<f64>::build(&loss).unwrap();
     /// ```
     pub fn build(_loss: &TrackedTensor<T>) -> AdResult<Self> {
         todo!()
     }
 
-    /// Executes the pre-built backward plan.
+    /// Executes the pre-built pullback plan.
     ///
     /// # Examples
     ///
@@ -643,8 +643,8 @@ impl<T: ScalarBase + HasAlgebra> BackwardPlan<T> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_autodiff::{BackwardPlan, NodeId};
-    /// let _id_fn: fn(&BackwardPlan<f64>) -> NodeId = BackwardPlan::loss_node;
+    /// use tenferro_autodiff::{PullbackPlan, NodeId};
+    /// let _id_fn: fn(&PullbackPlan<f64>) -> NodeId = PullbackPlan::loss_node;
     /// ```
     pub fn loss_node(&self) -> NodeId {
         self.loss
@@ -663,7 +663,7 @@ pub fn clear_tape<T: ScalarBase>() {
     todo!()
 }
 
-/// Runs reverse-mode backward from a scalar loss tensor.
+/// Runs reverse-mode pullback from a scalar loss tensor.
 ///
 /// # Errors
 ///
@@ -672,9 +672,9 @@ pub fn clear_tape<T: ScalarBase>() {
 /// # Examples
 ///
 /// ```ignore
-/// let grads = tenferro_autodiff::backward(&loss).unwrap();
+/// let grads = tenferro_autodiff::pullback(&loss).unwrap();
 /// ```
-pub fn backward<T: ScalarBase + HasAlgebra>(_loss: &TrackedTensor<T>) -> AdResult<Gradients<T>> {
+pub fn pullback<T: ScalarBase + HasAlgebra>(_loss: &TrackedTensor<T>) -> AdResult<Gradients<T>> {
     todo!()
 }
 
@@ -704,7 +704,7 @@ pub struct HvpResult<T: ScalarBase> {
 /// Computes gradient and Hessian-vector product via forward-over-reverse.
 ///
 /// Leaf tensors with tangents (created via [`TrackedTensor::leaf_with_tangent`])
-/// define the direction *v*. The function runs backward through the tape,
+/// define the direction *v*. The function runs pullback through the tape,
 /// propagating both cotangents (ḡ) and cotangent-tangents (dḡ) at each node.
 ///
 /// Returns both ∇f(x) (in [`HvpResult::gradients`]) and H·v (in

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -628,13 +628,13 @@ pub fn einsum_with_plan_into<T: ScalarBase + HasAlgebra>(
 /// Tracked einsum (reverse-mode AD).
 ///
 /// This is the AD-aware counterpart of [`einsum`]. It records the operation
-/// on the reverse-mode tape so that [`tenferro_autodiff::backward`] can
+/// on the reverse-mode tape so that [`tenferro_autodiff::pullback`] can
 /// compute gradients through it.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use tenferro_autodiff::{TrackedTensor, backward, clear_tape};
+/// use tenferro_autodiff::{TrackedTensor, pullback, clear_tape};
 /// use tenferro_einsum::tracked_einsum;
 /// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_device::LogicalMemorySpace;
@@ -652,7 +652,7 @@ pub fn einsum_with_plan_into<T: ScalarBase + HasAlgebra>(
 /// ));
 /// let c = tracked_einsum("ij,jk->ik", &[&a, &b]).unwrap();
 /// let loss = tracked_einsum("ij,ij->", &[&c, &c]).unwrap();
-/// let grads = backward(&loss).unwrap();
+/// let grads = pullback(&loss).unwrap();
 /// let _ga = grads.get(a.node_id().unwrap()).unwrap();
 /// ```
 pub fn tracked_einsum<T: ScalarBase + HasAlgebra>(


### PR DESCRIPTION
## Summary

- Complete ChainRules.jl naming alignment (follows #8)
- `backward()` → `pullback()`, `BackwardPlan` → `PullbackPlan`
- `SaveForBackward` → `SaveForPullback`, `RecomputeOnBackward` → `RecomputeOnPullback`
- HVP names unchanged (no ChainRules.jl equivalent)

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes
- [x] No old names remain in autodiff/einsum source

🤖 Generated with [Claude Code](https://claude.com/claude-code)