### PR TITLE
refactor: split chainrules-core into traits + AD engine crate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,8 @@ Layer 4: tenferro-einsum       — High-level einsum on Tensor<T>, N-ary tree, a
 Layer 3: tenferro-tensor       — Tensor<T> = DataBuffer + shape + strides, zero-copy view ops,
                                  impl Differentiable for Tensor<T>
 Layer 2: tenferro-prims        — "Tensor BLAS": TensorPrims<A> trait (algebra-parameterized), plan-based execution
-Shared:  chainrules-core     — Generic AD framework: Differentiable trait, TrackedTensor<V>, DualTensor<V>,
-                                 ReverseRule<V>/ForwardRule<V>, pullback, tape (no tensor deps)
+Shared:  chainrules-core     — Core AD traits: Differentiable, ReverseRule<V>, ForwardRule<V> (no tensor deps)
+         chainrules           — AD engine: TrackedTensor<V>, DualTensor<V>, pullback, hvp (← chainrules-core)
          tenferro-algebra      — HasAlgebra trait, Semiring trait, Standard type
          tenferro-device       — Device enum, Error/Result types
 Layer 1: CPU backends          — strided-kernel + GEMM (faer/cblas) [future]
@@ -108,17 +108,21 @@ Layer 1: CPU backends          — strided-kernel + GEMM (faer/cblas) [future]
 Foundation: strided-rs    — Independent workspace (strided-traits → strided-view → strided-kernel)
 ```
 
-`chainrules-core` is a **generic AD framework** (like Julia's ChainRulesCore.jl) that
-does not depend on any tensor type. The `Differentiable` trait defines the tangent space;
-`Tensor<T>` implements it in `tenferro-tensor`. Operation-specific AD rules live with
-their operations: `tenferro-einsum` owns einsum AD functions
-(`tracked_einsum`, `dual_einsum`, `einsum_rrule`, `einsum_frule`).
+`chainrules-core` defines core AD traits (like Julia's ChainRulesCore.jl), independent
+of any tensor type. `chainrules` provides the AD engine (TrackedTensor, DualTensor,
+pullback, hvp). `Tensor<T>` implements `Differentiable` in `tenferro-tensor`.
+Operation-specific AD rules live with their operations: `tenferro-einsum` owns einsum
+AD functions (`tracked_einsum`, `dual_einsum`, `einsum_rrule`, `einsum_frule`).
 
 ### Dependency Graph (POC)
 
 ```
 chainrules-core (← thiserror only, no tensor deps)
-    │  Differentiable trait, TrackedTensor<V>, DualTensor<V>
+    │  Differentiable trait, ReverseRule<V>, ForwardRule<V>
+    │
+    ↓
+chainrules (← chainrules-core)
+    │  TrackedTensor<V>, DualTensor<V>, pullback, hvp
     │
 tenferro-device (← strided-view for StridedError, ← thiserror)
     │
@@ -137,6 +141,6 @@ tenferro-prims   tenferro-tensor
     └──────────┬─────────────┘
                ↓
           tenferro-einsum
-              (← strided-traits, ← chainrules-core)
+              (← strided-traits, ← chainrules)
 ```
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "tenferro-tensor",
     "tenferro-einsum",
     "chainrules-core",
+    "chainrules",
 ]
 resolver = "2"

--- a/chainrules-core/src/lib.rs
+++ b/chainrules-core/src/lib.rs
@@ -1,82 +1,39 @@
-//! Generic automatic differentiation framework.
+//! Core AD trait definitions (like Julia's ChainRulesCore.jl).
 //!
-//! This crate provides type-agnostic AD infrastructure, independent of any
-//! specific tensor or array type. It follows the design of Julia's
-//! ChainRulesCore.jl: the [`Differentiable`] trait defines the tangent space
-//! for any value type, while [`ReverseRule`] and [`ForwardRule`] define
-//! per-operation AD rules.
+//! This crate defines the interface for automatic differentiation without
+//! providing an AD engine. It contains:
 //!
-//! - Reverse-mode AD (rrule/pullback) via [`TrackedTensor`]
-//! - Forward-mode AD (frule/pushforward) via [`DualTensor`]
-//! - Rule extension traits ([`ReverseRule`], [`ForwardRule`])
-//! - Forward-over-reverse HVP via [`hvp`]
+//! - [`Differentiable`] — tangent space definition for any value type
+//! - [`ReverseRule`] — per-operation reverse-mode rule (rrule/pullback)
+//! - [`ForwardRule`] — per-operation forward-mode rule (frule/pushforward)
+//! - Error types ([`AutodiffError`], [`AdResult`])
+//! - [`NodeId`], [`SavePolicy`] — graph node identifier and save strategy
+//!
+//! The AD engine (`TrackedTensor`, `DualTensor`, `pullback`, `hvp`) lives in
+//! the [`chainrules`](https://docs.rs/chainrules) crate.
 //!
 //! Operation-specific AD rules (e.g., einsum rrule/frule) live in the crate
-//! that defines the operation. See `tenferro-einsum` for einsum AD functions.
-//!
-//! Bodies are intentionally `todo!()` in the current POC phase.
+//! that defines the operation.
 //!
 //! # Examples
 //!
-//! Reverse-mode usage (with operation-specific AD functions from other crates):
+//! Implementing `Differentiable` for a custom type:
 //!
 //! ```ignore
-//! use chainrules_core::{TrackedTensor, pullback, clear_tape};
-//! use tenferro_einsum::tracked_einsum;
-//! use tenferro_tensor::{MemoryOrder, Tensor};
-//! use tenferro_device::LogicalMemorySpace;
+//! use chainrules_core::Differentiable;
 //!
-//! clear_tape::<Tensor<f64>>();
-//! let a = TrackedTensor::leaf(Tensor::ones(
-//!     &[2, 3],
-//!     LogicalMemorySpace::MainMemory,
-//!     MemoryOrder::ColumnMajor,
-//! ));
-//! let b = TrackedTensor::leaf(Tensor::ones(
-//!     &[3, 4],
-//!     LogicalMemorySpace::MainMemory,
-//!     MemoryOrder::ColumnMajor,
-//! ));
-//! let c = tracked_einsum("ij,jk->ik", &[&a, &b]).unwrap();
-//! let loss = tracked_einsum("ij,ij->", &[&c, &c]).unwrap();
-//! let grads = pullback(&loss).unwrap();
-//! let _ga = grads.get(a.node_id().unwrap()).unwrap();
-//! ```
+//! #[derive(Clone)]
+//! struct MyVec(Vec<f64>);
 //!
-//! Forward-mode usage:
-//!
-//! ```ignore
-//! use chainrules_core::DualTensor;
-//! use tenferro_einsum::dual_einsum;
-//! use tenferro_tensor::{MemoryOrder, Tensor};
-//!
-//! let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::ColumnMajor).unwrap();
-//! let da = Tensor::<f64>::ones(&[2, 2], tenferro_device::LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
-//! let b = Tensor::<f64>::ones(&[2, 2], tenferro_device::LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
-//!
-//! let a_dual = DualTensor::with_tangent(a, da).unwrap();
-//! let b_dual = DualTensor::new(b);
-//! let c_dual = dual_einsum("ij,jk->ik", &[&a_dual, &b_dual]).unwrap();
-//! let _jvp = c_dual.tangent();
-//! ```
-//!
-//! Forward-over-reverse HVP (Hessian-vector product):
-//!
-//! ```ignore
-//! use chainrules_core::{TrackedTensor, hvp, clear_tape};
-//! use tenferro_einsum::tracked_einsum;
-//! use tenferro_tensor::{MemoryOrder, Tensor};
-//! use tenferro_device::LogicalMemorySpace;
-//!
-//! clear_tape::<Tensor<f64>>();
-//! let x = TrackedTensor::leaf_with_tangent(
-//!     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),
-//!     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),  // direction v
-//! ).unwrap();
-//! let loss = tracked_einsum("i,i->", &[&x, &x]).unwrap();  // f(x) = x·x
-//! let result = hvp(&loss).unwrap();
-//! let _grad = result.gradients;  // ∇f(x) = 2x
-//! let _hv = result.hvp;          // H·v = 2v
+//! impl Differentiable for MyVec {
+//!     type Tangent = MyVec;
+//!     fn zero_tangent(&self) -> MyVec {
+//!         MyVec(vec![0.0; self.0.len()])
+//!     }
+//!     fn accumulate_tangent(a: MyVec, b: &MyVec) -> MyVec {
+//!         MyVec(a.0.iter().zip(&b.0).map(|(x, y)| x + y).collect())
+//!     }
+//! }
 //! ```
 
 /// Trait defining the tangent space for a differentiable type.
@@ -153,9 +110,9 @@ pub enum AutodiffError {
 /// # Examples
 ///
 /// ```ignore
-/// use chainrules_core::{AdResult, TrackedTensor, Differentiable};
+/// use chainrules_core::AdResult;
 ///
-/// fn takes_ad_result<V: Differentiable>(_x: AdResult<TrackedTensor<V>>) {}
+/// fn returns_ad_result() -> AdResult<()> { Ok(()) }
 /// ```
 pub type AdResult<T> = std::result::Result<T, AutodiffError>;
 
@@ -218,353 +175,6 @@ pub enum SavePolicy {
     SaveForPullback,
     /// Discard forward tensors and require recomputation/checkpointing later.
     RecomputeOnPullback,
-}
-
-/// Value wrapper for reverse-mode AD.
-///
-/// Wraps any [`Differentiable`] value and connects it to the reverse-mode
-/// tape for gradient computation.
-///
-/// # Examples
-///
-/// ```ignore
-/// use chainrules_core::TrackedTensor;
-/// use tenferro_tensor::{MemoryOrder, Tensor};
-/// use tenferro_device::LogicalMemorySpace;
-///
-/// let a = TrackedTensor::leaf(Tensor::<f64>::ones(
-///     &[2, 3],
-///     LogicalMemorySpace::MainMemory,
-///     MemoryOrder::ColumnMajor,
-/// ));
-/// assert!(a.requires_grad());
-/// ```
-pub struct TrackedTensor<V: Differentiable> {
-    value: V,
-    node_id: Option<NodeId>,
-    requires_grad: bool,
-    tangent: Option<V::Tangent>,
-}
-
-impl<V: Differentiable> TrackedTensor<V> {
-    /// Creates a tracked value with `requires_grad = false`.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use chainrules_core::TrackedTensor;
-    /// let x = TrackedTensor::new(value);
-    /// assert!(!x.requires_grad());
-    /// ```
-    pub fn new(value: V) -> Self {
-        Self {
-            value,
-            node_id: None,
-            requires_grad: false,
-            tangent: None,
-        }
-    }
-
-    /// Creates a leaf value requiring gradient.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use chainrules_core::TrackedTensor;
-    /// let x = TrackedTensor::leaf(value);
-    /// assert!(x.requires_grad());
-    /// ```
-    pub fn leaf(_value: V) -> Self {
-        todo!()
-    }
-
-    /// Creates a tracked value with an explicit `requires_grad` flag.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use chainrules_core::TrackedTensor;
-    /// let x = TrackedTensor::with_requires_grad(value, true);
-    /// ```
-    pub fn with_requires_grad(_value: V, _requires_grad: bool) -> Self {
-        todo!()
-    }
-
-    /// Returns the underlying value.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let v = tracked.value();
-    /// ```
-    pub fn value(&self) -> &V {
-        &self.value
-    }
-
-    /// Consumes and returns the underlying value.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let raw = tracked.into_value();
-    /// ```
-    pub fn into_value(self) -> V {
-        self.value
-    }
-
-    /// Returns whether this value participates in gradient propagation.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// assert!(tracked.requires_grad());
-    /// ```
-    pub fn requires_grad(&self) -> bool {
-        self.requires_grad
-    }
-
-    /// Returns the graph node ID when this value is connected to the tape.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// if let Some(id) = tracked.node_id() {
-    ///     println!("node = {}", id.index());
-    /// }
-    /// ```
-    pub fn node_id(&self) -> Option<NodeId> {
-        self.node_id
-    }
-
-    /// Creates a leaf value requiring gradient, with a tangent for HVP.
-    ///
-    /// The tangent defines the perturbation direction *v* used in
-    /// forward-over-reverse Hessian-vector product computation.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AutodiffError::TangentShapeMismatch`] if shapes differ.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use chainrules_core::TrackedTensor;
-    /// let x = TrackedTensor::leaf_with_tangent(value, tangent).unwrap();
-    /// assert!(x.requires_grad());
-    /// assert!(x.has_tangent());
-    /// ```
-    pub fn leaf_with_tangent(_value: V, _tangent: V::Tangent) -> AdResult<Self> {
-        todo!()
-    }
-
-    /// Returns the tangent for HVP, or `None` if not set.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// if let Some(t) = tracked.tangent() {
-    ///     // use tangent
-    /// }
-    /// ```
-    pub fn tangent(&self) -> Option<&V::Tangent> {
-        self.tangent.as_ref()
-    }
-
-    /// Returns whether this tracked value has a tangent for HVP.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// assert!(tracked.has_tangent());
-    /// ```
-    pub fn has_tangent(&self) -> bool {
-        self.tangent.is_some()
-    }
-
-    /// Returns a detached value that does not require gradients.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let detached = tracked.detach();
-    /// assert!(!detached.requires_grad());
-    /// ```
-    pub fn detach(&self) -> Self {
-        todo!()
-    }
-}
-
-/// Value wrapper for forward-mode AD.
-///
-/// # Examples
-///
-/// ```ignore
-/// use chainrules_core::DualTensor;
-/// let dual = DualTensor::new(primal);
-/// assert!(!dual.has_tangent());
-/// ```
-pub struct DualTensor<V: Differentiable> {
-    primal: V,
-    tangent: Option<V::Tangent>,
-}
-
-impl<V: Differentiable> DualTensor<V> {
-    /// Creates a dual value with zero tangent.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use chainrules_core::DualTensor;
-    /// let x = DualTensor::new(primal);
-    /// ```
-    pub fn new(primal: V) -> Self {
-        Self {
-            primal,
-            tangent: None,
-        }
-    }
-
-    /// Creates a dual value with explicit tangent.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AutodiffError::TangentShapeMismatch`] if shapes differ.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use chainrules_core::DualTensor;
-    /// let x = DualTensor::with_tangent(primal, tangent).unwrap();
-    /// ```
-    pub fn with_tangent(_primal: V, _tangent: V::Tangent) -> AdResult<Self> {
-        todo!()
-    }
-
-    /// Returns the primal value.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let p = dual.primal();
-    /// ```
-    pub fn primal(&self) -> &V {
-        &self.primal
-    }
-
-    /// Returns the tangent, or `None` for zero tangent.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let maybe_t = dual.tangent();
-    /// ```
-    pub fn tangent(&self) -> Option<&V::Tangent> {
-        self.tangent.as_ref()
-    }
-
-    /// Returns whether this dual value has a non-zero tangent.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// assert!(dual.has_tangent());
-    /// ```
-    pub fn has_tangent(&self) -> bool {
-        self.tangent.is_some()
-    }
-
-    /// Consumes and returns `(primal, tangent)`.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let (p, t) = dual.into_parts();
-    /// ```
-    pub fn into_parts(self) -> (V, Option<V::Tangent>) {
-        (self.primal, self.tangent)
-    }
-
-    /// Returns a dual value with tangent detached (set to zero).
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let c = dual.detach_tangent();
-    /// assert!(!c.has_tangent());
-    /// ```
-    pub fn detach_tangent(&self) -> Self {
-        todo!()
-    }
-}
-
-/// Accumulated gradients indexed by [`NodeId`].
-///
-/// # Examples
-///
-/// ```ignore
-/// use chainrules_core::{Gradients, Differentiable};
-/// // V::Tangent is the gradient type
-/// let mut grads = Gradients::<MyType>::new();
-/// ```
-pub struct Gradients<V: Differentiable> {
-    entries: Vec<(NodeId, V::Tangent)>,
-}
-
-impl<V: Differentiable> Gradients<V> {
-    /// Creates an empty gradient container.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use chainrules_core::Gradients;
-    /// let grads = Gradients::<MyType>::new();
-    /// ```
-    pub fn new() -> Self {
-        Self { entries: vec![] }
-    }
-
-    /// Returns the gradient for `node`, if present.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// if let Some(g) = grads.get(node) {
-    ///     // use gradient
-    /// }
-    /// ```
-    pub fn get(&self, _node: NodeId) -> Option<&V::Tangent> {
-        todo!()
-    }
-
-    /// Inserts or accumulates a gradient for `node`.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// grads.accumulate(node, grad);
-    /// ```
-    pub fn accumulate(&mut self, _node: NodeId, _grad: V::Tangent) -> AdResult<()> {
-        todo!()
-    }
-
-    /// Returns all `(node, grad)` entries.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// for (node, grad) in grads.entries() {
-    ///     println!("{}", node.index());
-    /// }
-    /// ```
-    pub fn entries(&self) -> &[(NodeId, V::Tangent)] {
-        &self.entries
-    }
-}
-
-impl<V: Differentiable> Default for Gradients<V> {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 /// Reverse-mode AD rule interface (rrule).
@@ -647,144 +257,8 @@ pub trait ForwardRule<V: Differentiable> {
     fn pushforward(&self, tangents: &[Option<&V::Tangent>]) -> AdResult<V::Tangent>;
 }
 
-/// Compiled pullback execution plan.
-///
-/// # Examples
-///
-/// ```ignore
-/// let plan = chainrules_core::PullbackPlan::<MyType>::build(&loss).unwrap();
-/// ```
-#[derive(Debug, Clone)]
-pub struct PullbackPlan<V: Differentiable> {
-    loss: NodeId,
-    _marker: std::marker::PhantomData<V>,
-}
-
-impl<V: Differentiable> PullbackPlan<V> {
-    /// Builds a pullback plan from a loss value.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let plan = chainrules_core::PullbackPlan::build(&loss).unwrap();
-    /// ```
-    pub fn build(_loss: &TrackedTensor<V>) -> AdResult<Self> {
-        todo!()
-    }
-
-    /// Executes the pre-built pullback plan.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let grads = plan.execute(&loss).unwrap();
-    /// ```
-    pub fn execute(&self, _loss: &TrackedTensor<V>) -> AdResult<Gradients<V>> {
-        todo!()
-    }
-
-    /// Returns loss node ID for this plan.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use chainrules_core::{PullbackPlan, NodeId};
-    /// let _id_fn: fn(&PullbackPlan<f64>) -> NodeId = PullbackPlan::loss_node;
-    /// ```
-    pub fn loss_node(&self) -> NodeId {
-        self.loss
-    }
-}
-
-/// Clears the current reverse-mode tape/graph for type `V`.
-///
-/// # Examples
-///
-/// ```ignore
-/// chainrules_core::clear_tape::<Tensor<f64>>();
-/// ```
-pub fn clear_tape<V: Differentiable>() {
-    let _ = std::marker::PhantomData::<V>;
-    todo!()
-}
-
-/// Runs reverse-mode pullback from a scalar loss value.
-///
-/// # Errors
-///
-/// Returns [`AutodiffError::NonScalarLoss`] for non-scalar losses.
-///
-/// # Examples
-///
-/// ```ignore
-/// let grads = chainrules_core::pullback(&loss).unwrap();
-/// ```
-pub fn pullback<V: Differentiable>(_loss: &TrackedTensor<V>) -> AdResult<Gradients<V>> {
-    todo!()
-}
-
-/// Result of a forward-over-reverse HVP computation.
-///
-/// Contains both the standard gradient and the Hessian-vector
-/// product H*v, where v is the tangent direction set on leaf values
-/// via [`TrackedTensor::leaf_with_tangent`].
-///
-/// # Examples
-///
-/// ```ignore
-/// use chainrules_core::{TrackedTensor, hvp, HvpResult};
-/// use tenferro_einsum::tracked_einsum;
-///
-/// let result: HvpResult<Tensor<f64>> = hvp(&loss).unwrap();
-/// let _grad = result.gradients.get(x.node_id().unwrap());
-/// let _hv = result.hvp.get(x.node_id().unwrap());
-/// ```
-pub struct HvpResult<V: Differentiable> {
-    /// Gradients.
-    pub gradients: Gradients<V>,
-    /// Hessian-vector product: H*v.
-    pub hvp: Gradients<V>,
-}
-
-/// Computes gradient and Hessian-vector product via forward-over-reverse.
-///
-/// Leaf values with tangents (created via [`TrackedTensor::leaf_with_tangent`])
-/// define the direction *v*. The function runs pullback through the tape,
-/// propagating both cotangents and cotangent-tangents at each node.
-///
-/// Returns both the gradient (in [`HvpResult::gradients`]) and H*v (in
-/// [`HvpResult::hvp`]).
-///
-/// # Errors
-///
-/// Returns [`AutodiffError::NonScalarLoss`] for non-scalar losses.
-/// Returns [`AutodiffError::HvpNotSupported`] if any ReverseRule on the tape
-/// does not implement `pullback_with_tangents`.
-///
-/// # Examples
-///
-/// ```ignore
-/// use chainrules_core::{TrackedTensor, hvp, clear_tape};
-/// use tenferro_einsum::tracked_einsum;
-/// use tenferro_tensor::{MemoryOrder, Tensor};
-/// use tenferro_device::LogicalMemorySpace;
-///
-/// clear_tape::<Tensor<f64>>();
-/// let x = TrackedTensor::leaf_with_tangent(
-///     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),
-///     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),
-/// ).unwrap();
-/// let loss = tracked_einsum("i,i->", &[&x, &x]).unwrap();  // f(x) = x*x
-/// let result = hvp(&loss).unwrap();
-/// let _grad = result.gradients;
-/// let _hv = result.hvp;
-/// ```
-pub fn hvp<V: Differentiable>(_loss: &TrackedTensor<V>) -> AdResult<HvpResult<V>> {
-    todo!()
-}
-
 // ============================================================================
-// Differentiable impl for f64 (enables PullbackPlan doc test)
+// Differentiable impls for primitive types
 // ============================================================================
 
 impl Differentiable for f64 {

--- a/chainrules/Cargo.toml
+++ b/chainrules/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "chainrules"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "AD engine: TrackedTensor, DualTensor, pullback, hvp."
+publish = false
+
+[dependencies]
+chainrules-core = { path = "../chainrules-core" }

--- a/chainrules/src/lib.rs
+++ b/chainrules/src/lib.rs
@@ -1,0 +1,563 @@
+//! AD engine: tape-based reverse-mode and dual-number forward-mode.
+//!
+//! This crate provides the AD execution engine, built on top of
+//! [`chainrules_core`] traits. It is analogous to Zygote.jl in the Julia
+//! ecosystem: a concrete AD engine that uses ChainRulesCore.jl interfaces.
+//!
+//! - Reverse-mode AD via [`TrackedTensor`] and [`pullback`]
+//! - Forward-mode AD via [`DualTensor`]
+//! - Forward-over-reverse HVP via [`hvp`]
+//!
+//! Operation-specific AD rules (e.g., einsum rrule/frule) live in the crate
+//! that defines the operation. See `tenferro-einsum` for einsum AD functions.
+//!
+//! Bodies are intentionally `todo!()` in the current POC phase.
+//!
+//! # Examples
+//!
+//! Reverse-mode usage (with operation-specific AD functions from other crates):
+//!
+//! ```ignore
+//! use chainrules::{TrackedTensor, pullback, clear_tape};
+//! use tenferro_einsum::tracked_einsum;
+//! use tenferro_tensor::{MemoryOrder, Tensor};
+//! use tenferro_device::LogicalMemorySpace;
+//!
+//! clear_tape::<Tensor<f64>>();
+//! let a = TrackedTensor::leaf(Tensor::ones(
+//!     &[2, 3],
+//!     LogicalMemorySpace::MainMemory,
+//!     MemoryOrder::ColumnMajor,
+//! ));
+//! let b = TrackedTensor::leaf(Tensor::ones(
+//!     &[3, 4],
+//!     LogicalMemorySpace::MainMemory,
+//!     MemoryOrder::ColumnMajor,
+//! ));
+//! let c = tracked_einsum("ij,jk->ik", &[&a, &b]).unwrap();
+//! let loss = tracked_einsum("ij,ij->", &[&c, &c]).unwrap();
+//! let grads = pullback(&loss).unwrap();
+//! let _ga = grads.get(a.node_id().unwrap()).unwrap();
+//! ```
+//!
+//! Forward-mode usage:
+//!
+//! ```ignore
+//! use chainrules::DualTensor;
+//! use tenferro_einsum::dual_einsum;
+//! use tenferro_tensor::{MemoryOrder, Tensor};
+//!
+//! let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::ColumnMajor).unwrap();
+//! let da = Tensor::<f64>::ones(&[2, 2], tenferro_device::LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
+//! let b = Tensor::<f64>::ones(&[2, 2], tenferro_device::LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
+//!
+//! let a_dual = DualTensor::with_tangent(a, da).unwrap();
+//! let b_dual = DualTensor::new(b);
+//! let c_dual = dual_einsum("ij,jk->ik", &[&a_dual, &b_dual]).unwrap();
+//! let _jvp = c_dual.tangent();
+//! ```
+//!
+//! Forward-over-reverse HVP (Hessian-vector product):
+//!
+//! ```ignore
+//! use chainrules::{TrackedTensor, hvp, clear_tape};
+//! use tenferro_einsum::tracked_einsum;
+//! use tenferro_tensor::{MemoryOrder, Tensor};
+//! use tenferro_device::LogicalMemorySpace;
+//!
+//! clear_tape::<Tensor<f64>>();
+//! let x = TrackedTensor::leaf_with_tangent(
+//!     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),
+//!     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),  // direction v
+//! ).unwrap();
+//! let loss = tracked_einsum("i,i->", &[&x, &x]).unwrap();  // f(x) = x·x
+//! let result = hvp(&loss).unwrap();
+//! let _grad = result.gradients;  // ∇f(x) = 2x
+//! let _hv = result.hvp;          // H·v = 2v
+//! ```
+
+// Re-export all core traits so downstream can depend on just `chainrules`.
+pub use chainrules_core::*;
+
+/// Value wrapper for reverse-mode AD.
+///
+/// Wraps any [`Differentiable`] value and connects it to the reverse-mode
+/// tape for gradient computation.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules::TrackedTensor;
+/// use tenferro_tensor::{MemoryOrder, Tensor};
+/// use tenferro_device::LogicalMemorySpace;
+///
+/// let a = TrackedTensor::leaf(Tensor::<f64>::ones(
+///     &[2, 3],
+///     LogicalMemorySpace::MainMemory,
+///     MemoryOrder::ColumnMajor,
+/// ));
+/// assert!(a.requires_grad());
+/// ```
+pub struct TrackedTensor<V: Differentiable> {
+    value: V,
+    node_id: Option<NodeId>,
+    requires_grad: bool,
+    tangent: Option<V::Tangent>,
+}
+
+impl<V: Differentiable> TrackedTensor<V> {
+    /// Creates a tracked value with `requires_grad = false`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use chainrules::TrackedTensor;
+    /// let x = TrackedTensor::new(value);
+    /// assert!(!x.requires_grad());
+    /// ```
+    pub fn new(value: V) -> Self {
+        Self {
+            value,
+            node_id: None,
+            requires_grad: false,
+            tangent: None,
+        }
+    }
+
+    /// Creates a leaf value requiring gradient.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use chainrules::TrackedTensor;
+    /// let x = TrackedTensor::leaf(value);
+    /// assert!(x.requires_grad());
+    /// ```
+    pub fn leaf(_value: V) -> Self {
+        todo!()
+    }
+
+    /// Creates a tracked value with an explicit `requires_grad` flag.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use chainrules::TrackedTensor;
+    /// let x = TrackedTensor::with_requires_grad(value, true);
+    /// ```
+    pub fn with_requires_grad(_value: V, _requires_grad: bool) -> Self {
+        todo!()
+    }
+
+    /// Returns the underlying value.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let v = tracked.value();
+    /// ```
+    pub fn value(&self) -> &V {
+        &self.value
+    }
+
+    /// Consumes and returns the underlying value.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let raw = tracked.into_value();
+    /// ```
+    pub fn into_value(self) -> V {
+        self.value
+    }
+
+    /// Returns whether this value participates in gradient propagation.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// assert!(tracked.requires_grad());
+    /// ```
+    pub fn requires_grad(&self) -> bool {
+        self.requires_grad
+    }
+
+    /// Returns the graph node ID when this value is connected to the tape.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// if let Some(id) = tracked.node_id() {
+    ///     println!("node = {}", id.index());
+    /// }
+    /// ```
+    pub fn node_id(&self) -> Option<NodeId> {
+        self.node_id
+    }
+
+    /// Creates a leaf value requiring gradient, with a tangent for HVP.
+    ///
+    /// The tangent defines the perturbation direction *v* used in
+    /// forward-over-reverse Hessian-vector product computation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AutodiffError::TangentShapeMismatch`] if shapes differ.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use chainrules::TrackedTensor;
+    /// let x = TrackedTensor::leaf_with_tangent(value, tangent).unwrap();
+    /// assert!(x.requires_grad());
+    /// assert!(x.has_tangent());
+    /// ```
+    pub fn leaf_with_tangent(_value: V, _tangent: V::Tangent) -> AdResult<Self> {
+        todo!()
+    }
+
+    /// Returns the tangent for HVP, or `None` if not set.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// if let Some(t) = tracked.tangent() {
+    ///     // use tangent
+    /// }
+    /// ```
+    pub fn tangent(&self) -> Option<&V::Tangent> {
+        self.tangent.as_ref()
+    }
+
+    /// Returns whether this tracked value has a tangent for HVP.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// assert!(tracked.has_tangent());
+    /// ```
+    pub fn has_tangent(&self) -> bool {
+        self.tangent.is_some()
+    }
+
+    /// Returns a detached value that does not require gradients.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let detached = tracked.detach();
+    /// assert!(!detached.requires_grad());
+    /// ```
+    pub fn detach(&self) -> Self {
+        todo!()
+    }
+}
+
+/// Value wrapper for forward-mode AD.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules::DualTensor;
+/// let dual = DualTensor::new(primal);
+/// assert!(!dual.has_tangent());
+/// ```
+pub struct DualTensor<V: Differentiable> {
+    primal: V,
+    tangent: Option<V::Tangent>,
+}
+
+impl<V: Differentiable> DualTensor<V> {
+    /// Creates a dual value with zero tangent.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use chainrules::DualTensor;
+    /// let x = DualTensor::new(primal);
+    /// ```
+    pub fn new(primal: V) -> Self {
+        Self {
+            primal,
+            tangent: None,
+        }
+    }
+
+    /// Creates a dual value with explicit tangent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AutodiffError::TangentShapeMismatch`] if shapes differ.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use chainrules::DualTensor;
+    /// let x = DualTensor::with_tangent(primal, tangent).unwrap();
+    /// ```
+    pub fn with_tangent(_primal: V, _tangent: V::Tangent) -> AdResult<Self> {
+        todo!()
+    }
+
+    /// Returns the primal value.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let p = dual.primal();
+    /// ```
+    pub fn primal(&self) -> &V {
+        &self.primal
+    }
+
+    /// Returns the tangent, or `None` for zero tangent.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let maybe_t = dual.tangent();
+    /// ```
+    pub fn tangent(&self) -> Option<&V::Tangent> {
+        self.tangent.as_ref()
+    }
+
+    /// Returns whether this dual value has a non-zero tangent.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// assert!(dual.has_tangent());
+    /// ```
+    pub fn has_tangent(&self) -> bool {
+        self.tangent.is_some()
+    }
+
+    /// Consumes and returns `(primal, tangent)`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let (p, t) = dual.into_parts();
+    /// ```
+    pub fn into_parts(self) -> (V, Option<V::Tangent>) {
+        (self.primal, self.tangent)
+    }
+
+    /// Returns a dual value with tangent detached (set to zero).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let c = dual.detach_tangent();
+    /// assert!(!c.has_tangent());
+    /// ```
+    pub fn detach_tangent(&self) -> Self {
+        todo!()
+    }
+}
+
+/// Accumulated gradients indexed by [`NodeId`].
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules::{Gradients, Differentiable};
+/// // V::Tangent is the gradient type
+/// let mut grads = Gradients::<MyType>::new();
+/// ```
+pub struct Gradients<V: Differentiable> {
+    entries: Vec<(NodeId, V::Tangent)>,
+}
+
+impl<V: Differentiable> Gradients<V> {
+    /// Creates an empty gradient container.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use chainrules::Gradients;
+    /// let grads = Gradients::<MyType>::new();
+    /// ```
+    pub fn new() -> Self {
+        Self { entries: vec![] }
+    }
+
+    /// Returns the gradient for `node`, if present.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// if let Some(g) = grads.get(node) {
+    ///     // use gradient
+    /// }
+    /// ```
+    pub fn get(&self, _node: NodeId) -> Option<&V::Tangent> {
+        todo!()
+    }
+
+    /// Inserts or accumulates a gradient for `node`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// grads.accumulate(node, grad);
+    /// ```
+    pub fn accumulate(&mut self, _node: NodeId, _grad: V::Tangent) -> AdResult<()> {
+        todo!()
+    }
+
+    /// Returns all `(node, grad)` entries.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// for (node, grad) in grads.entries() {
+    ///     println!("{}", node.index());
+    /// }
+    /// ```
+    pub fn entries(&self) -> &[(NodeId, V::Tangent)] {
+        &self.entries
+    }
+}
+
+impl<V: Differentiable> Default for Gradients<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Compiled pullback execution plan.
+///
+/// # Examples
+///
+/// ```ignore
+/// let plan = chainrules::PullbackPlan::<MyType>::build(&loss).unwrap();
+/// ```
+#[derive(Debug, Clone)]
+pub struct PullbackPlan<V: Differentiable> {
+    loss: NodeId,
+    _marker: std::marker::PhantomData<V>,
+}
+
+impl<V: Differentiable> PullbackPlan<V> {
+    /// Builds a pullback plan from a loss value.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let plan = chainrules::PullbackPlan::build(&loss).unwrap();
+    /// ```
+    pub fn build(_loss: &TrackedTensor<V>) -> AdResult<Self> {
+        todo!()
+    }
+
+    /// Executes the pre-built pullback plan.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let grads = plan.execute(&loss).unwrap();
+    /// ```
+    pub fn execute(&self, _loss: &TrackedTensor<V>) -> AdResult<Gradients<V>> {
+        todo!()
+    }
+
+    /// Returns loss node ID for this plan.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chainrules::{PullbackPlan, NodeId};
+    /// let _id_fn: fn(&PullbackPlan<f64>) -> NodeId = PullbackPlan::loss_node;
+    /// ```
+    pub fn loss_node(&self) -> NodeId {
+        self.loss
+    }
+}
+
+/// Clears the current reverse-mode tape/graph for type `V`.
+///
+/// # Examples
+///
+/// ```ignore
+/// chainrules::clear_tape::<Tensor<f64>>();
+/// ```
+pub fn clear_tape<V: Differentiable>() {
+    let _ = std::marker::PhantomData::<V>;
+    todo!()
+}
+
+/// Runs reverse-mode pullback from a scalar loss value.
+///
+/// # Errors
+///
+/// Returns [`AutodiffError::NonScalarLoss`] for non-scalar losses.
+///
+/// # Examples
+///
+/// ```ignore
+/// let grads = chainrules::pullback(&loss).unwrap();
+/// ```
+pub fn pullback<V: Differentiable>(_loss: &TrackedTensor<V>) -> AdResult<Gradients<V>> {
+    todo!()
+}
+
+/// Result of a forward-over-reverse HVP computation.
+///
+/// Contains both the standard gradient and the Hessian-vector
+/// product H*v, where v is the tangent direction set on leaf values
+/// via [`TrackedTensor::leaf_with_tangent`].
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules::{TrackedTensor, hvp, HvpResult};
+/// use tenferro_einsum::tracked_einsum;
+///
+/// let result: HvpResult<Tensor<f64>> = hvp(&loss).unwrap();
+/// let _grad = result.gradients.get(x.node_id().unwrap());
+/// let _hv = result.hvp.get(x.node_id().unwrap());
+/// ```
+pub struct HvpResult<V: Differentiable> {
+    /// Gradients.
+    pub gradients: Gradients<V>,
+    /// Hessian-vector product: H*v.
+    pub hvp: Gradients<V>,
+}
+
+/// Computes gradient and Hessian-vector product via forward-over-reverse.
+///
+/// Leaf values with tangents (created via [`TrackedTensor::leaf_with_tangent`])
+/// define the direction *v*. The function runs pullback through the tape,
+/// propagating both cotangents and cotangent-tangents at each node.
+///
+/// Returns both the gradient (in [`HvpResult::gradients`]) and H*v (in
+/// [`HvpResult::hvp`]).
+///
+/// # Errors
+///
+/// Returns [`AutodiffError::NonScalarLoss`] for non-scalar losses.
+/// Returns [`AutodiffError::HvpNotSupported`] if any ReverseRule on the tape
+/// does not implement `pullback_with_tangents`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules::{TrackedTensor, hvp, clear_tape};
+/// use tenferro_einsum::tracked_einsum;
+/// use tenferro_tensor::{MemoryOrder, Tensor};
+/// use tenferro_device::LogicalMemorySpace;
+///
+/// clear_tape::<Tensor<f64>>();
+/// let x = TrackedTensor::leaf_with_tangent(
+///     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),
+///     Tensor::ones(&[3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),
+/// ).unwrap();
+/// let loss = tracked_einsum("i,i->", &[&x, &x]).unwrap();  // f(x) = x*x
+/// let result = hvp(&loss).unwrap();
+/// let _grad = result.gradients;
+/// let _hv = result.hvp;
+/// ```
+pub fn hvp<V: Differentiable>(_loss: &TrackedTensor<V>) -> AdResult<HvpResult<V>> {
+    todo!()
+}

--- a/docs/api_index.md
+++ b/docs/api_index.md
@@ -21,8 +21,10 @@ Layer 3: tenferro-tensor     Tensor<T> = DataBuffer + shape + strides,
                              zero-copy view ops, impl Differentiable
 Layer 2: tenferro-prims      "Tensor BLAS": TensorPrims<A> trait
                              (algebra-parameterized), plan-based execution
-Shared:  chainrules-core   Generic AD framework: Differentiable trait,
-                             TrackedTensor<V>, DualTensor<V>, rules (no tensor deps)
+Shared:  chainrules-core   Core AD traits: Differentiable, ReverseRule<V>,
+                             ForwardRule<V> (no tensor deps)
+         chainrules          AD engine: TrackedTensor<V>, DualTensor<V>,
+                             pullback, hvp (← chainrules-core)
          tenferro-algebra    HasAlgebra trait, Semiring trait, Standard type
          tenferro-device     Device enum, Error/Result types
 
@@ -59,13 +61,17 @@ and zero-copy view operations (`permute`, `broadcast`, `diagonal`, `reshape`).
 
 ### chainrules-core
 
-Generic AD framework (like Julia's ChainRulesCore.jl), independent of any
+Core AD trait definitions (like Julia's ChainRulesCore.jl), independent of any
 tensor type. `Differentiable` trait defines the tangent space; concrete types
-(e.g., `Tensor<T>`) implement it in their own crates.
+(e.g., `Tensor<T>`) implement it in their own crates. Rule extension traits
+(`ReverseRule<V>`, `ForwardRule<V>`) for per-operation AD rules.
 
-Provides `TrackedTensor<V>` (reverse-mode), `DualTensor<V>` (forward-mode),
-`pullback()`, `hvp()`, and rule extension traits (`ReverseRule<V>`,
-`ForwardRule<V>` -- named after Julia's ChainRules.jl).
+### chainrules
+
+AD engine (like Zygote.jl in Julia's ecosystem). Provides `TrackedTensor<V>`
+(reverse-mode), `DualTensor<V>` (forward-mode), `pullback()`, `hvp()`.
+Depends only on `chainrules-core`. Re-exports all of `chainrules-core`
+so downstream crates can depend on just `chainrules` for both traits and engine.
 
 Operation-specific AD rules live with their operations, not here.
 

--- a/docs/design/chainrules_core_design.md
+++ b/docs/design/chainrules_core_design.md
@@ -10,38 +10,48 @@ work that is not yet complete in POC.
 
 ## Position in Workspace Architecture
 
-`chainrules-core` is a **generic AD framework** (like Julia's ChainRulesCore.jl)
-that does not depend on any tensor type. It defines the `Differentiable` trait
-for tangent space operations, and generic wrapper types (`TrackedTensor<V>`,
-`DualTensor<V>`) parameterized by any `V: Differentiable`.
+The AD system is split into two crates following Rust convention
+(`foo-core` = traits, `foo` = full library):
 
-- `chainrules-core` depends only on `thiserror` (no tenferro crate deps).
+- **`chainrules-core`** — Pure trait definitions (like Julia's ChainRulesCore.jl).
+  Defines `Differentiable`, `ReverseRule<V>`, `ForwardRule<V>`, error types,
+  `NodeId`, `SavePolicy`. Depends only on `thiserror`.
+- **`chainrules`** — AD engine (like Zygote.jl). Provides `TrackedTensor<V>`,
+  `DualTensor<V>`, `pullback()`, `hvp()`, `Gradients<V>`, `PullbackPlan<V>`.
+  Depends only on `chainrules-core`. Re-exports all of `chainrules-core`.
+
+Neither crate depends on any tensor or tenferro crate.
+
 - `tenferro-tensor` depends on `chainrules-core` and implements
   `Differentiable for Tensor<T>`.
 - Operation-specific AD rules live with their operations:
   - Einsum AD functions (`tracked_einsum`, `dual_einsum`, `einsum_rrule`,
     `einsum_frule`) are in `tenferro-einsum`.
-  - Future operations (e.g., block-sparse matmul) define their own AD rules
-    in their own crates.
-- `tenferro-einsum` depends on `chainrules-core` to use the AD framework.
+  - Future operations define their own AD rules in their own crates.
+- `tenferro-einsum` depends on `chainrules` (which re-exports core).
 
 ```
-chainrules-core          ← Generic AD framework (Differentiable, no tensor deps)
+chainrules-core          ← Core AD traits (Differentiable, no tensor deps)
     ↑
-tenferro-tensor            ← impl Differentiable for Tensor<T>
+chainrules               ← AD engine (TrackedTensor, pullback, hvp)
     ↑
-tenferro-einsum            ← Einsum + einsum AD rules
+tenferro-tensor            ← impl Differentiable for Tensor<T> (depends on chainrules-core)
+    ↑
+tenferro-einsum            ← Einsum + einsum AD rules (depends on chainrules)
 ```
 
 ## Scope
 
 Current POC scope (in `chainrules-core`):
 
-- Public API skeleton for reverse-mode and forward-mode
-- `TrackedTensor`, `DualTensor`, `pullback`, `Gradients`, `PullbackPlan`
-- Trait extension points: `ReverseRule`, `ForwardRule`
+- `Differentiable` trait, `ReverseRule<V>`, `ForwardRule<V>` traits
+- Error types (`AutodiffError`, `AdResult`), `NodeId`, `SavePolicy`
+
+Current POC scope (in `chainrules`):
+
+- `TrackedTensor<V>`, `DualTensor<V>`, `pullback`, `Gradients`, `PullbackPlan`
 - Forward-over-reverse HVP: `HvpResult`, `hvp()`,
-  `ReverseRule::pullback_with_tangents()`, `TrackedTensor::leaf_with_tangent()`
+  `TrackedTensor::leaf_with_tangent()`
 
 Current POC scope (in `tenferro-einsum`):
 
@@ -57,23 +67,27 @@ Planned scope (not yet implemented):
 
 ## API Layers
 
-1. AD framework (`chainrules-core`)
+1. Core AD traits (`chainrules-core`)
 
 - `Differentiable` — trait defining tangent space (zero_tangent, accumulate_tangent)
+- `ReverseRule<V>`, `ForwardRule<V>` — rule extension traits
+  (named after Julia's ChainRules.jl: rrule/frule)
+  (`ReverseRule` includes `pullback_with_tangents` for HVP support)
+- `AutodiffError`, `AdResult`, `NodeId`, `SavePolicy`
+
+2. AD engine (`chainrules`)
+
 - `TrackedTensor<V>` — reverse-mode wrapper (with optional tangent for HVP)
 - `DualTensor<V>` — forward-mode wrapper
 - `pullback(loss)` — reverse-mode execution
 - `hvp(loss)` — forward-over-reverse HVP execution
 - `clear_tape<V>()` — tape management
 - `Gradients<V>`, `PullbackPlan<V>`, `HvpResult<V>` — result and plan types
-- `ReverseRule<V>`, `ForwardRule<V>` — rule extension traits
-  (named after Julia's ChainRules.jl: rrule/frule)
-  (`ReverseRule` includes `pullback_with_tangents` for HVP support)
 
 All types are parameterized by `V: Differentiable` (not `T: ScalarBase`),
 making the framework independent of any specific tensor or array type.
 
-2. Operation-specific AD rules (in each operation's crate)
+3. Operation-specific AD rules (in each operation's crate)
 
 Einsum AD rules (in `tenferro-einsum`):
 

--- a/docs/plans/2026-02-15-autodiff-api-skeleton-design.md
+++ b/docs/plans/2026-02-15-autodiff-api-skeleton-design.md
@@ -28,16 +28,14 @@ Applied to tenferro as:
 
 ## Architecture: AD Framework vs Operation AD Rules
 
-The AD framework (`chainrules-core`) is a **pure framework** that does not
-depend on any operation crate. Operation-specific AD rules live with their
-operations:
+The AD system is split into two crates following Rust convention:
 
-- `chainrules-core` — framework: `TrackedTensor`, `DualTensor`, `pullback()`,
-  `ReverseRule`, `ForwardRule`, tape management
+- `chainrules-core` — traits: `Differentiable`, `ReverseRule`, `ForwardRule`
+- `chainrules` — AD engine: `TrackedTensor`, `DualTensor`, `pullback()`, tape management
 - `tenferro-einsum` — einsum AD rules: `tracked_einsum`, `dual_einsum`,
   `einsum_rrule`, `einsum_frule`
 
-Dependency direction: `tenferro-einsum → chainrules-core` (not the reverse).
+Dependency direction: `tenferro-einsum → chainrules → chainrules-core`.
 
 This design enables user-defined operations to register their own AD rules
 without modifying the AD framework.
@@ -46,36 +44,28 @@ without modifying the AD framework.
 
 ### chainrules-core
 
-Dependencies:
-
-- `thiserror` (only dependency — no tensor or algebra deps)
+Dependencies: `thiserror` (only dependency — no tensor or algebra deps)
 
 Public API:
 
-Core trait:
-
 - `Differentiable` — tangent space definition (`Tangent` type, `zero_tangent`,
   `accumulate_tangent`). Like Julia's ChainRulesCore.jl.
+- `ReverseRule<V>`: `pullback(cotangent) -> [(NodeId, V::Tangent)]`,
+  `pullback_with_tangents(cotangent, cotangent_tangent) -> [(NodeId, V::Tangent, V::Tangent)]`
+- `ForwardRule<V>`: `pushforward(input_tangents) -> V::Tangent`
+- `AutodiffError`, `AdResult<T>`, `NodeId`, `SavePolicy`
 
-Core types:
+### chainrules
 
-- `AutodiffError`, `AdResult<T>`
-- `NodeId`
+Dependencies: `chainrules-core`
+
+Public API (re-exports all of `chainrules-core`):
+
 - `TrackedTensor<V: Differentiable>` (with optional tangent for HVP)
 - `DualTensor<V: Differentiable>`
 - `Gradients<V: Differentiable>`
 - `PullbackPlan<V: Differentiable>`
 - `HvpResult<V: Differentiable>`
-- `SavePolicy`
-
-Rule traits:
-
-- `ReverseRule<V>`: `pullback(cotangent) -> [(NodeId, V::Tangent)]`,
-  `pullback_with_tangents(cotangent, cotangent_tangent) -> [(NodeId, V::Tangent, V::Tangent)]`
-- `ForwardRule<V>`: `pushforward(input_tangents) -> V::Tangent`
-
-Core functions:
-
 - `clear_tape<V>()`
 - `pullback(loss: &TrackedTensor<V>) -> AdResult<Gradients<V>>`
 - `hvp(loss: &TrackedTensor<V>) -> AdResult<HvpResult<V>>`

--- a/tenferro-einsum/Cargo.toml
+++ b/tenferro-einsum/Cargo.toml
@@ -11,5 +11,5 @@ tenferro-device = { path = "../tenferro-device" }
 tenferro-algebra = { path = "../tenferro-algebra" }
 tenferro-prims = { path = "../tenferro-prims" }
 tenferro-tensor = { path = "../tenferro-tensor" }
-chainrules-core = { path = "../chainrules-core" }
+chainrules = { path = "../chainrules" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs" }

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -206,7 +206,7 @@
 //! // a.set_preferred_compute_device(None);
 //! ```
 
-use chainrules_core::{AdResult, Differentiable, DualTensor, TrackedTensor};
+use chainrules::{AdResult, Differentiable, DualTensor, TrackedTensor};
 use strided_traits::ScalarBase;
 use tenferro_algebra::HasAlgebra;
 use tenferro_device::Result;
@@ -628,13 +628,13 @@ pub fn einsum_with_plan_into<T: ScalarBase + HasAlgebra>(
 /// Tracked einsum (reverse-mode AD).
 ///
 /// This is the AD-aware counterpart of [`einsum`]. It records the operation
-/// on the reverse-mode tape so that [`chainrules_core::pullback`] can
+/// on the reverse-mode tape so that [`chainrules::pullback`] can
 /// compute gradients through it.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use chainrules_core::{TrackedTensor, pullback, clear_tape};
+/// use chainrules::{TrackedTensor, pullback, clear_tape};
 /// use tenferro_einsum::tracked_einsum;
 /// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_device::LogicalMemorySpace;
@@ -673,7 +673,7 @@ where
 /// # Examples
 ///
 /// ```ignore
-/// use chainrules_core::DualTensor;
+/// use chainrules::DualTensor;
 /// use tenferro_einsum::dual_einsum;
 /// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_device::LogicalMemorySpace;


### PR DESCRIPTION
## Summary
- Extract AD engine types (`TrackedTensor`, `DualTensor`, `Gradients`, `PullbackPlan`, `HvpResult`, `pullback`, `hvp`, `clear_tape`) from `chainrules-core` into new `chainrules` crate
- `chainrules-core` now contains only core AD traits (`Differentiable`, `ReverseRule`, `ForwardRule`) like Julia's ChainRulesCore.jl
- `chainrules` re-exports all of `chainrules-core`, following Rust `foo-core`/`foo` convention
- `tenferro-einsum` depends on `chainrules`; `tenferro-tensor` keeps `chainrules-core` dep

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes (all crates compile and doc-tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)