### PR TITLE
refactor: remove Clone bound from Differentiable, consume self in detach

### DIFF
--- a/chainrules-core/src/lib.rs
+++ b/chainrules-core/src/lib.rs
@@ -46,6 +46,11 @@
 /// For most tensor types, `Tangent = Self` (e.g., the tangent of a matrix
 /// is another matrix of the same shape).
 ///
+/// Note: This trait intentionally does **not** require `Clone` on the primal
+/// type. `Clone` is only required on `Tangent` (for gradient accumulation).
+/// Large values (e.g., tensors) may be expensive to clone; the AD engine
+/// avoids cloning primals by taking ownership where needed.
+///
 /// # Examples
 ///
 /// ```ignore
@@ -58,7 +63,7 @@
 ///     let _acc = V::accumulate_tangent(zero.clone(), &x.zero_tangent());
 /// }
 /// ```
-pub trait Differentiable: Clone {
+pub trait Differentiable {
     /// The tangent type for this value.
     ///
     /// For most types, this is `Self` (e.g., tangent of a tensor is a tensor).

--- a/chainrules/src/lib.rs
+++ b/chainrules/src/lib.rs
@@ -240,7 +240,7 @@ impl<V: Differentiable> TrackedTensor<V> {
         self.tangent.is_some()
     }
 
-    /// Returns a detached value that does not require gradients.
+    /// Consumes and returns a detached value that does not require gradients.
     ///
     /// # Examples
     ///
@@ -248,7 +248,7 @@ impl<V: Differentiable> TrackedTensor<V> {
     /// let detached = tracked.detach();
     /// assert!(!detached.requires_grad());
     /// ```
-    pub fn detach(&self) -> Self {
+    pub fn detach(self) -> Self {
         todo!()
     }
 }
@@ -343,7 +343,7 @@ impl<V: Differentiable> DualTensor<V> {
         (self.primal, self.tangent)
     }
 
-    /// Returns a dual value with tangent detached (set to zero).
+    /// Consumes and returns a dual value with tangent removed.
     ///
     /// # Examples
     ///
@@ -351,7 +351,7 @@ impl<V: Differentiable> DualTensor<V> {
     /// let c = dual.detach_tangent();
     /// assert!(!c.has_tangent());
     /// ```
-    pub fn detach_tangent(&self) -> Self {
+    pub fn detach_tangent(self) -> Self {
         todo!()
     }
 }

--- a/docs/design/chainrules_core_design.md
+++ b/docs/design/chainrules_core_design.md
@@ -124,6 +124,23 @@ runtime implementation is not complete in current POC.
 5. **AD framework does not depend on operation crates.** Each operation
    crate owns its AD rules. This avoids circular dependencies and keeps
    the framework extensible to user-defined operations.
+6. **`Differentiable` does not require `Clone` on the primal type.**
+   Only `Tangent: Clone` is required (for gradient accumulation at
+   fan-out nodes). Large values like tensors may be expensive to clone;
+   the AD engine avoids cloning primals by taking ownership
+   (`detach(self)`, not `detach(&self)`). Implementations that need
+   cheap duplication (e.g., for tape storage) should use internal
+   reference counting (`Arc`) rather than relying on `Clone`.
+7. **Tape lifetime: `NodeId` + runtime validation (POC).**
+   `TrackedTensor` references the tape via `NodeId(usize)`, not a
+   lifetime parameter or `Arc<Tape>`. This keeps the API simple.
+   `NodeId` can become invalid after `clear_tape()` — detected at
+   runtime, not compile time. Future migration path: store
+   `Arc<Tape>` inside `TrackedTensor` (grabbed from thread-local at
+   `leaf()` time). This is an internal change that does **not** alter
+   public API signatures, because the tape is accessed through the
+   `TrackedTensor` itself (e.g., `pullback(&loss)` reads `loss`'s
+   internal tape reference).
 
 ## Out of Scope in This Phase
 


### PR DESCRIPTION
## Summary
- Remove `Clone` bound from `Differentiable` trait — only `Tangent: Clone` remains (needed for gradient accumulation)
- Change `TrackedTensor::detach(&self)` to `detach(self)` — avoids requiring Clone on primal type
- Change `DualTensor::detach_tangent(&self)` to `detach_tangent(self)` — same rationale
- Document design decisions in `chainrules_core_design.md`:
  - Tape lifetime strategy: NodeId + runtime validation now, Arc<Tape> migration path for future
  - Why Differentiable does not require Clone

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)