### PR TITLE
refactor: add DLPack interop, remove strided-rs from tensor layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ members = [
     "chainrules",
 ]
 resolver = "2"
+
+[workspace.dependencies]
+num-complex = "0.4"
+num-traits = "0.2"
+thiserror = "2"

--- a/chainrules-core/Cargo.toml
+++ b/chainrules-core/Cargo.toml
@@ -7,4 +7,4 @@ description = "Generic automatic differentiation framework (ChainRulesCore.jl-st
 publish = false
 
 [dependencies]
-thiserror = "2"
+thiserror.workspace = true

--- a/docs/api_index.md
+++ b/docs/api_index.md
@@ -16,7 +16,8 @@ in tensor4all-meta for high-level architecture and future phase plans.
 
 ```
 Layer 5: tenferro-capi       C-API (FFI) for Julia/Python: exposes einsum + SVD
-                             with stateless rrule/frule (f64 only)
+                             with stateless rrule/frule (f64 only),
+                             DLPack v1.0 zero-copy tensor exchange
 Layer 4: tenferro-einsum     High-level einsum on Tensor<T>, N-ary contraction
                              tree, algebra dispatch, einsum AD rules
          tenferro-linalg     Tensor-level SVD/QR/LU/eigen, linalg AD rules
@@ -28,10 +29,11 @@ Shared:  chainrules-core   Core AD traits: Differentiable, ReverseRule<V>,
                              ForwardRule<V> (no tensor deps)
          chainrules          AD engine: Tape<V>, TrackedTensor<V>,
                              DualTensor<V> (← chainrules-core)
-         tenferro-algebra    HasAlgebra trait, Semiring trait, Standard type
+         tenferro-algebra    HasAlgebra trait, Semiring trait, Standard type,
+                             Scalar trait, Conjugate trait
          tenferro-device     Device enum, Error/Result types
 
-Foundation: strided-rs       Independent workspace
+Foundation: strided-rs       Independent workspace (used only by tenferro-prims)
                              (strided-traits -> strided-view -> strided-kernel)
 ```
 
@@ -44,7 +46,10 @@ Shared infrastructure: `LogicalMemorySpace` (MainMemory, GpuMemory),
 
 Minimal algebra foundation. `HasAlgebra` trait maps scalar types to their
 algebra (e.g., `f64 -> Standard`), enabling automatic backend inference.
-`Semiring` trait for algebra-generic operations.
+`Semiring` trait for algebra-generic operations. `Scalar` trait (blanket impl
+for `Copy + Send + Sync + Add + Mul + Zero + One + PartialEq`) defines
+minimum element type requirements. `Conjugate` trait for complex conjugation
+(identity for real types).
 
 ### tenferro-prims
 
@@ -58,9 +63,10 @@ Core ops (universal set): `batched_gemm`, `reduce`, `trace`, `permute`,
 
 ### tenferro-tensor
 
-`Tensor<T>` type with `DataBuffer` (CPU/GPU), shape/strides metadata,
-and zero-copy view operations (`permute`, `broadcast`, `diagonal`, `reshape`).
-`TensorView<'a, T>` for borrowed views.
+`Tensor<T>` type with `DataBuffer` (Rust-owned or externally-owned via DLPack),
+shape/strides metadata, and zero-copy view operations (`permute`, `broadcast`,
+`diagonal`, `reshape`). `TensorView<'a, T>` for borrowed views. `DataBuffer<T>`
+is an opaque struct abstracting over ownership (no strided-rs dependency).
 
 ### chainrules-core
 
@@ -113,8 +119,8 @@ Exposes tensor lifecycle, einsum, and SVD (including AD rules) via
 opaque pointers and status codes. f64 only in this POC phase.
 
 Design principles: opaque `TfeTensorF64` handles, `tfe_status_t`
-error codes, `catch_unwind` for panic safety, column-major data layout,
-copy semantics at FFI boundary.
+error codes, `catch_unwind` for panic safety, DLPack v1.0 for zero-copy
+tensor exchange across language boundaries (NumPy, PyTorch, JAX, DLPack.jl).
 
 AD approach: stateless `rrule`/`frule` only — host languages manage
 their own AD tapes (ChainRules.jl, PyTorch autograd, JAX custom_vjp).
@@ -123,6 +129,11 @@ Tape/TrackedTensor/DualTensor are NOT exposed.
 Tensor lifecycle: `tfe_tensor_f64_from_data`, `tfe_tensor_f64_zeros`,
 `tfe_tensor_f64_clone`, `tfe_tensor_f64_release`, `tfe_tensor_f64_ndim`,
 `tfe_tensor_f64_shape`, `tfe_tensor_f64_len`, `tfe_tensor_f64_data`.
+
+DLPack interop: `tfe_tensor_f64_to_dlpack` (consuming zero-copy export),
+`tfe_tensor_f64_from_dlpack` (zero-copy import). Supports CPU, CUDA, ROCm
+devices. DLPack v1.0 C ABI types (`DLManagedTensorVersioned`, `DLTensor`,
+`DLDevice`, `DLDataType`) are defined directly in the crate.
 
 Einsum: `tfe_einsum_f64`, `tfe_einsum_rrule_f64`, `tfe_einsum_frule_f64`.
 

--- a/tenferro-algebra/Cargo.toml
+++ b/tenferro-algebra/Cargo.toml
@@ -7,5 +7,5 @@ description = "Algebra traits (HasAlgebra, Semiring, Standard) for the tenferro 
 publish = false
 
 [dependencies]
-strided-traits = { git = "https://github.com/tensor4all/strided-rs" }
-num-complex = "0.4"
+num-complex.workspace = true
+num-traits.workspace = true

--- a/tenferro-algebra/src/lib.rs
+++ b/tenferro-algebra/src/lib.rs
@@ -1,8 +1,10 @@
 //! Algebra traits for the tenferro workspace.
 //!
-//! This crate provides the minimal algebra foundation for
-//! `TensorPrims<A>`:
+//! This crate provides the minimal algebra foundation:
 //!
+//! - [`Scalar`]: Minimum requirements for tensor element types
+//!   (`Copy + Send + Sync + Add + Mul + Zero + One + PartialEq`).
+//! - [`Conjugate`]: Complex conjugation (identity for real types).
 //! - [`HasAlgebra`]: Maps a scalar type `T` to its default algebra `A`.
 //!   Enables automatic inference: `Tensor<f64>` → `Standard`,
 //!   `Tensor<MaxPlus<f64>>` → `MaxPlus` (in external crate).
@@ -18,16 +20,99 @@
 //! # Examples
 //!
 //! ```
-//! use tenferro_algebra::{HasAlgebra, Standard};
+//! use tenferro_algebra::{HasAlgebra, Scalar, Standard};
 //!
 //! // f64 maps to Standard algebra automatically
 //! fn check_algebra<T: HasAlgebra<Algebra = Standard>>() {}
 //! check_algebra::<f64>();
 //! check_algebra::<f32>();
+//!
+//! // Scalar is automatically implemented for numeric types
+//! fn needs_scalar<T: Scalar>() {}
+//! needs_scalar::<f64>();
+//! needs_scalar::<f32>();
 //! ```
 
 use num_complex::{Complex32, Complex64};
-use strided_traits::ScalarBase;
+
+/// Scalar element type for tensors.
+///
+/// Minimum requirements for a type to be stored in a `Tensor<T>`.
+/// All standard numeric types (`f32`, `f64`, `Complex32`, `Complex64`)
+/// satisfy this trait automatically via the blanket implementation.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_algebra::Scalar;
+///
+/// fn needs_scalar<T: Scalar>() {}
+/// needs_scalar::<f64>();
+/// needs_scalar::<f32>();
+/// ```
+pub trait Scalar:
+    Copy
+    + Send
+    + Sync
+    + std::ops::Add<Output = Self>
+    + std::ops::Mul<Output = Self>
+    + num_traits::Zero
+    + num_traits::One
+    + PartialEq
+{
+}
+
+impl<T> Scalar for T where
+    T: Copy
+        + Send
+        + Sync
+        + std::ops::Add<Output = Self>
+        + std::ops::Mul<Output = Self>
+        + num_traits::Zero
+        + num_traits::One
+        + PartialEq
+{
+}
+
+/// Complex conjugation for tensor element types.
+///
+/// Default implementation returns `self` unchanged, which is correct
+/// for real-valued types. Complex types override with actual conjugation.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_algebra::Conjugate;
+///
+/// // Real types: conj is identity
+/// assert_eq!(3.14_f64.conj(), 3.14_f64);
+///
+/// // Complex types: conj negates imaginary part
+/// use num_complex::Complex64;
+/// let z = Complex64::new(1.0, 2.0);
+/// assert_eq!(z.conj(), Complex64::new(1.0, -2.0));
+/// ```
+pub trait Conjugate: Copy {
+    /// Return the complex conjugate of this value.
+    fn conj(self) -> Self {
+        self
+    }
+}
+
+impl Conjugate for f32 {}
+impl Conjugate for f64 {}
+
+impl Conjugate for Complex32 {
+    fn conj(self) -> Self {
+        Complex32::conj(&self)
+    }
+}
+
+impl Conjugate for Complex64 {
+    fn conj(self) -> Self {
+        Complex64::conj(&self)
+    }
+}
 
 /// Maps a scalar type `T` to its default algebra `A`.
 ///
@@ -90,7 +175,7 @@ impl HasAlgebra for Complex64 {
 /// - `zero() = -∞`, `one() = 0`, `add = max`, `mul = +`
 pub trait Semiring {
     /// The scalar type for this semiring.
-    type Scalar: ScalarBase;
+    type Scalar: Scalar;
 
     /// Additive identity element.
     fn zero() -> Self::Scalar;

--- a/tenferro-capi/src/lib.rs
+++ b/tenferro-capi/src/lib.rs
@@ -1,7 +1,7 @@
 //! C-API (FFI) for tenferro.
 //!
-//! Exposes tensor lifecycle, einsum, and SVD (including AD rules) to
-//! host languages such as Julia, Python (JAX, PyTorch), and C/C++.
+//! Exposes tensor lifecycle, einsum, SVD (including AD rules), and DLPack
+//! interop to host languages such as Julia, Python (JAX, PyTorch), and C/C++.
 //!
 //! # Design principles
 //!
@@ -15,19 +15,25 @@
 //!   and **not** exposed via FFI. Host languages manage their own AD tapes
 //!   (ChainRules.jl, PyTorch autograd, JAX custom_vjp).
 //! - **f64 only** in this POC phase. All functions carry the `_f64` suffix.
-//! - **Column-major order** (Julia/BLAS convention) for data layout.
-//! - **Copy semantics** at FFI boundary: `tfe_tensor_f64_from_data` copies
-//!   the caller's data into a Rust-owned buffer.
+//! - **DLPack interop**: Zero-copy tensor exchange with Julia, Python, and
+//!   other frameworks via [`DLManagedTensorVersioned`]. Supports CPU and
+//!   GPU memory. Use [`tfe_tensor_f64_to_dlpack`] (export) and
+//!   [`tfe_tensor_f64_from_dlpack`] (import).
+//! - **Copy semantics** for convenience functions: `tfe_tensor_f64_from_data`
+//!   copies the caller's data into a Rust-owned buffer. For zero-copy, use
+//!   DLPack.
 //!
 //! # Memory ownership
 //!
 //! | Allocation | Freed by |
 //! |-----------|----------|
 //! | Tensor from `_from_data` / `_zeros` / `_clone` | `tfe_tensor_f64_release` |
+//! | Tensor from `_from_dlpack` | `tfe_tensor_f64_release` (calls DLPack deleter) |
 //! | Output tensor (via `**_out`) | `tfe_tensor_f64_release` |
 //! | Gradient tensor (rrule output) | `tfe_tensor_f64_release` |
 //! | `grads_out` array (einsum rrule) | Caller provides buffer |
 //! | Input `data` pointer | Caller (data is copied) |
+//! | `DLManagedTensorVersioned` from `_to_dlpack` | Consumer calls `deleter` |
 //!
 //! # Example (C pseudocode)
 //!
@@ -49,7 +55,7 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(non_camel_case_types)]
 
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 
 // ============================================================================
 // Status codes
@@ -69,6 +75,101 @@ pub const TFE_SHAPE_MISMATCH: tfe_status_t = -2;
 
 /// Internal error (Rust panic or unexpected failure).
 pub const TFE_INTERNAL_ERROR: tfe_status_t = -3;
+
+// ============================================================================
+// DLPack v1.0 C ABI types
+// ============================================================================
+
+/// DLPack version information.
+#[repr(C)]
+pub struct DLPackVersion {
+    /// Major version (1 for DLPack v1.0).
+    pub major: u32,
+    /// Minor version.
+    pub minor: u32,
+}
+
+/// DLPack device descriptor.
+#[repr(C)]
+pub struct DLDevice {
+    /// Device type (see `kDLCPU`, `kDLCUDA`, `kDLROCM`).
+    pub device_type: i32,
+    /// Device ID (0 for default).
+    pub device_id: i32,
+}
+
+/// DLPack data type descriptor.
+#[repr(C)]
+pub struct DLDataType {
+    /// Type code (see `kDLFloat`, `kDLInt`, `kDLComplex`).
+    pub code: u8,
+    /// Number of bits per element (e.g., 64 for f64).
+    pub bits: u8,
+    /// Number of lanes (1 for scalar, >1 for SIMD vector types).
+    pub lanes: u16,
+}
+
+/// DLPack tensor descriptor (unmanaged).
+///
+/// Describes the memory layout of a tensor without ownership information.
+/// Used as a field within [`DLManagedTensorVersioned`].
+#[repr(C)]
+pub struct DLTensor {
+    /// Pointer to the data. For GPU tensors, this is a device pointer.
+    pub data: *mut c_void,
+    /// Device where the data resides.
+    pub device: DLDevice,
+    /// Number of dimensions.
+    pub ndim: i32,
+    /// Data type.
+    pub dtype: DLDataType,
+    /// Shape array (length = ndim). Owned by the manager.
+    pub shape: *mut i64,
+    /// Strides array in **element units** (not bytes). NULL = row-major contiguous.
+    pub strides: *mut i64,
+    /// Byte offset from `data` pointer to the first element.
+    pub byte_offset: u64,
+}
+
+/// DLPack managed tensor with version and ownership (DLPack v1.0+).
+///
+/// This is the primary type for DLPack tensor exchange. The `deleter`
+/// callback must be called by the consumer when the data is no longer needed.
+#[repr(C)]
+pub struct DLManagedTensorVersioned {
+    /// DLPack version.
+    pub version: DLPackVersion,
+    /// Opaque pointer for the producer's use (e.g., Box<Tensor>).
+    pub manager_ctx: *mut c_void,
+    /// Callback to free resources. Must be called exactly once by the consumer.
+    pub deleter: Option<unsafe extern "C" fn(*mut DLManagedTensorVersioned)>,
+    /// Bitmask flags (see `DLPACK_FLAG_*` constants).
+    pub flags: u64,
+    /// The tensor descriptor.
+    pub dl_tensor: DLTensor,
+}
+
+// DLDeviceType constants
+/// CPU device.
+pub const KDLCPU: i32 = 1;
+/// NVIDIA CUDA device.
+pub const KDLCUDA: i32 = 2;
+/// AMD ROCm device.
+pub const KDLROCM: i32 = 10;
+
+// DLDataTypeCode constants
+/// Integer type code.
+pub const KDLINT: u8 = 0;
+/// Floating-point type code.
+pub const KDLFLOAT: u8 = 2;
+/// Complex type code.
+pub const KDLCOMPLEX: u8 = 5;
+
+// DLPack flags
+/// Data is read-only (consumer must not write).
+pub const DLPACK_FLAG_BITMASK_READ_ONLY: u64 = 1 << 0;
+/// Data was copied (not zero-copy).
+pub const DLPACK_FLAG_BITMASK_IS_COPIED: u64 = 1 << 1;
 
 // ============================================================================
 // Opaque tensor handle
@@ -99,10 +200,14 @@ pub struct TfeTensorF64 {
 // Tensor lifecycle
 // ============================================================================
 
-/// Create a tensor from caller-provided data (column-major order).
+/// Create a tensor from caller-provided data (copy semantics).
 ///
 /// The data is **copied** into Rust-owned storage. The caller retains
 /// ownership of the `data` pointer and may free it after this call.
+/// The internal memory layout (strides) is implementation-defined.
+///
+/// For zero-copy tensor exchange with specific memory layouts, use
+/// [`tfe_tensor_f64_from_dlpack`] instead.
 ///
 /// # Safety
 ///
@@ -132,6 +237,8 @@ pub unsafe extern "C" fn tfe_tensor_f64_from_data(
 }
 
 /// Create a tensor filled with zeros.
+///
+/// The internal memory layout is implementation-defined.
 ///
 /// # Safety
 ///
@@ -181,6 +288,9 @@ pub unsafe extern "C" fn tfe_tensor_f64_clone(
 ///
 /// After this call, `tensor` is invalid and must not be used.
 /// Passing a null pointer is a no-op.
+///
+/// For tensors imported via DLPack, this calls the DLPack deleter
+/// to notify the external owner that the data is no longer needed.
 ///
 /// # Safety
 ///
@@ -238,7 +348,7 @@ pub unsafe extern "C" fn tfe_tensor_f64_len(_tensor: *const TfeTensorF64) -> usi
     todo!()
 }
 
-/// Return a pointer to the tensor's raw data (column-major order).
+/// Return a pointer to the tensor's raw data buffer.
 ///
 /// The pointer is valid until `tfe_tensor_f64_release` is called on
 /// the tensor.
@@ -259,6 +369,87 @@ pub unsafe extern "C" fn tfe_tensor_f64_len(_tensor: *const TfeTensorF64) -> usi
 /// ```
 #[no_mangle]
 pub unsafe extern "C" fn tfe_tensor_f64_data(_tensor: *const TfeTensorF64) -> *const f64 {
+    todo!()
+}
+
+// ============================================================================
+// DLPack interop
+// ============================================================================
+
+/// Export a tensor as a DLPack managed tensor (zero-copy).
+///
+/// The tensor handle is **consumed** by this call and must not be
+/// used afterwards (do not call `tfe_tensor_f64_release` on it).
+///
+/// The returned `DLManagedTensorVersioned` must be consumed by the
+/// caller (e.g., passed to Julia `DLPack.from_dlpack()` or Python
+/// `numpy.from_dlpack()`). The consumer must call the `deleter`
+/// callback when done with the data.
+///
+/// If the tensor is NULL, returns NULL and sets status to `TFE_INVALID_ARGUMENT`.
+///
+/// # Safety
+///
+/// - `tensor` must be a valid tensor pointer or NULL.
+/// - `status` must be a valid, non-null pointer.
+///
+/// # Examples (C)
+///
+/// ```c
+/// tfe_status_t status;
+/// tfe_tensor_f64 *t = tfe_tensor_f64_zeros(shape, 2, &status);
+///
+/// // Export to DLPack (tensor handle is consumed)
+/// DLManagedTensorVersioned *dl = tfe_tensor_f64_to_dlpack(t, &status);
+/// // t is now invalid — do NOT call tfe_tensor_f64_release(t)
+///
+/// // Pass dl to Julia/Python, which calls dl->deleter(dl) when done
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn tfe_tensor_f64_to_dlpack(
+    _tensor: *mut TfeTensorF64,
+    _status: *mut tfe_status_t,
+) -> *mut DLManagedTensorVersioned {
+    todo!()
+}
+
+/// Import a DLPack managed tensor as a tenferro tensor (zero-copy).
+///
+/// Takes ownership of the `DLManagedTensorVersioned`. The deleter
+/// callback will be called when the returned tensor is released
+/// via `tfe_tensor_f64_release`.
+///
+/// The tensor data is NOT copied. The returned tensor references
+/// the same memory as the DLPack tensor.
+///
+/// Currently only `kDLCPU` device and float64 dtype are accepted
+/// (POC phase). Returns NULL with `TFE_INVALID_ARGUMENT` for other
+/// device types or dtypes.
+///
+/// # Safety
+///
+/// - `managed` must be a valid pointer to a `DLManagedTensorVersioned`.
+/// - The DLPack tensor's data must remain valid until the deleter is called.
+/// - `status` must be a valid, non-null pointer.
+///
+/// # Examples (C)
+///
+/// ```c
+/// // Obtain DLManagedTensorVersioned* from Julia/Python
+/// DLManagedTensorVersioned *dl = /* ... */;
+///
+/// tfe_status_t status;
+/// tfe_tensor_f64 *t = tfe_tensor_f64_from_dlpack(dl, &status);
+/// // dl is now owned by t — do NOT call dl->deleter(dl)
+///
+/// // Use t in einsum, SVD, etc.
+/// tfe_tensor_f64_release(t); // calls DLPack deleter internally
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn tfe_tensor_f64_from_dlpack(
+    _managed: *mut DLManagedTensorVersioned,
+    _status: *mut tfe_status_t,
+) -> *mut TfeTensorF64 {
     todo!()
 }
 

--- a/tenferro-device/Cargo.toml
+++ b/tenferro-device/Cargo.toml
@@ -7,5 +7,4 @@ description = "Device abstraction and shared error types for the tenferro worksp
 publish = false
 
 [dependencies]
-strided-view = { git = "https://github.com/tensor4all/strided-rs" }
-thiserror = "1.0"
+thiserror.workspace = true

--- a/tenferro-device/src/lib.rs
+++ b/tenferro-device/src/lib.rs
@@ -153,9 +153,9 @@ pub enum Error {
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
 
-    /// An error propagated from strided-view operations.
-    #[error(transparent)]
-    Strided(#[from] strided_view::StridedError),
+    /// An error related to strided memory layout (invalid strides, out-of-bounds offset, etc.).
+    #[error("stride error: {0}")]
+    StrideError(String),
 }
 
 /// Result type alias using [`Error`].

--- a/tenferro-einsum/Cargo.toml
+++ b/tenferro-einsum/Cargo.toml
@@ -12,4 +12,3 @@ tenferro-algebra = { path = "../tenferro-algebra" }
 tenferro-prims = { path = "../tenferro-prims" }
 tenferro-tensor = { path = "../tenferro-tensor" }
 chainrules = { path = "../chainrules" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs" }

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -207,8 +207,7 @@
 //! ```
 
 use chainrules::{AdResult, Differentiable, DualTensor, TrackedTensor};
-use strided_traits::ScalarBase;
-use tenferro_algebra::HasAlgebra;
+use tenferro_algebra::{HasAlgebra, Scalar};
 use tenferro_device::Result;
 use tenferro_tensor::Tensor;
 
@@ -391,7 +390,7 @@ impl ContractionTree {
 ///
 /// Returns an error if the notation is invalid or tensor shapes are
 /// incompatible with the subscripts.
-pub fn einsum<T: ScalarBase + HasAlgebra>(
+pub fn einsum<T: Scalar + HasAlgebra>(
     subscripts: &str,
     operands: &[&Tensor<T>],
 ) -> Result<Tensor<T>> {
@@ -406,7 +405,7 @@ pub fn einsum<T: ScalarBase + HasAlgebra>(
 /// # Errors
 ///
 /// Returns an error if tensor shapes are incompatible with the subscripts.
-pub fn einsum_with_subscripts<T: ScalarBase + HasAlgebra>(
+pub fn einsum_with_subscripts<T: Scalar + HasAlgebra>(
     subscripts: &Subscripts,
     operands: &[&Tensor<T>],
 ) -> Result<Tensor<T>> {
@@ -423,7 +422,7 @@ pub fn einsum_with_subscripts<T: ScalarBase + HasAlgebra>(
 ///
 /// Returns an error if the operand shapes do not match those used to
 /// build the contraction tree.
-pub fn einsum_with_plan<T: ScalarBase + HasAlgebra>(
+pub fn einsum_with_plan<T: Scalar + HasAlgebra>(
     tree: &ContractionTree,
     operands: &[&Tensor<T>],
 ) -> Result<Tensor<T>> {
@@ -458,7 +457,7 @@ pub fn einsum_with_plan<T: ScalarBase + HasAlgebra>(
 ///
 /// Returns an error if the notation is invalid or tensor shapes are
 /// incompatible with the subscripts.
-pub fn einsum_owned<T: ScalarBase + HasAlgebra>(
+pub fn einsum_owned<T: Scalar + HasAlgebra>(
     _subscripts: &str,
     _operands: Vec<Tensor<T>>,
 ) -> Result<Tensor<T>> {
@@ -473,7 +472,7 @@ pub fn einsum_owned<T: ScalarBase + HasAlgebra>(
 /// # Errors
 ///
 /// Returns an error if tensor shapes are incompatible with the subscripts.
-pub fn einsum_with_subscripts_owned<T: ScalarBase + HasAlgebra>(
+pub fn einsum_with_subscripts_owned<T: Scalar + HasAlgebra>(
     _subscripts: &Subscripts,
     _operands: Vec<Tensor<T>>,
 ) -> Result<Tensor<T>> {
@@ -491,7 +490,7 @@ pub fn einsum_with_subscripts_owned<T: ScalarBase + HasAlgebra>(
 ///
 /// Returns an error if the operand shapes do not match those used to
 /// build the contraction tree.
-pub fn einsum_with_plan_owned<T: ScalarBase + HasAlgebra>(
+pub fn einsum_with_plan_owned<T: Scalar + HasAlgebra>(
     _tree: &ContractionTree,
     _operands: Vec<Tensor<T>>,
 ) -> Result<Tensor<T>> {
@@ -539,7 +538,7 @@ pub fn einsum_with_plan_owned<T: ScalarBase + HasAlgebra>(
 ///
 /// Returns an error if the notation is invalid, tensor shapes are
 /// incompatible, or the output shape does not match the expected result.
-pub fn einsum_into<T: ScalarBase + HasAlgebra>(
+pub fn einsum_into<T: Scalar + HasAlgebra>(
     subscripts: &str,
     operands: &[&Tensor<T>],
     alpha: T,
@@ -572,7 +571,7 @@ pub fn einsum_into<T: ScalarBase + HasAlgebra>(
 ///
 /// Returns an error if tensor shapes are incompatible with the subscripts
 /// or the output shape does not match.
-pub fn einsum_with_subscripts_into<T: ScalarBase + HasAlgebra>(
+pub fn einsum_with_subscripts_into<T: Scalar + HasAlgebra>(
     subscripts: &Subscripts,
     operands: &[&Tensor<T>],
     alpha: T,
@@ -611,7 +610,7 @@ pub fn einsum_with_subscripts_into<T: ScalarBase + HasAlgebra>(
 ///
 /// Returns an error if the operand shapes do not match those used to
 /// build the contraction tree, or the output shape is incorrect.
-pub fn einsum_with_plan_into<T: ScalarBase + HasAlgebra>(
+pub fn einsum_with_plan_into<T: Scalar + HasAlgebra>(
     tree: &ContractionTree,
     operands: &[&Tensor<T>],
     alpha: T,
@@ -655,7 +654,7 @@ pub fn einsum_with_plan_into<T: ScalarBase + HasAlgebra>(
 /// let grads = tape.pullback(&loss).unwrap();
 /// let _ga = grads.get(a.node_id().unwrap()).unwrap();
 /// ```
-pub fn tracked_einsum<T: ScalarBase + HasAlgebra>(
+pub fn tracked_einsum<T: Scalar + HasAlgebra>(
     _subscripts: &str,
     _operands: &[&TrackedTensor<Tensor<T>>],
 ) -> AdResult<TrackedTensor<Tensor<T>>>
@@ -689,7 +688,7 @@ where
 /// let c_dual = dual_einsum("ij,jk->ik", &[&a_dual, &b_dual]).unwrap();
 /// let _tangent = c_dual.tangent();
 /// ```
-pub fn dual_einsum<T: ScalarBase + HasAlgebra>(
+pub fn dual_einsum<T: Scalar + HasAlgebra>(
     _subscripts: &str,
     _operands: &[&DualTensor<Tensor<T>>],
 ) -> AdResult<DualTensor<Tensor<T>>>
@@ -723,7 +722,7 @@ where
 /// let grads = einsum_rrule("ij,jk->ik", &[&a, &b], &grad_c).unwrap();
 /// assert_eq!(grads.len(), 2);
 /// ```
-pub fn einsum_rrule<T: ScalarBase + HasAlgebra>(
+pub fn einsum_rrule<T: Scalar + HasAlgebra>(
     _subscripts: &str,
     _operands: &[&Tensor<T>],
     _cotangent: &Tensor<T>,
@@ -754,7 +753,7 @@ pub fn einsum_rrule<T: ScalarBase + HasAlgebra>(
 ///
 /// let dc = einsum_frule("ij,jk->ik", &[&a, &b], &[Some(&da), None]).unwrap();
 /// ```
-pub fn einsum_frule<T: ScalarBase + HasAlgebra>(
+pub fn einsum_frule<T: Scalar + HasAlgebra>(
     _subscripts: &str,
     _primals: &[&Tensor<T>],
     _tangents: &[Option<&Tensor<T>>],
@@ -802,7 +801,7 @@ pub fn einsum_frule<T: ScalarBase + HasAlgebra>(
 /// let (_grad_a, _hvp_a) = &results[0];
 /// let (_grad_b, _hvp_b) = &results[1];
 /// ```
-pub fn einsum_hvp<T: ScalarBase + HasAlgebra>(
+pub fn einsum_hvp<T: Scalar + HasAlgebra>(
     _subscripts: &str,
     _primals: &[&Tensor<T>],
     _tangents: &[Option<&Tensor<T>>],

--- a/tenferro-linalg/Cargo.toml
+++ b/tenferro-linalg/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 tenferro-device = { path = "../tenferro-device" }
+tenferro-algebra = { path = "../tenferro-algebra" }
 tenferro-tensor = { path = "../tenferro-tensor" }
 chainrules = { path = "../chainrules" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs" }

--- a/tenferro-linalg/src/lib.rs
+++ b/tenferro-linalg/src/lib.rs
@@ -81,7 +81,7 @@
 //! ```
 
 use chainrules::{AdResult, Differentiable, DualTensor, TrackedTensor};
-use strided_traits::ScalarBase;
+use tenferro_algebra::Scalar;
 use tenferro_device::Result;
 use tenferro_tensor::Tensor;
 
@@ -110,7 +110,7 @@ use tenferro_tensor::Tensor;
 /// let result = svd(&a, &[0], &[1], None).unwrap();
 /// assert_eq!(result.s.ndim(), 1);
 /// ```
-pub struct SvdResult<T: ScalarBase> {
+pub struct SvdResult<T: Scalar> {
     /// Left singular vectors. Shape: `left_dims... × k`.
     pub u: Tensor<T>,
     /// Singular values (descending order). Shape: `[k]`.
@@ -174,7 +174,7 @@ impl Default for SvdOptions {
 /// assert_eq!(result.q.dims(), &[4, 3]);
 /// assert_eq!(result.r.dims(), &[3, 3]);
 /// ```
-pub struct QrResult<T: ScalarBase> {
+pub struct QrResult<T: Scalar> {
     /// Orthonormal factor. Shape: `left_dims... × k`.
     pub q: Tensor<T>,
     /// Upper triangular factor. Shape: `k × right_dims...`.
@@ -202,7 +202,7 @@ pub struct QrResult<T: ScalarBase> {
 /// let result = lu(&a, &[0], &[1]).unwrap();
 /// assert_eq!(result.p.len(), 3);
 /// ```
-pub struct LuResult<T: ScalarBase> {
+pub struct LuResult<T: Scalar> {
     /// Row permutation vector (partial pivoting). Length: `m`.
     pub p: Vec<usize>,
     /// Unit lower triangular factor. Shape: `left_dims... × k`.
@@ -231,7 +231,7 @@ pub struct LuResult<T: ScalarBase> {
 /// assert_eq!(result.values.dims(), &[3]);
 /// assert_eq!(result.vectors.dims(), &[3, 3]);
 /// ```
-pub struct EigenResult<T: ScalarBase> {
+pub struct EigenResult<T: Scalar> {
     /// Eigenvalues. Shape: `[n]`.
     pub values: Tensor<T>,
     /// Right eigenvectors (columns). Shape: `left_dims... × n`.
@@ -278,7 +278,7 @@ pub struct EigenResult<T: ScalarBase> {
 ///
 /// Returns an error if `left` and `right` do not form a valid partition
 /// of `0..tensor.ndim()`.
-pub fn svd<T: ScalarBase>(
+pub fn svd<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -315,7 +315,7 @@ pub fn svd<T: ScalarBase>(
 ///
 /// Returns an error if `left` and `right` do not form a valid partition
 /// of `0..tensor.ndim()`.
-pub fn qr<T: ScalarBase>(
+pub fn qr<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -351,7 +351,7 @@ pub fn qr<T: ScalarBase>(
 ///
 /// Returns an error if `left` and `right` do not form a valid partition
 /// of `0..tensor.ndim()`.
-pub fn lu<T: ScalarBase>(
+pub fn lu<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -387,7 +387,7 @@ pub fn lu<T: ScalarBase>(
 ///
 /// Returns an error if `left` and `right` do not form a valid partition
 /// of `0..tensor.ndim()`, or if the resulting matrix is not square.
-pub fn eigen<T: ScalarBase>(
+pub fn eigen<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -421,7 +421,7 @@ pub fn eigen<T: ScalarBase>(
 ///     vt: None,
 /// };
 /// ```
-pub struct SvdCotangent<T: ScalarBase> {
+pub struct SvdCotangent<T: Scalar> {
     /// Cotangent for U. Shape must match `SvdResult::u`.
     pub u: Option<Tensor<T>>,
     /// Cotangent for S. Shape must match `SvdResult::s`.
@@ -439,7 +439,7 @@ pub struct SvdCotangent<T: ScalarBase> {
 ///
 /// let cotangent = QrCotangent::<f64> { q: None, r: None };
 /// ```
-pub struct QrCotangent<T: ScalarBase> {
+pub struct QrCotangent<T: Scalar> {
     /// Cotangent for Q. Shape must match `QrResult::q`.
     pub q: Option<Tensor<T>>,
     /// Cotangent for R. Shape must match `QrResult::r`.
@@ -457,7 +457,7 @@ pub struct QrCotangent<T: ScalarBase> {
 ///
 /// let cotangent = LuCotangent::<f64> { l: None, u: None };
 /// ```
-pub struct LuCotangent<T: ScalarBase> {
+pub struct LuCotangent<T: Scalar> {
     /// Cotangent for L. Shape must match `LuResult::l`.
     pub l: Option<Tensor<T>>,
     /// Cotangent for U. Shape must match `LuResult::u`.
@@ -473,7 +473,7 @@ pub struct LuCotangent<T: ScalarBase> {
 ///
 /// let cotangent = EigenCotangent::<f64> { values: None, vectors: None };
 /// ```
-pub struct EigenCotangent<T: ScalarBase> {
+pub struct EigenCotangent<T: Scalar> {
     /// Cotangent for eigenvalues. Shape must match `EigenResult::values`.
     pub values: Option<Tensor<T>>,
     /// Cotangent for eigenvectors. Shape must match `EigenResult::vectors`.
@@ -503,7 +503,7 @@ pub struct EigenCotangent<T: ScalarBase> {
 /// let result = tracked_svd(&a, &[0], &[1], None).unwrap();
 /// // result.u, result.s, result.vt are TrackedTensor values
 /// ```
-pub struct TrackedSvdResult<T: ScalarBase>
+pub struct TrackedSvdResult<T: Scalar>
 where
     Tensor<T>: Differentiable,
 {
@@ -530,7 +530,7 @@ where
 ///     LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor));
 /// let result = tracked_qr(&a, &[0], &[1]).unwrap();
 /// ```
-pub struct TrackedQrResult<T: ScalarBase>
+pub struct TrackedQrResult<T: Scalar>
 where
     Tensor<T>: Differentiable,
 {
@@ -557,7 +557,7 @@ where
 ///     LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor));
 /// let result = tracked_lu(&a, &[0], &[1]).unwrap();
 /// ```
-pub struct TrackedLuResult<T: ScalarBase>
+pub struct TrackedLuResult<T: Scalar>
 where
     Tensor<T>: Differentiable,
 {
@@ -584,7 +584,7 @@ where
 ///     LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor));
 /// let result = tracked_eigen(&a, &[0], &[1]).unwrap();
 /// ```
-pub struct TrackedEigenResult<T: ScalarBase>
+pub struct TrackedEigenResult<T: Scalar>
 where
     Tensor<T>: Differentiable,
 {
@@ -615,7 +615,7 @@ where
 /// let a_dual = DualTensor::with_tangent(a, da).unwrap();
 /// let result = dual_svd(&a_dual, &[0], &[1], None).unwrap();
 /// ```
-pub struct DualSvdResult<T: ScalarBase>
+pub struct DualSvdResult<T: Scalar>
 where
     Tensor<T>: Differentiable,
 {
@@ -644,7 +644,7 @@ where
 /// let a_dual = DualTensor::with_tangent(a, da).unwrap();
 /// let result = dual_qr(&a_dual, &[0], &[1]).unwrap();
 /// ```
-pub struct DualQrResult<T: ScalarBase>
+pub struct DualQrResult<T: Scalar>
 where
     Tensor<T>: Differentiable,
 {
@@ -671,7 +671,7 @@ where
 /// let a_dual = DualTensor::with_tangent(a, da).unwrap();
 /// let result = dual_lu(&a_dual, &[0], &[1]).unwrap();
 /// ```
-pub struct DualLuResult<T: ScalarBase>
+pub struct DualLuResult<T: Scalar>
 where
     Tensor<T>: Differentiable,
 {
@@ -700,7 +700,7 @@ where
 /// let a_dual = DualTensor::with_tangent(a, da).unwrap();
 /// let result = dual_eigen(&a_dual, &[0], &[1]).unwrap();
 /// ```
-pub struct DualEigenResult<T: ScalarBase>
+pub struct DualEigenResult<T: Scalar>
 where
     Tensor<T>: Differentiable,
 {
@@ -733,7 +733,7 @@ where
 /// let a = tape.leaf(Tensor::zeros(&[3, 4], mem, col));
 /// let result = tracked_svd(&a, &[0], &[1], None).unwrap();
 /// ```
-pub fn tracked_svd<T: ScalarBase>(
+pub fn tracked_svd<T: Scalar>(
     _tensor: &TrackedTensor<Tensor<T>>,
     _left: &[usize],
     _right: &[usize],
@@ -760,7 +760,7 @@ where
 ///     LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor));
 /// let result = tracked_qr(&a, &[0], &[1]).unwrap();
 /// ```
-pub fn tracked_qr<T: ScalarBase>(
+pub fn tracked_qr<T: Scalar>(
     _tensor: &TrackedTensor<Tensor<T>>,
     _left: &[usize],
     _right: &[usize],
@@ -786,7 +786,7 @@ where
 ///     LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor));
 /// let result = tracked_lu(&a, &[0], &[1]).unwrap();
 /// ```
-pub fn tracked_lu<T: ScalarBase>(
+pub fn tracked_lu<T: Scalar>(
     _tensor: &TrackedTensor<Tensor<T>>,
     _left: &[usize],
     _right: &[usize],
@@ -812,7 +812,7 @@ where
 ///     LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor));
 /// let result = tracked_eigen(&a, &[0], &[1]).unwrap();
 /// ```
-pub fn tracked_eigen<T: ScalarBase>(
+pub fn tracked_eigen<T: Scalar>(
     _tensor: &TrackedTensor<Tensor<T>>,
     _left: &[usize],
     _right: &[usize],
@@ -844,7 +844,7 @@ where
 /// let a_dual = DualTensor::with_tangent(a, da).unwrap();
 /// let result = dual_svd(&a_dual, &[0], &[1], None).unwrap();
 /// ```
-pub fn dual_svd<T: ScalarBase>(
+pub fn dual_svd<T: Scalar>(
     _tensor: &DualTensor<Tensor<T>>,
     _left: &[usize],
     _right: &[usize],
@@ -873,7 +873,7 @@ where
 /// let a_dual = DualTensor::with_tangent(a, da).unwrap();
 /// let result = dual_qr(&a_dual, &[0], &[1]).unwrap();
 /// ```
-pub fn dual_qr<T: ScalarBase>(
+pub fn dual_qr<T: Scalar>(
     _tensor: &DualTensor<Tensor<T>>,
     _left: &[usize],
     _right: &[usize],
@@ -901,7 +901,7 @@ where
 /// let a_dual = DualTensor::with_tangent(a, da).unwrap();
 /// let result = dual_lu(&a_dual, &[0], &[1]).unwrap();
 /// ```
-pub fn dual_lu<T: ScalarBase>(
+pub fn dual_lu<T: Scalar>(
     _tensor: &DualTensor<Tensor<T>>,
     _left: &[usize],
     _right: &[usize],
@@ -929,7 +929,7 @@ where
 /// let a_dual = DualTensor::with_tangent(a, da).unwrap();
 /// let result = dual_eigen(&a_dual, &[0], &[1]).unwrap();
 /// ```
-pub fn dual_eigen<T: ScalarBase>(
+pub fn dual_eigen<T: Scalar>(
     _tensor: &DualTensor<Tensor<T>>,
     _left: &[usize],
     _right: &[usize],
@@ -968,7 +968,7 @@ where
 /// };
 /// let grad_a = svd_rrule(&a, &[0], &[1], None, &cotangent).unwrap();
 /// ```
-pub fn svd_rrule<T: ScalarBase>(
+pub fn svd_rrule<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -996,7 +996,7 @@ pub fn svd_rrule<T: ScalarBase>(
 /// };
 /// let grad_a = qr_rrule(&a, &[0], &[1], &cotangent).unwrap();
 /// ```
-pub fn qr_rrule<T: ScalarBase>(
+pub fn qr_rrule<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -1023,7 +1023,7 @@ pub fn qr_rrule<T: ScalarBase>(
 /// };
 /// let grad_a = lu_rrule(&a, &[0], &[1], &cotangent).unwrap();
 /// ```
-pub fn lu_rrule<T: ScalarBase>(
+pub fn lu_rrule<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -1050,7 +1050,7 @@ pub fn lu_rrule<T: ScalarBase>(
 /// };
 /// let grad_a = eigen_rrule(&a, &[0], &[1], &cotangent).unwrap();
 /// ```
-pub fn eigen_rrule<T: ScalarBase>(
+pub fn eigen_rrule<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -1080,7 +1080,7 @@ pub fn eigen_rrule<T: ScalarBase>(
 /// let da = Tensor::<f64>::ones(&[3, 4], mem, col);
 /// let result = svd_frule(&a, &[0], &[1], None, Some(&da)).unwrap();
 /// ```
-pub fn svd_frule<T: ScalarBase>(
+pub fn svd_frule<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -1105,7 +1105,7 @@ pub fn svd_frule<T: ScalarBase>(
 /// let da = Tensor::<f64>::ones(&[4, 3], mem, col);
 /// let result = qr_frule(&a, &[0], &[1], Some(&da)).unwrap();
 /// ```
-pub fn qr_frule<T: ScalarBase>(
+pub fn qr_frule<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -1129,7 +1129,7 @@ pub fn qr_frule<T: ScalarBase>(
 /// let da = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let result = lu_frule(&a, &[0], &[1], Some(&da)).unwrap();
 /// ```
-pub fn lu_frule<T: ScalarBase>(
+pub fn lu_frule<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],
@@ -1153,7 +1153,7 @@ pub fn lu_frule<T: ScalarBase>(
 /// let da = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let result = eigen_frule(&a, &[0], &[1], Some(&da)).unwrap();
 /// ```
-pub fn eigen_frule<T: ScalarBase>(
+pub fn eigen_frule<T: Scalar>(
     _tensor: &Tensor<T>,
     _left: &[usize],
     _right: &[usize],

--- a/tenferro-tensor/Cargo.toml
+++ b/tenferro-tensor/Cargo.toml
@@ -8,7 +8,5 @@ publish = false
 
 [dependencies]
 tenferro-device = { path = "../tenferro-device" }
+tenferro-algebra = { path = "../tenferro-algebra" }
 chainrules-core = { path = "../chainrules-core" }
-strided-view = { git = "https://github.com/tensor4all/strided-rs" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs" }
-num-traits = "0.2"

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -8,14 +8,22 @@
 //! - **Data operations**: [`Tensor::contiguous`] / [`Tensor::into_contiguous`] copy
 //!   data into a contiguous layout (the consuming variant avoids allocation when
 //!   the tensor is already contiguous)
-//! - **strided-rs interop**: [`Tensor::view`] / [`Tensor::view_mut`] produce
-//!   [`StridedView`] / [`StridedViewMut`] for use with `TensorPrims` backends
+//! - **DLPack interop**: [`DataBuffer`] supports both Rust-owned (`Vec<T>`) and
+//!   externally-owned memory (e.g., imported via DLPack) with automatic cleanup.
 //!
 //! # Memory layout
 //!
 //! [`Tensor`] stores explicit strides and is not tied to any particular memory
 //! order. [`MemoryOrder`] is only used as a parameter when allocating new memory
 //! (e.g., [`Tensor::zeros`], [`Tensor::contiguous`]).
+//!
+//! # No strided-rs dependency
+//!
+//! This crate does **not** depend on `strided-rs`. The strided-rs types
+//! (`StridedView`, `StridedViewMut`) are backend implementation details
+//! used only in `tenferro-prims`. To pass tensor data to prims backends,
+//! use [`DataBuffer::as_slice`] combined with [`Tensor::dims`],
+//! [`Tensor::strides`], and [`Tensor::offset`].
 //!
 //! # Examples
 //!
@@ -91,18 +99,8 @@
 //! // to_tensor() / contiguous(): materialize a view into owned Tensor
 //! let owned = tv_t.to_tensor(MemoryOrder::ColumnMajor);
 //! ```
-//!
-//! ## Interop with strided-rs
-//!
-//! ```ignore
-//! // Get a StridedView for use with TensorPrims or strided-kernel
-//! let view = a.view();
-//! let mut b_mut = b;
-//! let view_mut = b_mut.view_mut();
-//! ```
 
-use strided_traits::{ElementOpApply, ScalarBase};
-use strided_view::{StridedArray, StridedView, StridedViewMut};
+use tenferro_algebra::{Conjugate, Scalar};
 use tenferro_device::{ComputeDevice, LogicalMemorySpace, OpKind, Result};
 
 /// Memory ordering for new allocations.
@@ -124,16 +122,178 @@ pub enum MemoryOrder {
     RowMajor,
 }
 
-/// Owned data buffer, device-aware.
+// ============================================================================
+// DataBuffer — unified owned/external storage
+// ============================================================================
+
+/// Data storage for tensor elements.
 ///
-/// Wraps the underlying storage for a tensor's data. Currently only CPU
-/// storage is supported via [`StridedArray`].
-#[derive(Clone)]
-pub enum DataBuffer<T> {
-    /// CPU-resident data backed by a [`StridedArray`].
-    Cpu(StridedArray<T>),
-    // Future: Cuda(CudaBuffer<T>), Hip(HipBuffer<T>)
+/// Abstracts over ownership: data may be Rust-owned ([`Vec<T>`]) or
+/// externally-owned (e.g., imported via DLPack with a release callback).
+/// Shape and stride metadata are NOT stored here — they live on
+/// [`Tensor<T>`].
+///
+/// # Clone behavior
+///
+/// Cloning an externally-owned buffer performs a **deep copy** into a new
+/// Rust-owned `Vec<T>`. The release callback cannot be cloned; the clone
+/// is always Rust-owned.
+pub struct DataBuffer<T> {
+    inner: BufferInner<T>,
 }
+
+/// Private ownership representation.
+enum BufferInner<T> {
+    /// Rust-owned contiguous data.
+    Owned(Vec<T>),
+    /// Externally-owned data with release callback.
+    External {
+        ptr: *const T,
+        len: usize,
+        /// Called on drop to notify the external owner.
+        release: Option<Box<dyn FnOnce() + Send>>,
+    },
+}
+
+// Safety: External buffer pointers are treated as Send/Sync since
+// the external framework guarantees the data is valid for the lifetime
+// of the DataBuffer. The release callback is Send.
+unsafe impl<T: Send> Send for DataBuffer<T> {}
+unsafe impl<T: Sync> Sync for DataBuffer<T> {}
+
+impl<T: Copy> Clone for DataBuffer<T> {
+    fn clone(&self) -> Self {
+        match &self.inner {
+            BufferInner::Owned(v) => DataBuffer {
+                inner: BufferInner::Owned(v.clone()),
+            },
+            // Deep copy: can't clone the release callback.
+            BufferInner::External { ptr, len, .. } => {
+                let slice = unsafe { std::slice::from_raw_parts(*ptr, *len) };
+                DataBuffer {
+                    inner: BufferInner::Owned(slice.to_vec()),
+                }
+            }
+        }
+    }
+}
+
+impl<T> Drop for DataBuffer<T> {
+    fn drop(&mut self) {
+        if let BufferInner::External { release, .. } = &mut self.inner {
+            if let Some(f) = release.take() {
+                f();
+            }
+        }
+    }
+}
+
+impl<T> DataBuffer<T> {
+    /// Create a buffer from an owned `Vec<T>`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tensor::DataBuffer;
+    ///
+    /// let buf = DataBuffer::from_vec(vec![1.0, 2.0, 3.0]);
+    /// assert_eq!(buf.len(), 3);
+    /// assert!(buf.is_owned());
+    /// ```
+    pub fn from_vec(v: Vec<T>) -> Self {
+        DataBuffer {
+            inner: BufferInner::Owned(v),
+        }
+    }
+
+    /// Create a buffer from externally-owned data with a release callback.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must point to a valid, properly aligned allocation of at
+    ///   least `len` elements of type `T`.
+    /// - The allocation must remain valid until the release callback is invoked
+    ///   (which happens when this `DataBuffer` is dropped).
+    /// - The release callback must correctly notify the external owner.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tensor::DataBuffer;
+    ///
+    /// let data = vec![1.0, 2.0, 3.0];
+    /// let ptr = data.as_ptr();
+    /// let len = data.len();
+    /// let buf = unsafe {
+    ///     DataBuffer::from_external(ptr, len, move || drop(data))
+    /// };
+    /// assert!(!buf.is_owned());
+    /// ```
+    pub unsafe fn from_external(
+        ptr: *const T,
+        len: usize,
+        release: impl FnOnce() + Send + 'static,
+    ) -> Self {
+        DataBuffer {
+            inner: BufferInner::External {
+                ptr,
+                len,
+                release: Some(Box::new(release)),
+            },
+        }
+    }
+
+    /// Returns the raw data as a slice.
+    pub fn as_slice(&self) -> &[T] {
+        match &self.inner {
+            BufferInner::Owned(v) => v.as_slice(),
+            BufferInner::External { ptr, len, .. } => unsafe {
+                std::slice::from_raw_parts(*ptr, *len)
+            },
+        }
+    }
+
+    /// Returns the raw data as a mutable slice, if Rust-owned.
+    ///
+    /// Returns `None` for externally-owned buffers (they are read-only
+    /// through tenferro).
+    pub fn as_mut_slice(&mut self) -> Option<&mut [T]> {
+        match &mut self.inner {
+            BufferInner::Owned(v) => Some(v.as_mut_slice()),
+            BufferInner::External { .. } => None,
+        }
+    }
+
+    /// Returns the number of elements in the buffer.
+    pub fn len(&self) -> usize {
+        match &self.inner {
+            BufferInner::Owned(v) => v.len(),
+            BufferInner::External { len, .. } => *len,
+        }
+    }
+
+    /// Returns `true` if the buffer has no elements.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns `true` if the buffer is Rust-owned (backed by `Vec<T>`).
+    pub fn is_owned(&self) -> bool {
+        matches!(self.inner, BufferInner::Owned(_))
+    }
+
+    /// Returns a raw pointer to the data.
+    pub fn as_ptr(&self) -> *const T {
+        match &self.inner {
+            BufferInner::Owned(v) => v.as_ptr(),
+            BufferInner::External { ptr, .. } => *ptr,
+        }
+    }
+}
+
+// ============================================================================
+// Tensor<T>
+// ============================================================================
 
 /// Multi-dimensional dense tensor.
 ///
@@ -146,11 +306,12 @@ pub enum DataBuffer<T> {
 /// and [`diagonal`](Tensor::diagonal) return new `Tensor` values that share the
 /// same underlying data buffer, modifying only the dims/strides/offset metadata.
 ///
-/// ## strided-rs interop
+/// ## Accessing raw data
 ///
-/// Use [`view`](Tensor::view) and [`view_mut`](Tensor::view_mut) to obtain
-/// [`StridedView`] / [`StridedViewMut`] references for passing to
-/// low-level operations.
+/// Use [`DataBuffer::as_slice`] via [`Tensor::buffer`] combined with
+/// [`dims`](Tensor::dims), [`strides`](Tensor::strides), and
+/// [`offset`](Tensor::offset) to construct backend-specific views
+/// (e.g., `StridedView` in `tenferro-prims`).
 ///
 /// ## GPU async support
 ///
@@ -158,24 +319,20 @@ pub enum DataBuffer<T> {
 /// [`CompletionEvent`]. When a GPU operation produces a tensor, `event`
 /// is set to `Some(...)`. Passing this tensor to another GPU operation
 /// chains via stream dependencies without CPU synchronization. Methods
-/// that access data from CPU (e.g., [`view`](Tensor::view),
-/// [`conj`](Tensor::conj)) call [`wait`](Tensor::wait) internally.
+/// that access data from CPU call [`wait`](Tensor::wait) internally.
 /// For CPU tensors, `event` is always `None` with zero overhead.
 ///
 /// See `tenferro-einsum` crate docs for async chaining examples.
-pub struct Tensor<T: ScalarBase> {
+pub struct Tensor<T: Scalar> {
     buffer: DataBuffer<T>,
     dims: Vec<usize>,
     strides: Vec<isize>,
     offset: isize,
     /// The logical memory space where this tensor's data resides.
     logical_memory_space: LogicalMemorySpace,
-    /// Optional preferred compute device override. When `None`, the
-    /// device is selected automatically via
-    /// [`preferred_compute_devices`](tenferro_device::preferred_compute_devices).
+    /// Optional preferred compute device override.
     preferred_compute_device: Option<ComputeDevice>,
-    /// Pending GPU computation event. `None` for CPU tensors or
-    /// when GPU computation has completed.
+    /// Pending GPU computation event.
     event: Option<CompletionEvent>,
 }
 
@@ -194,7 +351,7 @@ pub struct Tensor<T: ScalarBase> {
 /// The crate-internal `as_operand_view()` skips the wait and
 /// propagates the pending event, allowing accelerator operations to chain
 /// without CPU synchronization.
-pub struct TensorView<'a, T: ScalarBase> {
+pub struct TensorView<'a, T: Scalar> {
     data: &'a DataBuffer<T>,
     dims: Vec<usize>,
     strides: Vec<isize>,
@@ -203,13 +360,11 @@ pub struct TensorView<'a, T: ScalarBase> {
     logical_memory_space: LogicalMemorySpace,
     /// Optional preferred compute device override from the source tensor.
     preferred_compute_device: Option<ComputeDevice>,
-    /// Pending event from the source tensor. Always `None` in public API
-    /// (wait is performed before construction). Used by crate-internal
-    /// `as_operand_view()` to propagate pending events for pipeline chaining.
+    /// Pending event from the source tensor. Always `None` in public API.
     event: Option<&'a CompletionEvent>,
 }
 
-impl<'a, T: ScalarBase> TensorView<'a, T> {
+impl<'a, T: Scalar> TensorView<'a, T> {
     /// Returns the shape (size of each dimension).
     pub fn dims(&self) -> &[usize] {
         &self.dims
@@ -233,6 +388,16 @@ impl<'a, T: ScalarBase> TensorView<'a, T> {
     /// Returns the preferred compute device override, if set.
     pub fn preferred_compute_device(&self) -> Option<ComputeDevice> {
         self.preferred_compute_device
+    }
+
+    /// Returns a reference to the underlying data buffer.
+    pub fn buffer(&self) -> &DataBuffer<T> {
+        self.data
+    }
+
+    /// Returns the element offset into the data buffer.
+    pub fn offset(&self) -> isize {
+        self.offset
     }
 
     // ========================================================================
@@ -291,7 +456,7 @@ impl<'a, T: ScalarBase> TensorView<'a, T> {
     /// For real types, returns a copy unchanged.
     pub fn conj(&self) -> Tensor<T>
     where
-        T: ElementOpApply,
+        T: Conjugate,
     {
         todo!()
     }
@@ -308,7 +473,7 @@ pub struct CompletionEvent {
     _private: (),
 }
 
-impl<T: ScalarBase> Clone for Tensor<T> {
+impl<T: Scalar> Clone for Tensor<T> {
     fn clone(&self) -> Self {
         Self {
             buffer: self.buffer.clone(),
@@ -325,7 +490,7 @@ impl<T: ScalarBase> Clone for Tensor<T> {
     }
 }
 
-impl<T: ScalarBase> Tensor<T> {
+impl<T: Scalar> Tensor<T> {
     // ========================================================================
     // Constructors
     // ========================================================================
@@ -378,12 +543,30 @@ impl<T: ScalarBase> Tensor<T> {
         todo!()
     }
 
-    /// Create a tensor from an existing [`StridedArray`].
+    /// Create a tensor from an owned `Vec<T>` with explicit layout.
     ///
-    /// Takes ownership of the array. The tensor inherits the array's
-    /// dims, strides, and offset. Memory space is set to
-    /// [`LogicalMemorySpace::MainMemory`].
-    pub fn from_strided_array(_array: StridedArray<T>) -> Self {
+    /// Takes ownership of the data. The caller specifies the dims, strides,
+    /// and offset that describe how the data is laid out.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the layout is inconsistent with the data length.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// // 2×3 column-major: strides [1, 2], offset 0
+    /// let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    /// let t = Tensor::<f64>::from_vec(data, &[2, 3], &[1, 2], 0).unwrap();
+    /// ```
+    pub fn from_vec(
+        _data: Vec<T>,
+        _dims: &[usize],
+        _strides: &[isize],
+        _offset: isize,
+    ) -> Result<Self> {
         todo!()
     }
 
@@ -393,17 +576,32 @@ impl<T: ScalarBase> Tensor<T> {
 
     /// Returns the shape (size of each dimension).
     pub fn dims(&self) -> &[usize] {
-        todo!()
+        &self.dims
     }
 
     /// Returns the strides (in units of `T`).
     pub fn strides(&self) -> &[isize] {
-        todo!()
+        &self.strides
+    }
+
+    /// Returns the element offset into the data buffer.
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+
+    /// Returns a reference to the underlying data buffer.
+    pub fn buffer(&self) -> &DataBuffer<T> {
+        &self.buffer
+    }
+
+    /// Returns a mutable reference to the underlying data buffer.
+    pub fn buffer_mut(&mut self) -> &mut DataBuffer<T> {
+        &mut self.buffer
     }
 
     /// Returns the number of dimensions (rank).
     pub fn ndim(&self) -> usize {
-        todo!()
+        self.dims.len()
     }
 
     /// Returns the total number of elements.
@@ -456,21 +654,7 @@ impl<T: ScalarBase> Tensor<T> {
     // View operations (zero-copy, public API waits if pending)
     // ========================================================================
 
-    /// Returns an immutable strided view of the tensor data.
-    ///
-    /// Waits for any pending accelerator computation before returning.
-    pub fn view(&self) -> StridedView<'_, T> {
-        todo!()
-    }
-
-    /// Returns a mutable strided view of the tensor data.
-    ///
-    /// Waits for any pending accelerator computation before returning.
-    pub fn view_mut(&mut self) -> StridedViewMut<'_, T> {
-        todo!()
-    }
-
-    /// Returns a [`TensorView`] for CPU data inspection.
+    /// Returns a [`TensorView`] for data inspection.
     ///
     /// Waits for any pending accelerator computation before returning.
     /// The returned view has `event = None` (data is ready to read).
@@ -638,28 +822,25 @@ impl<T: ScalarBase> Tensor<T> {
     /// ```
     pub fn conj(&self) -> Tensor<T>
     where
-        T: ElementOpApply,
+        T: Conjugate,
     {
-        match &self.buffer {
-            DataBuffer::Cpu(array) => {
-                // Conjugation is element-wise and position-independent,
-                // so we conjugate the raw buffer directly and preserve layout.
-                let conj_data: Vec<T> = array.data().iter().copied().map(T::conj).collect();
-                let src_offset = array.view().offset();
-                let new_array =
-                    StridedArray::from_parts(conj_data, array.dims(), array.strides(), src_offset)
-                        .expect("internal: conjugated buffer has identical layout");
-
-                Tensor {
-                    buffer: DataBuffer::Cpu(new_array),
-                    dims: self.dims.clone(),
-                    strides: self.strides.clone(),
-                    offset: self.offset,
-                    logical_memory_space: self.logical_memory_space,
-                    preferred_compute_device: self.preferred_compute_device,
-                    event: None,
-                }
-            }
+        // Conjugation is element-wise and position-independent,
+        // so we conjugate the raw buffer directly and preserve layout.
+        let conj_data: Vec<T> = self
+            .buffer
+            .as_slice()
+            .iter()
+            .copied()
+            .map(T::conj)
+            .collect();
+        Tensor {
+            buffer: DataBuffer::from_vec(conj_data),
+            dims: self.dims.clone(),
+            strides: self.strides.clone(),
+            offset: self.offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: None,
         }
     }
 
@@ -669,7 +850,7 @@ impl<T: ScalarBase> Tensor<T> {
     /// reusing the buffer if no other references exist.
     pub fn into_conj(self) -> Tensor<T>
     where
-        T: ElementOpApply,
+        T: Conjugate,
     {
         todo!()
     }
@@ -694,10 +875,9 @@ impl<T: ScalarBase> Tensor<T> {
     /// Wait for any pending GPU computation to complete.
     ///
     /// No-op for CPU tensors or when GPU computation has already completed.
-    /// Methods that access tensor data from CPU ([`view`](Tensor::view),
-    /// [`conj`](Tensor::conj), [`contiguous`](Tensor::contiguous)) call
-    /// this internally, so explicit calls are only needed when the caller
-    /// wants to ensure completion at a specific point.
+    /// Methods that access tensor data from CPU call this internally, so
+    /// explicit calls are only needed when the caller wants to ensure
+    /// completion at a specific point.
     ///
     /// # Examples
     ///
@@ -713,7 +893,6 @@ impl<T: ScalarBase> Tensor<T> {
     /// // Chaining: implicit sync via stream dependencies, no CPU wait
     /// let d = einsum("ij,jk->ik", &[&c, &e_gpu]).unwrap();
     /// //  → detects c.event → chains on GPU → returns immediately
-    /// d.view();  // view() calls wait() internally
     /// ```
     pub fn wait(&self) {
         // Currently a no-op: only CPU tensors exist (event is always None).
@@ -734,7 +913,7 @@ impl<T: ScalarBase> Tensor<T> {
 // Differentiable impl — connects Tensor<T> to the generic AD framework
 // ============================================================================
 
-impl<T: ScalarBase> chainrules_core::Differentiable for Tensor<T> {
+impl<T: Scalar> chainrules_core::Differentiable for Tensor<T> {
     type Tangent = Tensor<T>;
 
     fn zero_tangent(&self) -> Tensor<T> {
@@ -745,3 +924,10 @@ impl<T: ScalarBase> chainrules_core::Differentiable for Tensor<T> {
         todo!()
     }
 }
+
+// ============================================================================
+// PhantomData usage for unused type parameter warning suppression
+// ============================================================================
+
+// DataBuffer<T> uses T directly in Vec<T> and *const T, so no PhantomData needed.
+// This module-level comment documents the design decision.


### PR DESCRIPTION
## Summary

- Add `Scalar` and `Conjugate` traits to `tenferro-algebra` (replaces strided-traits' `ScalarBase` and `ElementOpApply`), removing strided-rs as a dependency from the tensor layer
- Unify `DataBuffer<T>` as an opaque struct with private `Owned(Vec<T>)` / `External { ptr, len, release }` variants, enabling zero-copy DLPack import
- Add DLPack v1.0 C ABI types (`DLManagedTensorVersioned`, `DLTensor`, `DLDevice`, `DLDataType`) and export/import functions (`tfe_tensor_f64_to_dlpack`, `tfe_tensor_f64_from_dlpack`) to `tenferro-capi`
- Remove `tfe_memory_order_t` from C-API (DLPack communicates layout via strides)
- Unify workspace dependencies (`num-complex`, `num-traits`, `thiserror`)
- strided-rs dependency is now confined to `tenferro-prims` only (where it belongs as a CPU backend detail)

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes (all crates compile, all tests OK)
- [ ] Verify DLPack round-trip once implementations are added (future)

🤖 Generated with [Claude Code](https://claude.com/claude-code)