### PR TITLE
refactor: expand LogicalMemorySpace for DLPack device types

### DIFF
--- a/docs/design/tenferro_design.md
+++ b/docs/design/tenferro_design.md
@@ -40,8 +40,12 @@ The device crate provides shared infrastructure used across all tenferro crates.
 pub enum LogicalMemorySpace {
     /// Always-available host memory.
     MainMemory,
-    /// GPU-accessible memory space. A space may be attached to one or many GPUs.
-    GpuMemory { space_id: usize },
+    /// Host memory pinned for fast GPU transfer (cudaMallocHost / hipMallocHost).
+    PinnedMemory,
+    /// GPU-resident device memory.
+    GpuMemory { device_id: usize },
+    /// CUDA managed/unified memory (cudaMallocManaged). Accessible from CPU and all GPUs.
+    ManagedMemory,
 }
 
 /// Compute device where kernels execute.

--- a/docs/design/tenferro_einsum_internal_design.md
+++ b/docs/design/tenferro_einsum_internal_design.md
@@ -300,8 +300,12 @@ The POC `tenferro-device` crate provides a memory/compute separation abstraction
 pub enum LogicalMemorySpace {
     /// Always-available host memory.
     MainMemory,
-    /// GPU-accessible memory space.
-    GpuMemory { space_id: usize },
+    /// Host memory pinned for fast GPU transfer (cudaMallocHost / hipMallocHost).
+    PinnedMemory,
+    /// GPU-resident device memory.
+    GpuMemory { device_id: usize },
+    /// CUDA managed/unified memory (cudaMallocManaged). Accessible from CPU and all GPUs.
+    ManagedMemory,
 }
 
 /// Compute device where kernels execute.

--- a/tenferro-capi/src/lib.rs
+++ b/tenferro-capi/src/lib.rs
@@ -92,9 +92,11 @@ pub struct DLPackVersion {
 /// DLPack device descriptor.
 #[repr(C)]
 pub struct DLDevice {
-    /// Device type (see `kDLCPU`, `kDLCUDA`, `kDLROCM`).
+    /// Device type (see `KDLCPU`, `KDLCUDA`, `KDLCUDA_HOST`, `KDLCUDA_MANAGED`,
+    /// `KDLROCM`, `KDLROCM_HOST`).
     pub device_type: i32,
-    /// Device ID (0 for default).
+    /// Device ID. 0 for CPU, pinned, and managed memory; GPU ordinal for
+    /// device-local memory.
     pub device_id: i32,
 }
 
@@ -152,10 +154,16 @@ pub struct DLManagedTensorVersioned {
 // DLDeviceType constants
 /// CPU device.
 pub const KDLCPU: i32 = 1;
-/// NVIDIA CUDA device.
+/// NVIDIA CUDA GPU device memory.
 pub const KDLCUDA: i32 = 2;
-/// AMD ROCm device.
+/// Pinned CUDA CPU memory (`cudaMallocHost`).
+pub const KDLCUDA_HOST: i32 = 3;
+/// AMD ROCm GPU device memory.
 pub const KDLROCM: i32 = 10;
+/// Pinned ROCm CPU memory (`hipMallocHost`).
+pub const KDLROCM_HOST: i32 = 11;
+/// CUDA managed/unified memory (`cudaMallocManaged`).
+pub const KDLCUDA_MANAGED: i32 = 13;
 
 // DLDataTypeCode constants
 /// Integer type code.

--- a/tenferro-device/src/lib.rs
+++ b/tenferro-device/src/lib.rs
@@ -26,15 +26,40 @@ use std::fmt;
 /// can be processed by any CPU, while a tensor on
 /// [`GpuMemory`](LogicalMemorySpace::GpuMemory) can be processed by any
 /// compute device with access to that GPU memory space.
+///
+/// The variants align with DLPack `DLDeviceType` constants:
+///
+/// | Variant | DLPack `device_type` |
+/// |---------|---------------------|
+/// | `MainMemory` | `kDLCPU` (1) |
+/// | `PinnedMemory` | `kDLCUDAHost` (3) / `kDLROCMHost` (11) |
+/// | `GpuMemory` | `kDLCUDA` (2) / `kDLROCM` (10) |
+/// | `ManagedMemory` | `kDLCUDAManaged` (13) |
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LogicalMemorySpace {
     /// System main memory (CPU-accessible RAM).
+    ///
+    /// Corresponds to DLPack `kDLCPU` (`device_id = 0`).
     MainMemory,
-    /// GPU-resident memory identified by a space ID.
+    /// Host memory pinned for fast GPU transfer (`cudaMallocHost` / `hipMallocHost`).
+    ///
+    /// Accessible from the CPU but optimized for DMA transfer to/from
+    /// a specific GPU. Corresponds to DLPack `kDLCUDAHost` or `kDLROCMHost`
+    /// (`device_id = 0`).
+    PinnedMemory,
+    /// GPU-resident memory identified by a device ID.
+    ///
+    /// Corresponds to DLPack `kDLCUDA` or `kDLROCM` with the given `device_id`.
     GpuMemory {
-        /// Logical GPU memory space identifier.
-        space_id: usize,
+        /// Zero-based GPU device index (matches DLPack `device_id`).
+        device_id: usize,
     },
+    /// CUDA Unified/Managed memory (`cudaMallocManaged`).
+    ///
+    /// Accessible from both CPU and all GPUs. The CUDA runtime handles
+    /// page migration automatically. Corresponds to DLPack `kDLCUDAManaged`
+    /// (`device_id = 0`).
+    ManagedMemory,
 }
 
 /// Compute device that can execute tensor operations.

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -161,7 +161,7 @@
 //! use tenferro_device::LogicalMemorySpace;
 //!
 //! // In production, obtain memory spaces via BackendRegistry (future API).
-//! let gpu_mem = LogicalMemorySpace::GpuMemory { space_id: 0 };
+//! let gpu_mem = LogicalMemorySpace::GpuMemory { device_id: 0 };
 //! let col = MemoryOrder::ColumnMajor;
 //!
 //! let a = Tensor::<f64>::zeros(&[3, 4], gpu_mem, col);
@@ -185,17 +185,17 @@
 //!
 //! let col = MemoryOrder::ColumnMajor;
 //! // In production, obtain memory spaces via BackendRegistry (future API).
-//! let gpu_mem = LogicalMemorySpace::GpuMemory { space_id: 0 };
+//! let gpu_mem = LogicalMemorySpace::GpuMemory { device_id: 0 };
 //!
 //! let mut a = Tensor::<f64>::zeros(&[3, 4], gpu_mem, col);
 //! let mut b = Tensor::<f64>::zeros(&[4, 5], gpu_mem, col);
 //!
 //! // Pin tensors to CUDA device 1 (overrides automatic device selection).
-//! // This works when CUDA device 1 can access GpuMemory { space_id: 0 }
+//! // This works when CUDA device 1 can access GpuMemory { device_id: 0 }
 //! // (e.g., same physical GPU or NVLink-connected peer).
 //! // If the device cannot access the memory space, einsum returns
 //! // Err(NoCompatibleComputeDevice). In that case, transfer explicitly:
-//! //   let a = a.to_memory_space_async(GpuMemory { space_id: 1 }).unwrap();
+//! //   let a = a.to_memory_space_async(GpuMemory { device_id: 1 }).unwrap();
 //! a.set_preferred_compute_device(Some(ComputeDevice::Cuda { device_id: 1 }));
 //! b.set_preferred_compute_device(Some(ComputeDevice::Cuda { device_id: 1 }));
 //!


### PR DESCRIPTION
## Summary
- Add `PinnedMemory` and `ManagedMemory` variants to `LogicalMemorySpace`, aligning with DLPack `kDLCUDAHost`/`kDLROCMHost` (3/11) and `kDLCUDAManaged` (13)
- Rename `GpuMemory { space_id }` → `GpuMemory { device_id }` for consistency with DLPack `device_id`
- Add `KDLCUDA_HOST`, `KDLROCM_HOST`, `KDLCUDA_MANAGED` constants to `tenferro-capi`
- Update design docs to reflect new enum variants

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)