### PR TITLE
feat: add tenferro-tropical API skeleton (MaxPlus, MinPlus, MaxMul)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "tenferro-einsum",
     "tenferro-linalg",
     "tenferro-capi",
+    "tenferro-tropical",
     "chainrules-core",
     "chainrules",
 ]

--- a/tenferro-tropical/Cargo.toml
+++ b/tenferro-tropical/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tenferro-tropical"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Tropical semiring tensor operations (MaxPlus, MinPlus, MaxMul) for the tenferro workspace."
+publish = false
+
+[dependencies]
+tenferro-device = { path = "../tenferro-device" }
+tenferro-algebra = { path = "../tenferro-algebra" }
+tenferro-prims = { path = "../tenferro-prims" }
+strided-view = { git = "https://github.com/tensor4all/strided-rs" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs" }
+num-traits = { workspace = true }

--- a/tenferro-tropical/src/algebra.rs
+++ b/tenferro-tropical/src/algebra.rs
@@ -1,0 +1,171 @@
+//! Tropical algebra markers, [`HasAlgebra`], and [`Semiring`] implementations.
+//!
+//! Each zero-sized struct identifies a tropical algebra for use with
+//! [`TensorPrims<A>`](tenferro_prims::TensorPrims). The orphan rule is
+//! satisfied because the algebra markers are defined in this crate.
+//!
+//! | Algebra marker | Scalar wrapper | ⊕ | ⊗ |
+//! |----------------|---------------|---|---|
+//! | [`MaxPlusAlgebra`] | [`MaxPlus<T>`](crate::MaxPlus) | max | + |
+//! | [`MinPlusAlgebra`] | [`MinPlus<T>`](crate::MinPlus) | min | + |
+//! | [`MaxMulAlgebra`] | [`MaxMul<T>`](crate::MaxMul) | max | × |
+
+use tenferro_algebra::{HasAlgebra, Semiring};
+
+use crate::scalar::{MaxMul, MaxPlus, MinPlus};
+
+/// Algebra marker for the max-plus tropical semiring (⊕ = max, ⊗ = +).
+///
+/// Used as the algebra parameter `A` in
+/// [`TensorPrims<MaxPlusAlgebra>`](tenferro_prims::TensorPrims).
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tropical::MaxPlusAlgebra;
+/// use tenferro_prims::{CpuBackend, TensorPrims};
+///
+/// // Check extension support
+/// let has_contract = CpuBackend::has_extension_for::<f64>(
+///     tenferro_prims::Extension::Contract,
+/// );
+/// ```
+pub struct MaxPlusAlgebra;
+
+/// Algebra marker for the min-plus tropical semiring (⊕ = min, ⊗ = +).
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tropical::MinPlusAlgebra;
+/// use tenferro_prims::{CpuBackend, TensorPrims};
+///
+/// let has_contract = CpuBackend::has_extension_for::<f64>(
+///     tenferro_prims::Extension::Contract,
+/// );
+/// ```
+pub struct MinPlusAlgebra;
+
+/// Algebra marker for the max-times tropical semiring (⊕ = max, ⊗ = ×).
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tropical::MaxMulAlgebra;
+/// use tenferro_prims::{CpuBackend, TensorPrims};
+///
+/// let has_contract = CpuBackend::has_extension_for::<f64>(
+///     tenferro_prims::Extension::Contract,
+/// );
+/// ```
+pub struct MaxMulAlgebra;
+
+// ---------------------------------------------------------------------------
+// HasAlgebra: scalar → algebra mapping
+// ---------------------------------------------------------------------------
+
+impl HasAlgebra for MaxPlus<f32> {
+    type Algebra = MaxPlusAlgebra;
+}
+
+impl HasAlgebra for MaxPlus<f64> {
+    type Algebra = MaxPlusAlgebra;
+}
+
+impl HasAlgebra for MinPlus<f32> {
+    type Algebra = MinPlusAlgebra;
+}
+
+impl HasAlgebra for MinPlus<f64> {
+    type Algebra = MinPlusAlgebra;
+}
+
+impl HasAlgebra for MaxMul<f32> {
+    type Algebra = MaxMulAlgebra;
+}
+
+impl HasAlgebra for MaxMul<f64> {
+    type Algebra = MaxMulAlgebra;
+}
+
+// ---------------------------------------------------------------------------
+// Semiring implementations (f64 only for POC)
+// ---------------------------------------------------------------------------
+
+/// Max-plus semiring over `MaxPlus<f64>`.
+///
+/// - `zero()` = MaxPlus(−∞)
+/// - `one()` = MaxPlus(0.0)
+/// - `add(a, b)` = max(a, b)
+/// - `mul(a, b)` = a + b (ordinary addition)
+impl Semiring for MaxPlusAlgebra {
+    type Scalar = MaxPlus<f64>;
+
+    fn zero() -> Self::Scalar {
+        todo!()
+    }
+
+    fn one() -> Self::Scalar {
+        todo!()
+    }
+
+    fn add(_a: Self::Scalar, _b: Self::Scalar) -> Self::Scalar {
+        todo!()
+    }
+
+    fn mul(_a: Self::Scalar, _b: Self::Scalar) -> Self::Scalar {
+        todo!()
+    }
+}
+
+/// Min-plus semiring over `MinPlus<f64>`.
+///
+/// - `zero()` = MinPlus(+∞)
+/// - `one()` = MinPlus(0.0)
+/// - `add(a, b)` = min(a, b)
+/// - `mul(a, b)` = a + b (ordinary addition)
+impl Semiring for MinPlusAlgebra {
+    type Scalar = MinPlus<f64>;
+
+    fn zero() -> Self::Scalar {
+        todo!()
+    }
+
+    fn one() -> Self::Scalar {
+        todo!()
+    }
+
+    fn add(_a: Self::Scalar, _b: Self::Scalar) -> Self::Scalar {
+        todo!()
+    }
+
+    fn mul(_a: Self::Scalar, _b: Self::Scalar) -> Self::Scalar {
+        todo!()
+    }
+}
+
+/// Max-times semiring over `MaxMul<f64>`.
+///
+/// - `zero()` = MaxMul(0.0)
+/// - `one()` = MaxMul(1.0)
+/// - `add(a, b)` = max(a, b)
+/// - `mul(a, b)` = a × b (ordinary multiplication)
+impl Semiring for MaxMulAlgebra {
+    type Scalar = MaxMul<f64>;
+
+    fn zero() -> Self::Scalar {
+        todo!()
+    }
+
+    fn one() -> Self::Scalar {
+        todo!()
+    }
+
+    fn add(_a: Self::Scalar, _b: Self::Scalar) -> Self::Scalar {
+        todo!()
+    }
+
+    fn mul(_a: Self::Scalar, _b: Self::Scalar) -> Self::Scalar {
+        todo!()
+    }
+}

--- a/tenferro-tropical/src/argmax.rs
+++ b/tenferro-tropical/src/argmax.rs
@@ -1,0 +1,81 @@
+//! Argmax tracking for tropical backward pass (automatic differentiation).
+//!
+//! In tropical semirings, the "gradient" of a contraction is determined by
+//! which elements "won" the max (or min) comparisons. [`ArgmaxTracker`]
+//! records the winner indices during the forward pass so that the backward
+//! pass can route gradients to the correct elements.
+//!
+//! This is the tropical analogue of storing intermediate activations for
+//! backpropagation in standard neural network training.
+
+/// Tracks winner indices from tropical forward-pass operations.
+///
+/// During a tropical contraction `C[i,j] = max_k (A[i,k] + B[k,j])`,
+/// the tracker records which `k` achieved the maximum for each `(i,j)`.
+/// The backward pass uses these indices to route gradients.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tropical::ArgmaxTracker;
+///
+/// // Create a tracker for a 3×5 output
+/// let tracker = ArgmaxTracker::new(&[3, 5]);
+///
+/// // After forward pass, query the winner index for output element (1, 2)
+/// let k_winner = tracker.winner_index(&[1, 2]);
+/// ```
+pub struct ArgmaxTracker {
+    /// Shape of the output tensor.
+    output_shape: Vec<usize>,
+    /// Winner indices (flat storage, one per output element).
+    /// Each entry records the contraction index that achieved the optimum.
+    indices: Vec<usize>,
+}
+
+impl ArgmaxTracker {
+    /// Create a new tracker for an output of the given shape.
+    ///
+    /// All winner indices are initialized to 0.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tropical::ArgmaxTracker;
+    ///
+    /// let tracker = ArgmaxTracker::new(&[3, 5]);
+    /// assert_eq!(tracker.output_shape(), &[3, 5]);
+    /// ```
+    pub fn new(_output_shape: &[usize]) -> Self {
+        todo!()
+    }
+
+    /// Return the output shape.
+    pub fn output_shape(&self) -> &[usize] {
+        &self.output_shape
+    }
+
+    /// Return the winner indices as a flat slice.
+    pub fn indices(&self) -> &[usize] {
+        &self.indices
+    }
+
+    /// Return a mutable reference to the winner indices.
+    pub fn indices_mut(&mut self) -> &mut [usize] {
+        &mut self.indices
+    }
+
+    /// Look up the winner index for a given multi-dimensional output position.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tropical::ArgmaxTracker;
+    ///
+    /// let tracker = ArgmaxTracker::new(&[3, 5]);
+    /// let k = tracker.winner_index(&[1, 2]);
+    /// ```
+    pub fn winner_index(&self, _position: &[usize]) -> usize {
+        todo!()
+    }
+}

--- a/tenferro-tropical/src/lib.rs
+++ b/tenferro-tropical/src/lib.rs
@@ -1,0 +1,80 @@
+//! Tropical semiring tensor operations for the tenferro workspace.
+//!
+//! This crate extends the tenferro algebra-parameterized architecture with
+//! three tropical semirings:
+//!
+//! | Semiring | ⊕ (add) | ⊗ (mul) | Zero | One | Use case |
+//! |----------|---------|---------|------|-----|----------|
+//! | MaxPlus  | max     | +       | −∞   | 0   | Shortest path, optimal alignment |
+//! | MinPlus  | min     | +       | +∞   | 0   | Shortest path (Dijkstra) |
+//! | MaxMul   | max     | ×       | 0    | 1   | Viterbi, max-probability paths |
+//!
+//! # Architecture
+//!
+//! The crate provides:
+//!
+//! - **Scalar wrappers** ([`MaxPlus<T>`], [`MinPlus<T>`], [`MaxMul<T>`]):
+//!   `#[repr(transparent)]` newtypes that redefine `Add`/`Mul` with tropical
+//!   semantics. Satisfy the [`Scalar`](tenferro_algebra::Scalar) blanket impl.
+//!
+//! - **Algebra markers** ([`MaxPlusAlgebra`], [`MinPlusAlgebra`], [`MaxMulAlgebra`]):
+//!   Zero-sized types used as the algebra parameter `A` in
+//!   [`TensorPrims<A>`](tenferro_prims::TensorPrims).
+//!
+//! - **[`TensorPrims`](tenferro_prims::TensorPrims) implementations**:
+//!   `impl TensorPrims<MaxPlusAlgebra> for CpuBackend` etc. Orphan rule
+//!   compatible because algebra markers are defined locally.
+//!
+//! - **[`ArgmaxTracker`]**: Records winner indices during tropical forward
+//!   pass for use in automatic differentiation.
+//!
+//! # Examples
+//!
+//! ## Scalar arithmetic
+//!
+//! ```ignore
+//! use tenferro_tropical::MaxPlus;
+//!
+//! let a = MaxPlus(3.0_f64);
+//! let b = MaxPlus(5.0_f64);
+//! let c = a + b;   // MaxPlus(5.0) — tropical add = max
+//! let d = a * b;   // MaxPlus(8.0) — tropical mul = ordinary +
+//! ```
+//!
+//! ## Algebra dispatch
+//!
+//! ```ignore
+//! use tenferro_algebra::HasAlgebra;
+//! use tenferro_tropical::{MaxPlus, MaxPlusAlgebra};
+//!
+//! // MaxPlus<f64> automatically maps to MaxPlusAlgebra
+//! fn check<T: HasAlgebra<Algebra = MaxPlusAlgebra>>() {}
+//! check::<MaxPlus<f64>>();
+//! ```
+//!
+//! ## Plan-based tropical contraction
+//!
+//! ```ignore
+//! use tenferro_prims::{CpuBackend, TensorPrims, PrimDescriptor};
+//! use tenferro_tropical::MaxPlusAlgebra;
+//!
+//! let desc = PrimDescriptor::BatchedGemm {
+//!     batch_dims: vec![], m: 3, n: 5, k: 4,
+//! };
+//! // Under MaxPlusAlgebra, GEMM computes:
+//! //   C[i,j] = max_k (A[i,k] + B[k,j])
+//! let plan = <CpuBackend as TensorPrims<MaxPlusAlgebra>>::plan::<f64>(
+//!     &desc, &[&[3, 4], &[4, 5], &[3, 5]],
+//! ).unwrap();
+//! ```
+
+pub mod algebra;
+pub mod argmax;
+pub mod prims;
+pub mod scalar;
+
+// Re-export primary types at crate root.
+pub use algebra::{MaxMulAlgebra, MaxPlusAlgebra, MinPlusAlgebra};
+pub use argmax::ArgmaxTracker;
+pub use prims::TropicalPlan;
+pub use scalar::{MaxMul, MaxPlus, MinPlus};

--- a/tenferro-tropical/src/prims.rs
+++ b/tenferro-tropical/src/prims.rs
@@ -1,0 +1,169 @@
+//! [`TensorPrims`] implementations for tropical algebras on [`CpuBackend`].
+//!
+//! Each tropical algebra gets its own `impl TensorPrims<XxxAlgebra> for CpuBackend`.
+//! The orphan rule is satisfied because `XxxAlgebra` is defined in this crate.
+//!
+//! Extended operations (Contract, ElementwiseMul) are not supported for
+//! tropical algebras — `has_extension_for` always returns `false`.
+
+use std::marker::PhantomData;
+
+use strided_traits::ScalarBase;
+use strided_view::{StridedView, StridedViewMut};
+use tenferro_device::Result;
+use tenferro_prims::{CpuBackend, Extension, PrimDescriptor, ReduceOp, TensorPrims};
+
+use crate::algebra::{MaxMulAlgebra, MaxPlusAlgebra, MinPlusAlgebra};
+
+/// Execution plan for tropical primitive operations on CPU.
+///
+/// Analogous to [`CpuPlan`](tenferro_prims::CpuPlan) but for tropical
+/// algebras. The plan captures pre-computed kernel selection information.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_prims::{CpuBackend, TensorPrims, PrimDescriptor, ReduceOp};
+/// use tenferro_tropical::{MaxPlusAlgebra, TropicalPlan};
+///
+/// let desc = PrimDescriptor::Reduce {
+///     modes_a: vec![0, 1],
+///     modes_c: vec![0],
+///     op: ReduceOp::Max,
+/// };
+/// let plan: TropicalPlan<f64> = CpuBackend::plan::<f64>(&desc, &[&[3, 4], &[3]]).unwrap();
+/// ```
+pub enum TropicalPlan<T: ScalarBase> {
+    /// Plan for batched GEMM under tropical algebra.
+    BatchedGemm {
+        /// Number of rows.
+        m: usize,
+        /// Number of columns.
+        n: usize,
+        /// Contraction dimension.
+        k: usize,
+        _marker: PhantomData<T>,
+    },
+    /// Plan for reduction under tropical algebra.
+    Reduce {
+        /// Axis to reduce over.
+        axis: usize,
+        /// Reduction operation.
+        op: ReduceOp,
+        _marker: PhantomData<T>,
+    },
+    /// Plan for trace under tropical algebra.
+    Trace {
+        /// Paired modes.
+        paired: Vec<(u32, u32)>,
+        _marker: PhantomData<T>,
+    },
+    /// Plan for permutation.
+    Permute {
+        /// Permutation mapping.
+        perm: Vec<usize>,
+        _marker: PhantomData<T>,
+    },
+    /// Plan for anti-trace (AD backward).
+    AntiTrace {
+        /// Paired modes.
+        paired: Vec<(u32, u32)>,
+        _marker: PhantomData<T>,
+    },
+    /// Plan for anti-diag (AD backward).
+    AntiDiag {
+        /// Paired modes.
+        paired: Vec<(u32, u32)>,
+        _marker: PhantomData<T>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// impl TensorPrims<MaxPlusAlgebra> for CpuBackend
+// ---------------------------------------------------------------------------
+
+impl TensorPrims<MaxPlusAlgebra> for CpuBackend {
+    type Plan<T: ScalarBase> = TropicalPlan<T>;
+
+    fn plan<T: ScalarBase>(
+        _desc: &PrimDescriptor,
+        _shapes: &[&[usize]],
+    ) -> Result<TropicalPlan<T>> {
+        todo!()
+    }
+
+    fn execute<T: ScalarBase>(
+        _plan: &TropicalPlan<T>,
+        _alpha: T,
+        _inputs: &[&StridedView<T>],
+        _beta: T,
+        _output: &mut StridedViewMut<T>,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    /// Tropical backends do not support extended operations.
+    fn has_extension_for<T: ScalarBase>(_ext: Extension) -> bool {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// impl TensorPrims<MinPlusAlgebra> for CpuBackend
+// ---------------------------------------------------------------------------
+
+impl TensorPrims<MinPlusAlgebra> for CpuBackend {
+    type Plan<T: ScalarBase> = TropicalPlan<T>;
+
+    fn plan<T: ScalarBase>(
+        _desc: &PrimDescriptor,
+        _shapes: &[&[usize]],
+    ) -> Result<TropicalPlan<T>> {
+        todo!()
+    }
+
+    fn execute<T: ScalarBase>(
+        _plan: &TropicalPlan<T>,
+        _alpha: T,
+        _inputs: &[&StridedView<T>],
+        _beta: T,
+        _output: &mut StridedViewMut<T>,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    /// Tropical backends do not support extended operations.
+    fn has_extension_for<T: ScalarBase>(_ext: Extension) -> bool {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// impl TensorPrims<MaxMulAlgebra> for CpuBackend
+// ---------------------------------------------------------------------------
+
+impl TensorPrims<MaxMulAlgebra> for CpuBackend {
+    type Plan<T: ScalarBase> = TropicalPlan<T>;
+
+    fn plan<T: ScalarBase>(
+        _desc: &PrimDescriptor,
+        _shapes: &[&[usize]],
+    ) -> Result<TropicalPlan<T>> {
+        todo!()
+    }
+
+    fn execute<T: ScalarBase>(
+        _plan: &TropicalPlan<T>,
+        _alpha: T,
+        _inputs: &[&StridedView<T>],
+        _beta: T,
+        _output: &mut StridedViewMut<T>,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    /// Tropical backends do not support extended operations.
+    fn has_extension_for<T: ScalarBase>(_ext: Extension) -> bool {
+        false
+    }
+}

--- a/tenferro-tropical/src/scalar.rs
+++ b/tenferro-tropical/src/scalar.rs
@@ -1,0 +1,232 @@
+//! Tropical scalar wrapper types.
+//!
+//! Each newtype redefines `Add` and `Mul` so that the [`Scalar`](tenferro_algebra::Scalar)
+//! blanket impl is satisfied with tropical semantics:
+//!
+//! | Type | `+` (⊕) | `*` (⊗) | Zero | One |
+//! |------|---------|---------|------|-----|
+//! | [`MaxPlus<T>`] | max | + | −∞ | 0 |
+//! | [`MinPlus<T>`] | min | + | +∞ | 0 |
+//! | [`MaxMul<T>`] | max | × | 0 | 1 |
+//!
+//! All arithmetic bodies use `todo!()` (POC skeleton).
+
+use std::fmt;
+use std::ops;
+
+/// Max-plus tropical scalar: ⊕ = max, ⊗ = +.
+///
+/// The most common tropical semiring, used for shortest-path and
+/// optimal-alignment problems. Wraps any ordered numeric type `T`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tropical::MaxPlus;
+///
+/// let a = MaxPlus(3.0_f64);
+/// let b = MaxPlus(5.0_f64);
+///
+/// // Tropical addition = max
+/// let c = a + b;   // MaxPlus(5.0)
+///
+/// // Tropical multiplication = ordinary addition
+/// let d = a * b;   // MaxPlus(8.0)
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct MaxPlus<T>(pub T);
+
+/// Min-plus tropical scalar: ⊕ = min, ⊗ = +.
+///
+/// Used for shortest-path problems (Dijkstra, Bellman–Ford).
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tropical::MinPlus;
+///
+/// let a = MinPlus(3.0_f64);
+/// let b = MinPlus(5.0_f64);
+///
+/// // Tropical addition = min
+/// let c = a + b;   // MinPlus(3.0)
+///
+/// // Tropical multiplication = ordinary addition
+/// let d = a * b;   // MinPlus(8.0)
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct MinPlus<T>(pub T);
+
+/// Max-times tropical scalar: ⊕ = max, ⊗ = ×.
+///
+/// Used for probabilistic models where you want the most likely
+/// path (Viterbi algorithm with probabilities in [0, 1]).
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tropical::MaxMul;
+///
+/// let a = MaxMul(0.3_f64);
+/// let b = MaxMul(0.7_f64);
+///
+/// // Tropical addition = max
+/// let c = a + b;   // MaxMul(0.7)
+///
+/// // Tropical multiplication = ordinary multiplication
+/// let d = a * b;   // MaxMul(0.21)
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct MaxMul<T>(pub T);
+
+// ---------------------------------------------------------------------------
+// Display
+// ---------------------------------------------------------------------------
+
+impl<T: fmt::Display> fmt::Display for MaxPlus<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MaxPlus({})", self.0)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for MinPlus<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MinPlus({})", self.0)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for MaxMul<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MaxMul({})", self.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MaxPlus<T>: Add (= max), Mul (= +), Zero (= −∞), One (= 0)
+// ---------------------------------------------------------------------------
+
+impl<T: Copy + PartialOrd> ops::Add for MaxPlus<T> {
+    type Output = Self;
+
+    /// Tropical addition: max(a, b).
+    fn add(self, _rhs: Self) -> Self {
+        todo!()
+    }
+}
+
+impl<T: Copy + ops::Add<Output = T>> ops::Mul for MaxPlus<T> {
+    type Output = Self;
+
+    /// Tropical multiplication: a + b (ordinary addition).
+    fn mul(self, _rhs: Self) -> Self {
+        todo!()
+    }
+}
+
+impl<T: num_traits::Float> num_traits::Zero for MaxPlus<T> {
+    /// Additive identity: −∞ (negative infinity).
+    fn zero() -> Self {
+        todo!()
+    }
+
+    fn is_zero(&self) -> bool {
+        todo!()
+    }
+}
+
+impl<T: num_traits::Float> num_traits::One for MaxPlus<T> {
+    /// Multiplicative identity: 0.
+    fn one() -> Self {
+        todo!()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MinPlus<T>: Add (= min), Mul (= +), Zero (= +∞), One (= 0)
+// ---------------------------------------------------------------------------
+
+impl<T: Copy + PartialOrd> ops::Add for MinPlus<T> {
+    type Output = Self;
+
+    /// Tropical addition: min(a, b).
+    fn add(self, _rhs: Self) -> Self {
+        todo!()
+    }
+}
+
+impl<T: Copy + ops::Add<Output = T>> ops::Mul for MinPlus<T> {
+    type Output = Self;
+
+    /// Tropical multiplication: a + b (ordinary addition).
+    fn mul(self, _rhs: Self) -> Self {
+        todo!()
+    }
+}
+
+impl<T: num_traits::Float> num_traits::Zero for MinPlus<T> {
+    /// Additive identity: +∞ (positive infinity).
+    fn zero() -> Self {
+        todo!()
+    }
+
+    fn is_zero(&self) -> bool {
+        todo!()
+    }
+}
+
+impl<T: num_traits::Float> num_traits::One for MinPlus<T> {
+    /// Multiplicative identity: 0.
+    fn one() -> Self {
+        todo!()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MaxMul<T>: Add (= max), Mul (= ×), Zero (= 0), One (= 1)
+// ---------------------------------------------------------------------------
+
+impl<T: Copy + PartialOrd> ops::Add for MaxMul<T> {
+    type Output = Self;
+
+    /// Tropical addition: max(a, b).
+    fn add(self, _rhs: Self) -> Self {
+        todo!()
+    }
+}
+
+impl<T: Copy + ops::Mul<Output = T>> ops::Mul for MaxMul<T> {
+    type Output = Self;
+
+    /// Tropical multiplication: a × b (ordinary multiplication).
+    fn mul(self, _rhs: Self) -> Self {
+        todo!()
+    }
+}
+
+impl<T: num_traits::Float> num_traits::Zero for MaxMul<T> {
+    /// Additive identity: 0 (for max, 0 is the identity when values are non-negative).
+    fn zero() -> Self {
+        todo!()
+    }
+
+    fn is_zero(&self) -> bool {
+        todo!()
+    }
+}
+
+impl<T: num_traits::Float> num_traits::One for MaxMul<T> {
+    /// Multiplicative identity: 1.
+    fn one() -> Self {
+        todo!()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unsafe marker traits — MaxPlus/MinPlus/MaxMul are Send + Sync if T is.
+// These are automatically derived from the inner T via #[repr(transparent)].
+// ---------------------------------------------------------------------------
+
+// Send and Sync are auto-derived since the wrapper is transparent over T.


### PR DESCRIPTION
## Summary
- Add `tenferro-tropical` crate with three tropical semiring scalar wrappers: `MaxPlus<T>` (⊕=max, ⊗=+), `MinPlus<T>` (⊕=min, ⊗=+), `MaxMul<T>` (⊕=max, ⊗=×)
- Algebra markers (`MaxPlusAlgebra`, `MinPlusAlgebra`, `MaxMulAlgebra`) with `HasAlgebra` and `Semiring` impls, plus `TensorPrims` impls for `CpuBackend`
- `ArgmaxTracker` for tropical backward pass (AD winner-index tracking)
- All function bodies use `todo!()` (POC skeleton phase)

## Test Plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes (13 doc-tests correctly ignored)
- [x] Build succeeds with `cargo build -p tenferro-tropical`

🤖 Generated with [Claude Code](https://claude.com/claude-code)