### PR TITLE
feat: add dlpack-core and chainrules-linalg with GPU-compatible types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ members = [
     "extension/tenferro-tropical",
     "extension/tenferro-tropical-capi",
     # extern (general-purpose, non-tenferro)
+    "extern/dlpack-core",
     "extern/chainrules-core",
     "extern/chainrules",
+    "extern/chainrules-linalg",
 ]
 resolver = "2"
 

--- a/extern/chainrules-linalg/Cargo.toml
+++ b/extern/chainrules-linalg/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "chainrules-linalg"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Matrix-level linear algebra decompositions with AD rules (rrule/frule)."
+publish = false
+
+[dependencies]
+chainrules-core = { path = "../chainrules-core" }
+dlpack-core = { path = "../dlpack-core" }

--- a/extern/chainrules-linalg/src/lib.rs
+++ b/extern/chainrules-linalg/src/lib.rs
@@ -1,0 +1,556 @@
+//! Matrix-level linear algebra decompositions with AD rules.
+//!
+//! This crate provides 2D matrix SVD, QR, LU, and eigendecomposition along
+//! with their reverse-mode (rrule/pullback) and forward-mode (frule/pushforward)
+//! differentiation rules, following Mathieu (2019) and related literature.
+//!
+//! The API uses [`dlpack_core::MatrixView`] for inputs and [`dlpack_core::Matrix`]
+//! for outputs, enabling GPU-transparent operation. An [`Alloc`](dlpack_core::Alloc)
+//! trait object is passed to each function for device-aware memory allocation.
+//!
+//! Higher-level crates (e.g., `tenferro-linalg`) handle N-dimensional tensor
+//! matricization/unmatricization and delegate to this crate for the pure
+//! 2D matrix AD math.
+//!
+//! # Examples
+//!
+//! ## SVD of a column-major matrix
+//!
+//! ```ignore
+//! use dlpack_core::{Matrix, Alloc};
+//! use chainrules_linalg::mat_svd;
+//!
+//! let data = vec![1.0f64; 12];
+//! let a = Matrix::from_vec(data, 3, 4, [1, 3]);
+//!
+//! let alloc = CpuAlloc; // implements Alloc
+//! let result = mat_svd(&a.as_view(), None, &alloc);
+//! assert_eq!(result.k, 3); // k = min(m, n)
+//! ```
+//!
+//! ## Reverse-mode AD through SVD
+//!
+//! ```ignore
+//! use dlpack_core::Matrix;
+//! use chainrules_linalg::{mat_svd, mat_svd_rrule, MatSvdCotangent};
+//!
+//! let a = Matrix::from_vec(vec![1.0f64; 12], 3, 4, [1, 3]);
+//! let result = mat_svd(&a.as_view(), None, &alloc);
+//!
+//! // Cotangent: only backprop through singular values
+//! let ds = vec![1.0; result.k];
+//! let cotangent = MatSvdCotangent { u: None, s: Some(&ds), vt: None };
+//! let grad_a = mat_svd_rrule(&a.as_view(), &cotangent, None, &alloc);
+//! assert_eq!(grad_a.nrows(), 3);
+//! assert_eq!(grad_a.ncols(), 4);
+//! ```
+
+use dlpack_core::{Alloc, Matrix, MatrixView};
+
+// ============================================================================
+// Result types (using dlpack_core::Matrix<T>)
+// ============================================================================
+
+/// SVD result: `A = U * diag(S) * Vt`.
+///
+/// All matrices are stored in column-major order.
+///
+/// - `u`: shape `m × k` (left singular vectors)
+/// - `s`: singular values, length `k`
+/// - `vt`: shape `k × n` (right singular vectors transposed)
+///
+/// where `k = min(m, n)` (or truncated rank if options were applied).
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_svd;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 12], 3, 4, [1, 3]);
+/// let result = mat_svd(&a.as_view(), None, &alloc);
+/// assert_eq!(result.u.nrows(), 3);
+/// assert_eq!(result.s.len(), result.k);
+/// ```
+pub struct MatSvdResult<T> {
+    /// Left singular vectors (column-major, m × k).
+    pub u: Matrix<T>,
+    /// Singular values (descending order), length k.
+    pub s: Vec<T>,
+    /// Right singular vectors transposed (column-major, k × n).
+    pub vt: Matrix<T>,
+    /// Number of rows of the input matrix.
+    pub m: usize,
+    /// Number of columns of the input matrix.
+    pub n: usize,
+    /// Number of singular values kept.
+    pub k: usize,
+}
+
+/// Options for truncated SVD.
+///
+/// When both `max_rank` and `cutoff` are specified, the more restrictive
+/// constraint applies.
+///
+/// # Examples
+///
+/// ```
+/// use chainrules_linalg::MatSvdOptions;
+///
+/// let opts = MatSvdOptions {
+///     max_rank: Some(10),
+///     cutoff: Some(1e-12),
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct MatSvdOptions {
+    /// Maximum number of singular values to keep. `None` means no limit.
+    pub max_rank: Option<usize>,
+    /// Discard singular values below this threshold. `None` means no cutoff.
+    pub cutoff: Option<f64>,
+}
+
+impl Default for MatSvdOptions {
+    fn default() -> Self {
+        Self {
+            max_rank: None,
+            cutoff: None,
+        }
+    }
+}
+
+/// QR decomposition result: `A = Q * R`.
+///
+/// - `q`: shape `m × k` (orthonormal columns)
+/// - `r`: shape `k × n` (upper triangular)
+///
+/// where `k = min(m, n)`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_qr;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 12], 4, 3, [1, 4]);
+/// let result = mat_qr(&a.as_view(), &alloc);
+/// assert_eq!(result.q.nrows(), 4);
+/// ```
+pub struct MatQrResult<T> {
+    /// Orthonormal factor Q (column-major, m × k).
+    pub q: Matrix<T>,
+    /// Upper triangular factor R (column-major, k × n).
+    pub r: Matrix<T>,
+    /// Number of rows of the input matrix.
+    pub m: usize,
+    /// Number of columns of the input matrix.
+    pub n: usize,
+    /// Rank k = min(m, n).
+    pub k: usize,
+}
+
+/// LU decomposition result: `A = P * L * U` (partial pivoting).
+///
+/// - `p`: row permutation vector of length `m`
+/// - `l`: shape `m × k` (unit lower triangular)
+/// - `u`: shape `k × n` (upper triangular)
+///
+/// where `k = min(m, n)`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_lu;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 9], 3, 3, [1, 3]);
+/// let result = mat_lu(&a.as_view(), &alloc);
+/// assert_eq!(result.p.len(), 3);
+/// ```
+pub struct MatLuResult<T> {
+    /// Row permutation vector (partial pivoting), length m.
+    pub p: Vec<usize>,
+    /// Unit lower triangular factor L (column-major, m × k).
+    pub l: Matrix<T>,
+    /// Upper triangular factor U (column-major, k × n).
+    pub u: Matrix<T>,
+    /// Number of rows of the input matrix.
+    pub m: usize,
+    /// Number of columns of the input matrix.
+    pub n: usize,
+    /// Rank k = min(m, n).
+    pub k: usize,
+}
+
+/// Eigendecomposition result: `A * V = V * diag(values)`.
+///
+/// Only valid for square matrices.
+///
+/// - `values`: eigenvalues, length `n`
+/// - `vectors`: right eigenvectors (column-major, n × n)
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_eigen;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 9], 3, 3, [1, 3]);
+/// let result = mat_eigen(&a.as_view(), &alloc);
+/// assert_eq!(result.values.len(), 3);
+/// ```
+pub struct MatEigenResult<T> {
+    /// Eigenvalues, length n.
+    pub values: Vec<T>,
+    /// Right eigenvectors (column-major, n × n).
+    pub vectors: Matrix<T>,
+    /// Matrix dimension n.
+    pub n: usize,
+}
+
+// ============================================================================
+// Cotangent types
+// ============================================================================
+
+/// Cotangent (adjoint) for SVD outputs.
+///
+/// Each field is `Option` because the user may not need gradients for
+/// all outputs (e.g., only `s` for singular value optimization).
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::MatSvdCotangent;
+///
+/// let ds = vec![1.0f64; 3];
+/// let cotangent = MatSvdCotangent { u: None, s: Some(&ds), vt: None };
+/// ```
+pub struct MatSvdCotangent<'a, T> {
+    /// Cotangent for U (m × k). `None` if not needed.
+    pub u: Option<MatrixView<'a, T>>,
+    /// Cotangent for S (length k). `None` if not needed.
+    pub s: Option<&'a [T]>,
+    /// Cotangent for Vt (k × n). `None` if not needed.
+    pub vt: Option<MatrixView<'a, T>>,
+}
+
+/// Cotangent (adjoint) for QR outputs.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::MatQrCotangent;
+///
+/// let cotangent = MatQrCotangent::<f64> { q: None, r: None };
+/// ```
+pub struct MatQrCotangent<'a, T> {
+    /// Cotangent for Q (m × k). `None` if not needed.
+    pub q: Option<MatrixView<'a, T>>,
+    /// Cotangent for R (k × n). `None` if not needed.
+    pub r: Option<MatrixView<'a, T>>,
+}
+
+/// Cotangent (adjoint) for LU outputs.
+///
+/// The permutation `p` is discrete and has no gradient.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::MatLuCotangent;
+///
+/// let cotangent = MatLuCotangent::<f64> { l: None, u: None };
+/// ```
+pub struct MatLuCotangent<'a, T> {
+    /// Cotangent for L (m × k). `None` if not needed.
+    pub l: Option<MatrixView<'a, T>>,
+    /// Cotangent for U (k × n). `None` if not needed.
+    pub u: Option<MatrixView<'a, T>>,
+}
+
+/// Cotangent (adjoint) for eigendecomposition outputs.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::MatEigenCotangent;
+///
+/// let cotangent = MatEigenCotangent::<f64> { values: None, vectors: None };
+/// ```
+pub struct MatEigenCotangent<'a, T> {
+    /// Cotangent for eigenvalues (length n). `None` if not needed.
+    pub values: Option<&'a [T]>,
+    /// Cotangent for eigenvectors (n × n). `None` if not needed.
+    pub vectors: Option<MatrixView<'a, T>>,
+}
+
+// ============================================================================
+// SVD functions
+// ============================================================================
+
+/// Compute the SVD of a 2D matrix.
+///
+/// Decomposes `A` into `U * diag(S) * Vt`.
+///
+/// # Arguments
+///
+/// * `a` — Input matrix (m × n)
+/// * `options` — Optional truncation parameters
+/// * `alloc` — Device-aware allocator for output matrices
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_svd;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 12], 3, 4, [1, 3]);
+/// let result = mat_svd(&a.as_view(), None, &alloc);
+/// ```
+pub fn mat_svd<T: Clone>(
+    _a: &MatrixView<'_, T>,
+    _options: Option<&MatSvdOptions>,
+    _alloc: &dyn Alloc,
+) -> MatSvdResult<T> {
+    todo!()
+}
+
+/// Reverse-mode AD rule for SVD (pullback).
+///
+/// Given the input matrix and cotangents for the SVD outputs, computes
+/// the gradient of the input matrix. Implements Mathieu (2019).
+///
+/// # Arguments
+///
+/// * `a` — Input matrix (m × n) used in the forward pass
+/// * `cotangent` — Cotangents for SVD outputs (U, S, Vt)
+/// * `options` — Same truncation options used in the forward pass
+/// * `alloc` — Device-aware allocator for the output gradient matrix
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::{mat_svd_rrule, MatSvdCotangent};
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 12], 3, 4, [1, 3]);
+/// let ds = vec![1.0; 3];
+/// let cotangent = MatSvdCotangent { u: None, s: Some(&ds), vt: None };
+/// let grad = mat_svd_rrule(&a.as_view(), &cotangent, None, &alloc);
+/// assert_eq!(grad.nrows(), 3);
+/// ```
+pub fn mat_svd_rrule<T: Clone>(
+    _a: &MatrixView<'_, T>,
+    _cotangent: &MatSvdCotangent<'_, T>,
+    _options: Option<&MatSvdOptions>,
+    _alloc: &dyn Alloc,
+) -> Matrix<T> {
+    todo!()
+}
+
+/// Forward-mode AD rule for SVD (pushforward / JVP).
+///
+/// Returns a pair of (primal result, tangent result).
+///
+/// # Arguments
+///
+/// * `a` — Input matrix (m × n)
+/// * `tangent` — Tangent of the input matrix (m × n)
+/// * `options` — Optional truncation parameters
+/// * `alloc` — Device-aware allocator for output matrices
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_svd_frule;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 12], 3, 4, [1, 3]);
+/// let da = Matrix::from_vec(vec![0.1f64; 12], 3, 4, [1, 3]);
+/// let (result, dresult) = mat_svd_frule(&a.as_view(), &da.as_view(), None, &alloc);
+/// ```
+pub fn mat_svd_frule<T: Clone>(
+    _a: &MatrixView<'_, T>,
+    _tangent: &MatrixView<'_, T>,
+    _options: Option<&MatSvdOptions>,
+    _alloc: &dyn Alloc,
+) -> (MatSvdResult<T>, MatSvdResult<T>) {
+    todo!()
+}
+
+// ============================================================================
+// QR functions
+// ============================================================================
+
+/// Compute the thin QR decomposition of a 2D matrix.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_qr;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 12], 4, 3, [1, 4]);
+/// let result = mat_qr(&a.as_view(), &alloc);
+/// ```
+pub fn mat_qr<T: Clone>(_a: &MatrixView<'_, T>, _alloc: &dyn Alloc) -> MatQrResult<T> {
+    todo!()
+}
+
+/// Reverse-mode AD rule for QR (pullback).
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::{mat_qr_rrule, MatQrCotangent};
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 12], 4, 3, [1, 4]);
+/// let cotangent = MatQrCotangent { q: None, r: None };
+/// let grad = mat_qr_rrule(&a.as_view(), &cotangent, &alloc);
+/// ```
+pub fn mat_qr_rrule<T: Clone>(
+    _a: &MatrixView<'_, T>,
+    _cotangent: &MatQrCotangent<'_, T>,
+    _alloc: &dyn Alloc,
+) -> Matrix<T> {
+    todo!()
+}
+
+/// Forward-mode AD rule for QR (pushforward / JVP).
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_qr_frule;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 12], 4, 3, [1, 4]);
+/// let da = Matrix::from_vec(vec![0.1f64; 12], 4, 3, [1, 4]);
+/// let (result, dresult) = mat_qr_frule(&a.as_view(), &da.as_view(), &alloc);
+/// ```
+pub fn mat_qr_frule<T: Clone>(
+    _a: &MatrixView<'_, T>,
+    _tangent: &MatrixView<'_, T>,
+    _alloc: &dyn Alloc,
+) -> (MatQrResult<T>, MatQrResult<T>) {
+    todo!()
+}
+
+// ============================================================================
+// LU functions
+// ============================================================================
+
+/// Compute the LU decomposition with partial pivoting.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_lu;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 9], 3, 3, [1, 3]);
+/// let result = mat_lu(&a.as_view(), &alloc);
+/// ```
+pub fn mat_lu<T: Clone>(_a: &MatrixView<'_, T>, _alloc: &dyn Alloc) -> MatLuResult<T> {
+    todo!()
+}
+
+/// Reverse-mode AD rule for LU (pullback).
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::{mat_lu_rrule, MatLuCotangent};
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 9], 3, 3, [1, 3]);
+/// let cotangent = MatLuCotangent { l: None, u: None };
+/// let grad = mat_lu_rrule(&a.as_view(), &cotangent, &alloc);
+/// ```
+pub fn mat_lu_rrule<T: Clone>(
+    _a: &MatrixView<'_, T>,
+    _cotangent: &MatLuCotangent<'_, T>,
+    _alloc: &dyn Alloc,
+) -> Matrix<T> {
+    todo!()
+}
+
+/// Forward-mode AD rule for LU (pushforward / JVP).
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_lu_frule;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 9], 3, 3, [1, 3]);
+/// let da = Matrix::from_vec(vec![0.1f64; 9], 3, 3, [1, 3]);
+/// let (result, dresult) = mat_lu_frule(&a.as_view(), &da.as_view(), &alloc);
+/// ```
+pub fn mat_lu_frule<T: Clone>(
+    _a: &MatrixView<'_, T>,
+    _tangent: &MatrixView<'_, T>,
+    _alloc: &dyn Alloc,
+) -> (MatLuResult<T>, MatLuResult<T>) {
+    todo!()
+}
+
+// ============================================================================
+// Eigen functions
+// ============================================================================
+
+/// Compute the eigendecomposition of a square matrix.
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_eigen;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 9], 3, 3, [1, 3]);
+/// let result = mat_eigen(&a.as_view(), &alloc);
+/// ```
+pub fn mat_eigen<T: Clone>(_a: &MatrixView<'_, T>, _alloc: &dyn Alloc) -> MatEigenResult<T> {
+    todo!()
+}
+
+/// Reverse-mode AD rule for eigendecomposition (pullback).
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::{mat_eigen_rrule, MatEigenCotangent};
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 9], 3, 3, [1, 3]);
+/// let cotangent = MatEigenCotangent { values: None, vectors: None };
+/// let grad = mat_eigen_rrule(&a.as_view(), &cotangent, &alloc);
+/// ```
+pub fn mat_eigen_rrule<T: Clone>(
+    _a: &MatrixView<'_, T>,
+    _cotangent: &MatEigenCotangent<'_, T>,
+    _alloc: &dyn Alloc,
+) -> Matrix<T> {
+    todo!()
+}
+
+/// Forward-mode AD rule for eigendecomposition (pushforward / JVP).
+///
+/// # Examples
+///
+/// ```ignore
+/// use chainrules_linalg::mat_eigen_frule;
+/// use dlpack_core::Matrix;
+///
+/// let a = Matrix::from_vec(vec![1.0f64; 9], 3, 3, [1, 3]);
+/// let da = Matrix::from_vec(vec![0.1f64; 9], 3, 3, [1, 3]);
+/// let (result, dresult) = mat_eigen_frule(&a.as_view(), &da.as_view(), &alloc);
+/// ```
+pub fn mat_eigen_frule<T: Clone>(
+    _a: &MatrixView<'_, T>,
+    _tangent: &MatrixView<'_, T>,
+    _alloc: &dyn Alloc,
+) -> (MatEigenResult<T>, MatEigenResult<T>) {
+    todo!()
+}

--- a/extern/dlpack-core/Cargo.toml
+++ b/extern/dlpack-core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "dlpack-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Lightweight DLPack-compatible tensor and matrix containers with device abstraction."
+publish = false

--- a/extern/dlpack-core/src/lib.rs
+++ b/extern/dlpack-core/src/lib.rs
@@ -1,0 +1,944 @@
+//! Lightweight DLPack-compatible tensor and matrix containers.
+//!
+//! This crate provides minimal, GPU-aware data containers for N-dimensional
+//! tensors and 2D matrices. The design follows the [DLPack v1.0](https://github.com/dmlc/dlpack)
+//! device model, enabling zero-copy interop across frameworks and devices
+//! (CPU, CUDA, ROCm, etc.).
+//!
+//! # Key types
+//!
+//! - [`DeviceType`] / [`DLDevice`] — DLPack-compatible device identification
+//! - [`Matrix`] / [`MatrixView`] / [`MatrixViewMut`] — Owned / borrowed 2D containers
+//! - [`Tensor`] / [`TensorView`] / [`TensorViewMut`] — Owned / borrowed N-dimensional containers
+//! - [`Alloc`] — Device-aware memory allocator trait
+//!
+//! # Design
+//!
+//! Owned types ([`Matrix`], [`Tensor`]) carry a deleter callback that frees
+//! memory on drop, following the `DLManagedTensor` pattern. This allows a
+//! single type to own CPU heap memory, CUDA device memory, or any other
+//! device-specific allocation.
+//!
+//! View types ([`MatrixView`], [`TensorView`]) are borrowed references with
+//! no ownership — they carry a pointer, shape, strides, and device info.
+//!
+//! # Examples
+//!
+//! ## CPU matrix from a Vec
+//!
+//! ```
+//! use dlpack_core::{Matrix, DLDevice, DeviceType};
+//!
+//! // 3×4 column-major matrix on CPU
+//! let data = vec![0.0f64; 12];
+//! let mat = Matrix::from_vec(data, 3, 4, [1, 3]);
+//! assert_eq!(mat.nrows(), 3);
+//! assert_eq!(mat.ncols(), 4);
+//! assert_eq!(mat.device().device_type, DeviceType::Cpu);
+//! ```
+//!
+//! ## Borrowing a view
+//!
+//! ```
+//! use dlpack_core::{Matrix, MatrixView};
+//!
+//! let mat = Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3, [1, 2]);
+//! let view = mat.as_view();
+//! assert_eq!(view.nrows(), 2);
+//! assert_eq!(view.ncols(), 3);
+//! ```
+
+use std::marker::PhantomData;
+
+// ============================================================================
+// Device types (DLPack v1.0 compatible)
+// ============================================================================
+
+/// DLPack-compatible device type identifier.
+///
+/// Values match the DLPack v1.0 specification (`DLDeviceType` enum).
+///
+/// # Examples
+///
+/// ```
+/// use dlpack_core::DeviceType;
+///
+/// assert_eq!(DeviceType::Cpu as u32, 1);
+/// assert_eq!(DeviceType::Cuda as u32, 2);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u32)]
+pub enum DeviceType {
+    /// CPU (host) memory.
+    Cpu = 1,
+    /// NVIDIA CUDA device memory.
+    Cuda = 2,
+    /// CUDA pinned (page-locked host) memory.
+    CudaHost = 3,
+    /// AMD ROCm device memory.
+    Rocm = 10,
+    /// ROCm pinned host memory.
+    RocmHost = 11,
+    /// CUDA managed (unified) memory.
+    CudaManaged = 13,
+}
+
+/// DLPack-compatible device descriptor.
+///
+/// Identifies a specific device by type and ordinal index.
+///
+/// # Examples
+///
+/// ```
+/// use dlpack_core::{DLDevice, DeviceType};
+///
+/// let cpu = DLDevice::cpu();
+/// assert_eq!(cpu.device_type, DeviceType::Cpu);
+/// assert_eq!(cpu.device_id, 0);
+///
+/// let gpu = DLDevice::new(DeviceType::Cuda, 0);
+/// assert_eq!(gpu.device_type, DeviceType::Cuda);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DLDevice {
+    /// Device type (CPU, CUDA, ROCm, etc.).
+    pub device_type: DeviceType,
+    /// Device ordinal (0 for single-device systems).
+    pub device_id: i32,
+}
+
+impl DLDevice {
+    /// Creates a new device descriptor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::{DLDevice, DeviceType};
+    ///
+    /// let dev = DLDevice::new(DeviceType::Cuda, 1);
+    /// assert_eq!(dev.device_id, 1);
+    /// ```
+    pub fn new(device_type: DeviceType, device_id: i32) -> Self {
+        Self {
+            device_type,
+            device_id,
+        }
+    }
+
+    /// Returns the CPU device (id=0).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::{DLDevice, DeviceType};
+    ///
+    /// let cpu = DLDevice::cpu();
+    /// assert_eq!(cpu.device_type, DeviceType::Cpu);
+    /// ```
+    pub fn cpu() -> Self {
+        Self {
+            device_type: DeviceType::Cpu,
+            device_id: 0,
+        }
+    }
+}
+
+// ============================================================================
+// Allocator trait
+// ============================================================================
+
+/// Device-aware memory allocator.
+///
+/// Provides allocation and deallocation for a specific device. Implementations
+/// exist for CPU (`Vec`-based) and GPU backends (cuMalloc, hipMalloc, etc.).
+///
+/// The allocator returns a raw pointer and a deleter callback. The deleter
+/// is stored in the owned container ([`Matrix`] or [`Tensor`]) and called
+/// on drop.
+///
+/// # Examples
+///
+/// ```ignore
+/// use dlpack_core::{Alloc, DLDevice};
+///
+/// struct CpuAlloc;
+/// impl Alloc for CpuAlloc {
+///     fn alloc(&self, device: DLDevice, size_bytes: usize, align: usize)
+///         -> (*mut u8, Box<dyn FnOnce(*mut u8)>)
+///     {
+///         // CPU allocation using Vec
+///         todo!()
+///     }
+/// }
+/// ```
+pub trait Alloc {
+    /// Allocates `size_bytes` of memory on the given device.
+    ///
+    /// Returns `(ptr, deleter)` where `deleter` will be called with `ptr`
+    /// when the owning container is dropped.
+    fn alloc(
+        &self,
+        device: DLDevice,
+        size_bytes: usize,
+        align: usize,
+    ) -> (*mut u8, Box<dyn FnOnce(*mut u8)>);
+}
+
+// ============================================================================
+// Matrix — Owned 2D container
+// ============================================================================
+
+/// Owned 2D matrix with device-aware memory management.
+///
+/// Memory is freed on drop via the stored deleter callback, following the
+/// `DLManagedTensor` ownership pattern. This allows a single type to hold
+/// CPU heap memory, CUDA device memory, or any other allocation.
+///
+/// # Layout
+///
+/// Element `(i, j)` is at byte offset `(i * strides[0] + j * strides[1]) * size_of::<T>()`
+/// from `ptr`. Strides are in units of elements (not bytes).
+///
+/// - Column-major: `strides = [1, nrows]`
+/// - Row-major: `strides = [ncols, 1]`
+///
+/// # Examples
+///
+/// ```
+/// use dlpack_core::Matrix;
+///
+/// // 3×4 column-major matrix from Vec
+/// let mat = Matrix::from_vec(vec![0.0f64; 12], 3, 4, [1, 3]);
+/// assert_eq!(mat.nrows(), 3);
+/// assert_eq!(mat.ncols(), 4);
+/// ```
+pub struct Matrix<T> {
+    ptr: *mut T,
+    nrows: usize,
+    ncols: usize,
+    strides: [isize; 2],
+    device: DLDevice,
+    deleter: Option<Box<dyn FnOnce(*mut u8)>>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Matrix<T> {
+    /// Creates a CPU matrix from a `Vec<T>`, taking ownership of the data.
+    ///
+    /// The `Vec` is consumed and its memory is managed by the `Matrix`.
+    /// The deleter reconstructs and drops the `Vec` on drop.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` — Data vector (length must be >= nrows * ncols for the given strides)
+    /// * `nrows` — Number of rows
+    /// * `ncols` — Number of columns
+    /// * `strides` — Element strides `[row_stride, col_stride]`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::Matrix;
+    ///
+    /// let mat = Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 2, 2, [1, 2]);
+    /// assert_eq!(mat.nrows(), 2);
+    /// ```
+    pub fn from_vec(data: Vec<T>, nrows: usize, ncols: usize, strides: [isize; 2]) -> Self {
+        let cap = data.capacity();
+        let len = data.len();
+        let ptr = Box::into_raw(data.into_boxed_slice()) as *mut T;
+        let deleter: Box<dyn FnOnce(*mut u8)> = Box::new(move |p: *mut u8| unsafe {
+            let _ = Vec::from_raw_parts(p as *mut T, len, cap);
+        });
+        Self {
+            ptr,
+            nrows,
+            ncols,
+            strides,
+            device: DLDevice::cpu(),
+            deleter: Some(deleter),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Creates a matrix from a raw pointer with a custom deleter.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must be valid for reads/writes of `nrows * ncols` elements
+    ///   (according to the stride layout) on the specified device.
+    /// - `deleter` must correctly free the memory when called with `ptr`.
+    /// - The caller must ensure the pointer remains valid until the `Matrix`
+    ///   is dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use dlpack_core::{Matrix, DLDevice, DeviceType};
+    ///
+    /// // Wrapping externally-allocated GPU memory
+    /// let gpu_ptr = cuda_malloc(1024);
+    /// let mat = unsafe {
+    ///     Matrix::<f64>::from_raw(
+    ///         gpu_ptr, 16, 16, [1, 16],
+    ///         DLDevice::new(DeviceType::Cuda, 0),
+    ///         Box::new(|p| cuda_free(p)),
+    ///     )
+    /// };
+    /// ```
+    pub unsafe fn from_raw(
+        ptr: *mut T,
+        nrows: usize,
+        ncols: usize,
+        strides: [isize; 2],
+        device: DLDevice,
+        deleter: Box<dyn FnOnce(*mut u8)>,
+    ) -> Self {
+        Self {
+            ptr,
+            nrows,
+            ncols,
+            strides,
+            device,
+            deleter: Some(deleter),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Number of rows.
+    pub fn nrows(&self) -> usize {
+        self.nrows
+    }
+
+    /// Number of columns.
+    pub fn ncols(&self) -> usize {
+        self.ncols
+    }
+
+    /// Element strides `[row_stride, col_stride]`.
+    pub fn strides(&self) -> [isize; 2] {
+        self.strides
+    }
+
+    /// Device where the data resides.
+    pub fn device(&self) -> DLDevice {
+        self.device
+    }
+
+    /// Raw pointer to the data.
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+
+    /// Mutable raw pointer to the data.
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.ptr
+    }
+
+    /// Creates an immutable view of this matrix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::Matrix;
+    ///
+    /// let mat = Matrix::from_vec(vec![1.0; 6], 2, 3, [1, 2]);
+    /// let view = mat.as_view();
+    /// assert_eq!(view.nrows(), 2);
+    /// ```
+    pub fn as_view(&self) -> MatrixView<'_, T> {
+        MatrixView {
+            ptr: self.ptr,
+            nrows: self.nrows,
+            ncols: self.ncols,
+            strides: self.strides,
+            device: self.device,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Creates a mutable view of this matrix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::Matrix;
+    ///
+    /// let mut mat = Matrix::from_vec(vec![1.0; 6], 2, 3, [1, 2]);
+    /// let view = mat.as_view_mut();
+    /// assert_eq!(view.nrows(), 2);
+    /// ```
+    pub fn as_view_mut(&mut self) -> MatrixViewMut<'_, T> {
+        MatrixViewMut {
+            ptr: self.ptr,
+            nrows: self.nrows,
+            ncols: self.ncols,
+            strides: self.strides,
+            device: self.device,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Drop for Matrix<T> {
+    fn drop(&mut self) {
+        if let Some(del) = self.deleter.take() {
+            del(self.ptr as *mut u8);
+        }
+    }
+}
+
+// ============================================================================
+// MatrixView — Borrowed immutable 2D view
+// ============================================================================
+
+/// Borrowed immutable 2D matrix view.
+///
+/// Carries a pointer, shape, strides, and device info without ownership.
+/// The data must outlive the view (enforced by lifetime `'a`).
+///
+/// # Examples
+///
+/// ```
+/// use dlpack_core::{MatrixView, DLDevice};
+///
+/// let data = vec![1.0f64; 6];
+/// let view = MatrixView::new(data.as_ptr(), 2, 3, [1, 2], DLDevice::cpu());
+/// assert_eq!(view.nrows(), 2);
+/// assert_eq!(view.ncols(), 3);
+/// ```
+pub struct MatrixView<'a, T> {
+    ptr: *const T,
+    nrows: usize,
+    ncols: usize,
+    strides: [isize; 2],
+    device: DLDevice,
+    _phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> MatrixView<'a, T> {
+    /// Creates a new immutable matrix view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::{MatrixView, DLDevice};
+    ///
+    /// let data = vec![0.0f64; 12];
+    /// let view = MatrixView::new(data.as_ptr(), 3, 4, [1, 3], DLDevice::cpu());
+    /// assert_eq!(view.nrows(), 3);
+    /// ```
+    pub fn new(
+        ptr: *const T,
+        nrows: usize,
+        ncols: usize,
+        strides: [isize; 2],
+        device: DLDevice,
+    ) -> Self {
+        Self {
+            ptr,
+            nrows,
+            ncols,
+            strides,
+            device,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Number of rows.
+    pub fn nrows(&self) -> usize {
+        self.nrows
+    }
+
+    /// Number of columns.
+    pub fn ncols(&self) -> usize {
+        self.ncols
+    }
+
+    /// Element strides `[row_stride, col_stride]`.
+    pub fn strides(&self) -> [isize; 2] {
+        self.strides
+    }
+
+    /// Device where the data resides.
+    pub fn device(&self) -> DLDevice {
+        self.device
+    }
+
+    /// Raw pointer to the data.
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+}
+
+// ============================================================================
+// MatrixViewMut — Borrowed mutable 2D view
+// ============================================================================
+
+/// Borrowed mutable 2D matrix view.
+///
+/// Same as [`MatrixView`] but allows mutation of the underlying data.
+///
+/// # Examples
+///
+/// ```
+/// use dlpack_core::{MatrixViewMut, DLDevice};
+///
+/// let mut data = vec![0.0f64; 6];
+/// let view = MatrixViewMut::new(data.as_mut_ptr(), 2, 3, [1, 2], DLDevice::cpu());
+/// assert_eq!(view.nrows(), 2);
+/// ```
+pub struct MatrixViewMut<'a, T> {
+    ptr: *mut T,
+    nrows: usize,
+    ncols: usize,
+    strides: [isize; 2],
+    device: DLDevice,
+    _phantom: PhantomData<&'a mut T>,
+}
+
+impl<'a, T> MatrixViewMut<'a, T> {
+    /// Creates a new mutable matrix view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::{MatrixViewMut, DLDevice};
+    ///
+    /// let mut data = vec![0.0f64; 12];
+    /// let view = MatrixViewMut::new(data.as_mut_ptr(), 3, 4, [1, 3], DLDevice::cpu());
+    /// assert_eq!(view.nrows(), 3);
+    /// ```
+    pub fn new(
+        ptr: *mut T,
+        nrows: usize,
+        ncols: usize,
+        strides: [isize; 2],
+        device: DLDevice,
+    ) -> Self {
+        Self {
+            ptr,
+            nrows,
+            ncols,
+            strides,
+            device,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Number of rows.
+    pub fn nrows(&self) -> usize {
+        self.nrows
+    }
+
+    /// Number of columns.
+    pub fn ncols(&self) -> usize {
+        self.ncols
+    }
+
+    /// Element strides `[row_stride, col_stride]`.
+    pub fn strides(&self) -> [isize; 2] {
+        self.strides
+    }
+
+    /// Device where the data resides.
+    pub fn device(&self) -> DLDevice {
+        self.device
+    }
+
+    /// Raw pointer to the data.
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+
+    /// Mutable raw pointer to the data.
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.ptr
+    }
+}
+
+// ============================================================================
+// Tensor — Owned N-dimensional container
+// ============================================================================
+
+/// Owned N-dimensional tensor with device-aware memory management.
+///
+/// The N-dimensional generalization of [`Matrix`]. Memory is freed on drop
+/// via the stored deleter callback.
+///
+/// # Examples
+///
+/// ```
+/// use dlpack_core::Tensor;
+///
+/// // 2×3×4 tensor from Vec
+/// let data = vec![0.0f64; 24];
+/// let t = Tensor::from_vec(data, vec![2, 3, 4], vec![1, 2, 6]);
+/// assert_eq!(t.ndim(), 3);
+/// assert_eq!(t.shape(), &[2, 3, 4]);
+/// ```
+pub struct Tensor<T> {
+    ptr: *mut T,
+    shape: Vec<usize>,
+    strides: Vec<isize>,
+    device: DLDevice,
+    deleter: Option<Box<dyn FnOnce(*mut u8)>>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Tensor<T> {
+    /// Creates a CPU tensor from a `Vec<T>`, taking ownership.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::Tensor;
+    ///
+    /// let t = Tensor::from_vec(vec![0.0f64; 6], vec![2, 3], vec![1, 2]);
+    /// assert_eq!(t.ndim(), 2);
+    /// ```
+    pub fn from_vec(data: Vec<T>, shape: Vec<usize>, strides: Vec<isize>) -> Self {
+        let cap = data.capacity();
+        let len = data.len();
+        let ptr = Box::into_raw(data.into_boxed_slice()) as *mut T;
+        let deleter: Box<dyn FnOnce(*mut u8)> = Box::new(move |p: *mut u8| unsafe {
+            let _ = Vec::from_raw_parts(p as *mut T, len, cap);
+        });
+        Self {
+            ptr,
+            shape,
+            strides,
+            device: DLDevice::cpu(),
+            deleter: Some(deleter),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Creates a tensor from a raw pointer with a custom deleter.
+    ///
+    /// # Safety
+    ///
+    /// Same requirements as [`Matrix::from_raw`].
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use dlpack_core::{Tensor, DLDevice, DeviceType};
+    ///
+    /// let gpu_ptr = cuda_malloc(1024);
+    /// let t = unsafe {
+    ///     Tensor::<f64>::from_raw(
+    ///         gpu_ptr, vec![16, 16], vec![1, 16],
+    ///         DLDevice::new(DeviceType::Cuda, 0),
+    ///         Box::new(|p| cuda_free(p)),
+    ///     )
+    /// };
+    /// ```
+    pub unsafe fn from_raw(
+        ptr: *mut T,
+        shape: Vec<usize>,
+        strides: Vec<isize>,
+        device: DLDevice,
+        deleter: Box<dyn FnOnce(*mut u8)>,
+    ) -> Self {
+        Self {
+            ptr,
+            shape,
+            strides,
+            device,
+            deleter: Some(deleter),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Number of dimensions.
+    pub fn ndim(&self) -> usize {
+        self.shape.len()
+    }
+
+    /// Shape (dimension sizes).
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Element strides.
+    pub fn strides(&self) -> &[isize] {
+        &self.strides
+    }
+
+    /// Device where the data resides.
+    pub fn device(&self) -> DLDevice {
+        self.device
+    }
+
+    /// Raw pointer to the data.
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+
+    /// Mutable raw pointer to the data.
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.ptr
+    }
+
+    /// Creates an immutable view of this tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::Tensor;
+    ///
+    /// let t = Tensor::from_vec(vec![0.0f64; 6], vec![2, 3], vec![1, 2]);
+    /// let view = t.as_view();
+    /// assert_eq!(view.ndim(), 2);
+    /// ```
+    pub fn as_view(&self) -> TensorView<'_, T> {
+        TensorView {
+            ptr: self.ptr,
+            shape: self.shape.clone(),
+            strides: self.strides.clone(),
+            device: self.device,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Creates a mutable view of this tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::Tensor;
+    ///
+    /// let mut t = Tensor::from_vec(vec![0.0f64; 6], vec![2, 3], vec![1, 2]);
+    /// let view = t.as_view_mut();
+    /// assert_eq!(view.ndim(), 2);
+    /// ```
+    pub fn as_view_mut(&mut self) -> TensorViewMut<'_, T> {
+        TensorViewMut {
+            ptr: self.ptr,
+            shape: self.shape.clone(),
+            strides: self.strides.clone(),
+            device: self.device,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Drop for Tensor<T> {
+    fn drop(&mut self) {
+        if let Some(del) = self.deleter.take() {
+            del(self.ptr as *mut u8);
+        }
+    }
+}
+
+// ============================================================================
+// TensorView — Borrowed immutable N-dimensional view
+// ============================================================================
+
+/// Borrowed immutable N-dimensional tensor view.
+///
+/// # Examples
+///
+/// ```
+/// use dlpack_core::{TensorView, DLDevice};
+///
+/// let data = vec![0.0f64; 24];
+/// let view = TensorView::new(
+///     data.as_ptr(), vec![2, 3, 4], vec![1, 2, 6], DLDevice::cpu(),
+/// );
+/// assert_eq!(view.ndim(), 3);
+/// assert_eq!(view.shape(), &[2, 3, 4]);
+/// ```
+pub struct TensorView<'a, T> {
+    ptr: *const T,
+    shape: Vec<usize>,
+    strides: Vec<isize>,
+    device: DLDevice,
+    _phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> TensorView<'a, T> {
+    /// Creates a new immutable tensor view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::{TensorView, DLDevice};
+    ///
+    /// let data = vec![0.0f64; 6];
+    /// let view = TensorView::new(data.as_ptr(), vec![2, 3], vec![1, 2], DLDevice::cpu());
+    /// assert_eq!(view.ndim(), 2);
+    /// ```
+    pub fn new(ptr: *const T, shape: Vec<usize>, strides: Vec<isize>, device: DLDevice) -> Self {
+        Self {
+            ptr,
+            shape,
+            strides,
+            device,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Number of dimensions.
+    pub fn ndim(&self) -> usize {
+        self.shape.len()
+    }
+
+    /// Shape (dimension sizes).
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Element strides.
+    pub fn strides(&self) -> &[isize] {
+        &self.strides
+    }
+
+    /// Device where the data resides.
+    pub fn device(&self) -> DLDevice {
+        self.device
+    }
+
+    /// Raw pointer to the data.
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+}
+
+// ============================================================================
+// TensorViewMut — Borrowed mutable N-dimensional view
+// ============================================================================
+
+/// Borrowed mutable N-dimensional tensor view.
+///
+/// # Examples
+///
+/// ```
+/// use dlpack_core::{TensorViewMut, DLDevice};
+///
+/// let mut data = vec![0.0f64; 6];
+/// let view = TensorViewMut::new(
+///     data.as_mut_ptr(), vec![2, 3], vec![1, 2], DLDevice::cpu(),
+/// );
+/// assert_eq!(view.ndim(), 2);
+/// ```
+pub struct TensorViewMut<'a, T> {
+    ptr: *mut T,
+    shape: Vec<usize>,
+    strides: Vec<isize>,
+    device: DLDevice,
+    _phantom: PhantomData<&'a mut T>,
+}
+
+impl<'a, T> TensorViewMut<'a, T> {
+    /// Creates a new mutable tensor view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::{TensorViewMut, DLDevice};
+    ///
+    /// let mut data = vec![0.0f64; 6];
+    /// let view = TensorViewMut::new(
+    ///     data.as_mut_ptr(), vec![2, 3], vec![1, 2], DLDevice::cpu(),
+    /// );
+    /// assert_eq!(view.ndim(), 2);
+    /// ```
+    pub fn new(ptr: *mut T, shape: Vec<usize>, strides: Vec<isize>, device: DLDevice) -> Self {
+        Self {
+            ptr,
+            shape,
+            strides,
+            device,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Number of dimensions.
+    pub fn ndim(&self) -> usize {
+        self.shape.len()
+    }
+
+    /// Shape (dimension sizes).
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Element strides.
+    pub fn strides(&self) -> &[isize] {
+        &self.strides
+    }
+
+    /// Device where the data resides.
+    pub fn device(&self) -> DLDevice {
+        self.device
+    }
+
+    /// Raw pointer to the data.
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+
+    /// Mutable raw pointer to the data.
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.ptr
+    }
+}
+
+// ============================================================================
+// Conversions: Matrix <-> Tensor (ndim == 2)
+// ============================================================================
+
+impl<T> Matrix<T> {
+    /// Converts this matrix into a 2D tensor, transferring ownership.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::Matrix;
+    ///
+    /// let mat = Matrix::from_vec(vec![0.0f64; 6], 2, 3, [1, 2]);
+    /// let t = mat.into_tensor();
+    /// assert_eq!(t.ndim(), 2);
+    /// assert_eq!(t.shape(), &[2, 3]);
+    /// ```
+    pub fn into_tensor(mut self) -> Tensor<T> {
+        let deleter = self.deleter.take();
+        let tensor = Tensor {
+            ptr: self.ptr,
+            shape: vec![self.nrows, self.ncols],
+            strides: vec![self.strides[0], self.strides[1]],
+            device: self.device,
+            deleter,
+            _phantom: PhantomData,
+        };
+        // Prevent double-free: self.deleter is now None, so Drop is a no-op.
+        std::mem::forget(self);
+        tensor
+    }
+}
+
+impl<'a, T> MatrixView<'a, T> {
+    /// Creates a 2D tensor view from this matrix view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dlpack_core::{MatrixView, DLDevice};
+    ///
+    /// let data = vec![0.0f64; 6];
+    /// let mv = MatrixView::new(data.as_ptr(), 2, 3, [1, 2], DLDevice::cpu());
+    /// let tv = mv.as_tensor_view();
+    /// assert_eq!(tv.ndim(), 2);
+    /// ```
+    pub fn as_tensor_view(&self) -> TensorView<'a, T> {
+        TensorView {
+            ptr: self.ptr,
+            shape: vec![self.nrows, self.ncols],
+            strides: vec![self.strides[0], self.strides[1]],
+            device: self.device,
+            _phantom: PhantomData,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `extern/dlpack-core` crate: DLPack-compatible containers with device abstraction
  - `DLDevice`/`DeviceType` for CPU/CUDA/ROCm device identification
  - `Matrix<T>`/`MatrixView`/`MatrixViewMut` — 2D containers with deleter callback
  - `Tensor<T>`/`TensorView`/`TensorViewMut` — N-dim containers (same pattern)
  - `Alloc` trait for device-aware memory allocation
- Add `extern/chainrules-linalg` crate: matrix-level linalg AD using dlpack-core types
  - 12 functions: 4 decompositions (SVD/QR/LU/eigen) × 3 (forward/rrule/frule)
  - All functions take `&dyn Alloc` for GPU-transparent allocation
  - All bodies `todo!()` (POC skeleton)
- 11 → 13 POC crates

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes (24 dlpack-core doc-tests pass)

Generated with [Claude Code](https://claude.com/claude-code)