### PR TITLE
fix: add missing chainrules-linalg dependency to tenferro-linalg

### DIFF
--- a/tenferro-linalg/Cargo.toml
+++ b/tenferro-linalg/Cargo.toml
@@ -11,3 +11,4 @@ tenferro-device = { path = "../tenferro-device" }
 tenferro-algebra = { path = "../tenferro-algebra" }
 tenferro-tensor = { path = "../tenferro-tensor" }
 chainrules = { path = "../extern/chainrules" }
+chainrules-linalg = { path = "../extern/chainrules-linalg" }


### PR DESCRIPTION
## Summary
- Add `chainrules-linalg` dependency to `tenferro-linalg/Cargo.toml`
- `tenferro-linalg` delegates 2D matrix-level AD rules to `chainrules-linalg`, but the dependency was missing

## Test plan
- [x] `cargo check -p tenferro-linalg` passes
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)