### PR TITLE
feat(linalg): add prims dep + SVD rrule skeleton

### DIFF
--- a/tenferro-linalg/Cargo.toml
+++ b/tenferro-linalg/Cargo.toml
@@ -9,5 +9,6 @@ publish = false
 [dependencies]
 tenferro-device = { path = "../tenferro-device" }
 tenferro-algebra = { path = "../tenferro-algebra" }
+tenferro-prims = { path = "../tenferro-prims" }
 tenferro-tensor = { path = "../tenferro-tensor" }
 chainrules-core = { path = "../extern/chainrules-core" }

--- a/tenferro-linalg/src/lib.rs
+++ b/tenferro-linalg/src/lib.rs
@@ -114,6 +114,7 @@
 use chainrules_core::AdResult;
 use tenferro_algebra::Scalar;
 use tenferro_device::Result;
+use tenferro_prims::UnaryOp;
 use tenferro_tensor::Tensor;
 
 // ============================================================================
@@ -490,7 +491,45 @@ pub fn svd_rrule<T: Scalar>(
     _cotangent: &SvdCotangent<T>,
     _options: Option<&SvdOptions>,
 ) -> AdResult<Tensor<T>> {
-    todo!()
+    // SVD reverse-mode AD (Mathieu 2019).
+    //
+    // Given: A = U · diag(S) · Vt, with cotangents dU, dS, dVt.
+    //
+    // Algorithm (all operations batched over `*` dims):
+    //
+    // 1. Forward pass: (U, S, Vt) = svd(A)
+    //    → Already computed by the caller; recompute or cache as needed.
+    //
+    // 2. Build F-matrix: F_ij = 1/(σ_j² - σ_i²) for i≠j, 0 for i=j.
+    //    Ops: ElementwiseMul(S, S) → S², broadcast, subtract, Reciprocal,
+    //         zero diagonal.
+    //    Prims used: ElementwiseMul, ElementwiseUnary(Reciprocal).
+    //
+    // 3. Compute Ut·dU (k×k batched):
+    //    Ops: BatchedGemm(Ut, dU)
+    //    Prims used: BatchedGemm.
+    //
+    // 4. Symmetrize: M = Ut·dU - (Ut·dU)^T via permute.
+    //    Ops: permute (zero-copy), alpha/beta subtraction.
+    //    Prims used: Permute (metadata only), BatchedGemm with beta=-1.
+    //
+    // 5. Hadamard product: F ⊙ M
+    //    Prims used: ElementwiseMul.
+    //
+    // 6. Add diagonal dS: F⊙M + diag(dS)
+    //    Prims used: AntiTrace (embed 1D → diagonal of 2D).
+    //
+    // 7. Assemble: dA = U · (F⊙M + diag(dS)) · Vt
+    //    Prims used: BatchedGemm (two multiplications).
+    //
+    // 8. (Full-rank case, m > n) Add projector term:
+    //    dA += (I - U·Ut) · dU · diag(1/S) · Vt
+    //    Prims used: eye, BatchedGemm, ElementwiseUnary(Reciprocal).
+
+    // Suppress unused import warning in skeleton.
+    let _ = UnaryOp::Reciprocal;
+
+    todo!("SVD rrule: implement steps 1-8 using tenferro-prims operations")
 }
 
 /// Reverse-mode AD rule for QR (VJP / pullback).


### PR DESCRIPTION
## Summary
- Add `tenferro-prims` as dependency of `tenferro-linalg` so AD rules can compose prims operations
- Replace `svd_rrule` `todo!()` with documented algorithm structure (Mathieu 2019) showing how each step maps to prims operations (BatchedGemm, ElementwiseMul, ElementwiseUnary(Reciprocal), AntiTrace, Permute, eye)

Closes #33

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)