### PR TITLE
chore: centralize strided deps and add device API example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ resolver = "2"
 num-complex = "0.4"
 num-traits = "0.2"
 thiserror = "2"
+strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "7aa260c68607b5706b9ee552ff51e38005adc7a9" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "7aa260c68607b5706b9ee552ff51e38005adc7a9" }

--- a/extension/tenferro-tropical/Cargo.toml
+++ b/extension/tenferro-tropical/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 tenferro-device = { path = "../../tenferro-device" }
 tenferro-algebra = { path = "../../tenferro-algebra" }
 tenferro-prims = { path = "../../tenferro-prims" }
-strided-view = { git = "https://github.com/tensor4all/strided-rs" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs" }
+strided-view.workspace = true
+strided-traits.workspace = true
 num-traits = { workspace = true }

--- a/tenferro-device/src/lib.rs
+++ b/tenferro-device/src/lib.rs
@@ -122,6 +122,22 @@ pub enum OpKind {
 ///
 /// Returns [`Error::NoCompatibleComputeDevice`] if no compute device can
 /// execute the given operation on the specified memory space.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_device::{
+///     preferred_compute_devices, ComputeDevice, LogicalMemorySpace, OpKind,
+/// };
+///
+/// let devices = preferred_compute_devices(
+///     LogicalMemorySpace::MainMemory,
+///     OpKind::BatchedGemm,
+/// ).unwrap();
+///
+/// // Typically includes CPU for main memory workloads.
+/// assert!(devices.contains(&ComputeDevice::Cpu { device_id: 0 }));
+/// ```
 pub fn preferred_compute_devices(
     _space: LogicalMemorySpace,
     _op_kind: OpKind,

--- a/tenferro-prims/Cargo.toml
+++ b/tenferro-prims/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 [dependencies]
 tenferro-device = { path = "../tenferro-device" }
 tenferro-algebra = { path = "../tenferro-algebra" }
-strided-view = { git = "https://github.com/tensor4all/strided-rs" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs" }
+strided-view.workspace = true
+strided-traits.workspace = true


### PR DESCRIPTION
## Summary
- move `strided-view` and `strided-traits` to workspace dependencies
- pin `strided-rs` git dependencies to commit `7aa260c68607b5706b9ee552ff51e38005adc7a9`
- switch crate manifests to `workspace = true` for these deps
- add `# Examples` doc section to `preferred_compute_devices`

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace`

Generated with [Claude Code](https://claude.com/claude-code)
