### PR TITLE
fix: update broken links to deleted tenferro_design.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Built on top of [strided-rs](https://github.com/tensor4all/strided-rs) for cache
 
 See [`docs/design/`](docs/design/) for architecture and design documents, including:
 
-- [Unified Tensor Backend Design](docs/design/tenferro_unified_tensor_backend.md) — high-level architecture, crate structure, roadmap
-- [tenferro Design](docs/design/tenferro_design.md) — detailed per-crate API designs
-- [libtorch Reference](docs/design/libtorch_reference.md) — PyTorch feature survey for design reference
+- [Architecture](docs/design/architecture.md) — workspace layers, crate dependency graph, device layer
+- [Design Documents](docs/design/README.md) — per-crate API designs (tensor, prims, einsum, algebra, autodiff, etc.)
 
 ## Documentation
 

--- a/docs/api_index.md
+++ b/docs/api_index.md
@@ -9,7 +9,7 @@ and automatic differentiation.
 in place; most function bodies use `todo!()`. The purpose of this phase is to
 validate the API design before writing implementations.
 
-See the [design document](https://github.com/tensor4all/tenferro-rs/blob/main/docs/design/tenferro_design.md)
+See the [design documents](https://github.com/tensor4all/tenferro-rs/blob/main/docs/design/README.md)
 for architecture, API design, and future phase plans.
 
 ## Workspace Architecture

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -167,7 +167,7 @@ cat <<'TOPPAGE' >"$OUT_DIR/index.html"
         <section class="card">
           <h2>Detailed Design (MD)</h2>
           <p>Canonical design document on GitHub.</p>
-          <a href="https://github.com/tensor4all/tenferro-rs/blob/main/docs/design/tenferro_design.md">Open tenferro_design.md</a>
+          <a href="https://github.com/tensor4all/tenferro-rs/blob/main/docs/design/README.md">Open design documents</a>
         </section>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- Fix 3 broken links to `docs/design/tenferro_design.md` (deleted in fb60cf6 restructuring)
- `README.md`: update design doc links to `architecture.md` and `docs/design/README.md`
- `docs/api_index.md`: update link to `docs/design/README.md`
- `scripts/build_docs_site.sh`: update link in generated HTML

## Test plan
- [x] Verify new links resolve correctly on GitHub
- [x] No code changes

Generated with [Claude Code](https://claude.com/claude-code)