### PR TITLE
docs: rename Hip → Rocm in design docs

### DIFF
--- a/docs/api_index.md
+++ b/docs/api_index.md
@@ -123,7 +123,7 @@ minimum element type requirements. `Conjugate` trait for complex conjugation
 ### [tenferro-device](tenferro_device/index.html) <small>(Shared)</small>
 
 Shared infrastructure: `LogicalMemorySpace` (MainMemory, GpuMemory),
-`ComputeDevice` (Cpu, Cuda, Hip), workspace-wide `Error`/`Result` types.
+`ComputeDevice` (Cpu, Cuda, Rocm), workspace-wide `Error`/`Result` types.
 
 ## External Crates (extern/)
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -77,7 +77,7 @@ pub enum LogicalMemorySpace {
 pub enum ComputeDevice {
     Cpu { device_id: usize },
     Cuda { device_id: usize },
-    Hip { device_id: usize },
+    Rocm { device_id: usize },
 }
 
 /// Operation kind used for capability filtering.


### PR DESCRIPTION
## Summary

- `architecture.md`: `ComputeDevice::Hip` → `ComputeDevice::Rocm`
- `api_index.md`: `(Cpu, Cuda, Hip)` → `(Cpu, Cuda, Rocm)`
- Plan docs under `docs/plans/` are historical and left unchanged

Closes #45

## Test plan

- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)