### PR TITLE
docs: add linalg.md design doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ tenferro-rs depends on strided-rs but does not absorb it. strided-rs has no BLAS
 
 See [`docs/design/`](docs/design/) for architecture and design documents.
 
+**Note**: Files under `docs/plans/` are historical records of past design discussions and decisions. They may contradict the current API or design — do not update them to match the current state.
+
 ## Code Style
 
 - `cargo fmt --all` for formatting (always run before committing)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -11,6 +11,7 @@
 | [tensor.md](./tensor.md) | `Tensor<T>`, `TensorView`, ownership model, async `CompletionEvent` |
 | [algebra.md](./algebra.md) | `HasAlgebra`, `Semiring`, tropical and user-defined algebra extensibility |
 | [autodiff.md](./autodiff.md) | `chainrules-core`/`chainrules` AD architecture, linalg AD rules, SVD rrule |
+| [linalg.md](./linalg.md) | `tenferro-linalg` decompositions, solvers, utilities, stateless AD rules |
 | [testing.md](./testing.md) | Testing strategy, linalg test cases ([JSON](../../tenferro-linalg/tests/data/linalg_cases.json)), gradient check method |
 
 ## Reference

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -15,6 +15,7 @@ Per-crate API details are in companion documents:
 [tensor](./tensor.md),
 [algebra](./algebra.md),
 [autodiff](./autodiff.md),
+[linalg](./linalg.md),
 [contraction-pipeline](./contraction-pipeline.md).
 
 ## Layered Architecture

--- a/docs/design/linalg.md
+++ b/docs/design/linalg.md
@@ -1,0 +1,317 @@
+# Linear Algebra
+
+Batched matrix decompositions and solvers with stateless AD rules.
+
+---
+
+## Position in Workspace Architecture
+
+`tenferro-linalg` sits at Layer 4, alongside `tenferro-einsum`:
+
+```
+Layer 4: tenferro-einsum   — N-ary einsum + einsum AD
+         tenferro-linalg   — SVD/QR/LU/eigen + linalg AD ← this crate
+Layer 3: tenferro-prims    — TensorPrims<A> trait
+Layer 2: tenferro-tensor   — Tensor<T>, view ops
+```
+
+Dependencies: `tenferro-device`, `tenferro-algebra`, `tenferro-prims`,
+`tenferro-tensor`, `chainrules-core`.
+
+Note: depends on `chainrules-core` (traits only), **not** full `chainrules`
+(engine). This crate provides stateless AD rules — it never creates tapes
+or tracked tensors.
+
+---
+
+## Dimension Convention
+
+**First 2 dimensions = matrix, remaining = batch.**
+
+```
+Input shape: (m, n, *)
+             ├──┘  └──── batch dimensions (independent problems)
+             matrix
+```
+
+This is the column-major counterpart to PyTorch's `(*, m, n)`: in col-major
+layout the first dimensions are contiguous, so placing the matrix there
+lets LAPACK/cuSOLVER operate without transposition.
+
+**Requirement**: all inputs must be column-major contiguous.
+
+For arbitrary tensor decomposition (e.g., SVD along legs [0,1] vs [2,3]),
+the caller performs `permute` + `reshape` + `contiguous(ColumnMajor)` before
+calling linalg functions. This is **not** linalg's responsibility — linalg
+operates on matrices only.
+
+---
+
+## Operations
+
+### Decompositions
+
+| Function | Input shape | Result type | Description |
+|----------|-------------|-------------|-------------|
+| `svd` | `(m, n, *)` | `SvdResult { u, s, vt }` | `A = U diag(S) Vt`, optional truncation via `SvdOptions` |
+| `qr` | `(m, n, *)` | `QrResult { q, r }` | `A = QR`, thin QR |
+| `lu` | `(m, n, *)` | `LuResult { p, l, u }` | `A = PLU`, with `LuPivot` strategy |
+| `cholesky` | `(n, n, *)` | `Tensor<T>` | `A = LLᴴ`, returns lower triangular L |
+| `eigen` | `(n, n, *)` | `EigenResult { values, vectors }` | Symmetric/Hermitian eigendecomposition |
+| `eig` | `(n, n, *)` | `EigenResult { values, vectors }` | General (non-symmetric) eigendecomposition |
+
+### Solvers
+
+| Function | Inputs | Output | Description |
+|----------|--------|--------|-------------|
+| `solve` | `A: (n,n,*)`, `b: (n,*)` or `(n,k,*)` | `Tensor<T>` | General square system `Ax = b` |
+| `solve_triangular` | `A: (n,n,*)`, `b: (n,*)`, `upper: bool` | `Tensor<T>` | Triangular system |
+| `lstsq` | `A: (m,n,*)`, `b: (m,*)` | `LstsqResult { x, residual }` | Least squares `argmin \|\|Ax-b\|\|²` (m >= n) |
+
+### Utilities
+
+| Function | Input shape | Output | Description |
+|----------|-------------|--------|-------------|
+| `inv` | `(n, n, *)` | `Tensor<T>` | Matrix inverse |
+| `det` | `(n, n, *)` | `Tensor<T>` shape `(*)` | Determinant |
+| `slogdet` | `(n, n, *)` | `SlogdetResult { sign, logabsdet }` | Numerically stable log-determinant |
+| `pinv` | `(m, n, *)` | `Tensor<T>` | Moore-Penrose pseudoinverse (SVD-based) |
+| `matrix_exp` | `(n, n, *)` | `Tensor<T>` | Matrix exponential exp(A) |
+| `norm` | `(m, n, *)` or `(n, *)` | `Tensor<T>` | Matrix/vector norm (`NormKind`) |
+
+---
+
+## Result Types
+
+Structured result types avoid positional return confusion:
+
+```rust
+pub struct SvdResult<T: Scalar> {
+    pub u: Tensor<T>,   // (m, k, *)
+    pub s: Tensor<T>,   // (k, *)
+    pub vt: Tensor<T>,  // (k, n, *)
+}
+
+pub struct QrResult<T: Scalar> {
+    pub q: Tensor<T>,   // (m, k, *)
+    pub r: Tensor<T>,   // (k, n, *)
+}
+
+pub struct LuResult<T: Scalar> {
+    pub p: Option<Vec<usize>>,  // None when NoPivot
+    pub l: Tensor<T>,           // (m, k, *)
+    pub u: Tensor<T>,           // (k, n, *)
+}
+
+pub struct EigenResult<T: Scalar> {
+    pub values: Tensor<T>,   // (n, *)
+    pub vectors: Tensor<T>,  // (n, n, *)
+}
+
+pub struct SlogdetResult<T: Scalar> {
+    pub sign: Tensor<T>,       // (*)
+    pub logabsdet: Tensor<T>,  // (*)
+}
+
+pub struct LstsqResult<T: Scalar> {
+    pub x: Tensor<T>,        // (n, *)
+    pub residual: Tensor<T>, // (m, *)
+}
+```
+
+Where `k = min(m, n)`.
+
+---
+
+## Options and Configuration
+
+### SVD Truncation
+
+```rust
+pub struct SvdOptions {
+    pub max_rank: Option<usize>,  // cap number of singular values
+    pub cutoff: Option<f64>,      // discard below threshold
+}
+```
+
+When both are set, the more restrictive constraint applies.
+
+### LU Pivoting
+
+```rust
+pub enum LuPivot {
+    Partial,   // row pivoting (default, stable)
+    NoPivot,   // no pivoting (faster, unstable)
+}
+```
+
+### Norm Kind
+
+```rust
+pub enum NormKind {
+    Fro,         // Frobenius / L2
+    Nuclear,     // sum of singular values
+    Spectral,    // largest singular value
+    L1,          // max abs column sum / sum abs
+    Inf,         // max abs row sum / max abs
+    Lp(f64),     // general Lp (vectors only)
+}
+```
+
+---
+
+## AD Rules
+
+All AD rules are **stateless free functions** — no `tracked_*` / `dual_*`
+wrappers. The chainrules tape engine composes `permute_backward` +
+`reshape_backward` + `svd_rrule` etc. via the standard chain rule
+automatically.
+
+### Cotangent Types
+
+Structured cotangent types with `Option` fields allow partial gradient
+computation (e.g., gradient only through singular values):
+
+```rust
+pub struct SvdCotangent<T: Scalar> {
+    pub u: Option<Tensor<T>>,
+    pub s: Option<Tensor<T>>,
+    pub vt: Option<Tensor<T>>,
+}
+
+pub struct QrCotangent<T: Scalar> {
+    pub q: Option<Tensor<T>>,
+    pub r: Option<Tensor<T>>,
+}
+
+pub struct LuCotangent<T: Scalar> {
+    pub l: Option<Tensor<T>>,
+    pub u: Option<Tensor<T>>,
+}
+
+pub struct EigenCotangent<T: Scalar> {
+    pub values: Option<Tensor<T>>,
+    pub vectors: Option<Tensor<T>>,
+}
+
+pub struct SlogdetCotangent<T: Scalar> {
+    pub logabsdet: Option<Tensor<T>>,
+    // sign is piecewise constant, not differentiable
+}
+```
+
+Gradient types for multi-input operations:
+
+```rust
+pub struct SolveGrad<T: Scalar> {
+    pub a: Tensor<T>,
+    pub b: Tensor<T>,
+}
+
+pub struct LstsqGrad<T: Scalar> {
+    pub a: Tensor<T>,
+    pub b: Tensor<T>,
+}
+```
+
+### rrule Functions (Reverse-Mode / VJP)
+
+| Function | Signature (abbreviated) |
+|----------|------------------------|
+| `svd_rrule` | `(tensor, cotangent: &SvdCotangent, options) -> AdResult<Tensor>` |
+| `qr_rrule` | `(tensor, cotangent: &QrCotangent) -> AdResult<Tensor>` |
+| `lu_rrule` | `(tensor, cotangent: &LuCotangent, pivot) -> AdResult<Tensor>` |
+| `eigen_rrule` | `(tensor, cotangent: &EigenCotangent) -> AdResult<Tensor>` |
+| `eig_rrule` | `(tensor, cotangent: &EigenCotangent) -> AdResult<Tensor>` |
+| `lstsq_rrule` | `(a, b, cotangent) -> AdResult<LstsqGrad>` |
+| `cholesky_rrule` | `(tensor, cotangent) -> AdResult<Tensor>` |
+| `solve_rrule` | `(a, b, cotangent) -> AdResult<SolveGrad>` |
+| `inv_rrule` | `(tensor, cotangent) -> AdResult<Tensor>` |
+| `det_rrule` | `(tensor, cotangent) -> AdResult<Tensor>` |
+| `slogdet_rrule` | `(tensor, cotangent: &SlogdetCotangent) -> AdResult<Tensor>` |
+| `pinv_rrule` | `(tensor, cotangent, rcond) -> AdResult<Tensor>` |
+| `matrix_exp_rrule` | `(tensor, cotangent) -> AdResult<Tensor>` |
+| `norm_rrule` | `(tensor, cotangent, kind) -> AdResult<Tensor>` |
+
+### frule Functions (Forward-Mode / JVP)
+
+| Function | Signature (abbreviated) |
+|----------|------------------------|
+| `svd_frule` | `(tensor, tangent, options) -> AdResult<(SvdResult, SvdResult)>` |
+| `qr_frule` | `(tensor, tangent) -> AdResult<(QrResult, QrResult)>` |
+| `lu_frule` | `(tensor, tangent, pivot) -> AdResult<(LuResult, LuResult)>` |
+| `eigen_frule` | `(tensor, tangent) -> AdResult<(EigenResult, EigenResult)>` |
+| `eig_frule` | `(tensor, tangent) -> AdResult<(EigenResult, EigenResult)>` |
+| `lstsq_frule` | `(a, b, tangent_a, tangent_b) -> AdResult<(LstsqResult, LstsqResult)>` |
+| `cholesky_frule` | `(tensor, tangent) -> AdResult<(Tensor, Tensor)>` |
+| `solve_frule` | `(a, b, tangent_a, tangent_b) -> AdResult<(Tensor, Tensor)>` |
+| `inv_frule` | `(tensor, tangent) -> AdResult<(Tensor, Tensor)>` |
+| `det_frule` | `(tensor, tangent) -> AdResult<(Tensor, Tensor)>` |
+| `slogdet_frule` | `(tensor, tangent) -> AdResult<(SlogdetResult, SlogdetResult)>` |
+| `eig_frule` | `(tensor, tangent) -> AdResult<(EigenResult, EigenResult)>` |
+| `pinv_frule` | `(tensor, tangent, rcond) -> AdResult<(Tensor, Tensor)>` |
+| `matrix_exp_frule` | `(tensor, tangent) -> AdResult<(Tensor, Tensor)>` |
+| `norm_frule` | `(tensor, tangent, kind) -> AdResult<(Tensor, Tensor)>` |
+
+frule return type convention: `(primal_result, tangent_result)` with the
+same type for both.
+
+### Key AD Formulas
+
+**SVD rrule** (Mathieu 2019): see [autodiff.md](./autodiff.md) for the
+8-step algorithm. All steps use `tenferro-prims` operations (BatchedGemm,
+ElementwiseMul, ElementwiseUnary, Permute, AntiTrace) plus tensor-level
+additions (eye, tril/triu).
+
+**inv rrule**: `dA = -A⁻ᴴ cotangent A⁻ᴴ`
+
+**det rrule**: `dA = det(A) cotangent A⁻ᵀ`
+
+**slogdet rrule**: `dA = cotangent_logabsdet A⁻ᵀ`
+
+**solve rrule** (Ax = b): `db = A⁻ᵀ cotangent`, `dA = -db xᵀ`
+
+---
+
+## Backend Mapping
+
+```
+tenferro-linalg functions
+    │
+    ├── CPU: matricize → faer (dsyev/dgesdd/dgeqrf/dgetrf/dpotrf) → unmatricize
+    │
+    └── GPU: matricize → cuSOLVER (Xgesvd/Xgeqrf/Xgetrf/Xpotrf) → unmatricize
+```
+
+The linalg crate calls `tenferro-prims` operations for its AD formulas
+(BatchedGemm, ElementwiseMul, etc.) but calls external LAPACK/cuSOLVER
+directly for the forward decompositions (not through TensorPrims).
+
+---
+
+## Design Decisions
+
+1. **Matrix-only API.** Higher-level tensor decomposition (e.g., SVD along
+   arbitrary legs) belongs in application layers (TensorKit equivalent).
+   Linalg takes `(m, n, *)` matrices.
+
+2. **Stateless AD only.** No `tracked_*` wrappers — the chainrules tape
+   engine composes linalg AD rules with permute/reshape backward passes.
+   This avoids coupling linalg to the AD engine implementation.
+
+3. **Cotangent types with Option fields.** Enables partial gradient
+   computation (e.g., SVD gradient through `s` only is always numerically
+   stable, avoiding the F-matrix singularity issues that arise when
+   differentiating through `U`/`Vt` with degenerate singular values).
+
+4. **Column-major contiguous requirement.** Avoids hidden copies. If data
+   is row-major, the caller explicitly calls `contiguous(ColumnMajor)`.
+
+5. **chainrules-core dependency, not chainrules.** Linalg only uses
+   `AdResult` from chainrules-core. It never creates tapes or tracked
+   tensors, so the full engine is unnecessary.
+
+6. **tenferro-prims dependency.** AD formulas use TensorPrims operations
+   (BatchedGemm, ElementwiseMul, ElementwiseUnary, Permute, AntiTrace).
+   The `UnaryOp` enum (`Reciprocal`, `Sqrt`, etc.) was added to
+   tenferro-prims specifically for linalg AD needs.


### PR DESCRIPTION
## Summary
- Add `docs/design/linalg.md` covering the full `tenferro-linalg` API: dimension convention, 15 operations (decompositions/solvers/utilities), result/option/cotangent types, stateless AD rules (rrule/frule), backend mapping, and design decisions
- Add note to AGENTS.md that `docs/plans/` files are historical records
- Link linalg.md from architecture.md and design README

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)