### PR TITLE
docs: fill remaining design doc gaps (#60, #61, #62)

### DIFF
--- a/docs/design/algebra.md
+++ b/docs/design/algebra.md
@@ -135,3 +135,49 @@ AD must remain algebra-aware:
   `TensorPrims<A>` rather than hard-coding only standard arithmetic.
 
 See [autodiff.md](./autodiff.md) for the full AD architecture.
+
+---
+
+## Migration Checklist
+
+Steps for migrating to the typed algebra model consistently across the workspace.
+Work through these in order; each step unblocks the next.
+
+1. **Each algebra type must carry its scalar via `Semiring::Scalar`.**
+   - `Standard<T>` already does this. Any new algebra must define `type Scalar = …`
+     in its `Semiring` impl — not a free `T` parameter on the impl itself.
+   - Verify: `grep -r "impl Semiring"` — every impl must have an explicit
+     `type Scalar` associated type, not a generic `T` that floats free.
+
+2. **`HasAlgebra` impls map scalar types to their typed algebra.**
+   - Add `impl HasAlgebra for MyScalar { type Algebra = MyAlgebra; }` in the
+     crate that owns `MyScalar`. This is the only place `HasAlgebra` belongs;
+     do not add redundant impls elsewhere.
+   - `HasAlgebra` is UX sugar only — the algebra `A` is the source of truth.
+     Code that needs the algebra explicitly should accept `A: Semiring`, not
+     `T: HasAlgebra`.
+
+3. **`TensorPrims<A>` impls must be parameterized by the typed algebra `A`.**
+   - Signature: `impl TensorPrims<MyAlgebra> for CpuBackend { … }`
+   - The scalar type inside the impl is `<MyAlgebra as Semiring>::Scalar`,
+     not a free `T`. Use `A::Scalar` in method bodies instead of bare `T`.
+
+4. **Einsum and linalg functions use `A: Semiring` bounds for algebra-generic code.**
+   - Replace any `T: Scalar + HasAlgebra` bound with `A: Semiring` where the
+     function needs to be algebra-generic.
+   - Keep `T: HasAlgebra<Algebra = A>` on the public-facing thin wrapper so
+     callers do not have to spell out `A`.
+
+5. **Tropical algebras already carry their scalar via `Semiring::Scalar`.**
+   - `MaxPlus<T>`, `MinPlus<T>`, etc. define `type Scalar = T` in their
+     `Semiring` impls. No special case needed.
+   - Confirm tropical `HasAlgebra` impls are in `tenferro-tropical`, not in
+     `tenferro-algebra`. Tropical types must not leak into the algebra core.
+
+6. **Future: tighten `TensorPrims<A>` method signatures to use `A::Scalar`.**
+   - Currently `plan<T: ScalarBase>` and `execute<T: ScalarBase>` use a free
+     `T` unconstrained relative to `A`. A future tightening would add
+     `where T: ScalarBase, A: Semiring<Scalar = T>` (or remove the free `T`
+     and use `A::Scalar` directly).
+   - Do not make this change until all existing impls are migrated to step 3,
+     to avoid a large simultaneous diff.

--- a/docs/design/autodiff.md
+++ b/docs/design/autodiff.md
@@ -166,10 +166,32 @@ not create tapes or tracked tensors.
 
 AD must remain algebra-aware:
 
-- Standard arithmetic: direct rrule/frule formulas over `+/*`.
-- Tropical algebra (`tenferro-tropical`): may need algebra-specific state
-  (e.g., argmax path information for max-plus variants).
-- API design relies on `HasAlgebra` and `TensorPrims<A>` for extensibility.
+- **Standard arithmetic** (`Standard<T>`): direct rrule/frule formulas over
+  `+/*`. The algebra type `A = Standard<T>` determines which primitive
+  operations are available (e.g., cuTENSOR-backed `TensorPrims<Standard<T>>`).
+- **Tropical algebra** (`tenferro-tropical`): requires algebra-specific state
+  during the backward pass. For max-plus/min-plus einsum, the rrule must track
+  argmax indices — the positions of the winning elements that achieved the
+  tropical sum. These indices are not computable from the output alone and must
+  be saved during the forward pass.
+
+  **GPU tropical AD note:** On GPU, tropical backward requires argmax-capable
+  custom kernels that are distinct from cuTENSOR/hipTensor primitives. cuTENSOR
+  operates on ring algebras (multiply-add); it has no native support for
+  max-plus argmax index tracking. A GPU tropical backward pass therefore
+  requires a separately implemented custom kernel (e.g., via CUDA/HIP or a
+  vendor-agnostic compute shader). This is a non-trivial infrastructure
+  requirement and must be planned separately from standard einsum GPU support.
+
+**Role of `HasAlgebra` and `TensorPrims<A>`:**
+
+- `HasAlgebra` (on `Tensor<T>`) is an **inference convenience trait** — it
+  allows the compiler to infer `A` from `T` for the common case, avoiding
+  explicit algebra type annotations at call sites.
+- The AD math and rule contracts (rrule/frule signatures, cotangent types)
+  depend on the algebra type `A` directly. `HasAlgebra` does not affect
+  correctness; it only reduces boilerplate for users who do not need a custom
+  algebra.
 
 See [algebra.md](./algebra.md) for the algebra system design.
 

--- a/docs/design/einsum-cpu-porting-notes.md
+++ b/docs/design/einsum-cpu-porting-notes.md
@@ -5,6 +5,13 @@ This document details how the einsum CPU implementation is structured in
 
 **Purpose**: Detect potential problems before implementation begins.
 
+See [tensor-prims.md](./tensor-prims.md) for the canonical `TensorPrims<A>`
+trait definition, `PrimDescriptor` enum, `PlanCache` key policy, and the
+`CpuBackend` / `CpuContext` type definitions referenced throughout this
+document. See [gpu-backend-design.md](./gpu-backend-design.md) for the
+GPU-specific plan lifecycle, stride-sensitive cache key policy, and the
+tropical GPU kernel integration plan.
+
 ## Reference Implementations
 
 The algorithms in `strided-einsum2`, `strided-opteinsum`, and `omeinsum-rs`
@@ -94,7 +101,8 @@ for i in 0..I {
 
 No dependency on strided-einsum2, Contract, or any einsum-level logic.
 GPU backends may compose these via `Contract(eye, ∂C)` using
-cuTENSOR/hipTENSOR — see `gpu-backend-design.md`.
+cuTENSOR/hipTENSOR — see
+[gpu-backend-design.md](./gpu-backend-design.md).
 
 ### Type Adaptation
 
@@ -120,7 +128,7 @@ In CpuBackend, convert to strided-view's `Conj` op when building
 
 On GPU, cuTENSOR supports `CUTENSOR_OP_CONJ` in tensor descriptors for
 lazy conjugation. Standalone `Tensor::conj()` requires CPU transfer for
-GPU tensors. See `gpu-backend-design.md` G11.
+GPU tensors. See [gpu-backend-design.md](./gpu-backend-design.md) G11.
 
 **Algebra parameterization**: strided-einsum2 has no algebra concept.
 `TensorPrims<A>` is parameterized by algebra `A`.  For `Standard<S>` algebra,
@@ -228,13 +236,151 @@ trait).
 | ~~P4~~ | ~~Thread-local buffer pool~~ | — | ~~Merged into P6~~ → Removed (global allocator) |
 | P5 | Algebra-specific dispatch (tropical, etc.) | Medium | `Standard<S>` → faer/blas.  Non-`Standard<S>` → naive fallback.  Dispatch on `A: Semiring` bounds |
 | ~~P6~~ | ~~Unified BufferPool~~ | — | **Removed**: Global allocator (mimalloc/jemalloc) handles intermediate buffer reuse. No custom pool needed for CPU. GPU device-memory pool is separate |
-| **P7** | **single_tensor_einsum via prims** | **Medium** | Route all steps (diag, trace, permute, broadcast, anti-diag) through `TensorPrims`.  Cache plans in `CpuContext.PlanCache` keyed by `(PrimDescriptor, shapes)` to avoid repeated plan generation |
-| **P8** | **Parenthesized tree notation** | **Medium** | Support parenthesized contraction order in parser.  Parser returns `Subscripts` + `Option<ContractionTree>`.  POC skeleton needs update |
-| **P9** | **Generative output (size_dict)** | **Medium** | Support `size_dict` for output labels not present in inputs.  Add parameter to tenferro-einsum public API.  POC skeleton needs update |
-| P10 | omeco dependency | Low | Add to workspace dependencies |
-| **P11** | **Explicit context passing in einsum API** | **High** | All einsum functions gain `ctx: &mut B::Context` and `B: TensorPrims<A>` type parameter.  Follows Rust idiom (explicit `&mut`, no global state).  All 9 einsum functions + AD functions need signature changes.  See revised signatures below |
-| **P12** | **strided-einsum2 / omeinsum-rs deprecation** | — | Both deprecated. Algorithms are reference material, not dependencies. tenferro-prims and tenferro-einsum contain self-contained implementations |
-| P13 | AntiTrace/AntiDiag CPU implementation | Low | Simple loops (scatter-add / write-to-diagonal). No dependency on strided-einsum2 or Contract. GPU uses Contract(eye, ∂C) composition |
+| **P7** | **single_tensor_einsum via prims** | **Medium** | See expanded entry below |
+| **P8** | **Parenthesized tree notation** | **Medium** | See expanded entry below |
+| **P9** | **Generative output (size_dict)** | **Medium** | See expanded entry below |
+| P10 | omeco dependency | Low | See expanded entry below |
+| **P11** | **Explicit context passing in einsum API** | **High** | See expanded entry below |
+| **P12** | **strided-einsum2 / omeinsum-rs deprecation** | — | See expanded entry below |
+| P13 | AntiTrace/AntiDiag CPU implementation | Low | See expanded entry below |
+
+---
+
+### P7: single_tensor_einsum via TensorPrims
+
+**Status**: Decided
+
+**Decision**: Route all steps of `single_tensor_einsum` (diag extraction,
+trace, permute, broadcast, anti-diag) through `TensorPrims::plan()` /
+`TensorPrims::execute()`. Cache plans in `CpuContext.plan_cache` keyed by
+`(PrimDescriptor variant + mode labels, concrete dimension sizes)` to avoid
+repeated plan generation on repeated calls with the same shapes. No direct
+calls to strided-kernel from the einsum layer.
+
+**Next action**: N/A — decision is recorded. Update `tenferro-prims/src/cpu.rs`
+and `tenferro-einsum/src/lib.rs` to implement accordingly when moving out of
+POC phase. Cache key policy details are in
+[tensor-prims.md](./tensor-prims.md) under "PlanCache".
+
+**Success condition**: `single_tensor_einsum` is implemented entirely via
+`TensorPrims` calls; no direct import of `strided-kernel` symbols from
+`tenferro-einsum`.
+
+---
+
+### P8: Parenthesized tree notation
+
+**Status**: Decided
+
+**Decision**: The einsum parser must support a parenthesized contraction-order
+notation (e.g., `"((ij,jk),kl)->il"`) in addition to the flat notation.
+`Subscripts::parse()` returns `Subscripts` + `Option<ContractionTree>`. When
+a parenthesized tree is present, `ContractionTree` is populated directly from
+the notation; otherwise the optimizer (`omeco`) generates the tree.
+
+**Next action**: Update `tenferro-einsum/src/parse.rs` (or equivalent)
+to handle parenthesized input. The POC `Subscripts::parse()` stub signature
+must be updated to return or accept an `Option<ContractionTree>` companion.
+
+**Success condition**: Round-trip test passes: `parse("((ij,jk),kl)->il")`
+produces a `ContractionTree` that encodes the `(ij,jk)` contraction before
+`kl`; flat notation `"ij,jk,kl->il"` falls back to optimizer.
+
+---
+
+### P9: Generative output (size_dict)
+
+**Status**: Decided
+
+**Decision**: Add an optional `size_dict: Option<&HashMap<char, usize>>`
+parameter to `einsum` and related public functions. This allows output index
+labels that do not appear in any input operand (e.g., zero-padding or
+broadcasting output dimensions). The parameter is `None` for the common case.
+
+**Next action**: Update signatures in `tenferro-einsum/src/lib.rs`. The POC
+stub for `einsum` must be updated to include the parameter. See also the
+revised signatures in P11 below.
+
+**Success condition**: `einsum` with a `size_dict` providing a dimension for
+an output-only label produces a correctly-shaped result tensor.
+
+---
+
+### P10: omeco dependency
+
+**Status**: Decided
+
+**Decision**: Add `omeco` to `[workspace.dependencies]` in the root
+`Cargo.toml`, then reference it with `omeco.workspace = true` in
+`tenferro-einsum/Cargo.toml`. `ContractionTree::optimize()` delegates to the
+omeco greedy optimizer.
+
+**Next action**: Add `omeco` entry to workspace `Cargo.toml` and to
+`tenferro-einsum/Cargo.toml`. Verify version compatibility.
+
+**Success condition**: `cargo build -p tenferro-einsum` succeeds with omeco as
+a dependency; `ContractionTree::optimize()` calls the omeco API without
+compilation errors.
+
+---
+
+### P11: Explicit context passing in einsum API
+
+**Status**: Decided
+
+**Decision**: All public einsum functions (9 variants + all AD functions) gain
+`ctx: &mut B::Context` and a `B: TensorPrims<A>` type parameter. This follows
+the Rust idiom of explicit ownership and mutability — no global/thread-local
+state. See "Revised einsum Signatures" subsection below for the exact
+before/after signatures.
+
+**Next action**: Update all 9 einsum function stubs + all AD function stubs in
+`tenferro-einsum/src/lib.rs`. The `TensorPrims<A>` trait is defined in
+[tensor-prims.md](./tensor-prims.md); implementations live in `tenferro-prims`.
+
+**Success condition**: `cargo check -p tenferro-einsum` passes with the new
+signatures; no einsum function remains with the old single-type-parameter form.
+
+---
+
+### P12: strided-einsum2 / omeinsum-rs deprecation
+
+**Status**: Decided
+
+**Decision**: Both crates are deprecated. Their algorithms serve as reference
+material only — tenferro-prims and tenferro-einsum contain self-contained
+re-implementations. No `Cargo.toml` dependency on either crate is added at
+any layer.
+
+**Next action**: N/A — decision is recorded. Ensure neither crate appears as a
+dependency in any `Cargo.toml` in this workspace. If algorithm questions arise
+during implementation, consult source of the reference crates directly.
+
+**Success condition**: `grep -r "strided-einsum2\|omeinsum-rs"
+Cargo.toml` (workspace and all crates) returns no results.
+
+---
+
+### P13: AntiTrace/AntiDiag CPU implementation
+
+**Status**: Decided
+
+**Decision**: Implement as simple loops on CPU (scatter-add for anti_trace,
+write-to-diagonal for anti_diag). No dependency on strided-einsum2 or on the
+`Contract` extended operation. GPU backends compose these via
+`Contract(eye(I), ∂C)` using cuTENSOR/hipTENSOR — see
+[gpu-backend-design.md](./gpu-backend-design.md) under "AntiTrace / AntiDiag
+GPU Implementation".
+
+**Next action**: N/A — decision is recorded. Implement the loop bodies in
+`tenferro-prims/src/cpu.rs` under `CpuBackend::execute()` for the
+`PrimDescriptor::AntiTrace` and `PrimDescriptor::AntiDiag` arms.
+
+**Success condition**: Unit tests for anti_trace and anti_diag pass on CPU;
+gradient correctness verified via finite-difference check for a `trace()`
+operation.
+
+---
 
 ### Revised einsum Signatures (P11)
 

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -6,6 +6,10 @@ both CUDA (cuTENSOR) and ROCm (hipTENSOR) backends.
 **Purpose**: Detect potential problems before implementation begins.
 Define the types, modules, and API mapping needed for GPU support.
 
+See [tensor-prims.md](./tensor-prims.md) for the `TensorPrims<A>` trait
+definition, `PrimDescriptor` enum, and the plan-cache key policy that
+applies to both CPU and GPU backends.
+
 ---
 
 ## Design Principles
@@ -309,6 +313,70 @@ standalone `conj()` で実データをコピーする場合は CPU 転送が必�
 | resolve_conj stubs | tenferro-prims/src/lib.rs | 各バックエンドに resolve_conj() 追加 |
 | UnaryOp::Conj | tenferro-prims/src/lib.rs | resolve_conj 用の新 UnaryOp variant |
 | prims → tensor dep | tenferro-prims/Cargo.toml | resolve_conj が Tensor<T> を扱うため |
+
+---
+
+## Tropical GPU Path: Custom Kernels
+
+cuTENSOR and hipTENSOR implement standard arithmetic only (`+`, `*`, `f32`,
+`f64`, complex). They have no mechanism for user-defined semiring operations
+such as `(max, +)` or `(max, ×)`. Tropical algebra GPU support therefore
+requires a **separate custom kernel path**, independent of the cuTENSOR path.
+
+### Boundary between the two paths
+
+| Algebra | GPU path | Library |
+|---------|----------|---------|
+| `Standard<f32/f64/Complex>` | cuTENSOR / hipTENSOR | dlopen at runtime |
+| `MaxPlus<T>`, `MinPlus<T>`, `MaxMul<T>` | custom kernels | separate integration target |
+| User-defined algebra | custom kernels (user-provided) | user crate |
+
+The `CudaBackend` / `RocmBackend` types implement `TensorPrims<Standard<S>>`
+only. They do not implement `TensorPrims<MaxPlus<S>>` or any other
+non-standard algebra — that would be a type error at compile time.
+
+### Tropical GPU implementation target
+
+For tropical argmax-capable GPU flows the integration target is a library
+such as `tropical-gemm-cuda` (or an equivalent CUDA/HIP kernel library).
+The expected integration shape is:
+
+```rust
+// tenferro-tropical (future GPU support)
+pub struct TropicalCudaBackend {
+    _lib: libloading::Library,   // tropical-gemm-cuda.so, loaded at runtime
+}
+
+impl TensorPrims<MaxPlus<f64>> for TropicalCudaBackend {
+    // delegates to tropical-gemm-cuda kernels, not cuTENSOR
+    fn has_extension_for<T: ScalarBase>(ext: Extension) -> bool { … }
+    …
+}
+```
+
+This backend lives in `tenferro-tropical`, not in `tenferro-prims`, preserving
+the same separation used for the CPU tropical path.
+
+### Argmax state for AD
+
+Tropical argmax-capable variants (e.g. max-plus Viterbi) need to store the
+argmax index tensor alongside the result so that the backward pass can
+reconstruct the gradient path. This is algebra-specific state that cuTENSOR
+cannot carry; it must be allocated and managed by the custom kernel. When
+designing the tropical GPU backend, the plan type must accommodate an optional
+argmax buffer:
+
+```rust
+enum TropicalCudaPlan<T: ScalarBase> {
+    Contract {
+        // argmax buffer allocated on GPU alongside the output
+        argmax_device_ptr: Option<*mut u64>,
+        …
+        _marker: PhantomData<T>,
+    },
+    …
+}
+```
 
 ---
 

--- a/docs/design/linalg.md
+++ b/docs/design/linalg.md
@@ -167,6 +167,14 @@ wrappers. The chainrules tape engine composes `permute_backward` +
 `reshape_backward` + `svd_rrule` etc. via the standard chain rule
 automatically.
 
+`tenferro-linalg` depends on **`chainrules-core` only** (not the full
+`chainrules` engine). It uses `AdResult` and the `Differentiable` trait from
+`chainrules-core`; it never creates tapes or `TrackedTensor` values. See
+[autodiff.md](./autodiff.md) for the overall AD crate split and the algebra
+interaction model. For how the algebra type `A` (e.g., `Standard<T>`) affects
+which backend primitives are dispatched during the AD formulas, see
+[algebra.md](./algebra.md).
+
 ### Cotangent Types
 
 Structured cotangent types with `Option` fields allow partial gradient

--- a/docs/design/tensor-prims.md
+++ b/docs/design/tensor-prims.md
@@ -345,11 +345,33 @@ pub struct PlanCache {
 Plan cache is stored in the Context (CpuContext, CudaContext, RocmContext).
 This is why `plan()` and `execute()` take `&mut Context`.
 
-**Cache key design** (to be finalized):
-- CPU: keyed by `(PrimDescriptor, shapes)` — strides are not part of the
-  key because CPU plans depend on shape, not layout
-- GPU: keyed by `(PrimDescriptor, shapes, strides)` — cuTENSOR plans are
-  stride-dependent (see gpu-backend-design.md G4)
+**Cache key policy** (decided):
+
+- **CPU** (`CpuBackend`): Key = `(PrimDescriptor variant, input shapes,
+  output shape)`. Strides are **not** included because `CpuPlan` records
+  the shape-derived loop structure; strides are resolved at `execute()`
+  time from the live `StridedView`. Concretely, the key must include:
+  - The `PrimDescriptor` discriminant (enum variant tag)
+  - All mode labels (`modes_a`, `modes_b`, `modes_c`) from the descriptor
+  - The concrete dimension value for each mode (i.e., the shapes of all
+    input and output tensors)
+  - For `BatchedGemm`: `(batch_dims, m, n, k)`
+  - For `Reduce`/`Trace`: the `ReduceOp` kind
+  - For `ElementwiseUnary`: the `UnaryOp` kind
+
+- **GPU** (`CudaBackend`, `RocmBackend`): Key = `(PrimDescriptor variant,
+  input shapes, output shape, input strides, output strides, scalar data
+  type)`. cuTENSOR/hipTENSOR plans encode memory layout into the plan
+  handle — a plan created for row-major input cannot be reused for
+  column-major input. Concretely, the key must include everything in the
+  CPU key **plus**:
+  - The stride vector for each input tensor
+  - The stride vector for the output tensor
+  - The scalar element type (e.g., `f32` vs `f64`), encoded as a
+    `cutensorDataType_t` / `hiptensorDataType_t` discriminant
+
+  See [gpu-backend-design.md](./gpu-backend-design.md) for the full GPU
+  plan lifecycle and the G4 problem entry.
 
 ---
 

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -236,6 +236,72 @@ Here `H` and `op` are random Hermitian (or symmetric) matrices, generated indepe
 - Degenerate singular/eigenvalues (stress test for `η` regularization)
 - frule (JVP) — BackwardsLinalg.jl only covers rrule
 
+---
+
+## AD Test Matrix
+
+Coverage targets for reverse-mode (rrule/VJP), forward-mode (frule/JVP), and
+Hessian-vector product (hvp) across all differentiable operations.
+
+**Test ownership:**
+
+- Unit tests for each rule live in the crate that owns the rule:
+  - `tenferro-einsum/tests/` — einsum AD tests
+  - `tenferro-linalg/tests/` — linalg AD tests
+  - `chainrules/tests/` — tape/tracking infrastructure tests
+- Workspace-level integration tests (in `tests/` at the workspace root) cover
+  cross-crate AD scenarios: e.g., an einsum followed by an SVD inside a single
+  tape, or C-API roundtrip correctness for AD.
+
+### Einsum AD
+
+| Operation | rrule | frule | hvp | Tropical-specific | Notes |
+|-----------|-------|-------|-----|-------------------|-------|
+| Matmul `ij,jk->ik` (Standard) | planned | planned | planned | — | Finite-diff + hand-computed |
+| Trace `ii->` (Standard) | planned | planned | — | — | Gradient = identity diagonal |
+| Sum `ij->` (Standard) | planned | planned | — | — | Gradient = all-ones |
+| Transpose `ij->ji` (Standard) | planned | planned | — | — | |
+| 3-tensor chain (Standard) | planned | planned | planned | — | Full chain rule |
+| MaxPlus matmul (tropical) | planned | — | — | argmax route | Sparse gradient via argmax; GPU requires custom kernel |
+| MinPlus matmul (tropical) | planned | — | — | argmax route | Same kernel requirement as MaxPlus |
+| MaxPlus chain (tropical) | planned | — | — | argmax route | Gradient sparsity increases with chain length |
+
+Notes:
+- frule for tropical einsum is not planned: tropical algebra has no
+  meaningful JVP (the `max` operation is not differentiable in the usual sense).
+- hvp for tropical einsum is not planned for the same reason.
+- argmax route testing may require a custom kernel infrastructure separate from
+  cuTENSOR/hipTensor; CPU-only tests can run with the reference kernel.
+
+### Linalg AD
+
+| Operation | rrule | frule | hvp | Tropical-specific | Notes |
+|-----------|-------|-------|-----|-------------------|-------|
+| SVD | planned | planned | — | — | Finite-diff gradient check per cotangent branch |
+| QR | planned | planned | — | — | Joint dQ+dR; phase freedom handled by reconstruction |
+| LU | planned | planned | — | — | dL, dU, joint dL+dU branches |
+| Eigen (symmetric) | planned | planned | — | — | dE only, dU only |
+| Cholesky | planned | planned | — | — | |
+| `solve` / `lstsq` | planned | planned | — | — | dA and db branches isolated |
+| `inv` | planned | planned | — | — | |
+| `det` / `slogdet` | planned | planned | — | — | |
+| `pinv` | planned | — | — | — | SVD-based; frule deferred |
+| `matrix_exp` | planned | — | — | — | Complex frule; deferred |
+| `norm` | planned | planned | — | — | Fro and L2 norms first |
+
+Notes:
+- hvp for linalg operations is not planned in the POC phase. Second-order
+  differentiation through linalg (e.g., SVD Hessians) is mathematically
+  complex and deferred.
+- All linalg AD tests use the finite-difference gradient check method
+  documented above (ported from BackwardsLinalg.jl). frule tests additionally
+  verify the JVP–VJP consistency identity: `⟨cotangent, frule(tangent)⟩ = ⟨rrule(cotangent), tangent⟩`.
+- `tenferro-linalg` AD rules depend only on `chainrules-core` (not the full
+  `chainrules` engine); test infrastructure must not require a tape to call
+  `svd_rrule` etc. directly.
+
+---
+
 ### chainrules-core / chainrules
 
 - Tape: leaf registration, pullback execution


### PR DESCRIPTION
## Summary
- **#60**: Add migration checklist to algebra.md; add tropical GPU custom-kernel section to gpu-backend-design.md
- **#61**: Add plan cache key policy to tensor-prims.md; convert P7-P13 to actionable format in einsum-cpu-porting-notes.md; add cross-doc links
- **#62**: Align autodiff.md with typed algebra; add AD cross-links to linalg.md; add AD test matrix to testing.md

Closes #60
Closes #61
Closes #62

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` all pass
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)