### PR TITLE
docs/feat: unify tropical AD policy and define error contract (#66, #67, #68)

### DIFF
--- a/docs/design/autodiff.md
+++ b/docs/design/autodiff.md
@@ -175,6 +175,11 @@ AD must remain algebra-aware:
   tropical sum. These indices are not computable from the output alone and must
   be saved during the forward pass.
 
+  **Argmax tie-break rule**: When multiple elements share the maximum (or minimum)
+  value, the element with the **smallest linear index** (row-major traversal order)
+  wins. This rule is deterministic and must be consistent across CPU, GPU, and C-API
+  backends.
+
   **GPU tropical AD note:** On GPU, tropical backward requires argmax-capable
   custom kernels that are distinct from cuTENSOR/hipTensor primitives. cuTENSOR
   operates on ring algebras (multiply-add); it has no native support for
@@ -194,6 +199,34 @@ AD must remain algebra-aware:
   algebra.
 
 See [algebra.md](./algebra.md) for the algebra system design.
+
+---
+
+## Error Contract for Unsupported AD Modes
+
+When an operation does not support a particular AD mode, it returns
+`AutodiffError::ModeNotSupported` rather than a generic error string.
+This allows callers — including C-API / FFI layers — to branch on the
+error variant without parsing error messages.
+
+```rust
+use chainrules_core::AutodiffError;
+
+let err = AutodiffError::ModeNotSupported {
+    mode: "frule".into(),
+    reason: "tropical einsum supports rrule only (max is not smooth)".into(),
+};
+```
+
+**Operations that return `ModeNotSupported`:**
+
+| Operation | Unsupported modes | Reason |
+|-----------|-------------------|--------|
+| Tropical einsum (`MaxPlus`, `MinPlus`, `MaxMul`) | `frule` (JVP) | `max`/`min` is not smooth; JVP is undefined |
+| Tropical einsum (`MaxPlus`, `MinPlus`, `MaxMul`) | `hvp` | Requires a smooth frule; not available |
+
+For standard arithmetic algebra, all three modes (`rrule`, `frule`, `hvp`)
+are supported where implemented.
 
 ---
 

--- a/docs/design/capi.md
+++ b/docs/design/capi.md
@@ -22,6 +22,13 @@ Dependencies: `tenferro-device`, `tenferro-tensor`, `tenferro-einsum`,
 Tropical extension: `tenferro-tropical-capi` (separate shared library)
 reuses `TfeTensorF64` handles and adds tropical einsum functions.
 
+**Error mapping for unsupported AD modes:** `AutodiffError::ModeNotSupported`
+maps to `TFE_INVALID_ARGUMENT` in the C-API. No `_frule_<algebra>_f64`
+functions are provided for tropical einsum (consistent with issue #66);
+if a caller were to invoke such a path internally, it would surface as
+`TFE_INVALID_ARGUMENT` with a descriptive message, not a panic or
+`TFE_INTERNAL_ERROR`.
+
 ---
 
 ## Design Principles
@@ -201,8 +208,15 @@ selected by function name, not tensor type (`MaxPlus<f64>` is
 | `tfe_tropical_einsum_minplus_f64` | MinPlus (⊕=min, ⊗=+) |
 | `tfe_tropical_einsum_maxmul_f64` | MaxMul (⊕=max, ⊗=×) |
 
-Each has corresponding `_rrule_<algebra>_f64` and `_frule_<algebra>_f64`
-functions (same signatures as standard einsum AD).
+Each has a corresponding `_rrule_<algebra>_f64` function (same signature as
+standard einsum rrule). No `_frule_<algebra>_f64` is provided for tropical
+einsum: tropical semirings (max/min) are not smooth, so JVP is not
+well-defined. Only VJP (rrule via argmax) is supported.
+
+The **smallest linear index wins** tie-break rule applies to all tropical rrule
+functions: when multiple elements share the maximum (or minimum) value, the
+gradient is routed to the element with the smallest linear index. This is
+consistent across CPU and GPU backends.
 
 ---
 

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -366,6 +366,10 @@ cannot carry; it must be allocated and managed by the custom kernel. When
 designing the tropical GPU backend, the plan type must accommodate an optional
 argmax buffer:
 
+**Tie-break contract**: The argmax buffer must store the smallest linear index
+when ties occur. Custom GPU kernels must implement this deterministically
+(e.g., via `atomicMin` on the index when values are equal).
+
 ```rust
 enum TropicalCudaPlan<T: ScalarBase> {
     Contract {

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -124,6 +124,7 @@ Port from `tests/tropical.rs` and tropical-related tests in other files.
 | MaxPlus chain | `test_tropical_chain` (integration.rs) | |
 | Tropical unary ops | `test_tropical_unary_*` (unary_ops.rs) | trace, sum, row/col max |
 | Tropical backward | `test_backward_tropical_matmul` (backward.rs) | Sparse gradients via argmax |
+| Tropical argmax tie-break | new test | Verify that when multiple elements share the max, the gradient flows to the smallest-index element. Must produce identical results on CPU and GPU backends. |
 | Shortest path (MinPlus) | `test_minplus_shortest_path` | Bellman-Ford step |
 | Viterbi (MaxMul) | `test_viterbi_example` | |
 
@@ -272,6 +273,35 @@ Notes:
 - hvp for tropical einsum is not planned for the same reason.
 - argmax route testing may require a custom kernel infrastructure separate from
   cuTENSOR/hipTensor; CPU-only tests can run with the reference kernel.
+
+#### Error path: `ModeNotSupported`
+
+These tests verify the explicit error contract for unsupported AD modes
+(issue #68). They live in `tenferro-tropical/tests/` and must not depend
+on a full AD tape.
+
+| Test | Expected result |
+|------|----------------|
+| Call tropical einsum frule (`MaxPlus`) | `Err(AutodiffError::ModeNotSupported { mode: "frule", .. })` |
+| Call tropical einsum frule (`MinPlus`) | `Err(AutodiffError::ModeNotSupported { mode: "frule", .. })` |
+| Call tropical einsum frule (`MaxMul`) | `Err(AutodiffError::ModeNotSupported { mode: "frule", .. })` |
+| Call tropical einsum hvp (`MaxPlus`) | `Err(AutodiffError::ModeNotSupported { mode: "hvp", .. })` |
+| Call tropical einsum hvp (`MinPlus`) | `Err(AutodiffError::ModeNotSupported { mode: "hvp", .. })` |
+
+Example test structure:
+
+```rust
+#[test]
+fn tropical_frule_returns_mode_not_supported() {
+    let result = einsum_frule(/* tropical MaxPlus ctx */, "ij,jk->ik", &primals, &tangents);
+    match result {
+        Err(AutodiffError::ModeNotSupported { ref mode, .. }) => {
+            assert_eq!(mode, "frule");
+        }
+        other => panic!("expected ModeNotSupported, got {other:?}"),
+    }
+}
+```
 
 ### Linalg AD
 

--- a/extern/chainrules-core/src/lib.rs
+++ b/extern/chainrules-core/src/lib.rs
@@ -105,6 +105,28 @@ pub enum AutodiffError {
     /// A ReverseRule does not support HVP (pullback_with_tangents).
     #[error("HVP not supported by this ReverseRule implementation")]
     HvpNotSupported,
+    /// The requested AD mode is not supported for the given algebra or operation.
+    ///
+    /// For example, tropical einsum does not support frule (JVP) or hvp —
+    /// only rrule (VJP) via the argmax route is available.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use chainrules_core::AutodiffError;
+    ///
+    /// let err = AutodiffError::ModeNotSupported {
+    ///     mode: "frule".into(),
+    ///     reason: "tropical einsum supports rrule only (max is not smooth)".into(),
+    /// };
+    /// ```
+    #[error("AD mode not supported: {mode} — {reason}")]
+    ModeNotSupported {
+        /// The unsupported mode (e.g., "frule", "hvp").
+        mode: String,
+        /// Explanation of why this mode is not supported.
+        reason: String,
+    },
     /// Generic AD argument error.
     #[error("invalid autodiff argument: {0}")]
     InvalidArgument(String),


### PR DESCRIPTION
## Summary
- **#66**: Unify tropical einsum AD to rrule-only — remove frule from tropical C-API
- **#67**: Define deterministic argmax tie-break rule (smallest linear index wins) across CPU/GPU/C-API
- **#68**: Add `ModeNotSupported` error variant to `AutodiffError` for unsupported AD modes

Closes #66
Closes #67
Closes #68

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo build --workspace` succeeds
- [x] `cargo test --workspace` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)