### PR TITLE
docs: add device.md design doc and sync architecture

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -5,6 +5,7 @@
 | Document | Description |
 |----------|-------------|
 | [architecture.md](./architecture.md) | Workspace layers, crate dependency graph, device layer, ecosystem relationships |
+| [device.md](./device.md) | `tenferro-device`: memory spaces, compute devices, error types, device selection |
 | [tensor-prims.md](./tensor-prims.md) | `TensorPrims<A>` trait, `PrimDescriptor`, plan-based execution, CPU/GPU backends |
 | [einsum.md](./einsum.md) | Einsum public API (9 functions), N-ary contraction tree, algebra dispatch |
 | [contraction-pipeline.md](./contraction-pipeline.md) | Binary contraction pipeline, copy elision, `MakeContiguous`, HPTT experiments |

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -64,72 +64,13 @@ implementation, `BackendRegistry`, and `TensorLibVtable` are future work.
 
 ## tenferro-device
 
-The device crate provides shared infrastructure used across all tenferro crates.
+Device abstraction and shared error types. Provides `LogicalMemorySpace`,
+`ComputeDevice`, `OpKind`, `preferred_compute_devices()`, and the workspace
+`Error`/`Result` types.
 
-```rust
-/// Logical memory space where tensor buffers reside.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum LogicalMemorySpace {
-    MainMemory,
-    PinnedMemory,
-    GpuMemory { device_id: usize },
-    ManagedMemory,
-}
+Dependencies: `thiserror` only.
 
-/// Compute device where kernels execute.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ComputeDevice {
-    Cpu { device_id: usize },
-    Cuda { device_id: usize },
-    Rocm { device_id: usize },
-}
-
-/// Operation kind used for capability filtering.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum OpKind { Contract, BatchedGemm, Reduce, Trace, Permute, ElementwiseMul }
-
-/// Returns executable compute devices in descending preference order.
-pub fn preferred_compute_devices(
-    space: LogicalMemorySpace,
-    op_kind: OpKind,
-) -> Result<Vec<ComputeDevice>>;
-```
-
-**Error types** using `thiserror`:
-
-```rust
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("shape mismatch: expected {expected:?}, got {got:?}")]
-    ShapeMismatch { expected: Vec<usize>, got: Vec<usize> },
-
-    #[error("rank mismatch: expected {expected}, got {got}")]
-    RankMismatch { expected: usize, got: usize },
-
-    #[error("device error: {0}")]
-    DeviceError(String),
-
-    #[error("no compatible compute device for {op:?} in memory space {space:?}")]
-    NoCompatibleComputeDevice { space: LogicalMemorySpace, op: OpKind },
-
-    #[error("operation across distinct logical memory spaces is not allowed by default")]
-    CrossMemorySpaceOperation,
-
-    #[error("invalid argument: {0}")]
-    InvalidArgument(String),
-
-    #[error(transparent)]
-    Strided(#[from] strided_view::StridedError),
-}
-
-pub type Result<T> = std::result::Result<T, Error>;
-```
-
-**Dependencies**: `strided-view` (for `StridedError`), `thiserror`.
-
-**Note**: `BackendRegistry`, `CudaBackend`, `RocmBackend`, and
-`TensorLibVtable` are **not** in the POC. They are planned for future
-GPU support.
+See [device.md](./device.md) for the full API reference.
 
 ---
 
@@ -145,9 +86,8 @@ tenferro-device              tenferro-algebra
   (LogicalMemorySpace +        (HasAlgebra trait (UX sugar),
    ComputeDevice, Error,       Semiring trait,
    Result)                     Standard<T> typed algebra)
-  (depends on: strided-view
-   for StridedError,
-   thiserror)
+  (depends on: thiserror
+   only)
                               (depends on: strided-traits,
                                num-complex)
         │                              │

--- a/docs/design/device.md
+++ b/docs/design/device.md
@@ -1,0 +1,179 @@
+# tenferro-device
+
+Device abstraction and shared error types for the tenferro workspace.
+
+---
+
+## Position in Workspace Architecture
+
+`tenferro-device` is a **shared foundation crate** depended upon by every other
+tenferro crate. It has no tensor or algebra dependency — only `thiserror`. Its
+role is to:
+
+- Define the vocabulary for *where data lives* (`LogicalMemorySpace`) and
+  *which hardware computes* (`ComputeDevice`).
+- Classify tensor operations for capability queries (`OpKind`).
+- Provide the single `Error` / `Result` pair used across the entire workspace.
+
+---
+
+## Core Types
+
+### LogicalMemorySpace
+
+Describes where tensor buffer data physically resides. Separates the concept
+of data location from execution hardware: a tensor in `MainMemory` can be
+processed by any CPU, while a tensor in `GpuMemory { device_id: 1 }` can only
+be processed by a device with access to that GPU.
+
+| Variant | Fields | DLPack `device_type` |
+|---------|--------|----------------------|
+| `MainMemory` | — | `kDLCPU` (1) |
+| `PinnedMemory` | — | `kDLCUDAHost` (3) / `kDLROCMHost` (11) |
+| `GpuMemory` | `device_id: usize` | `kDLCUDA` (2) / `kDLROCM` (10) |
+| `ManagedMemory` | — | `kDLCUDAManaged` (13) |
+
+`GpuMemory.device_id` matches the DLPack `device_id` field (zero-based GPU
+index). For `MainMemory`, `PinnedMemory`, and `ManagedMemory` the DLPack
+`device_id` is always 0.
+
+### ComputeDevice
+
+Identifies the hardware unit that executes tensor kernels. A compute device is
+independent of where the data resides — the backend is responsible for
+validating that it can access the required memory space.
+
+| Variant | Fields | `Display` format |
+|---------|--------|-----------------|
+| `Cpu` | `device_id: usize` | `cpu:<id>` |
+| `Cuda` | `device_id: usize` | `cuda:<id>` |
+| `Rocm` | `device_id: usize` | `rocm:<id>` |
+
+`device_id = 0` is the default device for each variant.
+
+```rust
+use tenferro_device::ComputeDevice;
+
+let dev = ComputeDevice::Cpu { device_id: 0 };
+assert_eq!(format!("{dev}"), "cpu:0");
+```
+
+### OpKind
+
+Classifies a tensor operation for device-capability filtering. Passed to
+`preferred_compute_devices` so callers can query which hardware can execute a
+specific class of work on a given memory space.
+
+| Variant | Description |
+|---------|-------------|
+| `Contract` | General tensor contraction |
+| `BatchedGemm` | Batched matrix-matrix multiply |
+| `Reduce` | Reduction (sum, max, min) over one or more modes |
+| `Trace` | Diagonal contraction of paired modes |
+| `Permute` | Mode permutation (transpose) |
+| `ElementwiseMul` | Element-wise multiplication |
+
+---
+
+## Device Selection
+
+### `preferred_compute_devices`
+
+```rust
+pub fn preferred_compute_devices(
+    space: LogicalMemorySpace,
+    op_kind: OpKind,
+) -> Result<Vec<ComputeDevice>>
+```
+
+Returns a list of compute devices capable of executing `op_kind` on data
+residing in `space`, ordered from most preferred to least preferred.
+
+**Selection rules (planned, not yet implemented):**
+
+| Memory space | Typically preferred devices |
+|---|---|
+| `MainMemory` | `Cpu { device_id: 0 }` |
+| `PinnedMemory` | `Cuda { device_id: 0 }` first, then `Cpu { device_id: 0 }` |
+| `GpuMemory { device_id }` | `Cuda { device_id }` or `Rocm { device_id }` |
+| `ManagedMemory` | `Cuda { device_id: 0 }` first, then `Cpu { device_id: 0 }` |
+
+Returns `Error::NoCompatibleComputeDevice` if no registered backend can handle
+the requested combination.
+
+---
+
+## Error Types
+
+### Error enum
+
+The single `Error` type used by every tenferro crate. Upstream crates map their
+own errors into this enum's variants.
+
+| Variant | Fields | `Display` format |
+|---------|--------|-----------------|
+| `ShapeMismatch` | `expected: Vec<usize>`, `got: Vec<usize>` | `shape mismatch: expected [...], got [...]` |
+| `RankMismatch` | `expected: usize`, `got: usize` | `rank mismatch: expected N, got M` |
+| `DeviceError` | `String` | `device error: <msg>` |
+| `NoCompatibleComputeDevice` | `space: LogicalMemorySpace`, `op: OpKind` | `no compatible compute device for <op> on <space>` |
+| `CrossMemorySpaceOperation` | `left: LogicalMemorySpace`, `right: LogicalMemorySpace` | `cross-memory-space operation between <left> and <right>` |
+| `InvalidArgument` | `String` | `invalid argument: <msg>` |
+| `StrideError` | `String` | `stride error: <msg>` |
+
+`CrossMemorySpaceOperation` carries both operand spaces so diagnostics can show
+exactly which spaces were mixed. `StrideError` wraps a plain `String` rather
+than using `#[from] strided_view::StridedError` to avoid a dependency on
+`strided-view` in this crate.
+
+```rust
+use tenferro_device::Error;
+
+let err = Error::InvalidArgument("bad index".into());
+assert!(err.to_string().contains("bad index"));
+```
+
+### Relationship with `tenferro-tensor::effective_compute_devices`
+
+`Tensor<T>` carries an optional `preferred_compute_device: Option<ComputeDevice>`
+field. When resolving which device to use for an operation:
+
+1. If `preferred_compute_device` is `Some(dev)`, that device is used directly
+   (no call to `preferred_compute_devices`).
+2. If it is `None`, the tensor's `LogicalMemorySpace` and the `OpKind` are
+   passed to `preferred_compute_devices` to obtain the ranked list.
+
+This lets callers pin a specific GPU without going through the global selection
+logic, which is useful when constructing tensors on a non-default device.
+
+---
+
+## Dependencies
+
+- `thiserror` only — no `strided-view`, no `strided-traits`, no algebra crates.
+
+---
+
+## Design Decisions
+
+### 1. LogicalMemorySpace vs ComputeDevice separation
+
+Keeping "where data lives" distinct from "which hardware computes" mirrors the
+DLPack model and avoids conflating two orthogonal concerns. It allows, for
+example, a `MainMemory` tensor to be processed by `Cpu { device_id: 0 }` while
+a `GpuMemory { device_id: 1 }` tensor is processed by `Cuda { device_id: 1 }`,
+with explicit transfer required to cross boundaries.
+
+### 2. StrideError(String) instead of #[from] StridedError
+
+Using `#[from] strided_view::StridedError` would add `strided-view` as a
+dependency of `tenferro-device`, pulling it into every downstream crate even
+when only error types are needed. A plain `StrideError(String)` avoids this
+coupling: callers that use `strided-view` convert errors at the boundary with
+`.map_err(|e| Error::StrideError(e.to_string()))`.
+
+### 3. CrossMemorySpaceOperation carries left/right fields for diagnostics
+
+An error message that reports both operand memory spaces (`left` and `right`)
+makes it immediately obvious which tensor is on which space, without the caller
+having to re-inspect the tensors. This is especially useful in multi-step
+einsum trees where the errant pair may be two levels deep.


### PR DESCRIPTION
## Summary
- Create `docs/design/device.md` with full API reference matching actual `tenferro-device/src/lib.rs`
- Fix `architecture.md`: replace outdated device section with summary + link
  - `CrossMemorySpaceOperation` now correctly shows `left`/`right` fields
  - `StrideError(String)` replaces wrong `Strided(#[from] strided_view::StridedError)`
  - Dependencies corrected to `thiserror` only (not `strided-view`)
- Add `device.md` to `README.md` core design table

Closes #70

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` all pass
- [x] device.md matches actual source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)