### PR TITLE
docs: AD notes index and capi implementation plan

### DIFF
--- a/docs/AD/README.md
+++ b/docs/AD/README.md
@@ -1,0 +1,36 @@
+# AD Formula Notes
+
+Mathematical derivations for the automatic differentiation rules (rrule/frule)
+implemented in `tenferro-linalg`.
+
+## Purpose
+
+These notes contain the step-by-step mathematics behind each AD rule:
+derivations from first principles, intermediate matrix identities, and
+verification procedures (reconstruction checks, finite-difference gradient checks).
+
+## Role distinction
+
+| Location | Content |
+|----------|---------|
+| [`docs/design/autodiff.md`](../design/autodiff.md) | Architecture and API: crate split, trait definitions, AD engine design, algebra interaction |
+| [`docs/design/linalg.md`](../design/linalg.md) | Linalg API: function signatures, result types, cotangent types, rrule/frule tables |
+| `docs/AD/` (this directory) | Mathematical details: derivations, formulas, verification for each operation |
+
+## Notes
+
+| File | Operation | Description |
+|------|-----------|-------------|
+| [svd.md](./svd.md) | SVD (`svd_rrule`) | Reverse-mode rule for `A = U diag(S) Vt`; F-matrix, non-square corrections, complex gauge |
+| [qr.md](./qr.md) | QR / LQ (`qr_rrule`) | Reverse-mode rule for `A = QR` and `A = LQ`; `copyltu` helper, full-rank and wide/tall cases |
+| [lu.md](./lu.md) | LU (`lu_rrule`, `lu_frule`) | Reverse-mode and forward-mode rules for `PA = LU`; square, wide, and tall cases |
+| [cholesky.md](./cholesky.md) | Cholesky (`cholesky_rrule`) | Reverse-mode rule for `A = LLH` |
+| [eigen.md](./eigen.md) | Symmetric eigen (`eigen_rrule`) | Reverse-mode rule for symmetric/Hermitian eigendecomposition |
+| [eig.md](./eig.md) | General eigen (`eig_rrule`) | Reverse-mode rule for general (non-symmetric) eigendecomposition |
+| [inv.md](./inv.md) | Matrix inverse (`inv_rrule`) | AD rules for `inv(A)`; formula `dA = -A^{-H} cotangent A^{-H}` |
+| [det.md](./det.md) | Determinant and slogdet | AD rules for `det(A)` and `slogdet(A)` |
+| [solve.md](./solve.md) | Linear solve (`solve_rrule`) | AD rules for `Ax = b` and triangular solve |
+| [lstsq.md](./lstsq.md) | Least squares (`lstsq_rrule`) | Reverse-mode rule for `argmin ||Ax - b||^2` |
+| [pinv.md](./pinv.md) | Pseudoinverse (`pinv_rrule`) | AD rules for Moore-Penrose pseudoinverse |
+| [matrix_exp.md](./matrix_exp.md) | Matrix exponential (`matrix_exp_rrule`) | AD rules for `exp(A)` |
+| [norm.md](./norm.md) | Norm (`norm_rrule`) | AD rules for matrix and vector norms |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -16,6 +16,12 @@
 | [capi.md](./capi.md) | C-API (FFI): opaque handles, DLPack interop, einsum + SVD + AD rules |
 | [testing.md](./testing.md) | Testing strategy, linalg test cases ([JSON](../../tenferro-linalg/tests/data/linalg_cases.json)), gradient check method |
 
+## AD Formula Notes
+
+| Document | Description |
+|----------|-------------|
+| [AD Formula Notes](../AD/README.md) | Mathematical derivations for SVD, QR, LU, and other rrule/frule formulas |
+
 ## Reference
 
 | Document | Description |

--- a/docs/design/autodiff.md
+++ b/docs/design/autodiff.md
@@ -1,5 +1,7 @@
 # Automatic Differentiation
 
+For detailed mathematical derivations of AD rules, see [AD Formula Notes](../AD/README.md).
+
 ## Position in Workspace Architecture
 
 The AD system is split into two crates following Rust convention

--- a/docs/design/capi.md
+++ b/docs/design/capi.md
@@ -244,3 +244,81 @@ consistent across CPU and GPU backends.
 5. **`catch_unwind` for panic safety.** All extern "C" functions wrap
    their body in `catch_unwind` to prevent Rust panics from unwinding
    through C frames (undefined behavior).
+
+---
+
+## Implementation Phases
+
+### Phase 1: Tensor Lifecycle + Status Plumbing
+- Implement: `tfe_tensor_f64_from_data`, `_zeros`, `_clone`, `_release`, `_ndim`, `_shape`, `_len`, `_data`
+- Status plumbing: `catch_unwind` wrapper, `tfe_status_t` return convention
+- Exit criteria: All tensor lifecycle functions pass null-safety and round-trip tests
+
+### Phase 2: DLPack Import/Export
+- Implement: `tfe_tensor_f64_to_dlpack`, `_from_dlpack`
+- Exit criteria: Round-trip test (Rust -> DLPack -> Rust) preserves data, shape, strides; deleter is called exactly once
+
+### Phase 3: Einsum + SVD + AD
+- Implement: `tfe_einsum_f64`, `_rrule`, `_frule`; `tfe_svd_f64`, `_rrule`, `_frule`
+- Exit criteria: Gradient check passes for einsum rrule/frule; SVD round-trip U*S*Vt ~= A
+
+### Phase 4: Tropical C-API
+- Implement: `tfe_tropical_einsum_maxplus_f64` etc. + `_rrule` variants
+- No `_frule` for tropical (rrule-only policy)
+- Exit criteria: Tropical einsum matches CPU reference; rrule gradient check passes
+
+---
+
+## Error Mapping
+
+| Rust Error | `tfe_status_t` | Notes |
+|-----------|---------------|-------|
+| `tenferro_device::Error::InvalidArgument` | `TFE_INVALID_ARGUMENT` (-1) | |
+| `tenferro_device::Error::ShapeMismatch` | `TFE_SHAPE_MISMATCH` (-2) | |
+| `tenferro_device::Error::RankMismatch` | `TFE_SHAPE_MISMATCH` (-2) | Shape/rank grouped |
+| `tenferro_device::Error::DeviceError` | `TFE_INTERNAL_ERROR` (-3) | |
+| `tenferro_device::Error::NoCompatibleComputeDevice` | `TFE_INTERNAL_ERROR` (-3) | |
+| `tenferro_device::Error::CrossMemorySpaceOperation` | `TFE_INVALID_ARGUMENT` (-1) | |
+| `tenferro_device::Error::StrideError` | `TFE_INVALID_ARGUMENT` (-1) | |
+| `chainrules_core::AutodiffError::ModeNotSupported` | `TFE_INVALID_ARGUMENT` (-1) | Tropical frule/hvp |
+| `chainrules_core::AutodiffError::*` (other) | `TFE_INTERNAL_ERROR` (-3) | |
+| Rust panic (caught by `catch_unwind`) | `TFE_INTERNAL_ERROR` (-3) | |
+
+Status message: human-readable, non-empty. Written to an internal thread-local buffer accessible via future `tfe_last_error_message()` API.
+
+---
+
+## C-API Test Matrix
+
+| Category | Test Cases |
+|----------|-----------|
+| NULL safety | NULL tensor pointer to all query functions; NULL status pointer |
+| Invalid shape | Zero-dim shape, empty data with non-zero shape, mismatched len |
+| Einsum errors | Invalid subscript string, shape mismatch between operands |
+| DLPack | Unsupported dtype, device mismatch, deleter called exactly once |
+| Ownership | Double release (must not crash), release after to_dlpack (must not crash) |
+| Panic safety | Internal panic caught and converted to TFE_INTERNAL_ERROR |
+| AD error paths | Tropical frule returns TFE_INVALID_ARGUMENT; NULL cotangent in rrule |
+
+See [testing.md](./testing.md) for the workspace-level testing strategy.
+
+---
+
+## ABI Policy
+
+### Header Generation
+C header generated via `cbindgen` from `tenferro-capi/src/lib.rs`.
+Run `cbindgen --config cbindgen.toml --output tenferro.h` after API changes.
+
+### Symbol Naming
+All public symbols use the `tfe_` prefix. Tropical extension uses `tfe_tropical_` prefix.
+
+### Versioning
+- Shared library versioned as `libtenferro.so.{major}.{minor}.{patch}`
+- ABI compatibility: patch releases are backward-compatible; minor releases may add symbols; major releases may break ABI
+- Version query: `tfe_version()` returns `(major, minor, patch)` tuple
+
+### Backward Compatibility
+- Existing function signatures are frozen after 1.0
+- New functions added with new names (no overloading)
+- Deprecated functions kept for one major version cycle

--- a/docs/design/linalg.md
+++ b/docs/design/linalg.md
@@ -175,6 +175,9 @@ interaction model. For how the algebra type `A` (e.g., `Standard<T>`) affects
 which backend primitives are dispatched during the AD formulas, see
 [algebra.md](./algebra.md).
 
+For the step-by-step mathematical derivations of each rule, see the
+[AD Formula Notes](../AD/README.md).
+
 ### Cotangent Types
 
 Structured cotangent types with `Option` fields allow partial gradient


### PR DESCRIPTION
## Summary
- Create `docs/AD/README.md` as a discoverable index for all 13 AD formula derivation files, with cross-links from `autodiff.md`, `linalg.md`, and the design `README.md` (closes #71)
- Add implementation phases, error mapping table, C-API test matrix, and ABI policy sections to `docs/design/capi.md` (closes #72)

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes
- [x] All cross-links point to existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)