### PR TITLE
docs(AD): use GitHub-compatible math macros in formula notes

### DIFF
--- a/docs/AD/cholesky.md
+++ b/docs/AD/cholesky.md
@@ -8,11 +8,11 @@ $$
 
 ## Auxiliary operator
 
-Define $\varphi(X) = \operatorname{tril}(X) - \tfrac{1}{2}\operatorname{diag}(X)$
+Define $\varphi(X) = \mathrm{tril}(X) - \tfrac{1}{2}\mathrm{diag}(X)$
 (extract lower triangle, halve the diagonal).
 
 Its adjoint is
-$\varphi^*(X) = \tfrac{1}{2}(X + X^{\mathsf{H}} - \operatorname{diag}(X))$.
+$\varphi^*(X) = \tfrac{1}{2}(X + X^{\mathsf{H}} - \mathrm{diag}(X))$.
 
 ## Forward rule (JVP)
 
@@ -41,7 +41,7 @@ $L^{-1}\dot{L} = \varphi(L^{-1}\dot{A}\,L^{-\mathsf{H}})$, hence $\dot{L} = L\,\
 
 1. Solve $T \leftarrow L^{-1}\,\dot{A}$ (triangular solve, left)
 2. Solve $T \leftarrow T\,L^{-\mathsf{H}}$ (triangular solve, right)
-3. $T \leftarrow \operatorname{tril}(T) - \tfrac{1}{2}\operatorname{diag}(T)$
+3. $T \leftarrow \mathrm{tril}(T) - \tfrac{1}{2}\mathrm{diag}(T)$
 4. $\dot{L} \leftarrow L\,T$
 
 ## Reverse rule (VJP)
@@ -49,14 +49,14 @@ $L^{-1}\dot{L} = \varphi(L^{-1}\dot{A}\,L^{-\mathsf{H}})$, hence $\dot{L} = L\,\
 Given cotangent $\bar{L}$:
 
 $$
-\bar{A} = L^{-\mathsf{H}}\,\varphi^*\!\bigl(\operatorname{tril}(L^{\mathsf{H}}\bar{L})\bigr)\,L^{-1}
+\bar{A} = L^{-\mathsf{H}}\,\varphi^*\!\bigl(\mathrm{tril}(L^{\mathsf{H}}\bar{L})\bigr)\,L^{-1}
 $$
 
 **Derivation.** Taking the adjoint of the JVP linear map $\dot{A} \mapsto \dot{L}$:
 
 $$
 \delta\ell = \langle \bar{L},\,\dot{L}\rangle
-= \operatorname{tr}\!\bigl(\bar{L}^{\mathsf{H}}\,L\,\varphi(L^{-1}\dot{A}\,L^{-\mathsf{H}})\bigr)
+= \mathrm{tr}\!\bigl(\bar{L}^{\mathsf{H}}\,L\,\varphi(L^{-1}\dot{A}\,L^{-\mathsf{H}})\bigr)
 $$
 
 Working through the adjoint chain:
@@ -65,15 +65,15 @@ Working through the adjoint chain:
 2. Adjoint of left-multiply by $L$: left-multiply by $L^{\mathsf{H}}$, then project to lower triangle
 3. Adjoint of $L^{-1}(\cdot)L^{-\mathsf{H}}$: $L^{-\mathsf{H}}(\cdot)L^{-1}$
 
-This yields $\bar{A} = L^{-\mathsf{H}}\,\varphi^*(\operatorname{tril}(L^{\mathsf{H}}\bar{L}))\,L^{-1}$.
+This yields $\bar{A} = L^{-\mathsf{H}}\,\varphi^*(\mathrm{tril}(L^{\mathsf{H}}\bar{L}))\,L^{-1}$.
 
 The output $\bar{A}$ is symmetric (Hermitian), consistent with the constraint on $A$.
 
 **Algorithm:**
 
-1. $S \leftarrow \operatorname{tril}(L^{\mathsf{H}}\bar{L})$
-2. $S \leftarrow \tfrac{1}{2}(S + S^{\mathsf{H}} - \operatorname{diag}(S))$
-   (equivalently: $S \leftarrow \tfrac{1}{2}(S + \operatorname{tril}(S,-1)^{\mathsf{H}})$)
+1. $S \leftarrow \mathrm{tril}(L^{\mathsf{H}}\bar{L})$
+2. $S \leftarrow \tfrac{1}{2}(S + S^{\mathsf{H}} - \mathrm{diag}(S))$
+   (equivalently: $S \leftarrow \tfrac{1}{2}(S + \mathrm{tril}(S,-1)^{\mathsf{H}})$)
 3. Solve $\bar{A} \leftarrow L^{-\mathsf{H}}\,S$ (triangular solve, left)
 4. Solve $\bar{A} \leftarrow \bar{A}\,L^{-1}$ (triangular solve, right)
 

--- a/docs/AD/det.md
+++ b/docs/AD/det.md
@@ -13,7 +13,7 @@ $$
 By Jacobi's formula (1841):
 
 $$
-\dot{d} = \det(A) \cdot \operatorname{tr}(A^{-1} \dot{A})
+\dot{d} = \det(A) \cdot \mathrm{tr}(A^{-1} \dot{A})
 $$
 
 ### Reverse mode (VJP)
@@ -24,15 +24,15 @@ $$
 \bar{A} = \bar{d} \cdot \det(A) \cdot A^{-\mathsf{T}}
 $$
 
-Equivalently, $\bar{A} = \bar{d} \cdot \operatorname{adj}(A)^{\mathsf{T}}$, where
-$\operatorname{adj}(A) = \det(A) \cdot A^{-1}$ is the classical adjugate.
+Equivalently, $\bar{A} = \bar{d} \cdot \mathrm{adj}(A)^{\mathsf{T}}$, where
+$\mathrm{adj}(A) = \det(A) \cdot A^{-1}$ is the classical adjugate.
 
 **Derivation.** From the JVP:
 
 $$
 \delta\ell = \langle \bar{d},\, \dot{d} \rangle
-= \bar{d} \cdot \det(A) \cdot \operatorname{tr}(A^{-1} \dot{A})
-= \operatorname{tr}\!\bigl((\bar{d} \cdot \det(A) \cdot A^{-\mathsf{T}})^{\mathsf{T}} \dot{A}\bigr)
+= \bar{d} \cdot \det(A) \cdot \mathrm{tr}(A^{-1} \dot{A})
+= \mathrm{tr}\!\bigl((\bar{d} \cdot \det(A) \cdot A^{-\mathsf{T}})^{\mathsf{T}} \dot{A}\bigr)
 $$
 
 Reading off: $\bar{A} = \bar{d} \cdot \det(A) \cdot A^{-\mathsf{T}}$.
@@ -40,13 +40,13 @@ Reading off: $\bar{A} = \bar{d} \cdot \det(A) \cdot A^{-\mathsf{T}}$.
 ### Singular matrix handling
 
 When $A$ is singular, $A^{-1}$ does not exist, but
-$\operatorname{adj}(A)^{\mathsf{T}}$ is well-defined:
+$\mathrm{adj}(A)^{\mathsf{T}}$ is well-defined:
 
-- $\operatorname{rank}(A) = N-1$: $\operatorname{adj}(A)$ is rank 1,
+- $\mathrm{rank}(A) = N-1$: $\mathrm{adj}(A)$ is rank 1,
   computable via SVD: $A = U \Sigma V^{\mathsf{H}}$ gives
-  $\operatorname{adj}(A) = V \operatorname{diag}(d) U^{\mathsf{H}}$
+  $\mathrm{adj}(A) = V \mathrm{diag}(d) U^{\mathsf{H}}$
   where $d_k = \prod_{i \neq k} \sigma_i$.
-- $\operatorname{rank}(A) \leq N-2$: $\operatorname{adj}(A) = 0$.
+- $\mathrm{rank}(A) \leq N-2$: $\mathrm{adj}(A) = 0$.
 
 PyTorch uses `prod_safe_zeros_backward` (leave-one-out product via
 exclusive cumulative product) for the SVD-based adjugate.
@@ -58,51 +58,51 @@ exclusive cumulative product) for the SVD-based adjugate.
 ### Forward
 
 $$
-(\operatorname{sign}, \operatorname{logabsdet}) = \operatorname{slogdet}(A)
+(\mathrm{sign}, \mathrm{logabsdet}) = \mathrm{slogdet}(A)
 $$
 
-where $\det(A) = \operatorname{sign} \cdot \exp(\operatorname{logabsdet})$.
+where $\det(A) = \mathrm{sign} \cdot \exp(\mathrm{logabsdet})$.
 
-- Real: $\operatorname{sign} \in \{-1, 0, +1\}$,
-  $\operatorname{logabsdet} = \log|\det(A)|$.
-- Complex: $\operatorname{sign} = \det(A)/|\det(A)|$ (unit complex),
-  $\operatorname{logabsdet} = \log|\det(A)|$.
+- Real: $\mathrm{sign} \in \{-1, 0, +1\}$,
+  $\mathrm{logabsdet} = \log|\det(A)|$.
+- Complex: $\mathrm{sign} = \det(A)/|\det(A)|$ (unit complex),
+  $\mathrm{logabsdet} = \log|\det(A)|$.
 
 ### Forward mode (JVP)
 
-Let $w = \operatorname{tr}(A^{-1} \dot{A})$.
+Let $w = \mathrm{tr}(A^{-1} \dot{A})$.
 
 **Real case:**
 
 $$
-\dot{\operatorname{logabsdet}} = w, \qquad
-\dot{\operatorname{sign}} = 0
+\dot{\mathrm{logabsdet}} = w, \qquad
+\dot{\mathrm{sign}} = 0
 $$
 
-($\operatorname{sign}$ is piecewise constant.)
+($\mathrm{sign}$ is piecewise constant.)
 
 **Complex case:**
 
 $$
-\dot{\operatorname{logabsdet}} = \operatorname{Re}(w), \qquad
-\dot{\operatorname{sign}} = i \cdot \operatorname{Im}(w) \cdot \operatorname{sign}
+\dot{\mathrm{logabsdet}} = \mathrm{Re}(w), \qquad
+\dot{\mathrm{sign}} = i \cdot \mathrm{Im}(w) \cdot \mathrm{sign}
 $$
 
-**Derivation.** From $\log\det(A) = \operatorname{logabsdet} + i\arg(\det(A))$
-and Jacobi's formula $d(\log\det(A)) = \operatorname{tr}(A^{-1} dA)$,
+**Derivation.** From $\log\det(A) = \mathrm{logabsdet} + i\arg(\det(A))$
+and Jacobi's formula $d(\log\det(A)) = \mathrm{tr}(A^{-1} dA)$,
 the real part gives the log-magnitude derivative and the imaginary part
 gives the argument (phase) derivative. Since
-$\operatorname{sign} = e^{i\arg(\det(A))}$, we get
-$d(\operatorname{sign}) = i \cdot d(\arg) \cdot \operatorname{sign}$.
+$\mathrm{sign} = e^{i\arg(\det(A))}$, we get
+$d(\mathrm{sign}) = i \cdot d(\arg) \cdot \mathrm{sign}$.
 
 ### Reverse mode (VJP)
 
-Given cotangents $(\overline{\operatorname{sign}},\, \overline{\operatorname{logabsdet}})$:
+Given cotangents $(\overline{\mathrm{sign}},\, \overline{\mathrm{logabsdet}})$:
 
-**Real case** ($\overline{\operatorname{sign}}$ has no contribution):
+**Real case** ($\overline{\mathrm{sign}}$ has no contribution):
 
 $$
-\bar{A} = \overline{\operatorname{logabsdet}} \cdot A^{-\mathsf{T}}
+\bar{A} = \overline{\mathrm{logabsdet}} \cdot A^{-\mathsf{T}}
 $$
 
 **Complex case:**
@@ -114,26 +114,26 @@ $$
 where
 
 $$
-g = \overline{\operatorname{logabsdet}}
-  - i \cdot \operatorname{Im}(\overline{\operatorname{sign}}^* \cdot \operatorname{sign})
+g = \overline{\mathrm{logabsdet}}
+  - i \cdot \mathrm{Im}(\overline{\mathrm{sign}}^* \cdot \mathrm{sign})
 $$
 
 **Derivation.** Taking the adjoint of the JVP for each output:
 
-- logabsdet cotangent: $\langle \bar{g}_{\mathrm{abs}},\, \operatorname{Re}(w) \rangle
-  = \operatorname{Re}(\bar{g}_{\mathrm{abs}} \cdot w)
+- logabsdet cotangent: $\langle \bar{g}_{\mathrm{abs}},\, \mathrm{Re}(w) \rangle
+  = \mathrm{Re}(\bar{g}_{\mathrm{abs}} \cdot w)
   = \langle \bar{g}_{\mathrm{abs}} \cdot A^{-\mathsf{H}},\, \dot{A} \rangle$.
 
-- sign cotangent: Using $\operatorname{Re}(z \cdot \operatorname{Im}(w))
-  = \operatorname{Re}(-\operatorname{Re}(z) \cdot i \cdot w)$, we get
-  contribution $-i \cdot \operatorname{Im}(\bar{g}_{\mathrm{sign}}^* \cdot \operatorname{sign}) \cdot A^{-\mathsf{H}}$.
+- sign cotangent: Using $\mathrm{Re}(z \cdot \mathrm{Im}(w))
+  = \mathrm{Re}(-\mathrm{Re}(z) \cdot i \cdot w)$, we get
+  contribution $-i \cdot \mathrm{Im}(\bar{g}_{\mathrm{sign}}^* \cdot \mathrm{sign}) \cdot A^{-\mathsf{H}}$.
 
 Combining yields the formula above.
 
 ### Note on singularity
 
 `slogdet` is **not differentiable** at singular matrices
-($\operatorname{logabsdet} = -\infty$), unlike `det`.
+($\mathrm{logabsdet} = -\infty$), unlike `det`.
 
 ## Implementation notes
 

--- a/docs/AD/eig.md
+++ b/docs/AD/eig.md
@@ -3,7 +3,7 @@
 ## Forward
 
 $$
-A V = V \operatorname{diag}(\lambda), \quad A \in \mathbb{C}^{N \times N}
+A V = V \mathrm{diag}(\lambda), \quad A \in \mathbb{C}^{N \times N}
 $$
 
 where $V$ is the matrix of right eigenvectors (columns) and $\lambda$ the
@@ -23,12 +23,12 @@ $$
 
 ## Forward rule (JVP)
 
-Differentiating $AV = V\operatorname{diag}(\lambda)$ and left-multiplying by $V^{-1}$:
+Differentiating $AV = V\mathrm{diag}(\lambda)$ and left-multiplying by $V^{-1}$:
 
 $$
-V^{-1}\dot{A}\,V = V^{-1}\dot{V}\,\operatorname{diag}(\lambda)
-- \operatorname{diag}(\lambda)\,V^{-1}\dot{V}
-+ \operatorname{diag}(\dot{\lambda})
+V^{-1}\dot{A}\,V = V^{-1}\dot{V}\,\mathrm{diag}(\lambda)
+- \mathrm{diag}(\lambda)\,V^{-1}\dot{V}
++ \mathrm{diag}(\dot{\lambda})
 $$
 
 Define $\Delta P = V^{-1}\dot{A}\,V$.
@@ -52,7 +52,7 @@ $$
 **Normalization correction** (for $\|v_i\| = 1$ convention):
 
 $$
-\dot{V} = \dot{V}_{\mathrm{raw}} - V\,\operatorname{diag}\!\bigl(\operatorname{Re}(V^{\mathsf{H}}\dot{V}_{\mathrm{raw}})\bigr)
+\dot{V} = \dot{V}_{\mathrm{raw}} - V\,\mathrm{diag}\!\bigl(\mathrm{Re}(V^{\mathsf{H}}\dot{V}_{\mathrm{raw}})\bigr)
 $$
 
 This projects out the component that would change the eigenvector norms.
@@ -64,7 +64,7 @@ Given cotangents $\bar{\lambda}$ (eigenvalue) and $\bar{V}$ (eigenvector):
 **Step 1: Normalization adjoint**
 
 $$
-\bar{V}_{\mathrm{adj}} = \bar{V} - V\,\operatorname{diag}\!\bigl(\operatorname{Re}(V^{\mathsf{H}}\bar{V})\bigr)
+\bar{V}_{\mathrm{adj}} = \bar{V} - V\,\mathrm{diag}\!\bigl(\mathrm{Re}(V^{\mathsf{H}}\bar{V})\bigr)
 $$
 
 **Step 2: Inner gradient matrix**
@@ -84,12 +84,12 @@ $$
 \bar{A} = V^{-\mathsf{H}}\,G\,V^{\mathsf{H}}
 $$
 
-For real $A$: $\bar{A} = \operatorname{Re}(\bar{A})$.
+For real $A$: $\bar{A} = \mathrm{Re}(\bar{A})$.
 
 ### Gauge invariance check
 
 Eigenvectors are defined up to a complex phase $e^{i\phi}$. The loss function
-must be gauge-invariant, verified by $\operatorname{Im}(\operatorname{diag}(V^{\mathsf{H}}\bar{V})) \approx 0$.
+must be gauge-invariant, verified by $\mathrm{Im}(\mathrm{diag}(V^{\mathsf{H}}\bar{V})) \approx 0$.
 
 ## Relationship to symmetric case
 

--- a/docs/AD/eigen.md
+++ b/docs/AD/eigen.md
@@ -3,7 +3,7 @@
 ## Forward
 
 $$
-A = U \operatorname{diag}(E) \, U^\dagger, \quad A \in \mathbb{C}^{N \times N}, \quad A = A^\dagger
+A = U \mathrm{diag}(E) \, U^\dagger, \quad A \in \mathbb{C}^{N \times N}, \quad A = A^\dagger
 $$
 
 - $U \in \mathbb{C}^{N \times N}$, $U^\dagger U = I_N$ (unitary eigenvector matrix)
@@ -32,13 +32,13 @@ it uses $E_i - E_j$ directly, since eigenvalues can be negative.
 ### Step 2: Build the inner matrix $D$
 
 $$
-D = \frac{1}{2}\left(F \odot (\bar{U}^\dagger U) + (F \odot (\bar{U}^\dagger U))^\dagger\right) + \operatorname{diag}(\bar{E})
+D = \frac{1}{2}\left(F \odot (\bar{U}^\dagger U) + (F \odot (\bar{U}^\dagger U))^\dagger\right) + \mathrm{diag}(\bar{E})
 $$
 
 The symmetrization $\frac{1}{2}(X + X^\dagger)$ ensures $D$ is Hermitian, which
 guarantees $\bar{A}$ is Hermitian.
 
-When $\bar{U} = 0$: $D = \operatorname{diag}(\bar{E})$.
+When $\bar{U} = 0$: $D = \mathrm{diag}(\bar{E})$.
 
 ### Step 3: Apply the basis transformation
 
@@ -48,16 +48,16 @@ $$
 
 ### Derivation
 
-From $AU = U \operatorname{diag}(E)$, differentiating:
+From $AU = U \mathrm{diag}(E)$, differentiating:
 
 $$
-dA \cdot U + A \cdot dU = dU \cdot \operatorname{diag}(E) + U \cdot \operatorname{diag}(dE)
+dA \cdot U + A \cdot dU = dU \cdot \mathrm{diag}(E) + U \cdot \mathrm{diag}(dE)
 $$
 
-Left-multiply by $U^\dagger$ and use $U^\dagger A = \operatorname{diag}(E) U^\dagger$:
+Left-multiply by $U^\dagger$ and use $U^\dagger A = \mathrm{diag}(E) U^\dagger$:
 
 $$
-U^\dagger dA \cdot U = U^\dagger dU \cdot \operatorname{diag}(E) - \operatorname{diag}(E) \cdot U^\dagger dU + \operatorname{diag}(dE)
+U^\dagger dA \cdot U = U^\dagger dU \cdot \mathrm{diag}(E) - \mathrm{diag}(E) \cdot U^\dagger dU + \mathrm{diag}(dE)
 $$
 
 Define $\Omega = U^\dagger dU$ (skew-Hermitian from $U^\dagger U = I$).
@@ -88,7 +88,7 @@ and using the separation above yields the formula in Steps 2-3.
 ### Reconstruction check (forward)
 
 $$
-\|A - U \operatorname{diag}(E) U^\dagger\|_F < \varepsilon, \quad U^\dagger U \approx I
+\|A - U \mathrm{diag}(E) U^\dagger\|_F < \varepsilon, \quad U^\dagger U \approx I
 $$
 
 ### Gradient check (backward)
@@ -96,9 +96,9 @@ $$
 Scalar test functions (see [`docs/design/testing.md`](../design/testing.md)):
 
 - **dE only:** $f(A) = \sum_i E_i$
-- **dU only:** $f(A) = \operatorname{Re}(v^\dagger \operatorname{op} \, v)$, $v = U_{:,1}$
+- **dU only:** $f(A) = \mathrm{Re}(v^\dagger \mathrm{op} \, v)$, $v = U_{:,1}$
 
-where $\operatorname{op}$ is a random Hermitian (or symmetric) matrix independent of $A$.
+where $\mathrm{op}$ is a random Hermitian (or symmetric) matrix independent of $A$.
 
 **Input matrix:** $A$ must be Hermitian. Generate as $A = B + B^\dagger$
 where $B$ has entries from uniform $[-1, 1]$ (real and imaginary parts).

--- a/docs/AD/inv.md
+++ b/docs/AD/inv.md
@@ -30,8 +30,8 @@ $$
 
 $$
 \delta\ell = \langle \bar{B},\,\dot{B}\rangle
-= \operatorname{tr}(\bar{B}^{\mathsf{H}}(-B\,\dot{A}\,B))
-= -\operatorname{tr}(B\,\bar{B}^{\mathsf{H}}\,B\,\dot{A})
+= \mathrm{tr}(\bar{B}^{\mathsf{H}}(-B\,\dot{A}\,B))
+= -\mathrm{tr}(B\,\bar{B}^{\mathsf{H}}\,B\,\dot{A})
 = \langle -B^{\mathsf{H}}\bar{B}\,B^{\mathsf{H}},\,\dot{A}\rangle
 $$
 

--- a/docs/AD/lstsq.md
+++ b/docs/AD/lstsq.md
@@ -112,10 +112,10 @@ $$
 Scalar test function (from BackwardsLinalg.jl):
 
 $$
-f(A, b) = x^\dagger \operatorname{op} \, x, \quad x = A \backslash b
+f(A, b) = x^\dagger \mathrm{op} \, x, \quad x = A \backslash b
 $$
 
-where $\operatorname{op}$ is a random Hermitian matrix independent of $A$ and $b$.
+where $\mathrm{op}$ is a random Hermitian matrix independent of $A$ and $b$.
 
 Two separate gradient checks:
 - **$\bar{A}$:** fix $b$, perturb $A$

--- a/docs/AD/lu.md
+++ b/docs/AD/lu.md
@@ -12,8 +12,8 @@ $$
 
 ## Notation
 
-- $\operatorname{tril}_-(X)$: **strictly** lower triangular part of $X$ (zero diagonal)
-- $\operatorname{triu}(X)$: upper triangular part of $X$ (including diagonal)
+- $\mathrm{tril}_-(X)$: **strictly** lower triangular part of $X$ (zero diagonal)
+- $\mathrm{triu}(X)$: upper triangular part of $X$ (including diagonal)
 
 Since $L$ is *unit* lower triangular, $dL$ has zero diagonal, so:
 - $\dot{L}$ (tangent) is strictly lower triangular
@@ -38,8 +38,8 @@ This intermediate separates uniquely into strictly-lower and upper-triangular pa
 Therefore:
 
 $$
-\dot{L} = L \operatorname{tril}_-(\dot{F}), \qquad
-\dot{U} = \operatorname{triu}(\dot{F}) \, U
+\dot{L} = L \mathrm{tril}_-(\dot{F}), \qquad
+\dot{U} = \mathrm{triu}(\dot{F}) \, U
 $$
 
 **Derivation:** From $PA = LU$, differentiating ($P$ constant):
@@ -68,16 +68,16 @@ $$
 $$
 
 $$
-\dot{L} = L \operatorname{tril}_-(\dot{F}), \qquad
-\dot{U}_1 = \operatorname{triu}(\dot{F}) \, U_1
+\dot{L} = L \mathrm{tril}_-(\dot{F}), \qquad
+\dot{U}_1 = \mathrm{triu}(\dot{F}) \, U_1
 $$
 
 $$
-\dot{U}_2 = L^{-1} P \dot{A}_2 - \operatorname{tril}_-(\dot{F}) \, U_2
+\dot{U}_2 = L^{-1} P \dot{A}_2 - \mathrm{tril}_-(\dot{F}) \, U_2
 $$
 
 The last equation follows from differentiating $U_2 = L^{-1} P A_2$:
-$\dot{U}_2 = L^{-1}(P \dot{A}_2 - \dot{L} U_2) = L^{-1} P \dot{A}_2 - \operatorname{tril}_-(\dot{F}) U_2$.
+$\dot{U}_2 = L^{-1}(P \dot{A}_2 - \dot{L} U_2) = L^{-1} P \dot{A}_2 - \mathrm{tril}_-(\dot{F}) U_2$.
 
 ### Tall case ($M > N$)
 
@@ -90,12 +90,12 @@ $$
 $$
 
 $$
-\dot{L}_1 = L_1 \operatorname{tril}_-(\dot{F}), \qquad
-\dot{U} = \operatorname{triu}(\dot{F}) \, U
+\dot{L}_1 = L_1 \mathrm{tril}_-(\dot{F}), \qquad
+\dot{U} = \mathrm{triu}(\dot{F}) \, U
 $$
 
 $$
-\dot{L}_2 = P_2 \dot{A} \, U^{-1} - L_2 \operatorname{triu}(\dot{F})
+\dot{L}_2 = P_2 \dot{A} \, U^{-1} - L_2 \mathrm{triu}(\dot{F})
 $$
 
 ## Pullback (rrule)
@@ -107,7 +107,7 @@ $$
 Define:
 
 $$
-\bar{F} = \operatorname{tril}_-(L^\dagger \bar{L}) + \operatorname{triu}(\bar{U} U^\dagger)
+\bar{F} = \mathrm{tril}_-(L^\dagger \bar{L}) + \mathrm{triu}(\bar{U} U^\dagger)
 $$
 
 Then:
@@ -118,26 +118,26 @@ $$
 
 **Derivation:** From the pushforward, $\delta\ell = \langle \bar{L}, \dot{L} \rangle + \langle \bar{U}, \dot{U} \rangle$ (Frobenius inner product).
 
-Substituting $\dot{L} = L \operatorname{tril}_-(\dot{F})$ and $\dot{U} = \operatorname{triu}(\dot{F}) U$:
+Substituting $\dot{L} = L \mathrm{tril}_-(\dot{F})$ and $\dot{U} = \mathrm{triu}(\dot{F}) U$:
 
 $$
-\delta\ell = \operatorname{Re}\operatorname{tr}\!\left(
-  \operatorname{tril}_-(L^\dagger \bar{L})^\dagger \dot{F}
-  + \operatorname{triu}(\bar{U} U^\dagger)^\dagger \dot{F}
+\delta\ell = \mathrm{Re}\mathrm{tr}\!\left(
+  \mathrm{tril}_-(L^\dagger \bar{L})^\dagger \dot{F}
+  + \mathrm{triu}(\bar{U} U^\dagger)^\dagger \dot{F}
 \right)
-= \operatorname{Re}\operatorname{tr}(\bar{F}^\dagger \dot{F})
+= \mathrm{Re}\mathrm{tr}(\bar{F}^\dagger \dot{F})
 $$
 
 where we used the identities:
-- $\langle X, \operatorname{tril}_-(Y) \rangle = \langle \operatorname{tril}_-(X), Y \rangle$
+- $\langle X, \mathrm{tril}_-(Y) \rangle = \langle \mathrm{tril}_-(X), Y \rangle$
   (strictly-lower projection is self-adjoint)
-- $\langle X, \operatorname{triu}(Y) \rangle = \langle \operatorname{triu}(X), Y \rangle$
+- $\langle X, \mathrm{triu}(Y) \rangle = \langle \mathrm{triu}(X), Y \rangle$
   (upper-triangular projection is self-adjoint)
 
 Substituting $\dot{F} = L^{-1} P \dot{A} U^{-1}$:
 
 $$
-\delta\ell = \operatorname{Re}\operatorname{tr}\!\left(
+\delta\ell = \mathrm{Re}\mathrm{tr}\!\left(
   (P^T L^{-\dagger} \bar{F} U^{-\dagger})^\dagger \dot{A}
 \right)
 $$
@@ -152,8 +152,8 @@ Define:
 
 $$
 \bar{H}_1 = \left(
-  \operatorname{tril}_-(L^\dagger \bar{L} - \bar{U}_2 U_2^\dagger)
-  + \operatorname{triu}(\bar{U}_1 U_1^\dagger)
+  \mathrm{tril}_-(L^\dagger \bar{L} - \bar{U}_2 U_2^\dagger)
+  + \mathrm{triu}(\bar{U}_1 U_1^\dagger)
 \right) U_1^{-\dagger}
 $$
 
@@ -169,7 +169,7 @@ $$
 
 **Derivation:** From $U_2 = L^{-1} P A_2$, the cotangent of $A_2$ through $U_2$ is
 $\bar{A}_2 = P^T L^{-\dagger} \bar{U}_2$. The cotangent of $Q$ (here $L$) receives an additional
-contribution $-\bar{U}_2 U_2^\dagger$ from $\dot{U}_2$'s dependence on $\operatorname{tril}_-(\dot{F})$.
+contribution $-\bar{U}_2 U_2^\dagger$ from $\dot{U}_2$'s dependence on $\mathrm{tril}_-(\dot{F})$.
 
 ### Tall case ($M > N$)
 
@@ -179,8 +179,8 @@ Define:
 
 $$
 \bar{H}_1 = L_1^{-\dagger} \left(
-  \operatorname{tril}_-(L_1^\dagger \bar{L}_1)
-  + \operatorname{triu}(\bar{U} U^\dagger - L_2^\dagger \bar{L}_2)
+  \mathrm{tril}_-(L_1^\dagger \bar{L}_1)
+  + \mathrm{triu}(\bar{U} U^\dagger - L_2^\dagger \bar{L}_2)
 \right)
 $$
 
@@ -196,7 +196,7 @@ $$
 
 **Derivation:** From $L_2 = P_2 A U^{-1}$, the cotangent of $A$ through $L_2$ is
 $\bar{A} \mathrel{+}= P_2^T \bar{L}_2 U^{-\dagger}$. The $\bar{U}$ term receives an additional
-contribution $-L_2^\dagger \bar{L}_2$ from $\dot{L}_2$'s dependence on $\operatorname{triu}(\dot{F})$.
+contribution $-L_2^\dagger \bar{L}_2$ from $\dot{L}_2$'s dependence on $\mathrm{triu}(\dot{F})$.
 
 ## Implementation notes
 
@@ -217,11 +217,11 @@ $L$ is unit lower triangular, $U$ is upper triangular.
 
 Scalar test functions (see [`docs/design/testing.md`](../design/testing.md)):
 
-- **dL only:** $f(A) = \operatorname{Re}(v^\dagger \operatorname{op} \, v)$, $v = L_{:,1}$
-- **dU only:** $f(A) = \operatorname{Re}(v^\dagger \operatorname{op} \, v)$, $v = U_{1,:}$
-- **joint dL+dU:** $f(A) = \operatorname{Re}(L_{1,1}^* \, U_{1,1})$
+- **dL only:** $f(A) = \mathrm{Re}(v^\dagger \mathrm{op} \, v)$, $v = L_{:,1}$
+- **dU only:** $f(A) = \mathrm{Re}(v^\dagger \mathrm{op} \, v)$, $v = U_{1,:}$
+- **joint dL+dU:** $f(A) = \mathrm{Re}(L_{1,1}^* \, U_{1,1})$
 
-where $\operatorname{op}$ is a random Hermitian matrix independent of $A$.
+where $\mathrm{op}$ is a random Hermitian matrix independent of $A$.
 
 ## References
 

--- a/docs/AD/matrix_exp.md
+++ b/docs/AD/matrix_exp.md
@@ -54,8 +54,8 @@ $$
 
 $$
 \langle \bar{B},\, L(A, E) \rangle
-= \int_0^1 \operatorname{tr}\!\bigl(\bar{B}^{\mathsf{H}}\,\exp(sA)\,E\,\exp((1{-}s)A)\bigr)\,ds
-= \operatorname{tr}\!\Bigl(\bigl[\int_0^1 \exp(sA^{\mathsf{H}})\,\bar{B}\,\exp((1{-}s)A^{\mathsf{H}})\,ds\bigr]^{\mathsf{H}} E\Bigr)
+= \int_0^1 \mathrm{tr}\!\bigl(\bar{B}^{\mathsf{H}}\,\exp(sA)\,E\,\exp((1{-}s)A)\bigr)\,ds
+= \mathrm{tr}\!\Bigl(\bigl[\int_0^1 \exp(sA^{\mathsf{H}})\,\bar{B}\,\exp((1{-}s)A^{\mathsf{H}})\,ds\bigr]^{\mathsf{H}} E\Bigr)
 = \langle L(A^{\mathsf{H}}, \bar{B}),\, E \rangle
 $$
 

--- a/docs/AD/norm.md
+++ b/docs/AD/norm.md
@@ -9,7 +9,7 @@ $$
 ### Forward rule (JVP)
 
 $$
-\dot{n} = \frac{\sum_i |x_i|^{p-2}\,\operatorname{Re}(\bar{x}_i\,\dot{x}_i)}{\|x\|_p^{p-1}}
+\dot{n} = \frac{\sum_i |x_i|^{p-2}\,\mathrm{Re}(\bar{x}_i\,\dot{x}_i)}{\|x\|_p^{p-1}}
 $$
 
 ### Reverse rule (VJP)
@@ -23,16 +23,16 @@ $$
 | $p$ | $\bar{x}$ (VJP) | Notes |
 |-----|-----------------|-------|
 | $0$ | $0$ | $\ell^0$ "norm" is piecewise constant |
-| $1$ | $\bar{n}\,\operatorname{sgn}(x)$ | Subgradient at $x_i = 0$ |
+| $1$ | $\bar{n}\,\mathrm{sgn}(x)$ | Subgradient at $x_i = 0$ |
 | $2$ | $\bar{n}\,x / \|x\|_2$ | Masked at $\|x\| = 0$ |
-| $\infty$ | $\bar{n}\,\operatorname{sgn}(x) \cdot \mathbb{1}_{|x| = \|x\|_\infty} / k$ | $k$ = multiplicity of max |
+| $\infty$ | $\bar{n}\,\mathrm{sgn}(x) \cdot \mathbb{1}_{|x| = \|x\|_\infty} / k$ | $k$ = multiplicity of max |
 
 ---
 
 ## 2. Frobenius norm
 
 $$
-\|A\|_F = \sqrt{\operatorname{tr}(A^{\mathsf{H}}A)}
+\|A\|_F = \sqrt{\mathrm{tr}(A^{\mathsf{H}}A)}
 $$
 
 Equivalent to the vector 2-norm of the flattened matrix.
@@ -40,7 +40,7 @@ Equivalent to the vector 2-norm of the flattened matrix.
 ### Forward rule (JVP)
 
 $$
-\dot{n} = \frac{\operatorname{Re}\!\operatorname{tr}(A^{\mathsf{H}}\dot{A})}{\|A\|_F}
+\dot{n} = \frac{\mathrm{Re}\!\mathrm{tr}(A^{\mathsf{H}}\dot{A})}{\|A\|_F}
 $$
 
 ### Reverse rule (VJP)
@@ -54,7 +54,7 @@ $$
 ## 3. Nuclear norm (trace norm)
 
 $$
-\|A\|_* = \sum_i \sigma_i(A) = \operatorname{tr}(S)
+\|A\|_* = \sum_i \sigma_i(A) = \mathrm{tr}(S)
 $$
 
 where $A = U S V^{\mathsf{H}}$ is the SVD.
@@ -62,7 +62,7 @@ where $A = U S V^{\mathsf{H}}$ is the SVD.
 ### Forward rule (JVP)
 
 $$
-\dot{n} = \operatorname{Re}\!\operatorname{tr}(U^{\mathsf{H}}\,\dot{A}\,V)
+\dot{n} = \mathrm{Re}\!\mathrm{tr}(U^{\mathsf{H}}\,\dot{A}\,V)
 $$
 
 ### Reverse rule (VJP)
@@ -72,8 +72,8 @@ $$
 $$
 
 **Derivation.** Since $\|A\|_* = \sum_i \sigma_i$ and
-$\dot{\sigma}_i = \operatorname{Re}(u_i^{\mathsf{H}}\,\dot{A}\,v_i)$,
-summing gives $\dot{n} = \operatorname{Re}\!\operatorname{tr}(U^{\mathsf{H}}\dot{A}\,V)$.
+$\dot{\sigma}_i = \mathrm{Re}(u_i^{\mathsf{H}}\,\dot{A}\,v_i)$,
+summing gives $\dot{n} = \mathrm{Re}\!\mathrm{tr}(U^{\mathsf{H}}\dot{A}\,V)$.
 The adjoint is $\bar{A} = \bar{n}\,U V^{\mathsf{H}}$.
 
 **Non-smooth case** ($A$ rank-deficient): the subdifferential is
@@ -93,7 +93,7 @@ $$
 For simple $\sigma_{\max}$ (multiplicity 1):
 
 $$
-\dot{n} = \operatorname{Re}(u_1^{\mathsf{H}}\,\dot{A}\,v_1)
+\dot{n} = \mathrm{Re}(u_1^{\mathsf{H}}\,\dot{A}\,v_1)
 $$
 
 where $u_1, v_1$ are the leading singular vectors.

--- a/docs/AD/pinv.md
+++ b/docs/AD/pinv.md
@@ -3,7 +3,7 @@
 ## Forward
 
 $$
-A^+ = \operatorname{pinv}(A), \quad A \in \mathbb{C}^{M \times N}
+A^+ = \mathrm{pinv}(A), \quad A \in \mathbb{C}^{M \times N}
 $$
 
 where $A^+$ is the Moore-Penrose pseudoinverse satisfying $A A^+ A = A$,
@@ -14,8 +14,8 @@ evaluation point. The pseudoinverse is not continuous at rank-changing points.
 
 ## Notation
 
-- $P_{\mathrm{col}} = A A^+$: orthogonal projector onto $\operatorname{col}(A)$
-- $P_{\mathrm{row}} = A^+ A$: orthogonal projector onto $\operatorname{row}(A)$
+- $P_{\mathrm{col}} = A A^+$: orthogonal projector onto $\mathrm{col}(A)$
+- $P_{\mathrm{row}} = A^+ A$: orthogonal projector onto $\mathrm{row}(A)$
 
 ## Forward rule (JVP)
 

--- a/docs/AD/qr.md
+++ b/docs/AD/qr.md
@@ -12,15 +12,15 @@ $$
 ## Helper: `copyltu` (Hermitianize from lower triangle)
 
 $$
-\operatorname{copyltu}(M)_{ij} = \begin{cases}
+\mathrm{copyltu}(M)_{ij} = \begin{cases}
   M_{ij} & \text{if } i > j \\
-  \operatorname{Re}(M_{ii}) & \text{if } i = j \\
+  \mathrm{Re}(M_{ii}) & \text{if } i = j \\
   \overline{M_{ji}} & \text{if } i < j
 \end{cases}
 $$
 
 This constructs a Hermitian matrix from the lower triangular part of $M$.
-For real matrices: $\operatorname{tril}(M) + \operatorname{tril}(M)^T - \operatorname{diag}(\operatorname{diag}(M))$.
+For real matrices: $\mathrm{tril}(M) + \mathrm{tril}(M)^T - \mathrm{diag}(\mathrm{diag}(M))$.
 
 ## QR Case 1: Full-rank ($M \geq N$, square $R$)
 
@@ -39,7 +39,7 @@ Both terms are $N \times N$.
 ### Step 2: Hermitianize
 
 $$
-H = \operatorname{copyltu}(W)
+H = \mathrm{copyltu}(W)
 $$
 
 **Why:** The constraint $Q^\dagger Q = I$ means $Q^\dagger dQ$ is skew-Hermitian.
@@ -66,7 +66,7 @@ where $R^{-\dagger} = (R^\dagger)^{-1} = (R^{-1})^\dagger$.
 ### Complete formula (full-rank)
 
 $$
-\bar{A} = \left[\bar{Q} + Q \cdot \operatorname{copyltu}(R \bar{R}^\dagger - \bar{Q}^\dagger Q)\right] R^{-\dagger}
+\bar{A} = \left[\bar{Q} + Q \cdot \mathrm{copyltu}(R \bar{R}^\dagger - \bar{Q}^\dagger Q)\right] R^{-\dagger}
 $$
 
 ### Derivation
@@ -113,7 +113,7 @@ Partition $\bar{R} = [\bar{U} \mid \bar{D}]$.
 Apply the full-rank QR backward with the augmented cotangent:
 
 $$
-\bar{A}_1 = \operatorname{qr\_back\_fullrank}(Q, U, \bar{Q} + A_2 \bar{D}^\dagger, \bar{U})
+\bar{A}_1 = \mathrm{qr\_back\_fullrank}(Q, U, \bar{Q} + A_2 \bar{D}^\dagger, \bar{U})
 $$
 
 **Combine:**
@@ -147,7 +147,7 @@ W = L^\dagger \bar{L} - \bar{Q} Q^\dagger
 $$
 
 $$
-H = \operatorname{copyltu}(W)
+H = \mathrm{copyltu}(W)
 $$
 
 $$
@@ -163,7 +163,7 @@ $$
 ### Complete formula (full-rank)
 
 $$
-\bar{A} = L^{-\dagger} \left[\operatorname{copyltu}(L^\dagger \bar{L} - \bar{Q} Q^\dagger) Q + \bar{Q}\right]
+\bar{A} = L^{-\dagger} \left[\mathrm{copyltu}(L^\dagger \bar{L} - \bar{Q} Q^\dagger) Q + \bar{Q}\right]
 $$
 
 ## LQ Case 2: Tall $L$ ($M > N$, $K = N$)
@@ -183,7 +183,7 @@ and $A = \begin{pmatrix} U \\ D \end{pmatrix} Q$, so $A_1 = UQ$ and $A_2 = DQ$.
 Partition $\bar{L} = \begin{pmatrix} \bar{U} \\ \bar{D} \end{pmatrix}$.
 
 $$
-\bar{A}_1 = \operatorname{lq\_back\_fullrank}(U, Q, \bar{U}, \bar{Q} + \bar{D}^\dagger A_2)
+\bar{A}_1 = \mathrm{lq\_back\_fullrank}(U, Q, \bar{U}, \bar{Q} + \bar{D}^\dagger A_2)
 $$
 
 $$
@@ -207,10 +207,10 @@ $$
 Scalar test function (exercises both $\bar{Q}$ and $\bar{R}$ jointly):
 
 $$
-f(A) = \operatorname{Re}(v^\dagger \operatorname{op} \, v + v_2^\dagger \operatorname{op}_2 \, v_2), \quad v = Q_{:,1}, \quad v_2 = R_{2,:}
+f(A) = \mathrm{Re}(v^\dagger \mathrm{op} \, v + v_2^\dagger \mathrm{op}_2 \, v_2), \quad v = Q_{:,1}, \quad v_2 = R_{2,:}
 $$
 
-where $\operatorname{op}, \operatorname{op}_2$ are random Hermitian matrices independent of $A$.
+where $\mathrm{op}, \mathrm{op}_2$ are random Hermitian matrices independent of $A$.
 
 ## References
 

--- a/docs/AD/solve.md
+++ b/docs/AD/solve.md
@@ -40,8 +40,8 @@ $$
 $$
 
 **Derivation.** The second term:
-$\langle G,\, \dot{A}\,X\rangle = \operatorname{tr}(G^{\mathsf{H}}\,\dot{A}\,X)
-= \operatorname{tr}(X\,G^{\mathsf{H}}\,\dot{A})
+$\langle G,\, \dot{A}\,X\rangle = \mathrm{tr}(G^{\mathsf{H}}\,\dot{A}\,X)
+= \mathrm{tr}(X\,G^{\mathsf{H}}\,\dot{A})
 = \langle G\,X^{\mathsf{H}},\, \dot{A}\rangle$,
 so $\bar{A} = -G\,X^{\mathsf{H}}$.
 
@@ -52,11 +52,11 @@ triangular solves instead of general LU solves. Additionally, the
 cotangent $\bar{A}$ must be projected onto the triangular structure:
 
 $$
-\bar{A} = \operatorname{tril}(-G\,X^{\mathsf{H}}) \quad \text{(lower triangular case)}
+\bar{A} = \mathrm{tril}(-G\,X^{\mathsf{H}}) \quad \text{(lower triangular case)}
 $$
 
 $$
-\bar{A} = \operatorname{triu}(-G\,X^{\mathsf{H}}) \quad \text{(upper triangular case)}
+\bar{A} = \mathrm{triu}(-G\,X^{\mathsf{H}}) \quad \text{(upper triangular case)}
 $$
 
 For unit-triangular matrices, the diagonal of $\bar{A}$ is additionally

--- a/docs/AD/svd.md
+++ b/docs/AD/svd.md
@@ -7,7 +7,7 @@ A = U \Sigma V^\dagger, \quad A \in \mathbb{C}^{M \times N}, \quad K = \min(M, N
 $$
 
 - $U \in \mathbb{C}^{M \times K}$, $U^\dagger U = I_K$
-- $\Sigma = \operatorname{diag}(\sigma_1, \ldots, \sigma_K)$, $\sigma_i > 0$, descending
+- $\Sigma = \mathrm{diag}(\sigma_1, \ldots, \sigma_K)$, $\sigma_i > 0$, descending
 - $V \in \mathbb{C}^{N \times K}$, $V^\dagger V = I_K$
 
 ## Reverse rule
@@ -43,7 +43,7 @@ $$
 
 $$
 \Gamma_{\bar{U}} = (J + J^\dagger) \Sigma
-  + \operatorname{diag}(i \cdot \operatorname{Im}(\operatorname{diag}(U^\dagger \bar{U})) \cdot S_\text{inv})
+  + \mathrm{diag}(i \cdot \mathrm{Im}(\mathrm{diag}(U^\dagger \bar{U})) \cdot S_\text{inv})
 $$
 
 **Derivation:**
@@ -51,7 +51,7 @@ Differentiating $U^\dagger U = I$ gives $U^\dagger dU$ skew-Hermitian.
 The off-diagonal part of $U^\dagger dU$ is determined by $F$ and the SVD
 differential equation. The diagonal of $U^\dagger dU$ is purely imaginary
 (gauge freedom in the complex case), requiring the second term.
-For real SVD, the diagonal term vanishes since $\operatorname{Im}(\operatorname{diag}(U^T \bar{U})) = 0$.
+For real SVD, the diagonal term vanishes since $\mathrm{Im}(\mathrm{diag}(U^T \bar{U})) = 0$.
 
 #### From $\bar{V}$ (dV path)
 
@@ -70,7 +70,7 @@ is already absorbed by the $\bar{U}$ term.
 #### From $\bar{S}$ (dS path)
 
 $$
-\Gamma_{\bar{S}} = \operatorname{diag}(\bar{S})
+\Gamma_{\bar{S}} = \mathrm{diag}(\bar{S})
 $$
 
 This is the simplest cotangent path: $\sigma_i$ are independent real parameters.
@@ -90,7 +90,7 @@ Perturbations in the orthogonal complement require additional terms.
 **When $M > K$ (tall $A$, thin $U$):**
 
 $$
-\bar{A} \mathrel{+}= (\bar{U} - U U^\dagger \bar{U}) \operatorname{diag}(S_\text{inv}) V^\dagger
+\bar{A} \mathrel{+}= (\bar{U} - U U^\dagger \bar{U}) \mathrm{diag}(S_\text{inv}) V^\dagger
 $$
 
 The projector $(I_M - U U^\dagger)$ extracts the component of $\bar{U}$ in the
@@ -99,7 +99,7 @@ orthogonal complement of the column space of $U$.
 **When $N > K$ (wide $A$, thin $V$):**
 
 $$
-\bar{A} \mathrel{+}= U \operatorname{diag}(S_\text{inv}) (\bar{V}^\dagger - \bar{V}^\dagger V V^\dagger)
+\bar{A} \mathrel{+}= U \mathrm{diag}(S_\text{inv}) (\bar{V}^\dagger - \bar{V}^\dagger V V^\dagger)
 $$
 
 Analogous correction for the orthogonal complement of $V$.
@@ -110,8 +110,8 @@ For general $M \times N$ with $K = \min(M, N)$:
 
 $$
 \bar{A} = U \Gamma V^\dagger
-  + \mathbf{1}_{M > K} (I_M - U U^\dagger) \bar{U} \operatorname{diag}(S_\text{inv}) V^\dagger
-  + \mathbf{1}_{N > K} U \operatorname{diag}(S_\text{inv}) (I_N - V V^\dagger) \bar{V}^\dagger
+  + \mathbf{1}_{M > K} (I_M - U U^\dagger) \bar{U} \mathrm{diag}(S_\text{inv}) V^\dagger
+  + \mathbf{1}_{N > K} U \mathrm{diag}(S_\text{inv}) (I_N - V V^\dagger) \bar{V}^\dagger
 $$
 
 where $\mathbf{1}$ denotes the indicator function and $\Gamma$ is defined in Step 2.
@@ -121,7 +121,7 @@ where $\mathbf{1}$ denotes the indicator function and $\Gamma$ is defined in Ste
 ### Reconstruction check (forward)
 
 $$
-\|A - U \operatorname{diag}(S) V^\dagger\|_F < \varepsilon
+\|A - U \mathrm{diag}(S) V^\dagger\|_F < \varepsilon
 $$
 
 $U^\dagger U \approx I$, $V^\dagger V \approx I$, $S \geq 0$ descending.
@@ -131,10 +131,10 @@ $U^\dagger U \approx I$, $V^\dagger V \approx I$, $S \geq 0$ descending.
 Finite-difference gradient check with scalar test functions
 (see [`docs/design/testing.md`](../design/testing.md) for details):
 
-- **dU only:** $f(A) = \operatorname{Re}(\psi^\dagger H \psi)$, $\psi = U_{:,1}$
-- **dV only:** $f(A) = \operatorname{Re}(\psi^\dagger H \psi)$, $\psi = V_{:,1}$
+- **dU only:** $f(A) = \mathrm{Re}(\psi^\dagger H \psi)$, $\psi = U_{:,1}$
+- **dV only:** $f(A) = \mathrm{Re}(\psi^\dagger H \psi)$, $\psi = V_{:,1}$
 - **dS only:** $f(A) = \sum_i \sigma_i$
-- **joint dU+dV:** $f(A) = \operatorname{Re}(U_{1,1}^* V_{1,1})$
+- **joint dU+dV:** $f(A) = \mathrm{Re}(U_{1,1}^* V_{1,1})$
 
 where $H$ is a random Hermitian matrix independent of $A$.
 


### PR DESCRIPTION
## Summary
- Replace unsupported LaTeX macro `\operatorname{...}` with GitHub-compatible `\mathrm{...}` in AD rule notes.
- Update all formula docs under `docs/AD/` to avoid GitHub math rendering warnings.

## Why
GitHub math rendering reported: `The following macros are not allowed: operatorname`.
This change keeps the formulas readable while removing unsupported macro usage.

## Verification
- Searched repository for remaining `\\operatorname{` occurrences in docs.
- Confirmed no matches remain in `docs/AD`, `docs/design`, `README.md`, or `docs/api_index.md`.

Generated with [Claude Code](https://claude.com/claude-code)
