### PR TITLE
feat(algebra): implement Semiring for Standard<T>

### DIFF
--- a/tenferro-algebra/src/lib.rs
+++ b/tenferro-algebra/src/lib.rs
@@ -220,28 +220,30 @@ pub trait Semiring {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tenferro_algebra::{Semiring, Standard};
 ///
 /// let z = <Standard<f64> as Semiring>::zero();
 /// let o = <Standard<f64> as Semiring>::one();
+/// assert_eq!(z, 0.0);
+/// assert_eq!(o, 1.0);
 /// ```
 impl<T: Scalar> Semiring for Standard<T> {
     type Scalar = T;
 
     fn zero() -> T {
-        todo!()
+        T::zero()
     }
 
     fn one() -> T {
-        todo!()
+        T::one()
     }
 
-    fn add(_a: T, _b: T) -> T {
-        todo!()
+    fn add(a: T, b: T) -> T {
+        a + b
     }
 
-    fn mul(_a: T, _b: T) -> T {
-        todo!()
+    fn mul(a: T, b: T) -> T {
+        a * b
     }
 }

--- a/tenferro-algebra/tests/algebra_tests.rs
+++ b/tenferro-algebra/tests/algebra_tests.rs
@@ -1,0 +1,269 @@
+//! Tests for tenferro-algebra: Scalar blanket, Conjugate, HasAlgebra,
+//! Semiring axioms for Standard<T>.
+
+use num_complex::{Complex32, Complex64};
+use tenferro_algebra::{Conjugate, HasAlgebra, Scalar, Semiring, Standard};
+
+// ============================================================================
+// Scalar blanket impl
+// ============================================================================
+
+#[test]
+fn f32_is_scalar() {
+    fn assert_scalar<T: Scalar>() {}
+    assert_scalar::<f32>();
+}
+
+#[test]
+fn f64_is_scalar() {
+    fn assert_scalar<T: Scalar>() {}
+    assert_scalar::<f64>();
+}
+
+#[test]
+fn complex32_is_scalar() {
+    fn assert_scalar<T: Scalar>() {}
+    assert_scalar::<Complex32>();
+}
+
+#[test]
+fn complex64_is_scalar() {
+    fn assert_scalar<T: Scalar>() {}
+    assert_scalar::<Complex64>();
+}
+
+// ============================================================================
+// Conjugate
+// ============================================================================
+
+#[test]
+fn conjugate_f32_identity() {
+    assert_eq!(3.14_f32.conj(), 3.14_f32);
+}
+
+#[test]
+fn conjugate_f64_identity() {
+    assert_eq!(2.718_f64.conj(), 2.718_f64);
+}
+
+#[test]
+fn conjugate_complex32() {
+    let z = Complex32::new(1.0, 2.0);
+    assert_eq!(z.conj(), Complex32::new(1.0, -2.0));
+}
+
+#[test]
+fn conjugate_complex64() {
+    let z = Complex64::new(3.0, -4.0);
+    assert_eq!(z.conj(), Complex64::new(3.0, 4.0));
+}
+
+#[test]
+fn conjugate_real_zero() {
+    assert_eq!(0.0_f64.conj(), 0.0_f64);
+}
+
+#[test]
+fn conjugate_complex_zero() {
+    let z = Complex64::new(0.0, 0.0);
+    assert_eq!(z.conj(), Complex64::new(0.0, 0.0));
+}
+
+#[test]
+fn conjugate_involution() {
+    let z = Complex64::new(1.0, 2.0);
+    assert_eq!(z.conj().conj(), z);
+}
+
+// ============================================================================
+// HasAlgebra
+// ============================================================================
+
+#[test]
+fn has_algebra_f32() {
+    fn check<T: HasAlgebra<Algebra = Standard<T>>>() {}
+    check::<f32>();
+}
+
+#[test]
+fn has_algebra_f64() {
+    fn check<T: HasAlgebra<Algebra = Standard<T>>>() {}
+    check::<f64>();
+}
+
+#[test]
+fn has_algebra_complex32() {
+    fn check<T: HasAlgebra<Algebra = Standard<T>>>() {}
+    check::<Complex32>();
+}
+
+#[test]
+fn has_algebra_complex64() {
+    fn check<T: HasAlgebra<Algebra = Standard<T>>>() {}
+    check::<Complex64>();
+}
+
+// ============================================================================
+// Semiring: Standard<f64> basic operations
+// ============================================================================
+
+#[test]
+fn semiring_f64_zero() {
+    assert_eq!(<Standard<f64> as Semiring>::zero(), 0.0_f64);
+}
+
+#[test]
+fn semiring_f64_one() {
+    assert_eq!(<Standard<f64> as Semiring>::one(), 1.0_f64);
+}
+
+#[test]
+fn semiring_f64_add() {
+    assert_eq!(<Standard<f64> as Semiring>::add(2.0, 3.0), 5.0);
+}
+
+#[test]
+fn semiring_f64_mul() {
+    assert_eq!(<Standard<f64> as Semiring>::mul(2.0, 3.0), 6.0);
+}
+
+// ============================================================================
+// Semiring: Standard<f32>
+// ============================================================================
+
+#[test]
+fn semiring_f32_zero() {
+    assert_eq!(<Standard<f32> as Semiring>::zero(), 0.0_f32);
+}
+
+#[test]
+fn semiring_f32_one() {
+    assert_eq!(<Standard<f32> as Semiring>::one(), 1.0_f32);
+}
+
+#[test]
+fn semiring_f32_add() {
+    assert_eq!(<Standard<f32> as Semiring>::add(1.5_f32, 2.5_f32), 4.0_f32);
+}
+
+#[test]
+fn semiring_f32_mul() {
+    assert_eq!(<Standard<f32> as Semiring>::mul(2.0_f32, 3.0_f32), 6.0_f32);
+}
+
+// ============================================================================
+// Semiring: Standard<Complex64>
+// ============================================================================
+
+#[test]
+fn semiring_complex64_zero() {
+    assert_eq!(
+        <Standard<Complex64> as Semiring>::zero(),
+        Complex64::new(0.0, 0.0)
+    );
+}
+
+#[test]
+fn semiring_complex64_one() {
+    assert_eq!(
+        <Standard<Complex64> as Semiring>::one(),
+        Complex64::new(1.0, 0.0)
+    );
+}
+
+#[test]
+fn semiring_complex64_add() {
+    let a = Complex64::new(1.0, 2.0);
+    let b = Complex64::new(3.0, 4.0);
+    assert_eq!(
+        <Standard<Complex64> as Semiring>::add(a, b),
+        Complex64::new(4.0, 6.0)
+    );
+}
+
+#[test]
+fn semiring_complex64_mul() {
+    let a = Complex64::new(1.0, 2.0);
+    let b = Complex64::new(3.0, 4.0);
+    // (1+2i)(3+4i) = 3+4i+6i+8i² = 3+10i-8 = -5+10i
+    assert_eq!(
+        <Standard<Complex64> as Semiring>::mul(a, b),
+        Complex64::new(-5.0, 10.0)
+    );
+}
+
+// ============================================================================
+// Semiring axioms: additive identity
+// ============================================================================
+
+#[test]
+fn semiring_additive_identity_f64() {
+    let z = <Standard<f64> as Semiring>::zero();
+    assert_eq!(<Standard<f64> as Semiring>::add(5.0, z), 5.0);
+    assert_eq!(<Standard<f64> as Semiring>::add(z, 5.0), 5.0);
+}
+
+// ============================================================================
+// Semiring axioms: multiplicative identity
+// ============================================================================
+
+#[test]
+fn semiring_multiplicative_identity_f64() {
+    let o = <Standard<f64> as Semiring>::one();
+    assert_eq!(<Standard<f64> as Semiring>::mul(7.0, o), 7.0);
+    assert_eq!(<Standard<f64> as Semiring>::mul(o, 7.0), 7.0);
+}
+
+// ============================================================================
+// Semiring axioms: associativity of add
+// ============================================================================
+
+#[test]
+fn semiring_add_associativity_f64() {
+    type S = Standard<f64>;
+    let (a, b, c) = (1.0, 2.0, 3.0);
+    assert_eq!(S::add(S::add(a, b), c), S::add(a, S::add(b, c)));
+}
+
+// ============================================================================
+// Semiring axioms: associativity of mul
+// ============================================================================
+
+#[test]
+fn semiring_mul_associativity_f64() {
+    type S = Standard<f64>;
+    let (a, b, c) = (2.0, 3.0, 4.0);
+    assert_eq!(S::mul(S::mul(a, b), c), S::mul(a, S::mul(b, c)));
+}
+
+// ============================================================================
+// Semiring axioms: distributivity
+// ============================================================================
+
+#[test]
+fn semiring_left_distributivity_f64() {
+    type S = Standard<f64>;
+    let (a, b, c) = (2.0, 3.0, 4.0);
+    // a * (b + c) == a*b + a*c
+    assert_eq!(S::mul(a, S::add(b, c)), S::add(S::mul(a, b), S::mul(a, c)));
+}
+
+#[test]
+fn semiring_right_distributivity_f64() {
+    type S = Standard<f64>;
+    let (a, b, c) = (2.0, 3.0, 4.0);
+    // (a + b) * c == a*c + b*c
+    assert_eq!(S::mul(S::add(a, b), c), S::add(S::mul(a, c), S::mul(b, c)));
+}
+
+// ============================================================================
+// Semiring axioms: zero annihilates mul
+// ============================================================================
+
+#[test]
+fn semiring_zero_annihilates_f64() {
+    type S = Standard<f64>;
+    let z = S::zero();
+    assert_eq!(S::mul(5.0, z), z);
+    assert_eq!(S::mul(z, 5.0), z);
+}


### PR DESCRIPTION
## Summary
- Implement 4 `Semiring` methods (`zero`, `one`, `add`, `mul`) for `Standard<T>` — trivial one-liners delegating to `num_traits`/`std::ops`
- Add 34 integration tests: Scalar blanket, Conjugate, HasAlgebra, Semiring operations (f32/f64/Complex64), semiring axioms
- Enable Semiring doctest (remove `ignore` attribute)

Closes #89

## Test plan
- [x] `cargo test -p tenferro-algebra` — 34 tests + 5 doctests pass
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --workspace` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)