### PR TITLE
feat(tensor): implement all Tensor<T> methods and add 83 tests

### DIFF
--- a/tenferro-tensor/Cargo.toml
+++ b/tenferro-tensor/Cargo.toml
@@ -10,3 +10,4 @@ publish = false
 tenferro-device = { path = "../tenferro-device" }
 tenferro-algebra = { path = "../tenferro-algebra" }
 chainrules-core = { path = "../extern/chainrules-core" }
+num-traits.workspace = true

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -106,7 +106,150 @@
 use std::sync::Arc;
 
 use tenferro_algebra::{Conjugate, Scalar};
-use tenferro_device::{ComputeDevice, LogicalMemorySpace, OpKind, Result};
+use tenferro_device::{
+    preferred_compute_devices, ComputeDevice, Error, LogicalMemorySpace, OpKind, Result,
+};
+
+// ============================================================================
+// Private helpers
+// ============================================================================
+
+/// Compute contiguous strides for given dimensions and memory order.
+fn compute_contiguous_strides(dims: &[usize], order: MemoryOrder) -> Vec<isize> {
+    let ndim = dims.len();
+    if ndim == 0 {
+        return vec![];
+    }
+    let mut strides = vec![0isize; ndim];
+    match order {
+        MemoryOrder::ColumnMajor => {
+            strides[0] = 1;
+            for i in 1..ndim {
+                strides[i] = strides[i - 1] * dims[i - 1] as isize;
+            }
+        }
+        MemoryOrder::RowMajor => {
+            strides[ndim - 1] = 1;
+            for i in (0..ndim - 1).rev() {
+                strides[i] = strides[i + 1] * dims[i + 1] as isize;
+            }
+        }
+    }
+    strides
+}
+
+/// Check if strides match a contiguous layout for a specific memory order.
+fn is_contiguous_in_order(dims: &[usize], strides: &[isize], order: MemoryOrder) -> bool {
+    let ndim = dims.len();
+    if ndim == 0 {
+        return true;
+    }
+    if dims.iter().any(|&d| d == 0) {
+        return true;
+    }
+    let expected = compute_contiguous_strides(dims, order);
+    for i in 0..ndim {
+        if dims[i] > 1 && strides[i] != expected[i] {
+            return false;
+        }
+    }
+    true
+}
+
+/// Copy elements from strided source to a destination with different strides.
+fn copy_strided<T: Copy>(
+    src: &[T],
+    dims: &[usize],
+    src_strides: &[isize],
+    src_offset: isize,
+    dst: &mut [T],
+    dst_strides: &[isize],
+) {
+    let ndim = dims.len();
+    let n_elements: usize = dims.iter().product();
+    if n_elements == 0 {
+        return;
+    }
+    if ndim == 0 {
+        dst[0] = src[src_offset as usize];
+        return;
+    }
+    let mut index = vec![0usize; ndim];
+    for _ in 0..n_elements {
+        let src_pos = src_offset
+            + index
+                .iter()
+                .zip(src_strides)
+                .map(|(&i, &s)| i as isize * s)
+                .sum::<isize>();
+        let dst_pos: isize = index
+            .iter()
+            .zip(dst_strides)
+            .map(|(&i, &s)| i as isize * s)
+            .sum::<isize>();
+        dst[dst_pos as usize] = src[src_pos as usize];
+
+        for d in 0..ndim {
+            index[d] += 1;
+            if index[d] < dims[d] {
+                break;
+            }
+            index[d] = 0;
+        }
+    }
+}
+
+/// Element-wise addition of two strided tensors into a contiguous destination.
+fn add_strided<T: Copy + std::ops::Add<Output = T>>(
+    a: &[T],
+    dims: &[usize],
+    a_strides: &[isize],
+    a_offset: isize,
+    b: &[T],
+    b_strides: &[isize],
+    b_offset: isize,
+    dst: &mut [T],
+    dst_strides: &[isize],
+) {
+    let ndim = dims.len();
+    let n_elements: usize = dims.iter().product();
+    if n_elements == 0 {
+        return;
+    }
+    if ndim == 0 {
+        dst[0] = a[a_offset as usize] + b[b_offset as usize];
+        return;
+    }
+    let mut index = vec![0usize; ndim];
+    for _ in 0..n_elements {
+        let a_pos = a_offset
+            + index
+                .iter()
+                .zip(a_strides.iter())
+                .map(|(&i, &s)| i as isize * s)
+                .sum::<isize>();
+        let b_pos = b_offset
+            + index
+                .iter()
+                .zip(b_strides.iter())
+                .map(|(&i, &s)| i as isize * s)
+                .sum::<isize>();
+        let dst_pos: isize = index
+            .iter()
+            .zip(dst_strides.iter())
+            .map(|(&i, &s)| i as isize * s)
+            .sum::<isize>();
+        dst[dst_pos as usize] = a[a_pos as usize] + b[b_pos as usize];
+
+        for d in 0..ndim {
+            index[d] += 1;
+            if index[d] < dims[d] {
+                break;
+            }
+            index[d] = 0;
+        }
+    }
+}
 
 /// Memory ordering for new allocations.
 ///
@@ -685,8 +828,41 @@ impl<'a, T: Scalar> TensorView<'a, T> {
     /// let view = tensor.tensor_view(); // shape [3, 4]
     /// let transposed = view.permute(&[1, 0]).unwrap(); // shape [4, 3]
     /// ```
-    pub fn permute(&self, _perm: &[usize]) -> Result<TensorView<'a, T>> {
-        todo!()
+    pub fn permute(&self, perm: &[usize]) -> Result<TensorView<'a, T>> {
+        let ndim = self.ndim();
+        if perm.len() != ndim {
+            return Err(Error::InvalidArgument(format!(
+                "permutation length {} doesn't match ndim {}",
+                perm.len(),
+                ndim
+            )));
+        }
+        let mut seen = vec![false; ndim];
+        for &p in perm {
+            if p >= ndim {
+                return Err(Error::InvalidArgument(format!(
+                    "permutation index {p} out of range for ndim {ndim}"
+                )));
+            }
+            if seen[p] {
+                return Err(Error::InvalidArgument(format!(
+                    "duplicate index {p} in permutation"
+                )));
+            }
+            seen[p] = true;
+        }
+        let new_dims: Vec<usize> = perm.iter().map(|&p| self.dims[p]).collect();
+        let new_strides: Vec<isize> = perm.iter().map(|&p| self.strides[p]).collect();
+        Ok(TensorView {
+            data: self.data,
+            dims: new_dims,
+            strides: new_strides,
+            offset: self.offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: self.event,
+            conjugated: self.conjugated,
+        })
     }
 
     /// Broadcast this view to a larger shape.
@@ -704,8 +880,38 @@ impl<'a, T: Scalar> TensorView<'a, T> {
     /// let view = tensor.tensor_view(); // shape [1, 4]
     /// let expanded = view.broadcast(&[3, 4]).unwrap(); // shape [3, 4]
     /// ```
-    pub fn broadcast(&self, _target_dims: &[usize]) -> Result<TensorView<'a, T>> {
-        todo!()
+    pub fn broadcast(&self, target_dims: &[usize]) -> Result<TensorView<'a, T>> {
+        let ndim = self.ndim();
+        if target_dims.len() != ndim {
+            return Err(Error::InvalidArgument(format!(
+                "target dims length {} doesn't match ndim {}",
+                target_dims.len(),
+                ndim
+            )));
+        }
+        let mut new_strides = self.strides.clone();
+        for i in 0..ndim {
+            if self.dims[i] == target_dims[i] {
+                // keep stride
+            } else if self.dims[i] == 1 {
+                new_strides[i] = 0;
+            } else {
+                return Err(Error::ShapeMismatch {
+                    expected: self.dims.to_vec(),
+                    got: target_dims.to_vec(),
+                });
+            }
+        }
+        Ok(TensorView {
+            data: self.data,
+            dims: target_dims.to_vec(),
+            strides: new_strides,
+            offset: self.offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: self.event,
+            conjugated: self.conjugated,
+        })
     }
 
     /// Extract a diagonal view by merging pairs of axes.
@@ -721,8 +927,61 @@ impl<'a, T: Scalar> TensorView<'a, T> {
     /// let view = tensor.tensor_view(); // shape [3, 3]
     /// let diag = view.diagonal(&[(0, 1)]).unwrap(); // shape [3]
     /// ```
-    pub fn diagonal(&self, _axes: &[(usize, usize)]) -> Result<TensorView<'a, T>> {
-        todo!()
+    pub fn diagonal(&self, axes: &[(usize, usize)]) -> Result<TensorView<'a, T>> {
+        let ndim = self.ndim();
+        let mut used = vec![false; ndim];
+        let mut diag_dims = Vec::new();
+        let mut diag_strides = Vec::new();
+
+        for &(i, j) in axes {
+            if i >= ndim || j >= ndim {
+                return Err(Error::InvalidArgument(format!(
+                    "axis out of range: ({i}, {j}) for tensor with {ndim} dimensions"
+                )));
+            }
+            if i == j {
+                return Err(Error::InvalidArgument(format!(
+                    "diagonal axes must be distinct, got ({i}, {j})"
+                )));
+            }
+            if used[i] || used[j] {
+                return Err(Error::InvalidArgument(format!(
+                    "axis {i} or {j} used in multiple diagonal pairs"
+                )));
+            }
+            if self.dims[i] != self.dims[j] {
+                return Err(Error::ShapeMismatch {
+                    expected: vec![self.dims[i]],
+                    got: vec![self.dims[j]],
+                });
+            }
+            used[i] = true;
+            used[j] = true;
+            diag_dims.push(self.dims[i]);
+            diag_strides.push(self.strides[i] + self.strides[j]);
+        }
+
+        let mut new_dims = Vec::new();
+        let mut new_strides = Vec::new();
+        for k in 0..ndim {
+            if !used[k] {
+                new_dims.push(self.dims[k]);
+                new_strides.push(self.strides[k]);
+            }
+        }
+        new_dims.extend_from_slice(&diag_dims);
+        new_strides.extend_from_slice(&diag_strides);
+
+        Ok(TensorView {
+            data: self.data,
+            dims: new_dims,
+            strides: new_strides,
+            offset: self.offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: self.event,
+            conjugated: self.conjugated,
+        })
     }
 
     /// Select a single index along a dimension, removing that dimension.
@@ -747,8 +1006,34 @@ impl<'a, T: Scalar> TensorView<'a, T> {
     /// let mat = tv.select(2, 5).unwrap();
     /// assert_eq!(mat.dims(), &[3, 4]);
     /// ```
-    pub fn select(&self, _dim: usize, _index: usize) -> Result<TensorView<'a, T>> {
-        todo!()
+    pub fn select(&self, dim: usize, index: usize) -> Result<TensorView<'a, T>> {
+        let ndim = self.ndim();
+        if dim >= ndim {
+            return Err(Error::InvalidArgument(format!(
+                "dim {dim} out of range for tensor with {ndim} dimensions"
+            )));
+        }
+        if index >= self.dims[dim] {
+            return Err(Error::InvalidArgument(format!(
+                "index {index} out of range for dimension {dim} with size {}",
+                self.dims[dim]
+            )));
+        }
+        let new_offset = self.offset + index as isize * self.strides[dim];
+        let mut new_dims = self.dims.clone();
+        let mut new_strides = self.strides.clone();
+        new_dims.remove(dim);
+        new_strides.remove(dim);
+        Ok(TensorView {
+            data: self.data,
+            dims: new_dims,
+            strides: new_strides,
+            offset: new_offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: self.event,
+            conjugated: self.conjugated,
+        })
     }
 
     /// Narrow (slice) a dimension to a sub-range.
@@ -774,8 +1059,34 @@ impl<'a, T: Scalar> TensorView<'a, T> {
     /// let sub = tv.narrow(1, 2, 3).unwrap();
     /// assert_eq!(sub.dims(), &[3, 3]);
     /// ```
-    pub fn narrow(&self, _dim: usize, _start: usize, _length: usize) -> Result<TensorView<'a, T>> {
-        todo!()
+    pub fn narrow(&self, dim: usize, start: usize, length: usize) -> Result<TensorView<'a, T>> {
+        let ndim = self.ndim();
+        if dim >= ndim {
+            return Err(Error::InvalidArgument(format!(
+                "dim {dim} out of range for tensor with {ndim} dimensions"
+            )));
+        }
+        if start + length > self.dims[dim] {
+            return Err(Error::InvalidArgument(format!(
+                "narrow range {}..{} out of bounds for dimension {dim} with size {}",
+                start,
+                start + length,
+                self.dims[dim]
+            )));
+        }
+        let new_offset = self.offset + start as isize * self.strides[dim];
+        let mut new_dims = self.dims.clone();
+        new_dims[dim] = length;
+        Ok(TensorView {
+            data: self.data,
+            dims: new_dims,
+            strides: self.strides.clone(),
+            offset: new_offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: self.event,
+            conjugated: self.conjugated,
+        })
     }
 
     // ========================================================================
@@ -790,8 +1101,8 @@ impl<'a, T: Scalar> TensorView<'a, T> {
     /// let view = tensor.tensor_view();
     /// let owned = view.to_tensor(MemoryOrder::ColumnMajor);
     /// ```
-    pub fn to_tensor(&self, _order: MemoryOrder) -> Tensor<T> {
-        todo!()
+    pub fn to_tensor(&self, order: MemoryOrder) -> Tensor<T> {
+        self.contiguous(order)
     }
 
     /// Return a contiguous copy of this view's data.
@@ -802,8 +1113,34 @@ impl<'a, T: Scalar> TensorView<'a, T> {
     /// let view = tensor.tensor_view();
     /// let contig = view.contiguous(MemoryOrder::ColumnMajor);
     /// ```
-    pub fn contiguous(&self, _order: MemoryOrder) -> Tensor<T> {
-        todo!()
+    pub fn contiguous(&self, order: MemoryOrder) -> Tensor<T> {
+        let n_elements: usize = self.dims.iter().product();
+        let dst_strides = compute_contiguous_strides(&self.dims, order);
+        let mut data = vec![T::zero(); n_elements];
+        if n_elements > 0 {
+            let src = self
+                .data
+                .as_slice()
+                .expect("CPU-only: TensorView::contiguous");
+            copy_strided(
+                src,
+                &self.dims,
+                &self.strides,
+                self.offset,
+                &mut data,
+                &dst_strides,
+            );
+        }
+        Tensor {
+            buffer: DataBuffer::from_vec(data),
+            dims: self.dims.clone(),
+            strides: dst_strides,
+            offset: 0,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: None,
+            conjugated: self.conjugated,
+        }
     }
 
     /// Return a view with the conjugated flag toggled (lazy, zero-cost).
@@ -928,8 +1265,23 @@ impl<T: Scalar> Tensor<T> {
     ///     MemoryOrder::ColumnMajor,
     /// );
     /// ```
-    pub fn zeros(_dims: &[usize], _memory_space: LogicalMemorySpace, _order: MemoryOrder) -> Self {
-        todo!()
+    pub fn zeros(dims: &[usize], memory_space: LogicalMemorySpace, order: MemoryOrder) -> Self {
+        assert!(
+            memory_space == LogicalMemorySpace::MainMemory,
+            "GPU memory allocation not yet implemented"
+        );
+        let n_elements: usize = dims.iter().product();
+        let strides = compute_contiguous_strides(dims, order);
+        Tensor {
+            buffer: DataBuffer::from_vec(vec![T::zero(); n_elements]),
+            dims: dims.to_vec(),
+            strides,
+            offset: 0,
+            logical_memory_space: memory_space,
+            preferred_compute_device: None,
+            event: None,
+            conjugated: false,
+        }
     }
 
     /// Create a tensor filled with ones.
@@ -949,8 +1301,23 @@ impl<T: Scalar> Tensor<T> {
     /// let a = Tensor::<f64>::ones(&[2, 3],
     ///     LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
     /// ```
-    pub fn ones(_dims: &[usize], _memory_space: LogicalMemorySpace, _order: MemoryOrder) -> Self {
-        todo!()
+    pub fn ones(dims: &[usize], memory_space: LogicalMemorySpace, order: MemoryOrder) -> Self {
+        assert!(
+            memory_space == LogicalMemorySpace::MainMemory,
+            "GPU memory allocation not yet implemented"
+        );
+        let n_elements: usize = dims.iter().product();
+        let strides = compute_contiguous_strides(dims, order);
+        Tensor {
+            buffer: DataBuffer::from_vec(vec![T::one(); n_elements]),
+            dims: dims.to_vec(),
+            strides,
+            offset: 0,
+            logical_memory_space: memory_space,
+            preferred_compute_device: None,
+            event: None,
+            conjugated: false,
+        }
     }
 
     /// Create a tensor from a data slice.
@@ -971,8 +1338,26 @@ impl<T: Scalar> Tensor<T> {
     /// let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     /// let t = Tensor::<f64>::from_slice(&data, &[2, 3], MemoryOrder::ColumnMajor).unwrap();
     /// ```
-    pub fn from_slice(_data: &[T], _dims: &[usize], _order: MemoryOrder) -> Result<Self> {
-        todo!()
+    pub fn from_slice(data: &[T], dims: &[usize], order: MemoryOrder) -> Result<Self> {
+        let n_elements: usize = dims.iter().product();
+        if data.len() != n_elements {
+            return Err(Error::InvalidArgument(format!(
+                "data length {} doesn't match dims product {}",
+                data.len(),
+                n_elements
+            )));
+        }
+        let strides = compute_contiguous_strides(dims, order);
+        Ok(Tensor {
+            buffer: DataBuffer::from_vec(data.to_vec()),
+            dims: dims.to_vec(),
+            strides,
+            offset: 0,
+            logical_memory_space: LogicalMemorySpace::MainMemory,
+            preferred_compute_device: None,
+            event: None,
+            conjugated: false,
+        })
     }
 
     /// Create a tensor from an owned `Vec<T>` with explicit layout.
@@ -994,12 +1379,53 @@ impl<T: Scalar> Tensor<T> {
     /// let t = Tensor::<f64>::from_vec(data, &[2, 3], &[1, 2], 0).unwrap();
     /// ```
     pub fn from_vec(
-        _data: Vec<T>,
-        _dims: &[usize],
-        _strides: &[isize],
-        _offset: isize,
+        data: Vec<T>,
+        dims: &[usize],
+        strides: &[isize],
+        offset: isize,
     ) -> Result<Self> {
-        todo!()
+        let ndim = dims.len();
+        if strides.len() != ndim {
+            return Err(Error::InvalidArgument(format!(
+                "strides length {} doesn't match dims length {}",
+                strides.len(),
+                ndim
+            )));
+        }
+        let n_elements: usize = dims.iter().product();
+        if n_elements > 0 {
+            let mut min_pos = offset;
+            let mut max_pos = offset;
+            for k in 0..ndim {
+                if dims[k] == 0 {
+                    continue;
+                }
+                let extent = (dims[k] - 1) as isize * strides[k];
+                if extent >= 0 {
+                    max_pos += extent;
+                } else {
+                    min_pos += extent;
+                }
+            }
+            if min_pos < 0 || max_pos >= data.len() as isize {
+                return Err(Error::StrideError(format!(
+                    "layout accesses buffer positions {}..={} but buffer length is {}",
+                    min_pos,
+                    max_pos,
+                    data.len()
+                )));
+            }
+        }
+        Ok(Tensor {
+            buffer: DataBuffer::from_vec(data),
+            dims: dims.to_vec(),
+            strides: strides.to_vec(),
+            offset,
+            logical_memory_space: LogicalMemorySpace::MainMemory,
+            preferred_compute_device: None,
+            event: None,
+            conjugated: false,
+        })
     }
 
     /// Create an identity matrix.
@@ -1017,8 +1443,29 @@ impl<T: Scalar> Tensor<T> {
     ///     LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
     /// assert_eq!(id.dims(), &[3, 3]);
     /// ```
-    pub fn eye(_n: usize, _memory_space: LogicalMemorySpace, _order: MemoryOrder) -> Self {
-        todo!()
+    pub fn eye(n: usize, memory_space: LogicalMemorySpace, order: MemoryOrder) -> Self {
+        assert!(
+            memory_space == LogicalMemorySpace::MainMemory,
+            "GPU memory allocation not yet implemented"
+        );
+        let dims = [n, n];
+        let strides = compute_contiguous_strides(&dims, order);
+        let n_elements = n * n;
+        let mut data = vec![T::zero(); n_elements];
+        for i in 0..n {
+            let pos = (i as isize * strides[0] + i as isize * strides[1]) as usize;
+            data[pos] = T::one();
+        }
+        Tensor {
+            buffer: DataBuffer::from_vec(data),
+            dims: dims.to_vec(),
+            strides: strides.to_vec(),
+            offset: 0,
+            logical_memory_space: memory_space,
+            preferred_compute_device: None,
+            event: None,
+            conjugated: false,
+        }
     }
 
     // ========================================================================
@@ -1106,7 +1553,7 @@ impl<T: Scalar> Tensor<T> {
     /// assert_eq!(t.len(), 12);
     /// ```
     pub fn len(&self) -> usize {
-        todo!()
+        self.dims.iter().product()
     }
 
     /// Returns `true` if the tensor has zero elements.
@@ -1118,7 +1565,7 @@ impl<T: Scalar> Tensor<T> {
     /// assert!(t.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
-        todo!()
+        self.len() == 0
     }
 
     /// Returns the logical memory space where this tensor's data resides.
@@ -1201,9 +1648,13 @@ impl<T: Scalar> Tensor<T> {
     /// ```
     pub fn effective_compute_devices(
         &self,
-        _op_kind: OpKind,
+        op_kind: OpKind,
     ) -> tenferro_device::Result<Vec<ComputeDevice>> {
-        todo!()
+        if let Some(device) = self.preferred_compute_device {
+            Ok(vec![device])
+        } else {
+            preferred_compute_devices(self.logical_memory_space, op_kind)
+        }
     }
 
     // ========================================================================
@@ -1276,8 +1727,20 @@ impl<T: Scalar> Tensor<T> {
     /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col); // [3, 4]
     /// let transposed = t.permute(&[1, 0]).unwrap();    // [4, 3]
     /// ```
-    pub fn permute(&self, _perm: &[usize]) -> Result<Tensor<T>> {
-        todo!()
+    pub fn permute(&self, perm: &[usize]) -> Result<Tensor<T>> {
+        self.wait();
+        let view = self.tensor_view();
+        let pv = view.permute(perm)?;
+        Ok(Tensor {
+            buffer: self.buffer.clone(),
+            dims: pv.dims,
+            strides: pv.strides,
+            offset: pv.offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: None,
+            conjugated: self.conjugated,
+        })
     }
 
     /// Broadcast the tensor to a larger shape.
@@ -1299,8 +1762,20 @@ impl<T: Scalar> Tensor<T> {
     /// let b = t.broadcast(&[4, 3]).unwrap();
     /// assert_eq!(b.dims(), &[4, 3]);
     /// ```
-    pub fn broadcast(&self, _target_dims: &[usize]) -> Result<Tensor<T>> {
-        todo!()
+    pub fn broadcast(&self, target_dims: &[usize]) -> Result<Tensor<T>> {
+        self.wait();
+        let view = self.tensor_view();
+        let bv = view.broadcast(target_dims)?;
+        Ok(Tensor {
+            buffer: self.buffer.clone(),
+            dims: bv.dims,
+            strides: bv.strides,
+            offset: bv.offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: None,
+            conjugated: self.conjugated,
+        })
     }
 
     /// Extract a diagonal view by merging pairs of axes.
@@ -1324,8 +1799,20 @@ impl<T: Scalar> Tensor<T> {
     /// let d = t.diagonal(&[(0, 1)]).unwrap();
     /// assert_eq!(d.dims(), &[3]);
     /// ```
-    pub fn diagonal(&self, _axes: &[(usize, usize)]) -> Result<Tensor<T>> {
-        todo!()
+    pub fn diagonal(&self, axes: &[(usize, usize)]) -> Result<Tensor<T>> {
+        self.wait();
+        let view = self.tensor_view();
+        let dv = view.diagonal(axes)?;
+        Ok(Tensor {
+            buffer: self.buffer.clone(),
+            dims: dv.dims,
+            strides: dv.strides,
+            offset: dv.offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: None,
+            conjugated: self.conjugated,
+        })
     }
 
     /// Reshape the tensor to a new shape.
@@ -1348,8 +1835,37 @@ impl<T: Scalar> Tensor<T> {
     /// let r = t.reshape(&[6]).unwrap();
     /// assert_eq!(r.dims(), &[6]);
     /// ```
-    pub fn reshape(&self, _new_dims: &[usize]) -> Result<Tensor<T>> {
-        todo!()
+    pub fn reshape(&self, new_dims: &[usize]) -> Result<Tensor<T>> {
+        self.wait();
+        let old_len = self.len();
+        let new_len: usize = new_dims.iter().product();
+        if old_len != new_len {
+            return Err(Error::ShapeMismatch {
+                expected: self.dims.clone(),
+                got: new_dims.to_vec(),
+            });
+        }
+        if !self.is_contiguous() {
+            return Err(Error::StrideError(
+                "reshape requires contiguous data".into(),
+            ));
+        }
+        let order = if is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::ColumnMajor) {
+            MemoryOrder::ColumnMajor
+        } else {
+            MemoryOrder::RowMajor
+        };
+        let new_strides = compute_contiguous_strides(new_dims, order);
+        Ok(Tensor {
+            buffer: self.buffer.clone(),
+            dims: new_dims.to_vec(),
+            strides: new_strides,
+            offset: self.offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: None,
+            conjugated: self.conjugated,
+        })
     }
 
     /// Select a single index along a dimension, removing that dimension.
@@ -1374,8 +1890,20 @@ impl<T: Scalar> Tensor<T> {
     /// let mat = a.select(2, 5).unwrap();
     /// assert_eq!(mat.dims(), &[3, 4]);
     /// ```
-    pub fn select(&self, _dim: usize, _index: usize) -> Result<Tensor<T>> {
-        todo!()
+    pub fn select(&self, dim: usize, index: usize) -> Result<Tensor<T>> {
+        self.wait();
+        let view = self.tensor_view();
+        let sv = view.select(dim, index)?;
+        Ok(Tensor {
+            buffer: self.buffer.clone(),
+            dims: sv.dims,
+            strides: sv.strides,
+            offset: sv.offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: None,
+            conjugated: self.conjugated,
+        })
     }
 
     /// Narrow (slice) a dimension to a sub-range.
@@ -1400,8 +1928,20 @@ impl<T: Scalar> Tensor<T> {
     /// let sub = a.narrow(1, 2, 3).unwrap();
     /// assert_eq!(sub.dims(), &[3, 3]);
     /// ```
-    pub fn narrow(&self, _dim: usize, _start: usize, _length: usize) -> Result<Tensor<T>> {
-        todo!()
+    pub fn narrow(&self, dim: usize, start: usize, length: usize) -> Result<Tensor<T>> {
+        self.wait();
+        let view = self.tensor_view();
+        let nv = view.narrow(dim, start, length)?;
+        Ok(Tensor {
+            buffer: self.buffer.clone(),
+            dims: nv.dims,
+            strides: nv.strides,
+            offset: nv.offset,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: None,
+            conjugated: self.conjugated,
+        })
     }
 
     // ========================================================================
@@ -1423,8 +1963,13 @@ impl<T: Scalar> Tensor<T> {
     /// let c = t.contiguous(MemoryOrder::RowMajor);
     /// assert!(c.is_contiguous());
     /// ```
-    pub fn contiguous(&self, _order: MemoryOrder) -> Tensor<T> {
-        todo!()
+    pub fn contiguous(&self, order: MemoryOrder) -> Tensor<T> {
+        self.wait();
+        if is_contiguous_in_order(&self.dims, &self.strides, order) && self.offset == 0 {
+            return self.clone();
+        }
+        let view = self.tensor_view();
+        view.contiguous(order)
     }
 
     /// Consume this tensor and return a contiguous version.
@@ -1465,8 +2010,11 @@ impl<T: Scalar> Tensor<T> {
     /// );
     /// let b2 = b.into_contiguous(MemoryOrder::RowMajor); // no copy
     /// ```
-    pub fn into_contiguous(self, _order: MemoryOrder) -> Tensor<T> {
-        todo!()
+    pub fn into_contiguous(self, order: MemoryOrder) -> Tensor<T> {
+        if is_contiguous_in_order(&self.dims, &self.strides, order) && self.offset == 0 {
+            return self;
+        }
+        self.contiguous(order)
     }
 
     /// Returns `true` if the tensor data is contiguous in memory.
@@ -1483,7 +2031,8 @@ impl<T: Scalar> Tensor<T> {
     /// assert!(t.is_contiguous());
     /// ```
     pub fn is_contiguous(&self) -> bool {
-        todo!()
+        is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::ColumnMajor)
+            || is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::RowMajor)
     }
 
     /// Return a lazily-conjugated tensor (shared buffer, flag flip).
@@ -1582,8 +2131,66 @@ impl<T: Scalar> Tensor<T> {
     /// //  [1, 1, 0],
     /// //  [1, 1, 1]]
     /// ```
-    pub fn tril(&self, _diagonal: isize) -> Tensor<T> {
-        todo!()
+    pub fn tril(&self, diagonal: isize) -> Tensor<T> {
+        self.wait();
+        let ndim = self.ndim();
+        assert!(ndim >= 2, "tril requires at least 2 dimensions");
+        let m = self.dims[0];
+        let n = self.dims[1];
+        let order = MemoryOrder::ColumnMajor;
+        let out_strides = compute_contiguous_strides(&self.dims, order);
+        let total = self.len();
+        let mut data = vec![T::zero(); total];
+        let src = self.buffer.as_slice().expect("CPU-only: tril");
+        let batch_dims = &self.dims[2..];
+        let n_batch: usize = batch_dims.iter().product();
+        let n_batch = if n_batch == 0 { 1 } else { n_batch };
+        let mut batch_index = vec![0usize; batch_dims.len()];
+        for _ in 0..n_batch {
+            let src_batch_off: isize = batch_index
+                .iter()
+                .enumerate()
+                .map(|(k, &idx)| idx as isize * self.strides[k + 2])
+                .sum();
+            let dst_batch_off: isize = batch_index
+                .iter()
+                .enumerate()
+                .map(|(k, &idx)| idx as isize * out_strides[k + 2])
+                .sum();
+            for j in 0..n {
+                for i in 0..m {
+                    if (j as isize - i as isize) <= diagonal {
+                        let src_pos = (self.offset
+                            + src_batch_off
+                            + i as isize * self.strides[0]
+                            + j as isize * self.strides[1])
+                            as usize;
+                        let dst_pos = (dst_batch_off
+                            + i as isize * out_strides[0]
+                            + j as isize * out_strides[1])
+                            as usize;
+                        data[dst_pos] = src[src_pos];
+                    }
+                }
+            }
+            for d in 0..batch_dims.len() {
+                batch_index[d] += 1;
+                if batch_index[d] < batch_dims[d] {
+                    break;
+                }
+                batch_index[d] = 0;
+            }
+        }
+        Tensor {
+            buffer: DataBuffer::from_vec(data),
+            dims: self.dims.clone(),
+            strides: out_strides,
+            offset: 0,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: None,
+            conjugated: self.conjugated,
+        }
     }
 
     /// Extract the upper triangular part of a matrix.
@@ -1609,8 +2216,66 @@ impl<T: Scalar> Tensor<T> {
     /// //  [0, 1, 1],
     /// //  [0, 0, 1]]
     /// ```
-    pub fn triu(&self, _diagonal: isize) -> Tensor<T> {
-        todo!()
+    pub fn triu(&self, diagonal: isize) -> Tensor<T> {
+        self.wait();
+        let ndim = self.ndim();
+        assert!(ndim >= 2, "triu requires at least 2 dimensions");
+        let m = self.dims[0];
+        let n = self.dims[1];
+        let order = MemoryOrder::ColumnMajor;
+        let out_strides = compute_contiguous_strides(&self.dims, order);
+        let total = self.len();
+        let mut data = vec![T::zero(); total];
+        let src = self.buffer.as_slice().expect("CPU-only: triu");
+        let batch_dims = &self.dims[2..];
+        let n_batch: usize = batch_dims.iter().product();
+        let n_batch = if n_batch == 0 { 1 } else { n_batch };
+        let mut batch_index = vec![0usize; batch_dims.len()];
+        for _ in 0..n_batch {
+            let src_batch_off: isize = batch_index
+                .iter()
+                .enumerate()
+                .map(|(k, &idx)| idx as isize * self.strides[k + 2])
+                .sum();
+            let dst_batch_off: isize = batch_index
+                .iter()
+                .enumerate()
+                .map(|(k, &idx)| idx as isize * out_strides[k + 2])
+                .sum();
+            for j in 0..n {
+                for i in 0..m {
+                    if (j as isize - i as isize) >= diagonal {
+                        let src_pos = (self.offset
+                            + src_batch_off
+                            + i as isize * self.strides[0]
+                            + j as isize * self.strides[1])
+                            as usize;
+                        let dst_pos = (dst_batch_off
+                            + i as isize * out_strides[0]
+                            + j as isize * out_strides[1])
+                            as usize;
+                        data[dst_pos] = src[src_pos];
+                    }
+                }
+            }
+            for d in 0..batch_dims.len() {
+                batch_index[d] += 1;
+                if batch_index[d] < batch_dims[d] {
+                    break;
+                }
+                batch_index[d] = 0;
+            }
+        }
+        Tensor {
+            buffer: DataBuffer::from_vec(data),
+            dims: self.dims.clone(),
+            strides: out_strides,
+            offset: 0,
+            logical_memory_space: self.logical_memory_space,
+            preferred_compute_device: self.preferred_compute_device,
+            event: None,
+            conjugated: self.conjugated,
+        }
     }
 
     /// Asynchronously transfer this tensor to a different memory space.
@@ -1632,8 +2297,13 @@ impl<T: Scalar> Tensor<T> {
     /// let t = Tensor::<f64>::zeros(&[2, 3]);
     /// let t2 = t.to_memory_space_async(LogicalMemorySpace::MainMemory).unwrap();
     /// ```
-    pub fn to_memory_space_async(&self, _target: LogicalMemorySpace) -> Result<Tensor<T>> {
-        todo!()
+    pub fn to_memory_space_async(&self, target: LogicalMemorySpace) -> Result<Tensor<T>> {
+        if target == self.logical_memory_space {
+            return Ok(self.clone());
+        }
+        Err(Error::DeviceError(
+            "GPU memory transfer not yet implemented".into(),
+        ))
     }
 
     // ========================================================================
@@ -1706,7 +2376,11 @@ impl<T: Scalar> chainrules_core::Differentiable for Tensor<T> {
     /// let zt = t.zero_tangent();
     /// ```
     fn zero_tangent(&self) -> Tensor<T> {
-        todo!()
+        Tensor::zeros(
+            &self.dims,
+            self.logical_memory_space,
+            MemoryOrder::ColumnMajor,
+        )
     }
 
     /// Accumulates a tangent into this tensor (in-place addition).
@@ -1721,8 +2395,40 @@ impl<T: Scalar> chainrules_core::Differentiable for Tensor<T> {
     /// let tangent = Tensor::<f64>::zeros(&[2, 3]);
     /// t.accumulate_tangent(&tangent);
     /// ```
-    fn accumulate_tangent(_a: Tensor<T>, _b: &Tensor<T>) -> Tensor<T> {
-        todo!()
+    fn accumulate_tangent(a: Tensor<T>, b: &Tensor<T>) -> Tensor<T> {
+        assert_eq!(
+            a.dims, b.dims,
+            "tangent shape mismatch in accumulate_tangent"
+        );
+        let n_elements = a.len();
+        let order = MemoryOrder::ColumnMajor;
+        let dst_strides = compute_contiguous_strides(&a.dims, order);
+        let mut data = vec![T::zero(); n_elements];
+        if n_elements > 0 {
+            let a_src = a.buffer.as_slice().expect("CPU-only: accumulate_tangent");
+            let b_src = b.buffer.as_slice().expect("CPU-only: accumulate_tangent");
+            add_strided(
+                a_src,
+                &a.dims,
+                &a.strides,
+                a.offset,
+                b_src,
+                &b.strides,
+                b.offset,
+                &mut data,
+                &dst_strides,
+            );
+        }
+        Tensor {
+            buffer: DataBuffer::from_vec(data),
+            dims: a.dims.clone(),
+            strides: dst_strides,
+            offset: 0,
+            logical_memory_space: a.logical_memory_space,
+            preferred_compute_device: a.preferred_compute_device,
+            event: None,
+            conjugated: false,
+        }
     }
 }
 

--- a/tenferro-tensor/tests/tensor_tests.rs
+++ b/tenferro-tensor/tests/tensor_tests.rs
@@ -1,0 +1,775 @@
+//! Tests for tenferro-tensor: constructors, metadata, view ops, data ops,
+//! Differentiable impl.
+
+use tenferro_device::{ComputeDevice, LogicalMemorySpace, OpKind};
+use tenferro_tensor::{DataBuffer, MemoryOrder, Tensor};
+
+const MEM: LogicalMemorySpace = LogicalMemorySpace::MainMemory;
+const COL: MemoryOrder = MemoryOrder::ColumnMajor;
+const ROW: MemoryOrder = MemoryOrder::RowMajor;
+
+// ============================================================================
+// DataBuffer
+// ============================================================================
+
+#[test]
+fn databuffer_from_vec() {
+    let buf = DataBuffer::from_vec(vec![1.0, 2.0, 3.0]);
+    assert_eq!(buf.len(), 3);
+    assert!(buf.is_owned());
+    assert!(!buf.is_gpu());
+    assert!(buf.is_unique());
+}
+
+#[test]
+fn databuffer_as_slice() {
+    let buf = DataBuffer::from_vec(vec![1.0_f64, 2.0, 3.0]);
+    assert_eq!(buf.as_slice(), Some(&[1.0, 2.0, 3.0][..]));
+}
+
+#[test]
+fn databuffer_as_mut_slice() {
+    let mut buf = DataBuffer::from_vec(vec![1.0_f64, 2.0]);
+    buf.as_mut_slice().unwrap()[0] = 42.0;
+    assert_eq!(buf.as_slice().unwrap()[0], 42.0);
+}
+
+#[test]
+fn databuffer_shared_no_mut() {
+    let buf = DataBuffer::from_vec(vec![1.0_f64]);
+    let _buf2 = buf.clone();
+    let mut buf = buf;
+    assert!(buf.as_mut_slice().is_none());
+}
+
+#[test]
+fn databuffer_empty() {
+    let buf = DataBuffer::<f64>::from_vec(vec![]);
+    assert!(buf.is_empty());
+    assert_eq!(buf.len(), 0);
+}
+
+#[test]
+fn databuffer_clone_shares() {
+    let buf = DataBuffer::from_vec(vec![1.0_f64]);
+    assert!(buf.is_unique());
+    let _buf2 = buf.clone();
+    assert!(!buf.is_unique());
+}
+
+// ============================================================================
+// Tensor constructors
+// ============================================================================
+
+#[test]
+fn zeros_column_major() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    assert_eq!(t.dims(), &[3, 4]);
+    assert_eq!(t.strides(), &[1, 3]);
+    assert_eq!(t.offset(), 0);
+    assert_eq!(t.len(), 12);
+    let data = t.buffer().as_slice().unwrap();
+    assert!(data.iter().all(|&x| x == 0.0));
+}
+
+#[test]
+fn zeros_row_major() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, ROW);
+    assert_eq!(t.dims(), &[3, 4]);
+    assert_eq!(t.strides(), &[4, 1]);
+    let data = t.buffer().as_slice().unwrap();
+    assert!(data.iter().all(|&x| x == 0.0));
+}
+
+#[test]
+fn zeros_scalar() {
+    let t = Tensor::<f64>::zeros(&[], MEM, COL);
+    assert_eq!(t.dims(), &[] as &[usize]);
+    assert_eq!(t.len(), 1);
+    assert_eq!(t.ndim(), 0);
+}
+
+#[test]
+fn zeros_empty_dim() {
+    let t = Tensor::<f64>::zeros(&[0, 4], MEM, COL);
+    assert_eq!(t.len(), 0);
+    assert!(t.is_empty());
+}
+
+#[test]
+fn ones_basic() {
+    let t = Tensor::<f64>::ones(&[2, 3], MEM, COL);
+    let data = t.buffer().as_slice().unwrap();
+    assert!(data.iter().all(|&x| x == 1.0));
+    assert_eq!(t.len(), 6);
+}
+
+#[test]
+fn from_slice_column_major() {
+    let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let t = Tensor::<f64>::from_slice(&data, &[2, 3], COL).unwrap();
+    assert_eq!(t.dims(), &[2, 3]);
+    assert_eq!(t.strides(), &[1, 2]);
+    // Column-major: data[0]=t(0,0), data[1]=t(1,0), data[2]=t(0,1), ...
+    let buf = t.buffer().as_slice().unwrap();
+    assert_eq!(buf, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+}
+
+#[test]
+fn from_slice_row_major() {
+    let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let t = Tensor::<f64>::from_slice(&data, &[2, 3], ROW).unwrap();
+    assert_eq!(t.dims(), &[2, 3]);
+    assert_eq!(t.strides(), &[3, 1]);
+}
+
+#[test]
+fn from_slice_length_mismatch() {
+    let data = [1.0, 2.0, 3.0];
+    let result = Tensor::<f64>::from_slice(&data, &[2, 3], COL);
+    assert!(result.is_err());
+}
+
+#[test]
+fn from_vec_basic() {
+    let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let t = Tensor::<f64>::from_vec(data, &[2, 3], &[1, 2], 0).unwrap();
+    assert_eq!(t.dims(), &[2, 3]);
+    assert_eq!(t.strides(), &[1, 2]);
+}
+
+#[test]
+fn from_vec_with_offset() {
+    let data = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let t = Tensor::<f64>::from_vec(data, &[2, 3], &[1, 2], 1).unwrap();
+    assert_eq!(t.offset(), 1);
+}
+
+#[test]
+fn from_vec_invalid_layout() {
+    let data = vec![1.0, 2.0, 3.0];
+    let result = Tensor::<f64>::from_vec(data, &[2, 3], &[1, 2], 0);
+    assert!(result.is_err());
+}
+
+#[test]
+fn from_vec_strides_length_mismatch() {
+    let data = vec![1.0; 6];
+    let result = Tensor::<f64>::from_vec(data, &[2, 3], &[1], 0);
+    assert!(result.is_err());
+}
+
+#[test]
+fn eye_3x3_col_major() {
+    let t = Tensor::<f64>::eye(3, MEM, COL);
+    assert_eq!(t.dims(), &[3, 3]);
+    let data = t.buffer().as_slice().unwrap();
+    // Column-major: [1,0,0, 0,1,0, 0,0,1]
+    assert_eq!(data, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]);
+}
+
+#[test]
+fn eye_3x3_row_major() {
+    let t = Tensor::<f64>::eye(3, MEM, ROW);
+    assert_eq!(t.dims(), &[3, 3]);
+    let data = t.buffer().as_slice().unwrap();
+    // Row-major: [1,0,0, 0,1,0, 0,0,1]
+    assert_eq!(data, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]);
+}
+
+#[test]
+fn eye_1x1() {
+    let t = Tensor::<f64>::eye(1, MEM, COL);
+    assert_eq!(t.buffer().as_slice().unwrap(), &[1.0]);
+}
+
+// ============================================================================
+// Metadata
+// ============================================================================
+
+#[test]
+fn ndim() {
+    let t = Tensor::<f64>::zeros(&[2, 3, 4], MEM, COL);
+    assert_eq!(t.ndim(), 3);
+}
+
+#[test]
+fn len_3d() {
+    let t = Tensor::<f64>::zeros(&[2, 3, 4], MEM, COL);
+    assert_eq!(t.len(), 24);
+}
+
+#[test]
+fn is_empty_nonempty() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    assert!(!t.is_empty());
+}
+
+#[test]
+fn logical_memory_space() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    assert_eq!(t.logical_memory_space(), MEM);
+}
+
+#[test]
+fn preferred_compute_device_default_none() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    assert!(t.preferred_compute_device().is_none());
+}
+
+#[test]
+fn set_preferred_compute_device() {
+    let mut t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let dev = ComputeDevice::Cpu { device_id: 0 };
+    t.set_preferred_compute_device(Some(dev));
+    assert_eq!(t.preferred_compute_device(), Some(dev));
+}
+
+#[test]
+fn effective_compute_devices_default() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let devs = t.effective_compute_devices(OpKind::BatchedGemm).unwrap();
+    assert_eq!(devs, vec![ComputeDevice::Cpu { device_id: 0 }]);
+}
+
+#[test]
+fn effective_compute_devices_override() {
+    let mut t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let dev = ComputeDevice::Cpu { device_id: 1 };
+    t.set_preferred_compute_device(Some(dev));
+    let devs = t.effective_compute_devices(OpKind::Contract).unwrap();
+    assert_eq!(devs, vec![dev]);
+}
+
+#[test]
+fn is_conjugated_default_false() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    assert!(!t.is_conjugated());
+}
+
+#[test]
+fn is_ready_cpu() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    assert!(t.is_ready());
+}
+
+// ============================================================================
+// Clone (shallow)
+// ============================================================================
+
+#[test]
+fn clone_shares_buffer() {
+    let t = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0], &[3], COL).unwrap();
+    let t2 = t.clone();
+    assert!(!t.buffer().is_unique());
+    assert!(!t2.buffer().is_unique());
+    assert_eq!(t.buffer().as_ptr(), t2.buffer().as_ptr());
+}
+
+// ============================================================================
+// Conjugation
+// ============================================================================
+
+#[test]
+fn conj_toggles_flag() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let tc = t.conj();
+    assert!(tc.is_conjugated());
+    let tcc = tc.conj();
+    assert!(!tcc.is_conjugated());
+}
+
+#[test]
+fn into_conj() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let tc = t.into_conj();
+    assert!(tc.is_conjugated());
+}
+
+// ============================================================================
+// is_contiguous
+// ============================================================================
+
+#[test]
+fn contiguous_col_major() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    assert!(t.is_contiguous());
+}
+
+#[test]
+fn contiguous_row_major() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, ROW);
+    assert!(t.is_contiguous());
+}
+
+#[test]
+fn not_contiguous_after_permute() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    let tp = t.permute(&[1, 0]).unwrap();
+    // Transposed column-major: strides [3, 1] with dims [4, 3]
+    // This is actually row-major contiguous! So it IS contiguous.
+    // Let's test with a 3D case instead.
+    let t3 = Tensor::<f64>::zeros(&[2, 3, 4], MEM, COL);
+    let tp3 = t3.permute(&[2, 0, 1]).unwrap();
+    // dims [4, 2, 3], strides [6, 1, 2] — not contiguous in either order
+    assert!(!tp3.is_contiguous());
+    // But the 2D transpose IS contiguous (row-major)
+    assert!(tp.is_contiguous());
+}
+
+// ============================================================================
+// Permute
+// ============================================================================
+
+#[test]
+fn permute_transpose() {
+    let t = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
+    let tp = t.permute(&[1, 0]).unwrap();
+    assert_eq!(tp.dims(), &[3, 2]);
+    assert_eq!(tp.strides(), &[2, 1]);
+}
+
+#[test]
+fn permute_identity() {
+    let t = Tensor::<f64>::zeros(&[3, 4, 5], MEM, COL);
+    let tp = t.permute(&[0, 1, 2]).unwrap();
+    assert_eq!(tp.dims(), &[3, 4, 5]);
+    assert_eq!(tp.strides(), t.strides());
+}
+
+#[test]
+fn permute_3d() {
+    let t = Tensor::<f64>::zeros(&[2, 3, 4], MEM, COL);
+    let tp = t.permute(&[2, 0, 1]).unwrap();
+    assert_eq!(tp.dims(), &[4, 2, 3]);
+    // Col-major strides: [1, 2, 6] → permuted: [6, 1, 2]
+    assert_eq!(tp.strides(), &[6, 1, 2]);
+}
+
+#[test]
+fn permute_invalid_length() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    assert!(t.permute(&[0]).is_err());
+}
+
+#[test]
+fn permute_out_of_range() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    assert!(t.permute(&[0, 5]).is_err());
+}
+
+#[test]
+fn permute_duplicate() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    assert!(t.permute(&[0, 0]).is_err());
+}
+
+// ============================================================================
+// Broadcast
+// ============================================================================
+
+#[test]
+fn broadcast_expand_dim1() {
+    let t = Tensor::<f64>::ones(&[3, 1], MEM, COL);
+    let b = t.broadcast(&[3, 4]).unwrap();
+    assert_eq!(b.dims(), &[3, 4]);
+    assert_eq!(b.strides()[1], 0);
+}
+
+#[test]
+fn broadcast_same_shape() {
+    let t = Tensor::<f64>::ones(&[3, 4], MEM, COL);
+    let b = t.broadcast(&[3, 4]).unwrap();
+    assert_eq!(b.dims(), &[3, 4]);
+    assert_eq!(b.strides(), t.strides());
+}
+
+#[test]
+fn broadcast_incompatible() {
+    let t = Tensor::<f64>::ones(&[3, 2], MEM, COL);
+    assert!(t.broadcast(&[3, 4]).is_err());
+}
+
+// ============================================================================
+// Diagonal
+// ============================================================================
+
+#[test]
+fn diagonal_2d() {
+    let t = Tensor::<f64>::eye(3, MEM, COL);
+    let d = t.diagonal(&[(0, 1)]).unwrap();
+    assert_eq!(d.dims(), &[3]);
+    // Col-major strides [1, 3] → diagonal stride 1+3=4
+    assert_eq!(d.strides(), &[4]);
+}
+
+#[test]
+fn diagonal_data_access() {
+    let data = [1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0];
+    let t = Tensor::<f64>::from_slice(&data, &[3, 3], COL).unwrap();
+    let d = t.diagonal(&[(0, 1)]).unwrap();
+    // Diagonal elements: d(0)=t(0,0)=1, d(1)=t(1,1)=2, d(2)=t(2,2)=3
+    let buf = d.buffer().as_slice().unwrap();
+    let off = d.offset();
+    let s = d.strides()[0];
+    assert_eq!(buf[(off + 0 * s) as usize], 1.0);
+    assert_eq!(buf[(off + 1 * s) as usize], 2.0);
+    assert_eq!(buf[(off + 2 * s) as usize], 3.0);
+}
+
+#[test]
+fn diagonal_mismatched_dims() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    assert!(t.diagonal(&[(0, 1)]).is_err());
+}
+
+#[test]
+fn diagonal_same_axis() {
+    let t = Tensor::<f64>::zeros(&[3, 3], MEM, COL);
+    assert!(t.diagonal(&[(0, 0)]).is_err());
+}
+
+// ============================================================================
+// Reshape
+// ============================================================================
+
+#[test]
+fn reshape_flatten() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let r = t.reshape(&[6]).unwrap();
+    assert_eq!(r.dims(), &[6]);
+    assert_eq!(r.strides(), &[1]);
+}
+
+#[test]
+fn reshape_same_shape() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let r = t.reshape(&[2, 3]).unwrap();
+    assert_eq!(r.dims(), &[2, 3]);
+}
+
+#[test]
+fn reshape_different_shape() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let r = t.reshape(&[3, 2]).unwrap();
+    assert_eq!(r.dims(), &[3, 2]);
+}
+
+#[test]
+fn reshape_incompatible_size() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    assert!(t.reshape(&[5]).is_err());
+}
+
+#[test]
+fn reshape_non_contiguous_fails() {
+    let t = Tensor::<f64>::zeros(&[2, 3, 4], MEM, COL);
+    let tp = t.permute(&[2, 0, 1]).unwrap();
+    assert!(tp.reshape(&[24]).is_err());
+}
+
+// ============================================================================
+// Select
+// ============================================================================
+
+#[test]
+fn select_dim0() {
+    let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let t = Tensor::<f64>::from_slice(&data, &[2, 3], COL).unwrap();
+    let s = t.select(0, 1).unwrap();
+    assert_eq!(s.dims(), &[3]);
+    // Row 1: t(1,0)=2, t(1,1)=4, t(1,2)=6
+    let buf = s.buffer().as_slice().unwrap();
+    assert_eq!(buf[(s.offset() + 0 * s.strides()[0]) as usize], 2.0);
+    assert_eq!(buf[(s.offset() + 1 * s.strides()[0]) as usize], 4.0);
+    assert_eq!(buf[(s.offset() + 2 * s.strides()[0]) as usize], 6.0);
+}
+
+#[test]
+fn select_dim1() {
+    let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let t = Tensor::<f64>::from_slice(&data, &[2, 3], COL).unwrap();
+    let s = t.select(1, 2).unwrap();
+    assert_eq!(s.dims(), &[2]);
+    // Col 2: t(0,2)=5, t(1,2)=6
+    let buf = s.buffer().as_slice().unwrap();
+    assert_eq!(buf[(s.offset() + 0 * s.strides()[0]) as usize], 5.0);
+    assert_eq!(buf[(s.offset() + 1 * s.strides()[0]) as usize], 6.0);
+}
+
+#[test]
+fn select_out_of_range_dim() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    assert!(t.select(2, 0).is_err());
+}
+
+#[test]
+fn select_out_of_range_index() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    assert!(t.select(0, 3).is_err());
+}
+
+// ============================================================================
+// Narrow
+// ============================================================================
+
+#[test]
+fn narrow_basic() {
+    let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let t = Tensor::<f64>::from_slice(&data, &[2, 3], COL).unwrap();
+    let n = t.narrow(1, 1, 2).unwrap();
+    assert_eq!(n.dims(), &[2, 2]);
+    // Cols 1..3: t(0,1)=3, t(1,1)=4, t(0,2)=5, t(1,2)=6
+    let buf = n.buffer().as_slice().unwrap();
+    let off = n.offset();
+    assert_eq!(buf[(off + 0) as usize], 3.0); // t(0,1)
+    assert_eq!(buf[(off + 1) as usize], 4.0); // t(1,1)
+}
+
+#[test]
+fn narrow_full_range() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    let n = t.narrow(0, 0, 3).unwrap();
+    assert_eq!(n.dims(), &[3, 4]);
+    assert_eq!(n.offset(), 0);
+}
+
+#[test]
+fn narrow_out_of_range() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    assert!(t.narrow(1, 3, 2).is_err()); // 3+2=5 > 4
+}
+
+// ============================================================================
+// Contiguous / into_contiguous
+// ============================================================================
+
+#[test]
+fn contiguous_already_contiguous() {
+    let t = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
+    let c = t.contiguous(COL);
+    assert_eq!(c.buffer().as_slice(), t.buffer().as_slice());
+}
+
+#[test]
+fn contiguous_from_permuted() {
+    let t = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
+    let tp = t.permute(&[1, 0]).unwrap(); // [3, 2], strides [2, 1]
+    let c = tp.contiguous(COL);
+    assert_eq!(c.dims(), &[3, 2]);
+    assert_eq!(c.strides(), &[1, 3]);
+    assert_eq!(c.offset(), 0);
+    assert!(c.is_contiguous());
+    // Verify data: tp(0,0)=t(0,0)=1, tp(0,1)=t(1,0)=2,
+    //              tp(1,0)=t(0,1)=3, tp(1,1)=t(1,1)=4,
+    //              tp(2,0)=t(0,2)=5, tp(2,1)=t(1,2)=6
+    // Col-major [3,2]: layout is [tp(0,0),tp(1,0),tp(2,0), tp(0,1),tp(1,1),tp(2,1)]
+    //                            = [1, 3, 5, 2, 4, 6]
+    assert_eq!(
+        c.buffer().as_slice().unwrap(),
+        &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
+    );
+}
+
+#[test]
+fn into_contiguous_passthrough() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let ptr = t.buffer().as_ptr();
+    let c = t.into_contiguous(COL);
+    assert_eq!(c.buffer().as_ptr(), ptr);
+}
+
+#[test]
+fn into_contiguous_copies_when_needed() {
+    let t = Tensor::<f64>::zeros(&[2, 3, 4], MEM, COL);
+    let tp = t.permute(&[2, 0, 1]).unwrap();
+    let c = tp.into_contiguous(COL);
+    assert!(c.is_contiguous());
+    assert_eq!(c.offset(), 0);
+}
+
+// ============================================================================
+// Tril / Triu
+// ============================================================================
+
+#[test]
+fn tril_3x3() {
+    let t = Tensor::<f64>::ones(&[3, 3], MEM, COL);
+    let lower = t.tril(0);
+    assert_eq!(lower.dims(), &[3, 3]);
+    let data = lower.buffer().as_slice().unwrap();
+    // Col-major: col 0 = [1,1,1], col 1 = [0,1,1], col 2 = [0,0,1]
+    assert_eq!(data, &[1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0]);
+}
+
+#[test]
+fn triu_3x3() {
+    let t = Tensor::<f64>::ones(&[3, 3], MEM, COL);
+    let upper = t.triu(0);
+    assert_eq!(upper.dims(), &[3, 3]);
+    let data = upper.buffer().as_slice().unwrap();
+    // Col-major: col 0 = [1,0,0], col 1 = [1,1,0], col 2 = [1,1,1]
+    assert_eq!(data, &[1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0]);
+}
+
+#[test]
+fn tril_with_diagonal_offset() {
+    let t = Tensor::<f64>::ones(&[3, 3], MEM, COL);
+    let lower = t.tril(1);
+    let data = lower.buffer().as_slice().unwrap();
+    // tril(1): keep where j - i <= 1
+    // Col 0: all kept [1,1,1]; Col 1: row 0,1,2 where j=1: 1-0=1<=1, 1-1=0<=1, 1-2=-1<=1 → all kept [1,1,1]
+    // Col 2: 2-0=2>1 → 0; 2-1=1<=1 → 1; 2-2=0<=1 → 1 → [0,1,1]
+    assert_eq!(data, &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0]);
+}
+
+#[test]
+fn triu_with_negative_diagonal() {
+    let t = Tensor::<f64>::ones(&[3, 3], MEM, COL);
+    let upper = t.triu(-1);
+    let data = upper.buffer().as_slice().unwrap();
+    // triu(-1): keep where j - i >= -1
+    // Col 0: 0-0=0>=-1, 0-1=-1>=-1, 0-2=-2<-1 → [1,1,0]
+    // Col 1: 1-0=1>=-1, 1-1=0>=-1, 1-2=-1>=-1 → [1,1,1]
+    // Col 2: all >= -1 → [1,1,1]
+    assert_eq!(data, &[1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]);
+}
+
+#[test]
+fn tril_triu_complementary() {
+    let t = Tensor::<f64>::ones(&[3, 3], MEM, COL);
+    let lower = t.tril(0);
+    let upper = t.triu(1);
+    // tril(0) + triu(1) should reconstruct the original
+    let l_data = lower.buffer().as_slice().unwrap();
+    let u_data = upper.buffer().as_slice().unwrap();
+    for i in 0..9 {
+        assert_eq!(l_data[i] + u_data[i], 1.0, "mismatch at index {i}");
+    }
+}
+
+// ============================================================================
+// to_memory_space_async
+// ============================================================================
+
+#[test]
+fn to_memory_space_same_space() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let t2 = t.to_memory_space_async(MEM).unwrap();
+    assert_eq!(t2.dims(), &[2, 3]);
+}
+
+#[test]
+fn to_memory_space_gpu_fails() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    assert!(t
+        .to_memory_space_async(LogicalMemorySpace::GpuMemory { device_id: 0 })
+        .is_err());
+}
+
+// ============================================================================
+// TensorView operations
+// ============================================================================
+
+#[test]
+fn tensor_view_metadata() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    let v = t.tensor_view();
+    assert_eq!(v.dims(), &[3, 4]);
+    assert_eq!(v.strides(), t.strides());
+    assert_eq!(v.ndim(), 2);
+    assert_eq!(v.offset(), 0);
+    assert!(!v.is_conjugated());
+    assert_eq!(v.logical_memory_space(), MEM);
+    assert!(v.preferred_compute_device().is_none());
+}
+
+#[test]
+fn tensor_view_permute() {
+    let t = Tensor::<f64>::zeros(&[3, 4], MEM, COL);
+    let v = t.tensor_view();
+    let vp = v.permute(&[1, 0]).unwrap();
+    assert_eq!(vp.dims(), &[4, 3]);
+}
+
+#[test]
+fn tensor_view_broadcast() {
+    let t = Tensor::<f64>::ones(&[1, 3], MEM, COL);
+    let v = t.tensor_view();
+    let vb = v.broadcast(&[4, 3]).unwrap();
+    assert_eq!(vb.dims(), &[4, 3]);
+    assert_eq!(vb.strides()[0], 0);
+}
+
+#[test]
+fn tensor_view_select() {
+    let t = Tensor::<f64>::zeros(&[3, 4, 5], MEM, COL);
+    let v = t.tensor_view();
+    let vs = v.select(2, 2).unwrap();
+    assert_eq!(vs.dims(), &[3, 4]);
+}
+
+#[test]
+fn tensor_view_narrow() {
+    let t = Tensor::<f64>::zeros(&[3, 10], MEM, COL);
+    let v = t.tensor_view();
+    let vn = v.narrow(1, 2, 3).unwrap();
+    assert_eq!(vn.dims(), &[3, 3]);
+}
+
+#[test]
+fn tensor_view_to_tensor() {
+    let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let t = Tensor::<f64>::from_slice(&data, &[2, 3], COL).unwrap();
+    let v = t.tensor_view();
+    let vp = v.permute(&[1, 0]).unwrap();
+    let owned = vp.to_tensor(COL);
+    assert_eq!(owned.dims(), &[3, 2]);
+    assert!(owned.is_contiguous());
+}
+
+#[test]
+fn tensor_view_conj() {
+    let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let v = t.tensor_view();
+    let vc = v.conj();
+    assert!(vc.is_conjugated());
+}
+
+// ============================================================================
+// Differentiable
+// ============================================================================
+
+#[test]
+fn zero_tangent() {
+    use chainrules_core::Differentiable;
+
+    let t = Tensor::<f64>::ones(&[2, 3], MEM, COL);
+    let zt = t.zero_tangent();
+    assert_eq!(zt.dims(), &[2, 3]);
+    let data = zt.buffer().as_slice().unwrap();
+    assert!(data.iter().all(|&x| x == 0.0));
+}
+
+#[test]
+fn accumulate_tangent_basic() {
+    use chainrules_core::Differentiable;
+
+    let a = Tensor::<f64>::ones(&[2, 3], MEM, COL);
+    let b = Tensor::<f64>::ones(&[2, 3], MEM, COL);
+    let result = Tensor::<f64>::accumulate_tangent(a, &b);
+    assert_eq!(result.dims(), &[2, 3]);
+    let data = result.buffer().as_slice().unwrap();
+    assert!(data.iter().all(|&x| x == 2.0));
+}
+
+#[test]
+fn accumulate_tangent_with_zero() {
+    use chainrules_core::Differentiable;
+
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0], &[3], COL).unwrap();
+    let b = a.zero_tangent();
+    let result = Tensor::<f64>::accumulate_tangent(a, &b);
+    let data = result.buffer().as_slice().unwrap();
+    assert_eq!(data, &[1.0, 2.0, 3.0]);
+}


### PR DESCRIPTION
## Summary
- Implement all 28 `todo!()` methods in `tenferro-tensor` (constructors, view ops, data ops, metadata, AD traits)
- Add private helper functions for strided iteration (`copy_strided`, `add_strided`, `compute_contiguous_strides`)
- Add 83 integration tests covering all implemented functionality
- Add `num-traits` workspace dependency

Closes #91

## Test plan
- [x] All 83 new integration tests pass (`cargo test -p tenferro-tensor`)
- [x] All workspace tests pass (`cargo test --workspace`)
- [x] Formatting clean (`cargo fmt --all --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)