### PR TITLE
feat(chainrules): implement AD engine with Tape, pullback, HVP

### DIFF
--- a/extern/chainrules-core/src/lib.rs
+++ b/extern/chainrules-core/src/lib.rs
@@ -33,6 +33,12 @@
 //!     fn accumulate_tangent(a: MyVec, b: &MyVec) -> MyVec {
 //!         MyVec(a.0.iter().zip(&b.0).map(|(x, y)| x + y).collect())
 //!     }
+//!     fn num_elements(&self) -> usize {
+//!         self.0.len()
+//!     }
+//!     fn seed_cotangent(&self) -> MyVec {
+//!         MyVec(vec![1.0; self.0.len()])
+//!     }
 //! }
 //! ```
 
@@ -74,6 +80,20 @@ pub trait Differentiable {
 
     /// Accumulates (adds) two tangents: `a + b`.
     fn accumulate_tangent(a: Self::Tangent, b: &Self::Tangent) -> Self::Tangent;
+
+    /// Returns the number of scalar elements in this value.
+    ///
+    /// For scalar types (f64, f32), this is always 1.
+    /// For tensor types, this is the total number of elements.
+    fn num_elements(&self) -> usize;
+
+    /// Returns the seed cotangent for reverse-mode pullback.
+    ///
+    /// For a scalar loss, this returns the "one" tangent (1.0 for scalars,
+    /// ones-like for single-element tensors). Used internally by
+    /// [`Tape::pullback`](https://docs.rs/chainrules) to initialize the
+    /// backward pass.
+    fn seed_cotangent(&self) -> Self::Tangent;
 }
 
 /// AD-specific error type.
@@ -298,6 +318,14 @@ impl Differentiable for f64 {
     fn accumulate_tangent(a: f64, b: &f64) -> f64 {
         a + b
     }
+
+    fn num_elements(&self) -> usize {
+        1
+    }
+
+    fn seed_cotangent(&self) -> f64 {
+        1.0
+    }
 }
 
 impl Differentiable for f32 {
@@ -309,5 +337,13 @@ impl Differentiable for f32 {
 
     fn accumulate_tangent(a: f32, b: &f32) -> f32 {
         a + b
+    }
+
+    fn num_elements(&self) -> usize {
+        1
+    }
+
+    fn seed_cotangent(&self) -> f32 {
+        1.0
     }
 }

--- a/extern/chainrules-core/tests/core_tests.rs
+++ b/extern/chainrules-core/tests/core_tests.rs
@@ -26,6 +26,20 @@ fn f64_accumulate_with_zero() {
 }
 
 // ============================================================================
+// Differentiable for f64 (num_elements, seed_cotangent)
+// ============================================================================
+
+#[test]
+fn f64_num_elements() {
+    assert_eq!(42.0_f64.num_elements(), 1);
+}
+
+#[test]
+fn f64_seed_cotangent() {
+    assert_eq!(42.0_f64.seed_cotangent(), 1.0_f64);
+}
+
+// ============================================================================
 // Differentiable for f32
 // ============================================================================
 
@@ -37,6 +51,16 @@ fn f32_zero_tangent() {
 #[test]
 fn f32_accumulate_tangent() {
     assert_eq!(f32::accumulate_tangent(1.5, &2.5), 4.0);
+}
+
+#[test]
+fn f32_num_elements() {
+    assert_eq!(42.0_f32.num_elements(), 1);
+}
+
+#[test]
+fn f32_seed_cotangent() {
+    assert_eq!(42.0_f32.seed_cotangent(), 1.0_f32);
 }
 
 // ============================================================================

--- a/extern/chainrules/src/lib.rs
+++ b/extern/chainrules/src/lib.rs
@@ -11,8 +11,6 @@
 //! Operation-specific AD rules (e.g., einsum rrule/frule) live in the crate
 //! that defines the operation. See `tenferro-einsum` for einsum AD functions.
 //!
-//! Bodies are intentionally `todo!()` in the current POC phase.
-//!
 //! # Examples
 //!
 //! Reverse-mode usage (with operation-specific AD functions from other crates):
@@ -79,7 +77,35 @@
 // Re-export all core traits so downstream can depend on just `chainrules`.
 pub use chainrules_core::*;
 
+use std::cell::RefCell;
 use std::marker::PhantomData;
+use std::rc::Rc;
+
+// ============================================================================
+// Internal tape storage
+// ============================================================================
+
+/// A single node in the tape graph.
+struct TapeNode<V: Differentiable> {
+    /// None for leaf nodes, Some for operation nodes.
+    rule: Option<Box<dyn ReverseRule<V>>>,
+    /// Tangent for HVP (set on leaves via leaf_with_tangent, or computed
+    /// for operation outputs during record_op). Reserved for future use by
+    /// AD-aware operation functions that need to access saved tangents.
+    #[allow(dead_code)]
+    tangent: Option<V::Tangent>,
+    /// Whether this node is a leaf (created via Tape::leaf).
+    is_leaf: bool,
+}
+
+/// Internal shared tape state.
+struct TapeInner<V: Differentiable> {
+    nodes: Vec<TapeNode<V>>,
+}
+
+// ============================================================================
+// Tape
+// ============================================================================
 
 /// Reverse-mode AD tape.
 ///
@@ -119,7 +145,7 @@ use std::marker::PhantomData;
 /// let _ga = grads.get(a.node_id().unwrap()).unwrap();
 /// ```
 pub struct Tape<V: Differentiable> {
-    _marker: PhantomData<V>,
+    inner: Rc<RefCell<TapeInner<V>>>,
 }
 
 impl<V: Differentiable> Tape<V> {
@@ -127,14 +153,14 @@ impl<V: Differentiable> Tape<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use chainrules::Tape;
     ///
     /// let tape = Tape::<f64>::new();
     /// ```
     pub fn new() -> Self {
         Self {
-            _marker: PhantomData,
+            inner: Rc::new(RefCell::new(TapeInner { nodes: Vec::new() })),
         }
     }
 
@@ -145,15 +171,28 @@ impl<V: Differentiable> Tape<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use chainrules::Tape;
     ///
     /// let tape = Tape::<f64>::new();
     /// let x = tape.leaf(3.14);
     /// assert!(x.requires_grad());
     /// ```
-    pub fn leaf(&self, _value: V) -> TrackedTensor<V> {
-        todo!()
+    pub fn leaf(&self, value: V) -> TrackedTensor<V> {
+        let mut inner = self.inner.borrow_mut();
+        let node_id = NodeId::new(inner.nodes.len());
+        inner.nodes.push(TapeNode {
+            rule: None,
+            tangent: None,
+            is_leaf: true,
+        });
+        TrackedTensor {
+            value,
+            node_id: Some(node_id),
+            tape: Some(self.clone()),
+            requires_grad: true,
+            tangent: None,
+        }
     }
 
     /// Creates a leaf value with a tangent for HVP computation.
@@ -167,7 +206,7 @@ impl<V: Differentiable> Tape<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use chainrules::Tape;
     ///
     /// let tape = Tape::<f64>::new();
@@ -175,8 +214,53 @@ impl<V: Differentiable> Tape<V> {
     /// assert!(x.requires_grad());
     /// assert!(x.has_tangent());
     /// ```
-    pub fn leaf_with_tangent(&self, _value: V, _tangent: V::Tangent) -> AdResult<TrackedTensor<V>> {
-        todo!()
+    pub fn leaf_with_tangent(&self, value: V, tangent: V::Tangent) -> AdResult<TrackedTensor<V>> {
+        let mut inner = self.inner.borrow_mut();
+        let node_id = NodeId::new(inner.nodes.len());
+        inner.nodes.push(TapeNode {
+            rule: None,
+            tangent: Some(tangent.clone()),
+            is_leaf: true,
+        });
+        Ok(TrackedTensor {
+            value,
+            node_id: Some(node_id),
+            tape: Some(self.clone()),
+            requires_grad: true,
+            tangent: Some(tangent),
+        })
+    }
+
+    /// Records an operation on the tape, returning a tracked output.
+    ///
+    /// Called by AD-aware functions (e.g., `tracked_einsum`) to register
+    /// an operation node with its reverse-mode rule.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let y = tape.record_op(output_value, Box::new(my_rule), None);
+    /// ```
+    pub fn record_op(
+        &self,
+        output_value: V,
+        rule: Box<dyn ReverseRule<V>>,
+        output_tangent: Option<V::Tangent>,
+    ) -> TrackedTensor<V> {
+        let mut inner = self.inner.borrow_mut();
+        let node_id = NodeId::new(inner.nodes.len());
+        inner.nodes.push(TapeNode {
+            rule: Some(rule),
+            tangent: output_tangent.clone(),
+            is_leaf: false,
+        });
+        TrackedTensor {
+            value: output_value,
+            node_id: Some(node_id),
+            tape: Some(self.clone()),
+            requires_grad: true,
+            tangent: output_tangent,
+        }
     }
 
     /// Runs reverse-mode pullback from a scalar loss value.
@@ -189,16 +273,75 @@ impl<V: Differentiable> Tape<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// use chainrules::Tape;
+    /// ```
+    /// use chainrules::{Tape, Differentiable};
     ///
     /// let tape = Tape::<f64>::new();
     /// let x = tape.leaf(2.0);
-    /// // ... compute loss from x ...
     /// let grads = tape.pullback(&x).unwrap();
+    /// // d(x)/d(x) = 1.0
+    /// assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 1.0);
     /// ```
-    pub fn pullback(&self, _loss: &TrackedTensor<V>) -> AdResult<Gradients<V>> {
-        todo!()
+    pub fn pullback(&self, loss: &TrackedTensor<V>) -> AdResult<Gradients<V>> {
+        let loss_node = loss.node_id.ok_or(AutodiffError::MissingNode)?;
+        let n = loss.value.num_elements();
+        if n != 1 {
+            return Err(AutodiffError::NonScalarLoss { num_elements: n });
+        }
+
+        let inner = self.inner.borrow();
+        let num_nodes = inner.nodes.len();
+
+        // Initialize cotangents for all nodes
+        let mut cotangents: Vec<Option<V::Tangent>> = Vec::with_capacity(num_nodes);
+        for _ in 0..num_nodes {
+            cotangents.push(None);
+        }
+
+        // Seed the loss node
+        cotangents[loss_node.index()] = Some(loss.value.seed_cotangent());
+
+        // Traverse nodes in reverse order from loss to first node
+        for i in (0..=loss_node.index()).rev() {
+            // Skip leaf nodes (no rule to propagate through)
+            if inner.nodes[i].rule.is_none() {
+                continue;
+            }
+
+            // Take the accumulated cotangent for this node
+            let cot = match cotangents[i].take() {
+                Some(c) => c,
+                None => continue,
+            };
+
+            // Apply the pullback rule
+            let input_grads = inner.nodes[i].rule.as_ref().unwrap().pullback(&cot)?;
+
+            // Accumulate cotangents at input nodes
+            for (node_id, grad) in input_grads {
+                let idx = node_id.index();
+                match cotangents[idx].take() {
+                    Some(existing) => {
+                        cotangents[idx] = Some(V::accumulate_tangent(existing, &grad));
+                    }
+                    None => {
+                        cotangents[idx] = Some(grad);
+                    }
+                }
+            }
+        }
+
+        // Collect gradients for leaf nodes
+        let mut result = Gradients::new();
+        for (i, cot) in cotangents.into_iter().enumerate() {
+            if let Some(c) = cot {
+                if inner.nodes[i].is_leaf {
+                    result.entries.push((NodeId::new(i), c));
+                }
+            }
+        }
+
+        Ok(result)
     }
 
     /// Computes gradient and Hessian-vector product via forward-over-reverse.
@@ -234,15 +377,101 @@ impl<V: Differentiable> Tape<V> {
     /// let _grad = result.gradients;
     /// let _hv = result.hvp;
     /// ```
-    pub fn hvp(&self, _loss: &TrackedTensor<V>) -> AdResult<HvpResult<V>> {
-        todo!()
+    pub fn hvp(&self, loss: &TrackedTensor<V>) -> AdResult<HvpResult<V>> {
+        let loss_node = loss.node_id.ok_or(AutodiffError::MissingNode)?;
+        let n = loss.value.num_elements();
+        if n != 1 {
+            return Err(AutodiffError::NonScalarLoss { num_elements: n });
+        }
+
+        let inner = self.inner.borrow();
+        let num_nodes = inner.nodes.len();
+
+        // Initialize cotangents and cotangent-tangents
+        let mut cotangents: Vec<Option<V::Tangent>> = Vec::with_capacity(num_nodes);
+        let mut cot_tangents: Vec<Option<V::Tangent>> = Vec::with_capacity(num_nodes);
+        for _ in 0..num_nodes {
+            cotangents.push(None);
+            cot_tangents.push(None);
+        }
+
+        // Seed: cotangent = 1 (seed), cotangent_tangent = 0 (seed is constant)
+        cotangents[loss_node.index()] = Some(loss.value.seed_cotangent());
+        cot_tangents[loss_node.index()] = Some(loss.value.zero_tangent());
+
+        // Traverse in reverse
+        for i in (0..=loss_node.index()).rev() {
+            if inner.nodes[i].rule.is_none() {
+                continue;
+            }
+
+            let cot = match cotangents[i].take() {
+                Some(c) => c,
+                None => continue,
+            };
+            let cot_tan = cot_tangents[i].take().unwrap_or_else(|| {
+                // If no cotangent-tangent accumulated, use zero
+                // (We need a zero tangent but don't have the value; use the cotangent's zero)
+                // Since V::Tangent == V for most types, zero_tangent works on cot
+                loss.value.zero_tangent()
+            });
+
+            let results = inner.nodes[i]
+                .rule
+                .as_ref()
+                .unwrap()
+                .pullback_with_tangents(&cot, &cot_tan)?;
+
+            for (node_id, grad, grad_tan) in results {
+                let idx = node_id.index();
+
+                // Accumulate cotangent
+                match cotangents[idx].take() {
+                    Some(existing) => {
+                        cotangents[idx] = Some(V::accumulate_tangent(existing, &grad));
+                    }
+                    None => {
+                        cotangents[idx] = Some(grad);
+                    }
+                }
+
+                // Accumulate cotangent-tangent
+                match cot_tangents[idx].take() {
+                    Some(existing) => {
+                        cot_tangents[idx] = Some(V::accumulate_tangent(existing, &grad_tan));
+                    }
+                    None => {
+                        cot_tangents[idx] = Some(grad_tan);
+                    }
+                }
+            }
+        }
+
+        // Collect gradients and HVP for leaf nodes
+        let mut gradients = Gradients::new();
+        let mut hvp_grads = Gradients::new();
+        for i in 0..num_nodes {
+            if inner.nodes[i].is_leaf {
+                if let Some(c) = cotangents[i].take() {
+                    gradients.entries.push((NodeId::new(i), c));
+                }
+                if let Some(ct) = cot_tangents[i].take() {
+                    hvp_grads.entries.push((NodeId::new(i), ct));
+                }
+            }
+        }
+
+        Ok(HvpResult {
+            gradients,
+            hvp: hvp_grads,
+        })
     }
 }
 
 impl<V: Differentiable> Clone for Tape<V> {
     fn clone(&self) -> Self {
         Self {
-            _marker: PhantomData,
+            inner: self.inner.clone(),
         }
     }
 }
@@ -252,6 +481,10 @@ impl<V: Differentiable> Default for Tape<V> {
         Self::new()
     }
 }
+
+// ============================================================================
+// TrackedTensor
+// ============================================================================
 
 /// Value wrapper for reverse-mode AD.
 ///
@@ -289,9 +522,9 @@ impl<V: Differentiable> TrackedTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use chainrules::TrackedTensor;
-    /// let x = TrackedTensor::new(value);
+    /// let x = TrackedTensor::new(42.0_f64);
     /// assert!(!x.requires_grad());
     /// ```
     pub fn new(value: V) -> Self {
@@ -308,8 +541,10 @@ impl<V: Differentiable> TrackedTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let v = tracked.value();
+    /// ```
+    /// use chainrules::TrackedTensor;
+    /// let x = TrackedTensor::new(42.0_f64);
+    /// assert_eq!(*x.value(), 42.0);
     /// ```
     pub fn value(&self) -> &V {
         &self.value
@@ -319,8 +554,10 @@ impl<V: Differentiable> TrackedTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let raw = tracked.into_value();
+    /// ```
+    /// use chainrules::TrackedTensor;
+    /// let x = TrackedTensor::new(42.0_f64);
+    /// assert_eq!(x.into_value(), 42.0);
     /// ```
     pub fn into_value(self) -> V {
         self.value
@@ -330,8 +567,10 @@ impl<V: Differentiable> TrackedTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// assert!(tracked.requires_grad());
+    /// ```
+    /// use chainrules::TrackedTensor;
+    /// let x = TrackedTensor::new(42.0_f64);
+    /// assert!(!x.requires_grad());
     /// ```
     pub fn requires_grad(&self) -> bool {
         self.requires_grad
@@ -341,10 +580,10 @@ impl<V: Differentiable> TrackedTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// if let Some(id) = tracked.node_id() {
-    ///     println!("node = {}", id.index());
-    /// }
+    /// ```
+    /// use chainrules::TrackedTensor;
+    /// let x = TrackedTensor::new(42.0_f64);
+    /// assert!(x.node_id().is_none());
     /// ```
     pub fn node_id(&self) -> Option<NodeId> {
         self.node_id
@@ -354,10 +593,10 @@ impl<V: Differentiable> TrackedTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// if let Some(t) = tracked.tangent() {
-    ///     // use tangent
-    /// }
+    /// ```
+    /// use chainrules::TrackedTensor;
+    /// let x = TrackedTensor::new(42.0_f64);
+    /// assert!(x.tangent().is_none());
     /// ```
     pub fn tangent(&self) -> Option<&V::Tangent> {
         self.tangent.as_ref()
@@ -367,8 +606,10 @@ impl<V: Differentiable> TrackedTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// assert!(tracked.has_tangent());
+    /// ```
+    /// use chainrules::TrackedTensor;
+    /// let x = TrackedTensor::new(42.0_f64);
+    /// assert!(!x.has_tangent());
     /// ```
     pub fn has_tangent(&self) -> bool {
         self.tangent.is_some()
@@ -378,22 +619,36 @@ impl<V: Differentiable> TrackedTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let detached = tracked.detach();
+    /// ```
+    /// use chainrules::Tape;
+    /// let tape = Tape::<f64>::new();
+    /// let x = tape.leaf(3.14);
+    /// assert!(x.requires_grad());
+    /// let detached = x.detach();
     /// assert!(!detached.requires_grad());
     /// ```
     pub fn detach(self) -> Self {
-        todo!()
+        Self {
+            value: self.value,
+            node_id: None,
+            tape: None,
+            requires_grad: false,
+            tangent: None,
+        }
     }
 }
+
+// ============================================================================
+// DualTensor
+// ============================================================================
 
 /// Value wrapper for forward-mode AD.
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use chainrules::DualTensor;
-/// let dual = DualTensor::new(primal);
+/// let dual = DualTensor::new(3.14_f64);
 /// assert!(!dual.has_tangent());
 /// ```
 pub struct DualTensor<V: Differentiable> {
@@ -406,9 +661,10 @@ impl<V: Differentiable> DualTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use chainrules::DualTensor;
-    /// let x = DualTensor::new(primal);
+    /// let x = DualTensor::new(3.14_f64);
+    /// assert!(!x.has_tangent());
     /// ```
     pub fn new(primal: V) -> Self {
         Self {
@@ -425,20 +681,30 @@ impl<V: Differentiable> DualTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// use chainrules::DualTensor;
-    /// let x = DualTensor::with_tangent(primal, tangent).unwrap();
     /// ```
-    pub fn with_tangent(_primal: V, _tangent: V::Tangent) -> AdResult<Self> {
-        todo!()
+    /// use chainrules::DualTensor;
+    /// let x = DualTensor::with_tangent(3.14_f64, 1.0_f64).unwrap();
+    /// assert!(x.has_tangent());
+    /// assert_eq!(*x.tangent().unwrap(), 1.0);
+    /// ```
+    pub fn with_tangent(primal: V, tangent: V::Tangent) -> AdResult<Self> {
+        // Shape validation is type-specific; for scalars (f64, f32) there is
+        // nothing to validate. For tensors, the caller (e.g., dual_einsum)
+        // should validate shapes before calling this.
+        Ok(Self {
+            primal,
+            tangent: Some(tangent),
+        })
     }
 
     /// Returns the primal value.
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let p = dual.primal();
+    /// ```
+    /// use chainrules::DualTensor;
+    /// let x = DualTensor::new(3.14_f64);
+    /// assert_eq!(*x.primal(), 3.14);
     /// ```
     pub fn primal(&self) -> &V {
         &self.primal
@@ -448,8 +714,10 @@ impl<V: Differentiable> DualTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let maybe_t = dual.tangent();
+    /// ```
+    /// use chainrules::DualTensor;
+    /// let x = DualTensor::new(3.14_f64);
+    /// assert!(x.tangent().is_none());
     /// ```
     pub fn tangent(&self) -> Option<&V::Tangent> {
         self.tangent.as_ref()
@@ -459,8 +727,10 @@ impl<V: Differentiable> DualTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// assert!(dual.has_tangent());
+    /// ```
+    /// use chainrules::DualTensor;
+    /// let x = DualTensor::new(3.14_f64);
+    /// assert!(!x.has_tangent());
     /// ```
     pub fn has_tangent(&self) -> bool {
         self.tangent.is_some()
@@ -470,8 +740,12 @@ impl<V: Differentiable> DualTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let (p, t) = dual.into_parts();
+    /// ```
+    /// use chainrules::DualTensor;
+    /// let x = DualTensor::with_tangent(3.14_f64, 1.0).unwrap();
+    /// let (p, t) = x.into_parts();
+    /// assert_eq!(p, 3.14);
+    /// assert_eq!(t, Some(1.0));
     /// ```
     pub fn into_parts(self) -> (V, Option<V::Tangent>) {
         (self.primal, self.tangent)
@@ -481,23 +755,35 @@ impl<V: Differentiable> DualTensor<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let c = dual.detach_tangent();
+    /// ```
+    /// use chainrules::DualTensor;
+    /// let x = DualTensor::with_tangent(3.14_f64, 1.0).unwrap();
+    /// let c = x.detach_tangent();
     /// assert!(!c.has_tangent());
+    /// assert_eq!(*c.primal(), 3.14);
     /// ```
     pub fn detach_tangent(self) -> Self {
-        todo!()
+        Self {
+            primal: self.primal,
+            tangent: None,
+        }
     }
 }
+
+// ============================================================================
+// Gradients
+// ============================================================================
 
 /// Accumulated gradients indexed by [`NodeId`].
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use chainrules::{Gradients, Differentiable};
-/// // V::Tangent is the gradient type
-/// let mut grads = Gradients::<MyType>::new();
+/// ```
+/// use chainrules::{Gradients, NodeId};
+///
+/// let mut grads = Gradients::<f64>::new();
+/// grads.accumulate(NodeId::new(0), 3.0).unwrap();
+/// assert_eq!(*grads.get(NodeId::new(0)).unwrap(), 3.0);
 /// ```
 pub struct Gradients<V: Differentiable> {
     entries: Vec<(NodeId, V::Tangent)>,
@@ -508,9 +794,10 @@ impl<V: Differentiable> Gradients<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use chainrules::Gradients;
-    /// let grads = Gradients::<MyType>::new();
+    /// let grads = Gradients::<f64>::new();
+    /// assert!(grads.entries().is_empty());
     /// ```
     pub fn new() -> Self {
         Self { entries: vec![] }
@@ -520,34 +807,53 @@ impl<V: Differentiable> Gradients<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// if let Some(g) = grads.get(node) {
-    ///     // use gradient
-    /// }
     /// ```
-    pub fn get(&self, _node: NodeId) -> Option<&V::Tangent> {
-        todo!()
+    /// use chainrules::{Gradients, NodeId};
+    ///
+    /// let mut grads = Gradients::<f64>::new();
+    /// grads.accumulate(NodeId::new(0), 5.0).unwrap();
+    /// assert_eq!(*grads.get(NodeId::new(0)).unwrap(), 5.0);
+    /// assert!(grads.get(NodeId::new(1)).is_none());
+    /// ```
+    pub fn get(&self, node: NodeId) -> Option<&V::Tangent> {
+        self.entries
+            .iter()
+            .find(|(id, _)| *id == node)
+            .map(|(_, grad)| grad)
     }
 
     /// Inserts or accumulates a gradient for `node`.
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// grads.accumulate(node, grad);
     /// ```
-    pub fn accumulate(&mut self, _node: NodeId, _grad: V::Tangent) -> AdResult<()> {
-        todo!()
+    /// use chainrules::{Gradients, NodeId};
+    ///
+    /// let mut grads = Gradients::<f64>::new();
+    /// grads.accumulate(NodeId::new(0), 2.0).unwrap();
+    /// grads.accumulate(NodeId::new(0), 3.0).unwrap();
+    /// assert_eq!(*grads.get(NodeId::new(0)).unwrap(), 5.0);
+    /// ```
+    pub fn accumulate(&mut self, node: NodeId, grad: V::Tangent) -> AdResult<()> {
+        if let Some(entry) = self.entries.iter_mut().find(|(id, _)| *id == node) {
+            let existing = entry.1.clone();
+            entry.1 = V::accumulate_tangent(existing, &grad);
+        } else {
+            self.entries.push((node, grad));
+        }
+        Ok(())
     }
 
     /// Returns all `(node, grad)` entries.
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// for (node, grad) in grads.entries() {
-    ///     println!("{}", node.index());
-    /// }
+    /// ```
+    /// use chainrules::{Gradients, NodeId};
+    ///
+    /// let mut grads = Gradients::<f64>::new();
+    /// grads.accumulate(NodeId::new(0), 1.0).unwrap();
+    /// assert_eq!(grads.entries().len(), 1);
     /// ```
     pub fn entries(&self) -> &[(NodeId, V::Tangent)] {
         &self.entries
@@ -559,6 +865,10 @@ impl<V: Differentiable> Default for Gradients<V> {
         Self::new()
     }
 }
+
+// ============================================================================
+// PullbackPlan
+// ============================================================================
 
 /// Compiled pullback execution plan.
 ///
@@ -578,22 +888,38 @@ impl<V: Differentiable> PullbackPlan<V> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let plan = chainrules::PullbackPlan::build(&loss).unwrap();
     /// ```
-    pub fn build(_loss: &TrackedTensor<V>) -> AdResult<Self> {
-        todo!()
+    /// use chainrules::{Tape, PullbackPlan};
+    ///
+    /// let tape = Tape::<f64>::new();
+    /// let x = tape.leaf(2.0);
+    /// let plan = PullbackPlan::build(&x).unwrap();
+    /// assert_eq!(plan.loss_node().index(), 0);
+    /// ```
+    pub fn build(loss: &TrackedTensor<V>) -> AdResult<Self> {
+        let node_id = loss.node_id.ok_or(AutodiffError::MissingNode)?;
+        Ok(Self {
+            loss: node_id,
+            _marker: PhantomData,
+        })
     }
 
     /// Executes the pre-built pullback plan.
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let grads = plan.execute(&loss).unwrap();
     /// ```
-    pub fn execute(&self, _loss: &TrackedTensor<V>) -> AdResult<Gradients<V>> {
-        todo!()
+    /// use chainrules::{Tape, PullbackPlan};
+    ///
+    /// let tape = Tape::<f64>::new();
+    /// let x = tape.leaf(2.0);
+    /// let plan = PullbackPlan::build(&x).unwrap();
+    /// let grads = plan.execute(&x).unwrap();
+    /// assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 1.0);
+    /// ```
+    pub fn execute(&self, loss: &TrackedTensor<V>) -> AdResult<Gradients<V>> {
+        let tape = loss.tape.as_ref().ok_or(AutodiffError::MissingNode)?;
+        tape.pullback(loss)
     }
 
     /// Returns loss node ID for this plan.
@@ -608,6 +934,10 @@ impl<V: Differentiable> PullbackPlan<V> {
         self.loss
     }
 }
+
+// ============================================================================
+// HvpResult
+// ============================================================================
 
 /// Result of a forward-over-reverse HVP computation.
 ///

--- a/extern/chainrules/tests/chainrules_tests.rs
+++ b/extern/chainrules/tests/chainrules_tests.rs
@@ -1,0 +1,612 @@
+//! Tests for chainrules: Tape, TrackedTensor, DualTensor, Gradients,
+//! PullbackPlan, and pullback with dummy operations.
+
+use chainrules::{
+    AdResult, AutodiffError, Differentiable, DualTensor, Gradients, NodeId, PullbackPlan,
+    ReverseRule, Tape, TrackedTensor,
+};
+
+// ============================================================================
+// Tape creation
+// ============================================================================
+
+#[test]
+fn tape_new() {
+    let _tape = Tape::<f64>::new();
+}
+
+#[test]
+fn tape_default() {
+    let _tape = Tape::<f64>::default();
+}
+
+#[test]
+fn tape_clone_shares_state() {
+    let tape1 = Tape::<f64>::new();
+    let tape2 = tape1.clone();
+    // Both tapes share state: leaf on one is visible via pullback on the other
+    let x = tape1.leaf(2.0);
+    let grads = tape2.pullback(&x).unwrap();
+    assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 1.0);
+}
+
+// ============================================================================
+// Tape::leaf
+// ============================================================================
+
+#[test]
+fn leaf_requires_grad() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(3.14);
+    assert!(x.requires_grad());
+}
+
+#[test]
+fn leaf_has_node_id() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(3.14);
+    assert!(x.node_id().is_some());
+    assert_eq!(x.node_id().unwrap().index(), 0);
+}
+
+#[test]
+fn leaf_sequential_node_ids() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(1.0);
+    let y = tape.leaf(2.0);
+    assert_eq!(x.node_id().unwrap().index(), 0);
+    assert_eq!(y.node_id().unwrap().index(), 1);
+}
+
+#[test]
+fn leaf_no_tangent() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(1.0);
+    assert!(!x.has_tangent());
+    assert!(x.tangent().is_none());
+}
+
+// ============================================================================
+// Tape::leaf_with_tangent
+// ============================================================================
+
+#[test]
+fn leaf_with_tangent_has_tangent() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf_with_tangent(3.14, 1.0).unwrap();
+    assert!(x.requires_grad());
+    assert!(x.has_tangent());
+    assert_eq!(*x.tangent().unwrap(), 1.0);
+}
+
+#[test]
+fn leaf_with_tangent_has_node_id() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf_with_tangent(3.14, 1.0).unwrap();
+    assert!(x.node_id().is_some());
+}
+
+// ============================================================================
+// TrackedTensor::new
+// ============================================================================
+
+#[test]
+fn tracked_new_no_grad() {
+    let x = TrackedTensor::new(42.0_f64);
+    assert!(!x.requires_grad());
+    assert!(x.node_id().is_none());
+    assert!(!x.has_tangent());
+}
+
+#[test]
+fn tracked_value() {
+    let x = TrackedTensor::new(42.0_f64);
+    assert_eq!(*x.value(), 42.0);
+}
+
+#[test]
+fn tracked_into_value() {
+    let x = TrackedTensor::new(42.0_f64);
+    assert_eq!(x.into_value(), 42.0);
+}
+
+// ============================================================================
+// TrackedTensor::detach
+// ============================================================================
+
+#[test]
+fn detach_removes_grad() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(3.14);
+    assert!(x.requires_grad());
+    let d = x.detach();
+    assert!(!d.requires_grad());
+    assert!(d.node_id().is_none());
+    assert!(!d.has_tangent());
+    assert_eq!(*d.value(), 3.14);
+}
+
+#[test]
+fn detach_removes_tangent() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf_with_tangent(3.14, 1.0).unwrap();
+    assert!(x.has_tangent());
+    let d = x.detach();
+    assert!(!d.has_tangent());
+}
+
+// ============================================================================
+// DualTensor
+// ============================================================================
+
+#[test]
+fn dual_new_no_tangent() {
+    let x = DualTensor::new(3.14_f64);
+    assert!(!x.has_tangent());
+    assert_eq!(*x.primal(), 3.14);
+}
+
+#[test]
+fn dual_with_tangent() {
+    let x = DualTensor::with_tangent(3.14_f64, 1.0).unwrap();
+    assert!(x.has_tangent());
+    assert_eq!(*x.tangent().unwrap(), 1.0);
+    assert_eq!(*x.primal(), 3.14);
+}
+
+#[test]
+fn dual_into_parts() {
+    let x = DualTensor::with_tangent(3.14_f64, 1.0).unwrap();
+    let (p, t) = x.into_parts();
+    assert_eq!(p, 3.14);
+    assert_eq!(t, Some(1.0));
+}
+
+#[test]
+fn dual_into_parts_no_tangent() {
+    let x = DualTensor::new(3.14_f64);
+    let (p, t) = x.into_parts();
+    assert_eq!(p, 3.14);
+    assert_eq!(t, None);
+}
+
+#[test]
+fn dual_detach_tangent() {
+    let x = DualTensor::with_tangent(3.14_f64, 1.0).unwrap();
+    let c = x.detach_tangent();
+    assert!(!c.has_tangent());
+    assert_eq!(*c.primal(), 3.14);
+}
+
+// ============================================================================
+// Gradients
+// ============================================================================
+
+#[test]
+fn gradients_new_empty() {
+    let grads = Gradients::<f64>::new();
+    assert!(grads.entries().is_empty());
+}
+
+#[test]
+fn gradients_default() {
+    let grads = Gradients::<f64>::default();
+    assert!(grads.entries().is_empty());
+}
+
+#[test]
+fn gradients_get_missing() {
+    let grads = Gradients::<f64>::new();
+    assert!(grads.get(NodeId::new(0)).is_none());
+}
+
+#[test]
+fn gradients_accumulate_insert() {
+    let mut grads = Gradients::<f64>::new();
+    grads.accumulate(NodeId::new(0), 3.0).unwrap();
+    assert_eq!(*grads.get(NodeId::new(0)).unwrap(), 3.0);
+}
+
+#[test]
+fn gradients_accumulate_adds() {
+    let mut grads = Gradients::<f64>::new();
+    grads.accumulate(NodeId::new(0), 2.0).unwrap();
+    grads.accumulate(NodeId::new(0), 3.0).unwrap();
+    assert_eq!(*grads.get(NodeId::new(0)).unwrap(), 5.0);
+}
+
+#[test]
+fn gradients_accumulate_multiple_nodes() {
+    let mut grads = Gradients::<f64>::new();
+    grads.accumulate(NodeId::new(0), 1.0).unwrap();
+    grads.accumulate(NodeId::new(1), 2.0).unwrap();
+    assert_eq!(*grads.get(NodeId::new(0)).unwrap(), 1.0);
+    assert_eq!(*grads.get(NodeId::new(1)).unwrap(), 2.0);
+}
+
+#[test]
+fn gradients_entries() {
+    let mut grads = Gradients::<f64>::new();
+    grads.accumulate(NodeId::new(0), 1.0).unwrap();
+    grads.accumulate(NodeId::new(1), 2.0).unwrap();
+    assert_eq!(grads.entries().len(), 2);
+}
+
+// ============================================================================
+// Differentiable: num_elements and seed_cotangent for f64
+// ============================================================================
+
+#[test]
+fn f64_num_elements() {
+    assert_eq!(42.0_f64.num_elements(), 1);
+}
+
+#[test]
+fn f64_seed_cotangent() {
+    assert_eq!(42.0_f64.seed_cotangent(), 1.0_f64);
+}
+
+#[test]
+fn f32_num_elements() {
+    assert_eq!(42.0_f32.num_elements(), 1);
+}
+
+#[test]
+fn f32_seed_cotangent() {
+    assert_eq!(42.0_f32.seed_cotangent(), 1.0_f32);
+}
+
+// ============================================================================
+// Pullback: leaf only (d(x)/d(x) = 1)
+// ============================================================================
+
+#[test]
+fn pullback_leaf_identity() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(2.0);
+    let grads = tape.pullback(&x).unwrap();
+    assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 1.0);
+}
+
+#[test]
+fn pullback_missing_node_error() {
+    let tape = Tape::<f64>::new();
+    let x = TrackedTensor::new(2.0);
+    let result = tape.pullback(&x);
+    assert!(result.is_err());
+    match result {
+        Err(AutodiffError::MissingNode) => {}
+        Err(other) => panic!("expected MissingNode, got {other:?}"),
+        Ok(_) => panic!("expected error"),
+    }
+}
+
+// ============================================================================
+// Pullback with dummy operations
+// ============================================================================
+
+/// Rule: y = 2*x, so dy/dx = 2
+struct MultiplyBy2Rule {
+    input: NodeId,
+}
+
+impl ReverseRule<f64> for MultiplyBy2Rule {
+    fn pullback(&self, cotangent: &f64) -> AdResult<Vec<(NodeId, f64)>> {
+        Ok(vec![(self.input, cotangent * 2.0)])
+    }
+    fn inputs(&self) -> Vec<NodeId> {
+        vec![self.input]
+    }
+}
+
+#[test]
+fn pullback_single_op() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(3.0);
+    // y = 2*x = 6, dy/dx = 2
+    let y = tape.record_op(
+        6.0,
+        Box::new(MultiplyBy2Rule {
+            input: x.node_id().unwrap(),
+        }),
+        None,
+    );
+    let grads = tape.pullback(&y).unwrap();
+    assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 2.0);
+}
+
+#[test]
+fn pullback_chain_of_ops() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(3.0);
+    // y = 2*x
+    let y = tape.record_op(
+        6.0,
+        Box::new(MultiplyBy2Rule {
+            input: x.node_id().unwrap(),
+        }),
+        None,
+    );
+    // z = 2*y = 4*x
+    let z = tape.record_op(
+        12.0,
+        Box::new(MultiplyBy2Rule {
+            input: y.node_id().unwrap(),
+        }),
+        None,
+    );
+    let grads = tape.pullback(&z).unwrap();
+    // dz/dx = dz/dy * dy/dx = 2 * 2 = 4
+    assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 4.0);
+}
+
+/// Rule: z = x + y, so dz/dx = 1, dz/dy = 1
+struct AddRule {
+    inputs: Vec<NodeId>,
+}
+
+impl ReverseRule<f64> for AddRule {
+    fn pullback(&self, cotangent: &f64) -> AdResult<Vec<(NodeId, f64)>> {
+        Ok(self.inputs.iter().map(|&id| (id, *cotangent)).collect())
+    }
+    fn inputs(&self) -> Vec<NodeId> {
+        self.inputs.clone()
+    }
+}
+
+#[test]
+fn pullback_multi_input() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(2.0);
+    let y = tape.leaf(3.0);
+    // z = x + y = 5
+    let z = tape.record_op(
+        5.0,
+        Box::new(AddRule {
+            inputs: vec![x.node_id().unwrap(), y.node_id().unwrap()],
+        }),
+        None,
+    );
+    let grads = tape.pullback(&z).unwrap();
+    assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 1.0);
+    assert_eq!(*grads.get(y.node_id().unwrap()).unwrap(), 1.0);
+}
+
+/// Rule: y = x * x (same input used twice), so dy/dx = 2*x
+/// Pullback: returns two entries for the same input, each cotangent * x
+struct SquareRule {
+    input: NodeId,
+    saved_x: f64,
+}
+
+impl ReverseRule<f64> for SquareRule {
+    fn pullback(&self, cotangent: &f64) -> AdResult<Vec<(NodeId, f64)>> {
+        // d(x*x)/dx = 2x, but expressed as two contributions of x each
+        Ok(vec![
+            (self.input, cotangent * self.saved_x),
+            (self.input, cotangent * self.saved_x),
+        ])
+    }
+    fn inputs(&self) -> Vec<NodeId> {
+        vec![self.input]
+    }
+}
+
+#[test]
+fn pullback_repeated_input() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(3.0);
+    // y = x^2 = 9, dy/dx = 2*x = 6
+    let y = tape.record_op(
+        9.0,
+        Box::new(SquareRule {
+            input: x.node_id().unwrap(),
+            saved_x: 3.0,
+        }),
+        None,
+    );
+    let grads = tape.pullback(&y).unwrap();
+    assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 6.0);
+}
+
+#[test]
+fn pullback_diamond_graph() {
+    // x -> y1 = 2*x, x -> y2 = 2*x, z = y1 + y2
+    // dz/dx = dz/dy1 * dy1/dx + dz/dy2 * dy2/dx = 1*2 + 1*2 = 4
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(1.0);
+    let y1 = tape.record_op(
+        2.0,
+        Box::new(MultiplyBy2Rule {
+            input: x.node_id().unwrap(),
+        }),
+        None,
+    );
+    let y2 = tape.record_op(
+        2.0,
+        Box::new(MultiplyBy2Rule {
+            input: x.node_id().unwrap(),
+        }),
+        None,
+    );
+    let z = tape.record_op(
+        4.0,
+        Box::new(AddRule {
+            inputs: vec![y1.node_id().unwrap(), y2.node_id().unwrap()],
+        }),
+        None,
+    );
+    let grads = tape.pullback(&z).unwrap();
+    assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 4.0);
+}
+
+#[test]
+fn pullback_only_returns_leaf_grads() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(3.0);
+    let y = tape.record_op(
+        6.0,
+        Box::new(MultiplyBy2Rule {
+            input: x.node_id().unwrap(),
+        }),
+        None,
+    );
+    let grads = tape.pullback(&y).unwrap();
+    // Only leaf node (x) should have a gradient, not intermediate (y)
+    assert_eq!(grads.entries().len(), 1);
+    assert_eq!(grads.entries()[0].0, x.node_id().unwrap());
+}
+
+// ============================================================================
+// PullbackPlan
+// ============================================================================
+
+#[test]
+fn pullback_plan_build() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(2.0);
+    let plan = PullbackPlan::build(&x).unwrap();
+    assert_eq!(plan.loss_node().index(), 0);
+}
+
+#[test]
+fn pullback_plan_build_missing_node() {
+    let x = TrackedTensor::new(2.0_f64);
+    let result = PullbackPlan::build(&x);
+    assert!(result.is_err());
+}
+
+#[test]
+fn pullback_plan_execute() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(2.0);
+    let plan = PullbackPlan::build(&x).unwrap();
+    let grads = plan.execute(&x).unwrap();
+    assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 1.0);
+}
+
+#[test]
+fn pullback_plan_execute_with_op() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(3.0);
+    let y = tape.record_op(
+        6.0,
+        Box::new(MultiplyBy2Rule {
+            input: x.node_id().unwrap(),
+        }),
+        None,
+    );
+    let plan = PullbackPlan::build(&y).unwrap();
+    let grads = plan.execute(&y).unwrap();
+    assert_eq!(*grads.get(x.node_id().unwrap()).unwrap(), 2.0);
+}
+
+// ============================================================================
+// HVP with dummy operation
+// ============================================================================
+
+/// Rule: y = x^2
+/// pullback: dy = 2*x * dL
+/// pullback_with_tangents:
+///   cotangent of input = 2*x * dL (same as pullback)
+///   cotangent tangent of input = 2*dx * dL + 2*x * dL_tangent
+///   where dx is the tangent of x, dL is the cotangent, dL_tangent is cotangent tangent
+struct SquareRuleHvp {
+    input: NodeId,
+    saved_x: f64,
+    saved_dx: f64,
+}
+
+impl ReverseRule<f64> for SquareRuleHvp {
+    fn pullback(&self, cotangent: &f64) -> AdResult<Vec<(NodeId, f64)>> {
+        Ok(vec![(self.input, 2.0 * self.saved_x * cotangent)])
+    }
+
+    fn inputs(&self) -> Vec<NodeId> {
+        vec![self.input]
+    }
+
+    fn pullback_with_tangents(
+        &self,
+        cotangent: &f64,
+        cotangent_tangent: &f64,
+    ) -> AdResult<Vec<(NodeId, f64, f64)>> {
+        // grad = 2*x * cotangent
+        let grad = 2.0 * self.saved_x * cotangent;
+        // grad_tangent = 2*dx * cotangent + 2*x * cotangent_tangent
+        let grad_tangent = 2.0 * self.saved_dx * cotangent + 2.0 * self.saved_x * cotangent_tangent;
+        Ok(vec![(self.input, grad, grad_tangent)])
+    }
+}
+
+#[test]
+fn hvp_square_function() {
+    // f(x) = x^2, ∇f = 2x, H = 2, Hv = 2v
+    // x = 3.0, v = 1.0 (tangent direction)
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf_with_tangent(3.0, 1.0).unwrap();
+    // y = x^2 = 9
+    let y = tape.record_op(
+        9.0,
+        Box::new(SquareRuleHvp {
+            input: x.node_id().unwrap(),
+            saved_x: 3.0,
+            saved_dx: 1.0, // tangent of x
+        }),
+        None, // output tangent (dy = 2*x*dx = 6) not needed for hvp traversal
+    );
+    let result = tape.hvp(&y).unwrap();
+    // Gradient: d(x^2)/dx = 2*3 = 6
+    assert_eq!(*result.gradients.get(x.node_id().unwrap()).unwrap(), 6.0);
+    // HVP: H*v = 2*1 = 2
+    assert_eq!(*result.hvp.get(x.node_id().unwrap()).unwrap(), 2.0);
+}
+
+#[test]
+fn hvp_missing_node_error() {
+    let tape = Tape::<f64>::new();
+    let x = TrackedTensor::new(2.0_f64);
+    let result = tape.hvp(&x);
+    assert!(result.is_err());
+    match result {
+        Err(AutodiffError::MissingNode) => {}
+        Err(other) => panic!("expected MissingNode, got {other:?}"),
+        Ok(_) => panic!("expected error"),
+    }
+}
+
+// ============================================================================
+// record_op basics
+// ============================================================================
+
+#[test]
+fn record_op_creates_tracked() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(1.0);
+    let y = tape.record_op(
+        2.0,
+        Box::new(MultiplyBy2Rule {
+            input: x.node_id().unwrap(),
+        }),
+        None,
+    );
+    assert!(y.requires_grad());
+    assert!(y.node_id().is_some());
+    assert_eq!(y.node_id().unwrap().index(), 1);
+    assert_eq!(*y.value(), 2.0);
+}
+
+#[test]
+fn record_op_with_tangent() {
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf(1.0);
+    let y = tape.record_op(
+        2.0,
+        Box::new(MultiplyBy2Rule {
+            input: x.node_id().unwrap(),
+        }),
+        Some(2.0), // output tangent
+    );
+    assert!(y.has_tangent());
+    assert_eq!(*y.tangent().unwrap(), 2.0);
+}

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -2395,6 +2395,18 @@ impl<T: Scalar> chainrules_core::Differentiable for Tensor<T> {
     /// let tangent = Tensor::<f64>::zeros(&[2, 3]);
     /// t.accumulate_tangent(&tangent);
     /// ```
+    fn num_elements(&self) -> usize {
+        self.len()
+    }
+
+    fn seed_cotangent(&self) -> Tensor<T> {
+        Tensor::ones(
+            &self.dims,
+            self.logical_memory_space,
+            MemoryOrder::ColumnMajor,
+        )
+    }
+
     fn accumulate_tangent(a: Tensor<T>, b: &Tensor<T>) -> Tensor<T> {
         assert_eq!(
             a.dims, b.dims,


### PR DESCRIPTION
## Summary
- Implement all 11 `todo!()` methods in the `chainrules` crate (Tape, TrackedTensor, DualTensor, Gradients, PullbackPlan)
- Add `Tape::record_op` for operation registration on the tape
- Add `Rc<RefCell<TapeInner>>` internal state for shared tape graph
- Extend `chainrules-core::Differentiable` with `num_elements()` and `seed_cotangent()` (needed for pullback seed)
- Update `Tensor<T>` Differentiable impl with new methods
- Add 46 integration tests (tape, pullback, chain rule, diamond graph, HVP)
- Add 4 tests to chainrules-core for new Differentiable methods
- Enable doctests for simple f64 examples

Closes #92

## Test plan
- [x] 46 chainrules tests pass
- [x] 32 chainrules-core tests pass (including 4 new)
- [x] 83 tenferro-tensor tests pass
- [x] Full workspace tests pass (`cargo test --workspace`)
- [x] Formatting clean (`cargo fmt --all --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)