### PR TITLE
docs+ci: add coverage reporting workflow and prims-first linalg design notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,21 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage JSON
+        run: cargo llvm-cov --workspace --json --output-path coverage.json
+      - name: Report per-file thresholds (non-blocking)
+        run: python3 scripts/check-coverage.py --report-only coverage.json
+
   doc:
     name: cargo doc
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,22 @@ docs/site/
 # Logs
 *.log
 
+# Node.js / frontend artifacts
+node_modules/
+package-lock.json
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-store/
+.npm/
+.next/
+.nuxt/
+.svelte-kit/
+.parcel-cache/
+
+# Local AI/dev tooling artifacts
+.claude/
+
 # Editor / IDE
 .vscode/
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ Before pushing or creating a pull request, **all** of the following must pass:
 ```bash
 cargo fmt --all --check   # formatting
 cargo test --workspace    # all tests
+cargo llvm-cov --workspace --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
 ```
 
 If `cargo fmt --all --check` fails, run `cargo fmt --all` to fix formatting automatically.
@@ -87,6 +89,10 @@ cargo test test_name
 
 # Check formatting
 cargo fmt --check
+
+# Coverage check (per-file thresholds)
+cargo llvm-cov --workspace --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
 
 # Run benchmarks
 cargo bench
@@ -168,4 +174,3 @@ tenferro-device  tenferro-tensor
           tenferro-capi
               (← tenferro-tensor, ← tenferro-einsum, ← tenferro-linalg, ← tenferro-device)
 ```
-

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Output:
 - `target/docs-site/design/` (formal design docs)
 - `target/docs-site/api/` (`cargo doc --workspace` output)
 
+## Coverage
+
+Per-file line coverage is checked against thresholds in `coverage-thresholds.json`.
+Files listed in `exclude` are skipped from threshold checking.
+
+```bash
+cargo llvm-cov --workspace --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
+```
+
 ## License
 
 Licensed under either of:

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Per-file line coverage thresholds (%). Files not listed use 'default'.",
+  "default": 80,
+  "exclude": [
+    "extension/tenferro-burn/src/backward.rs",
+    "extension/tenferro-burn/src/convert.rs",
+    "extension/tenferro-burn/src/forward.rs",
+    "extension/tenferro-burn/src/lib.rs",
+    "extension/tenferro-mdarray/src/lib.rs",
+    "extension/tenferro-tropical-capi/src/lib.rs"
+  ],
+  "files": {
+    "extension/tenferro-tropical/src/prims.rs": 55,
+    "tenferro-capi/src/lib.rs": 65,
+    "tenferro-einsum/src/lib.rs": 65,
+    "tenferro-linalg/src/lib.rs": 30
+  }
+}

--- a/docs/design/linalg.md
+++ b/docs/design/linalg.md
@@ -300,6 +300,51 @@ directly for the forward decompositions (not through TensorPrims).
 
 ---
 
+## Prims-First Boundary
+
+The project adopts a **prims-first** implementation strategy where possible,
+with explicit boundaries:
+
+1. **Primal forward for heavy decompositions is backend-native.**
+   `svd/qr/lu/eig/cholesky/solve/lstsq` primal implementations use dedicated
+   CPU/GPU solver backends (faer/LAPACK/cuSOLVER family), not a decomposition
+   synthesized only from `TensorPrims`.
+
+2. **AD rules should be expressed in TensorPrims as far as practical.**
+   Reverse/forward rules are written with `BatchedGemm`, `Permute`, `Reduce`,
+   `Trace`, `AntiTrace`, `ElementwiseMul`, and `ElementwiseUnary` so the same
+   rule logic can run across CPU/GPU backends.
+
+3. **Why this split exists.**
+   Reconstructing full linalg primal kernels from generic prims is possible in
+   principle but is not practical for numerical stability, performance, and
+   implementation complexity.
+
+This keeps rule logic backend-agnostic while preserving production-grade
+numerics for primal evaluation.
+
+---
+
+## Design Record Workflow
+
+For linalg/prims integration changes, design records are managed as follows:
+
+1. **Source of truth lives in docs.**
+   Keep design details in existing files under `docs/design/` (this file and
+   `tensor-prims.md`) and formula-level notes in `docs/AD/`.
+
+2. **Issues track execution, not full specs.**
+   GitHub issues should capture scope, acceptance criteria, and task breakdown,
+   and must link back to the canonical design doc section.
+
+3. **One topic, one design anchor.**
+   For each major change, update one primary design location first, then create
+   a parent issue that references it and spawns implementation sub-issues.
+
+This reduces drift between discussion threads and technical decisions.
+
+---
+
 ## Design Decisions
 
 1. **Matrix-only API.** Higher-level tensor decomposition (e.g., SVD along

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Check per-file line coverage against thresholds defined in coverage-thresholds.json."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main():
+    root = Path(__file__).resolve().parent.parent
+    thresholds_path = root / "coverage-thresholds.json"
+
+    with open(thresholds_path) as f:
+        config = json.load(f)
+    default_threshold = config.get("default", 80)
+    file_thresholds = config.get("files", {})
+    excluded_files = set(config.get("exclude", []))
+
+    report_only = "--report-only" in sys.argv[1:]
+    args = [a for a in sys.argv[1:] if a != "--report-only"]
+
+    if len(args) > 0:
+        with open(args[0]) as f:
+            cov_data = json.load(f)
+    else:
+        cov_data = json.load(sys.stdin)
+
+    files = cov_data["data"][0]["files"]
+    root_str = str(root) + "/"
+
+    failures = []
+    passed = 0
+    skipped = 0
+
+    for entry in files:
+        abs_path = entry["filename"]
+        if abs_path.startswith(root_str):
+            rel_path = abs_path[len(root_str) :]
+        else:
+            rel_path = abs_path
+
+        if rel_path in excluded_files:
+            skipped += 1
+            continue
+
+        lines = entry["summary"]["lines"]
+        percent = lines["percent"]
+        threshold = file_thresholds.get(rel_path, default_threshold)
+
+        if percent < threshold:
+            failures.append((rel_path, percent, threshold))
+        else:
+            passed += 1
+
+    total = passed + len(failures)
+    print(f"Coverage check: {passed}/{total} files passed (excluded: {skipped})\n")
+
+    if failures:
+        print("FAILED files:")
+        for path, actual, required in sorted(failures):
+            print(f"  {path}: {actual:.1f}% < {required}%")
+        print()
+        if report_only:
+            print("Report-only mode: not failing.")
+            sys.exit(0)
+        sys.exit(1)
+    else:
+        print("All files meet their coverage thresholds.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add per-file coverage threshold configuration (`coverage-thresholds.json`)
- add `scripts/check-coverage.py` to report per-file coverage against thresholds
- add a non-blocking coverage report job to CI (`.github/workflows/ci.yml`)
- document coverage commands in `AGENTS.md` and `README.md`
- update `docs/design/linalg.md` with a prims-first boundary and design-record workflow
- ignore Node/frontend and local tooling artifacts in `.gitignore`

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace`

Generated with [Claude Code](https://claude.com/claude-code)
