### PR TITLE
fix(capi,tropical): address #111 #113 #114

### DIFF
--- a/extension/tenferro-tropical/src/prims.rs
+++ b/extension/tenferro-tropical/src/prims.rs
@@ -11,6 +11,7 @@
 //! `sum = sum + a * b` becomes `sum = max(sum, a_val + b_val)` for MaxPlus,
 //! which is exactly tropical GEMM.
 
+use std::collections::HashSet;
 use std::marker::PhantomData;
 
 use strided_traits::ScalarBase;
@@ -261,8 +262,34 @@ fn execute_trace<T: ScalarBase>(
     paired_axes: &[(usize, usize)],
     free_axes: &[usize],
 ) -> Result<()> {
+    if paired_axes.is_empty() {
+        return Err(Error::InvalidArgument(
+            "trace requires at least one paired axis".into(),
+        ));
+    }
+
     let in_dims = input.dims().to_vec();
     let out_dims = output.dims().to_vec();
+    for &(ax1, ax2) in paired_axes {
+        if ax1 >= in_dims.len() || ax2 >= in_dims.len() {
+            return Err(Error::InvalidArgument(
+                "trace paired axis out of bounds".into(),
+            ));
+        }
+    }
+    for &ax in free_axes {
+        if ax >= in_dims.len() {
+            return Err(Error::InvalidArgument(
+                "trace free axis out of bounds".into(),
+            ));
+        }
+    }
+    if out_dims.len() != free_axes.len() {
+        return Err(Error::InvalidArgument(
+            "trace output rank does not match free axes".into(),
+        ));
+    }
+
     let diag_dim = in_dims[paired_axes[0].0];
 
     for_each_index(&out_dims, |out_idx| {
@@ -324,10 +351,35 @@ fn execute_anti_trace<T: ScalarBase>(
     paired_axes: &[(usize, usize)],
     free_axes: &[usize],
 ) -> Result<()> {
+    if paired_axes.is_empty() {
+        return Err(Error::InvalidArgument(
+            "anti-trace requires at least one paired axis".into(),
+        ));
+    }
+
     scale_output(output, beta);
 
     let in_dims = input.dims().to_vec();
     let out_dims = output.dims().to_vec();
+    for &(ax1, ax2) in paired_axes {
+        if ax1 >= out_dims.len() || ax2 >= out_dims.len() {
+            return Err(Error::InvalidArgument(
+                "anti-trace paired axis out of bounds".into(),
+            ));
+        }
+    }
+    for &ax in free_axes {
+        if ax >= out_dims.len() {
+            return Err(Error::InvalidArgument(
+                "anti-trace free axis out of bounds".into(),
+            ));
+        }
+    }
+    if in_dims.len() != free_axes.len() {
+        return Err(Error::InvalidArgument(
+            "anti-trace input rank does not match free axes".into(),
+        ));
+    }
     let diag_dim = out_dims[paired_axes[0].0];
 
     for_each_index(&in_dims, |in_idx| {
@@ -356,10 +408,35 @@ fn execute_anti_diag<T: ScalarBase>(
     paired_axes: &[(usize, usize)],
     free_axes: &[usize],
 ) -> Result<()> {
+    if paired_axes.is_empty() {
+        return Err(Error::InvalidArgument(
+            "anti-diag requires at least one paired axis".into(),
+        ));
+    }
+
     scale_output(output, beta);
 
     let in_dims = input.dims().to_vec();
     let out_dims = output.dims().to_vec();
+    for &(ax1, ax2) in paired_axes {
+        if ax1 >= out_dims.len() || ax2 >= out_dims.len() {
+            return Err(Error::InvalidArgument(
+                "anti-diag paired axis out of bounds".into(),
+            ));
+        }
+    }
+    for &ax in free_axes {
+        if ax >= out_dims.len() {
+            return Err(Error::InvalidArgument(
+                "anti-diag free axis out of bounds".into(),
+            ));
+        }
+    }
+    if in_dims.len() != free_axes.len() {
+        return Err(Error::InvalidArgument(
+            "anti-diag input rank does not match free axes".into(),
+        ));
+    }
 
     for_each_index(&in_dims, |in_idx| {
         let val = alpha * input.get(in_idx);
@@ -380,26 +457,133 @@ fn execute_anti_diag<T: ScalarBase>(
 // Plan construction (shared logic for all three tropical algebras)
 // ===========================================================================
 
-fn tropical_plan<T: ScalarBase>(desc: &PrimDescriptor) -> Result<TropicalPlan<T>> {
+fn ensure_shape_count(shapes: &[&[usize]], expected: usize, op: &str) -> Result<()> {
+    if shapes.len() != expected {
+        return Err(Error::InvalidArgument(format!(
+            "{op} expects {expected} shapes, got {}",
+            shapes.len()
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_unique_modes(modes: &[u32], name: &str) -> Result<()> {
+    let mut seen = HashSet::new();
+    for &m in modes {
+        if !seen.insert(m) {
+            return Err(Error::InvalidArgument(format!(
+                "{name} contains duplicate mode label {m}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn ensure_pair_labels_unique(paired: &[(u32, u32)], name: &str) -> Result<()> {
+    let mut seen = HashSet::new();
+    for &(m1, m2) in paired {
+        if m1 == m2 {
+            return Err(Error::InvalidArgument(format!(
+                "{name} contains invalid pair ({m1},{m2})"
+            )));
+        }
+        if !seen.insert(m1) || !seen.insert(m2) {
+            return Err(Error::InvalidArgument(format!(
+                "{name} contains duplicated paired label"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn tropical_plan<T: ScalarBase>(
+    desc: &PrimDescriptor,
+    shapes: &[&[usize]],
+) -> Result<TropicalPlan<T>> {
     match desc {
         PrimDescriptor::BatchedGemm {
             batch_dims,
             m,
             n,
             k,
-        } => Ok(TropicalPlan::BatchedGemm {
-            batch_dims: batch_dims.clone(),
-            m: *m,
-            n: *n,
-            k: *k,
-            _marker: PhantomData,
-        }),
+        } => {
+            ensure_shape_count(shapes, 3, "BatchedGemm")?;
+            let a_shape = shapes[0];
+            let b_shape = shapes[1];
+            let c_shape = shapes[2];
+            let expected_rank = batch_dims.len() + 2;
+            if a_shape.len() != expected_rank
+                || b_shape.len() != expected_rank
+                || c_shape.len() != expected_rank
+            {
+                return Err(Error::InvalidArgument(
+                    "BatchedGemm rank mismatch between descriptor and shapes".into(),
+                ));
+            }
+            for (i, &bd) in batch_dims.iter().enumerate() {
+                if a_shape[i] != bd || b_shape[i] != bd || c_shape[i] != bd {
+                    return Err(Error::InvalidArgument(
+                        "BatchedGemm batch dimensions do not match shapes".into(),
+                    ));
+                }
+            }
+            let off = batch_dims.len();
+            if a_shape[off] != *m || a_shape[off + 1] != *k {
+                return Err(Error::InvalidArgument(
+                    "BatchedGemm A shape mismatch".into(),
+                ));
+            }
+            if b_shape[off] != *k || b_shape[off + 1] != *n {
+                return Err(Error::InvalidArgument(
+                    "BatchedGemm B shape mismatch".into(),
+                ));
+            }
+            if c_shape[off] != *m || c_shape[off + 1] != *n {
+                return Err(Error::InvalidArgument(
+                    "BatchedGemm C shape mismatch".into(),
+                ));
+            }
+
+            Ok(TropicalPlan::BatchedGemm {
+                batch_dims: batch_dims.clone(),
+                m: *m,
+                n: *n,
+                k: *k,
+                _marker: PhantomData,
+            })
+        }
 
         PrimDescriptor::Reduce {
             modes_a,
             modes_c,
             op,
         } => {
+            ensure_shape_count(shapes, 2, "Reduce")?;
+            ensure_unique_modes(modes_a, "modes_a")?;
+            ensure_unique_modes(modes_c, "modes_c")?;
+            let a_shape = shapes[0];
+            let c_shape = shapes[1];
+            if modes_a.len() != a_shape.len() || modes_c.len() != c_shape.len() {
+                return Err(Error::InvalidArgument(
+                    "Reduce mode rank does not match shape rank".into(),
+                ));
+            }
+            for &m in modes_c {
+                if !modes_a.contains(&m) {
+                    return Err(Error::InvalidArgument(
+                        "Reduce modes_c must be a subset of modes_a".into(),
+                    ));
+                }
+            }
+            for (out_ax, &m) in modes_c.iter().enumerate() {
+                let in_ax = mode_position(modes_a, m)?;
+                if a_shape[in_ax] != c_shape[out_ax] {
+                    return Err(Error::InvalidArgument(
+                        "Reduce output shape does not match input modes".into(),
+                    ));
+                }
+            }
+
             let reduced_axes: Vec<usize> = modes_a
                 .iter()
                 .enumerate()
@@ -418,6 +602,65 @@ fn tropical_plan<T: ScalarBase>(desc: &PrimDescriptor) -> Result<TropicalPlan<T>
             modes_c,
             paired,
         } => {
+            ensure_shape_count(shapes, 2, "Trace")?;
+            ensure_unique_modes(modes_a, "modes_a")?;
+            ensure_unique_modes(modes_c, "modes_c")?;
+            if paired.is_empty() {
+                return Err(Error::InvalidArgument(
+                    "Trace requires non-empty paired axes".into(),
+                ));
+            }
+            ensure_pair_labels_unique(paired, "Trace paired")?;
+            let a_shape = shapes[0];
+            let c_shape = shapes[1];
+            if modes_a.len() != a_shape.len() || modes_c.len() != c_shape.len() {
+                return Err(Error::InvalidArgument(
+                    "Trace mode rank does not match shape rank".into(),
+                ));
+            }
+
+            let paired_labels: HashSet<u32> =
+                paired.iter().flat_map(|(m1, m2)| [*m1, *m2]).collect();
+            for &(m1, m2) in paired {
+                if !modes_a.contains(&m1) || !modes_a.contains(&m2) {
+                    return Err(Error::InvalidArgument(
+                        "Trace paired labels must exist in modes_a".into(),
+                    ));
+                }
+                if modes_c.contains(&m1) || modes_c.contains(&m2) {
+                    return Err(Error::InvalidArgument(
+                        "Trace paired labels must be reduced (not present in modes_c)".into(),
+                    ));
+                }
+                let ax1 = mode_position(modes_a, m1)?;
+                let ax2 = mode_position(modes_a, m2)?;
+                if a_shape[ax1] != a_shape[ax2] {
+                    return Err(Error::InvalidArgument(
+                        "Trace paired dimensions must be equal".into(),
+                    ));
+                }
+            }
+            for &m in modes_a {
+                if !modes_c.contains(&m) && !paired_labels.contains(&m) {
+                    return Err(Error::InvalidArgument(
+                        "Trace modes_a contains labels neither free nor paired".into(),
+                    ));
+                }
+            }
+            for (out_ax, &m) in modes_c.iter().enumerate() {
+                if paired_labels.contains(&m) {
+                    return Err(Error::InvalidArgument(
+                        "Trace free labels must not be in paired set".into(),
+                    ));
+                }
+                let in_ax = mode_position(modes_a, m)?;
+                if a_shape[in_ax] != c_shape[out_ax] {
+                    return Err(Error::InvalidArgument(
+                        "Trace output shape does not match free modes".into(),
+                    ));
+                }
+            }
+
             let paired_axes: Vec<(usize, usize)> = paired
                 .iter()
                 .map(|(m1, m2)| Ok((mode_position(modes_a, *m1)?, mode_position(modes_a, *m2)?)))
@@ -434,6 +677,35 @@ fn tropical_plan<T: ScalarBase>(desc: &PrimDescriptor) -> Result<TropicalPlan<T>
         }
 
         PrimDescriptor::Permute { modes_a, modes_b } => {
+            ensure_shape_count(shapes, 2, "Permute")?;
+            ensure_unique_modes(modes_a, "modes_a")?;
+            ensure_unique_modes(modes_b, "modes_b")?;
+            let a_shape = shapes[0];
+            let b_shape = shapes[1];
+            if modes_a.len() != a_shape.len()
+                || modes_b.len() != b_shape.len()
+                || modes_a.len() != modes_b.len()
+            {
+                return Err(Error::InvalidArgument(
+                    "Permute mode rank does not match shape rank".into(),
+                ));
+            }
+            for &m in modes_b {
+                if !modes_a.contains(&m) {
+                    return Err(Error::InvalidArgument(
+                        "Permute modes_b must be a permutation of modes_a".into(),
+                    ));
+                }
+            }
+            for (out_ax, &m) in modes_b.iter().enumerate() {
+                let in_ax = mode_position(modes_a, m)?;
+                if a_shape[in_ax] != b_shape[out_ax] {
+                    return Err(Error::InvalidArgument(
+                        "Permute output shape does not match permutation".into(),
+                    ));
+                }
+            }
+
             let perm: Vec<usize> = modes_b
                 .iter()
                 .map(|m| mode_position(modes_a, *m))
@@ -449,6 +721,65 @@ fn tropical_plan<T: ScalarBase>(desc: &PrimDescriptor) -> Result<TropicalPlan<T>
             modes_c,
             paired,
         } => {
+            ensure_shape_count(shapes, 2, "AntiTrace")?;
+            ensure_unique_modes(modes_a, "modes_a")?;
+            ensure_unique_modes(modes_c, "modes_c")?;
+            if paired.is_empty() {
+                return Err(Error::InvalidArgument(
+                    "AntiTrace requires non-empty paired axes".into(),
+                ));
+            }
+            ensure_pair_labels_unique(paired, "AntiTrace paired")?;
+            let a_shape = shapes[0];
+            let c_shape = shapes[1];
+            if modes_a.len() != a_shape.len() || modes_c.len() != c_shape.len() {
+                return Err(Error::InvalidArgument(
+                    "AntiTrace mode rank does not match shape rank".into(),
+                ));
+            }
+
+            let paired_labels: HashSet<u32> =
+                paired.iter().flat_map(|(m1, m2)| [*m1, *m2]).collect();
+            for &(m1, m2) in paired {
+                if !modes_c.contains(&m1) || !modes_c.contains(&m2) {
+                    return Err(Error::InvalidArgument(
+                        "AntiTrace paired labels must exist in modes_c".into(),
+                    ));
+                }
+                if modes_a.contains(&m1) || modes_a.contains(&m2) {
+                    return Err(Error::InvalidArgument(
+                        "AntiTrace paired labels must not be in modes_a".into(),
+                    ));
+                }
+                let ax1 = mode_position(modes_c, m1)?;
+                let ax2 = mode_position(modes_c, m2)?;
+                if c_shape[ax1] != c_shape[ax2] {
+                    return Err(Error::InvalidArgument(
+                        "AntiTrace paired dimensions must be equal".into(),
+                    ));
+                }
+            }
+            for &m in modes_c {
+                if !modes_a.contains(&m) && !paired_labels.contains(&m) {
+                    return Err(Error::InvalidArgument(
+                        "AntiTrace modes_c contains labels neither free nor paired".into(),
+                    ));
+                }
+            }
+            for (in_ax, &m) in modes_a.iter().enumerate() {
+                if paired_labels.contains(&m) {
+                    return Err(Error::InvalidArgument(
+                        "AntiTrace free labels must not be in paired set".into(),
+                    ));
+                }
+                let out_ax = mode_position(modes_c, m)?;
+                if a_shape[in_ax] != c_shape[out_ax] {
+                    return Err(Error::InvalidArgument(
+                        "AntiTrace input shape does not match output free modes".into(),
+                    ));
+                }
+            }
+
             let paired_axes: Vec<(usize, usize)> = paired
                 .iter()
                 .map(|(m1, m2)| Ok((mode_position(modes_c, *m1)?, mode_position(modes_c, *m2)?)))
@@ -469,6 +800,66 @@ fn tropical_plan<T: ScalarBase>(desc: &PrimDescriptor) -> Result<TropicalPlan<T>
             modes_c,
             paired,
         } => {
+            ensure_shape_count(shapes, 2, "AntiDiag")?;
+            ensure_unique_modes(modes_a, "modes_a")?;
+            ensure_unique_modes(modes_c, "modes_c")?;
+            if paired.is_empty() {
+                return Err(Error::InvalidArgument(
+                    "AntiDiag requires non-empty paired axes".into(),
+                ));
+            }
+            ensure_pair_labels_unique(paired, "AntiDiag paired")?;
+            let a_shape = shapes[0];
+            let c_shape = shapes[1];
+            if modes_a.len() != a_shape.len() || modes_c.len() != c_shape.len() {
+                return Err(Error::InvalidArgument(
+                    "AntiDiag mode rank does not match shape rank".into(),
+                ));
+            }
+
+            let paired_labels: HashSet<u32> =
+                paired.iter().flat_map(|(m1, m2)| [*m1, *m2]).collect();
+            let free_labels: HashSet<u32> = modes_a.iter().copied().collect();
+            for &(m1, m2) in paired {
+                if !modes_c.contains(&m1) || !modes_c.contains(&m2) {
+                    return Err(Error::InvalidArgument(
+                        "AntiDiag paired labels must exist in modes_c".into(),
+                    ));
+                }
+                if !free_labels.contains(&m1) {
+                    return Err(Error::InvalidArgument(
+                        "AntiDiag first paired label must exist in modes_a".into(),
+                    ));
+                }
+                if free_labels.contains(&m2) {
+                    return Err(Error::InvalidArgument(
+                        "AntiDiag second paired label must not exist in modes_a".into(),
+                    ));
+                }
+                let ax1 = mode_position(modes_c, m1)?;
+                let ax2 = mode_position(modes_c, m2)?;
+                if c_shape[ax1] != c_shape[ax2] {
+                    return Err(Error::InvalidArgument(
+                        "AntiDiag paired dimensions must be equal".into(),
+                    ));
+                }
+            }
+            for &m in modes_c {
+                if !free_labels.contains(&m) && !paired_labels.contains(&m) {
+                    return Err(Error::InvalidArgument(
+                        "AntiDiag modes_c contains labels neither free nor paired".into(),
+                    ));
+                }
+            }
+            for (in_ax, &m) in modes_a.iter().enumerate() {
+                let out_ax = mode_position(modes_c, m)?;
+                if a_shape[in_ax] != c_shape[out_ax] {
+                    return Err(Error::InvalidArgument(
+                        "AntiDiag input shape does not match output free modes".into(),
+                    ));
+                }
+            }
+
             let paired_axes: Vec<(usize, usize)> = paired
                 .iter()
                 .map(|(m1, m2)| Ok((mode_position(modes_c, *m1)?, mode_position(modes_c, *m2)?)))
@@ -507,12 +898,26 @@ fn tropical_execute<T: ScalarBase>(
             n,
             k,
             ..
-        } => execute_batched_gemm(alpha, inputs, beta, output, batch_dims, *m, *n, *k),
+        } => {
+            if inputs.len() != 2 {
+                return Err(Error::InvalidArgument(
+                    "BatchedGemm execute requires 2 input tensors".into(),
+                ));
+            }
+            execute_batched_gemm(alpha, inputs, beta, output, batch_dims, *m, *n, *k)
+        }
 
         TropicalPlan::Reduce {
             reduced_axes, op, ..
         } => match op {
-            ReduceOp::Sum => execute_reduce_sum(alpha, inputs[0], beta, output, reduced_axes),
+            ReduceOp::Sum => {
+                if inputs.len() != 1 {
+                    return Err(Error::InvalidArgument(
+                        "Reduce execute requires 1 input tensor".into(),
+                    ));
+                }
+                execute_reduce_sum(alpha, inputs[0], beta, output, reduced_axes)
+            }
             ReduceOp::Max | ReduceOp::Min => {
                 // For tropical types, "Sum" reduction already uses tropical addition
                 // (max or min), so ReduceOp::Sum is the correct choice for callers.
@@ -527,21 +932,49 @@ fn tropical_execute<T: ScalarBase>(
             paired_axes,
             free_axes,
             ..
-        } => execute_trace(alpha, inputs[0], beta, output, paired_axes, free_axes),
+        } => {
+            if inputs.len() != 1 {
+                return Err(Error::InvalidArgument(
+                    "Trace execute requires 1 input tensor".into(),
+                ));
+            }
+            execute_trace(alpha, inputs[0], beta, output, paired_axes, free_axes)
+        }
 
-        TropicalPlan::Permute { perm, .. } => execute_permute(alpha, inputs[0], beta, output, perm),
+        TropicalPlan::Permute { perm, .. } => {
+            if inputs.len() != 1 {
+                return Err(Error::InvalidArgument(
+                    "Permute execute requires 1 input tensor".into(),
+                ));
+            }
+            execute_permute(alpha, inputs[0], beta, output, perm)
+        }
 
         TropicalPlan::AntiTrace {
             paired_axes,
             free_axes,
             ..
-        } => execute_anti_trace(alpha, inputs[0], beta, output, paired_axes, free_axes),
+        } => {
+            if inputs.len() != 1 {
+                return Err(Error::InvalidArgument(
+                    "AntiTrace execute requires 1 input tensor".into(),
+                ));
+            }
+            execute_anti_trace(alpha, inputs[0], beta, output, paired_axes, free_axes)
+        }
 
         TropicalPlan::AntiDiag {
             paired_axes,
             free_axes,
             ..
-        } => execute_anti_diag(alpha, inputs[0], beta, output, paired_axes, free_axes),
+        } => {
+            if inputs.len() != 1 {
+                return Err(Error::InvalidArgument(
+                    "AntiDiag execute requires 1 input tensor".into(),
+                ));
+            }
+            execute_anti_diag(alpha, inputs[0], beta, output, paired_axes, free_axes)
+        }
     }
 }
 
@@ -556,9 +989,9 @@ impl TensorPrims<MaxPlusAlgebra> for CpuBackend {
     fn plan<T: ScalarBase>(
         _ctx: &mut CpuContext,
         desc: &PrimDescriptor,
-        _shapes: &[&[usize]],
+        shapes: &[&[usize]],
     ) -> Result<TropicalPlan<T>> {
-        tropical_plan(desc)
+        tropical_plan(desc, shapes)
     }
 
     fn execute<T: ScalarBase>(
@@ -589,9 +1022,9 @@ impl TensorPrims<MinPlusAlgebra> for CpuBackend {
     fn plan<T: ScalarBase>(
         _ctx: &mut CpuContext,
         desc: &PrimDescriptor,
-        _shapes: &[&[usize]],
+        shapes: &[&[usize]],
     ) -> Result<TropicalPlan<T>> {
-        tropical_plan(desc)
+        tropical_plan(desc, shapes)
     }
 
     fn execute<T: ScalarBase>(
@@ -622,9 +1055,9 @@ impl TensorPrims<MaxMulAlgebra> for CpuBackend {
     fn plan<T: ScalarBase>(
         _ctx: &mut CpuContext,
         desc: &PrimDescriptor,
-        _shapes: &[&[usize]],
+        shapes: &[&[usize]],
     ) -> Result<TropicalPlan<T>> {
-        tropical_plan(desc)
+        tropical_plan(desc, shapes)
     }
 
     fn execute<T: ScalarBase>(

--- a/extension/tenferro-tropical/tests/tropical_tests.rs
+++ b/extension/tenferro-tropical/tests/tropical_tests.rs
@@ -913,3 +913,103 @@ fn tropical_no_extensions() {
         Extension::Contract
     ));
 }
+
+#[test]
+fn tropical_plan_trace_empty_paired_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::Trace {
+        modes_a: vec![0, 1],
+        modes_c: vec![0],
+        paired: vec![],
+    };
+    let err = match <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<
+        MaxPlus<f64>,
+    >(&mut ctx, &desc, &[&[2, 2], &[2]])
+    {
+        Ok(_) => panic!("expected InvalidArgument error"),
+        Err(e) => e,
+    };
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+#[test]
+fn tropical_plan_antidiag_invalid_pair_anchor_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::AntiDiag {
+        modes_a: vec![0],
+        modes_c: vec![0, 1],
+        // first paired label must exist in modes_a, but here it's 1
+        paired: vec![(1, 0)],
+    };
+    let err = match <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<
+        MaxPlus<f64>,
+    >(&mut ctx, &desc, &[&[2], &[2, 2]])
+    {
+        Ok(_) => panic!("expected InvalidArgument error"),
+        Err(e) => e,
+    };
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+#[test]
+fn tropical_plan_batched_gemm_shape_mismatch_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::BatchedGemm {
+        batch_dims: vec![],
+        m: 2,
+        n: 2,
+        k: 3,
+    };
+    // B shape is wrong (should be [3, 2], here [4, 2])
+    let err = match <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<
+        MaxPlus<f64>,
+    >(&mut ctx, &desc, &[&[2, 3], &[4, 2], &[2, 2]])
+    {
+        Ok(_) => panic!("expected InvalidArgument error"),
+        Err(e) => e,
+    };
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+#[test]
+fn tropical_execute_wrong_input_arity_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[2, 2]],
+        )
+        .unwrap();
+
+    let mut out = [MaxPlus::<f64>::zero(); 4];
+    let mut out_view = strided_view::StridedViewMut::new(&mut out, &[2, 2], &[1, 2], 0).unwrap();
+
+    let no_inputs: [&strided_view::StridedView<MaxPlus<f64>>; 0] = [];
+    let err = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &no_inputs,
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}

--- a/tenferro-capi/src/lib.rs
+++ b/tenferro-capi/src/lib.rs
@@ -439,19 +439,31 @@ fn matricize(
     right: &[usize],
 ) -> Result<(Tensor<f64>, Vec<usize>, Vec<usize>), tfe_status_t> {
     let dims = tensor.dims();
+    let mut seen = vec![false; dims.len()];
 
     // Validate indices
     for &l in left {
         if l >= dims.len() {
             return Err(TFE_INVALID_ARGUMENT);
         }
+        if seen[l] {
+            return Err(TFE_INVALID_ARGUMENT);
+        }
+        seen[l] = true;
     }
     for &r in right {
         if r >= dims.len() {
             return Err(TFE_INVALID_ARGUMENT);
         }
+        if seen[r] {
+            return Err(TFE_INVALID_ARGUMENT);
+        }
+        seen[r] = true;
     }
     if left.len() + right.len() != dims.len() {
+        return Err(TFE_INVALID_ARGUMENT);
+    }
+    if seen.iter().any(|&v| !v) {
         return Err(TFE_INVALID_ARGUMENT);
     }
 
@@ -474,6 +486,125 @@ fn matricize(
         .contiguous(MemoryOrder::ColumnMajor);
 
     Ok((permuted, left_dims, right_dims))
+}
+
+/// Compute inverse permutation: `inv_perm[perm[i]] = i`.
+fn inverse_permutation(perm: &[usize]) -> Vec<usize> {
+    let mut inv = vec![0; perm.len()];
+    for (i, &p) in perm.iter().enumerate() {
+        inv[p] = i;
+    }
+    inv
+}
+
+/// Convert public U-cotangent shape `[left_dims..., k]` to matrix shape `[m, k]`.
+fn u_cotangent_to_matrix(
+    cot_u: &Tensor<f64>,
+    left_dims: &[usize],
+) -> Result<(Tensor<f64>, usize), tfe_status_t> {
+    let u_dims = cot_u.dims();
+    if u_dims.len() != left_dims.len() + 1 {
+        return Err(TFE_SHAPE_MISMATCH);
+    }
+    if &u_dims[..left_dims.len()] != left_dims {
+        return Err(TFE_SHAPE_MISMATCH);
+    }
+    let k = u_dims[left_dims.len()];
+    let m: usize = left_dims.iter().product();
+    let mat = cot_u
+        .contiguous(MemoryOrder::ColumnMajor)
+        .reshape(&[m, k])
+        .map_err(|_| TFE_SHAPE_MISMATCH)?
+        .contiguous(MemoryOrder::ColumnMajor);
+    Ok((mat, k))
+}
+
+/// Convert public Vt-cotangent shape `[k, right_dims...]` to matrix shape `[k, n]`.
+fn vt_cotangent_to_matrix(
+    cot_vt: &Tensor<f64>,
+    right_dims: &[usize],
+) -> Result<(Tensor<f64>, usize), tfe_status_t> {
+    let vt_dims = cot_vt.dims();
+    if vt_dims.len() != right_dims.len() + 1 {
+        return Err(TFE_SHAPE_MISMATCH);
+    }
+    if &vt_dims[1..] != right_dims {
+        return Err(TFE_SHAPE_MISMATCH);
+    }
+    let k = vt_dims[0];
+    let n: usize = right_dims.iter().product();
+    let mat = cot_vt
+        .contiguous(MemoryOrder::ColumnMajor)
+        .reshape(&[k, n])
+        .map_err(|_| TFE_SHAPE_MISMATCH)?
+        .contiguous(MemoryOrder::ColumnMajor);
+    Ok((mat, k))
+}
+
+/// Validate S-cotangent shape `[k]`.
+fn validate_s_cotangent(cot_s: &Tensor<f64>) -> Result<usize, tfe_status_t> {
+    let dims = cot_s.dims();
+    if dims.len() != 1 {
+        return Err(TFE_SHAPE_MISMATCH);
+    }
+    Ok(dims[0])
+}
+
+/// Reshape matrix U (`[m, k]`) back to public shape `[left_dims..., k]`.
+fn u_matrix_to_public(u: Tensor<f64>, left_dims: &[usize]) -> Result<Tensor<f64>, tfe_status_t> {
+    if u.dims().len() != 2 {
+        return Err(TFE_SHAPE_MISMATCH);
+    }
+    let k = u.dims()[1];
+    let mut out_dims = left_dims.to_vec();
+    out_dims.push(k);
+    u.reshape(&out_dims)
+        .map_err(|_| TFE_SHAPE_MISMATCH)
+        .map(|t| t.contiguous(MemoryOrder::ColumnMajor))
+}
+
+/// Reshape matrix Vt (`[k, n]`) back to public shape `[k, right_dims...]`.
+fn vt_matrix_to_public(vt: Tensor<f64>, right_dims: &[usize]) -> Result<Tensor<f64>, tfe_status_t> {
+    if vt.dims().len() != 2 {
+        return Err(TFE_SHAPE_MISMATCH);
+    }
+    let k = vt.dims()[0];
+    let mut out_dims = vec![k];
+    out_dims.extend_from_slice(right_dims);
+    vt.reshape(&out_dims)
+        .map_err(|_| TFE_SHAPE_MISMATCH)
+        .map(|t| t.contiguous(MemoryOrder::ColumnMajor))
+}
+
+/// Convert input gradient from matrixized layout `[m, n]` back to original tensor layout.
+fn grad_matrix_to_public(
+    grad_matrix: Tensor<f64>,
+    original_dims: &[usize],
+    left: &[usize],
+    right: &[usize],
+    left_dims: &[usize],
+    right_dims: &[usize],
+) -> Result<Tensor<f64>, tfe_status_t> {
+    if grad_matrix.dims().len() != 2 {
+        return Err(TFE_SHAPE_MISMATCH);
+    }
+
+    let mut permuted_dims = left_dims.to_vec();
+    permuted_dims.extend_from_slice(right_dims);
+    let reshaped = grad_matrix
+        .contiguous(MemoryOrder::ColumnMajor)
+        .reshape(&permuted_dims)
+        .map_err(|_| TFE_SHAPE_MISMATCH)?;
+
+    let mut perm = Vec::with_capacity(original_dims.len());
+    perm.extend_from_slice(left);
+    perm.extend_from_slice(right);
+    let inv_perm = inverse_permutation(&perm);
+
+    reshaped
+        .permute(&inv_perm)
+        .map_err(|_| TFE_INTERNAL_ERROR)
+        .map(|t| t.contiguous(MemoryOrder::ColumnMajor))
 }
 
 // ============================================================================
@@ -1271,23 +1402,45 @@ pub unsafe extern "C" fn tfe_svd_rrule_f64(
             &[]
         };
 
-        let (matrix, _left_dims, _right_dims) = matricize(t, left_indices, right_indices)?;
+        let original_dims = t.dims().to_vec();
+        let (matrix, left_dims, right_dims) = matricize(t, left_indices, right_indices)?;
 
+        let mut inferred_k: Option<usize> = None;
         let cot_u = if cotangent_u.is_null() {
             None
         } else {
-            Some(handle_to_ref(cotangent_u).clone())
+            let (u_mat, k) = u_cotangent_to_matrix(handle_to_ref(cotangent_u), &left_dims)?;
+            inferred_k = Some(k);
+            Some(u_mat)
         };
         let cot_s = if cotangent_s.is_null() {
             None
         } else {
-            Some(handle_to_ref(cotangent_s).clone())
+            let cot_s_ref = handle_to_ref(cotangent_s);
+            let k = validate_s_cotangent(cot_s_ref)?;
+            if let Some(prev) = inferred_k {
+                if prev != k {
+                    return Err(TFE_SHAPE_MISMATCH);
+                }
+            } else {
+                inferred_k = Some(k);
+            }
+            Some(cot_s_ref.clone())
         };
         let cot_vt = if cotangent_vt.is_null() {
             None
         } else {
-            Some(handle_to_ref(cotangent_vt).clone())
+            let (vt_mat, k) = vt_cotangent_to_matrix(handle_to_ref(cotangent_vt), &right_dims)?;
+            if let Some(prev) = inferred_k {
+                if prev != k {
+                    return Err(TFE_SHAPE_MISMATCH);
+                }
+            } else {
+                inferred_k = Some(k);
+            }
+            Some(vt_mat)
         };
+        let _ = inferred_k;
 
         let cotangent = SvdCotangent {
             u: cot_u,
@@ -1296,7 +1449,16 @@ pub unsafe extern "C" fn tfe_svd_rrule_f64(
         };
 
         let opts = build_svd_options(max_rank, cutoff);
-        let grad = svd_rrule(&matrix, &cotangent, opts.as_ref()).map_err(|e| map_ad_error(&e))?;
+        let grad_matrix =
+            svd_rrule(&matrix, &cotangent, opts.as_ref()).map_err(|e| map_ad_error(&e))?;
+        let grad = grad_matrix_to_public(
+            grad_matrix,
+            &original_dims,
+            left_indices,
+            right_indices,
+            &left_dims,
+            &right_dims,
+        )?;
 
         Ok(tensor_to_handle(grad))
     }));
@@ -1371,7 +1533,7 @@ pub unsafe extern "C" fn tfe_svd_frule_f64(
             &[]
         };
 
-        let (matrix, _left_dims, _right_dims) = matricize(t, left_indices, right_indices)?;
+        let (matrix, left_dims, right_dims) = matricize(t, left_indices, right_indices)?;
 
         let tang = if tangent.is_null() {
             Tensor::<f64>::zeros(
@@ -1389,9 +1551,12 @@ pub unsafe extern "C" fn tfe_svd_frule_f64(
         let (_primal, tangent_result) =
             svd_frule(&matrix, &tang, opts.as_ref()).map_err(|e| map_ad_error(&e))?;
 
-        *u_out = tensor_to_handle(tangent_result.u);
+        let u_public = u_matrix_to_public(tangent_result.u, &left_dims)?;
+        let vt_public = vt_matrix_to_public(tangent_result.vt, &right_dims)?;
+
+        *u_out = tensor_to_handle(u_public);
         *s_out = tensor_to_handle(tangent_result.s);
-        *vt_out = tensor_to_handle(tangent_result.vt);
+        *vt_out = tensor_to_handle(vt_public);
         Ok(())
     }));
 

--- a/tenferro-capi/tests/capi_tests.rs
+++ b/tenferro-capi/tests/capi_tests.rs
@@ -3,6 +3,90 @@
 //! TDD approach: tests written to verify correctness based on docs/design/capi.md.
 
 use tenferro_capi::*;
+use tenferro_linalg::{svd_frule, svd_rrule, SvdCotangent};
+use tenferro_tensor::{MemoryOrder, Tensor};
+
+fn approx_eq_slice(actual: &[f64], expected: &[f64], tol: f64) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "length mismatch: {} != {}",
+        actual.len(),
+        expected.len()
+    );
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (a - e).abs() <= tol,
+            "mismatch at {i}: actual={a}, expected={e}, |diff|={}",
+            (a - e).abs()
+        );
+    }
+}
+
+unsafe fn handle_dims_data(
+    t: *const TfeTensorF64,
+    status: &mut tfe_status_t,
+) -> (Vec<usize>, Vec<f64>) {
+    let ndim = tfe_tensor_f64_ndim(t, status);
+    assert_eq!(*status, TFE_SUCCESS);
+    let mut dims = vec![0usize; ndim];
+    tfe_tensor_f64_shape(t, dims.as_mut_ptr(), status);
+    assert_eq!(*status, TFE_SUCCESS);
+    let len = tfe_tensor_f64_len(t, status);
+    assert_eq!(*status, TFE_SUCCESS);
+    let ptr = tfe_tensor_f64_data(t, status);
+    assert_eq!(*status, TFE_SUCCESS);
+    let data = std::slice::from_raw_parts(ptr, len).to_vec();
+    (dims, data)
+}
+
+fn matrixize_for_test(
+    tensor: &Tensor<f64>,
+    left: &[usize],
+    right: &[usize],
+) -> (Tensor<f64>, Vec<usize>, Vec<usize>) {
+    let dims = tensor.dims();
+    let left_dims: Vec<usize> = left.iter().map(|&i| dims[i]).collect();
+    let right_dims: Vec<usize> = right.iter().map(|&i| dims[i]).collect();
+    let m: usize = left_dims.iter().product();
+    let n: usize = right_dims.iter().product();
+
+    let mut perm = Vec::with_capacity(dims.len());
+    perm.extend_from_slice(left);
+    perm.extend_from_slice(right);
+    let matrix = tensor
+        .permute(&perm)
+        .unwrap()
+        .contiguous(MemoryOrder::ColumnMajor)
+        .reshape(&[m, n])
+        .unwrap()
+        .contiguous(MemoryOrder::ColumnMajor);
+    (matrix, left_dims, right_dims)
+}
+
+fn unmatrixize_grad_for_test(
+    grad_matrix: Tensor<f64>,
+    left: &[usize],
+    right: &[usize],
+    left_dims: &[usize],
+    right_dims: &[usize],
+) -> Tensor<f64> {
+    let mut perm_dims = left_dims.to_vec();
+    perm_dims.extend_from_slice(right_dims);
+    let reshaped = grad_matrix.reshape(&perm_dims).unwrap();
+
+    let mut perm = Vec::with_capacity(left.len() + right.len());
+    perm.extend_from_slice(left);
+    perm.extend_from_slice(right);
+    let mut inv = vec![0usize; perm.len()];
+    for (i, &p) in perm.iter().enumerate() {
+        inv[p] = i;
+    }
+    reshaped
+        .permute(&inv)
+        .unwrap()
+        .contiguous(MemoryOrder::ColumnMajor)
+}
 
 // ============================================================================
 // Phase 1: Tensor lifecycle tests
@@ -439,6 +523,20 @@ fn einsum_rrule_matmul() {
         // grad_B shape should be (2, 2)
         assert_eq!(tfe_tensor_f64_len(grads[1] as *const _, &mut status), 4);
 
+        // Numeric oracle:
+        // grad_A = cot * B^T, grad_B = A^T * cot, with cot = ones(2x2).
+        // A = [[1,2],[3,4]], B = [[5,6],[7,8]].
+        // grad_A = [[11,15],[11,15]]  -> col-major [11,11,15,15]
+        // grad_B = [[4,4],[6,6]]      -> col-major [4,6,4,6]
+        let grad_a_ptr = tfe_tensor_f64_data(grads[0] as *const _, &mut status);
+        assert_eq!(status, TFE_SUCCESS);
+        let grad_b_ptr = tfe_tensor_f64_data(grads[1] as *const _, &mut status);
+        assert_eq!(status, TFE_SUCCESS);
+        let grad_a = std::slice::from_raw_parts(grad_a_ptr, 4);
+        let grad_b = std::slice::from_raw_parts(grad_b_ptr, 4);
+        approx_eq_slice(grad_a, &[11.0, 11.0, 15.0, 15.0], 1e-12);
+        approx_eq_slice(grad_b, &[4.0, 6.0, 4.0, 6.0], 1e-12);
+
         tfe_tensor_f64_release(grads[0]);
         tfe_tensor_f64_release(grads[1]);
         tfe_tensor_f64_release(cot as *mut _);
@@ -740,5 +838,202 @@ fn svd_null_tensor_returns_error() {
             &mut status,
         );
         assert_eq!(status, TFE_INVALID_ARGUMENT);
+    }
+}
+
+#[test]
+fn svd_rrule_rank3_permuted_axes_matches_rust_oracle() {
+    unsafe {
+        let shape = [2_usize, 3, 2];
+        let left = [2_usize, 0];
+        let right = [1_usize];
+        let mut status: tfe_status_t = -999;
+
+        let a_data: Vec<f64> = (0..12).map(|i| (i + 1) as f64).collect();
+        let cot_u_data: Vec<f64> = (0..12).map(|i| 0.1 * (i as f64 + 1.0)).collect();
+        let cot_s_data = [0.3_f64, -0.2, 0.5];
+        let cot_vt_data: Vec<f64> = (0..9).map(|i| -0.05 * (i as f64 + 1.0)).collect();
+
+        let a = tfe_tensor_f64_from_data(
+            a_data.as_ptr(),
+            a_data.len(),
+            shape.as_ptr(),
+            3,
+            &mut status,
+        );
+        assert_eq!(status, TFE_SUCCESS);
+        let cot_u_shape = [2_usize, 2, 3]; // [left_dims..., k]
+        let cot_vt_shape = [3_usize, 3]; // [k, right_dims...]
+        let cot_s_shape = [3_usize];
+        let cot_u = tfe_tensor_f64_from_data(
+            cot_u_data.as_ptr(),
+            cot_u_data.len(),
+            cot_u_shape.as_ptr(),
+            cot_u_shape.len(),
+            &mut status,
+        );
+        assert_eq!(status, TFE_SUCCESS);
+        let cot_s = tfe_tensor_f64_from_data(
+            cot_s_data.as_ptr(),
+            cot_s_data.len(),
+            cot_s_shape.as_ptr(),
+            cot_s_shape.len(),
+            &mut status,
+        );
+        assert_eq!(status, TFE_SUCCESS);
+        let cot_vt = tfe_tensor_f64_from_data(
+            cot_vt_data.as_ptr(),
+            cot_vt_data.len(),
+            cot_vt_shape.as_ptr(),
+            cot_vt_shape.len(),
+            &mut status,
+        );
+        assert_eq!(status, TFE_SUCCESS);
+
+        let grad = tfe_svd_rrule_f64(
+            a as *const _,
+            left.as_ptr(),
+            left.len(),
+            right.as_ptr(),
+            right.len(),
+            0,
+            -1.0,
+            cot_u as *const _,
+            cot_s as *const _,
+            cot_vt as *const _,
+            &mut status,
+        );
+        assert_eq!(status, TFE_SUCCESS);
+        assert!(!grad.is_null());
+
+        let (grad_dims, grad_data) = handle_dims_data(grad as *const _, &mut status);
+        assert_eq!(grad_dims, shape);
+
+        let t = Tensor::from_slice(&a_data, &shape, MemoryOrder::ColumnMajor).unwrap();
+        let (matrix, left_dims, right_dims) = matrixize_for_test(&t, &left, &right);
+        let cot_u_public =
+            Tensor::from_slice(&cot_u_data, &cot_u_shape, MemoryOrder::ColumnMajor).unwrap();
+        let cot_s_public =
+            Tensor::from_slice(&cot_s_data, &cot_s_shape, MemoryOrder::ColumnMajor).unwrap();
+        let cot_vt_public =
+            Tensor::from_slice(&cot_vt_data, &cot_vt_shape, MemoryOrder::ColumnMajor).unwrap();
+
+        let m: usize = left_dims.iter().product();
+        let n: usize = right_dims.iter().product();
+        let cot_u_mat = cot_u_public.reshape(&[m, cot_s_data.len()]).unwrap();
+        let cot_vt_mat = cot_vt_public.reshape(&[cot_s_data.len(), n]).unwrap();
+        let cot = SvdCotangent {
+            u: Some(cot_u_mat),
+            s: Some(cot_s_public),
+            vt: Some(cot_vt_mat),
+        };
+        let grad_matrix = svd_rrule(&matrix, &cot, None).unwrap();
+        let grad_expected =
+            unmatrixize_grad_for_test(grad_matrix, &left, &right, &left_dims, &right_dims);
+        let expected_data = grad_expected
+            .buffer()
+            .as_slice()
+            .expect("CPU tensor")
+            .to_vec();
+        approx_eq_slice(&grad_data, &expected_data, 1e-10);
+
+        tfe_tensor_f64_release(grad);
+        tfe_tensor_f64_release(cot_vt);
+        tfe_tensor_f64_release(cot_s);
+        tfe_tensor_f64_release(cot_u);
+        tfe_tensor_f64_release(a);
+    }
+}
+
+#[test]
+fn svd_frule_rank3_permuted_axes_matches_rust_oracle() {
+    unsafe {
+        let shape = [2_usize, 3, 2];
+        let left = [2_usize, 0];
+        let right = [1_usize];
+        let mut status: tfe_status_t = -999;
+
+        let a_data: Vec<f64> = (0..12).map(|i| 0.2 * (i as f64 + 1.0)).collect();
+        let da_data: Vec<f64> = (0..12).map(|i| -0.1 * (i as f64 + 1.0)).collect();
+        let a = tfe_tensor_f64_from_data(
+            a_data.as_ptr(),
+            a_data.len(),
+            shape.as_ptr(),
+            3,
+            &mut status,
+        );
+        assert_eq!(status, TFE_SUCCESS);
+        let da = tfe_tensor_f64_from_data(
+            da_data.as_ptr(),
+            da_data.len(),
+            shape.as_ptr(),
+            3,
+            &mut status,
+        );
+        assert_eq!(status, TFE_SUCCESS);
+
+        let mut du: *mut TfeTensorF64 = std::ptr::null_mut();
+        let mut ds: *mut TfeTensorF64 = std::ptr::null_mut();
+        let mut dvt: *mut TfeTensorF64 = std::ptr::null_mut();
+        tfe_svd_frule_f64(
+            a as *const _,
+            left.as_ptr(),
+            left.len(),
+            right.as_ptr(),
+            right.len(),
+            0,
+            -1.0,
+            da as *const _,
+            &mut du,
+            &mut ds,
+            &mut dvt,
+            &mut status,
+        );
+        assert_eq!(status, TFE_SUCCESS);
+        assert!(!du.is_null());
+        assert!(!ds.is_null());
+        assert!(!dvt.is_null());
+
+        let (du_dims, du_data) = handle_dims_data(du as *const _, &mut status);
+        let (ds_dims, ds_data) = handle_dims_data(ds as *const _, &mut status);
+        let (dvt_dims, dvt_data) = handle_dims_data(dvt as *const _, &mut status);
+        assert_eq!(du_dims, vec![2, 2, 3]); // [left_dims..., k]
+        assert_eq!(ds_dims, vec![3]); // [k]
+        assert_eq!(dvt_dims, vec![3, 3]); // [k, right_dims...]
+
+        let t = Tensor::from_slice(&a_data, &shape, MemoryOrder::ColumnMajor).unwrap();
+        let dt = Tensor::from_slice(&da_data, &shape, MemoryOrder::ColumnMajor).unwrap();
+        let (matrix, left_dims, right_dims) = matrixize_for_test(&t, &left, &right);
+        let (tang_matrix, _, _) = matrixize_for_test(&dt, &left, &right);
+        let (_primal, tangent_result) = svd_frule(&matrix, &tang_matrix, None).unwrap();
+
+        let k = tangent_result.s.len();
+        let mut du_expected_dims = left_dims.clone();
+        du_expected_dims.push(k);
+        let du_expected = tangent_result
+            .u
+            .reshape(&du_expected_dims)
+            .unwrap()
+            .contiguous(MemoryOrder::ColumnMajor);
+        let mut dvt_expected_dims = vec![k];
+        dvt_expected_dims.extend_from_slice(&right_dims);
+        let dvt_expected = tangent_result
+            .vt
+            .reshape(&dvt_expected_dims)
+            .unwrap()
+            .contiguous(MemoryOrder::ColumnMajor);
+        let du_expected_data = du_expected.buffer().as_slice().expect("CPU tensor");
+        let ds_expected_data = tangent_result.s.buffer().as_slice().expect("CPU tensor");
+        let dvt_expected_data = dvt_expected.buffer().as_slice().expect("CPU tensor");
+
+        approx_eq_slice(&du_data, du_expected_data, 1e-10);
+        approx_eq_slice(&ds_data, ds_expected_data, 1e-10);
+        approx_eq_slice(&dvt_data, dvt_expected_data, 1e-10);
+
+        tfe_tensor_f64_release(dvt);
+        tfe_tensor_f64_release(ds);
+        tfe_tensor_f64_release(du);
+        tfe_tensor_f64_release(da);
+        tfe_tensor_f64_release(a);
     }
 }


### PR DESCRIPTION
## Summary
- fix C-API SVD AD layout handling for nontrivial left/right partitions
- strengthen C-API AD tests with numeric oracles for einsum_rrule and rank>2 SVD AD
- add tropical TensorPrims plan/execute validation and return structured InvalidArgument errors

## Issues
- Closes #111
- Closes #113
- Closes #114

## Validation
- cargo fmt --all --check
- cargo test -p tenferro-capi
- cargo test -p tenferro-tropical
- cargo test --workspace

Generated with [Claude Code](https://claude.com/claude-code)