### PR TITLE
fix(prims): apply element-wise conjugation for complex scalars in resolve_conj (#135)

### DIFF
--- a/tenferro-prims/Cargo.toml
+++ b/tenferro-prims/Cargo.toml
@@ -15,3 +15,6 @@ strided-traits.workspace = true
 strided-perm.workspace = true
 rayon = "1.10"
 libloading.workspace = true
+
+[dev-dependencies]
+num-complex.workspace = true

--- a/tenferro-prims/src/lib.rs
+++ b/tenferro-prims/src/lib.rs
@@ -91,7 +91,7 @@ use std::marker::PhantomData;
 
 use strided_traits::ScalarBase;
 use strided_view::{StridedView, StridedViewMut};
-use tenferro_algebra::{Scalar, Standard};
+use tenferro_algebra::{Conjugate, Scalar, Standard};
 use tenferro_device::{Error, Result};
 
 /// Reduction operation kind.
@@ -594,24 +594,24 @@ impl CpuBackend {
     /// let a_resolved = CpuBackend::resolve_conj(&mut ctx, &a_conj);
     /// assert!(!a_resolved.is_conjugated());
     /// ```
-    pub fn resolve_conj<T: Scalar>(
+    pub fn resolve_conj<T: Scalar + Conjugate>(
         _ctx: &mut CpuContext,
         src: &tenferro_tensor::Tensor<T>,
     ) -> tenferro_tensor::Tensor<T> {
         if !src.is_conjugated() {
             return src.clone();
         }
-        // Create a fresh non-conjugated copy of the data.
-        // For real types (f64, f32), conjugation is identity, so raw data copy is correct.
-        // Complex types would additionally need element-wise conjugation (requires
-        // Conjugate trait bound, not available via Scalar).
+        // Create a fresh non-conjugated copy with element-wise conjugation applied.
+        // For real types (f64, f32), Conjugate::conj() is identity so this is a plain copy.
+        // For complex types (Complex64, Complex32), conj() negates the imaginary part.
         let contiguous = src.contiguous(tenferro_tensor::MemoryOrder::ColumnMajor);
         let data = contiguous
             .buffer()
             .as_slice()
             .expect("CPU tensor must have CPU-accessible data");
+        let conjugated_data: Vec<T> = data.iter().map(|&v| v.conj()).collect();
         tenferro_tensor::Tensor::from_slice(
-            data,
+            &conjugated_data,
             src.dims(),
             tenferro_tensor::MemoryOrder::ColumnMajor,
         )

--- a/tenferro-prims/tests/prims_tests.rs
+++ b/tenferro-prims/tests/prims_tests.rs
@@ -709,6 +709,134 @@ fn reduce_sum_with_alpha_beta() {
 // ============================================================================
 
 #[test]
+fn permute_complex64() {
+    use num_complex::Complex64;
+
+    let mut ctx = CpuContext::new(1);
+    let a = StridedArray::from_fn_col_major(&[2, 3], |idx| {
+        Complex64::new((idx[0] * 3 + idx[1] + 1) as f64, 0.0)
+    });
+    let mut b = StridedArray::<Complex64>::col_major(&[3, 2]);
+
+    let desc = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+    let plan = cpu_plan::<Complex64>(&mut ctx, &desc, &[&[2, 3], &[3, 2]]).unwrap();
+    cpu_execute(
+        &mut ctx,
+        &plan,
+        Complex64::new(1.0, 0.0),
+        &[&a.view()],
+        Complex64::new(0.0, 0.0),
+        &mut b.view_mut(),
+    )
+    .unwrap();
+
+    for i in 0..2 {
+        for j in 0..3 {
+            assert_eq!(b.view().get(&[j, i]), a.view().get(&[i, j]));
+        }
+    }
+}
+
+// ============================================================================
+// resolve_conj for Complex64
+// ============================================================================
+
+#[test]
+fn resolve_conj_complex64_non_conjugated() {
+    use num_complex::Complex64;
+    use tenferro_tensor::{MemoryOrder, Tensor};
+
+    let mut ctx = CpuContext::new(1);
+    let data = vec![
+        Complex64::new(1.0, 2.0),
+        Complex64::new(3.0, 4.0),
+        Complex64::new(5.0, 6.0),
+        Complex64::new(7.0, 8.0),
+    ];
+    let t = Tensor::<Complex64>::from_slice(&data, &[2, 2], MemoryOrder::ColumnMajor).unwrap();
+    assert!(!t.is_conjugated());
+
+    let resolved = CpuBackend::resolve_conj(&mut ctx, &t);
+    assert!(!resolved.is_conjugated());
+    assert_eq!(resolved.dims(), t.dims());
+
+    // Data should be unchanged (no conjugation applied)
+    let resolved_data = resolved
+        .buffer()
+        .as_slice()
+        .expect("CPU tensor must have CPU-accessible data");
+    for (orig, res) in data.iter().zip(resolved_data.iter()) {
+        assert_eq!(orig, res);
+    }
+}
+
+#[test]
+fn resolve_conj_complex64_conjugated() {
+    use num_complex::Complex64;
+    use tenferro_tensor::{MemoryOrder, Tensor};
+
+    let mut ctx = CpuContext::new(1);
+    let data = vec![
+        Complex64::new(1.0, 2.0),
+        Complex64::new(3.0, 4.0),
+        Complex64::new(5.0, 6.0),
+        Complex64::new(7.0, 8.0),
+    ];
+    let t = Tensor::<Complex64>::from_slice(&data, &[2, 2], MemoryOrder::ColumnMajor).unwrap();
+    let t_conj = t.into_conj();
+    assert!(t_conj.is_conjugated());
+
+    let resolved = CpuBackend::resolve_conj(&mut ctx, &t_conj);
+    assert!(!resolved.is_conjugated());
+    assert_eq!(resolved.dims(), &[2, 2]);
+
+    // Data should have imaginary parts negated
+    let resolved_data = resolved
+        .buffer()
+        .as_slice()
+        .expect("CPU tensor must have CPU-accessible data");
+    let expected = vec![
+        Complex64::new(1.0, -2.0),
+        Complex64::new(3.0, -4.0),
+        Complex64::new(5.0, -6.0),
+        Complex64::new(7.0, -8.0),
+    ];
+    for (exp, res) in expected.iter().zip(resolved_data.iter()) {
+        assert_eq!(exp, res, "expected {exp}, got {res}");
+    }
+}
+
+#[test]
+fn resolve_conj_f64_conjugated_is_identity() {
+    use tenferro_tensor::{MemoryOrder, Tensor};
+
+    let mut ctx = CpuContext::new(1);
+    let data = vec![1.0_f64, 2.0, 3.0, 4.0];
+    let t = Tensor::<f64>::from_slice(&data, &[2, 2], MemoryOrder::ColumnMajor).unwrap();
+    let t_conj = t.into_conj();
+    assert!(t_conj.is_conjugated());
+
+    let resolved = CpuBackend::resolve_conj(&mut ctx, &t_conj);
+    assert!(!resolved.is_conjugated());
+
+    // For real types, conjugation is identity — data should be unchanged
+    let resolved_data = resolved
+        .buffer()
+        .as_slice()
+        .expect("CPU tensor must have CPU-accessible data");
+    for (orig, res) in data.iter().zip(resolved_data.iter()) {
+        assert!((orig - res).abs() < 1e-15, "expected {orig}, got {res}");
+    }
+}
+
+// ============================================================================
+// f32 type
+// ============================================================================
+
+#[test]
 fn permute_f32() {
     let mut ctx = CpuContext::new(1);
     let a = StridedArray::from_fn_col_major(&[2, 3], |idx| (idx[0] * 3 + idx[1] + 1) as f32);


### PR DESCRIPTION
## Summary
- Add `Conjugate` trait bound to `CpuBackend::resolve_conj` so it can apply element-wise conjugation
- Fix the implementation to map `Conjugate::conj()` over all elements when the tensor is lazily conjugated, instead of just copying raw data
- For real types (`f64`, `f32`), `conj()` is identity, so behavior is unchanged
- For complex types (`Complex64`, `Complex32`), `conj()` now correctly negates the imaginary part

## Test plan
- [x] `resolve_conj_complex64_conjugated` -- verifies imaginary parts are negated for a conjugated Complex64 tensor
- [x] `resolve_conj_complex64_non_conjugated` -- verifies non-conjugated Complex64 tensor is returned unchanged
- [x] `resolve_conj_f64_conjugated_is_identity` -- verifies real-type conjugation remains identity
- [x] `permute_complex64` -- verifies Complex64 works with the CPU backend more broadly
- [x] All existing tests pass unchanged

Closes #135

Generated with [Claude Code](https://claude.com/claude-code)