### PR TITLE
feat(prims,einsum): wire PlanCache into hot paths (#138)

### DIFF
--- a/tenferro-einsum/tests/einsum_tests.rs
+++ b/tenferro-einsum/tests/einsum_tests.rs
@@ -509,6 +509,89 @@ fn einsum_into_accumulate() {
 }
 
 // ============================================================================
+// einsum: plan cache integration
+// ============================================================================
+
+#[test]
+fn einsum_reuses_cached_plans() {
+    // Repeated einsum calls with the same contraction populate the plan cache
+    // and subsequent calls reuse cached plans.
+    let mut ctx = CpuContext::new(1);
+    assert!(ctx.plan_cache_mut().is_empty());
+
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
+    let b = Tensor::<f64>::from_slice(
+        &[
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ],
+        &[3, 4],
+        COL,
+    )
+    .unwrap();
+
+    // First call: populates cache
+    let c1 = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+    let cache_size_after_first = ctx.plan_cache_mut().len();
+    assert!(
+        cache_size_after_first > 0,
+        "cache should be populated after first einsum call"
+    );
+
+    // Second call with same shapes: cache should not grow
+    let c2 = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+    let cache_size_after_second = ctx.plan_cache_mut().len();
+    assert_eq!(
+        cache_size_after_first, cache_size_after_second,
+        "cache should not grow when same contraction is repeated"
+    );
+
+    // Results should be identical
+    for i in 0..2 {
+        for k in 0..4 {
+            assert!(
+                (get(&c1, &[i, k]) - get(&c2, &[i, k])).abs() < 1e-10,
+                "results should be identical across calls"
+            );
+        }
+    }
+}
+
+#[test]
+fn einsum_different_shapes_miss_cache() {
+    // Calling einsum with different-shaped tensors should produce cache misses.
+    let mut ctx = CpuContext::new(1);
+
+    // 2x3 @ 3x4
+    let a1 = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
+    let b1 = Tensor::<f64>::from_slice(
+        &[
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ],
+        &[3, 4],
+        COL,
+    )
+    .unwrap();
+    let _c1 = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a1, &b1], None).unwrap();
+    let cache_size_1 = ctx.plan_cache_mut().len();
+
+    // 3x2 @ 2x5 (different shapes)
+    let a2 = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[3, 2], COL).unwrap();
+    let b2 = Tensor::<f64>::from_slice(
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+        &[2, 5],
+        COL,
+    )
+    .unwrap();
+    let _c2 = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a2, &b2], None).unwrap();
+    let cache_size_2 = ctx.plan_cache_mut().len();
+
+    assert!(
+        cache_size_2 > cache_size_1,
+        "different shapes should produce additional cache entries"
+    );
+}
+
+// ============================================================================
 // einsum: AD rules (standalone) -- kept on f64 only
 // ============================================================================
 

--- a/tenferro-prims/src/lib.rs
+++ b/tenferro-prims/src/lib.rs
@@ -84,9 +84,10 @@
 //! }
 //! ```
 
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::ffi::c_void;
+use std::hash::Hash;
 use std::marker::PhantomData;
 
 use strided_traits::ScalarBase;
@@ -104,7 +105,7 @@ use tenferro_device::{Error, Result};
 /// let op = ReduceOp::Sum;
 /// assert_eq!(op, ReduceOp::Sum);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ReduceOp {
     /// Sum reduction.
     Sum,
@@ -131,7 +132,7 @@ pub enum ReduceOp {
 /// let op = UnaryOp::Reciprocal;
 /// assert_eq!(op, UnaryOp::Reciprocal);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnaryOp {
     /// Negate: `-x`.
     Negate,
@@ -162,7 +163,7 @@ pub enum UnaryOp {
 /// // Check if element-wise multiplication is available for f64
 /// let available = CpuBackend::has_extension_for::<f64>(Extension::ElementwiseMul);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Extension {
     /// Fused contraction (permute + GEMM). Maps to `cutensorContract` on GPU
     /// backends (not yet implemented).
@@ -192,6 +193,7 @@ pub enum Extension {
 ///     batch_dims: vec![], m: 3, n: 5, k: 4,
 /// };
 /// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PrimDescriptor {
     // ====================================================================
     // Core operations (every backend must implement)
@@ -400,7 +402,7 @@ pub trait TensorPrims<A> {
 ///
 /// Created by [`CpuBackend::plan`](TensorPrims::plan) and consumed by
 /// [`CpuBackend::execute`](TensorPrims::execute).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CpuPlan<T: ScalarBase> {
     /// Plan for batched GEMM.
     BatchedGemm {
@@ -474,30 +476,113 @@ pub enum CpuPlan<T: ScalarBase> {
     MakeContiguous { _marker: PhantomData<T> },
 }
 
-/// Cache for pre-computed execution plans, keyed by `(PrimDescriptor, shapes)`.
+/// Composite key for plan cache lookup.
+///
+/// Discriminates plans by scalar type ([`TypeId`]), operation descriptor
+/// ([`PrimDescriptor`]), and tensor shapes. Two calls that match on all
+/// three components will produce identical plans, so the cached plan can
+/// be reused.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct PlanCacheKey {
+    /// Scalar type discriminator (e.g., `TypeId::of::<f64>()`).
+    type_id: TypeId,
+    /// Operation descriptor.
+    descriptor: PrimDescriptor,
+    /// Shapes of all tensor operands (inputs + output).
+    shapes: Vec<Vec<usize>>,
+}
+
+impl PlanCacheKey {
+    /// Build a cache key from scalar type, descriptor, and shapes.
+    fn new<T: 'static>(desc: &PrimDescriptor, shapes: &[&[usize]]) -> Self {
+        Self {
+            type_id: TypeId::of::<T>(),
+            descriptor: desc.clone(),
+            shapes: shapes.iter().map(|s| s.to_vec()).collect(),
+        }
+    }
+}
+
+/// Cache for pre-computed execution plans, keyed by
+/// `(TypeId, PrimDescriptor, shapes)`.
 ///
 /// Avoids repeated plan generation when the same operation is executed
 /// with the same shapes (e.g., single-tensor einsum steps in a loop).
+/// Plans are stored type-erased and downcast on retrieval.
+///
+/// # Cache semantics
+///
+/// - **Hit**: A call to [`get`](PlanCache::get) with the same scalar type,
+///   descriptor, and shapes returns a clone of the cached plan.
+/// - **Miss**: A call with different shapes, descriptor, or scalar type
+///   returns `None`. The caller should build a new plan and
+///   [`insert`](PlanCache::insert) it.
+/// - **Thread safety**: `PlanCache` is not `Sync`; it is owned by a single
+///   [`CpuContext`] and accessed via `&mut`.
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tenferro_prims::PlanCache;
 ///
 /// let cache = PlanCache::new();
+/// assert_eq!(cache.len(), 0);
 /// ```
 pub struct PlanCache {
-    // Internal representation is private.
-    // Key: (PrimDescriptor hash, shapes hash) → type-erased plan.
-    _entries: HashMap<u64, Box<dyn Any>>,
+    entries: HashMap<PlanCacheKey, Box<dyn Any>>,
 }
 
 impl PlanCache {
     /// Create a new empty plan cache.
     pub fn new() -> Self {
         Self {
-            _entries: HashMap::new(),
+            entries: HashMap::new(),
         }
+    }
+
+    /// Returns the number of cached plans.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` if the cache contains no plans.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Look up a cached plan for the given scalar type, descriptor, and shapes.
+    ///
+    /// Returns `Some(plan)` on cache hit, `None` on miss. The plan is
+    /// cloned out of the cache so the cache retains its copy.
+    pub fn get<T: ScalarBase + Clone + 'static>(
+        &self,
+        desc: &PrimDescriptor,
+        shapes: &[&[usize]],
+    ) -> Option<CpuPlan<T>> {
+        let key = PlanCacheKey::new::<T>(desc, shapes);
+        self.entries
+            .get(&key)
+            .and_then(|boxed| boxed.downcast_ref::<CpuPlan<T>>())
+            .cloned()
+    }
+
+    /// Insert a plan into the cache for the given scalar type, descriptor,
+    /// and shapes.
+    ///
+    /// If an entry with the same key already exists, it is replaced.
+    pub fn insert<T: ScalarBase + Clone + 'static>(
+        &mut self,
+        desc: &PrimDescriptor,
+        shapes: &[&[usize]],
+        plan: CpuPlan<T>,
+    ) {
+        let key = PlanCacheKey::new::<T>(desc, shapes);
+        self.entries.insert(key, Box::new(plan));
+    }
+
+    /// Remove all cached plans.
+    pub fn clear(&mut self) {
+        self.entries.clear();
     }
 }
 
@@ -621,6 +706,228 @@ impl CpuBackend {
             tenferro_tensor::MemoryOrder::ColumnMajor,
         )
         .expect("from_slice should succeed with valid data and dims")
+    }
+
+    /// Build a CPU plan from a descriptor and shapes (without cache lookup).
+    ///
+    /// This is the internal plan construction logic, factored out of
+    /// [`TensorPrims::plan`] so that the trait method can wrap it with
+    /// cache lookup/insert.
+    fn build_plan<T: ScalarBase>(desc: &PrimDescriptor, shapes: &[&[usize]]) -> Result<CpuPlan<T>> {
+        match desc {
+            PrimDescriptor::BatchedGemm {
+                batch_dims,
+                m,
+                n,
+                k,
+            } => {
+                // BatchedGemm expects 3 shapes: A, B, C
+                validate_shape_count(shapes, 3, "BatchedGemm")?;
+                let expected_a: Vec<usize> = batch_dims.iter().copied().chain([*m, *k]).collect();
+                let expected_b: Vec<usize> = batch_dims.iter().copied().chain([*k, *n]).collect();
+                let expected_c: Vec<usize> = batch_dims.iter().copied().chain([*m, *n]).collect();
+                validate_shape_eq(shapes[0], &expected_a, "BatchedGemm input A")?;
+                validate_shape_eq(shapes[1], &expected_b, "BatchedGemm input B")?;
+                validate_shape_eq(shapes[2], &expected_c, "BatchedGemm output C")?;
+                Ok(CpuPlan::BatchedGemm {
+                    batch_dims: batch_dims.clone(),
+                    m: *m,
+                    n: *n,
+                    k: *k,
+                    _marker: PhantomData,
+                })
+            }
+
+            PrimDescriptor::Reduce {
+                modes_a,
+                modes_c,
+                op,
+            } => {
+                // Reduce expects 2 shapes: A (input), C (output)
+                validate_shape_count(shapes, 2, "Reduce")?;
+                validate_rank(shapes[0], modes_a.len(), "Reduce input A")?;
+                validate_rank(shapes[1], modes_c.len(), "Reduce output C")?;
+                // reduced_axes = positions in modes_a not present in modes_c
+                let reduced_axes: Vec<usize> = modes_a
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, m)| !modes_c.contains(m))
+                    .map(|(i, _)| i)
+                    .collect();
+                Ok(CpuPlan::Reduce {
+                    reduced_axes,
+                    op: *op,
+                    _marker: PhantomData,
+                })
+            }
+
+            PrimDescriptor::Trace {
+                modes_a,
+                modes_c,
+                paired,
+            } => {
+                // Trace expects 2 shapes: A (input), C (output)
+                validate_shape_count(shapes, 2, "Trace")?;
+                validate_rank(shapes[0], modes_a.len(), "Trace input A")?;
+                validate_rank(shapes[1], modes_c.len(), "Trace output C")?;
+                let paired_axes: Vec<(usize, usize)> = paired
+                    .iter()
+                    .map(|(m1, m2)| {
+                        Ok((mode_position(modes_a, *m1)?, mode_position(modes_a, *m2)?))
+                    })
+                    .collect::<Result<_>>()?;
+                // Validate that paired axes have equal dimensions
+                for &(ax1, ax2) in &paired_axes {
+                    if shapes[0][ax1] != shapes[0][ax2] {
+                        return Err(Error::InvalidArgument(format!(
+                            "Trace paired axes ({ax1}, {ax2}) have mismatched dimensions: {} vs {}",
+                            shapes[0][ax1], shapes[0][ax2]
+                        )));
+                    }
+                }
+                let free_axes: Vec<usize> = modes_c
+                    .iter()
+                    .map(|m| mode_position(modes_a, *m))
+                    .collect::<Result<_>>()?;
+                Ok(CpuPlan::Trace {
+                    paired_axes,
+                    free_axes,
+                    _marker: PhantomData,
+                })
+            }
+
+            PrimDescriptor::Permute { modes_a, modes_b } => {
+                // Permute expects 2 shapes: A (input), B (output)
+                validate_shape_count(shapes, 2, "Permute")?;
+                validate_rank(shapes[0], modes_a.len(), "Permute input A")?;
+                validate_rank(shapes[1], modes_b.len(), "Permute output B")?;
+                // perm[out_axis] = in_axis
+                let perm: Vec<usize> = modes_b
+                    .iter()
+                    .map(|m| mode_position(modes_a, *m))
+                    .collect::<Result<_>>()?;
+                Ok(CpuPlan::Permute {
+                    perm,
+                    _marker: PhantomData,
+                })
+            }
+
+            PrimDescriptor::AntiTrace {
+                modes_a,
+                modes_c,
+                paired,
+            } => {
+                // AntiTrace expects 2 shapes: A (input), C (output)
+                validate_shape_count(shapes, 2, "AntiTrace")?;
+                validate_rank(shapes[0], modes_a.len(), "AntiTrace input A")?;
+                validate_rank(shapes[1], modes_c.len(), "AntiTrace output C")?;
+                let paired_axes: Vec<(usize, usize)> = paired
+                    .iter()
+                    .map(|(m1, m2)| {
+                        Ok((mode_position(modes_c, *m1)?, mode_position(modes_c, *m2)?))
+                    })
+                    .collect::<Result<_>>()?;
+                // Validate that paired axes in output have equal dimensions
+                for &(ax1, ax2) in &paired_axes {
+                    if shapes[1][ax1] != shapes[1][ax2] {
+                        return Err(Error::InvalidArgument(format!(
+                            "AntiTrace paired axes ({ax1}, {ax2}) have mismatched dimensions: {} vs {}",
+                            shapes[1][ax1], shapes[1][ax2]
+                        )));
+                    }
+                }
+                let free_axes: Vec<usize> = modes_a
+                    .iter()
+                    .map(|m| mode_position(modes_c, *m))
+                    .collect::<Result<_>>()?;
+                Ok(CpuPlan::AntiTrace {
+                    paired_axes,
+                    free_axes,
+                    _marker: PhantomData,
+                })
+            }
+
+            PrimDescriptor::AntiDiag {
+                modes_a,
+                modes_c,
+                paired,
+            } => {
+                // AntiDiag expects 2 shapes: A (input), C (output)
+                validate_shape_count(shapes, 2, "AntiDiag")?;
+                validate_rank(shapes[0], modes_a.len(), "AntiDiag input A")?;
+                validate_rank(shapes[1], modes_c.len(), "AntiDiag output C")?;
+                let paired_axes: Vec<(usize, usize)> = paired
+                    .iter()
+                    .map(|(m1, m2)| {
+                        Ok((mode_position(modes_c, *m1)?, mode_position(modes_c, *m2)?))
+                    })
+                    .collect::<Result<_>>()?;
+                let free_axes: Vec<usize> = modes_a
+                    .iter()
+                    .map(|m| mode_position(modes_c, *m))
+                    .collect::<Result<_>>()?;
+                Ok(CpuPlan::AntiDiag {
+                    paired_axes,
+                    free_axes,
+                    _marker: PhantomData,
+                })
+            }
+
+            PrimDescriptor::ElementwiseUnary { op } => {
+                // ElementwiseUnary expects 2 shapes: A (input), C (output)
+                validate_shape_count(shapes, 2, "ElementwiseUnary")?;
+                Ok(CpuPlan::ElementwiseUnary {
+                    op: *op,
+                    _marker: PhantomData,
+                })
+            }
+
+            PrimDescriptor::Contract {
+                modes_a,
+                modes_b,
+                modes_c,
+            } => {
+                // Contract expects 3 shapes: A, B, C
+                validate_shape_count(shapes, 3, "Contract")?;
+                validate_rank(shapes[0], modes_a.len(), "Contract input A")?;
+                validate_rank(shapes[1], modes_b.len(), "Contract input B")?;
+                validate_rank(shapes[2], modes_c.len(), "Contract output C")?;
+                // Validate contracted dimensions match between A and B
+                for &mode in modes_a.iter() {
+                    if let Some(b_pos) = modes_b.iter().position(|&m| m == mode) {
+                        let a_pos = modes_a.iter().position(|&m| m == mode).unwrap();
+                        if shapes[0][a_pos] != shapes[1][b_pos] {
+                            return Err(Error::InvalidArgument(format!(
+                                "Contract mode {mode} has mismatched dimensions: A={} vs B={}",
+                                shapes[0][a_pos], shapes[1][b_pos]
+                            )));
+                        }
+                    }
+                }
+                Ok(CpuPlan::Contract {
+                    modes_a: modes_a.clone(),
+                    modes_b: modes_b.clone(),
+                    modes_c: modes_c.clone(),
+                    _marker: PhantomData,
+                })
+            }
+
+            PrimDescriptor::ElementwiseMul => {
+                // ElementwiseMul expects 3 shapes: A, B, C
+                validate_shape_count(shapes, 3, "ElementwiseMul")?;
+                Ok(CpuPlan::ElementwiseMul {
+                    _marker: PhantomData,
+                })
+            }
+
+            PrimDescriptor::MakeContiguous => {
+                // MakeContiguous expects 2 shapes: A (input), C (output)
+                validate_shape_count(shapes, 2, "MakeContiguous")?;
+                Ok(CpuPlan::MakeContiguous {
+                    _marker: PhantomData,
+                })
+            }
+        }
     }
 }
 
@@ -1083,224 +1390,21 @@ impl<S: Scalar> TensorPrims<Standard<S>> for CpuBackend {
     type Context = CpuContext;
 
     fn plan<T: ScalarBase>(
-        _ctx: &mut CpuContext,
+        ctx: &mut CpuContext,
         desc: &PrimDescriptor,
         shapes: &[&[usize]],
     ) -> Result<CpuPlan<T>> {
-        match desc {
-            PrimDescriptor::BatchedGemm {
-                batch_dims,
-                m,
-                n,
-                k,
-            } => {
-                // BatchedGemm expects 3 shapes: A, B, C
-                validate_shape_count(shapes, 3, "BatchedGemm")?;
-                let expected_a: Vec<usize> = batch_dims.iter().copied().chain([*m, *k]).collect();
-                let expected_b: Vec<usize> = batch_dims.iter().copied().chain([*k, *n]).collect();
-                let expected_c: Vec<usize> = batch_dims.iter().copied().chain([*m, *n]).collect();
-                validate_shape_eq(shapes[0], &expected_a, "BatchedGemm input A")?;
-                validate_shape_eq(shapes[1], &expected_b, "BatchedGemm input B")?;
-                validate_shape_eq(shapes[2], &expected_c, "BatchedGemm output C")?;
-                Ok(CpuPlan::BatchedGemm {
-                    batch_dims: batch_dims.clone(),
-                    m: *m,
-                    n: *n,
-                    k: *k,
-                    _marker: PhantomData,
-                })
-            }
-
-            PrimDescriptor::Reduce {
-                modes_a,
-                modes_c,
-                op,
-            } => {
-                // Reduce expects 2 shapes: A (input), C (output)
-                validate_shape_count(shapes, 2, "Reduce")?;
-                validate_rank(shapes[0], modes_a.len(), "Reduce input A")?;
-                validate_rank(shapes[1], modes_c.len(), "Reduce output C")?;
-                // reduced_axes = positions in modes_a not present in modes_c
-                let reduced_axes: Vec<usize> = modes_a
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, m)| !modes_c.contains(m))
-                    .map(|(i, _)| i)
-                    .collect();
-                Ok(CpuPlan::Reduce {
-                    reduced_axes,
-                    op: *op,
-                    _marker: PhantomData,
-                })
-            }
-
-            PrimDescriptor::Trace {
-                modes_a,
-                modes_c,
-                paired,
-            } => {
-                // Trace expects 2 shapes: A (input), C (output)
-                validate_shape_count(shapes, 2, "Trace")?;
-                validate_rank(shapes[0], modes_a.len(), "Trace input A")?;
-                validate_rank(shapes[1], modes_c.len(), "Trace output C")?;
-                let paired_axes: Vec<(usize, usize)> = paired
-                    .iter()
-                    .map(|(m1, m2)| {
-                        Ok((mode_position(modes_a, *m1)?, mode_position(modes_a, *m2)?))
-                    })
-                    .collect::<Result<_>>()?;
-                // Validate that paired axes have equal dimensions
-                for &(ax1, ax2) in &paired_axes {
-                    if shapes[0][ax1] != shapes[0][ax2] {
-                        return Err(Error::InvalidArgument(format!(
-                            "Trace paired axes ({ax1}, {ax2}) have mismatched dimensions: {} vs {}",
-                            shapes[0][ax1], shapes[0][ax2]
-                        )));
-                    }
-                }
-                let free_axes: Vec<usize> = modes_c
-                    .iter()
-                    .map(|m| mode_position(modes_a, *m))
-                    .collect::<Result<_>>()?;
-                Ok(CpuPlan::Trace {
-                    paired_axes,
-                    free_axes,
-                    _marker: PhantomData,
-                })
-            }
-
-            PrimDescriptor::Permute { modes_a, modes_b } => {
-                // Permute expects 2 shapes: A (input), B (output)
-                validate_shape_count(shapes, 2, "Permute")?;
-                validate_rank(shapes[0], modes_a.len(), "Permute input A")?;
-                validate_rank(shapes[1], modes_b.len(), "Permute output B")?;
-                // perm[out_axis] = in_axis
-                let perm: Vec<usize> = modes_b
-                    .iter()
-                    .map(|m| mode_position(modes_a, *m))
-                    .collect::<Result<_>>()?;
-                Ok(CpuPlan::Permute {
-                    perm,
-                    _marker: PhantomData,
-                })
-            }
-
-            PrimDescriptor::AntiTrace {
-                modes_a,
-                modes_c,
-                paired,
-            } => {
-                // AntiTrace expects 2 shapes: A (input), C (output)
-                validate_shape_count(shapes, 2, "AntiTrace")?;
-                validate_rank(shapes[0], modes_a.len(), "AntiTrace input A")?;
-                validate_rank(shapes[1], modes_c.len(), "AntiTrace output C")?;
-                let paired_axes: Vec<(usize, usize)> = paired
-                    .iter()
-                    .map(|(m1, m2)| {
-                        Ok((mode_position(modes_c, *m1)?, mode_position(modes_c, *m2)?))
-                    })
-                    .collect::<Result<_>>()?;
-                // Validate that paired axes in output have equal dimensions
-                for &(ax1, ax2) in &paired_axes {
-                    if shapes[1][ax1] != shapes[1][ax2] {
-                        return Err(Error::InvalidArgument(format!(
-                            "AntiTrace paired axes ({ax1}, {ax2}) have mismatched dimensions: {} vs {}",
-                            shapes[1][ax1], shapes[1][ax2]
-                        )));
-                    }
-                }
-                let free_axes: Vec<usize> = modes_a
-                    .iter()
-                    .map(|m| mode_position(modes_c, *m))
-                    .collect::<Result<_>>()?;
-                Ok(CpuPlan::AntiTrace {
-                    paired_axes,
-                    free_axes,
-                    _marker: PhantomData,
-                })
-            }
-
-            PrimDescriptor::AntiDiag {
-                modes_a,
-                modes_c,
-                paired,
-            } => {
-                // AntiDiag expects 2 shapes: A (input), C (output)
-                validate_shape_count(shapes, 2, "AntiDiag")?;
-                validate_rank(shapes[0], modes_a.len(), "AntiDiag input A")?;
-                validate_rank(shapes[1], modes_c.len(), "AntiDiag output C")?;
-                let paired_axes: Vec<(usize, usize)> = paired
-                    .iter()
-                    .map(|(m1, m2)| {
-                        Ok((mode_position(modes_c, *m1)?, mode_position(modes_c, *m2)?))
-                    })
-                    .collect::<Result<_>>()?;
-                let free_axes: Vec<usize> = modes_a
-                    .iter()
-                    .map(|m| mode_position(modes_c, *m))
-                    .collect::<Result<_>>()?;
-                Ok(CpuPlan::AntiDiag {
-                    paired_axes,
-                    free_axes,
-                    _marker: PhantomData,
-                })
-            }
-
-            PrimDescriptor::ElementwiseUnary { op } => {
-                // ElementwiseUnary expects 2 shapes: A (input), C (output)
-                validate_shape_count(shapes, 2, "ElementwiseUnary")?;
-                Ok(CpuPlan::ElementwiseUnary {
-                    op: *op,
-                    _marker: PhantomData,
-                })
-            }
-
-            PrimDescriptor::Contract {
-                modes_a,
-                modes_b,
-                modes_c,
-            } => {
-                // Contract expects 3 shapes: A, B, C
-                validate_shape_count(shapes, 3, "Contract")?;
-                validate_rank(shapes[0], modes_a.len(), "Contract input A")?;
-                validate_rank(shapes[1], modes_b.len(), "Contract input B")?;
-                validate_rank(shapes[2], modes_c.len(), "Contract output C")?;
-                // Validate contracted dimensions match between A and B
-                for &mode in modes_a.iter() {
-                    if let Some(b_pos) = modes_b.iter().position(|&m| m == mode) {
-                        let a_pos = modes_a.iter().position(|&m| m == mode).unwrap();
-                        if shapes[0][a_pos] != shapes[1][b_pos] {
-                            return Err(Error::InvalidArgument(format!(
-                                "Contract mode {mode} has mismatched dimensions: A={} vs B={}",
-                                shapes[0][a_pos], shapes[1][b_pos]
-                            )));
-                        }
-                    }
-                }
-                Ok(CpuPlan::Contract {
-                    modes_a: modes_a.clone(),
-                    modes_b: modes_b.clone(),
-                    modes_c: modes_c.clone(),
-                    _marker: PhantomData,
-                })
-            }
-
-            PrimDescriptor::ElementwiseMul => {
-                // ElementwiseMul expects 3 shapes: A, B, C
-                validate_shape_count(shapes, 3, "ElementwiseMul")?;
-                Ok(CpuPlan::ElementwiseMul {
-                    _marker: PhantomData,
-                })
-            }
-
-            PrimDescriptor::MakeContiguous => {
-                // MakeContiguous expects 2 shapes: A (input), C (output)
-                validate_shape_count(shapes, 2, "MakeContiguous")?;
-                Ok(CpuPlan::MakeContiguous {
-                    _marker: PhantomData,
-                })
-            }
+        // Check cache first
+        if let Some(cached) = ctx.plan_cache.get::<T>(desc, shapes) {
+            return Ok(cached);
         }
+
+        let plan = Self::build_plan::<T>(desc, shapes)?;
+
+        // Store in cache for future reuse
+        ctx.plan_cache.insert::<T>(desc, shapes, plan.clone());
+
+        Ok(plan)
     }
 
     fn execute<T: ScalarBase>(

--- a/tenferro-prims/tests/prims_tests.rs
+++ b/tenferro-prims/tests/prims_tests.rs
@@ -70,6 +70,186 @@ fn cpu_context_plan_cache() {
 }
 
 // ============================================================================
+// PlanCache: cache hit/miss semantics
+// ============================================================================
+
+#[test]
+fn plan_cache_hit_same_signature() {
+    // Repeated plan() calls with the same descriptor+shapes should hit the cache.
+    let mut ctx = CpuContext::new(1);
+    assert!(ctx.plan_cache_mut().is_empty());
+
+    let desc = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+
+    // First call: cache miss, builds and stores the plan.
+    let _plan1 = cpu_plan::<f64>(&mut ctx, &desc, &[&[2, 3], &[3, 2]]).unwrap();
+    assert_eq!(ctx.plan_cache_mut().len(), 1);
+
+    // Second call: cache hit, should not increase cache size.
+    let _plan2 = cpu_plan::<f64>(&mut ctx, &desc, &[&[2, 3], &[3, 2]]).unwrap();
+    assert_eq!(ctx.plan_cache_mut().len(), 1);
+}
+
+#[test]
+fn plan_cache_miss_different_shapes() {
+    // Different shapes should produce separate cache entries.
+    let mut ctx = CpuContext::new(1);
+
+    let desc = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+
+    let _plan1 = cpu_plan::<f64>(&mut ctx, &desc, &[&[2, 3], &[3, 2]]).unwrap();
+    assert_eq!(ctx.plan_cache_mut().len(), 1);
+
+    // Different shapes: 4x5 instead of 2x3
+    let _plan2 = cpu_plan::<f64>(&mut ctx, &desc, &[&[4, 5], &[5, 4]]).unwrap();
+    assert_eq!(ctx.plan_cache_mut().len(), 2);
+}
+
+#[test]
+fn plan_cache_miss_different_scalar_type() {
+    // Same descriptor and shapes but different scalar type should miss.
+    let mut ctx = CpuContext::new(1);
+
+    let desc = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+
+    let _plan_f64 = cpu_plan::<f64>(&mut ctx, &desc, &[&[2, 3], &[3, 2]]).unwrap();
+    assert_eq!(ctx.plan_cache_mut().len(), 1);
+
+    let _plan_f32 = cpu_plan::<f32>(&mut ctx, &desc, &[&[2, 3], &[3, 2]]).unwrap();
+    assert_eq!(ctx.plan_cache_mut().len(), 2);
+}
+
+#[test]
+fn plan_cache_miss_different_descriptor() {
+    // Same shapes but different descriptor should miss.
+    let mut ctx = CpuContext::new(1);
+
+    let desc1 = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+    let desc2 = PrimDescriptor::MakeContiguous;
+
+    let _plan1 = cpu_plan::<f64>(&mut ctx, &desc1, &[&[2, 3], &[3, 2]]).unwrap();
+    assert_eq!(ctx.plan_cache_mut().len(), 1);
+
+    let _plan2 = cpu_plan::<f64>(&mut ctx, &desc2, &[&[2, 3], &[2, 3]]).unwrap();
+    assert_eq!(ctx.plan_cache_mut().len(), 2);
+}
+
+#[test]
+fn plan_cache_clear() {
+    let mut ctx = CpuContext::new(1);
+
+    let desc = PrimDescriptor::MakeContiguous;
+    let _plan = cpu_plan::<f64>(&mut ctx, &desc, &[&[3, 4], &[3, 4]]).unwrap();
+    assert_eq!(ctx.plan_cache_mut().len(), 1);
+
+    ctx.plan_cache_mut().clear();
+    assert!(ctx.plan_cache_mut().is_empty());
+}
+
+#[test]
+fn plan_cache_hit_produces_correct_results() {
+    // Verify that a cached plan produces the same correct results as the original.
+    let mut ctx = CpuContext::new(1);
+
+    let desc = PrimDescriptor::Contract {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 2],
+        modes_c: vec![0, 2],
+    };
+    let shapes: &[&[usize]] = &[&[2, 3], &[3, 4], &[2, 4]];
+
+    // Build and cache the plan
+    let _plan1 = cpu_plan::<f64>(&mut ctx, &desc, shapes).unwrap();
+    assert_eq!(ctx.plan_cache_mut().len(), 1);
+
+    // Use cached plan for actual computation
+    let a = StridedArray::from_fn_col_major(&[2, 3], |idx| (idx[0] * 3 + idx[1] + 1) as f64);
+    let b = StridedArray::from_fn_col_major(&[3, 4], |idx| (idx[0] * 4 + idx[1] + 1) as f64);
+    let mut c = StridedArray::<f64>::col_major(&[2, 4]);
+
+    let plan2 = cpu_plan::<f64>(&mut ctx, &desc, shapes).unwrap();
+    cpu_execute(
+        &mut ctx,
+        &plan2,
+        1.0,
+        &[&a.view(), &b.view()],
+        0.0,
+        &mut c.view_mut(),
+    )
+    .unwrap();
+
+    // Verify results match manual computation
+    for i in 0..2 {
+        for j in 0..4 {
+            let mut expected = 0.0;
+            for k in 0..3 {
+                expected += a.view().get(&[i, k]) * b.view().get(&[k, j]);
+            }
+            assert!(
+                (c.view().get(&[i, j]) - expected).abs() < 1e-10,
+                "C[{i},{j}] = {}, expected {expected}",
+                c.view().get(&[i, j])
+            );
+        }
+    }
+}
+
+#[test]
+fn plan_cache_complex64_separate_from_f64() {
+    use num_complex::Complex64;
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+
+    // Build f64 plan
+    let _plan_f64 = cpu_plan::<f64>(&mut ctx, &desc, &[&[2, 3], &[3, 2]]).unwrap();
+
+    // Build Complex64 plan with same shapes
+    let _plan_c64 = cpu_plan::<Complex64>(&mut ctx, &desc, &[&[2, 3], &[3, 2]]).unwrap();
+
+    // Should be 2 distinct cache entries
+    assert_eq!(ctx.plan_cache_mut().len(), 2);
+
+    // Execute Complex64 plan to verify it works correctly
+    let a = StridedArray::from_fn_col_major(&[2, 3], |idx| {
+        Complex64::new((idx[0] * 3 + idx[1] + 1) as f64, 0.0)
+    });
+    let mut b = StridedArray::<Complex64>::col_major(&[3, 2]);
+
+    let plan = cpu_plan::<Complex64>(&mut ctx, &desc, &[&[2, 3], &[3, 2]]).unwrap();
+    cpu_execute(
+        &mut ctx,
+        &plan,
+        Complex64::new(1.0, 0.0),
+        &[&a.view()],
+        Complex64::new(0.0, 0.0),
+        &mut b.view_mut(),
+    )
+    .unwrap();
+
+    for i in 0..2 {
+        for j in 0..3 {
+            assert_eq!(b.view().get(&[j, i]), a.view().get(&[i, j]));
+        }
+    }
+}
+
+// ============================================================================
 // has_extension_for
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Implement `PlanCache` with type-erased storage keyed by `(TypeId, PrimDescriptor, shapes)` for safe cache discrimination across scalar types and operation signatures
- Wire cache lookup/insert into `CpuBackend::plan()` so repeated calls with the same descriptor and shapes return cached plans
- Extract plan construction into `CpuBackend::build_plan()` inherent method for clean separation of caching and plan-building logic
- Add 7 unit tests for cache hit/miss/clear behavior and 2 einsum integration tests verifying end-to-end cache reuse

## Test plan

- [x] `plan_cache_hit_same_signature` — same descriptor + shapes returns cached plan
- [x] `plan_cache_miss_different_shapes` — different shapes miss the cache
- [x] `plan_cache_miss_different_scalar_type` — f64 vs f32 plans are separate
- [x] `plan_cache_miss_different_descriptor` — different PrimDescriptors miss the cache
- [x] `plan_cache_clear` — `clear()` empties the cache
- [x] `plan_cache_hit_produces_correct_results` — cached plan executes correctly
- [x] `plan_cache_complex64_separate_from_f64` — Complex64 vs f64 are separate entries
- [x] `einsum_reuses_cached_plans` — einsum populates and reuses cache
- [x] `einsum_different_shapes_miss_cache` — einsum with different shapes creates new entries
- [x] All existing tests pass (`cargo test --workspace`)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)