### PR TITLE
refactor: rename generic type params A/B to Alg/Backend

### DIFF
--- a/extension/tenferro-tropical/src/algebra.rs
+++ b/extension/tenferro-tropical/src/algebra.rs
@@ -1,7 +1,7 @@
 //! Tropical algebra markers, [`HasAlgebra`], and [`Semiring`] implementations.
 //!
 //! Each zero-sized struct identifies a tropical algebra for use with
-//! [`TensorPrims<A>`](tenferro_prims::TensorPrims). The orphan rule is
+//! [`TensorPrims<Alg>`](tenferro_prims::TensorPrims). The orphan rule is
 //! satisfied because the algebra markers are defined in this crate.
 //!
 //! | Algebra marker | Scalar wrapper | ⊕ | ⊗ |
@@ -16,7 +16,7 @@ use crate::scalar::{MaxMul, MaxPlus, MinPlus};
 
 /// Algebra marker for the max-plus tropical semiring (⊕ = max, ⊗ = +).
 ///
-/// Used as the algebra parameter `A` in
+/// Used as the algebra parameter `Alg` in
 /// [`TensorPrims<MaxPlusAlgebra>`](tenferro_prims::TensorPrims).
 ///
 /// # Examples

--- a/extension/tenferro-tropical/src/lib.rs
+++ b/extension/tenferro-tropical/src/lib.rs
@@ -18,8 +18,8 @@
 //!   semantics. Satisfy the [`Scalar`](tenferro_algebra::Scalar) blanket impl.
 //!
 //! - **Algebra markers** ([`MaxPlusAlgebra`], [`MinPlusAlgebra`], [`MaxMulAlgebra`]):
-//!   Zero-sized types used as the algebra parameter `A` in
-//!   [`TensorPrims<A>`](tenferro_prims::TensorPrims).
+//!   Zero-sized types used as the algebra parameter `Alg` in
+//!   [`TensorPrims<Alg>`](tenferro_prims::TensorPrims).
 //!
 //! - **[`TensorPrims`](tenferro_prims::TensorPrims) implementations**:
 //!   `impl TensorPrims<MaxPlusAlgebra> for CpuBackend` etc. Orphan rule

--- a/tenferro-algebra/src/lib.rs
+++ b/tenferro-algebra/src/lib.rs
@@ -5,12 +5,12 @@
 //! - [`Scalar`]: Minimum requirements for tensor element types
 //!   (`Copy + Send + Sync + Add + Mul + Zero + One + PartialEq`).
 //! - [`Conjugate`]: Complex conjugation (identity for real types).
-//! - [`HasAlgebra`]: Maps a scalar type `T` to its default algebra `A`.
+//! - [`HasAlgebra`]: Maps a scalar type `T` to its default algebra `Alg`.
 //!   Enables automatic inference: `Tensor<f64>` → `Standard<f64>`,
 //!   `Tensor<MaxPlus<f64>>` → `MaxPlusAlgebra` (in external crate).
-//!   This is UX sugar — the core model is `A::Scalar`-centric.
+//!   This is UX sugar — the core model is `Alg::Scalar`-centric.
 //! - [`Semiring`]: Defines zero, one, add, mul for algebra-generic operations.
-//!   The algebra type `A` carries its scalar type via `A::Scalar`.
+//!   The algebra type `Alg` carries its scalar type via `Alg::Scalar`.
 //! - [`Standard<T>`](Standard): Typed standard arithmetic algebra (add = `+`, mul = `*`).
 //!
 //! # Extensibility
@@ -118,13 +118,13 @@ impl Conjugate for Complex64 {
     }
 }
 
-/// Maps a scalar type `T` to its default algebra `A`.
+/// Maps a scalar type `T` to its default algebra `Alg`.
 ///
 /// Enables automatic algebra inference: `Tensor<f64>` → `Standard<f64>`,
 /// `Tensor<MaxPlus<f64>>` → `MaxPlusAlgebra` (in external crate).
 ///
 /// This trait is **UX sugar** for default algebra inference. The core
-/// algebra model is `A::Scalar`-centric (see [`Semiring`]).
+/// algebra model is `Alg::Scalar`-centric (see [`Semiring`]).
 ///
 /// # Implementing for custom types
 ///
@@ -144,7 +144,7 @@ pub trait HasAlgebra {
 /// Typed standard arithmetic algebra (add = `+`, mul = `*`).
 ///
 /// The type parameter `T` carries the scalar type, making the algebra
-/// `A::Scalar`-centric. This is the canonical core model — `HasAlgebra`
+/// `Alg::Scalar`-centric. This is the canonical core model — `HasAlgebra`
 /// provides UX sugar for automatic inference (e.g., `f64` → `Standard<f64>`).
 ///
 /// This is the default algebra for built-in numeric types (`f32`, `f64`,
@@ -180,9 +180,9 @@ impl HasAlgebra for Complex64 {
 
 /// Semiring trait for algebra-generic operations.
 ///
-/// The algebra type `A` carries its scalar type via `A::Scalar`. This
-/// is the **core algebra model** — `TensorPrims<A>` and einsum/linalg
-/// trait bounds are centered on `A::Scalar`.
+/// The algebra type `Alg` carries its scalar type via `Alg::Scalar`. This
+/// is the **core algebra model** — `TensorPrims<Alg>` and einsum/linalg
+/// trait bounds are centered on `Alg::Scalar`.
 ///
 /// Defines the four fundamental operations needed for tensor contractions
 /// under a given algebra:

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -15,8 +15,8 @@
 //!
 //! # Backend dispatch
 //!
-//! The backend is passed explicitly as a type parameter `B: TensorPrims<A>`
-//! with a mutable context `&mut B::Context`.  This follows Rust idiom of
+//! The backend is passed explicitly as a type parameter `Backend: TensorPrims<Alg>`
+//! with a mutable context `&mut Backend::Context`.  This follows Rust idiom of
 //! explicit ownership and mutability (no global/thread-local state).
 //! The context provides access to the thread pool and plan cache.
 //!
@@ -503,8 +503,8 @@ fn manual_einsum<T: Scalar>(
 // ============================================================================
 
 /// Execute a single-tensor einsum operation via TensorPrims.
-fn execute_single_tensor_einsum<T, A, B>(
-    ctx: &mut B::Context,
+fn execute_single_tensor_einsum<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subs_a: &[u32],
     subs_c: &[u32],
     input: &Tensor<T>,
@@ -513,8 +513,8 @@ fn execute_single_tensor_einsum<T, A, B>(
     output: &mut Tensor<T>,
 ) -> Result<()>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     // Count label occurrences in input and output
     let mut label_positions: HashMap<u32, Vec<usize>> = HashMap::new();
@@ -545,10 +545,10 @@ where
                 modes_b: subs_c.to_vec(),
             };
             let shapes = [input.dims(), output.dims()];
-            let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+            let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
             let input_sv = tensor_to_view(input)?;
             let mut output_sv = tensor_to_view_mut(output)?;
-            B::execute(ctx, &plan, alpha, &[&input_sv], beta, &mut output_sv)
+            Backend::execute(ctx, &plan, alpha, &[&input_sv], beta, &mut output_sv)
         } else if output_set.is_subset(&input_set) {
             // Reduction (sum over labels not in output)
             let desc = PrimDescriptor::Reduce {
@@ -557,10 +557,10 @@ where
                 op: ReduceOp::Sum,
             };
             let shapes = [input.dims(), output.dims()];
-            let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+            let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
             let input_sv = tensor_to_view(input)?;
             let mut output_sv = tensor_to_view_mut(output)?;
-            B::execute(ctx, &plan, alpha, &[&input_sv], beta, &mut output_sv)
+            Backend::execute(ctx, &plan, alpha, &[&input_sv], beta, &mut output_sv)
         } else {
             Err(Error::InvalidArgument(
                 "output labels contain labels not in input".into(),
@@ -622,10 +622,10 @@ where
                 paired,
             };
             let shapes = [input.dims(), output.dims()];
-            let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+            let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
             let input_sv = tensor_to_view(input)?;
             let mut output_sv = tensor_to_view_mut(output)?;
-            B::execute(ctx, &plan, alpha, &[&input_sv], beta, &mut output_sv)
+            Backend::execute(ctx, &plan, alpha, &[&input_sv], beta, &mut output_sv)
         } else {
             // Diagonal extraction: repeated labels appear in output
             // Diagonal extraction + copy
@@ -686,9 +686,9 @@ where
                     modes_b: subs_c.to_vec(),
                 };
                 let shapes = [diag_tensor.dims(), output.dims()];
-                let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+                let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
                 let mut output_sv = tensor_to_view_mut(output)?;
-                B::execute(ctx, &plan, alpha, &[&sv], beta, &mut output_sv)
+                Backend::execute(ctx, &plan, alpha, &[&sv], beta, &mut output_sv)
             } else {
                 // Copy diagonal to contiguous temp, then reduce
                 let diag_tensor = diag_tensor.contiguous(MemoryOrder::ColumnMajor);
@@ -698,10 +698,10 @@ where
                     op: ReduceOp::Sum,
                 };
                 let shapes = [diag_tensor.dims(), output.dims()];
-                let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+                let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
                 let diag_sv = tensor_to_view(&diag_tensor)?;
                 let mut output_sv = tensor_to_view_mut(output)?;
-                B::execute(ctx, &plan, alpha, &[&diag_sv], beta, &mut output_sv)
+                Backend::execute(ctx, &plan, alpha, &[&diag_sv], beta, &mut output_sv)
             }
         }
     } else if repeated_labels.is_empty() && output_has_repeated {
@@ -742,10 +742,10 @@ where
             paired,
         };
         let shapes = [input.dims(), output.dims()];
-        let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+        let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
         let input_sv = tensor_to_view(input)?;
         let mut output_sv = tensor_to_view_mut(output)?;
-        B::execute(ctx, &plan, alpha, &[&input_sv], beta, &mut output_sv)
+        Backend::execute(ctx, &plan, alpha, &[&input_sv], beta, &mut output_sv)
     } else {
         Err(Error::InvalidArgument(
             "simultaneous repeated labels in both input and output not yet supported".into(),
@@ -758,8 +758,8 @@ where
 // ============================================================================
 
 /// Execute a pairwise contraction of two tensors via TensorPrims.
-fn execute_pairwise_contraction<T, A, B>(
-    ctx: &mut B::Context,
+fn execute_pairwise_contraction<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subs_a: &[u32],
     subs_b: &[u32],
     subs_c: &[u32],
@@ -770,34 +770,36 @@ fn execute_pairwise_contraction<T, A, B>(
     output: &mut Tensor<T>,
 ) -> Result<()>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     // Check for element-wise multiplication (same labels, same order)
-    if subs_a == subs_b && subs_a == subs_c && B::has_extension_for::<T>(Extension::ElementwiseMul)
+    if subs_a == subs_b
+        && subs_a == subs_c
+        && Backend::has_extension_for::<T>(Extension::ElementwiseMul)
     {
         let desc = PrimDescriptor::ElementwiseMul;
         let shapes = [a.dims(), b.dims(), output.dims()];
-        let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+        let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
         let a_sv = tensor_to_view(a)?;
         let b_sv = tensor_to_view(b)?;
         let mut out_sv = tensor_to_view_mut(output)?;
-        return B::execute(ctx, &plan, alpha, &[&a_sv, &b_sv], beta, &mut out_sv);
+        return Backend::execute(ctx, &plan, alpha, &[&a_sv, &b_sv], beta, &mut out_sv);
     }
 
     // General contraction via Contract extension
-    if B::has_extension_for::<T>(Extension::Contract) {
+    if Backend::has_extension_for::<T>(Extension::Contract) {
         let desc = PrimDescriptor::Contract {
             modes_a: subs_a.to_vec(),
             modes_b: subs_b.to_vec(),
             modes_c: subs_c.to_vec(),
         };
         let shapes = [a.dims(), b.dims(), output.dims()];
-        let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+        let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
         let a_sv = tensor_to_view(a)?;
         let b_sv = tensor_to_view(b)?;
         let mut out_sv = tensor_to_view_mut(output)?;
-        B::execute(ctx, &plan, alpha, &[&a_sv, &b_sv], beta, &mut out_sv)
+        Backend::execute(ctx, &plan, alpha, &[&a_sv, &b_sv], beta, &mut out_sv)
     } else {
         Err(Error::DeviceError(
             "backend does not support Contract extension".into(),
@@ -810,8 +812,8 @@ where
 // ============================================================================
 
 /// Execute a ContractionTree against concrete input tensors.
-fn execute_tree<T, A, B>(
-    ctx: &mut B::Context,
+fn execute_tree<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     tree: &ContractionTree,
     operands: &[&Tensor<T>],
     alpha: T,
@@ -819,8 +821,8 @@ fn execute_tree<T, A, B>(
     output: &mut Tensor<T>,
 ) -> Result<()>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let n_inputs = tree.subscripts.inputs.len();
 
@@ -831,7 +833,7 @@ where
                 "ContractionTree with no steps requires exactly 1 input".into(),
             ));
         }
-        return execute_single_tensor_einsum::<T, A, B>(
+        return execute_single_tensor_einsum::<T, Alg, Backend>(
             ctx,
             &tree.subscripts.inputs[0],
             &tree.subscripts.output,
@@ -863,7 +865,7 @@ where
 
         if is_last {
             // Last step: write directly to output with alpha/beta
-            execute_pairwise_contraction::<T, A, B>(
+            execute_pairwise_contraction::<T, Alg, Backend>(
                 ctx,
                 subs_left,
                 subs_right,
@@ -883,7 +885,7 @@ where
             let memory_space = infer_memory_space(operands)?;
             let mut result =
                 Tensor::<T>::zeros(&result_shape, memory_space, MemoryOrder::ColumnMajor);
-            execute_pairwise_contraction::<T, A, B>(
+            execute_pairwise_contraction::<T, Alg, Backend>(
                 ctx,
                 subs_left,
                 subs_right,
@@ -1225,24 +1227,26 @@ impl ContractionTree {
 ///
 /// Returns an error if the notation is invalid or tensor shapes are
 /// incompatible with the subscripts.
-pub fn einsum<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subscripts: &str,
     operands: &[&Tensor<T>],
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<Tensor<T>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let subs = Subscripts::parse(subscripts)?;
-    let mut output = einsum_with_subscripts::<T, A, B>(ctx, &subs, operands, size_dict)?;
+    let mut output = einsum_with_subscripts::<T, Alg, Backend>(ctx, &subs, operands, size_dict)?;
 
     // Auto-propagate forward-mode tangents
     if operands.iter().any(|t| t.has_fw_grad()) {
         let tangents: Vec<Option<&Tensor<T>>> = operands.iter().map(|t| t.fw_grad()).collect();
         // einsum_frule_impl calls einsum_with_subscripts (not einsum), so no recursion
-        if let Ok(output_tangent) = einsum_frule_impl::<T, A, B>(ctx, &subs, operands, &tangents) {
+        if let Ok(output_tangent) =
+            einsum_frule_impl::<T, Alg, Backend>(ctx, &subs, operands, &tangents)
+        {
             output.set_fw_grad(output_tangent);
         }
     }
@@ -1258,19 +1262,19 @@ where
 /// # Errors
 ///
 /// Returns an error if tensor shapes are incompatible with the subscripts.
-pub fn einsum_with_subscripts<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_with_subscripts<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subscripts: &Subscripts,
     operands: &[&Tensor<T>],
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<Tensor<T>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let shapes: Vec<&[usize]> = operands.iter().map(|t| t.dims()).collect();
     let tree = ContractionTree::optimize(subscripts, &shapes)?;
-    einsum_with_plan::<T, A, B>(ctx, &tree, operands, size_dict)
+    einsum_with_plan::<T, Alg, Backend>(ctx, &tree, operands, size_dict)
 }
 
 /// Execute einsum with a pre-optimized [`ContractionTree`].
@@ -1283,15 +1287,15 @@ where
 ///
 /// Returns an error if the operand shapes do not match those used to
 /// build the contraction tree.
-pub fn einsum_with_plan<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_with_plan<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     tree: &ContractionTree,
     operands: &[&Tensor<T>],
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<Tensor<T>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     // Merge size_dict from tree and optional extra
     let mut sd = tree.size_dict.clone();
@@ -1304,7 +1308,7 @@ where
     // Allocate the output tensor on the same memory space as the operands.
     let memory_space = infer_memory_space(operands)?;
     let mut output = Tensor::<T>::zeros(&output_shape, memory_space, MemoryOrder::ColumnMajor);
-    execute_tree::<T, A, B>(ctx, tree, operands, T::one(), T::zero(), &mut output)?;
+    execute_tree::<T, Alg, Backend>(ctx, tree, operands, T::one(), T::zero(), &mut output)?;
     Ok(output)
 }
 
@@ -1341,18 +1345,18 @@ where
 ///
 /// Returns an error if the notation is invalid or tensor shapes are
 /// incompatible with the subscripts.
-pub fn einsum_owned<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_owned<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subscripts: &str,
     operands: Vec<Tensor<T>>,
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<Tensor<T>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let refs: Vec<&Tensor<T>> = operands.iter().collect();
-    einsum::<T, A, B>(ctx, subscripts, &refs, size_dict)
+    einsum::<T, Alg, Backend>(ctx, subscripts, &refs, size_dict)
 }
 
 /// Execute einsum with pre-built [`Subscripts`], consuming the input tensors.
@@ -1363,18 +1367,18 @@ where
 /// # Errors
 ///
 /// Returns an error if tensor shapes are incompatible with the subscripts.
-pub fn einsum_with_subscripts_owned<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_with_subscripts_owned<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subscripts: &Subscripts,
     operands: Vec<Tensor<T>>,
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<Tensor<T>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let refs: Vec<&Tensor<T>> = operands.iter().collect();
-    einsum_with_subscripts::<T, A, B>(ctx, subscripts, &refs, size_dict)
+    einsum_with_subscripts::<T, Alg, Backend>(ctx, subscripts, &refs, size_dict)
 }
 
 /// Execute einsum with a pre-optimized [`ContractionTree`], consuming the
@@ -1388,18 +1392,18 @@ where
 ///
 /// Returns an error if the operand shapes do not match those used to
 /// build the contraction tree.
-pub fn einsum_with_plan_owned<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_with_plan_owned<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     tree: &ContractionTree,
     operands: Vec<Tensor<T>>,
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<Tensor<T>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let refs: Vec<&Tensor<T>> = operands.iter().collect();
-    einsum_with_plan::<T, A, B>(ctx, tree, &refs, size_dict)
+    einsum_with_plan::<T, Alg, Backend>(ctx, tree, &refs, size_dict)
 }
 
 // ============================================================================
@@ -1447,8 +1451,8 @@ where
 ///
 /// Returns an error if the notation is invalid, tensor shapes are
 /// incompatible, or the output shape does not match the expected result.
-pub fn einsum_into<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_into<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subscripts: &str,
     operands: &[&Tensor<T>],
     alpha: T,
@@ -1457,11 +1461,13 @@ pub fn einsum_into<T, A, B>(
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<()>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let subs = Subscripts::parse(subscripts)?;
-    einsum_with_subscripts_into::<T, A, B>(ctx, &subs, operands, alpha, beta, output, size_dict)
+    einsum_with_subscripts_into::<T, Alg, Backend>(
+        ctx, &subs, operands, alpha, beta, output, size_dict,
+    )
 }
 
 /// Execute einsum with pre-built [`Subscripts`], accumulating into an existing output.
@@ -1491,8 +1497,8 @@ where
 ///
 /// Returns an error if tensor shapes are incompatible with the subscripts
 /// or the output shape does not match.
-pub fn einsum_with_subscripts_into<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_with_subscripts_into<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subscripts: &Subscripts,
     operands: &[&Tensor<T>],
     alpha: T,
@@ -1501,12 +1507,12 @@ pub fn einsum_with_subscripts_into<T, A, B>(
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<()>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let shapes: Vec<&[usize]> = operands.iter().map(|t| t.dims()).collect();
     let tree = ContractionTree::optimize(subscripts, &shapes)?;
-    einsum_with_plan_into::<T, A, B>(ctx, &tree, operands, alpha, beta, output, size_dict)
+    einsum_with_plan_into::<T, Alg, Backend>(ctx, &tree, operands, alpha, beta, output, size_dict)
 }
 
 /// Execute einsum with a pre-optimized [`ContractionTree`], accumulating
@@ -1542,8 +1548,8 @@ where
 ///
 /// Returns an error if the operand shapes do not match those used to
 /// build the contraction tree, or the output shape is incorrect.
-pub fn einsum_with_plan_into<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_with_plan_into<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     tree: &ContractionTree,
     operands: &[&Tensor<T>],
     alpha: T,
@@ -1552,11 +1558,11 @@ pub fn einsum_with_plan_into<T, A, B>(
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<()>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let _ = size_dict; // size_dict already captured in tree.size_dict
-    execute_tree::<T, A, B>(ctx, tree, operands, alpha, beta, output)
+    execute_tree::<T, Alg, Backend>(ctx, tree, operands, alpha, beta, output)
 }
 
 // ============================================================================
@@ -1565,23 +1571,23 @@ where
 
 /// ReverseRule for einsum — stores subscripts, primal tensors, and shared
 /// backend context for backend-optimized pullback.
-struct EinsumReverseRule<T, A, B>
+struct EinsumReverseRule<T, Alg, Backend>
 where
     T: Scalar,
-    B: TensorPrims<A>,
+    Backend: TensorPrims<Alg>,
     Tensor<T>: Differentiable<Tangent = Tensor<T>>,
 {
-    ctx: Rc<RefCell<B::Context>>,
+    ctx: Rc<RefCell<Backend::Context>>,
     subscripts: Subscripts,
     primals: Vec<Tensor<T>>,
     input_node_ids: Vec<Option<NodeId>>,
-    _phantom: PhantomData<A>,
+    _phantom: PhantomData<Alg>,
 }
 
-impl<T, A, B> ReverseRule<Tensor<T>> for EinsumReverseRule<T, A, B>
+impl<T, Alg, Backend> ReverseRule<Tensor<T>> for EinsumReverseRule<T, Alg, Backend>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
     Tensor<T>: Differentiable<Tangent = Tensor<T>>,
 {
     fn pullback(&self, cotangent: &Tensor<T>) -> AdResult<Vec<(NodeId, Tensor<T>)>> {
@@ -1612,17 +1618,24 @@ where
             };
 
             // Use backend-optimized einsum
-            let mut grad =
-                einsum_with_subscripts::<T, A, B>(&mut *ctx, &rev_subs, &rev_operands, None)
-                    .map_err(|e| chainrules::AutodiffError::InvalidArgument(format!("{e}")))?;
+            let mut grad = einsum_with_subscripts::<T, Alg, Backend>(
+                &mut *ctx,
+                &rev_subs,
+                &rev_operands,
+                None,
+            )
+            .map_err(|e| chainrules::AutodiffError::InvalidArgument(format!("{e}")))?;
 
             // Propagate fw_grad from operands through the reverse einsum
             if rev_operands.iter().any(|t| t.has_fw_grad()) {
                 let tangents: Vec<Option<&Tensor<T>>> =
                     rev_operands.iter().map(|t| t.fw_grad()).collect();
-                if let Ok(grad_tangent) =
-                    einsum_frule_impl::<T, A, B>(&mut *ctx, &rev_subs, &rev_operands, &tangents)
-                {
+                if let Ok(grad_tangent) = einsum_frule_impl::<T, Alg, Backend>(
+                    &mut *ctx,
+                    &rev_subs,
+                    &rev_operands,
+                    &tangents,
+                ) {
                     grad.set_fw_grad(grad_tangent);
                 }
             }
@@ -1675,14 +1688,14 @@ where
 /// let _ga = grads.get(a.node_id().unwrap()).unwrap();
 /// ```
 ///
-pub fn tracked_einsum<T, A: 'static, B>(
-    ctx: Rc<RefCell<B::Context>>,
+pub fn tracked_einsum<T, Alg: 'static, Backend>(
+    ctx: Rc<RefCell<Backend::Context>>,
     subscripts: &str,
     operands: &[&TrackedTensor<Tensor<T>>],
 ) -> AdResult<TrackedTensor<Tensor<T>>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A> + 'static,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg> + 'static,
     Tensor<T>: Differentiable<Tangent = Tensor<T>>,
 {
     let subs = Subscripts::parse(subscripts)
@@ -1690,7 +1703,7 @@ where
 
     // Extract primals and run forward einsum
     let primals: Vec<&Tensor<T>> = operands.iter().map(|op| op.value()).collect();
-    let output = einsum::<T, A, B>(&mut *ctx.borrow_mut(), subscripts, &primals, None)
+    let output = einsum::<T, Alg, Backend>(&mut *ctx.borrow_mut(), subscripts, &primals, None)
         .map_err(|e| chainrules::AutodiffError::InvalidArgument(format!("{e}")))?;
 
     // Check if any operand requires gradients
@@ -1719,7 +1732,7 @@ where
         }
     }
 
-    let rule = EinsumReverseRule::<T, A, B> {
+    let rule = EinsumReverseRule::<T, Alg, Backend> {
         ctx: ctx.clone(),
         subscripts: subs,
         primals: primals.iter().map(|&t| t.clone()).collect(),
@@ -1757,27 +1770,27 @@ where
 /// let c_dual = dual_einsum::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a_dual, &b_dual]).unwrap();
 /// let _tangent = c_dual.tangent();
 /// ```
-pub fn dual_einsum<T, A, B>(
-    ctx: &mut B::Context,
+pub fn dual_einsum<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subscripts: &str,
     operands: &[&DualTensor<Tensor<T>>],
 ) -> AdResult<DualTensor<Tensor<T>>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
     Tensor<T>: Differentiable<Tangent = Tensor<T>>,
 {
     // Extract primals
     let primals: Vec<&Tensor<T>> = operands.iter().map(|op| op.primal()).collect();
 
     // Compute primal output
-    let output = einsum::<T, A, B>(ctx, subscripts, &primals, None)
+    let output = einsum::<T, Alg, Backend>(ctx, subscripts, &primals, None)
         .map_err(|e| chainrules::AutodiffError::InvalidArgument(format!("{e}")))?;
 
     // Compute tangent: dC = sum_k einsum(subs, [A0, ..., dAk, ..., An])
     let tangents: Vec<Option<&Tensor<T>>> = operands.iter().map(|op| op.tangent()).collect();
 
-    let tangent = einsum_frule::<T, A, B>(ctx, subscripts, &primals, &tangents);
+    let tangent = einsum_frule::<T, Alg, Backend>(ctx, subscripts, &primals, &tangents);
 
     match tangent {
         Ok(t) => DualTensor::with_tangent(output, t),
@@ -1809,15 +1822,15 @@ where
 /// let grads = einsum_rrule::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &grad_c).unwrap();
 /// assert_eq!(grads.len(), 2);
 /// ```
-pub fn einsum_rrule<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_rrule<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subscripts: &str,
     operands: &[&Tensor<T>],
     cotangent: &Tensor<T>,
 ) -> Result<Vec<Tensor<T>>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let subs = Subscripts::parse(subscripts)?;
     let n = operands.len();
@@ -1841,7 +1854,7 @@ where
             output: subs.inputs[k].clone(),
         };
 
-        let grad = einsum_with_subscripts::<T, A, B>(ctx, &rev_subs, &rev_operands, None)?;
+        let grad = einsum_with_subscripts::<T, Alg, Backend>(ctx, &rev_subs, &rev_operands, None)?;
         grads.push(grad);
     }
 
@@ -1872,15 +1885,15 @@ where
 /// let dc = einsum_frule::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &[Some(&da), None]).unwrap();
 /// ```
 /// Internal frule implementation with pre-parsed subscripts.
-fn einsum_frule_impl<T, A, B>(
-    ctx: &mut B::Context,
+fn einsum_frule_impl<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subs: &Subscripts,
     primals: &[&Tensor<T>],
     tangents: &[Option<&Tensor<T>>],
 ) -> Result<Tensor<T>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let n = primals.len();
 
@@ -1892,7 +1905,7 @@ where
             let mut ops: Vec<&Tensor<T>> = primals.to_vec();
             ops[k] = tangent_k;
 
-            let term = einsum_with_subscripts::<T, A, B>(ctx, subs, &ops, None)?;
+            let term = einsum_with_subscripts::<T, Alg, Backend>(ctx, subs, &ops, None)?;
 
             result = Some(match result {
                 None => term,
@@ -1904,18 +1917,18 @@ where
     result.ok_or_else(|| Error::InvalidArgument("no tangents provided".into()))
 }
 
-pub fn einsum_frule<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_frule<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subscripts: &str,
     primals: &[&Tensor<T>],
     tangents: &[Option<&Tensor<T>>],
 ) -> Result<Tensor<T>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let subs = Subscripts::parse(subscripts)?;
-    einsum_frule_impl::<T, A, B>(ctx, &subs, primals, tangents)
+    einsum_frule_impl::<T, Alg, Backend>(ctx, &subs, primals, tangents)
 }
 
 /// Local HVP rule for einsum without building a global tape.
@@ -1959,8 +1972,8 @@ where
 /// let (_grad_a, _hvp_a) = &results[0];
 /// let (_grad_b, _hvp_b) = &results[1];
 /// ```
-pub fn einsum_hvp<T, A, B>(
-    ctx: &mut B::Context,
+pub fn einsum_hvp<T, Alg, Backend>(
+    ctx: &mut Backend::Context,
     subscripts: &str,
     primals: &[&Tensor<T>],
     tangents: &[Option<&Tensor<T>>],
@@ -1968,8 +1981,8 @@ pub fn einsum_hvp<T, A, B>(
     cotangent_tangent: &Tensor<T>,
 ) -> Result<Vec<(Tensor<T>, Tensor<T>)>>
 where
-    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
-    B: TensorPrims<A>,
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
 {
     let subs = Subscripts::parse(subscripts)?;
     let n = primals.len();
@@ -2000,7 +2013,8 @@ where
                 rev_operands.push(op);
             }
         }
-        let grad_k = einsum_with_subscripts::<T, A, B>(ctx, &rev_subs, &rev_operands, None)?;
+        let grad_k =
+            einsum_with_subscripts::<T, Alg, Backend>(ctx, &rev_subs, &rev_operands, None)?;
 
         // Compute hvp_k: differentiate the gradient w.r.t. v
         // hvp_k = einsum([dḡ, A_others...]) + sum_{j!=k} einsum([ḡ, ..., dA_j, ...])
@@ -2013,7 +2027,7 @@ where
                 ops.push(op);
             }
         }
-        let term = einsum_with_subscripts::<T, A, B>(ctx, &rev_subs, &ops, None)?;
+        let term = einsum_with_subscripts::<T, Alg, Backend>(ctx, &rev_subs, &ops, None)?;
         hvp_k = Some(term);
 
         // Terms from tangents of other primals
@@ -2032,7 +2046,7 @@ where
                         }
                     }
                 }
-                let term = einsum_with_subscripts::<T, A, B>(ctx, &rev_subs, &ops, None)?;
+                let term = einsum_with_subscripts::<T, Alg, Backend>(ctx, &rev_subs, &ops, None)?;
                 hvp_k = Some(match hvp_k {
                     None => term,
                     Some(existing) => Tensor::<T>::accumulate_tangent(existing, &term),

--- a/tenferro-prims/src/lib.rs
+++ b/tenferro-prims/src/lib.rs
@@ -1,7 +1,7 @@
 //! Tensor primitive operations for the tenferro workspace.
 //!
-//! This crate defines the [`TensorPrims<A>`] trait, a backend-agnostic interface
-//! parameterized by algebra `A`. The API follows the cuTENSOR plan-based execution
+//! This crate defines the [`TensorPrims<Alg>`] trait, a backend-agnostic interface
+//! parameterized by algebra `Alg`. The API follows the cuTENSOR plan-based execution
 //! pattern:
 //!
 //! 1. Create a [`PrimDescriptor`] specifying the operation and index modes
@@ -25,9 +25,9 @@
 //!
 //! # Algebra parameterization
 //!
-//! [`TensorPrims<A>`] is parameterized by algebra `A` (e.g.,
+//! [`TensorPrims<Alg>`] is parameterized by algebra `Alg` (e.g.,
 //! [`Standard<f64>`](Standard), `MaxPlusAlgebra`). The algebra type carries
-//! its scalar type via `A::Scalar` (see [`Semiring`](tenferro_algebra::Semiring)).
+//! its scalar type via `Alg::Scalar` (see [`Semiring`](tenferro_algebra::Semiring)).
 //! External crates implement `TensorPrims<MyAlgebra> for CpuBackend` (orphan rule
 //! compatible). The [`HasAlgebra`](tenferro_algebra::HasAlgebra) trait on scalar types
 //! provides UX sugar for automatic inference: `Tensor<f64>` → `Standard<f64>`.
@@ -326,7 +326,7 @@ pub enum PrimDescriptor {
     MakeContiguous,
 }
 
-/// Backend trait for tensor primitive operations, parameterized by algebra `A`.
+/// Backend trait for tensor primitive operations, parameterized by algebra `Alg`.
 ///
 /// Provides a cuTENSOR-compatible plan-based execution model for all
 /// operations. Core ops (batched_gemm, reduce, trace, permute,
@@ -336,7 +336,7 @@ pub enum PrimDescriptor {
 ///
 /// # Algebra parameterization
 ///
-/// The algebra parameter `A` enables extensibility: external crates can
+/// The algebra parameter `Alg` enables extensibility: external crates can
 /// implement `TensorPrims<MyAlgebra> for CpuBackend` (orphan rule compatible).
 ///
 /// # Execution context
@@ -360,7 +360,7 @@ pub enum PrimDescriptor {
 /// let plan = CpuBackend::plan::<f64>(&mut ctx, &desc, &[&[3, 4], &[4, 5], &[3, 5]]).unwrap();
 /// CpuBackend::execute(&mut ctx, &plan, 1.0, &[&a.view(), &b.view()], 0.0, &mut c.view_mut()).unwrap();
 /// ```
-pub trait TensorPrims<A> {
+pub trait TensorPrims<Alg> {
     /// Backend-specific plan type (no type erasure).
     type Plan<T: ScalarBase>;
 


### PR DESCRIPTION
## Summary
- Rename `A` → `Alg` and `B` → `Backend` in `TensorPrims<Alg>` trait and all einsum functions
- Update documentation references in tenferro-algebra and tenferro-tropical
- Leave unrelated generics unchanged (tenferro-linalg's `LinalgBackend`, tenferro-burn's `Backend`)

In the einsum/tensor context, single-letter `A`/`B` were easily confused with operand matrices. `Alg`/`Backend` make the intent clear.

Closes #166

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo fmt --all --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)