### PR TITLE
feat(einsum,tropical): fallback contraction for non-Contract backends

### DIFF
--- a/extension/tenferro-tropical/Cargo.toml
+++ b/extension/tenferro-tropical/Cargo.toml
@@ -14,3 +14,8 @@ strided-view.workspace = true
 strided-traits.workspace = true
 strided-perm.workspace = true
 num-traits = { workspace = true }
+tropical-gemm = { git = "https://github.com/TensorBFS/tropical-gemm", version = "0.2" }
+
+[dev-dependencies]
+tenferro-einsum = { path = "../../tenferro-einsum" }
+tenferro-tensor = { path = "../../tenferro-tensor" }

--- a/extension/tenferro-tropical/src/prims.rs
+++ b/extension/tenferro-tropical/src/prims.rs
@@ -18,8 +18,10 @@ use strided_traits::ScalarBase;
 use strided_view::{StridedView, StridedViewMut};
 use tenferro_device::{Error, Result};
 use tenferro_prims::{CpuBackend, CpuContext, Extension, PrimDescriptor, ReduceOp, TensorPrims};
+use tropical_gemm::{TropicalMaxMul, TropicalMaxPlus, TropicalMinPlus, TropicalSemiring};
 
 use crate::algebra::{MaxMulAlgebra, MaxPlusAlgebra, MinPlusAlgebra};
+use crate::scalar::{MaxMul, MaxPlus, MinPlus};
 
 /// Execution plan for tropical primitive operations on CPU.
 ///
@@ -93,6 +95,8 @@ pub enum TropicalPlan<T: ScalarBase> {
         free_axes: Vec<usize>,
         _marker: PhantomData<T>,
     },
+    /// Plan for making a tensor contiguous.
+    MakeContiguous { _marker: PhantomData<T> },
 }
 
 // ===========================================================================
@@ -161,7 +165,189 @@ fn scale_output<T: ScalarBase>(output: &mut StridedViewMut<T>, beta: T) {
 // Execute helpers (reused across all three tropical algebras)
 // ===========================================================================
 
-fn execute_batched_gemm<T: ScalarBase>(
+/// Trait for dispatching to SIMD-optimized tropical GEMM via tropical-gemm crate.
+///
+/// Maps tenferro's tropical scalar types to tropical-gemm's types and calls
+/// `tropical_matmul_strided_batched` for SIMD-accelerated computation.
+trait TropicalGemmDispatch: ScalarBase {
+    /// Extract the inner scalar value (f64 or f32).
+    fn inner_value(&self) -> f64;
+    /// Wrap an inner scalar value back into the tropical type.
+    fn from_inner(v: f64) -> Self;
+    /// Execute SIMD-optimized batched GEMM.
+    /// Input: row-major f64 buffers packed per batch element.
+    /// Returns: row-major f64 result buffer.
+    fn dispatch_gemm(
+        a: &[f64],
+        b: &[f64],
+        batch_size: usize,
+        m: usize,
+        k: usize,
+        n: usize,
+    ) -> Vec<f64>;
+}
+
+impl TropicalGemmDispatch for MaxPlus<f64> {
+    #[inline]
+    fn inner_value(&self) -> f64 {
+        self.0
+    }
+    #[inline]
+    fn from_inner(v: f64) -> Self {
+        MaxPlus(v)
+    }
+    fn dispatch_gemm(
+        a: &[f64],
+        b: &[f64],
+        batch_size: usize,
+        m: usize,
+        k: usize,
+        n: usize,
+    ) -> Vec<f64> {
+        if batch_size <= 1 {
+            let result = tropical_gemm::tropical_matmul::<TropicalMaxPlus<f64>>(a, m, k, b, n);
+            result.iter().map(|v| v.value()).collect()
+        } else {
+            let result = tropical_gemm::tropical_matmul_strided_batched::<TropicalMaxPlus<f64>>(
+                a, b, batch_size, m, k, n,
+            );
+            result.iter().map(|v| v.value()).collect()
+        }
+    }
+}
+
+impl TropicalGemmDispatch for MinPlus<f64> {
+    #[inline]
+    fn inner_value(&self) -> f64 {
+        self.0
+    }
+    #[inline]
+    fn from_inner(v: f64) -> Self {
+        MinPlus(v)
+    }
+    fn dispatch_gemm(
+        a: &[f64],
+        b: &[f64],
+        batch_size: usize,
+        m: usize,
+        k: usize,
+        n: usize,
+    ) -> Vec<f64> {
+        if batch_size <= 1 {
+            let result = tropical_gemm::tropical_matmul::<TropicalMinPlus<f64>>(a, m, k, b, n);
+            result.iter().map(|v| v.value()).collect()
+        } else {
+            let result = tropical_gemm::tropical_matmul_strided_batched::<TropicalMinPlus<f64>>(
+                a, b, batch_size, m, k, n,
+            );
+            result.iter().map(|v| v.value()).collect()
+        }
+    }
+}
+
+impl TropicalGemmDispatch for MaxMul<f64> {
+    #[inline]
+    fn inner_value(&self) -> f64 {
+        self.0
+    }
+    #[inline]
+    fn from_inner(v: f64) -> Self {
+        MaxMul(v)
+    }
+    fn dispatch_gemm(
+        a: &[f64],
+        b: &[f64],
+        batch_size: usize,
+        m: usize,
+        k: usize,
+        n: usize,
+    ) -> Vec<f64> {
+        if batch_size <= 1 {
+            let result = tropical_gemm::tropical_matmul::<TropicalMaxMul<f64>>(a, m, k, b, n);
+            result.iter().map(|v| v.value()).collect()
+        } else {
+            let result = tropical_gemm::tropical_matmul_strided_batched::<TropicalMaxMul<f64>>(
+                a, b, batch_size, m, k, n,
+            );
+            result.iter().map(|v| v.value()).collect()
+        }
+    }
+}
+
+/// SIMD-optimized tropical GEMM using the tropical-gemm crate.
+///
+/// Extracts data into row-major contiguous buffers, calls tropical-gemm,
+/// and writes results back with alpha/beta scaling.
+fn execute_batched_gemm_optimized<T: ScalarBase + TropicalGemmDispatch>(
+    alpha: T,
+    inputs: &[&StridedView<T>],
+    beta: T,
+    output: &mut StridedViewMut<T>,
+    batch_dims: &[usize],
+    m: usize,
+    n: usize,
+    k: usize,
+) -> Result<()> {
+    let a = inputs[0];
+    let b = inputs[1];
+    let batch_size: usize = batch_dims.iter().product::<usize>().max(1);
+
+    // Extract A into contiguous row-major f64 buffer: [batch, m, k] row-major
+    let a_total = batch_size * m * k;
+    let b_total = batch_size * k * n;
+    let mut a_buf = Vec::with_capacity(a_total);
+    let mut b_buf = Vec::with_capacity(b_total);
+
+    for batch_flat in 0..batch_size {
+        let batch_idx = unflatten_index(batch_flat, batch_dims);
+        for i in 0..m {
+            for j in 0..k {
+                let mut idx = batch_idx.clone();
+                idx.push(i);
+                idx.push(j);
+                a_buf.push(a.get(&idx).inner_value());
+            }
+        }
+    }
+    for batch_flat in 0..batch_size {
+        let batch_idx = unflatten_index(batch_flat, batch_dims);
+        for i in 0..k {
+            for j in 0..n {
+                let mut idx = batch_idx.clone();
+                idx.push(i);
+                idx.push(j);
+                b_buf.push(b.get(&idx).inner_value());
+            }
+        }
+    }
+
+    // Call SIMD-optimized tropical GEMM
+    let result = T::dispatch_gemm(&a_buf, &b_buf, batch_size, m, k, n);
+
+    // Write results back with alpha/beta scaling
+    for batch_flat in 0..batch_size {
+        let batch_idx = unflatten_index(batch_flat, batch_dims);
+        for i in 0..m {
+            for j in 0..n {
+                let mut c_idx = batch_idx.clone();
+                c_idx.push(i);
+                c_idx.push(j);
+                let flat = batch_flat * m * n + i * n + j;
+                let val = T::from_inner(result[flat]);
+                let old = if beta == T::zero() {
+                    T::zero()
+                } else {
+                    beta * output.get(&c_idx)
+                };
+                output.set(&c_idx, alpha * val + old);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Fallback loop-based tropical GEMM for unsupported scalar types (e.g., f32).
+fn execute_batched_gemm_fallback<T: ScalarBase>(
     alpha: T,
     inputs: &[&StridedView<T>],
     beta: T,
@@ -183,8 +369,6 @@ fn execute_batched_gemm<T: ScalarBase>(
         let batch_idx = unflatten_index(batch_flat, batch_dims);
         for i in 0..m {
             for j in 0..n {
-                // Initialize sum to the semiring zero (additive identity).
-                // For MaxPlus: -inf, for MinPlus: +inf, for MaxMul: 0.
                 let mut sum = T::zero();
                 for kk in 0..k {
                     let mut a_idx = batch_idx.clone();
@@ -193,8 +377,6 @@ fn execute_batched_gemm<T: ScalarBase>(
                     let mut b_idx = batch_idx.clone();
                     b_idx.push(kk);
                     b_idx.push(j);
-                    // sum = sum ⊕ (a[i,kk] ⊗ b[kk,j])
-                    // For MaxPlus: sum = max(sum, a + b)
                     sum = sum + a.get(&a_idx) * b.get(&b_idx);
                 }
                 let mut c_idx = batch_idx.clone();
@@ -875,15 +1057,27 @@ fn tropical_plan<T: ScalarBase>(
             })
         }
 
+        PrimDescriptor::MakeContiguous => {
+            ensure_shape_count(shapes, 2, "MakeContiguous")?;
+            if shapes[0] != shapes[1] {
+                return Err(Error::InvalidArgument(
+                    "MakeContiguous input and output shapes must match".into(),
+                ));
+            }
+            Ok(TropicalPlan::MakeContiguous {
+                _marker: PhantomData,
+            })
+        }
+
         PrimDescriptor::ElementwiseUnary { .. }
         | PrimDescriptor::Contract { .. }
-        | PrimDescriptor::ElementwiseMul
-        | PrimDescriptor::MakeContiguous => Err(Error::InvalidArgument(
+        | PrimDescriptor::ElementwiseMul => Err(Error::InvalidArgument(
             "tropical algebras do not support this operation".into(),
         )),
     }
 }
 
+/// Execute tropical operations using the fallback loop-based GEMM.
 fn tropical_execute<T: ScalarBase>(
     plan: &TropicalPlan<T>,
     alpha: T,
@@ -904,7 +1098,7 @@ fn tropical_execute<T: ScalarBase>(
                     "BatchedGemm execute requires 2 input tensors".into(),
                 ));
             }
-            execute_batched_gemm(alpha, inputs, beta, output, batch_dims, *m, *n, *k)
+            execute_batched_gemm_fallback(alpha, inputs, beta, output, batch_dims, *m, *n, *k)
         }
 
         TropicalPlan::Reduce {
@@ -975,12 +1169,189 @@ fn tropical_execute<T: ScalarBase>(
             }
             execute_anti_diag(alpha, inputs[0], beta, output, paired_axes, free_axes)
         }
+
+        TropicalPlan::MakeContiguous { .. } => {
+            if inputs.len() != 1 {
+                return Err(Error::InvalidArgument(
+                    "MakeContiguous execute requires 1 input tensor".into(),
+                ));
+            }
+            execute_make_contiguous(alpha, inputs[0], beta, output)
+        }
     }
+}
+
+fn execute_make_contiguous<T: ScalarBase>(
+    alpha: T,
+    input: &StridedView<T>,
+    beta: T,
+    output: &mut StridedViewMut<T>,
+) -> Result<()> {
+    if alpha == T::one() && beta == T::zero() {
+        strided_perm::copy_into(output, input).map_err(|e| Error::StrideError(e.to_string()))?;
+    } else {
+        let dims = output.dims().to_vec();
+        for_each_index(&dims, |idx| {
+            let val = alpha * input.get(idx);
+            if beta == T::zero() {
+                output.set(idx, val);
+            } else {
+                output.set(idx, val + beta * output.get(idx));
+            }
+        });
+    }
+    Ok(())
 }
 
 // ===========================================================================
 // impl TensorPrims<MaxPlusAlgebra> for CpuBackend
 // ===========================================================================
+
+/// Execute tropical operations with SIMD-optimized GEMM for MaxPlus<f64>.
+fn tropical_execute_maxplus<T: ScalarBase>(
+    plan: &TropicalPlan<T>,
+    alpha: T,
+    inputs: &[&StridedView<T>],
+    beta: T,
+    output: &mut StridedViewMut<T>,
+) -> Result<()> {
+    if let TropicalPlan::BatchedGemm {
+        batch_dims,
+        m,
+        n,
+        k,
+        ..
+    } = plan
+    {
+        if inputs.len() != 2 {
+            return Err(Error::InvalidArgument(
+                "BatchedGemm execute requires 2 input tensors".into(),
+            ));
+        }
+        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<MaxPlus<f64>>() {
+            // SAFETY: T == MaxPlus<f64> confirmed by TypeId check.
+            // All references are transmuted to the same repr(transparent) type.
+            let a = unsafe {
+                &*(inputs[0] as *const StridedView<T> as *const StridedView<MaxPlus<f64>>)
+            };
+            let b = unsafe {
+                &*(inputs[1] as *const StridedView<T> as *const StridedView<MaxPlus<f64>>)
+            };
+            let out = unsafe {
+                &mut *(output as *mut StridedViewMut<T> as *mut StridedViewMut<MaxPlus<f64>>)
+            };
+            let alpha = unsafe { *(&alpha as *const T as *const MaxPlus<f64>) };
+            let beta = unsafe { *(&beta as *const T as *const MaxPlus<f64>) };
+            return execute_batched_gemm_optimized(
+                alpha,
+                &[a, b],
+                beta,
+                out,
+                batch_dims,
+                *m,
+                *n,
+                *k,
+            );
+        }
+    }
+    tropical_execute(plan, alpha, inputs, beta, output)
+}
+
+/// Execute tropical operations with SIMD-optimized GEMM for MinPlus<f64>.
+fn tropical_execute_minplus<T: ScalarBase>(
+    plan: &TropicalPlan<T>,
+    alpha: T,
+    inputs: &[&StridedView<T>],
+    beta: T,
+    output: &mut StridedViewMut<T>,
+) -> Result<()> {
+    if let TropicalPlan::BatchedGemm {
+        batch_dims,
+        m,
+        n,
+        k,
+        ..
+    } = plan
+    {
+        if inputs.len() != 2 {
+            return Err(Error::InvalidArgument(
+                "BatchedGemm execute requires 2 input tensors".into(),
+            ));
+        }
+        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<MinPlus<f64>>() {
+            let a = unsafe {
+                &*(inputs[0] as *const StridedView<T> as *const StridedView<MinPlus<f64>>)
+            };
+            let b = unsafe {
+                &*(inputs[1] as *const StridedView<T> as *const StridedView<MinPlus<f64>>)
+            };
+            let out = unsafe {
+                &mut *(output as *mut StridedViewMut<T> as *mut StridedViewMut<MinPlus<f64>>)
+            };
+            let alpha = unsafe { *(&alpha as *const T as *const MinPlus<f64>) };
+            let beta = unsafe { *(&beta as *const T as *const MinPlus<f64>) };
+            return execute_batched_gemm_optimized(
+                alpha,
+                &[a, b],
+                beta,
+                out,
+                batch_dims,
+                *m,
+                *n,
+                *k,
+            );
+        }
+    }
+    tropical_execute(plan, alpha, inputs, beta, output)
+}
+
+/// Execute tropical operations with SIMD-optimized GEMM for MaxMul<f64>.
+fn tropical_execute_maxmul<T: ScalarBase>(
+    plan: &TropicalPlan<T>,
+    alpha: T,
+    inputs: &[&StridedView<T>],
+    beta: T,
+    output: &mut StridedViewMut<T>,
+) -> Result<()> {
+    if let TropicalPlan::BatchedGemm {
+        batch_dims,
+        m,
+        n,
+        k,
+        ..
+    } = plan
+    {
+        if inputs.len() != 2 {
+            return Err(Error::InvalidArgument(
+                "BatchedGemm execute requires 2 input tensors".into(),
+            ));
+        }
+        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<MaxMul<f64>>() {
+            let a = unsafe {
+                &*(inputs[0] as *const StridedView<T> as *const StridedView<MaxMul<f64>>)
+            };
+            let b = unsafe {
+                &*(inputs[1] as *const StridedView<T> as *const StridedView<MaxMul<f64>>)
+            };
+            let out = unsafe {
+                &mut *(output as *mut StridedViewMut<T> as *mut StridedViewMut<MaxMul<f64>>)
+            };
+            let alpha = unsafe { *(&alpha as *const T as *const MaxMul<f64>) };
+            let beta = unsafe { *(&beta as *const T as *const MaxMul<f64>) };
+            return execute_batched_gemm_optimized(
+                alpha,
+                &[a, b],
+                beta,
+                out,
+                batch_dims,
+                *m,
+                *n,
+                *k,
+            );
+        }
+    }
+    tropical_execute(plan, alpha, inputs, beta, output)
+}
 
 impl TensorPrims<MaxPlusAlgebra> for CpuBackend {
     type Plan<T: ScalarBase> = TropicalPlan<T>;
@@ -1002,10 +1373,9 @@ impl TensorPrims<MaxPlusAlgebra> for CpuBackend {
         beta: T,
         output: &mut StridedViewMut<T>,
     ) -> Result<()> {
-        tropical_execute(plan, alpha, inputs, beta, output)
+        tropical_execute_maxplus(plan, alpha, inputs, beta, output)
     }
 
-    /// Tropical backends do not support extended operations.
     fn has_extension_for<T: ScalarBase>(_ext: Extension) -> bool {
         false
     }
@@ -1035,10 +1405,9 @@ impl TensorPrims<MinPlusAlgebra> for CpuBackend {
         beta: T,
         output: &mut StridedViewMut<T>,
     ) -> Result<()> {
-        tropical_execute(plan, alpha, inputs, beta, output)
+        tropical_execute_minplus(plan, alpha, inputs, beta, output)
     }
 
-    /// Tropical backends do not support extended operations.
     fn has_extension_for<T: ScalarBase>(_ext: Extension) -> bool {
         false
     }
@@ -1068,10 +1437,9 @@ impl TensorPrims<MaxMulAlgebra> for CpuBackend {
         beta: T,
         output: &mut StridedViewMut<T>,
     ) -> Result<()> {
-        tropical_execute(plan, alpha, inputs, beta, output)
+        tropical_execute_maxmul(plan, alpha, inputs, beta, output)
     }
 
-    /// Tropical backends do not support extended operations.
     fn has_extension_for<T: ScalarBase>(_ext: Extension) -> bool {
         false
     }

--- a/extension/tenferro-tropical/tests/einsum_tests.rs
+++ b/extension/tenferro-tropical/tests/einsum_tests.rs
@@ -1,0 +1,496 @@
+//! Integration tests for einsum with tropical algebras.
+//!
+//! These tests verify that the fallback contraction path (Permute + BatchedGemm)
+//! works correctly when the Contract extension is unavailable.
+
+use tenferro_einsum::einsum;
+use tenferro_prims::CpuBackend;
+use tenferro_tensor::{MemoryOrder, Tensor};
+use tenferro_tropical::{MaxMul, MaxMulAlgebra, MaxPlus, MaxPlusAlgebra, MinPlus, MinPlusAlgebra};
+
+const COL: MemoryOrder = MemoryOrder::ColumnMajor;
+
+/// Helper: create a CpuContext for tropical einsum calls.
+fn ctx() -> tenferro_prims::CpuContext {
+    tenferro_prims::CpuContext::new(1)
+}
+
+// ============================================================================
+// MaxPlus matmul: C[i,k] = max_j(A[i,j] + B[j,k])
+// ============================================================================
+
+#[test]
+fn tropical_maxplus_matmul() {
+    let mut ctx = ctx();
+
+    // A = [[1, 3],
+    //      [2, 4]]  (2x2, column-major: data = [1,2,3,4])
+    let a = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(1.0), MaxPlus(2.0), MaxPlus(3.0), MaxPlus(4.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    // B = [[5, 7],
+    //      [6, 8]]  (2x2, column-major: data = [5,6,7,8])
+    let b = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(5.0), MaxPlus(6.0), MaxPlus(7.0), MaxPlus(8.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    // C[i,k] = max_j(A[i,j] + B[j,k])
+    // C[0,0] = max(1+5, 3+6) = max(6, 9) = 9
+    // C[1,0] = max(2+5, 4+6) = max(7, 10) = 10
+    // C[0,1] = max(1+7, 3+8) = max(8, 11) = 11
+    // C[1,1] = max(2+7, 4+8) = max(9, 12) = 12
+    let c =
+        einsum::<_, MaxPlusAlgebra, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+
+    assert_eq!(c.dims(), &[2, 2]);
+    let data = c.buffer().as_slice().unwrap();
+    // Column-major: [C[0,0], C[1,0], C[0,1], C[1,1]]
+    assert_eq!(data[0], MaxPlus(9.0));
+    assert_eq!(data[1], MaxPlus(10.0));
+    assert_eq!(data[2], MaxPlus(11.0));
+    assert_eq!(data[3], MaxPlus(12.0));
+}
+
+// ============================================================================
+// Trace: "ii->" reduces to max of diagonal elements
+// ============================================================================
+
+#[test]
+fn tropical_maxplus_trace() {
+    let mut ctx = ctx();
+
+    // A = [[1, 3],
+    //      [2, 4]]  column-major
+    let a = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(1.0), MaxPlus(2.0), MaxPlus(3.0), MaxPlus(4.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    // trace = A[0,0] ⊕ A[1,1] = max(1, 4) = 4
+    let tr = einsum::<_, MaxPlusAlgebra, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
+
+    assert_eq!(tr.dims(), &[] as &[usize]);
+    let data = tr.buffer().as_slice().unwrap();
+    assert_eq!(data[0], MaxPlus(4.0));
+}
+
+// ============================================================================
+// Batched matmul: "bij,bjk->bik"
+// ============================================================================
+
+#[test]
+fn tropical_maxplus_batch_matmul() {
+    let mut ctx = ctx();
+
+    // batch=2, m=2, k=2 → A is [2,2,2]
+    // Batch 0: [[1,3],[2,4]], Batch 1: [[5,7],[6,8]]
+    // Column-major: innermost dims vary first
+    // Shape [m=2, k=2, b=2] → wait, "bij" means dims [b, i, j]
+    // Let's use shape [b=2, i=2, j=2]
+    let a = Tensor::<MaxPlus<f64>>::from_slice(
+        &[
+            // b=0,i=0,j=0; b=1,i=0,j=0; b=0,i=1,j=0; b=1,i=1,j=0;
+            // b=0,i=0,j=1; b=1,i=0,j=1; b=0,i=1,j=1; b=1,i=1,j=1
+            MaxPlus(1.0),
+            MaxPlus(5.0),
+            MaxPlus(2.0),
+            MaxPlus(6.0),
+            MaxPlus(3.0),
+            MaxPlus(7.0),
+            MaxPlus(4.0),
+            MaxPlus(8.0),
+        ],
+        &[2, 2, 2],
+        COL,
+    )
+    .unwrap();
+
+    let b = Tensor::<MaxPlus<f64>>::from_slice(
+        &[
+            MaxPlus(0.5),
+            MaxPlus(1.5),
+            MaxPlus(0.5),
+            MaxPlus(1.5),
+            MaxPlus(1.0),
+            MaxPlus(2.0),
+            MaxPlus(1.0),
+            MaxPlus(2.0),
+        ],
+        &[2, 2, 2],
+        COL,
+    )
+    .unwrap();
+
+    let c =
+        einsum::<_, MaxPlusAlgebra, CpuBackend>(&mut ctx, "bij,bjk->bik", &[&a, &b], None).unwrap();
+
+    assert_eq!(c.dims(), &[2, 2, 2]);
+
+    // Verify batch 0:
+    // A0 = [[1,3],[2,4]], B0 = [[0.5,1.0],[0.5,1.0]]
+    // C0[0,0] = max(1+0.5, 3+0.5) = max(1.5, 3.5) = 3.5
+    // C0[1,0] = max(2+0.5, 4+0.5) = max(2.5, 4.5) = 4.5
+    // C0[0,1] = max(1+1.0, 3+1.0) = max(2.0, 4.0) = 4.0
+    // C0[1,1] = max(2+1.0, 4+1.0) = max(3.0, 5.0) = 5.0
+    let data = c.buffer().as_slice().unwrap();
+    // Column-major [b, i, k]: data[b + 2*i + 4*k]
+    assert_eq!(data[0], MaxPlus(3.5)); // b=0,i=0,k=0
+    assert_eq!(data[2], MaxPlus(4.5)); // b=0,i=1,k=0
+    assert_eq!(data[4], MaxPlus(4.0)); // b=0,i=0,k=1
+    assert_eq!(data[6], MaxPlus(5.0)); // b=0,i=1,k=1
+}
+
+// ============================================================================
+// Element-wise: "ij,ij->ij" (degenerate BatchedGemm with m=n=k=1)
+// ============================================================================
+
+#[test]
+fn tropical_maxplus_elementwise() {
+    let mut ctx = ctx();
+
+    let a = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(1.0), MaxPlus(2.0), MaxPlus(3.0), MaxPlus(4.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    let b = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(10.0), MaxPlus(20.0), MaxPlus(30.0), MaxPlus(40.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    // Element-wise tropical mul: C[i,j] = A[i,j] ⊗ B[i,j] = A[i,j] + B[i,j]
+    let c =
+        einsum::<_, MaxPlusAlgebra, CpuBackend>(&mut ctx, "ij,ij->ij", &[&a, &b], None).unwrap();
+
+    assert_eq!(c.dims(), &[2, 2]);
+    let data = c.buffer().as_slice().unwrap();
+    assert_eq!(data[0], MaxPlus(11.0));
+    assert_eq!(data[1], MaxPlus(22.0));
+    assert_eq!(data[2], MaxPlus(33.0));
+    assert_eq!(data[3], MaxPlus(44.0));
+}
+
+// ============================================================================
+// Outer product: "i,j->ij"
+// ============================================================================
+
+#[test]
+fn tropical_maxplus_outer_product() {
+    let mut ctx = ctx();
+
+    let a = Tensor::<MaxPlus<f64>>::from_slice(&[MaxPlus(1.0), MaxPlus(2.0)], &[2], COL).unwrap();
+
+    let b = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(10.0), MaxPlus(20.0), MaxPlus(30.0)],
+        &[3],
+        COL,
+    )
+    .unwrap();
+
+    // C[i,j] = A[i] ⊗ B[j] = A[i] + B[j]  (no sum modes, k=1)
+    let c = einsum::<_, MaxPlusAlgebra, CpuBackend>(&mut ctx, "i,j->ij", &[&a, &b], None).unwrap();
+
+    assert_eq!(c.dims(), &[2, 3]);
+    let data = c.buffer().as_slice().unwrap();
+    // Column-major: [C[0,0], C[1,0], C[0,1], C[1,1], C[0,2], C[1,2]]
+    assert_eq!(data[0], MaxPlus(11.0)); // 1+10
+    assert_eq!(data[1], MaxPlus(12.0)); // 2+10
+    assert_eq!(data[2], MaxPlus(21.0)); // 1+20
+    assert_eq!(data[3], MaxPlus(22.0)); // 2+20
+    assert_eq!(data[4], MaxPlus(31.0)); // 1+30
+    assert_eq!(data[5], MaxPlus(32.0)); // 2+30
+}
+
+// ============================================================================
+// Vector-matrix: "j,jk->k" (m=1)
+// ============================================================================
+
+#[test]
+fn tropical_maxplus_vecmat() {
+    let mut ctx = ctx();
+
+    let v = Tensor::<MaxPlus<f64>>::from_slice(&[MaxPlus(1.0), MaxPlus(3.0)], &[2], COL).unwrap();
+
+    // M = [[5, 7],
+    //      [6, 8]]  column-major
+    let m = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(5.0), MaxPlus(6.0), MaxPlus(7.0), MaxPlus(8.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    // C[k] = max_j(v[j] + M[j,k])
+    // C[0] = max(1+5, 3+6) = max(6, 9) = 9
+    // C[1] = max(1+7, 3+8) = max(8, 11) = 11
+    let c = einsum::<_, MaxPlusAlgebra, CpuBackend>(&mut ctx, "j,jk->k", &[&v, &m], None).unwrap();
+
+    assert_eq!(c.dims(), &[2]);
+    let data = c.buffer().as_slice().unwrap();
+    assert_eq!(data[0], MaxPlus(9.0));
+    assert_eq!(data[1], MaxPlus(11.0));
+}
+
+// ============================================================================
+// Full contraction (scalar result): "ij,ij->"
+// ============================================================================
+
+#[test]
+fn tropical_maxplus_full_contraction() {
+    let mut ctx = ctx();
+
+    let a = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(1.0), MaxPlus(2.0), MaxPlus(3.0), MaxPlus(4.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    let b = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(10.0), MaxPlus(20.0), MaxPlus(30.0), MaxPlus(40.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    // scalar = max_{i,j}(A[i,j] + B[i,j])
+    // = max(1+10, 2+20, 3+30, 4+40) = max(11, 22, 33, 44) = 44
+    let c = einsum::<_, MaxPlusAlgebra, CpuBackend>(&mut ctx, "ij,ij->", &[&a, &b], None).unwrap();
+
+    assert_eq!(c.dims(), &[] as &[usize]);
+    let data = c.buffer().as_slice().unwrap();
+    assert_eq!(data[0], MaxPlus(44.0));
+}
+
+// ============================================================================
+// Three-tensor chain: "ij,jk,kl->il"
+// ============================================================================
+
+#[test]
+fn tropical_maxplus_three_chain() {
+    let mut ctx = ctx();
+
+    let a = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(1.0), MaxPlus(2.0), MaxPlus(3.0), MaxPlus(4.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    let b = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(1.0), MaxPlus(1.0), MaxPlus(1.0), MaxPlus(1.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    let c_mat = Tensor::<MaxPlus<f64>>::from_slice(
+        &[MaxPlus(0.0), MaxPlus(0.0), MaxPlus(0.0), MaxPlus(0.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    // D = A ⊗ B ⊗ C  (tropical chain multiplication)
+    let d =
+        einsum::<_, MaxPlusAlgebra, CpuBackend>(&mut ctx, "ij,jk,kl->il", &[&a, &b, &c_mat], None)
+            .unwrap();
+
+    assert_eq!(d.dims(), &[2, 2]);
+
+    // AB[i,k] = max_j(A[i,j] + B[j,k])
+    // AB[0,0] = max(1+1, 3+1) = 4
+    // AB[1,0] = max(2+1, 4+1) = 5
+    // AB[0,1] = max(1+1, 3+1) = 4
+    // AB[1,1] = max(2+1, 4+1) = 5
+    //
+    // D[i,l] = max_k(AB[i,k] + C[k,l])
+    // D[0,0] = max(4+0, 4+0) = 4
+    // D[1,0] = max(5+0, 5+0) = 5
+    // D[0,1] = max(4+0, 4+0) = 4
+    // D[1,1] = max(5+0, 5+0) = 5
+    let data = d.buffer().as_slice().unwrap();
+    assert_eq!(data[0], MaxPlus(4.0));
+    assert_eq!(data[1], MaxPlus(5.0));
+    assert_eq!(data[2], MaxPlus(4.0));
+    assert_eq!(data[3], MaxPlus(5.0));
+}
+
+// ============================================================================
+// MinPlus matmul: shortest-path distance via adjacency matrix squaring
+// C[i,k] = min_j(A[i,j] + B[j,k])
+// ============================================================================
+
+#[test]
+fn tropical_minplus_matmul_shortest_path() {
+    let mut ctx = ctx();
+    let inf = f64::INFINITY;
+
+    // Weighted adjacency matrix W (3 nodes, edge weights, +inf = no edge):
+    //      to 0   to 1   to 2
+    // W = [[ 0,    1,   +inf],   from 0
+    //      [+inf,  0,    3  ],   from 1
+    //      [ 2,  +inf,   0  ]]   from 2
+    //
+    // Column-major 3x3: data[i + 3*j] = W[i,j]
+    let w = Tensor::<MinPlus<f64>>::from_slice(
+        &[
+            MinPlus(0.0),
+            MinPlus(inf),
+            MinPlus(2.0), // col 0
+            MinPlus(1.0),
+            MinPlus(0.0),
+            MinPlus(inf), // col 1
+            MinPlus(inf),
+            MinPlus(3.0),
+            MinPlus(0.0), // col 2
+        ],
+        &[3, 3],
+        COL,
+    )
+    .unwrap();
+
+    // W^2[i,k] = min_j(W[i,j] + W[j,k]) = 2-hop shortest paths
+    // W^2[0,0] = min(0+0, 1+inf, inf+2) = 0
+    // W^2[0,1] = min(0+1, 1+0, inf+inf) = 1
+    // W^2[0,2] = min(0+inf, 1+3, inf+0) = 4
+    // W^2[1,0] = min(inf+0, 0+inf, 3+2) = 5
+    // W^2[1,1] = min(inf+1, 0+0, 3+inf) = 0
+    // W^2[1,2] = min(inf+inf, 0+3, 3+0) = 3
+    // W^2[2,0] = min(2+0, inf+inf, 0+2) = 2
+    // W^2[2,1] = min(2+1, inf+0, 0+inf) = 3
+    // W^2[2,2] = min(2+inf, inf+3, 0+0) = 0
+    let w2 =
+        einsum::<_, MinPlusAlgebra, CpuBackend>(&mut ctx, "ij,jk->ik", &[&w, &w], None).unwrap();
+
+    assert_eq!(w2.dims(), &[3, 3]);
+    let data = w2.buffer().as_slice().unwrap();
+    // Column-major: data[i + 3*j]
+    assert_eq!(data[0], MinPlus(0.0)); // W^2[0,0]
+    assert_eq!(data[1], MinPlus(5.0)); // W^2[1,0]
+    assert_eq!(data[2], MinPlus(2.0)); // W^2[2,0]
+    assert_eq!(data[3], MinPlus(1.0)); // W^2[0,1]
+    assert_eq!(data[4], MinPlus(0.0)); // W^2[1,1]
+    assert_eq!(data[5], MinPlus(3.0)); // W^2[2,1]
+    assert_eq!(data[6], MinPlus(4.0)); // W^2[0,2]
+    assert_eq!(data[7], MinPlus(3.0)); // W^2[1,2]
+    assert_eq!(data[8], MinPlus(0.0)); // W^2[2,2]
+}
+
+// ============================================================================
+// MaxMul matmul: Viterbi-like max-probability path computation
+// C[i,k] = max_j(A[i,j] * B[j,k])
+// ============================================================================
+
+#[test]
+fn tropical_maxmul_matmul_viterbi() {
+    let mut ctx = ctx();
+
+    // Transition matrix T (3 states):
+    //      to 0   to 1   to 2
+    // T = [[0.1,  0.7,   0.2],   from 0
+    //      [0.3,  0.4,   0.3],   from 1
+    //      [0.5,  0.1,   0.4]]   from 2
+    //
+    // Emission probability matrix E (3 states, 2 observations):
+    //       obs 0  obs 1
+    // E = [[0.9,   0.1],   state 0
+    //      [0.2,   0.8],   state 1
+    //      [0.5,   0.5]]   state 2
+    //
+    // MaxMul(T^T * E) gives max transition-to-emission probabilities.
+    // P[i,k] = max_j(T[j,i] * E[j,k])  (T transposed so we look at incoming)
+
+    // T^T in column-major 3x3
+    let tt = Tensor::<MaxMul<f64>>::from_slice(
+        &[
+            MaxMul(0.1),
+            MaxMul(0.7),
+            MaxMul(0.2), // col 0 = row 0 of T
+            MaxMul(0.3),
+            MaxMul(0.4),
+            MaxMul(0.3), // col 1 = row 1 of T
+            MaxMul(0.5),
+            MaxMul(0.1),
+            MaxMul(0.4), // col 2 = row 2 of T
+        ],
+        &[3, 3],
+        COL,
+    )
+    .unwrap();
+
+    // E in column-major 3x2
+    let e = Tensor::<MaxMul<f64>>::from_slice(
+        &[
+            MaxMul(0.9),
+            MaxMul(0.2),
+            MaxMul(0.5), // col 0
+            MaxMul(0.1),
+            MaxMul(0.8),
+            MaxMul(0.5), // col 1
+        ],
+        &[3, 2],
+        COL,
+    )
+    .unwrap();
+
+    // P[i,k] = max_j(T^T[i,j] * E[j,k])
+    // P[0,0] = max(0.1*0.9, 0.3*0.2, 0.5*0.5) = max(0.09, 0.06, 0.25) = 0.25
+    // P[1,0] = max(0.7*0.9, 0.4*0.2, 0.1*0.5) = max(0.63, 0.08, 0.05) = 0.63
+    // P[2,0] = max(0.2*0.9, 0.3*0.2, 0.4*0.5) = max(0.18, 0.06, 0.20) = 0.20
+    // P[0,1] = max(0.1*0.1, 0.3*0.8, 0.5*0.5) = max(0.01, 0.24, 0.25) = 0.25
+    // P[1,1] = max(0.7*0.1, 0.4*0.8, 0.1*0.5) = max(0.07, 0.32, 0.05) = 0.32
+    // P[2,1] = max(0.2*0.1, 0.3*0.8, 0.4*0.5) = max(0.02, 0.24, 0.20) = 0.24
+    let p =
+        einsum::<_, MaxMulAlgebra, CpuBackend>(&mut ctx, "ij,jk->ik", &[&tt, &e], None).unwrap();
+
+    assert_eq!(p.dims(), &[3, 2]);
+    let data = p.buffer().as_slice().unwrap();
+    let eps = 1e-14;
+    assert!((data[0].0 - 0.25).abs() < eps); // P[0,0]
+    assert!((data[1].0 - 0.63).abs() < eps); // P[1,0]
+    assert!((data[2].0 - 0.20).abs() < eps); // P[2,0]
+    assert!((data[3].0 - 0.25).abs() < eps); // P[0,1]
+    assert!((data[4].0 - 0.32).abs() < eps); // P[1,1]
+    assert!((data[5].0 - 0.24).abs() < eps); // P[2,1]
+}
+
+// ============================================================================
+// MinPlus trace: minimum of diagonal elements (self-loop distances)
+// ============================================================================
+
+#[test]
+fn tropical_minplus_trace() {
+    let mut ctx = ctx();
+    let inf = f64::INFINITY;
+
+    // Distance matrix D (diagonal = self-loop costs):
+    // D = [[2,  5 ],
+    //      [inf, 3 ]]
+    let d = Tensor::<MinPlus<f64>>::from_slice(
+        &[MinPlus(2.0), MinPlus(inf), MinPlus(5.0), MinPlus(3.0)],
+        &[2, 2],
+        COL,
+    )
+    .unwrap();
+
+    // trace = D[0,0] ⊕ D[1,1] = min(2, 3) = 2
+    let tr = einsum::<_, MinPlusAlgebra, CpuBackend>(&mut ctx, "ii->", &[&d], None).unwrap();
+
+    assert_eq!(tr.dims(), &[] as &[usize]);
+    let data = tr.buffer().as_slice().unwrap();
+    assert_eq!(data[0], MinPlus(2.0));
+}

--- a/extension/tenferro-tropical/tests/tropical_tests.rs
+++ b/extension/tenferro-tropical/tests/tropical_tests.rs
@@ -885,6 +885,184 @@ fn maxplus_permute_transpose() {
 }
 
 // ============================================================================
+// Tropical trace execution test
+// ============================================================================
+
+#[test]
+fn maxplus_trace_3x3() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // A = [[10, 4, 7],   (3x3, column-major)
+    //      [ 2, 8, 5],
+    //      [ 6, 3, 1]]
+    //
+    // Trace = A[0,0] ⊕ A[1,1] ⊕ A[2,2] = max(10, 8, 1) = 10
+    let mut ctx = CpuContext::new(1);
+
+    // Column-major: data[i + 3*j]
+    let a_data = [
+        MaxPlus(10.0),
+        MaxPlus(2.0),
+        MaxPlus(6.0), // col 0
+        MaxPlus(4.0),
+        MaxPlus(8.0),
+        MaxPlus(3.0), // col 1
+        MaxPlus(7.0),
+        MaxPlus(5.0),
+        MaxPlus(1.0), // col 2
+    ];
+    let mut c_data = [MaxPlus::<f64>::zero()]; // scalar output
+
+    let a_view = strided_view::StridedView::new(&a_data, &[3, 3], &[1, 3], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[], &[], 0).unwrap();
+
+    let desc = PrimDescriptor::Trace {
+        modes_a: vec![0, 1],
+        modes_c: vec![],
+        paired: vec![(0, 1)],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[3, 3], &[]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &[&a_view],
+        MaxPlus::zero(),
+        &mut c_view,
+    )
+    .unwrap();
+
+    assert_eq!(c_data[0].0, 10.0); // max(10, 8, 1)
+}
+
+#[test]
+fn maxplus_trace_partial_3d() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // Partial trace: "iij->j" on a [2,2,3] tensor.
+    // Result[j] = max_i(A[i,i,j]) = max of diagonal slices.
+    //
+    // A[0,0,:] = [1, 2, 3]
+    // A[1,1,:] = [8, 5, 6]
+    // Result = [max(1,8), max(2,5), max(3,6)] = [8, 5, 6]
+    let mut ctx = CpuContext::new(1);
+
+    // Shape [2,2,3], column-major: data[i + 2*j + 4*k]
+    let a_data = [
+        // k=0: [[1,?],[?,8]]
+        MaxPlus(1.0),
+        MaxPlus(10.0), // i=0,j=0; i=1,j=0
+        MaxPlus(10.0),
+        MaxPlus(8.0), // i=0,j=1; i=1,j=1
+        // k=1: [[2,?],[?,5]]
+        MaxPlus(2.0),
+        MaxPlus(10.0),
+        MaxPlus(10.0),
+        MaxPlus(5.0),
+        // k=2: [[3,?],[?,6]]
+        MaxPlus(3.0),
+        MaxPlus(10.0),
+        MaxPlus(10.0),
+        MaxPlus(6.0),
+    ];
+    let mut c_data = [MaxPlus::<f64>::zero(); 3];
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2, 3], &[1, 2, 4], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[3], &[1], 0).unwrap();
+
+    let desc = PrimDescriptor::Trace {
+        modes_a: vec![0, 1, 2],
+        modes_c: vec![2],
+        paired: vec![(0, 1)],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2, 3], &[3]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &[&a_view],
+        MaxPlus::zero(),
+        &mut c_view,
+    )
+    .unwrap();
+
+    // Off-diagonal values are 10, but those are not summed in trace
+    assert_eq!(c_data[0].0, 8.0); // max(1, 8)
+    assert_eq!(c_data[1].0, 5.0); // max(2, 5)
+    assert_eq!(c_data[2].0, 6.0); // max(3, 6)
+}
+
+// ============================================================================
+// Anti-trace: embed scalar/vector into diagonal of a matrix
+// (AD backward of trace operation)
+// ============================================================================
+
+#[test]
+fn maxplus_anti_trace_scalar_to_diag() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // AntiTrace: scalar → 2x2 matrix with value on diagonal
+    // input = MaxPlus(5.0) (scalar)
+    // output[i,j] = alpha * input if i==j, else unchanged (beta * old)
+    //
+    // With alpha=1, beta=0:
+    // output = [[5, -inf],
+    //           [-inf, 5]]
+    let mut ctx = CpuContext::new(1);
+
+    let in_data = [MaxPlus(5.0)];
+    let mut out_data = [MaxPlus::<f64>::zero(); 4]; // 2x2
+
+    let in_view = strided_view::StridedView::new(&in_data, &[], &[], 0).unwrap();
+    let mut out_view =
+        strided_view::StridedViewMut::new(&mut out_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let desc = PrimDescriptor::AntiTrace {
+        modes_a: vec![],
+        modes_c: vec![0, 1],
+        paired: vec![(0, 1)],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[], &[2, 2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &[&in_view],
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap();
+
+    // Column-major: [out[0,0], out[1,0], out[0,1], out[1,1]]
+    // Diagonal gets 5.0, off-diagonal stays at zero (-inf) + 5.0 = 5.0...
+    // Actually anti-trace adds val to each diagonal position:
+    // out[d,d] += alpha * input for d in 0..diag_dim
+    // After scale_output with beta=0, all entries are -inf, then add 5.0 to diag
+    assert_eq!(out_data[0].0, 5.0); // [0,0] diagonal
+    assert_eq!(out_data[1].0, f64::NEG_INFINITY); // [1,0] off-diagonal
+    assert_eq!(out_data[2].0, f64::NEG_INFINITY); // [0,1] off-diagonal
+    assert_eq!(out_data[3].0, 5.0); // [1,1] diagonal
+}
+
+// ============================================================================
 // Extension not supported test
 // ============================================================================
 

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -757,6 +757,286 @@ where
 // Pairwise contraction execution
 // ============================================================================
 
+/// Classify contraction modes into batch, left-only, right-only, and summed.
+///
+/// - batch: modes in A ∩ B ∩ C (preserved in both inputs and output)
+/// - lo (left-only): modes in (A ∩ C) \ B (free modes of A)
+/// - ro (right-only): modes in (B ∩ C) \ A (free modes of B)
+/// - sum: modes in (A ∩ B) \ C (contracted/summed over)
+///
+/// Each category preserves the order in which modes first appear in subs_a
+/// (for batch, lo, sum) or subs_b (for ro).
+fn classify_modes(
+    subs_a: &[u32],
+    subs_b: &[u32],
+    subs_c: &[u32],
+) -> (Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>) {
+    let set_a: HashSet<u32> = subs_a.iter().copied().collect();
+    let set_b: HashSet<u32> = subs_b.iter().copied().collect();
+    let set_c: HashSet<u32> = subs_c.iter().copied().collect();
+
+    let mut batch = Vec::new();
+    let mut lo = Vec::new();
+    let mut sum = Vec::new();
+    let mut seen = HashSet::new();
+
+    // Scan A modes: classify as batch, lo, or sum
+    for &m in subs_a {
+        if !seen.insert(m) {
+            continue;
+        }
+        if set_b.contains(&m) && set_c.contains(&m) {
+            batch.push(m);
+        } else if set_c.contains(&m) && !set_b.contains(&m) {
+            lo.push(m);
+        } else if set_b.contains(&m) && !set_c.contains(&m) {
+            sum.push(m);
+        }
+        // mode only in A and not in B or C: ignored (won't appear in output)
+    }
+
+    // Scan B modes for right-only
+    let mut ro = Vec::new();
+    let mut seen_b = HashSet::new();
+    for &m in subs_b {
+        if !seen_b.insert(m) {
+            continue;
+        }
+        if set_c.contains(&m) && !set_a.contains(&m) {
+            ro.push(m);
+        }
+    }
+
+    (batch, lo, ro, sum)
+}
+
+/// Fallback pairwise contraction using core primitives only.
+///
+/// Decomposes a binary contraction into:
+/// 1. Permute A → [batch, lo, sum], B → [batch, sum, ro]
+/// 2. MakeContiguous (conditional copy)
+/// 3. Reshape to [batch..., m, k] and [batch..., k, n]
+/// 4. BatchedGemm → temp [batch..., m, n]
+/// 5. Reshape temp → [batch..., lo..., ro...]
+/// 6. Permute to output with alpha/beta
+fn fallback_pairwise_contraction<T, A, B>(
+    ctx: &mut B::Context,
+    subs_a: &[u32],
+    subs_b: &[u32],
+    subs_c: &[u32],
+    a: &Tensor<T>,
+    b: &Tensor<T>,
+    alpha: T,
+    beta: T,
+    output: &mut Tensor<T>,
+) -> Result<()>
+where
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
+    B: TensorPrims<A>,
+{
+    let (batch_modes, lo_modes, ro_modes, sum_modes) = classify_modes(subs_a, subs_b, subs_c);
+
+    // Build size_dict from input subscripts and shapes
+    let mut size_dict: HashMap<u32, usize> = HashMap::new();
+    for (&label, &dim) in subs_a.iter().zip(a.dims()) {
+        size_dict.insert(label, dim);
+    }
+    for (&label, &dim) in subs_b.iter().zip(b.dims()) {
+        size_dict.insert(label, dim);
+    }
+
+    let batch_sizes: Vec<usize> = batch_modes.iter().map(|m| size_dict[m]).collect();
+    let lo_sizes: Vec<usize> = lo_modes.iter().map(|m| size_dict[m]).collect();
+    let ro_sizes: Vec<usize> = ro_modes.iter().map(|m| size_dict[m]).collect();
+    let sum_sizes: Vec<usize> = sum_modes.iter().map(|m| size_dict[m]).collect();
+
+    let m: usize = lo_sizes.iter().product::<usize>().max(1);
+    let n: usize = ro_sizes.iter().product::<usize>().max(1);
+    let k: usize = sum_sizes.iter().product::<usize>().max(1);
+
+    // --- Step 1: Permute A to [batch, lo, sum] ---
+    let target_a: Vec<u32> = batch_modes
+        .iter()
+        .chain(lo_modes.iter())
+        .chain(sum_modes.iter())
+        .copied()
+        .collect();
+    let perm_a = permute_or_copy::<T, A, B>(ctx, a, subs_a, &target_a)?;
+
+    // --- Step 2: Permute B to [batch, sum, ro] ---
+    let target_b: Vec<u32> = batch_modes
+        .iter()
+        .chain(sum_modes.iter())
+        .chain(ro_modes.iter())
+        .copied()
+        .collect();
+    let perm_b = permute_or_copy::<T, A, B>(ctx, b, subs_b, &target_b)?;
+
+    // --- Step 3: Reshape to [batch..., m, k] and [batch..., k, n] ---
+    let a_gemm_shape: Vec<usize> = batch_sizes
+        .iter()
+        .copied()
+        .chain(std::iter::once(m))
+        .chain(std::iter::once(k))
+        .collect();
+    let b_gemm_shape: Vec<usize> = batch_sizes
+        .iter()
+        .copied()
+        .chain(std::iter::once(k))
+        .chain(std::iter::once(n))
+        .collect();
+    let c_gemm_shape: Vec<usize> = batch_sizes
+        .iter()
+        .copied()
+        .chain(std::iter::once(m))
+        .chain(std::iter::once(n))
+        .collect();
+
+    let a_reshaped = perm_a.reshape(&a_gemm_shape)?;
+    let b_reshaped = perm_b.reshape(&b_gemm_shape)?;
+
+    // --- Step 4: BatchedGemm → temp ---
+    let memory_space = a.logical_memory_space();
+    let mut temp = Tensor::<T>::zeros(&c_gemm_shape, memory_space, MemoryOrder::ColumnMajor);
+
+    let desc = PrimDescriptor::BatchedGemm {
+        batch_dims: batch_sizes.clone(),
+        m,
+        n,
+        k,
+    };
+    let shapes = [a_reshaped.dims(), b_reshaped.dims(), temp.dims()];
+    let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+    let a_sv = tensor_to_view(&a_reshaped)?;
+    let b_sv = tensor_to_view(&b_reshaped)?;
+    let mut temp_sv = tensor_to_view_mut(&mut temp)?;
+    B::execute(
+        ctx,
+        &plan,
+        T::one(),
+        &[&a_sv, &b_sv],
+        T::zero(),
+        &mut temp_sv,
+    )?;
+    drop(temp_sv);
+
+    // --- Step 5: Reshape temp → [batch..., lo..., ro...] and permute to output ---
+    let expanded_shape: Vec<usize> = batch_sizes
+        .iter()
+        .chain(lo_sizes.iter())
+        .chain(ro_sizes.iter())
+        .copied()
+        .collect();
+    let temp_expanded = temp.reshape(&expanded_shape)?;
+
+    // Canonical mode labels for the expanded temp
+    let canonical_modes: Vec<u32> = batch_modes
+        .iter()
+        .chain(lo_modes.iter())
+        .chain(ro_modes.iter())
+        .copied()
+        .collect();
+
+    // If canonical == subs_c, we can skip the final permute
+    if canonical_modes == subs_c {
+        // Direct copy with alpha/beta
+        if alpha == T::one() && beta == T::zero() {
+            *output = temp_expanded;
+        } else {
+            let desc = PrimDescriptor::Permute {
+                modes_a: canonical_modes.clone(),
+                modes_b: subs_c.to_vec(),
+            };
+            let shapes = [temp_expanded.dims(), output.dims()];
+            let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+            let src_sv = tensor_to_view(&temp_expanded)?;
+            let mut out_sv = tensor_to_view_mut(output)?;
+            B::execute(ctx, &plan, alpha, &[&src_sv], beta, &mut out_sv)?;
+        }
+    } else {
+        // Permute from canonical order to output order with alpha/beta
+        let desc = PrimDescriptor::Permute {
+            modes_a: canonical_modes,
+            modes_b: subs_c.to_vec(),
+        };
+        let shapes = [temp_expanded.dims(), output.dims()];
+        let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+        let src_sv = tensor_to_view(&temp_expanded)?;
+        let mut out_sv = tensor_to_view_mut(output)?;
+        B::execute(ctx, &plan, alpha, &[&src_sv], beta, &mut out_sv)?;
+    }
+
+    Ok(())
+}
+
+/// Permute a tensor to a target mode order and ensure contiguous layout.
+///
+/// If `current_subs == target_subs`, returns a contiguous copy (MakeContiguous)
+/// if needed. Otherwise, permutes to the target order, then makes contiguous.
+fn permute_or_copy<T, A, B>(
+    ctx: &mut B::Context,
+    tensor: &Tensor<T>,
+    current_subs: &[u32],
+    target_subs: &[u32],
+) -> Result<Tensor<T>>
+where
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
+    B: TensorPrims<A>,
+{
+    if current_subs == target_subs {
+        // No permutation needed; ensure contiguous
+        return make_contiguous_if_needed::<T, A, B>(ctx, tensor);
+    }
+
+    // Compute target shape from the permutation
+    let label_to_pos: HashMap<u32, usize> = current_subs
+        .iter()
+        .enumerate()
+        .map(|(i, &l)| (l, i))
+        .collect();
+    let target_shape: Vec<usize> = target_subs
+        .iter()
+        .map(|l| tensor.dims()[label_to_pos[l]])
+        .collect();
+
+    // Permute via prim
+    let memory_space = tensor.logical_memory_space();
+    let mut permuted = Tensor::<T>::zeros(&target_shape, memory_space, MemoryOrder::ColumnMajor);
+    let desc = PrimDescriptor::Permute {
+        modes_a: current_subs.to_vec(),
+        modes_b: target_subs.to_vec(),
+    };
+    let shapes = [tensor.dims(), permuted.dims()];
+    let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+    let src_sv = tensor_to_view(tensor)?;
+    let mut dst_sv = tensor_to_view_mut(&mut permuted)?;
+    B::execute(ctx, &plan, T::one(), &[&src_sv], T::zero(), &mut dst_sv)?;
+    drop(dst_sv);
+
+    // The result is already contiguous (freshly allocated)
+    Ok(permuted)
+}
+
+/// Ensure a tensor is contiguous, copying if necessary.
+fn make_contiguous_if_needed<T, A, B>(ctx: &mut B::Context, tensor: &Tensor<T>) -> Result<Tensor<T>>
+where
+    T: ScalarBase + Scalar + HasAlgebra<Algebra = A>,
+    B: TensorPrims<A>,
+{
+    if tensor.is_contiguous() {
+        return Ok(tensor.clone());
+    }
+    let memory_space = tensor.logical_memory_space();
+    let mut result = Tensor::<T>::zeros(tensor.dims(), memory_space, MemoryOrder::ColumnMajor);
+    let desc = PrimDescriptor::MakeContiguous;
+    let shapes = [tensor.dims(), result.dims()];
+    let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+    let src_sv = tensor_to_view(tensor)?;
+    let mut dst_sv = tensor_to_view_mut(&mut result)?;
+    B::execute(ctx, &plan, T::one(), &[&src_sv], T::zero(), &mut dst_sv)?;
+    Ok(result)
+}
+
 /// Execute a pairwise contraction of two tensors via TensorPrims.
 fn execute_pairwise_contraction<T, Alg, Backend>(
     ctx: &mut Backend::Context,
@@ -801,9 +1081,10 @@ where
         let mut out_sv = tensor_to_view_mut(output)?;
         Backend::execute(ctx, &plan, alpha, &[&a_sv, &b_sv], beta, &mut out_sv)
     } else {
-        Err(Error::DeviceError(
-            "backend does not support Contract extension".into(),
-        ))
+        // Fallback: decompose into Permute + BatchedGemm
+        fallback_pairwise_contraction::<T, Alg, Backend>(
+            ctx, subs_a, subs_b, subs_c, a, b, alpha, beta, output,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #148.

- **Fallback contraction pipeline**: When a backend does not support the `Contract` extension (e.g. tropical algebras), `execute_pairwise_contraction` in `tenferro-einsum` now decomposes binary contraction into core primitives: `Permute` + `MakeContiguous` + `BatchedGemm` + `Permute`. This enables einsum for all algebra types, not just those with Contract support.
- **SIMD-optimized tropical GEMM**: Integrates the [tropical-gemm](https://github.com/TensorBFS/tropical-gemm) library into `tenferro-tropical`'s `BatchedGemm` execution for f64 types (MaxPlus, MinPlus, MaxMul), dispatching to AVX-512/AVX2/NEON-accelerated kernels.
- **Integration tests**: 11 einsum tests covering MaxPlus, MinPlus, and MaxMul algebras through the fallback path (matmul, trace, batched matmul, element-wise, outer product, vector-matrix, full contraction, three-tensor chain, shortest-path, Viterbi).

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` — all tests pass
- [x] Coverage thresholds met (15/15 files pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)