### PR TITLE
test(chainrules): add HVP test with DAG merge point (#170)

### DIFF
--- a/extern/chainrules/tests/chainrules_tests.rs
+++ b/extern/chainrules/tests/chainrules_tests.rs
@@ -574,6 +574,87 @@ fn hvp_square_function() {
     assert_eq!(*result.hvp.get(x.node_id().unwrap()).unwrap(), 2.0);
 }
 
+/// Rule: z = a + b (HVP-aware addition)
+/// pullback: dz/da = cotangent, dz/db = cotangent
+/// pullback_with_tangents: pass cotangent and cotangent_tangent through unchanged
+struct AddRuleHvp {
+    inputs: Vec<NodeId>,
+}
+
+impl ReverseRule<f64> for AddRuleHvp {
+    fn pullback(&self, cotangent: &f64) -> AdResult<Vec<(NodeId, f64)>> {
+        Ok(self.inputs.iter().map(|&id| (id, *cotangent)).collect())
+    }
+
+    fn inputs(&self) -> Vec<NodeId> {
+        self.inputs.clone()
+    }
+
+    fn pullback_with_tangents(
+        &self,
+        cotangent: &f64,
+        cotangent_tangent: &f64,
+    ) -> AdResult<Vec<(NodeId, f64, f64)>> {
+        Ok(self
+            .inputs
+            .iter()
+            .map(|&id| (id, *cotangent, *cotangent_tangent))
+            .collect())
+    }
+}
+
+#[test]
+fn hvp_dag_merge_point() {
+    // f(x) = x^2 + x^2 = 2x^2
+    // ∇f = 4x, H = 4, Hv = 4v
+    // At x = 3.0, v = 1.0: gradient = 12, HVP = 4
+    //
+    // DAG:  x ──> y1 = x^2 ──> z = y1 + y2
+    //       └──> y2 = x^2 ──┘
+    //
+    // During reverse traversal, x receives cotangent contributions from
+    // both y1 and y2, hitting the Some(existing) accumulation branches
+    // on lines 448 and 458 of lib.rs.
+    let tape = Tape::<f64>::new();
+    let x = tape.leaf_with_tangent(3.0, 1.0).unwrap();
+
+    // y1 = x^2 = 9, tangent dy1 = 2*x*dx = 6
+    let y1 = tape.record_op(
+        9.0,
+        Box::new(SquareRuleHvp {
+            input: x.node_id().unwrap(),
+            saved_x: 3.0,
+            saved_dx: 1.0,
+        }),
+        None,
+    );
+    // y2 = x^2 = 9, tangent dy2 = 2*x*dx = 6
+    let y2 = tape.record_op(
+        9.0,
+        Box::new(SquareRuleHvp {
+            input: x.node_id().unwrap(),
+            saved_x: 3.0,
+            saved_dx: 1.0,
+        }),
+        None,
+    );
+    // z = y1 + y2 = 18
+    let z = tape.record_op(
+        18.0,
+        Box::new(AddRuleHvp {
+            inputs: vec![y1.node_id().unwrap(), y2.node_id().unwrap()],
+        }),
+        None,
+    );
+
+    let result = tape.hvp(&z).unwrap();
+
+    // Gradient: d(2x^2)/dx = 4*3 = 12
+    assert_eq!(*result.gradients.get(x.node_id().unwrap()).unwrap(), 12.0);
+    // HVP: H*v = 4*1 = 4
+    assert_eq!(*result.hvp.get(x.node_id().unwrap()).unwrap(), 4.0);
+}
+
 #[test]
 fn hvp_missing_node_error() {
     let tape = Tape::<f64>::new();


### PR DESCRIPTION
## Summary

- Adds `hvp_dag_merge_point` test with a diamond DAG (`x -> y1=x^2, x -> y2=x^2, z=y1+y2`) where leaf `x` receives cotangent contributions from both paths during reverse traversal
- Covers the previously uncovered `Some(existing)` accumulation branches (lines 448 and 458) in `Tape::hvp`
- Adds `AddRuleHvp` helper rule implementing `pullback_with_tangents` for addition

## Test plan

- [x] `cargo test -p chainrules` — all 47 tests pass
- [x] `cargo fmt --all --check` — clean
- [x] `cargo llvm-cov` confirms lines 448 and 458 now have count=1
- [x] `python3 scripts/check-coverage.py coverage.json` — all 15 files pass thresholds

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)