### PR TITLE
feat(tropical): f32 SIMD dispatch via tropical-gemm

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -10,7 +10,7 @@
     "extension/tenferro-tropical-capi/src/lib.rs"
   ],
   "files": {
-    "extension/tenferro-tropical/src/prims.rs": 55,
+    "extension/tenferro-tropical/src/prims.rs": 80,
     "tenferro-capi/src/lib.rs": 65,
     "tenferro-einsum/src/lib.rs": 65,
     "tenferro-linalg/src/lib.rs": 30,

--- a/extension/tenferro-tropical/src/algebra.rs
+++ b/extension/tenferro-tropical/src/algebra.rs
@@ -89,7 +89,12 @@ impl HasAlgebra for MaxMul<f64> {
 }
 
 // ---------------------------------------------------------------------------
-// Semiring implementations (f64 only for POC)
+// Semiring implementations
+//
+// The Semiring trait uses an associated type `type Scalar`, so each algebra
+// marker can only be associated with one scalar type. We use f64 as the
+// canonical Semiring scalar. f32 is fully supported at the TensorPrims level
+// (plan/execute) — only the Semiring constants are f64.
 // ---------------------------------------------------------------------------
 
 /// Max-plus semiring over `MaxPlus<f64>`.

--- a/extension/tenferro-tropical/src/prims.rs
+++ b/extension/tenferro-tropical/src/prims.rs
@@ -44,6 +44,7 @@ use crate::scalar::{MaxMul, MaxPlus, MinPlus};
 ///     &mut ctx, &desc, &[&[3, 4], &[3]],
 /// ).unwrap();
 /// ```
+#[derive(Debug)]
 pub enum TropicalPlan<T: ScalarBase> {
     /// Plan for batched GEMM under tropical algebra.
     BatchedGemm {
@@ -169,110 +170,71 @@ fn scale_output<T: ScalarBase>(output: &mut StridedViewMut<T>, beta: T) {
 ///
 /// Maps tenferro's tropical scalar types to tropical-gemm's types and calls
 /// `tropical_matmul_strided_batched` for SIMD-accelerated computation.
+/// Generic over the inner scalar type (f32 or f64).
 trait TropicalGemmDispatch: ScalarBase {
-    /// Extract the inner scalar value (f64 or f32).
-    fn inner_value(&self) -> f64;
+    /// The inner floating-point type (f32 or f64).
+    type Inner: Copy + Default;
+    /// Extract the inner scalar value.
+    fn inner_value(&self) -> Self::Inner;
     /// Wrap an inner scalar value back into the tropical type.
-    fn from_inner(v: f64) -> Self;
+    fn from_inner(v: Self::Inner) -> Self;
     /// Execute SIMD-optimized batched GEMM.
-    /// Input: row-major f64 buffers packed per batch element.
-    /// Returns: row-major f64 result buffer.
+    /// Input: row-major buffers packed per batch element.
+    /// Returns: row-major result buffer.
     fn dispatch_gemm(
-        a: &[f64],
-        b: &[f64],
+        a: &[Self::Inner],
+        b: &[Self::Inner],
         batch_size: usize,
         m: usize,
         k: usize,
         n: usize,
-    ) -> Vec<f64>;
+    ) -> Vec<Self::Inner>;
 }
 
-impl TropicalGemmDispatch for MaxPlus<f64> {
-    #[inline]
-    fn inner_value(&self) -> f64 {
-        self.0
-    }
-    #[inline]
-    fn from_inner(v: f64) -> Self {
-        MaxPlus(v)
-    }
-    fn dispatch_gemm(
-        a: &[f64],
-        b: &[f64],
-        batch_size: usize,
-        m: usize,
-        k: usize,
-        n: usize,
-    ) -> Vec<f64> {
-        if batch_size <= 1 {
-            let result = tropical_gemm::tropical_matmul::<TropicalMaxPlus<f64>>(a, m, k, b, n);
-            result.iter().map(|v| v.value()).collect()
-        } else {
-            let result = tropical_gemm::tropical_matmul_strided_batched::<TropicalMaxPlus<f64>>(
-                a, b, batch_size, m, k, n,
-            );
-            result.iter().map(|v| v.value()).collect()
+/// Implements `TropicalGemmDispatch` for a tropical scalar type.
+macro_rules! impl_tropical_gemm_dispatch {
+    ($tropical_ty:ident, $inner:ty, $gemm_ty:ty) => {
+        impl TropicalGemmDispatch for $tropical_ty<$inner> {
+            type Inner = $inner;
+            #[inline]
+            fn inner_value(&self) -> $inner {
+                self.0
+            }
+            #[inline]
+            fn from_inner(v: $inner) -> Self {
+                $tropical_ty(v)
+            }
+            fn dispatch_gemm(
+                a: &[$inner],
+                b: &[$inner],
+                batch_size: usize,
+                m: usize,
+                k: usize,
+                n: usize,
+            ) -> Vec<$inner> {
+                if batch_size <= 1 {
+                    let result = tropical_gemm::tropical_matmul::<$gemm_ty>(a, m, k, b, n);
+                    result.iter().map(|v| v.value()).collect()
+                } else {
+                    let result = tropical_gemm::tropical_matmul_strided_batched::<$gemm_ty>(
+                        a, b, batch_size, m, k, n,
+                    );
+                    result.iter().map(|v| v.value()).collect()
+                }
+            }
         }
-    }
+    };
 }
 
-impl TropicalGemmDispatch for MinPlus<f64> {
-    #[inline]
-    fn inner_value(&self) -> f64 {
-        self.0
-    }
-    #[inline]
-    fn from_inner(v: f64) -> Self {
-        MinPlus(v)
-    }
-    fn dispatch_gemm(
-        a: &[f64],
-        b: &[f64],
-        batch_size: usize,
-        m: usize,
-        k: usize,
-        n: usize,
-    ) -> Vec<f64> {
-        if batch_size <= 1 {
-            let result = tropical_gemm::tropical_matmul::<TropicalMinPlus<f64>>(a, m, k, b, n);
-            result.iter().map(|v| v.value()).collect()
-        } else {
-            let result = tropical_gemm::tropical_matmul_strided_batched::<TropicalMinPlus<f64>>(
-                a, b, batch_size, m, k, n,
-            );
-            result.iter().map(|v| v.value()).collect()
-        }
-    }
-}
+// f64 impls
+impl_tropical_gemm_dispatch!(MaxPlus, f64, TropicalMaxPlus<f64>);
+impl_tropical_gemm_dispatch!(MinPlus, f64, TropicalMinPlus<f64>);
+impl_tropical_gemm_dispatch!(MaxMul, f64, TropicalMaxMul<f64>);
 
-impl TropicalGemmDispatch for MaxMul<f64> {
-    #[inline]
-    fn inner_value(&self) -> f64 {
-        self.0
-    }
-    #[inline]
-    fn from_inner(v: f64) -> Self {
-        MaxMul(v)
-    }
-    fn dispatch_gemm(
-        a: &[f64],
-        b: &[f64],
-        batch_size: usize,
-        m: usize,
-        k: usize,
-        n: usize,
-    ) -> Vec<f64> {
-        if batch_size <= 1 {
-            let result = tropical_gemm::tropical_matmul::<TropicalMaxMul<f64>>(a, m, k, b, n);
-            result.iter().map(|v| v.value()).collect()
-        } else {
-            let result = tropical_gemm::tropical_matmul_strided_batched::<TropicalMaxMul<f64>>(
-                a, b, batch_size, m, k, n,
-            );
-            result.iter().map(|v| v.value()).collect()
-        }
-    }
-}
+// f32 impls
+impl_tropical_gemm_dispatch!(MaxPlus, f32, TropicalMaxPlus<f32>);
+impl_tropical_gemm_dispatch!(MinPlus, f32, TropicalMinPlus<f32>);
+impl_tropical_gemm_dispatch!(MaxMul, f32, TropicalMaxMul<f32>);
 
 /// SIMD-optimized tropical GEMM using the tropical-gemm crate.
 ///
@@ -292,11 +254,11 @@ fn execute_batched_gemm_optimized<T: ScalarBase + TropicalGemmDispatch>(
     let b = inputs[1];
     let batch_size: usize = batch_dims.iter().product::<usize>().max(1);
 
-    // Extract A into contiguous row-major f64 buffer: [batch, m, k] row-major
+    // Extract A into contiguous row-major buffer: [batch, m, k] row-major
     let a_total = batch_size * m * k;
     let b_total = batch_size * k * n;
-    let mut a_buf = Vec::with_capacity(a_total);
-    let mut b_buf = Vec::with_capacity(b_total);
+    let mut a_buf: Vec<T::Inner> = Vec::with_capacity(a_total);
+    let mut b_buf: Vec<T::Inner> = Vec::with_capacity(b_total);
 
     for batch_flat in 0..batch_size {
         let batch_idx = unflatten_index(batch_flat, batch_dims);
@@ -346,7 +308,7 @@ fn execute_batched_gemm_optimized<T: ScalarBase + TropicalGemmDispatch>(
     Ok(())
 }
 
-/// Fallback loop-based tropical GEMM for unsupported scalar types (e.g., f32).
+/// Fallback loop-based tropical GEMM for types without SIMD dispatch.
 fn execute_batched_gemm_fallback<T: ScalarBase>(
     alpha: T,
     inputs: &[&StridedView<T>],
@@ -1207,7 +1169,41 @@ fn execute_make_contiguous<T: ScalarBase>(
 // impl TensorPrims<MaxPlusAlgebra> for CpuBackend
 // ===========================================================================
 
-/// Execute tropical operations with SIMD-optimized GEMM for MaxPlus<f64>.
+/// Try to dispatch BatchedGemm to the SIMD-optimized path for a concrete type.
+///
+/// SAFETY: The TypeId check guarantees T == $concrete_ty before transmuting.
+/// All tropical scalar types are #[repr(transparent)] over their inner type,
+/// so the transmute is sound.
+macro_rules! try_simd_dispatch {
+    ($T:ty, $concrete_ty:ty, $inputs:expr, $alpha:expr, $beta:expr,
+     $output:expr, $batch_dims:expr, $m:expr, $n:expr, $k:expr) => {
+        if std::any::TypeId::of::<$T>() == std::any::TypeId::of::<$concrete_ty>() {
+            let a = unsafe {
+                &*($inputs[0] as *const StridedView<$T> as *const StridedView<$concrete_ty>)
+            };
+            let b = unsafe {
+                &*($inputs[1] as *const StridedView<$T> as *const StridedView<$concrete_ty>)
+            };
+            let out = unsafe {
+                &mut *($output as *mut StridedViewMut<$T> as *mut StridedViewMut<$concrete_ty>)
+            };
+            let alpha = unsafe { *(&$alpha as *const $T as *const $concrete_ty) };
+            let beta = unsafe { *(&$beta as *const $T as *const $concrete_ty) };
+            return execute_batched_gemm_optimized(
+                alpha,
+                &[a, b],
+                beta,
+                out,
+                $batch_dims,
+                $m,
+                $n,
+                $k,
+            );
+        }
+    };
+}
+
+/// Execute tropical operations with SIMD-optimized GEMM for MaxPlus<f64/f32>.
 fn tropical_execute_maxplus<T: ScalarBase>(
     plan: &TropicalPlan<T>,
     alpha: T,
@@ -1228,36 +1224,35 @@ fn tropical_execute_maxplus<T: ScalarBase>(
                 "BatchedGemm execute requires 2 input tensors".into(),
             ));
         }
-        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<MaxPlus<f64>>() {
-            // SAFETY: T == MaxPlus<f64> confirmed by TypeId check.
-            // All references are transmuted to the same repr(transparent) type.
-            let a = unsafe {
-                &*(inputs[0] as *const StridedView<T> as *const StridedView<MaxPlus<f64>>)
-            };
-            let b = unsafe {
-                &*(inputs[1] as *const StridedView<T> as *const StridedView<MaxPlus<f64>>)
-            };
-            let out = unsafe {
-                &mut *(output as *mut StridedViewMut<T> as *mut StridedViewMut<MaxPlus<f64>>)
-            };
-            let alpha = unsafe { *(&alpha as *const T as *const MaxPlus<f64>) };
-            let beta = unsafe { *(&beta as *const T as *const MaxPlus<f64>) };
-            return execute_batched_gemm_optimized(
-                alpha,
-                &[a, b],
-                beta,
-                out,
-                batch_dims,
-                *m,
-                *n,
-                *k,
-            );
-        }
+        try_simd_dispatch!(
+            T,
+            MaxPlus<f64>,
+            inputs,
+            alpha,
+            beta,
+            output,
+            batch_dims,
+            *m,
+            *n,
+            *k
+        );
+        try_simd_dispatch!(
+            T,
+            MaxPlus<f32>,
+            inputs,
+            alpha,
+            beta,
+            output,
+            batch_dims,
+            *m,
+            *n,
+            *k
+        );
     }
     tropical_execute(plan, alpha, inputs, beta, output)
 }
 
-/// Execute tropical operations with SIMD-optimized GEMM for MinPlus<f64>.
+/// Execute tropical operations with SIMD-optimized GEMM for MinPlus<f64/f32>.
 fn tropical_execute_minplus<T: ScalarBase>(
     plan: &TropicalPlan<T>,
     alpha: T,
@@ -1278,34 +1273,35 @@ fn tropical_execute_minplus<T: ScalarBase>(
                 "BatchedGemm execute requires 2 input tensors".into(),
             ));
         }
-        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<MinPlus<f64>>() {
-            let a = unsafe {
-                &*(inputs[0] as *const StridedView<T> as *const StridedView<MinPlus<f64>>)
-            };
-            let b = unsafe {
-                &*(inputs[1] as *const StridedView<T> as *const StridedView<MinPlus<f64>>)
-            };
-            let out = unsafe {
-                &mut *(output as *mut StridedViewMut<T> as *mut StridedViewMut<MinPlus<f64>>)
-            };
-            let alpha = unsafe { *(&alpha as *const T as *const MinPlus<f64>) };
-            let beta = unsafe { *(&beta as *const T as *const MinPlus<f64>) };
-            return execute_batched_gemm_optimized(
-                alpha,
-                &[a, b],
-                beta,
-                out,
-                batch_dims,
-                *m,
-                *n,
-                *k,
-            );
-        }
+        try_simd_dispatch!(
+            T,
+            MinPlus<f64>,
+            inputs,
+            alpha,
+            beta,
+            output,
+            batch_dims,
+            *m,
+            *n,
+            *k
+        );
+        try_simd_dispatch!(
+            T,
+            MinPlus<f32>,
+            inputs,
+            alpha,
+            beta,
+            output,
+            batch_dims,
+            *m,
+            *n,
+            *k
+        );
     }
     tropical_execute(plan, alpha, inputs, beta, output)
 }
 
-/// Execute tropical operations with SIMD-optimized GEMM for MaxMul<f64>.
+/// Execute tropical operations with SIMD-optimized GEMM for MaxMul<f64/f32>.
 fn tropical_execute_maxmul<T: ScalarBase>(
     plan: &TropicalPlan<T>,
     alpha: T,
@@ -1326,29 +1322,30 @@ fn tropical_execute_maxmul<T: ScalarBase>(
                 "BatchedGemm execute requires 2 input tensors".into(),
             ));
         }
-        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<MaxMul<f64>>() {
-            let a = unsafe {
-                &*(inputs[0] as *const StridedView<T> as *const StridedView<MaxMul<f64>>)
-            };
-            let b = unsafe {
-                &*(inputs[1] as *const StridedView<T> as *const StridedView<MaxMul<f64>>)
-            };
-            let out = unsafe {
-                &mut *(output as *mut StridedViewMut<T> as *mut StridedViewMut<MaxMul<f64>>)
-            };
-            let alpha = unsafe { *(&alpha as *const T as *const MaxMul<f64>) };
-            let beta = unsafe { *(&beta as *const T as *const MaxMul<f64>) };
-            return execute_batched_gemm_optimized(
-                alpha,
-                &[a, b],
-                beta,
-                out,
-                batch_dims,
-                *m,
-                *n,
-                *k,
-            );
-        }
+        try_simd_dispatch!(
+            T,
+            MaxMul<f64>,
+            inputs,
+            alpha,
+            beta,
+            output,
+            batch_dims,
+            *m,
+            *n,
+            *k
+        );
+        try_simd_dispatch!(
+            T,
+            MaxMul<f32>,
+            inputs,
+            alpha,
+            beta,
+            output,
+            batch_dims,
+            *m,
+            *n,
+            *k
+        );
     }
     tropical_execute(plan, alpha, inputs, beta, output)
 }

--- a/extension/tenferro-tropical/tests/tropical_tests.rs
+++ b/extension/tenferro-tropical/tests/tropical_tests.rs
@@ -1063,6 +1063,1104 @@ fn maxplus_anti_trace_scalar_to_diag() {
 }
 
 // ============================================================================
+// f32 matmul tests (verify SIMD dispatch for f32 types)
+// ============================================================================
+
+#[test]
+fn maxplus_matmul_2x2_f32() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // Same as maxplus_matmul_2x2 but with f32 — verifies f32 SIMD dispatch.
+    // A = [[1, 3],    B = [[0, 2],
+    //      [2, 4]]         [1, 0]]
+    // C[0,0] = max(1+0, 3+1) = 4
+    // C[0,1] = max(1+2, 3+0) = 3
+    // C[1,0] = max(2+0, 4+1) = 5
+    // C[1,1] = max(2+2, 4+0) = 4
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [
+        MaxPlus(1.0_f32),
+        MaxPlus(2.0_f32),
+        MaxPlus(3.0_f32),
+        MaxPlus(4.0_f32),
+    ];
+    let b_data = [
+        MaxPlus(0.0_f32),
+        MaxPlus(1.0_f32),
+        MaxPlus(2.0_f32),
+        MaxPlus(0.0_f32),
+    ];
+    let mut c_data = [MaxPlus::<f32>::zero(); 4];
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2], &[1, 2], 0).unwrap();
+    let b_view = strided_view::StridedView::new(&b_data, &[2, 2], &[1, 2], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let desc = PrimDescriptor::BatchedGemm {
+        batch_dims: vec![],
+        m: 2,
+        n: 2,
+        k: 2,
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f32>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[2, 2], &[2, 2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &[&a_view, &b_view],
+        MaxPlus::zero(),
+        &mut c_view,
+    )
+    .unwrap();
+
+    assert_eq!(c_data[0].0, 4.0_f32);
+    assert_eq!(c_data[1].0, 5.0_f32);
+    assert_eq!(c_data[2].0, 3.0_f32);
+    assert_eq!(c_data[3].0, 4.0_f32);
+}
+
+#[test]
+fn minplus_matmul_2x2_f32() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // MinPlus f32 SIMD dispatch.
+    // A = [[1, 3],    B = [[5, 2],
+    //      [2, 4]]         [1, 6]]
+    // C[0,0] = min(1+5, 3+1) = 4
+    // C[0,1] = min(1+2, 3+6) = 3
+    // C[1,0] = min(2+5, 4+1) = 5
+    // C[1,1] = min(2+2, 4+6) = 4
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [
+        MinPlus(1.0_f32),
+        MinPlus(2.0_f32),
+        MinPlus(3.0_f32),
+        MinPlus(4.0_f32),
+    ];
+    let b_data = [
+        MinPlus(5.0_f32),
+        MinPlus(1.0_f32),
+        MinPlus(2.0_f32),
+        MinPlus(6.0_f32),
+    ];
+    let mut c_data = [MinPlus::<f32>::zero(); 4];
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2], &[1, 2], 0).unwrap();
+    let b_view = strided_view::StridedView::new(&b_data, &[2, 2], &[1, 2], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let desc = PrimDescriptor::BatchedGemm {
+        batch_dims: vec![],
+        m: 2,
+        n: 2,
+        k: 2,
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra>>::plan::<MinPlus<f32>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[2, 2], &[2, 2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MinPlus::one(),
+        &[&a_view, &b_view],
+        MinPlus::zero(),
+        &mut c_view,
+    )
+    .unwrap();
+
+    assert_eq!(c_data[0].0, 4.0_f32);
+    assert_eq!(c_data[1].0, 5.0_f32);
+    assert_eq!(c_data[2].0, 3.0_f32);
+    assert_eq!(c_data[3].0, 4.0_f32);
+}
+
+#[test]
+fn maxmul_matmul_2x2_f32() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // MaxMul f32 SIMD dispatch.
+    // A = [[0.5, 0.3],    B = [[0.8, 0.1],
+    //      [0.2, 0.9]]         [0.4, 0.6]]
+    // C[0,0] = max(0.5*0.8, 0.3*0.4) = 0.40
+    // C[0,1] = max(0.5*0.1, 0.3*0.6) = 0.18
+    // C[1,0] = max(0.2*0.8, 0.9*0.4) = 0.36
+    // C[1,1] = max(0.2*0.1, 0.9*0.6) = 0.54
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [
+        MaxMul(0.5_f32),
+        MaxMul(0.2_f32),
+        MaxMul(0.3_f32),
+        MaxMul(0.9_f32),
+    ];
+    let b_data = [
+        MaxMul(0.8_f32),
+        MaxMul(0.4_f32),
+        MaxMul(0.1_f32),
+        MaxMul(0.6_f32),
+    ];
+    let mut c_data = [MaxMul::<f32>::zero(); 4];
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2], &[1, 2], 0).unwrap();
+    let b_view = strided_view::StridedView::new(&b_data, &[2, 2], &[1, 2], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let desc = PrimDescriptor::BatchedGemm {
+        batch_dims: vec![],
+        m: 2,
+        n: 2,
+        k: 2,
+    };
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra>>::plan::<MaxMul<f32>>(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2], &[2, 2]],
+    )
+    .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxMul::one(),
+        &[&a_view, &b_view],
+        MaxMul::zero(),
+        &mut c_view,
+    )
+    .unwrap();
+
+    assert!((c_data[0].0 - 0.40_f32).abs() < 1e-6);
+    assert!((c_data[1].0 - 0.36_f32).abs() < 1e-6);
+    assert!((c_data[2].0 - 0.18_f32).abs() < 1e-6);
+    assert!((c_data[3].0 - 0.54_f32).abs() < 1e-6);
+}
+
+// ============================================================================
+// Matmul accumulation test (C = alpha * A*B + beta * C_old)
+// ============================================================================
+
+#[test]
+fn maxplus_matmul_accumulate_with_beta() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // Tests accumulation: C_new = alpha * (A ⊗ B) ⊕ beta * C_old
+    // For MaxPlus with alpha=2, beta=1:
+    //   C_new[i,j] = max(2 + max_k(A[i,k] + B[k,j]), 1 + C_old[i,j])
+    //
+    // A = [[1, 3],   B = [[0, 2],
+    //      [2, 4]]        [1, 0]]
+    // A ⊗ B = [[4, 3], [5, 4]]  (same as maxplus_matmul_2x2)
+    //
+    // alpha=MaxPlus(2.0), so alpha * result = 2 + result:
+    // alpha*(A⊗B) = [[6, 5], [7, 6]]
+    //
+    // C_old = [[10, 0], [0, 10]]
+    // beta=MaxPlus(1.0), so beta * C_old = 1 + C_old:
+    // beta*C_old = [[11, 1], [1, 11]]
+    //
+    // C_new = max(alpha*(A⊗B), beta*C_old):
+    // C_new = [[max(6,11), max(5,1)], [max(7,1), max(6,11)]]
+    //       = [[11, 5], [7, 11]]
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [MaxPlus(1.0), MaxPlus(2.0), MaxPlus(3.0), MaxPlus(4.0)];
+    let b_data = [MaxPlus(0.0), MaxPlus(1.0), MaxPlus(2.0), MaxPlus(0.0)];
+    let mut c_data = [MaxPlus(10.0), MaxPlus(0.0), MaxPlus(0.0), MaxPlus(10.0)]; // col-major
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2], &[1, 2], 0).unwrap();
+    let b_view = strided_view::StridedView::new(&b_data, &[2, 2], &[1, 2], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let desc = PrimDescriptor::BatchedGemm {
+        batch_dims: vec![],
+        m: 2,
+        n: 2,
+        k: 2,
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[2, 2], &[2, 2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus(2.0), // alpha
+        &[&a_view, &b_view],
+        MaxPlus(1.0), // beta (non-zero: accumulate)
+        &mut c_view,
+    )
+    .unwrap();
+
+    // col-major: [C[0,0], C[1,0], C[0,1], C[1,1]]
+    assert_eq!(c_data[0].0, 11.0); // max(6, 11) = 11
+    assert_eq!(c_data[1].0, 7.0); // max(7, 1) = 7
+    assert_eq!(c_data[2].0, 5.0); // max(5, 1) = 5
+    assert_eq!(c_data[3].0, 11.0); // max(6, 11) = 11
+}
+
+// ============================================================================
+// Anti-diag execution test (AD backward of off-diagonal extraction)
+// ============================================================================
+
+#[test]
+fn maxplus_anti_diag_vector_to_matrix() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // AntiDiag: input vector [a, b] → output matrix where column j gets a copy
+    // of input[j] along the anti-diagonal pattern.
+    //
+    // With modes_a=[0], modes_c=[0,1], paired=[(0,1)]:
+    // This maps v[i] → M[i,j] where j = i (diagonal embedding).
+    // For input [5, 3]:
+    // output = [[5, -inf],
+    //           [-inf, 3]]
+    let mut ctx = CpuContext::new(1);
+
+    let in_data = [MaxPlus(5.0), MaxPlus(3.0)];
+    let mut out_data = [MaxPlus::<f64>::zero(); 4]; // 2x2
+
+    let in_view = strided_view::StridedView::new(&in_data, &[2], &[1], 0).unwrap();
+    let mut out_view =
+        strided_view::StridedViewMut::new(&mut out_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let desc = PrimDescriptor::AntiDiag {
+        modes_a: vec![0],
+        modes_c: vec![0, 1],
+        paired: vec![(0, 1)],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2], &[2, 2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &[&in_view],
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap();
+
+    // col-major: [M[0,0], M[1,0], M[0,1], M[1,1]]
+    assert_eq!(out_data[0].0, 5.0); // [0,0] = input[0]
+    assert_eq!(out_data[1].0, f64::NEG_INFINITY); // [1,0] off-diag
+    assert_eq!(out_data[2].0, f64::NEG_INFINITY); // [0,1] off-diag
+    assert_eq!(out_data[3].0, 3.0); // [1,1] = input[1]
+}
+
+// ============================================================================
+// MakeContiguous test
+// ============================================================================
+
+#[test]
+fn maxplus_make_contiguous() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // Test MakeContiguous: copy a strided (non-contiguous) view into a
+    // contiguous buffer. Input is a transposed view of a 2x3 matrix.
+    //
+    // A = [[1, 2, 3],   stored col-major: [1, 4, 2, 5, 3, 6]
+    //      [4, 5, 6]]
+    //
+    // Transposed view (3x2, strides=[2,1]):
+    // A^T = [[1, 4],
+    //        [2, 5],
+    //        [3, 6]]
+    //
+    // MakeContiguous should copy this into a fresh [3,2] contiguous buffer.
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [
+        MaxPlus(1.0),
+        MaxPlus(4.0),
+        MaxPlus(2.0),
+        MaxPlus(5.0),
+        MaxPlus(3.0),
+        MaxPlus(6.0),
+    ];
+    let mut out_data = [MaxPlus::<f64>::zero(); 6];
+
+    // Transposed view: shape [3,2], strides [2,1] — non-contiguous
+    let a_view = strided_view::StridedView::new(&a_data, &[3, 2], &[2, 1], 0).unwrap();
+    let mut out_view =
+        strided_view::StridedViewMut::new(&mut out_data, &[3, 2], &[1, 3], 0).unwrap();
+
+    let desc = PrimDescriptor::MakeContiguous;
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[3, 2], &[3, 2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &[&a_view],
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap();
+
+    // Output in col-major [3,2]: [1, 2, 3, 4, 5, 6]
+    assert_eq!(out_data[0].0, 1.0);
+    assert_eq!(out_data[1].0, 2.0);
+    assert_eq!(out_data[2].0, 3.0);
+    assert_eq!(out_data[3].0, 4.0);
+    assert_eq!(out_data[4].0, 5.0);
+    assert_eq!(out_data[5].0, 6.0);
+}
+
+// ============================================================================
+// Anti-trace with free axes (backward of partial trace)
+// ============================================================================
+
+#[test]
+fn maxplus_anti_trace_vec_to_3d() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // AntiTrace with free axes: "j->iij" — backward of partial trace "iij->j".
+    // Input: vector [a, b, c] (size 3, mode 2)
+    // Output: tensor [2,2,3] where output[d,d,j] += alpha * input[j]
+    //
+    // With alpha=1, beta=0, diag_dim=2:
+    // output[0,0,j] = input[j]
+    // output[1,1,j] = input[j]
+    // output[other] = -inf (MaxPlus zero)
+    let mut ctx = CpuContext::new(1);
+
+    let in_data = [MaxPlus(10.0), MaxPlus(20.0), MaxPlus(30.0)];
+    let mut out_data = [MaxPlus::<f64>::zero(); 12]; // 2×2×3
+
+    let in_view = strided_view::StridedView::new(&in_data, &[3], &[1], 0).unwrap();
+    let mut out_view =
+        strided_view::StridedViewMut::new(&mut out_data, &[2, 2, 3], &[1, 2, 4], 0).unwrap();
+
+    let desc = PrimDescriptor::AntiTrace {
+        modes_a: vec![2],       // free axis: mode 2 (k dimension)
+        modes_c: vec![0, 1, 2], // output: modes 0, 1, 2
+        paired: vec![(0, 1)],   // diagonal on modes 0 and 1
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[3], &[2, 2, 3]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &[&in_view],
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap();
+
+    // col-major [2,2,3], strides [1,2,4]:
+    // index(i,j,k) = i + 2*j + 4*k
+    let get = |i: usize, j: usize, k: usize| out_data[i + 2 * j + 4 * k].0;
+
+    // Diagonal entries: output[d,d,k] = input[k]
+    assert_eq!(get(0, 0, 0), 10.0);
+    assert_eq!(get(0, 0, 1), 20.0);
+    assert_eq!(get(0, 0, 2), 30.0);
+    assert_eq!(get(1, 1, 0), 10.0);
+    assert_eq!(get(1, 1, 1), 20.0);
+    assert_eq!(get(1, 1, 2), 30.0);
+
+    // Off-diagonal: stays at -inf (zero was set by scale_output)
+    assert_eq!(get(1, 0, 0), f64::NEG_INFINITY);
+    assert_eq!(get(0, 1, 0), f64::NEG_INFINITY);
+}
+
+// ============================================================================
+// Permute with alpha/beta scaling
+// ============================================================================
+
+#[test]
+fn maxplus_permute_with_alpha_beta() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // Tests permute with non-trivial alpha and beta:
+    // output = alpha * permute(input) ⊕ beta * output_old
+    //
+    // input = [[1, 3], [2, 4]]  (col-major: [1, 2, 3, 4])
+    // permute = transpose → [[1, 2], [3, 4]] (col-major: [1, 3, 2, 4])
+    //
+    // With alpha=MaxPlus(10.0), beta=MaxPlus(0.0):
+    //   alpha * permute = [11, 13, 12, 14]
+    //   beta * old = [0+5, 0+0, 0+0, 0+5] = [5, 0, 0, 5]
+    //   result = max of each = [11, 13, 12, 14]
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [MaxPlus(1.0), MaxPlus(2.0), MaxPlus(3.0), MaxPlus(4.0)];
+    let mut c_data = [MaxPlus(5.0), MaxPlus(0.0), MaxPlus(0.0), MaxPlus(5.0)];
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2], &[1, 2], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let desc = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[2, 2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus(10.0), // alpha
+        &[&a_view],
+        MaxPlus(0.0), // beta (non-zero: accumulate)
+        &mut c_view,
+    )
+    .unwrap();
+
+    // alpha * permuted = 10 + [1, 3, 2, 4] = [11, 13, 12, 14]
+    // beta * old = 0 + [5, 0, 0, 5] = [5, 0, 0, 5]
+    // result = max(alpha*permuted, beta*old)
+    assert_eq!(c_data[0].0, 11.0); // max(11, 5)
+    assert_eq!(c_data[1].0, 13.0); // max(13, 0)
+    assert_eq!(c_data[2].0, 12.0); // max(12, 0)
+    assert_eq!(c_data[3].0, 14.0); // max(14, 5)
+}
+
+// ============================================================================
+// MakeContiguous with alpha/beta scaling
+// ============================================================================
+
+#[test]
+fn maxplus_make_contiguous_with_alpha_beta() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // MakeContiguous with non-trivial alpha/beta exercises the slow path.
+    // input = [10, 20] (contiguous)
+    // alpha = MaxPlus(1.0), beta = MaxPlus(5.0)
+    // output_old = [0, 0]
+    //
+    // result = max(1+input, 5+old) = max([11, 21], [5, 5]) = [11, 21]
+    let mut ctx = CpuContext::new(1);
+
+    let in_data = [MaxPlus(10.0), MaxPlus(20.0)];
+    let mut out_data = [MaxPlus(0.0), MaxPlus(0.0)];
+
+    let in_view = strided_view::StridedView::new(&in_data, &[2], &[1], 0).unwrap();
+    let mut out_view = strided_view::StridedViewMut::new(&mut out_data, &[2], &[1], 0).unwrap();
+
+    let desc = PrimDescriptor::MakeContiguous;
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2], &[2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus(1.0), // alpha
+        &[&in_view],
+        MaxPlus(5.0), // beta (non-zero)
+        &mut out_view,
+    )
+    .unwrap();
+
+    assert_eq!(out_data[0].0, 11.0); // max(1+10, 5+0) = max(11, 5)
+    assert_eq!(out_data[1].0, 21.0); // max(1+20, 5+0) = max(21, 5)
+}
+
+// ============================================================================
+// scale_output with beta != 0 and beta != 1
+// ============================================================================
+
+#[test]
+fn maxplus_reduce_with_beta_accumulate() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, ReduceOp, TensorPrims};
+
+    // Reduce with non-zero beta tests the accumulation path in execute_reduce_sum.
+    // A = [[1, 3],    (col-major: [1, 2, 3, 4])
+    //      [2, 4]]
+    // reduce axis 1: result = [max(1,3), max(2,4)] = [3, 4]
+    // With alpha=MaxPlus(0.0), beta=MaxPlus(0.0):
+    //   output = max(0+[3,4], 0+[100,100]) = max([3,4], [100,100]) = [100, 100]
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [MaxPlus(1.0), MaxPlus(2.0), MaxPlus(3.0), MaxPlus(4.0)];
+    let mut c_data = [MaxPlus(100.0), MaxPlus(100.0)]; // pre-filled
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2], &[1, 2], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[2], &[1], 0).unwrap();
+
+    let desc = PrimDescriptor::Reduce {
+        modes_a: vec![0, 1],
+        modes_c: vec![0],
+        op: ReduceOp::Sum,
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus(0.0), // alpha = one
+        &[&a_view],
+        MaxPlus(0.0), // beta = one
+        &mut c_view,
+    )
+    .unwrap();
+
+    // alpha*reduce = 0+[3,4] = [3,4]
+    // beta*old = 0+[100,100] = [100,100]
+    // result = max([3,4], [100,100]) = [100, 100]
+    assert_eq!(c_data[0].0, 100.0);
+    assert_eq!(c_data[1].0, 100.0);
+}
+
+// ============================================================================
+// Trace with beta accumulate
+// ============================================================================
+
+#[test]
+fn maxplus_trace_with_beta_accumulate() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // Trace with non-zero beta: C_new = max(alpha * trace, beta * C_old)
+    // A = [[10, 4],    trace = max(10, 8) = 10
+    //      [2,  8]]
+    // With alpha=MaxPlus(0.0), beta=MaxPlus(0.0):
+    //   alpha*trace = 0+10 = 10
+    //   beta*old = 0+20 = 20
+    //   result = max(10, 20) = 20
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [MaxPlus(10.0), MaxPlus(2.0), MaxPlus(4.0), MaxPlus(8.0)];
+    let mut c_data = [MaxPlus(20.0)]; // pre-filled scalar
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2], &[1, 2], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[], &[], 0).unwrap();
+
+    let desc = PrimDescriptor::Trace {
+        modes_a: vec![0, 1],
+        modes_c: vec![],
+        paired: vec![(0, 1)],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus(0.0), // alpha
+        &[&a_view],
+        MaxPlus(0.0), // beta
+        &mut c_view,
+    )
+    .unwrap();
+
+    assert_eq!(c_data[0].0, 20.0); // max(0+10, 0+20) = 20
+}
+
+// ============================================================================
+// MinPlus non-GEMM operations (verifies the MinPlus algebra works for all prims)
+// ============================================================================
+
+#[test]
+fn minplus_reduce_column_min() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, ReduceOp, TensorPrims};
+
+    // MinPlus "sum" is min. Reduce axis 1 = min over columns.
+    // A = [[5, 1],   → result = [min(5,1), min(2,8)] = [1, 2]
+    //      [2, 8]]
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [MinPlus(5.0), MinPlus(2.0), MinPlus(1.0), MinPlus(8.0)];
+    let mut c_data = [MinPlus::<f64>::zero(); 2];
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2], &[1, 2], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[2], &[1], 0).unwrap();
+
+    let desc = PrimDescriptor::Reduce {
+        modes_a: vec![0, 1],
+        modes_c: vec![0],
+        op: ReduceOp::Sum,
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra>>::plan::<MinPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MinPlus::one(),
+        &[&a_view],
+        MinPlus::zero(),
+        &mut c_view,
+    )
+    .unwrap();
+
+    assert_eq!(c_data[0].0, 1.0); // min(5, 1)
+    assert_eq!(c_data[1].0, 2.0); // min(2, 8)
+}
+
+#[test]
+fn maxmul_permute_transpose() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // Verifies MaxMul algebra works for non-GEMM operations.
+    // Transpose [[0.5, 0.3], [0.2, 0.9]] → [[0.5, 0.2], [0.3, 0.9]]
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [MaxMul(0.5), MaxMul(0.2), MaxMul(0.3), MaxMul(0.9)];
+    let mut c_data = [MaxMul::<f64>::zero(); 4];
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2], &[1, 2], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let desc = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra>>::plan::<MaxMul<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2]],
+    )
+    .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxMul::one(),
+        &[&a_view],
+        MaxMul::zero(),
+        &mut c_view,
+    )
+    .unwrap();
+
+    // Transposed col-major: [0.5, 0.3, 0.2, 0.9]
+    assert!((c_data[0].0 - 0.5).abs() < 1e-15);
+    assert!((c_data[1].0 - 0.3).abs() < 1e-15);
+    assert!((c_data[2].0 - 0.2).abs() < 1e-15);
+    assert!((c_data[3].0 - 0.9).abs() < 1e-15);
+}
+
+// ============================================================================
+// Anti-trace with non-zero beta (accumulation into existing output)
+// ============================================================================
+
+#[test]
+fn maxplus_anti_trace_accumulate_beta() {
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    // Anti-trace with beta != 0: output = beta * output_old, then add alpha * diag.
+    // This exercises the scale_output function with beta != 0 && beta != 1.
+    //
+    // input = MaxPlus(5.0) (scalar)
+    // output_old = [[2, 3], [4, 6]]
+    // beta = MaxPlus(10.0): beta * output_old = 10 + [[2,3],[4,6]] = [[12,13],[14,16]]
+    // alpha = MaxPlus(0.0): alpha * input = 0 + 5 = 5
+    // Then add 5 to diagonal: output[d,d] += 5
+    // output[0,0] = max(12, 5) = 12
+    // output[1,0] = 14 (no addition)
+    // output[0,1] = 13 (no addition)
+    // output[1,1] = max(16, 5) = 16
+    let mut ctx = CpuContext::new(1);
+
+    let in_data = [MaxPlus(5.0)];
+    let mut out_data = [MaxPlus(2.0), MaxPlus(4.0), MaxPlus(3.0), MaxPlus(6.0)];
+
+    let in_view = strided_view::StridedView::new(&in_data, &[], &[], 0).unwrap();
+    let mut out_view =
+        strided_view::StridedViewMut::new(&mut out_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let desc = PrimDescriptor::AntiTrace {
+        modes_a: vec![],
+        modes_c: vec![0, 1],
+        paired: vec![(0, 1)],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[], &[2, 2]],
+        )
+        .unwrap();
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus(0.0), // alpha
+        &[&in_view],
+        MaxPlus(10.0), // beta != 0, != 1
+        &mut out_view,
+    )
+    .unwrap();
+
+    // scale_output: beta * old = 10 + [2,4,3,6] = [12,14,13,16]
+    // Then diag += alpha * input = 0 + 5 = 5
+    // [0,0] = max(12, 5) = 12; [1,0] = 14; [0,1] = 13; [1,1] = max(16, 5) = 16
+    assert_eq!(out_data[0].0, 12.0);
+    assert_eq!(out_data[1].0, 14.0);
+    assert_eq!(out_data[2].0, 13.0);
+    assert_eq!(out_data[3].0, 16.0);
+}
+
+// ============================================================================
+// Plan validation: ReduceOp::Max/Min returns error for tropical types
+// ============================================================================
+
+#[test]
+fn tropical_reduce_max_op_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, ReduceOp, TensorPrims};
+
+    // For tropical types, ReduceOp::Sum already implements the correct tropical
+    // reduction (max for MaxPlus, min for MinPlus). ReduceOp::Max is meaningless
+    // and should return an error.
+    let mut ctx = CpuContext::new(1);
+
+    let a_data = [MaxPlus(1.0), MaxPlus(2.0)];
+    let mut c_data = [MaxPlus::<f64>::zero()];
+
+    let a_view = strided_view::StridedView::new(&a_data, &[2], &[1], 0).unwrap();
+    let mut c_view = strided_view::StridedViewMut::new(&mut c_data, &[], &[], 0).unwrap();
+
+    let desc = PrimDescriptor::Reduce {
+        modes_a: vec![0],
+        modes_c: vec![],
+        op: ReduceOp::Sum,
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2], &[]],
+        )
+        .unwrap();
+
+    // Construct a ReduceOp::Max plan manually by planning with Sum then executing
+    // Actually, plan with Max directly:
+    let desc_max = PrimDescriptor::Reduce {
+        modes_a: vec![0],
+        modes_c: vec![],
+        op: ReduceOp::Max,
+    };
+    let plan_max = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<
+        MaxPlus<f64>,
+    >(&mut ctx, &desc_max, &[&[2], &[]])
+    .unwrap();
+    let err = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan_max,
+        MaxPlus::one(),
+        &[&a_view],
+        MaxPlus::zero(),
+        &mut c_view,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(_)));
+
+    // Also verify Sum works correctly (max(1, 2) = 2)
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &[&a_view],
+        MaxPlus::zero(),
+        &mut c_view,
+    )
+    .unwrap();
+    assert_eq!(c_data[0].0, 2.0);
+}
+
+// ============================================================================
+// Plan validation: unsupported operations
+// ============================================================================
+
+#[test]
+fn tropical_plan_contract_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::Contract {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 2],
+        modes_c: vec![0, 2],
+    };
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2, 3], &[3, 4], &[2, 4]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+#[test]
+fn tropical_plan_elementwise_mul_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::ElementwiseMul;
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2], &[2], &[2]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+// ============================================================================
+// Execute arity validation tests
+// ============================================================================
+
+#[test]
+fn tropical_execute_gemm_wrong_arity_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::BatchedGemm {
+        batch_dims: vec![],
+        m: 2,
+        n: 2,
+        k: 2,
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[2, 2], &[2, 2]],
+        )
+        .unwrap();
+
+    let a_data = [MaxPlus(1.0_f64); 4];
+    let a_view = strided_view::StridedView::new(&a_data, &[2, 2], &[1, 2], 0).unwrap();
+    let mut out_data = [MaxPlus::<f64>::zero(); 4];
+    let mut out_view =
+        strided_view::StridedViewMut::new(&mut out_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    // Pass 1 input instead of 2
+    let err = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &[&a_view], // wrong: need 2
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+#[test]
+fn tropical_execute_reduce_wrong_arity_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, ReduceOp, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::Reduce {
+        modes_a: vec![0, 1],
+        modes_c: vec![0],
+        op: ReduceOp::Sum,
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[2]],
+        )
+        .unwrap();
+
+    let mut out_data = [MaxPlus::<f64>::zero(); 2];
+    let mut out_view = strided_view::StridedViewMut::new(&mut out_data, &[2], &[1], 0).unwrap();
+
+    let no_inputs: [&strided_view::StridedView<MaxPlus<f64>>; 0] = [];
+    let err = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &no_inputs,
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+#[test]
+fn tropical_execute_trace_wrong_arity_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::Trace {
+        modes_a: vec![0, 1],
+        modes_c: vec![],
+        paired: vec![(0, 1)],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2, 2], &[]],
+        )
+        .unwrap();
+
+    let mut out_data = [MaxPlus::<f64>::zero()];
+    let mut out_view = strided_view::StridedViewMut::new(&mut out_data, &[], &[], 0).unwrap();
+
+    let no_inputs: [&strided_view::StridedView<MaxPlus<f64>>; 0] = [];
+    let err = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &no_inputs,
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+#[test]
+fn tropical_execute_anti_trace_wrong_arity_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::AntiTrace {
+        modes_a: vec![],
+        modes_c: vec![0, 1],
+        paired: vec![(0, 1)],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[], &[2, 2]],
+        )
+        .unwrap();
+
+    let mut out_data = [MaxPlus::<f64>::zero(); 4];
+    let mut out_view =
+        strided_view::StridedViewMut::new(&mut out_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let no_inputs: [&strided_view::StridedView<MaxPlus<f64>>; 0] = [];
+    let err = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &no_inputs,
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+#[test]
+fn tropical_execute_anti_diag_wrong_arity_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::AntiDiag {
+        modes_a: vec![0],
+        modes_c: vec![0, 1],
+        paired: vec![(0, 1)],
+    };
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2], &[2, 2]],
+        )
+        .unwrap();
+
+    let mut out_data = [MaxPlus::<f64>::zero(); 4];
+    let mut out_view =
+        strided_view::StridedViewMut::new(&mut out_data, &[2, 2], &[1, 2], 0).unwrap();
+
+    let no_inputs: [&strided_view::StridedView<MaxPlus<f64>>; 0] = [];
+    let err = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &no_inputs,
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+#[test]
+fn tropical_execute_make_contiguous_wrong_arity_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::MakeContiguous;
+    let plan =
+        <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+            &mut ctx,
+            &desc,
+            &[&[2], &[2]],
+        )
+        .unwrap();
+
+    let mut out_data = [MaxPlus::<f64>::zero(); 2];
+    let mut out_view = strided_view::StridedViewMut::new(&mut out_data, &[2], &[1], 0).unwrap();
+
+    let no_inputs: [&strided_view::StridedView<MaxPlus<f64>>; 0] = [];
+    let err = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::execute(
+        &mut ctx,
+        &plan,
+        MaxPlus::one(),
+        &no_inputs,
+        MaxPlus::zero(),
+        &mut out_view,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+// ============================================================================
 // Extension not supported test
 // ============================================================================
 
@@ -1090,6 +2188,204 @@ fn tropical_no_extensions() {
     >>::has_extension_for::<MaxMul<f64>>(
         Extension::Contract
     ));
+}
+
+// ============================================================================
+// Plan validation error tests (verifying API rejects invalid descriptors)
+// ============================================================================
+
+#[test]
+fn tropical_plan_reduce_mode_rank_mismatch_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, ReduceOp, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    // modes_a has 2 labels but shape has rank 3
+    let desc = PrimDescriptor::Reduce {
+        modes_a: vec![0, 1],
+        modes_c: vec![0],
+        op: ReduceOp::Sum,
+    };
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2, 3, 4], &[2]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+#[test]
+fn tropical_plan_reduce_output_shape_mismatch_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, ReduceOp, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::Reduce {
+        modes_a: vec![0, 1],
+        modes_c: vec![0],
+        op: ReduceOp::Sum,
+    };
+    // Output shape [3] doesn't match input mode 0 which has size 2
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[3]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+#[test]
+fn tropical_plan_trace_paired_dims_unequal_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    // Paired axes have unequal dimensions (mode 0: size 2, mode 1: size 3)
+    let desc = PrimDescriptor::Trace {
+        modes_a: vec![0, 1],
+        modes_c: vec![],
+        paired: vec![(0, 1)],
+    };
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2, 3], &[]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+#[test]
+fn tropical_plan_trace_output_shape_mismatch_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    // Free mode 2 has size 3 in input but output says size 4
+    let desc = PrimDescriptor::Trace {
+        modes_a: vec![0, 1, 2],
+        modes_c: vec![2],
+        paired: vec![(0, 1)],
+    };
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2, 2, 3], &[4]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+#[test]
+fn tropical_plan_permute_shape_mismatch_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    // Permuted output shape doesn't match: mode 0 has size 2, but output says 3
+    let desc = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2, 3], &[2, 3]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+#[test]
+fn tropical_plan_anti_trace_paired_dims_unequal_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    // AntiTrace: paired axes in output have unequal sizes (mode 0: size 2, mode 1: size 3)
+    let desc = PrimDescriptor::AntiTrace {
+        modes_a: vec![],
+        modes_c: vec![0, 1],
+        paired: vec![(0, 1)],
+    };
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[], &[2, 3]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+#[test]
+fn tropical_plan_anti_trace_input_shape_mismatch_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    // AntiTrace: free axis (mode 2) has size 3 in input but size 4 in output
+    let desc = PrimDescriptor::AntiTrace {
+        modes_a: vec![2],
+        modes_c: vec![0, 1, 2],
+        paired: vec![(0, 1)],
+    };
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[3], &[2, 2, 4]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+#[test]
+fn tropical_plan_anti_diag_paired_dims_unequal_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    // AntiDiag: paired axes in output have unequal sizes
+    let desc = PrimDescriptor::AntiDiag {
+        modes_a: vec![0],
+        modes_c: vec![0, 1],
+        paired: vec![(0, 1)],
+    };
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2], &[2, 3]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+#[test]
+fn tropical_plan_anti_diag_input_shape_mismatch_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    // AntiDiag: free axis (mode 0) has size 2 in input but size 3 in output
+    let desc = PrimDescriptor::AntiDiag {
+        modes_a: vec![0],
+        modes_c: vec![0, 1],
+        paired: vec![(0, 1)],
+    };
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2], &[3, 3]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
+}
+
+#[test]
+fn tropical_plan_make_contiguous_shape_mismatch_returns_error() {
+    use tenferro_device::Error;
+    use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+
+    let mut ctx = CpuContext::new(1);
+    let desc = PrimDescriptor::MakeContiguous;
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra>>::plan::<MaxPlus<f64>>(
+        &mut ctx,
+        &desc,
+        &[&[2, 3], &[2, 4]],
+    );
+    assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #177, partially addresses #180.

- **f32 SIMD dispatch**: All three tropical types (MaxPlus, MinPlus, MaxMul) now use SIMD-optimized GEMM via tropical-gemm for both f32 and f64 scalar types. Previously only f64 had SIMD dispatch; f32 fell back to scalar loops.
- **Refactored dispatch**: Introduced `TropicalGemmDispatch` trait with `type Inner` associated type and `impl_tropical_gemm_dispatch!` / `try_simd_dispatch!` macros to avoid code duplication across 6 type combinations.
- **Debug derive**: Added `#[derive(Debug)]` to `TropicalPlan` for ergonomic error handling.
- **Semiring docs**: Updated algebra.rs doc comment to clarify f32 is fully supported at the `TensorPrims` level; `Semiring` trait remains f64-only by design (associated type limitation).
- **Coverage**: 32 new tests covering f32 matmul for all types, accumulation (beta≠0), anti-diag execution, MakeContiguous, anti-trace with free axes, permute with scaling, MinPlus/MaxMul non-GEMM operations, plan validation errors, and execute arity checks. Coverage raised from 55% to 81%.

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` — all tests pass (97 tropical tests, full workspace green)
- [x] `cargo llvm-cov` + `check-coverage.py` — 15/15 files pass thresholds
- [x] f32 SIMD matmul verified for MaxPlus, MinPlus, MaxMul with hand-computed results

Generated with [Claude Code](https://claude.com/claude-code)