### PR TITLE
chore(tropical): document Semiring f32 design + update outdated docs

### DIFF
--- a/extension/tenferro-tropical/src/algebra.rs
+++ b/extension/tenferro-tropical/src/algebra.rs
@@ -92,9 +92,20 @@ impl HasAlgebra for MaxMul<f64> {
 // Semiring implementations
 //
 // The Semiring trait uses an associated type `type Scalar`, so each algebra
-// marker can only be associated with one scalar type. We use f64 as the
-// canonical Semiring scalar. f32 is fully supported at the TensorPrims level
-// (plan/execute) — only the Semiring constants are f64.
+// marker can only implement Semiring once (Rust does not allow two impls with
+// different associated types for the same struct). We choose f64 as the
+// canonical Semiring scalar for constant queries (zero/one/add/mul).
+//
+// f32 is fully supported at the TensorPrims level: plan() and execute() are
+// generic over `T: Scalar`, so MaxPlus<f32>, MinPlus<f32>, and MaxMul<f32>
+// work correctly through the standard operator overloads (Add/Mul/Zero/One
+// on the scalar wrappers). The Semiring trait is primarily used for querying
+// algebraic constants and is not in the critical TensorPrims execution path.
+//
+// If f32-specific Semiring constants are needed in the future, the options
+// are: (a) create separate algebra markers (MaxPlusF32Algebra, etc.), or
+// (b) make the Semiring trait generic (Semiring<T>). Both require changes
+// to tenferro-algebra and are deferred until a concrete use case arises.
 // ---------------------------------------------------------------------------
 
 /// Max-plus semiring over `MaxPlus<f64>`.

--- a/extension/tenferro-tropical/src/argmax.rs
+++ b/extension/tenferro-tropical/src/argmax.rs
@@ -16,14 +16,15 @@
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tenferro_tropical::ArgmaxTracker;
 ///
-/// // Create a tracker for a 3×5 output
+/// // Create a tracker for a 3x5 output
 /// let tracker = ArgmaxTracker::new(&[3, 5]);
 ///
 /// // After forward pass, query the winner index for output element (1, 2)
 /// let k_winner = tracker.winner_index(&[1, 2]);
+/// assert_eq!(k_winner, 0); // initialized to 0
 /// ```
 pub struct ArgmaxTracker {
     /// Shape of the output tensor.
@@ -40,7 +41,7 @@ impl ArgmaxTracker {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tropical::ArgmaxTracker;
     ///
     /// let tracker = ArgmaxTracker::new(&[3, 5]);
@@ -73,11 +74,12 @@ impl ArgmaxTracker {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tropical::ArgmaxTracker;
     ///
     /// let tracker = ArgmaxTracker::new(&[3, 5]);
     /// let k = tracker.winner_index(&[1, 2]);
+    /// assert_eq!(k, 0); // initialized to 0
     /// ```
     pub fn winner_index(&self, position: &[usize]) -> usize {
         // Column-major linear index

--- a/extension/tenferro-tropical/src/lib.rs
+++ b/extension/tenferro-tropical/src/lib.rs
@@ -32,24 +32,27 @@
 //!
 //! ## Scalar arithmetic
 //!
-//! ```ignore
+//! ```
 //! use tenferro_tropical::MaxPlus;
 //!
 //! let a = MaxPlus(3.0_f64);
 //! let b = MaxPlus(5.0_f64);
-//! let c = a + b;   // MaxPlus(5.0) — tropical add = max
-//! let d = a * b;   // MaxPlus(8.0) — tropical mul = ordinary +
+//! let c = a + b;   // MaxPlus(5.0) -- tropical add = max
+//! assert_eq!(c, MaxPlus(5.0));
+//! let d = a * b;   // MaxPlus(8.0) -- tropical mul = ordinary +
+//! assert_eq!(d, MaxPlus(8.0));
 //! ```
 //!
 //! ## Algebra dispatch
 //!
-//! ```ignore
+//! ```
 //! use tenferro_algebra::HasAlgebra;
 //! use tenferro_tropical::{MaxPlus, MaxPlusAlgebra};
 //!
-//! // MaxPlus<f64> automatically maps to MaxPlusAlgebra
+//! // MaxPlus<f64> and MaxPlus<f32> both map to MaxPlusAlgebra
 //! fn check<T: HasAlgebra<Algebra = MaxPlusAlgebra>>() {}
 //! check::<MaxPlus<f64>>();
+//! check::<MaxPlus<f32>>();
 //! ```
 //!
 //! ## Plan-based tropical contraction

--- a/extension/tenferro-tropical/src/scalar.rs
+++ b/extension/tenferro-tropical/src/scalar.rs
@@ -9,7 +9,7 @@
 //! | [`MinPlus<T>`] | min | + | +∞ | 0 |
 //! | [`MaxMul<T>`] | max | × | 0 | 1 |
 //!
-//! All arithmetic bodies use `todo!()` (POC skeleton).
+//! All arithmetic operations are fully implemented.
 
 use std::fmt;
 use std::ops;
@@ -21,17 +21,19 @@ use std::ops;
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tenferro_tropical::MaxPlus;
 ///
 /// let a = MaxPlus(3.0_f64);
 /// let b = MaxPlus(5.0_f64);
 ///
 /// // Tropical addition = max
-/// let c = a + b;   // MaxPlus(5.0)
+/// let c = a + b;
+/// assert_eq!(c, MaxPlus(5.0));
 ///
 /// // Tropical multiplication = ordinary addition
-/// let d = a * b;   // MaxPlus(8.0)
+/// let d = a * b;
+/// assert_eq!(d, MaxPlus(8.0));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 #[repr(transparent)]
@@ -43,17 +45,19 @@ pub struct MaxPlus<T>(pub T);
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tenferro_tropical::MinPlus;
 ///
 /// let a = MinPlus(3.0_f64);
 /// let b = MinPlus(5.0_f64);
 ///
 /// // Tropical addition = min
-/// let c = a + b;   // MinPlus(3.0)
+/// let c = a + b;
+/// assert_eq!(c, MinPlus(3.0));
 ///
 /// // Tropical multiplication = ordinary addition
-/// let d = a * b;   // MinPlus(8.0)
+/// let d = a * b;
+/// assert_eq!(d, MinPlus(8.0));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 #[repr(transparent)]
@@ -66,17 +70,19 @@ pub struct MinPlus<T>(pub T);
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tenferro_tropical::MaxMul;
 ///
 /// let a = MaxMul(0.3_f64);
 /// let b = MaxMul(0.7_f64);
 ///
 /// // Tropical addition = max
-/// let c = a + b;   // MaxMul(0.7)
+/// let c = a + b;
+/// assert_eq!(c, MaxMul(0.7));
 ///
 /// // Tropical multiplication = ordinary multiplication
-/// let d = a * b;   // MaxMul(0.21)
+/// let d = a * b;
+/// assert!((d.0 - 0.21).abs() < 1e-15);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 #[repr(transparent)]

--- a/extension/tenferro-tropical/tests/tropical_tests.rs
+++ b/extension/tenferro-tropical/tests/tropical_tests.rs
@@ -1,6 +1,4 @@
 //! Tests for tenferro-tropical: scalar types, algebra, argmax, and TensorPrims.
-//!
-//! TDD approach: tests written before implementation.
 
 use num_traits::{One, Zero};
 use tenferro_tensor::{MemoryOrder, Tensor};


### PR DESCRIPTION
## Summary
- Document why f32 Semiring impls are intentionally not added (Rust's associated type constraint limits each algebra marker to one Semiring impl; f32 is fully supported at TensorPrims level via operator overloads)
- Fix outdated doc comment in scalar.rs that incorrectly claimed "All arithmetic bodies use todo!() (POC skeleton)" -- all implementations are complete
- Enable 8 doc examples that were marked `ignore` but can now run (scalar.rs, argmax.rs, lib.rs)

Closes #180

## Test plan
- [x] All 97 existing tropical unit tests pass
- [x] 8 doc examples now run instead of being ignored
- [x] Full workspace tests pass
- [x] Coverage check passes (pre-existing gpu_stubs.rs failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)