### PR TITLE
refactor(algebra): enforce Algebra trait on TensorPrims

### DIFF
--- a/extension/tenferro-tropical/src/ad.rs
+++ b/extension/tenferro-tropical/src/ad.rs
@@ -250,6 +250,7 @@ pub fn tropical_einsum_rrule<T, Alg, Backend>(
     cotangent: &Tensor<T::Inner>,
 ) -> Result<Vec<Tensor<T::Inner>>>
 where
+    Alg: tenferro_algebra::Algebra,
     T: TropicalScalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
@@ -639,6 +640,7 @@ pub fn tracked_tropical_einsum<T, Alg, Backend>(
     operands: &[&TrackedTensor<Tensor<T::Inner>>],
 ) -> AdResult<TrackedTensor<Tensor<T::Inner>>>
 where
+    Alg: tenferro_algebra::Algebra,
     T: TropicalScalar + HasAlgebra<Algebra = Alg> + 'static,
     T::Inner: Scalar + HasAlgebra,
     Backend: TensorPrims<Alg>,

--- a/extension/tenferro-tropical/src/algebra.rs
+++ b/extension/tenferro-tropical/src/algebra.rs
@@ -12,7 +12,7 @@
 
 use std::marker::PhantomData;
 
-use tenferro_algebra::{HasAlgebra, Semiring};
+use tenferro_algebra::{Algebra, HasAlgebra, Semiring};
 
 use crate::scalar::{MaxMul, MaxPlus, MinPlus};
 
@@ -44,9 +44,15 @@ macro_rules! define_tropical_algebra {
             type Algebra = $marker<f64>;
         }
 
-        impl Semiring for $marker<f32> {
+        impl Algebra for $marker<f32> {
             type Scalar = $wrapper<f32>;
+        }
 
+        impl Algebra for $marker<f64> {
+            type Scalar = $wrapper<f64>;
+        }
+
+        impl Semiring for $marker<f32> {
             fn zero() -> Self::Scalar { $z32 }
             fn one() -> Self::Scalar { $o32 }
             fn add(a: Self::Scalar, b: Self::Scalar) -> Self::Scalar { a + b }
@@ -54,8 +60,6 @@ macro_rules! define_tropical_algebra {
         }
 
         impl Semiring for $marker<f64> {
-            type Scalar = $wrapper<f64>;
-
             fn zero() -> Self::Scalar { $z64 }
             fn one() -> Self::Scalar { $o64 }
             fn add(a: Self::Scalar, b: Self::Scalar) -> Self::Scalar { a + b }

--- a/extension/tenferro-tropical/src/prims.rs
+++ b/extension/tenferro-tropical/src/prims.rs
@@ -15,7 +15,7 @@ use std::collections::HashSet;
 use std::marker::PhantomData;
 
 use strided_view::{StridedView, StridedViewMut};
-use tenferro_algebra::Scalar;
+use tenferro_algebra::{Algebra, Scalar};
 use tenferro_device::{Error, Result};
 use tenferro_prims::{CpuBackend, CpuContext, Extension, PrimDescriptor, ReduceOp, TensorPrims};
 use tenferro_tensor::Tensor;
@@ -1230,31 +1230,35 @@ macro_rules! try_simd_dispatch {
 /// tropical scalar wrapper, then falls back to the generic `tropical_execute`.
 macro_rules! impl_tropical_prims {
     ($marker:ident, $wrapper:ident) => {
-        impl<S: Scalar> TensorPrims<$marker<S>> for CpuBackend {
-            type Plan<T: Scalar> = TropicalPlan<T>;
+        impl<S: Scalar + num_traits::Float> TensorPrims<$marker<S>> for CpuBackend
+        where
+            $marker<S>: Algebra<Scalar = $wrapper<S>>,
+            $wrapper<S>: Scalar,
+        {
+            type Plan = TropicalPlan<$wrapper<S>>;
             type Context = CpuContext;
 
-            fn plan<T: Scalar>(
+            fn plan(
                 _ctx: &mut CpuContext,
                 desc: &PrimDescriptor,
                 shapes: &[&[usize]],
-            ) -> Result<TropicalPlan<T>> {
+            ) -> Result<TropicalPlan<$wrapper<S>>> {
                 tropical_plan(desc, shapes)
             }
 
-            fn execute<T: Scalar>(
+            fn execute(
                 _ctx: &mut CpuContext,
-                plan: &TropicalPlan<T>,
-                alpha: T,
-                inputs: &[&Tensor<T>],
-                beta: T,
-                output: &mut Tensor<T>,
+                plan: &TropicalPlan<$wrapper<S>>,
+                alpha: $wrapper<S>,
+                inputs: &[&Tensor<$wrapper<S>>],
+                beta: $wrapper<S>,
+                output: &mut Tensor<$wrapper<S>>,
             ) -> Result<()> {
-                let views: Vec<StridedView<T>> = inputs
+                let views: Vec<StridedView<$wrapper<S>>> = inputs
                     .iter()
                     .map(|t| tensor_to_view(t))
                     .collect::<Result<Vec<_>>>()?;
-                let view_refs: Vec<&StridedView<T>> = views.iter().collect();
+                let view_refs: Vec<&StridedView<$wrapper<S>>> = views.iter().collect();
                 let mut out_view = tensor_to_view_mut(output)?;
 
                 if let TropicalPlan::BatchedGemm {
@@ -1271,7 +1275,7 @@ macro_rules! impl_tropical_prims {
                         ));
                     }
                     try_simd_dispatch!(
-                        T,
+                        $wrapper<S>,
                         $wrapper<f64>,
                         &view_refs,
                         alpha,
@@ -1283,7 +1287,7 @@ macro_rules! impl_tropical_prims {
                         *k
                     );
                     try_simd_dispatch!(
-                        T,
+                        $wrapper<S>,
                         $wrapper<f32>,
                         &view_refs,
                         alpha,
@@ -1298,7 +1302,7 @@ macro_rules! impl_tropical_prims {
                 tropical_execute(plan, alpha, &view_refs, beta, &mut out_view)
             }
 
-            fn has_extension_for<T: Scalar>(_ext: Extension) -> bool {
+            fn has_extension_for(_ext: Extension) -> bool {
                 false
             }
         }

--- a/extension/tenferro-tropical/tests/ad_tests.rs
+++ b/extension/tenferro-tropical/tests/ad_tests.rs
@@ -381,7 +381,7 @@ fn tracked_maxplus_matmul_pullback() {
     let ones_tracked = chainrules::TrackedTensor::new(ones);
 
     let ctx = Rc::new(RefCell::new(ctx()));
-    let loss = tracked_einsum::<f64, tenferro_algebra::Standard<f64>, tenferro_prims::CpuBackend>(
+    let loss = tracked_einsum::<tenferro_algebra::Standard<f64>, tenferro_prims::CpuBackend>(
         ctx.clone(),
         "ik,ik->",
         &[&c, &ones_tracked],

--- a/extension/tenferro-tropical/tests/einsum_tests.rs
+++ b/extension/tenferro-tropical/tests/einsum_tests.rs
@@ -46,8 +46,8 @@ fn tropical_maxplus_matmul() {
     // C[1,0] = max(2+5, 4+6) = max(7, 10) = 10
     // C[0,1] = max(1+7, 3+8) = max(8, 11) = 11
     // C[1,1] = max(2+7, 4+8) = max(9, 12) = 12
-    let c = einsum::<_, MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None)
-        .unwrap();
+    let c =
+        einsum::<MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
 
     assert_eq!(c.dims(), &[2, 2]);
     let data = c.buffer().as_slice().unwrap();
@@ -76,7 +76,7 @@ fn tropical_maxplus_trace() {
     .unwrap();
 
     // trace = A[0,0] ⊕ A[1,1] = max(1, 4) = 4
-    let tr = einsum::<_, MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
+    let tr = einsum::<MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
 
     assert_eq!(tr.dims(), &[] as &[usize]);
     let data = tr.buffer().as_slice().unwrap();
@@ -130,7 +130,7 @@ fn tropical_maxplus_batch_matmul() {
     )
     .unwrap();
 
-    let c = einsum::<_, MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "bij,bjk->bik", &[&a, &b], None)
+    let c = einsum::<MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "bij,bjk->bik", &[&a, &b], None)
         .unwrap();
 
     assert_eq!(c.dims(), &[2, 2, 2]);
@@ -172,8 +172,8 @@ fn tropical_maxplus_elementwise() {
     .unwrap();
 
     // Element-wise tropical mul: C[i,j] = A[i,j] ⊗ B[i,j] = A[i,j] + B[i,j]
-    let c = einsum::<_, MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ij,ij->ij", &[&a, &b], None)
-        .unwrap();
+    let c =
+        einsum::<MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ij,ij->ij", &[&a, &b], None).unwrap();
 
     assert_eq!(c.dims(), &[2, 2]);
     let data = c.buffer().as_slice().unwrap();
@@ -202,7 +202,7 @@ fn tropical_maxplus_outer_product() {
 
     // C[i,j] = A[i] ⊗ B[j] = A[i] + B[j]  (no sum modes, k=1)
     let c =
-        einsum::<_, MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "i,j->ij", &[&a, &b], None).unwrap();
+        einsum::<MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "i,j->ij", &[&a, &b], None).unwrap();
 
     assert_eq!(c.dims(), &[2, 3]);
     let data = c.buffer().as_slice().unwrap();
@@ -238,7 +238,7 @@ fn tropical_maxplus_vecmat() {
     // C[0] = max(1+5, 3+6) = max(6, 9) = 9
     // C[1] = max(1+7, 3+8) = max(8, 11) = 11
     let c =
-        einsum::<_, MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "j,jk->k", &[&v, &m], None).unwrap();
+        einsum::<MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "j,jk->k", &[&v, &m], None).unwrap();
 
     assert_eq!(c.dims(), &[2]);
     let data = c.buffer().as_slice().unwrap();
@@ -271,7 +271,7 @@ fn tropical_maxplus_full_contraction() {
     // scalar = max_{i,j}(A[i,j] + B[i,j])
     // = max(1+10, 2+20, 3+30, 4+40) = max(11, 22, 33, 44) = 44
     let c =
-        einsum::<_, MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ij,ij->", &[&a, &b], None).unwrap();
+        einsum::<MaxPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ij,ij->", &[&a, &b], None).unwrap();
 
     assert_eq!(c.dims(), &[] as &[usize]);
     let data = c.buffer().as_slice().unwrap();
@@ -308,7 +308,7 @@ fn tropical_maxplus_three_chain() {
     .unwrap();
 
     // D = A ⊗ B ⊗ C  (tropical chain multiplication)
-    let d = einsum::<_, MaxPlusAlgebra<f64>, CpuBackend>(
+    let d = einsum::<MaxPlusAlgebra<f64>, CpuBackend>(
         &mut ctx,
         "ij,jk,kl->il",
         &[&a, &b, &c_mat],
@@ -380,8 +380,8 @@ fn tropical_minplus_matmul_shortest_path() {
     // W^2[2,0] = min(2+0, inf+inf, 0+2) = 2
     // W^2[2,1] = min(2+1, inf+0, 0+inf) = 3
     // W^2[2,2] = min(2+inf, inf+3, 0+0) = 0
-    let w2 = einsum::<_, MinPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&w, &w], None)
-        .unwrap();
+    let w2 =
+        einsum::<MinPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&w, &w], None).unwrap();
 
     assert_eq!(w2.dims(), &[3, 3]);
     let data = w2.buffer().as_slice().unwrap();
@@ -461,8 +461,8 @@ fn tropical_maxmul_matmul_viterbi() {
     // P[0,1] = max(0.1*0.1, 0.3*0.8, 0.5*0.5) = max(0.01, 0.24, 0.25) = 0.25
     // P[1,1] = max(0.7*0.1, 0.4*0.8, 0.1*0.5) = max(0.07, 0.32, 0.05) = 0.32
     // P[2,1] = max(0.2*0.1, 0.3*0.8, 0.4*0.5) = max(0.02, 0.24, 0.20) = 0.24
-    let p = einsum::<_, MaxMulAlgebra<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&tt, &e], None)
-        .unwrap();
+    let p =
+        einsum::<MaxMulAlgebra<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&tt, &e], None).unwrap();
 
     assert_eq!(p.dims(), &[3, 2]);
     let data = p.buffer().as_slice().unwrap();
@@ -495,7 +495,7 @@ fn tropical_minplus_trace() {
     .unwrap();
 
     // trace = D[0,0] ⊕ D[1,1] = min(2, 3) = 2
-    let tr = einsum::<_, MinPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ii->", &[&d], None).unwrap();
+    let tr = einsum::<MinPlusAlgebra<f64>, CpuBackend>(&mut ctx, "ii->", &[&d], None).unwrap();
 
     assert_eq!(tr.dims(), &[] as &[usize]);
     let data = tr.buffer().as_slice().unwrap();

--- a/extension/tenferro-tropical/tests/tropical_tests.rs
+++ b/extension/tenferro-tropical/tests/tropical_tests.rs
@@ -557,9 +557,11 @@ fn maxplus_matmul_2x2() {
         n: 2,
         k: 2,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2], &[2, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -611,9 +613,11 @@ fn minplus_matmul_2x2() {
         n: 2,
         k: 2,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::plan::<
-        MinPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2], &[2, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -664,9 +668,11 @@ fn maxmul_matmul_2x2() {
         n: 2,
         k: 2,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::plan::<
-        MaxMul<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2], &[2, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::execute(
         &mut ctx,
@@ -761,9 +767,11 @@ fn shortest_path_minplus_bellman_ford_step() {
         n: 1,
         k: 3,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::plan::<
-        MinPlus<f64>,
-    >(&mut ctx, &desc, &[&[3, 3], &[3, 1], &[3, 1]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[3, 3], &[3, 1], &[3, 1]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -840,9 +848,11 @@ fn viterbi_maxmul_hmm_step() {
         n: 1,
         k: 2,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::plan::<
-        MaxMul<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 1], &[2, 1]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 1], &[2, 1]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::execute(
         &mut ctx,
@@ -886,9 +896,11 @@ fn maxplus_reduce_sum() {
         modes_c: vec![0],
         op: ReduceOp::Sum,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -932,9 +944,11 @@ fn maxplus_permute_transpose() {
         modes_a: vec![0, 1],
         modes_b: vec![1, 0],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -991,9 +1005,11 @@ fn maxplus_trace_3x3() {
         modes_c: vec![],
         paired: vec![(0, 1)],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[3, 3], &[]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[3, 3], &[]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1049,9 +1065,11 @@ fn maxplus_trace_partial_3d() {
         modes_c: vec![2],
         paired: vec![(0, 1)],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2, 3], &[3]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2, 3], &[3]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1103,9 +1121,11 @@ fn maxplus_anti_trace_scalar_to_diag() {
         modes_c: vec![0, 1],
         paired: vec![(0, 1)],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[], &[2, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1174,11 +1194,13 @@ fn maxplus_matmul_2x2_f32() {
         n: 2,
         k: 2,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f32>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f32>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2], &[2, 2]],
+    )
     .unwrap();
-    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f32>>>::execute(
         &mut ctx,
         &plan,
         MaxPlus::one(),
@@ -1236,11 +1258,13 @@ fn minplus_matmul_2x2_f32() {
         n: 2,
         k: 2,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::plan::<
-        MinPlus<f32>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f32>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2], &[2, 2]],
+    )
     .unwrap();
-    <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::execute(
+    <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f32>>>::execute(
         &mut ctx,
         &plan,
         MinPlus::one(),
@@ -1298,11 +1322,13 @@ fn maxmul_matmul_2x2_f32() {
         n: 2,
         k: 2,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::plan::<
-        MaxMul<f32>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f32>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2], &[2, 2]],
+    )
     .unwrap();
-    <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::execute(
+    <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f32>>>::execute(
         &mut ctx,
         &plan,
         MaxMul::one(),
@@ -1361,9 +1387,11 @@ fn maxplus_matmul_accumulate_with_beta() {
         n: 2,
         k: 2,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2], &[2, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1416,9 +1444,11 @@ fn maxplus_anti_diag_vector_to_matrix() {
         modes_c: vec![0, 1],
         paired: vec![(0, 1)],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2], &[2, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1479,9 +1509,11 @@ fn maxplus_make_contiguous() {
     .unwrap();
 
     let desc = PrimDescriptor::MakeContiguous;
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[3, 2], &[3, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[3, 2], &[3, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1536,9 +1568,11 @@ fn maxplus_anti_trace_vec_to_3d() {
         modes_c: vec![0, 1, 2], // output: modes 0, 1, 2
         paired: vec![(0, 1)],   // diagonal on modes 0 and 1
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[3], &[2, 2, 3]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[3], &[2, 2, 3]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1598,9 +1632,11 @@ fn maxplus_permute_with_alpha_beta() {
         modes_a: vec![0, 1],
         modes_b: vec![1, 0],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1645,9 +1681,11 @@ fn maxplus_make_contiguous_with_alpha_beta() {
     let mut output = Tensor::from_slice(&out_init, &[2], MemoryOrder::ColumnMajor).unwrap();
 
     let desc = PrimDescriptor::MakeContiguous;
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2], &[2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2], &[2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1691,9 +1729,11 @@ fn maxplus_reduce_with_beta_accumulate() {
         modes_c: vec![0],
         op: ReduceOp::Sum,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1741,9 +1781,11 @@ fn maxplus_trace_with_beta_accumulate() {
         modes_c: vec![],
         paired: vec![(0, 1)],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1783,9 +1825,11 @@ fn minplus_reduce_column_min() {
         modes_c: vec![0],
         op: ReduceOp::Sum,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::plan::<
-        MinPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MinPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1824,9 +1868,11 @@ fn maxmul_permute_transpose() {
         modes_a: vec![0, 1],
         modes_b: vec![1, 0],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::plan::<
-        MaxMul<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxMulAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1879,9 +1925,11 @@ fn maxplus_anti_trace_accumulate_beta() {
         modes_c: vec![0, 1],
         paired: vec![(0, 1)],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[], &[2, 2]],
+    )
     .unwrap();
     <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1928,9 +1976,11 @@ fn tropical_reduce_max_op_returns_error() {
         modes_c: vec![],
         op: ReduceOp::Sum,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2], &[]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2], &[]],
+    )
     .unwrap();
 
     // Construct a ReduceOp::Max plan manually by planning with Sum then executing
@@ -1940,9 +1990,11 @@ fn tropical_reduce_max_op_returns_error() {
         modes_c: vec![],
         op: ReduceOp::Max,
     };
-    let plan_max = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc_max, &[&[2], &[]])
+    let plan_max = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc_max,
+        &[&[2], &[]],
+    )
     .unwrap();
     let err = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::execute(
         &mut ctx,
@@ -1984,9 +2036,11 @@ fn tropical_plan_contract_returns_error() {
         modes_b: vec![1, 2],
         modes_c: vec![0, 2],
     };
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 3], &[3, 4], &[2, 4]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 3], &[3, 4], &[2, 4]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -1997,9 +2051,11 @@ fn tropical_plan_elementwise_mul_returns_error() {
 
     let mut ctx = CpuContext::new(1);
     let desc = PrimDescriptor::ElementwiseMul;
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2], &[2], &[2]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2], &[2], &[2]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2019,9 +2075,11 @@ fn tropical_execute_gemm_wrong_arity_returns_error() {
         n: 2,
         k: 2,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2], &[2, 2]],
+    )
     .unwrap();
 
     let a = Tensor::from_slice(&[MaxPlus(1.0_f64); 4], &[2, 2], MemoryOrder::ColumnMajor).unwrap();
@@ -2056,9 +2114,11 @@ fn tropical_execute_reduce_wrong_arity_returns_error() {
         modes_c: vec![0],
         op: ReduceOp::Sum,
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2]],
+    )
     .unwrap();
 
     let mut output =
@@ -2088,9 +2148,11 @@ fn tropical_execute_trace_wrong_arity_returns_error() {
         modes_c: vec![],
         paired: vec![(0, 1)],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[]],
+    )
     .unwrap();
 
     let mut output =
@@ -2120,9 +2182,11 @@ fn tropical_execute_anti_trace_wrong_arity_returns_error() {
         modes_c: vec![0, 1],
         paired: vec![(0, 1)],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[], &[2, 2]],
+    )
     .unwrap();
 
     let mut output = Tensor::from_slice(
@@ -2156,9 +2220,11 @@ fn tropical_execute_anti_diag_wrong_arity_returns_error() {
         modes_c: vec![0, 1],
         paired: vec![(0, 1)],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2], &[2, 2]],
+    )
     .unwrap();
 
     let mut output = Tensor::from_slice(
@@ -2188,9 +2254,11 @@ fn tropical_execute_make_contiguous_wrong_arity_returns_error() {
 
     let mut ctx = CpuContext::new(1);
     let desc = PrimDescriptor::MakeContiguous;
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2], &[2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2], &[2]],
+    )
     .unwrap();
 
     let mut output =
@@ -2219,24 +2287,16 @@ fn tropical_no_extensions() {
 
     assert!(!<CpuBackend as TensorPrims<
         tenferro_tropical::MaxPlusAlgebra<f64>,
-    >>::has_extension_for::<MaxPlus<f64>>(
-        Extension::Contract
-    ));
+    >>::has_extension_for(Extension::Contract));
     assert!(!<CpuBackend as TensorPrims<
         tenferro_tropical::MaxPlusAlgebra<f64>,
-    >>::has_extension_for::<MaxPlus<f64>>(
-        Extension::ElementwiseMul
-    ));
+    >>::has_extension_for(Extension::ElementwiseMul));
     assert!(!<CpuBackend as TensorPrims<
         tenferro_tropical::MinPlusAlgebra<f64>,
-    >>::has_extension_for::<MinPlus<f64>>(
-        Extension::Contract
-    ));
+    >>::has_extension_for(Extension::Contract));
     assert!(!<CpuBackend as TensorPrims<
         tenferro_tropical::MaxMulAlgebra<f64>,
-    >>::has_extension_for::<MaxMul<f64>>(
-        Extension::Contract
-    ));
+    >>::has_extension_for(Extension::Contract));
 }
 
 // ============================================================================
@@ -2255,9 +2315,11 @@ fn tropical_plan_reduce_mode_rank_mismatch_returns_error() {
         modes_c: vec![0],
         op: ReduceOp::Sum,
     };
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 3, 4], &[2]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 3, 4], &[2]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2273,9 +2335,11 @@ fn tropical_plan_reduce_output_shape_mismatch_returns_error() {
         op: ReduceOp::Sum,
     };
     // Output shape [3] doesn't match input mode 0 which has size 2
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[3]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[3]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2291,9 +2355,11 @@ fn tropical_plan_trace_paired_dims_unequal_returns_error() {
         modes_c: vec![],
         paired: vec![(0, 1)],
     };
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 3], &[]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 3], &[]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2309,9 +2375,11 @@ fn tropical_plan_trace_output_shape_mismatch_returns_error() {
         modes_c: vec![2],
         paired: vec![(0, 1)],
     };
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2, 3], &[4]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2, 3], &[4]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2326,9 +2394,11 @@ fn tropical_plan_permute_shape_mismatch_returns_error() {
         modes_a: vec![0, 1],
         modes_b: vec![1, 0],
     };
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 3], &[2, 3]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 3], &[2, 3]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2344,9 +2414,11 @@ fn tropical_plan_anti_trace_paired_dims_unequal_returns_error() {
         modes_c: vec![0, 1],
         paired: vec![(0, 1)],
     };
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[], &[2, 3]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[], &[2, 3]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2362,9 +2434,11 @@ fn tropical_plan_anti_trace_input_shape_mismatch_returns_error() {
         modes_c: vec![0, 1, 2],
         paired: vec![(0, 1)],
     };
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[3], &[2, 2, 4]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[3], &[2, 2, 4]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2380,9 +2454,11 @@ fn tropical_plan_anti_diag_paired_dims_unequal_returns_error() {
         modes_c: vec![0, 1],
         paired: vec![(0, 1)],
     };
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2], &[2, 3]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2], &[2, 3]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2398,9 +2474,11 @@ fn tropical_plan_anti_diag_input_shape_mismatch_returns_error() {
         modes_c: vec![0, 1],
         paired: vec![(0, 1)],
     };
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2], &[3, 3]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2], &[3, 3]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2411,9 +2489,11 @@ fn tropical_plan_make_contiguous_shape_mismatch_returns_error() {
 
     let mut ctx = CpuContext::new(1);
     let desc = PrimDescriptor::MakeContiguous;
-    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 3], &[2, 4]]);
+    let result = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 3], &[2, 4]],
+    );
     assert!(matches!(result, Err(Error::InvalidArgument(_))));
 }
 
@@ -2428,10 +2508,11 @@ fn tropical_plan_trace_empty_paired_returns_error() {
         modes_c: vec![0],
         paired: vec![],
     };
-    let err = match <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2]])
-    {
+    let err = match <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2]],
+    ) {
         Ok(_) => panic!("expected InvalidArgument error"),
         Err(e) => e,
     };
@@ -2450,10 +2531,11 @@ fn tropical_plan_antidiag_invalid_pair_anchor_returns_error() {
         // first paired label must exist in modes_a, but here it's 1
         paired: vec![(1, 0)],
     };
-    let err = match <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2], &[2, 2]])
-    {
+    let err = match <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2], &[2, 2]],
+    ) {
         Ok(_) => panic!("expected InvalidArgument error"),
         Err(e) => e,
     };
@@ -2473,10 +2555,11 @@ fn tropical_plan_batched_gemm_shape_mismatch_returns_error() {
         k: 3,
     };
     // B shape is wrong (should be [3, 2], here [4, 2])
-    let err = match <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 3], &[4, 2], &[2, 2]])
-    {
+    let err = match <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 3], &[4, 2], &[2, 2]],
+    ) {
         Ok(_) => panic!("expected InvalidArgument error"),
         Err(e) => e,
     };
@@ -2493,9 +2576,11 @@ fn tropical_execute_wrong_input_arity_returns_error() {
         modes_a: vec![0, 1],
         modes_b: vec![1, 0],
     };
-    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan::<
-        MaxPlus<f64>,
-    >(&mut ctx, &desc, &[&[2, 2], &[2, 2]])
+    let plan = <CpuBackend as TensorPrims<tenferro_tropical::MaxPlusAlgebra<f64>>>::plan(
+        &mut ctx,
+        &desc,
+        &[&[2, 2], &[2, 2]],
+    )
     .unwrap();
 
     let mut output = Tensor::from_slice(

--- a/tenferro-algebra/src/lib.rs
+++ b/tenferro-algebra/src/lib.rs
@@ -9,8 +9,8 @@
 //!   Enables automatic inference: `Tensor<f64>` → `Standard<f64>`,
 //!   `Tensor<MaxPlus<f64>>` → `MaxPlusAlgebra<f64>` (in external crate).
 //!   This is UX sugar — the core model is `Alg::Scalar`-centric.
-//! - [`Semiring`]: Defines zero, one, add, mul for algebra-generic operations.
-//!   The algebra type `Alg` carries its scalar type via `Alg::Scalar`.
+//! - [`Algebra`]: Associates an algebra marker with its scalar type (`Alg::Scalar`).
+//! - [`Semiring`]: Extends `Algebra` with zero, one, add, mul for algebra-generic operations.
 //! - [`Standard<T>`](Standard): Typed standard arithmetic algebra (add = `+`, mul = `*`).
 //!
 //! # Extensibility
@@ -161,6 +161,27 @@ impl HasAlgebra for Complex64 {
     type Algebra = Standard<Complex64>;
 }
 
+/// Associates an algebra marker with its scalar type.
+///
+/// This is the minimal trait required by [`TensorPrims`] — it provides
+/// the scalar type without requiring semiring operations.
+///
+/// [`Semiring`] extends `Algebra` with zero/one/add/mul.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_algebra::{Algebra, Standard};
+///
+/// fn needs_algebra<A: Algebra>() {}
+/// needs_algebra::<Standard<f64>>();
+/// needs_algebra::<Standard<f32>>();
+/// ```
+pub trait Algebra {
+    /// The scalar element type for tensors under this algebra.
+    type Scalar: Scalar;
+}
+
 /// Semiring trait for algebra-generic operations.
 ///
 /// The algebra type `Alg` carries its scalar type via `Alg::Scalar`. This
@@ -182,10 +203,7 @@ impl HasAlgebra for Complex64 {
 ///
 /// Tropical (MaxPlus) semiring (in external crate):
 /// - `zero() = -∞`, `one() = 0`, `add = max`, `mul = +`
-pub trait Semiring {
-    /// The scalar type for this semiring.
-    type Scalar: Scalar;
-
+pub trait Semiring: Algebra {
     /// Additive identity element.
     fn zero() -> Self::Scalar;
 
@@ -197,6 +215,10 @@ pub trait Semiring {
 
     /// Semiring multiplication.
     fn mul(a: Self::Scalar, b: Self::Scalar) -> Self::Scalar;
+}
+
+impl<T: Scalar> Algebra for Standard<T> {
+    type Scalar = T;
 }
 
 /// Standard arithmetic implements `Semiring` with `+` and `*`.
@@ -212,8 +234,6 @@ pub trait Semiring {
 /// assert_eq!(o, 1.0);
 /// ```
 impl<T: Scalar> Semiring for Standard<T> {
-    type Scalar = T;
-
     fn zero() -> T {
         T::zero()
     }

--- a/tenferro-capi/src/lib.rs
+++ b/tenferro-capi/src/lib.rs
@@ -1075,7 +1075,7 @@ pub unsafe extern "C" fn tfe_einsum_f64(
             .collect::<Result<Vec<_>, _>>()?;
 
         let mut ctx = CpuContext::new(1);
-        einsum::<f64, Standard<f64>, CpuBackend>(&mut ctx, subs, &ops, None)
+        einsum::<Standard<f64>, CpuBackend>(&mut ctx, subs, &ops, None)
             .map(|t| tensor_to_handle(t))
             .map_err(|e| map_device_error(&e))
     }));
@@ -1146,7 +1146,7 @@ pub unsafe extern "C" fn tfe_einsum_rrule_f64(
         let cot = handle_to_ref(cotangent);
 
         let mut ctx = CpuContext::new(1);
-        let grads = einsum_rrule::<f64, Standard<f64>, CpuBackend>(&mut ctx, subs, &ops, cot)
+        let grads = einsum_rrule::<Standard<f64>, CpuBackend>(&mut ctx, subs, &ops, cot)
             .map_err(|e| map_device_error(&e))?;
 
         let out_slice = std::slice::from_raw_parts_mut(grads_out, num_operands);
@@ -1225,7 +1225,7 @@ pub unsafe extern "C" fn tfe_einsum_frule_f64(
             .collect();
 
         let mut ctx = CpuContext::new(1);
-        einsum_frule::<f64, Standard<f64>, CpuBackend>(&mut ctx, subs, &primal_refs, &tangent_refs)
+        einsum_frule::<Standard<f64>, CpuBackend>(&mut ctx, subs, &primal_refs, &tangent_refs)
             .map(|t| tensor_to_handle(t))
             .map_err(|e| map_device_error(&e))
     }));

--- a/tenferro-einsum/Cargo.toml
+++ b/tenferro-einsum/Cargo.toml
@@ -13,6 +13,7 @@ tenferro-prims = { path = "../tenferro-prims" }
 tenferro-tensor = { path = "../tenferro-tensor" }
 chainrules = { path = "../extern/chainrules" }
 strided-view.workspace = true
+num-traits.workspace = true
 
 [dev-dependencies]
 num-complex.workspace = true

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -226,7 +226,8 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 
 use chainrules::{AdResult, Differentiable, DualTensor, NodeId, ReverseRule, TrackedTensor};
-use tenferro_algebra::{HasAlgebra, Scalar};
+use num_traits::{One, Zero};
+use tenferro_algebra::{Algebra, HasAlgebra, Scalar};
 use tenferro_device::{Error, LogicalMemorySpace, Result};
 use tenferro_prims::{Extension, PrimDescriptor, ReduceOp, TensorPrims};
 use tenferro_tensor::{MemoryOrder, Tensor};
@@ -479,17 +480,18 @@ fn manual_einsum<T: Scalar>(
 // ============================================================================
 
 /// Execute a single-tensor einsum operation via TensorPrims.
-fn execute_single_tensor_einsum<T, Alg, Backend>(
+fn execute_single_tensor_einsum<Alg, Backend>(
     ctx: &mut Backend::Context,
     subs_a: &[u32],
     subs_c: &[u32],
-    input: &Tensor<T>,
-    alpha: T,
-    beta: T,
-    output: &mut Tensor<T>,
+    input: &Tensor<Alg::Scalar>,
+    alpha: Alg::Scalar,
+    beta: Alg::Scalar,
+    output: &mut Tensor<Alg::Scalar>,
 ) -> Result<()>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     // Count label occurrences in input and output
@@ -521,7 +523,7 @@ where
                 modes_b: subs_c.to_vec(),
             };
             let shapes = [input.dims(), output.dims()];
-            let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
+            let plan = Backend::plan(ctx, &desc, &shapes)?;
             Backend::execute(ctx, &plan, alpha, &[input], beta, output)
         } else if output_set.is_subset(&input_set) {
             // Reduction (sum over labels not in output)
@@ -531,7 +533,7 @@ where
                 op: ReduceOp::Sum,
             };
             let shapes = [input.dims(), output.dims()];
-            let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
+            let plan = Backend::plan(ctx, &desc, &shapes)?;
             Backend::execute(ctx, &plan, alpha, &[input], beta, output)
         } else {
             Err(Error::InvalidArgument(
@@ -594,7 +596,7 @@ where
                 paired,
             };
             let shapes = [input.dims(), output.dims()];
-            let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
+            let plan = Backend::plan(ctx, &desc, &shapes)?;
             Backend::execute(ctx, &plan, alpha, &[input], beta, output)
         } else {
             // Diagonal extraction: repeated labels appear in output
@@ -643,7 +645,7 @@ where
                     modes_b: subs_c.to_vec(),
                 };
                 let shapes = [diag_tensor.dims(), output.dims()];
-                let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
+                let plan = Backend::plan(ctx, &desc, &shapes)?;
                 Backend::execute(ctx, &plan, alpha, &[&diag_tensor], beta, output)
             } else {
                 // Copy diagonal to contiguous temp, then reduce
@@ -654,7 +656,7 @@ where
                     op: ReduceOp::Sum,
                 };
                 let shapes = [diag_tensor.dims(), output.dims()];
-                let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
+                let plan = Backend::plan(ctx, &desc, &shapes)?;
                 Backend::execute(ctx, &plan, alpha, &[&diag_tensor], beta, output)
             }
         }
@@ -696,7 +698,7 @@ where
             paired,
         };
         let shapes = [input.dims(), output.dims()];
-        let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
+        let plan = Backend::plan(ctx, &desc, &shapes)?;
         Backend::execute(ctx, &plan, alpha, &[input], beta, output)
     } else {
         Err(Error::InvalidArgument(
@@ -771,19 +773,20 @@ fn classify_modes(
 /// 4. BatchedGemm → temp [batch..., m, n]
 /// 5. Reshape temp → [batch..., lo..., ro...]
 /// 6. Permute to output with alpha/beta
-fn fallback_pairwise_contraction<T, A, B>(
+fn fallback_pairwise_contraction<A, B>(
     ctx: &mut B::Context,
     subs_a: &[u32],
     subs_b: &[u32],
     subs_c: &[u32],
-    a: &Tensor<T>,
-    b: &Tensor<T>,
-    alpha: T,
-    beta: T,
-    output: &mut Tensor<T>,
+    a: &Tensor<A::Scalar>,
+    b: &Tensor<A::Scalar>,
+    alpha: A::Scalar,
+    beta: A::Scalar,
+    output: &mut Tensor<A::Scalar>,
 ) -> Result<()>
 where
-    T: Scalar + HasAlgebra<Algebra = A>,
+    A: Algebra,
+    A::Scalar: Scalar + HasAlgebra<Algebra = A>,
     B: TensorPrims<A>,
 {
     let (batch_modes, lo_modes, ro_modes, sum_modes) = classify_modes(subs_a, subs_b, subs_c);
@@ -813,7 +816,7 @@ where
         .chain(sum_modes.iter())
         .copied()
         .collect();
-    let perm_a = permute_or_copy::<T, A, B>(ctx, a, subs_a, &target_a)?;
+    let perm_a = permute_or_copy::<A, B>(ctx, a, subs_a, &target_a)?;
 
     // --- Step 2: Permute B to [batch, sum, ro] ---
     let target_b: Vec<u32> = batch_modes
@@ -822,7 +825,7 @@ where
         .chain(ro_modes.iter())
         .copied()
         .collect();
-    let perm_b = permute_or_copy::<T, A, B>(ctx, b, subs_b, &target_b)?;
+    let perm_b = permute_or_copy::<A, B>(ctx, b, subs_b, &target_b)?;
 
     // --- Step 3: Reshape to [batch..., m, k] and [batch..., k, n] ---
     let a_gemm_shape: Vec<usize> = batch_sizes
@@ -849,7 +852,8 @@ where
 
     // --- Step 4: BatchedGemm → temp ---
     let memory_space = a.logical_memory_space();
-    let mut temp = Tensor::<T>::zeros(&c_gemm_shape, memory_space, MemoryOrder::ColumnMajor);
+    let mut temp =
+        Tensor::<A::Scalar>::zeros(&c_gemm_shape, memory_space, MemoryOrder::ColumnMajor);
 
     let desc = PrimDescriptor::BatchedGemm {
         batch_dims: batch_sizes.clone(),
@@ -858,13 +862,13 @@ where
         k,
     };
     let shapes = [a_reshaped.dims(), b_reshaped.dims(), temp.dims()];
-    let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+    let plan = B::plan(ctx, &desc, &shapes)?;
     B::execute(
         ctx,
         &plan,
-        T::one(),
+        A::Scalar::one(),
         &[&a_reshaped, &b_reshaped],
-        T::zero(),
+        A::Scalar::zero(),
         &mut temp,
     )?;
 
@@ -888,7 +892,7 @@ where
     // If canonical == subs_c, we can skip the final permute
     if canonical_modes == subs_c {
         // Direct copy with alpha/beta
-        if alpha == T::one() && beta == T::zero() {
+        if alpha == A::Scalar::one() && beta == A::Scalar::zero() {
             *output = temp_expanded;
         } else {
             let desc = PrimDescriptor::Permute {
@@ -896,7 +900,7 @@ where
                 modes_b: subs_c.to_vec(),
             };
             let shapes = [temp_expanded.dims(), output.dims()];
-            let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+            let plan = B::plan(ctx, &desc, &shapes)?;
             B::execute(ctx, &plan, alpha, &[&temp_expanded], beta, output)?;
         }
     } else {
@@ -906,7 +910,7 @@ where
             modes_b: subs_c.to_vec(),
         };
         let shapes = [temp_expanded.dims(), output.dims()];
-        let plan = B::plan::<T>(ctx, &desc, &shapes)?;
+        let plan = B::plan(ctx, &desc, &shapes)?;
         B::execute(ctx, &plan, alpha, &[&temp_expanded], beta, output)?;
     }
 
@@ -917,19 +921,20 @@ where
 ///
 /// If `current_subs == target_subs`, returns a contiguous copy (MakeContiguous)
 /// if needed. Otherwise, permutes to the target order, then makes contiguous.
-fn permute_or_copy<T, A, B>(
+fn permute_or_copy<A, B>(
     ctx: &mut B::Context,
-    tensor: &Tensor<T>,
+    tensor: &Tensor<A::Scalar>,
     current_subs: &[u32],
     target_subs: &[u32],
-) -> Result<Tensor<T>>
+) -> Result<Tensor<A::Scalar>>
 where
-    T: Scalar + HasAlgebra<Algebra = A>,
+    A: Algebra,
+    A::Scalar: Scalar + HasAlgebra<Algebra = A>,
     B: TensorPrims<A>,
 {
     if current_subs == target_subs {
         // No permutation needed; ensure contiguous
-        return make_contiguous_if_needed::<T, A, B>(ctx, tensor);
+        return make_contiguous_if_needed::<A, B>(ctx, tensor);
     }
 
     // Compute target shape from the permutation
@@ -945,77 +950,96 @@ where
 
     // Permute via prim
     let memory_space = tensor.logical_memory_space();
-    let mut permuted = Tensor::<T>::zeros(&target_shape, memory_space, MemoryOrder::ColumnMajor);
+    let mut permuted =
+        Tensor::<A::Scalar>::zeros(&target_shape, memory_space, MemoryOrder::ColumnMajor);
     let desc = PrimDescriptor::Permute {
         modes_a: current_subs.to_vec(),
         modes_b: target_subs.to_vec(),
     };
     let shapes = [tensor.dims(), permuted.dims()];
-    let plan = B::plan::<T>(ctx, &desc, &shapes)?;
-    B::execute(ctx, &plan, T::one(), &[tensor], T::zero(), &mut permuted)?;
+    let plan = B::plan(ctx, &desc, &shapes)?;
+    B::execute(
+        ctx,
+        &plan,
+        A::Scalar::one(),
+        &[tensor],
+        A::Scalar::zero(),
+        &mut permuted,
+    )?;
 
     // The result is already contiguous (freshly allocated)
     Ok(permuted)
 }
 
 /// Ensure a tensor is contiguous, copying if necessary.
-fn make_contiguous_if_needed<T, A, B>(ctx: &mut B::Context, tensor: &Tensor<T>) -> Result<Tensor<T>>
+fn make_contiguous_if_needed<A, B>(
+    ctx: &mut B::Context,
+    tensor: &Tensor<A::Scalar>,
+) -> Result<Tensor<A::Scalar>>
 where
-    T: Scalar + HasAlgebra<Algebra = A>,
+    A: Algebra,
+    A::Scalar: Scalar + HasAlgebra<Algebra = A>,
     B: TensorPrims<A>,
 {
     if tensor.is_contiguous() {
         return Ok(tensor.clone());
     }
     let memory_space = tensor.logical_memory_space();
-    let mut result = Tensor::<T>::zeros(tensor.dims(), memory_space, MemoryOrder::ColumnMajor);
+    let mut result =
+        Tensor::<A::Scalar>::zeros(tensor.dims(), memory_space, MemoryOrder::ColumnMajor);
     let desc = PrimDescriptor::MakeContiguous;
     let shapes = [tensor.dims(), result.dims()];
-    let plan = B::plan::<T>(ctx, &desc, &shapes)?;
-    B::execute(ctx, &plan, T::one(), &[tensor], T::zero(), &mut result)?;
+    let plan = B::plan(ctx, &desc, &shapes)?;
+    B::execute(
+        ctx,
+        &plan,
+        A::Scalar::one(),
+        &[tensor],
+        A::Scalar::zero(),
+        &mut result,
+    )?;
     Ok(result)
 }
 
 /// Execute a pairwise contraction of two tensors via TensorPrims.
-fn execute_pairwise_contraction<T, Alg, Backend>(
+fn execute_pairwise_contraction<Alg, Backend>(
     ctx: &mut Backend::Context,
     subs_a: &[u32],
     subs_b: &[u32],
     subs_c: &[u32],
-    a: &Tensor<T>,
-    b: &Tensor<T>,
-    alpha: T,
-    beta: T,
-    output: &mut Tensor<T>,
+    a: &Tensor<Alg::Scalar>,
+    b: &Tensor<Alg::Scalar>,
+    alpha: Alg::Scalar,
+    beta: Alg::Scalar,
+    output: &mut Tensor<Alg::Scalar>,
 ) -> Result<()>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     // Check for element-wise multiplication (same labels, same order)
-    if subs_a == subs_b
-        && subs_a == subs_c
-        && Backend::has_extension_for::<T>(Extension::ElementwiseMul)
+    if subs_a == subs_b && subs_a == subs_c && Backend::has_extension_for(Extension::ElementwiseMul)
     {
         let desc = PrimDescriptor::ElementwiseMul;
         let shapes = [a.dims(), b.dims(), output.dims()];
-        let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
+        let plan = Backend::plan(ctx, &desc, &shapes)?;
         return Backend::execute(ctx, &plan, alpha, &[a, b], beta, output);
     }
 
     // General contraction via Contract extension
-    if Backend::has_extension_for::<T>(Extension::Contract) {
+    if Backend::has_extension_for(Extension::Contract) {
         let desc = PrimDescriptor::Contract {
             modes_a: subs_a.to_vec(),
             modes_b: subs_b.to_vec(),
             modes_c: subs_c.to_vec(),
         };
         let shapes = [a.dims(), b.dims(), output.dims()];
-        let plan = Backend::plan::<T>(ctx, &desc, &shapes)?;
+        let plan = Backend::plan(ctx, &desc, &shapes)?;
         Backend::execute(ctx, &plan, alpha, &[a, b], beta, output)
     } else {
         // Fallback: decompose into Permute + BatchedGemm
-        fallback_pairwise_contraction::<T, Alg, Backend>(
+        fallback_pairwise_contraction::<Alg, Backend>(
             ctx, subs_a, subs_b, subs_c, a, b, alpha, beta, output,
         )
     }
@@ -1026,16 +1050,17 @@ where
 // ============================================================================
 
 /// Execute a ContractionTree against concrete input tensors.
-fn execute_tree<T, Alg, Backend>(
+fn execute_tree<Alg, Backend>(
     ctx: &mut Backend::Context,
     tree: &ContractionTree,
-    operands: &[&Tensor<T>],
-    alpha: T,
-    beta: T,
-    output: &mut Tensor<T>,
+    operands: &[&Tensor<Alg::Scalar>],
+    alpha: Alg::Scalar,
+    beta: Alg::Scalar,
+    output: &mut Tensor<Alg::Scalar>,
 ) -> Result<()>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     let n_inputs = tree.subscripts.inputs.len();
@@ -1047,7 +1072,7 @@ where
                 "ContractionTree with no steps requires exactly 1 input".into(),
             ));
         }
-        return execute_single_tensor_einsum::<T, Alg, Backend>(
+        return execute_single_tensor_einsum::<Alg, Backend>(
             ctx,
             &tree.subscripts.inputs[0],
             &tree.subscripts.output,
@@ -1059,15 +1084,15 @@ where
     }
 
     // Multi-tensor case: follow the contraction tree
-    let mut intermediates: Vec<Tensor<T>> = Vec::new();
+    let mut intermediates: Vec<Tensor<Alg::Scalar>> = Vec::new();
 
     for (step_idx, step) in tree.steps.iter().enumerate() {
-        let left: &Tensor<T> = if step.left < n_inputs {
+        let left: &Tensor<Alg::Scalar> = if step.left < n_inputs {
             operands[step.left]
         } else {
             &intermediates[step.left - n_inputs]
         };
-        let right: &Tensor<T> = if step.right < n_inputs {
+        let right: &Tensor<Alg::Scalar> = if step.right < n_inputs {
             operands[step.right]
         } else {
             &intermediates[step.right - n_inputs]
@@ -1079,7 +1104,7 @@ where
 
         if is_last {
             // Last step: write directly to output with alpha/beta
-            execute_pairwise_contraction::<T, Alg, Backend>(
+            execute_pairwise_contraction::<Alg, Backend>(
                 ctx,
                 subs_left,
                 subs_right,
@@ -1098,16 +1123,16 @@ where
             let result_shape = compute_output_shape(subs_result, &tree.size_dict)?;
             let memory_space = infer_memory_space(operands)?;
             let mut result =
-                Tensor::<T>::zeros(&result_shape, memory_space, MemoryOrder::ColumnMajor);
-            execute_pairwise_contraction::<T, Alg, Backend>(
+                Tensor::<Alg::Scalar>::zeros(&result_shape, memory_space, MemoryOrder::ColumnMajor);
+            execute_pairwise_contraction::<Alg, Backend>(
                 ctx,
                 subs_left,
                 subs_right,
                 subs_result,
                 left,
                 right,
-                T::one(),
-                T::zero(),
+                Alg::Scalar::one(),
+                Alg::Scalar::zero(),
                 &mut result,
             )?;
             intermediates.push(result);
@@ -1441,25 +1466,27 @@ impl ContractionTree {
 ///
 /// Returns an error if the notation is invalid or tensor shapes are
 /// incompatible with the subscripts.
-pub fn einsum<T, Alg, Backend>(
+pub fn einsum<Alg, Backend>(
     ctx: &mut Backend::Context,
     subscripts: &str,
-    operands: &[&Tensor<T>],
+    operands: &[&Tensor<Alg::Scalar>],
     size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
+) -> Result<Tensor<Alg::Scalar>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     let subs = Subscripts::parse(subscripts)?;
-    let mut output = einsum_with_subscripts::<T, Alg, Backend>(ctx, &subs, operands, size_dict)?;
+    let mut output = einsum_with_subscripts::<Alg, Backend>(ctx, &subs, operands, size_dict)?;
 
     // Auto-propagate forward-mode tangents
     if operands.iter().any(|t| t.has_fw_grad()) {
-        let tangents: Vec<Option<&Tensor<T>>> = operands.iter().map(|t| t.fw_grad()).collect();
+        let tangents: Vec<Option<&Tensor<Alg::Scalar>>> =
+            operands.iter().map(|t| t.fw_grad()).collect();
         // einsum_frule_impl calls einsum_with_subscripts (not einsum), so no recursion
         if let Ok(output_tangent) =
-            einsum_frule_impl::<T, Alg, Backend>(ctx, &subs, operands, &tangents)
+            einsum_frule_impl::<Alg, Backend>(ctx, &subs, operands, &tangents)
         {
             output.set_fw_grad(output_tangent);
         }
@@ -1476,19 +1503,20 @@ where
 /// # Errors
 ///
 /// Returns an error if tensor shapes are incompatible with the subscripts.
-pub fn einsum_with_subscripts<T, Alg, Backend>(
+pub fn einsum_with_subscripts<Alg, Backend>(
     ctx: &mut Backend::Context,
     subscripts: &Subscripts,
-    operands: &[&Tensor<T>],
+    operands: &[&Tensor<Alg::Scalar>],
     size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
+) -> Result<Tensor<Alg::Scalar>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     let shapes: Vec<&[usize]> = operands.iter().map(|t| t.dims()).collect();
     let tree = ContractionTree::optimize(subscripts, &shapes)?;
-    einsum_with_plan::<T, Alg, Backend>(ctx, &tree, operands, size_dict)
+    einsum_with_plan::<Alg, Backend>(ctx, &tree, operands, size_dict)
 }
 
 /// Execute einsum with a pre-optimized [`ContractionTree`].
@@ -1501,14 +1529,15 @@ where
 ///
 /// Returns an error if the operand shapes do not match those used to
 /// build the contraction tree.
-pub fn einsum_with_plan<T, Alg, Backend>(
+pub fn einsum_with_plan<Alg, Backend>(
     ctx: &mut Backend::Context,
     tree: &ContractionTree,
-    operands: &[&Tensor<T>],
+    operands: &[&Tensor<Alg::Scalar>],
     size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
+) -> Result<Tensor<Alg::Scalar>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     // Merge size_dict from tree and optional extra
@@ -1521,8 +1550,16 @@ where
     let output_shape = compute_output_shape(&tree.subscripts.output, &sd)?;
     // Allocate the output tensor on the same memory space as the operands.
     let memory_space = infer_memory_space(operands)?;
-    let mut output = Tensor::<T>::zeros(&output_shape, memory_space, MemoryOrder::ColumnMajor);
-    execute_tree::<T, Alg, Backend>(ctx, tree, operands, T::one(), T::zero(), &mut output)?;
+    let mut output =
+        Tensor::<Alg::Scalar>::zeros(&output_shape, memory_space, MemoryOrder::ColumnMajor);
+    execute_tree::<Alg, Backend>(
+        ctx,
+        tree,
+        operands,
+        Alg::Scalar::one(),
+        Alg::Scalar::zero(),
+        &mut output,
+    )?;
     Ok(output)
 }
 
@@ -1559,18 +1596,19 @@ where
 ///
 /// Returns an error if the notation is invalid or tensor shapes are
 /// incompatible with the subscripts.
-pub fn einsum_owned<T, Alg, Backend>(
+pub fn einsum_owned<Alg, Backend>(
     ctx: &mut Backend::Context,
     subscripts: &str,
-    operands: Vec<Tensor<T>>,
+    operands: Vec<Tensor<Alg::Scalar>>,
     size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
+) -> Result<Tensor<Alg::Scalar>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
-    let refs: Vec<&Tensor<T>> = operands.iter().collect();
-    einsum::<T, Alg, Backend>(ctx, subscripts, &refs, size_dict)
+    let refs: Vec<&Tensor<Alg::Scalar>> = operands.iter().collect();
+    einsum::<Alg, Backend>(ctx, subscripts, &refs, size_dict)
 }
 
 /// Execute einsum with pre-built [`Subscripts`], consuming the input tensors.
@@ -1581,18 +1619,19 @@ where
 /// # Errors
 ///
 /// Returns an error if tensor shapes are incompatible with the subscripts.
-pub fn einsum_with_subscripts_owned<T, Alg, Backend>(
+pub fn einsum_with_subscripts_owned<Alg, Backend>(
     ctx: &mut Backend::Context,
     subscripts: &Subscripts,
-    operands: Vec<Tensor<T>>,
+    operands: Vec<Tensor<Alg::Scalar>>,
     size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
+) -> Result<Tensor<Alg::Scalar>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
-    let refs: Vec<&Tensor<T>> = operands.iter().collect();
-    einsum_with_subscripts::<T, Alg, Backend>(ctx, subscripts, &refs, size_dict)
+    let refs: Vec<&Tensor<Alg::Scalar>> = operands.iter().collect();
+    einsum_with_subscripts::<Alg, Backend>(ctx, subscripts, &refs, size_dict)
 }
 
 /// Execute einsum with a pre-optimized [`ContractionTree`], consuming the
@@ -1606,18 +1645,19 @@ where
 ///
 /// Returns an error if the operand shapes do not match those used to
 /// build the contraction tree.
-pub fn einsum_with_plan_owned<T, Alg, Backend>(
+pub fn einsum_with_plan_owned<Alg, Backend>(
     ctx: &mut Backend::Context,
     tree: &ContractionTree,
-    operands: Vec<Tensor<T>>,
+    operands: Vec<Tensor<Alg::Scalar>>,
     size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
+) -> Result<Tensor<Alg::Scalar>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
-    let refs: Vec<&Tensor<T>> = operands.iter().collect();
-    einsum_with_plan::<T, Alg, Backend>(ctx, tree, &refs, size_dict)
+    let refs: Vec<&Tensor<Alg::Scalar>> = operands.iter().collect();
+    einsum_with_plan::<Alg, Backend>(ctx, tree, &refs, size_dict)
 }
 
 // ============================================================================
@@ -1665,21 +1705,22 @@ where
 ///
 /// Returns an error if the notation is invalid, tensor shapes are
 /// incompatible, or the output shape does not match the expected result.
-pub fn einsum_into<T, Alg, Backend>(
+pub fn einsum_into<Alg, Backend>(
     ctx: &mut Backend::Context,
     subscripts: &str,
-    operands: &[&Tensor<T>],
-    alpha: T,
-    beta: T,
-    output: &mut Tensor<T>,
+    operands: &[&Tensor<Alg::Scalar>],
+    alpha: Alg::Scalar,
+    beta: Alg::Scalar,
+    output: &mut Tensor<Alg::Scalar>,
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<()>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     let subs = Subscripts::parse(subscripts)?;
-    einsum_with_subscripts_into::<T, Alg, Backend>(
+    einsum_with_subscripts_into::<Alg, Backend>(
         ctx, &subs, operands, alpha, beta, output, size_dict,
     )
 }
@@ -1711,22 +1752,23 @@ where
 ///
 /// Returns an error if tensor shapes are incompatible with the subscripts
 /// or the output shape does not match.
-pub fn einsum_with_subscripts_into<T, Alg, Backend>(
+pub fn einsum_with_subscripts_into<Alg, Backend>(
     ctx: &mut Backend::Context,
     subscripts: &Subscripts,
-    operands: &[&Tensor<T>],
-    alpha: T,
-    beta: T,
-    output: &mut Tensor<T>,
+    operands: &[&Tensor<Alg::Scalar>],
+    alpha: Alg::Scalar,
+    beta: Alg::Scalar,
+    output: &mut Tensor<Alg::Scalar>,
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<()>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     let shapes: Vec<&[usize]> = operands.iter().map(|t| t.dims()).collect();
     let tree = ContractionTree::optimize(subscripts, &shapes)?;
-    einsum_with_plan_into::<T, Alg, Backend>(ctx, &tree, operands, alpha, beta, output, size_dict)
+    einsum_with_plan_into::<Alg, Backend>(ctx, &tree, operands, alpha, beta, output, size_dict)
 }
 
 /// Execute einsum with a pre-optimized [`ContractionTree`], accumulating
@@ -1762,21 +1804,22 @@ where
 ///
 /// Returns an error if the operand shapes do not match those used to
 /// build the contraction tree, or the output shape is incorrect.
-pub fn einsum_with_plan_into<T, Alg, Backend>(
+pub fn einsum_with_plan_into<Alg, Backend>(
     ctx: &mut Backend::Context,
     tree: &ContractionTree,
-    operands: &[&Tensor<T>],
-    alpha: T,
-    beta: T,
-    output: &mut Tensor<T>,
+    operands: &[&Tensor<Alg::Scalar>],
+    alpha: Alg::Scalar,
+    beta: Alg::Scalar,
+    output: &mut Tensor<Alg::Scalar>,
     size_dict: Option<&HashMap<u32, usize>>,
 ) -> Result<()>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     let _ = size_dict; // size_dict already captured in tree.size_dict
-    execute_tree::<T, Alg, Backend>(ctx, tree, operands, alpha, beta, output)
+    execute_tree::<Alg, Backend>(ctx, tree, operands, alpha, beta, output)
 }
 
 // ============================================================================
@@ -1785,26 +1828,31 @@ where
 
 /// ReverseRule for einsum — stores subscripts, primal tensors, and shared
 /// backend context for backend-optimized pullback.
-struct EinsumReverseRule<T, Alg, Backend>
+struct EinsumReverseRule<Alg, Backend>
 where
-    T: Scalar,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
-    Tensor<T>: Differentiable<Tangent = Tensor<T>>,
+    Tensor<Alg::Scalar>: Differentiable<Tangent = Tensor<Alg::Scalar>>,
 {
     ctx: Rc<RefCell<Backend::Context>>,
     subscripts: Subscripts,
-    primals: Vec<Tensor<T>>,
+    primals: Vec<Tensor<Alg::Scalar>>,
     input_node_ids: Vec<Option<NodeId>>,
     _phantom: PhantomData<Alg>,
 }
 
-impl<T, Alg, Backend> ReverseRule<Tensor<T>> for EinsumReverseRule<T, Alg, Backend>
+impl<Alg, Backend> ReverseRule<Tensor<Alg::Scalar>> for EinsumReverseRule<Alg, Backend>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
-    Tensor<T>: Differentiable<Tangent = Tensor<T>>,
+    Tensor<Alg::Scalar>: Differentiable<Tangent = Tensor<Alg::Scalar>>,
 {
-    fn pullback(&self, cotangent: &Tensor<T>) -> AdResult<Vec<(NodeId, Tensor<T>)>> {
+    fn pullback(
+        &self,
+        cotangent: &Tensor<Alg::Scalar>,
+    ) -> AdResult<Vec<(NodeId, Tensor<Alg::Scalar>)>> {
         let n = self.primals.len();
         let mut results = Vec::new();
         let mut ctx = self.ctx.borrow_mut();
@@ -1817,7 +1865,7 @@ where
 
             // Build reverse einsum subscripts
             let mut rev_inputs_subs = vec![self.subscripts.output.clone()];
-            let mut rev_operands: Vec<&Tensor<T>> = vec![cotangent];
+            let mut rev_operands: Vec<&Tensor<Alg::Scalar>> = vec![cotangent];
 
             for (i, primal) in self.primals.iter().enumerate() {
                 if i != k {
@@ -1832,19 +1880,15 @@ where
             };
 
             // Use backend-optimized einsum
-            let mut grad = einsum_with_subscripts::<T, Alg, Backend>(
-                &mut *ctx,
-                &rev_subs,
-                &rev_operands,
-                None,
-            )
-            .map_err(|e| chainrules::AutodiffError::InvalidArgument(format!("{e}")))?;
+            let mut grad =
+                einsum_with_subscripts::<Alg, Backend>(&mut *ctx, &rev_subs, &rev_operands, None)
+                    .map_err(|e| chainrules::AutodiffError::InvalidArgument(format!("{e}")))?;
 
             // Propagate fw_grad from operands through the reverse einsum
             if rev_operands.iter().any(|t| t.has_fw_grad()) {
-                let tangents: Vec<Option<&Tensor<T>>> =
+                let tangents: Vec<Option<&Tensor<Alg::Scalar>>> =
                     rev_operands.iter().map(|t| t.fw_grad()).collect();
-                if let Ok(grad_tangent) = einsum_frule_impl::<T, Alg, Backend>(
+                if let Ok(grad_tangent) = einsum_frule_impl::<Alg, Backend>(
                     &mut *ctx,
                     &rev_subs,
                     &rev_operands,
@@ -1902,22 +1946,23 @@ where
 /// let _ga = grads.get(a.node_id().unwrap()).unwrap();
 /// ```
 ///
-pub fn tracked_einsum<T, Alg: 'static, Backend>(
+pub fn tracked_einsum<Alg: 'static, Backend>(
     ctx: Rc<RefCell<Backend::Context>>,
     subscripts: &str,
-    operands: &[&TrackedTensor<Tensor<T>>],
-) -> AdResult<TrackedTensor<Tensor<T>>>
+    operands: &[&TrackedTensor<Tensor<Alg::Scalar>>],
+) -> AdResult<TrackedTensor<Tensor<Alg::Scalar>>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg> + 'static,
-    Tensor<T>: Differentiable<Tangent = Tensor<T>>,
+    Tensor<Alg::Scalar>: Differentiable<Tangent = Tensor<Alg::Scalar>>,
 {
     let subs = Subscripts::parse(subscripts)
         .map_err(|e| chainrules::AutodiffError::InvalidArgument(format!("{e}")))?;
 
     // Extract primals and run forward einsum
-    let primals: Vec<&Tensor<T>> = operands.iter().map(|op| op.value()).collect();
-    let output = einsum::<T, Alg, Backend>(&mut *ctx.borrow_mut(), subscripts, &primals, None)
+    let primals: Vec<&Tensor<Alg::Scalar>> = operands.iter().map(|op| op.value()).collect();
+    let output = einsum::<Alg, Backend>(&mut *ctx.borrow_mut(), subscripts, &primals, None)
         .map_err(|e| chainrules::AutodiffError::InvalidArgument(format!("{e}")))?;
 
     // Check if any operand requires gradients
@@ -1946,7 +1991,7 @@ where
         }
     }
 
-    let rule = EinsumReverseRule::<T, Alg, Backend> {
+    let rule = EinsumReverseRule::<Alg, Backend> {
         ctx: ctx.clone(),
         subscripts: subs,
         primals: primals.iter().map(|&t| t.clone()).collect(),
@@ -1984,27 +2029,29 @@ where
 /// let c_dual = dual_einsum::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a_dual, &b_dual]).unwrap();
 /// let _tangent = c_dual.tangent();
 /// ```
-pub fn dual_einsum<T, Alg, Backend>(
+pub fn dual_einsum<Alg, Backend>(
     ctx: &mut Backend::Context,
     subscripts: &str,
-    operands: &[&DualTensor<Tensor<T>>],
-) -> AdResult<DualTensor<Tensor<T>>>
+    operands: &[&DualTensor<Tensor<Alg::Scalar>>],
+) -> AdResult<DualTensor<Tensor<Alg::Scalar>>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
-    Tensor<T>: Differentiable<Tangent = Tensor<T>>,
+    Tensor<Alg::Scalar>: Differentiable<Tangent = Tensor<Alg::Scalar>>,
 {
     // Extract primals
-    let primals: Vec<&Tensor<T>> = operands.iter().map(|op| op.primal()).collect();
+    let primals: Vec<&Tensor<Alg::Scalar>> = operands.iter().map(|op| op.primal()).collect();
 
     // Compute primal output
-    let output = einsum::<T, Alg, Backend>(ctx, subscripts, &primals, None)
+    let output = einsum::<Alg, Backend>(ctx, subscripts, &primals, None)
         .map_err(|e| chainrules::AutodiffError::InvalidArgument(format!("{e}")))?;
 
     // Compute tangent: dC = sum_k einsum(subs, [A0, ..., dAk, ..., An])
-    let tangents: Vec<Option<&Tensor<T>>> = operands.iter().map(|op| op.tangent()).collect();
+    let tangents: Vec<Option<&Tensor<Alg::Scalar>>> =
+        operands.iter().map(|op| op.tangent()).collect();
 
-    let tangent = einsum_frule::<T, Alg, Backend>(ctx, subscripts, &primals, &tangents);
+    let tangent = einsum_frule::<Alg, Backend>(ctx, subscripts, &primals, &tangents);
 
     match tangent {
         Ok(t) => DualTensor::with_tangent(output, t),
@@ -2036,14 +2083,15 @@ where
 /// let grads = einsum_rrule::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &grad_c).unwrap();
 /// assert_eq!(grads.len(), 2);
 /// ```
-pub fn einsum_rrule<T, Alg, Backend>(
+pub fn einsum_rrule<Alg, Backend>(
     ctx: &mut Backend::Context,
     subscripts: &str,
-    operands: &[&Tensor<T>],
-    cotangent: &Tensor<T>,
-) -> Result<Vec<Tensor<T>>>
+    operands: &[&Tensor<Alg::Scalar>],
+    cotangent: &Tensor<Alg::Scalar>,
+) -> Result<Vec<Tensor<Alg::Scalar>>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     let subs = Subscripts::parse(subscripts)?;
@@ -2054,7 +2102,7 @@ where
         // Build reverse subscripts for operand k:
         // grad_Ak = einsum([cotangent, A_0, ..., A_{k-1}, A_{k+1}, ..., A_n])
         let mut rev_inputs_subs = vec![subs.output.clone()];
-        let mut rev_operands: Vec<&Tensor<T>> = vec![cotangent];
+        let mut rev_operands: Vec<&Tensor<Alg::Scalar>> = vec![cotangent];
 
         for (i, &op) in operands.iter().enumerate() {
             if i != k {
@@ -2068,7 +2116,7 @@ where
             output: subs.inputs[k].clone(),
         };
 
-        let grad = einsum_with_subscripts::<T, Alg, Backend>(ctx, &rev_subs, &rev_operands, None)?;
+        let grad = einsum_with_subscripts::<Alg, Backend>(ctx, &rev_subs, &rev_operands, None)?;
         grads.push(grad);
     }
 
@@ -2099,31 +2147,32 @@ where
 /// let dc = einsum_frule::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &[Some(&da), None]).unwrap();
 /// ```
 /// Internal frule implementation with pre-parsed subscripts.
-fn einsum_frule_impl<T, Alg, Backend>(
+fn einsum_frule_impl<Alg, Backend>(
     ctx: &mut Backend::Context,
     subs: &Subscripts,
-    primals: &[&Tensor<T>],
-    tangents: &[Option<&Tensor<T>>],
-) -> Result<Tensor<T>>
+    primals: &[&Tensor<Alg::Scalar>],
+    tangents: &[Option<&Tensor<Alg::Scalar>>],
+) -> Result<Tensor<Alg::Scalar>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     let n = primals.len();
 
     // dC = sum_k einsum(subs, [A0, ..., dAk, ..., An]) for each k with tangent
-    let mut result: Option<Tensor<T>> = None;
+    let mut result: Option<Tensor<Alg::Scalar>> = None;
 
     for k in 0..n {
         if let Some(tangent_k) = tangents[k] {
-            let mut ops: Vec<&Tensor<T>> = primals.to_vec();
+            let mut ops: Vec<&Tensor<Alg::Scalar>> = primals.to_vec();
             ops[k] = tangent_k;
 
-            let term = einsum_with_subscripts::<T, Alg, Backend>(ctx, subs, &ops, None)?;
+            let term = einsum_with_subscripts::<Alg, Backend>(ctx, subs, &ops, None)?;
 
             result = Some(match result {
                 None => term,
-                Some(existing) => Tensor::<T>::accumulate_tangent(existing, &term),
+                Some(existing) => Tensor::<Alg::Scalar>::accumulate_tangent(existing, &term),
             });
         }
     }
@@ -2131,18 +2180,19 @@ where
     result.ok_or_else(|| Error::InvalidArgument("no tangents provided".into()))
 }
 
-pub fn einsum_frule<T, Alg, Backend>(
+pub fn einsum_frule<Alg, Backend>(
     ctx: &mut Backend::Context,
     subscripts: &str,
-    primals: &[&Tensor<T>],
-    tangents: &[Option<&Tensor<T>>],
-) -> Result<Tensor<T>>
+    primals: &[&Tensor<Alg::Scalar>],
+    tangents: &[Option<&Tensor<Alg::Scalar>>],
+) -> Result<Tensor<Alg::Scalar>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     let subs = Subscripts::parse(subscripts)?;
-    einsum_frule_impl::<T, Alg, Backend>(ctx, &subs, primals, tangents)
+    einsum_frule_impl::<Alg, Backend>(ctx, &subs, primals, tangents)
 }
 
 /// Local HVP rule for einsum without building a global tape.
@@ -2186,16 +2236,17 @@ where
 /// let (_grad_a, _hvp_a) = &results[0];
 /// let (_grad_b, _hvp_b) = &results[1];
 /// ```
-pub fn einsum_hvp<T, Alg, Backend>(
+pub fn einsum_hvp<Alg, Backend>(
     ctx: &mut Backend::Context,
     subscripts: &str,
-    primals: &[&Tensor<T>],
-    tangents: &[Option<&Tensor<T>>],
-    cotangent: &Tensor<T>,
-    cotangent_tangent: &Tensor<T>,
-) -> Result<Vec<(Tensor<T>, Tensor<T>)>>
+    primals: &[&Tensor<Alg::Scalar>],
+    tangents: &[Option<&Tensor<Alg::Scalar>>],
+    cotangent: &Tensor<Alg::Scalar>,
+    cotangent_tangent: &Tensor<Alg::Scalar>,
+) -> Result<Vec<(Tensor<Alg::Scalar>, Tensor<Alg::Scalar>)>>
 where
-    T: Scalar + HasAlgebra<Algebra = Alg>,
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
     Backend: TensorPrims<Alg>,
 {
     let subs = Subscripts::parse(subscripts)?;
@@ -2221,27 +2272,26 @@ where
         };
 
         // Compute gradient_k
-        let mut rev_operands: Vec<&Tensor<T>> = vec![cotangent];
+        let mut rev_operands: Vec<&Tensor<Alg::Scalar>> = vec![cotangent];
         for (i, &op) in primals.iter().enumerate() {
             if i != k {
                 rev_operands.push(op);
             }
         }
-        let grad_k =
-            einsum_with_subscripts::<T, Alg, Backend>(ctx, &rev_subs, &rev_operands, None)?;
+        let grad_k = einsum_with_subscripts::<Alg, Backend>(ctx, &rev_subs, &rev_operands, None)?;
 
         // Compute hvp_k: differentiate the gradient w.r.t. v
         // hvp_k = einsum([dḡ, A_others...]) + sum_{j!=k} einsum([ḡ, ..., dA_j, ...])
-        let mut hvp_k: Option<Tensor<T>>;
+        let mut hvp_k: Option<Tensor<Alg::Scalar>>;
 
         // Term from cotangent_tangent
-        let mut ops: Vec<&Tensor<T>> = vec![cotangent_tangent];
+        let mut ops: Vec<&Tensor<Alg::Scalar>> = vec![cotangent_tangent];
         for (i, &op) in primals.iter().enumerate() {
             if i != k {
                 ops.push(op);
             }
         }
-        let term = einsum_with_subscripts::<T, Alg, Backend>(ctx, &rev_subs, &ops, None)?;
+        let term = einsum_with_subscripts::<Alg, Backend>(ctx, &rev_subs, &ops, None)?;
         hvp_k = Some(term);
 
         // Terms from tangents of other primals
@@ -2250,7 +2300,7 @@ where
                 continue;
             }
             if let Some(tangent_j) = tangents[j] {
-                let mut ops: Vec<&Tensor<T>> = vec![cotangent];
+                let mut ops: Vec<&Tensor<Alg::Scalar>> = vec![cotangent];
                 for (i, &op) in primals.iter().enumerate() {
                     if i != k {
                         if i == j {
@@ -2260,10 +2310,10 @@ where
                         }
                     }
                 }
-                let term = einsum_with_subscripts::<T, Alg, Backend>(ctx, &rev_subs, &ops, None)?;
+                let term = einsum_with_subscripts::<Alg, Backend>(ctx, &rev_subs, &ops, None)?;
                 hvp_k = Some(match hvp_k {
                     None => term,
-                    Some(existing) => Tensor::<T>::accumulate_tangent(existing, &term),
+                    Some(existing) => Tensor::<Alg::Scalar>::accumulate_tangent(existing, &term),
                 });
             }
         }

--- a/tenferro-einsum/tests/einsum_tests.rs
+++ b/tenferro-einsum/tests/einsum_tests.rs
@@ -123,7 +123,7 @@ fn contraction_tree_single_tensor() {
     )
     .unwrap();
     let mut ctx = CpuContext::new(1);
-    let result = einsum_with_plan::<f64, S, CpuBackend>(&mut ctx, &tree, &[&a], None).unwrap();
+    let result = einsum_with_plan::<S, CpuBackend>(&mut ctx, &tree, &[&a], None).unwrap();
     assert_eq!(result.dims(), &[4, 3]);
 }
 
@@ -141,7 +141,7 @@ fn contraction_tree_two_tensors() {
     )
     .unwrap();
     let mut ctx = CpuContext::new(1);
-    let c = einsum_with_plan::<f64, S, CpuBackend>(&mut ctx, &tree, &[&a, &b], None).unwrap();
+    let c = einsum_with_plan::<S, CpuBackend>(&mut ctx, &tree, &[&a, &b], None).unwrap();
     assert_eq!(c.dims(), &[2, 4]);
 }
 
@@ -171,8 +171,7 @@ fn contraction_tree_from_pairs() {
     )
     .unwrap();
     let mut ctx = CpuContext::new(1);
-    let d = einsum_with_plan::<f64, S, CpuBackend>(&mut ctx, &tree, &[&a, &b, &c_tensor], None)
-        .unwrap();
+    let d = einsum_with_plan::<S, CpuBackend>(&mut ctx, &tree, &[&a, &b, &c_tensor], None).unwrap();
     assert_eq!(d.dims(), &[2, 5]);
 }
 
@@ -185,7 +184,7 @@ fn einsum_identity() {
     let mut ctx = CpuContext::new(1);
     // a[ij] -> a[ij] (identity copy)
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
-    let b = einsum::<f64, S, CpuBackend>(&mut ctx, "ij->ij", &[&a], None).unwrap();
+    let b = einsum::<S, CpuBackend>(&mut ctx, "ij->ij", &[&a], None).unwrap();
     assert_eq!(b.dims(), &[2, 3]);
     for i in 0..2 {
         for j in 0..3 {
@@ -198,7 +197,7 @@ fn einsum_identity() {
 fn einsum_transpose() {
     let mut ctx = CpuContext::new(1);
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
-    let b = einsum::<f64, S, CpuBackend>(&mut ctx, "ij->ji", &[&a], None).unwrap();
+    let b = einsum::<S, CpuBackend>(&mut ctx, "ij->ji", &[&a], None).unwrap();
     assert_eq!(b.dims(), &[3, 2]);
     for i in 0..2 {
         for j in 0..3 {
@@ -212,7 +211,7 @@ fn einsum_sum_reduce() {
     let mut ctx = CpuContext::new(1);
     // Sum over j: result_i = sum_j a_{ij}
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
-    let b = einsum::<f64, S, CpuBackend>(&mut ctx, "ij->i", &[&a], None).unwrap();
+    let b = einsum::<S, CpuBackend>(&mut ctx, "ij->i", &[&a], None).unwrap();
     assert_eq!(b.dims(), &[2]);
     // a is column-major: a[0,0]=1, a[1,0]=2, a[0,1]=3, a[1,1]=4, a[0,2]=5, a[1,2]=6
     // b[0] = a[0,0] + a[0,1] + a[0,2] = 1+3+5 = 9
@@ -226,7 +225,7 @@ fn einsum_full_contraction() {
     let mut ctx = CpuContext::new(1);
     // Sum all elements: scalar = sum_{ij} a_{ij}
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
-    let b = einsum::<f64, S, CpuBackend>(&mut ctx, "ij->", &[&a], None).unwrap();
+    let b = einsum::<S, CpuBackend>(&mut ctx, "ij->", &[&a], None).unwrap();
     assert!(b.dims().is_empty());
     assert!((scalar_val(&b) - 21.0).abs() < 1e-10);
 }
@@ -237,7 +236,7 @@ fn einsum_trace() {
     // tr(A) = sum_i a_{ii}
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
     // column-major: a[0,0]=1, a[1,0]=2, a[0,1]=3, a[1,1]=4
-    let tr = einsum::<f64, S, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
+    let tr = einsum::<S, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
     assert!(tr.dims().is_empty());
     assert!((scalar_val(&tr) - 5.0).abs() < 1e-10); // 1 + 4 = 5
 }
@@ -250,7 +249,7 @@ fn einsum_diagonal_extraction() {
         .unwrap();
     // column-major: a[0,0]=1, a[1,0]=2, a[2,0]=3, a[0,1]=4, a[1,1]=5, a[2,1]=6,
     //               a[0,2]=7, a[1,2]=8, a[2,2]=9
-    let d = einsum::<f64, S, CpuBackend>(&mut ctx, "ii->i", &[&a], None).unwrap();
+    let d = einsum::<S, CpuBackend>(&mut ctx, "ii->i", &[&a], None).unwrap();
     assert_eq!(d.dims(), &[3]);
     assert!((get(&d, &[0]) - 1.0).abs() < 1e-10);
     assert!((get(&d, &[1]) - 5.0).abs() < 1e-10);
@@ -262,7 +261,7 @@ fn einsum_diagonal_embedding() {
     let mut ctx = CpuContext::new(1);
     // Diagonal embedding: v_i -> diag(v)_{ii}
     let v = Tensor::<f64>::from_slice(&[2.0, 3.0, 5.0], &[3], COL).unwrap();
-    let d = einsum::<f64, S, CpuBackend>(&mut ctx, "i->ii", &[&v], None).unwrap();
+    let d = einsum::<S, CpuBackend>(&mut ctx, "i->ii", &[&v], None).unwrap();
     assert_eq!(d.dims(), &[3, 3]);
     for i in 0..3 {
         for j in 0..3 {
@@ -293,7 +292,7 @@ fn einsum_matmul() {
         COL,
     )
     .unwrap();
-    let c = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+    let c = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
     assert_eq!(c.dims(), &[2, 4]);
 
     // Verify against manual computation
@@ -317,7 +316,7 @@ fn einsum_outer_product() {
     let mut ctx = CpuContext::new(1);
     let u = Tensor::<f64>::from_slice(&[1.0, 2.0], &[2], COL).unwrap();
     let v = Tensor::<f64>::from_slice(&[3.0, 4.0, 5.0], &[3], COL).unwrap();
-    let m = einsum::<f64, S, CpuBackend>(&mut ctx, "i,j->ij", &[&u, &v], None).unwrap();
+    let m = einsum::<S, CpuBackend>(&mut ctx, "i,j->ij", &[&u, &v], None).unwrap();
     assert_eq!(m.dims(), &[2, 3]);
 
     for i in 0..2 {
@@ -337,7 +336,7 @@ fn einsum_dot_product() {
     let mut ctx = CpuContext::new(1);
     let u = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0], &[3], COL).unwrap();
     let v = Tensor::<f64>::from_slice(&[4.0, 5.0, 6.0], &[3], COL).unwrap();
-    let d = einsum::<f64, S, CpuBackend>(&mut ctx, "i,i->", &[&u, &v], None).unwrap();
+    let d = einsum::<S, CpuBackend>(&mut ctx, "i,i->", &[&u, &v], None).unwrap();
     assert!(d.dims().is_empty());
     // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
     assert!((scalar_val(&d) - 32.0).abs() < 1e-10);
@@ -349,7 +348,7 @@ fn einsum_matvec() {
     // y = A @ x
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
     let x = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0], &[3], COL).unwrap();
-    let y = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,j->i", &[&a, &x], None).unwrap();
+    let y = einsum::<S, CpuBackend>(&mut ctx, "ij,j->i", &[&a, &x], None).unwrap();
     assert_eq!(y.dims(), &[2]);
 
     for i in 0..2 {
@@ -371,7 +370,7 @@ fn einsum_elementwise_mul() {
     // Hadamard product: C_{ij} = A_{ij} * B_{ij}
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
     let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], COL).unwrap();
-    let c = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,ij->ij", &[&a, &b], None).unwrap();
+    let c = einsum::<S, CpuBackend>(&mut ctx, "ij,ij->ij", &[&a, &b], None).unwrap();
     assert_eq!(c.dims(), &[2, 2]);
 
     for i in 0..2 {
@@ -397,14 +396,14 @@ fn einsum_three_matrices() {
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
     let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], COL).unwrap();
     let c = Tensor::<f64>::from_slice(&[9.0, 10.0, 11.0, 12.0], &[2, 2], COL).unwrap();
-    let d = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk,kl->il", &[&a, &b, &c], None).unwrap();
+    let d = einsum::<S, CpuBackend>(&mut ctx, "ij,jk,kl->il", &[&a, &b, &c], None).unwrap();
     assert_eq!(d.dims(), &[2, 2]);
 
     // Verify: D = A @ B @ C
     // First compute AB
-    let ab = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+    let ab = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
     // Then ABC
-    let abc = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&ab, &c], None).unwrap();
+    let abc = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&ab, &c], None).unwrap();
 
     for i in 0..2 {
         for j in 0..2 {
@@ -435,7 +434,7 @@ fn einsum_with_subscripts_matmul() {
         COL,
     )
     .unwrap();
-    let c = einsum_with_subscripts::<f64, S, CpuBackend>(&mut ctx, &subs, &[&a, &b], None).unwrap();
+    let c = einsum_with_subscripts::<S, CpuBackend>(&mut ctx, &subs, &[&a, &b], None).unwrap();
     assert_eq!(c.dims(), &[2, 4]);
 }
 
@@ -451,7 +450,7 @@ fn einsum_owned_matmul() {
         COL,
     )
     .unwrap();
-    let c = einsum_owned::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", vec![a, b], None).unwrap();
+    let c = einsum_owned::<S, CpuBackend>(&mut ctx, "ij,jk->ik", vec![a, b], None).unwrap();
     assert_eq!(c.dims(), &[2, 4]);
 }
 
@@ -463,8 +462,7 @@ fn einsum_into_overwrite() {
     let mut c = Tensor::<f64>::zeros(&[2, 2], MEM, COL);
 
     // C = 1.0 * (A @ B) + 0.0 * C
-    einsum_into::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], 1.0, 0.0, &mut c, None)
-        .unwrap();
+    einsum_into::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], 1.0, 0.0, &mut c, None).unwrap();
 
     for i in 0..2 {
         for k in 0..2 {
@@ -489,8 +487,7 @@ fn einsum_into_accumulate() {
     let mut c = Tensor::<f64>::ones(&[2, 2], MEM, COL);
 
     // C = 2.0 * (A @ B) + 3.0 * C
-    einsum_into::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], 2.0, 3.0, &mut c, None)
-        .unwrap();
+    einsum_into::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], 2.0, 3.0, &mut c, None).unwrap();
 
     for i in 0..2 {
         for k in 0..2 {
@@ -530,7 +527,7 @@ fn einsum_reuses_cached_plans() {
     .unwrap();
 
     // First call: populates cache
-    let c1 = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+    let c1 = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
     let cache_size_after_first = ctx.plan_cache_mut().len();
     assert!(
         cache_size_after_first > 0,
@@ -538,7 +535,7 @@ fn einsum_reuses_cached_plans() {
     );
 
     // Second call with same shapes: cache should not grow
-    let c2 = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+    let c2 = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
     let cache_size_after_second = ctx.plan_cache_mut().len();
     assert_eq!(
         cache_size_after_first, cache_size_after_second,
@@ -571,7 +568,7 @@ fn einsum_different_shapes_miss_cache() {
         COL,
     )
     .unwrap();
-    let _c1 = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a1, &b1], None).unwrap();
+    let _c1 = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a1, &b1], None).unwrap();
     let cache_size_1 = ctx.plan_cache_mut().len();
 
     // 3x2 @ 2x5 (different shapes)
@@ -582,7 +579,7 @@ fn einsum_different_shapes_miss_cache() {
         COL,
     )
     .unwrap();
-    let _c2 = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a2, &b2], None).unwrap();
+    let _c2 = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a2, &b2], None).unwrap();
     let cache_size_2 = ctx.plan_cache_mut().len();
 
     assert!(
@@ -609,8 +606,7 @@ fn einsum_rrule_matmul() {
     .unwrap();
     let grad_c = Tensor::<f64>::ones(&[2, 4], MEM, COL);
 
-    let grads =
-        einsum_rrule::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &grad_c).unwrap();
+    let grads = einsum_rrule::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &grad_c).unwrap();
     assert_eq!(grads.len(), 2);
 
     // grad_A = grad_C @ B^T: shape [2,4] x [4,3] = [2,3]
@@ -619,8 +615,7 @@ fn einsum_rrule_matmul() {
     assert_eq!(grads[1].dims(), &[3, 4]);
 
     // Verify grad_A = einsum("ik,jk->ij", [grad_c, b]) = grad_c @ b^T
-    let expected_ga =
-        einsum::<f64, S, CpuBackend>(&mut ctx, "ik,jk->ij", &[&grad_c, &b], None).unwrap();
+    let expected_ga = einsum::<S, CpuBackend>(&mut ctx, "ik,jk->ij", &[&grad_c, &b], None).unwrap();
     for i in 0..2 {
         for j in 0..3 {
             assert!(
@@ -631,8 +626,7 @@ fn einsum_rrule_matmul() {
     }
 
     // Verify grad_B = einsum("ij,ik->jk", [a, grad_c]) = a^T @ grad_c
-    let expected_gb =
-        einsum::<f64, S, CpuBackend>(&mut ctx, "ij,ik->jk", &[&a, &grad_c], None).unwrap();
+    let expected_gb = einsum::<S, CpuBackend>(&mut ctx, "ij,ik->jk", &[&a, &grad_c], None).unwrap();
     for i in 0..3 {
         for j in 0..4 {
             assert!(
@@ -658,13 +652,12 @@ fn einsum_frule_matmul() {
     let da = Tensor::<f64>::ones(&[2, 3], MEM, COL);
 
     // dC = einsum("ij,jk->ik", [dA, B]) since only A has a tangent
-    let dc =
-        einsum_frule::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &[Some(&da), None])
-            .unwrap();
+    let dc = einsum_frule::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &[Some(&da), None])
+        .unwrap();
     assert_eq!(dc.dims(), &[2, 4]);
 
     // Verify: dC = dA @ B
-    let expected = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&da, &b], None).unwrap();
+    let expected = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&da, &b], None).unwrap();
     for i in 0..2 {
         for k in 0..4 {
             assert!(
@@ -684,17 +677,13 @@ fn einsum_frule_both_tangents() {
     let db = Tensor::<f64>::ones(&[2, 2], MEM, COL);
 
     // dC = dA @ B + A @ dB
-    let dc = einsum_frule::<f64, S, CpuBackend>(
-        &mut ctx,
-        "ij,jk->ik",
-        &[&a, &b],
-        &[Some(&da), Some(&db)],
-    )
-    .unwrap();
+    let dc =
+        einsum_frule::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &[Some(&da), Some(&db)])
+            .unwrap();
     assert_eq!(dc.dims(), &[2, 2]);
 
-    let term1 = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&da, &b], None).unwrap();
-    let term2 = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &db], None).unwrap();
+    let term1 = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&da, &b], None).unwrap();
+    let term2 = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &db], None).unwrap();
 
     for i in 0..2 {
         for k in 0..2 {
@@ -718,7 +707,7 @@ fn einsum_shape_mismatch() {
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
     let b = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
     // j=3 in A but j=2 in B -> shape mismatch
-    let result = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None);
+    let result = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None);
     assert!(
         matches!(result, Err(tenferro_device::Error::ShapeMismatch { .. })),
         "expected ShapeMismatch, got: {:?}",
@@ -731,7 +720,7 @@ fn einsum_wrong_operand_count() {
     let mut ctx = CpuContext::new(1);
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
     // Subscripts say 2 inputs but only 1 provided
-    let result = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a], None);
+    let result = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a], None);
     assert!(
         matches!(result, Err(tenferro_device::Error::InvalidArgument(_))),
         "expected InvalidArgument for wrong operand count, got: {:?}",
@@ -769,11 +758,11 @@ fn tracked_einsum_matmul_pullback() {
     let b_id = b.node_id().expect("leaf should have node_id");
 
     // C = A @ B  (tracked)
-    let c = tracked_einsum::<f64, S, CpuBackend>(ctx.clone(), "ij,jk->ik", &[&a, &b])
+    let c = tracked_einsum::<S, CpuBackend>(ctx.clone(), "ij,jk->ik", &[&a, &b])
         .expect("tracked_einsum should succeed");
 
     // loss = sum_{ij} C_{ij}^2  via "ij,ij->"
-    let loss = tracked_einsum::<f64, S, CpuBackend>(ctx.clone(), "ij,ij->", &[&c, &c])
+    let loss = tracked_einsum::<S, CpuBackend>(ctx.clone(), "ij,ij->", &[&c, &c])
         .expect("tracked_einsum for loss should succeed");
 
     // Pullback
@@ -807,7 +796,7 @@ fn tracked_einsum_matmul_pullback() {
 
     // Numerical verification: d(loss)/dA = 2 * C @ B^T
     // C = A @ B
-    let c_val = einsum::<f64, S, CpuBackend>(
+    let c_val = einsum::<S, CpuBackend>(
         &mut ctx.borrow_mut(),
         "ij,jk->ik",
         &[&a_data, &b_data],
@@ -815,7 +804,7 @@ fn tracked_einsum_matmul_pullback() {
     )
     .expect("einsum for C");
     // grad_C = 2 * C (since loss = sum C_{ik}^2)
-    let two_c = einsum::<f64, S, CpuBackend>(
+    let two_c = einsum::<S, CpuBackend>(
         &mut ctx.borrow_mut(),
         "ij,->ij",
         &[
@@ -827,11 +816,11 @@ fn tracked_einsum_matmul_pullback() {
     .expect("scale by 2");
     // grad_A = grad_C @ B^T = einsum("ik,jk->ij", [2*C, B])
     let expected_ga =
-        einsum::<f64, S, CpuBackend>(&mut ctx.borrow_mut(), "ik,jk->ij", &[&two_c, &b_data], None)
+        einsum::<S, CpuBackend>(&mut ctx.borrow_mut(), "ik,jk->ij", &[&two_c, &b_data], None)
             .expect("expected grad_A");
     // grad_B = A^T @ grad_C = einsum("ij,ik->jk", [A, 2*C])
     let expected_gb =
-        einsum::<f64, S, CpuBackend>(&mut ctx.borrow_mut(), "ij,ik->jk", &[&a_data, &two_c], None)
+        einsum::<S, CpuBackend>(&mut ctx.borrow_mut(), "ij,ik->jk", &[&a_data, &two_c], None)
             .expect("expected grad_B");
 
     for i in 0..2 {
@@ -873,7 +862,7 @@ fn tracked_einsum_rejects_mixed_tapes() {
     let a = tape1.leaf(a_data);
     let b = tape2.leaf(b_data);
 
-    let result = tracked_einsum::<f64, S, CpuBackend>(ctx.clone(), "ij,jk->ik", &[&a, &b]);
+    let result = tracked_einsum::<S, CpuBackend>(ctx.clone(), "ij,jk->ik", &[&a, &b]);
     assert!(result.is_err(), "expected error for mixed-tape operands");
 }
 
@@ -1005,7 +994,7 @@ macro_rules! typed_einsum_tests {
                 let a = make_tensor(&[2, 3], |idx| {
                     <$T as TestScalar>::from_usize(idx[0] * 3 + idx[1] + 1)
                 });
-                let b = einsum::<$T, TS, CpuBackend>(&mut ctx, "ij->ij", &[&a], None).unwrap();
+                let b = einsum::<TS, CpuBackend>(&mut ctx, "ij->ij", &[&a], None).unwrap();
                 assert_eq!(b.dims(), &[2, 3]);
                 for i in 0..2 {
                     for j in 0..3 {
@@ -1020,7 +1009,7 @@ macro_rules! typed_einsum_tests {
                 let a = make_tensor(&[2, 3], |idx| {
                     <$T as TestScalar>::from_usize(idx[0] * 3 + idx[1] + 1)
                 });
-                let b = einsum::<$T, TS, CpuBackend>(&mut ctx, "ij->ji", &[&a], None).unwrap();
+                let b = einsum::<TS, CpuBackend>(&mut ctx, "ij->ji", &[&a], None).unwrap();
                 assert_eq!(b.dims(), &[3, 2]);
                 for i in 0..2 {
                     for j in 0..3 {
@@ -1035,7 +1024,7 @@ macro_rules! typed_einsum_tests {
                 let a = make_tensor(&[2, 3], |idx| {
                     <$T as TestScalar>::from_usize(idx[0] * 3 + idx[1] + 1)
                 });
-                let b = einsum::<$T, TS, CpuBackend>(&mut ctx, "ij->i", &[&a], None).unwrap();
+                let b = einsum::<TS, CpuBackend>(&mut ctx, "ij->i", &[&a], None).unwrap();
                 assert_eq!(b.dims(), &[2]);
                 for i in 0..2 {
                     let mut expected = <$T as TestScalar>::from_f64(0.0);
@@ -1058,7 +1047,7 @@ macro_rules! typed_einsum_tests {
                 let a = make_tensor(&[2, 3], |idx| {
                     <$T as TestScalar>::from_usize(idx[0] * 3 + idx[1] + 1)
                 });
-                let b = einsum::<$T, TS, CpuBackend>(&mut ctx, "ij->", &[&a], None).unwrap();
+                let b = einsum::<TS, CpuBackend>(&mut ctx, "ij->", &[&a], None).unwrap();
                 assert!(b.dims().is_empty());
                 // sum of 1..6 = 21
                 let expected = <$T as TestScalar>::from_f64(21.0);
@@ -1079,7 +1068,7 @@ macro_rules! typed_einsum_tests {
                 });
                 // a[0,0]=1, a[0,1]=2, a[1,0]=3, a[1,1]=4
                 // trace = a[0,0] + a[1,1] = 1 + 4 = 5
-                let tr = einsum::<$T, TS, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
+                let tr = einsum::<TS, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
                 assert!(tr.dims().is_empty());
                 let expected = get_t(&a, &[0, 0]) + get_t(&a, &[1, 1]);
                 assert!(
@@ -1099,8 +1088,7 @@ macro_rules! typed_einsum_tests {
                 let b = make_tensor(&[3, 4], |idx| {
                     <$T as TestScalar>::from_usize(idx[0] * 4 + idx[1] + 1)
                 });
-                let c =
-                    einsum::<$T, TS, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+                let c = einsum::<TS, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
                 assert_eq!(c.dims(), &[2, 4]);
 
                 for i in 0..2 {
@@ -1125,7 +1113,7 @@ macro_rules! typed_einsum_tests {
                 let mut ctx = CpuContext::new(1);
                 let u = make_tensor(&[2], |idx| <$T as TestScalar>::from_usize(idx[0] + 1));
                 let v = make_tensor(&[3], |idx| <$T as TestScalar>::from_usize(idx[0] + 3));
-                let m = einsum::<$T, TS, CpuBackend>(&mut ctx, "i,j->ij", &[&u, &v], None).unwrap();
+                let m = einsum::<TS, CpuBackend>(&mut ctx, "i,j->ij", &[&u, &v], None).unwrap();
                 assert_eq!(m.dims(), &[2, 3]);
 
                 for i in 0..2 {
@@ -1146,7 +1134,7 @@ macro_rules! typed_einsum_tests {
                 let mut ctx = CpuContext::new(1);
                 let u = make_tensor(&[3], |idx| <$T as TestScalar>::from_usize(idx[0] + 1));
                 let v = make_tensor(&[3], |idx| <$T as TestScalar>::from_usize(idx[0] + 4));
-                let d = einsum::<$T, TS, CpuBackend>(&mut ctx, "i,i->", &[&u, &v], None).unwrap();
+                let d = einsum::<TS, CpuBackend>(&mut ctx, "i,i->", &[&u, &v], None).unwrap();
                 assert!(d.dims().is_empty());
                 // u = [1,2,3], v = [4,5,6], dot = 4+10+18 = 32
                 let expected = <$T as TestScalar>::from_f64(32.0);
@@ -1167,8 +1155,7 @@ macro_rules! typed_einsum_tests {
                 let b = make_tensor(&[2, 2], |idx| {
                     <$T as TestScalar>::from_usize(idx[0] * 2 + idx[1] + 5)
                 });
-                let c =
-                    einsum::<$T, TS, CpuBackend>(&mut ctx, "ij,ij->ij", &[&a, &b], None).unwrap();
+                let c = einsum::<TS, CpuBackend>(&mut ctx, "ij,ij->ij", &[&a, &b], None).unwrap();
                 assert_eq!(c.dims(), &[2, 2]);
 
                 for i in 0..2 {
@@ -1196,15 +1183,14 @@ macro_rules! typed_einsum_tests {
                 let c = make_tensor(&[2, 2], |idx| {
                     <$T as TestScalar>::from_usize(idx[0] * 2 + idx[1] + 9)
                 });
-                let d = einsum::<$T, TS, CpuBackend>(&mut ctx, "ij,jk,kl->il", &[&a, &b, &c], None)
+                let d = einsum::<TS, CpuBackend>(&mut ctx, "ij,jk,kl->il", &[&a, &b, &c], None)
                     .unwrap();
                 assert_eq!(d.dims(), &[2, 2]);
 
                 // Verify: D = A @ B @ C
-                let ab =
-                    einsum::<$T, TS, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+                let ab = einsum::<TS, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
                 let abc =
-                    einsum::<$T, TS, CpuBackend>(&mut ctx, "ij,jk->ik", &[&ab, &c], None).unwrap();
+                    einsum::<TS, CpuBackend>(&mut ctx, "ij,jk->ik", &[&ab, &c], None).unwrap();
 
                 for i in 0..2 {
                     for j in 0..2 {
@@ -1293,7 +1279,7 @@ fn einsum_self_contraction_trace() {
     // 2x3x2 tensor
     let data: Vec<f64> = (1..=12).map(|x| x as f64).collect();
     let t = Tensor::<f64>::from_slice(&data, &[2, 3, 2], COL).unwrap();
-    let v = einsum::<f64, S, CpuBackend>(&mut ctx, "ijk->j", &[&t], None).unwrap();
+    let v = einsum::<S, CpuBackend>(&mut ctx, "ijk->j", &[&t], None).unwrap();
     assert_eq!(v.dims(), &[3]);
 
     // Manual verification: sum over i and k
@@ -1319,7 +1305,7 @@ fn einsum_partial_trace_with_free_index() {
     let mut ctx = CpuContext::new(1);
     let data: Vec<f64> = (1..=12).map(|x| x as f64).collect();
     let t = Tensor::<f64>::from_slice(&data, &[2, 2, 3], COL).unwrap();
-    let v = einsum::<f64, S, CpuBackend>(&mut ctx, "iij->j", &[&t], None).unwrap();
+    let v = einsum::<S, CpuBackend>(&mut ctx, "iij->j", &[&t], None).unwrap();
     assert_eq!(v.dims(), &[3]);
 
     // Manual: v[j] = sum_i T[i,i,j]
@@ -1343,7 +1329,7 @@ fn einsum_trace_rank3_to_vector() {
     let mut ctx = CpuContext::new(1);
     let data: Vec<f64> = (1..=18).map(|x| x as f64).collect();
     let t = Tensor::<f64>::from_slice(&data, &[3, 2, 3], COL).unwrap();
-    let v = einsum::<f64, S, CpuBackend>(&mut ctx, "iji->j", &[&t], None).unwrap();
+    let v = einsum::<S, CpuBackend>(&mut ctx, "iji->j", &[&t], None).unwrap();
     assert_eq!(v.dims(), &[2]);
 
     // Manual: v[j] = sum_i T[i,j,i]
@@ -1366,7 +1352,7 @@ fn einsum_three_way_repeated_label_trace() {
     let mut ctx = CpuContext::new(1);
     let data: Vec<f64> = (1..=27).map(|x| x as f64).collect();
     let t = Tensor::<f64>::from_slice(&data, &[3, 3, 3], COL).unwrap();
-    let s = einsum::<f64, S, CpuBackend>(&mut ctx, "iii->", &[&t], None).unwrap();
+    let s = einsum::<S, CpuBackend>(&mut ctx, "iii->", &[&t], None).unwrap();
     assert!(s.dims().is_empty());
 
     // Manual: sum_i T[i,i,i]
@@ -1388,7 +1374,7 @@ fn einsum_batched_dot_product() {
     let mut ctx = CpuContext::new(1);
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[3, 2], COL).unwrap();
     let b = Tensor::<f64>::from_slice(&[7.0, 8.0, 9.0, 10.0, 11.0, 12.0], &[3, 2], COL).unwrap();
-    let c = einsum::<f64, S, CpuBackend>(&mut ctx, "bi,bi->b", &[&a, &b], None).unwrap();
+    let c = einsum::<S, CpuBackend>(&mut ctx, "bi,bi->b", &[&a, &b], None).unwrap();
     assert_eq!(c.dims(), &[3]);
 
     // Manual: c[b] = sum_i A[b,i] * B[b,i]
@@ -1426,12 +1412,12 @@ fn einsum_size_dict_explicit_shapes() {
     let b = Tensor::<f64>::from_slice(&b_data, &[3, 5], COL).unwrap();
     let c = Tensor::<f64>::from_slice(&c_data, &[5, 4], COL).unwrap();
 
-    let d = einsum_with_plan::<f64, S, CpuBackend>(&mut ctx, &tree, &[&a, &b, &c], None).unwrap();
+    let d = einsum_with_plan::<S, CpuBackend>(&mut ctx, &tree, &[&a, &b, &c], None).unwrap();
     assert_eq!(d.dims(), &[2, 4]);
 
     // Verify via sequential pairwise
-    let ab = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
-    let abc = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&ab, &c], None).unwrap();
+    let ab = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+    let abc = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&ab, &c], None).unwrap();
 
     for i in 0..2 {
         for j in 0..4 {
@@ -1452,7 +1438,7 @@ fn einsum_size_dict_output_only_label() {
     // This verifies the size-dict handles output-only repeated labels correctly.
     let mut ctx = CpuContext::new(1);
     let v = Tensor::<f64>::from_slice(&[7.0, 8.0, 9.0, 10.0], &[4], COL).unwrap();
-    let d = einsum::<f64, S, CpuBackend>(&mut ctx, "i->ii", &[&v], None).unwrap();
+    let d = einsum::<S, CpuBackend>(&mut ctx, "i->ii", &[&v], None).unwrap();
     assert_eq!(d.dims(), &[4, 4]);
 
     for i in 0..4 {
@@ -1526,7 +1512,7 @@ fn einsum_complex_diagonal_extraction() {
         .map(|x| Complex64::new(x as f64, -(x as f64)))
         .collect();
     let a = Tensor::<Complex64>::from_slice(&data, &[3, 3], COL).unwrap();
-    let d = einsum::<Complex64, CS, CpuBackend>(&mut ctx, "ii->i", &[&a], None).unwrap();
+    let d = einsum::<CS, CpuBackend>(&mut ctx, "ii->i", &[&a], None).unwrap();
     assert_eq!(d.dims(), &[3]);
 
     // Column-major 3x3: a[i,j] at offset i + 3*j
@@ -1558,7 +1544,7 @@ fn einsum_complex_diagonal_embedding() {
         Complex64::new(5.0, 0.5),
     ];
     let v = Tensor::<Complex64>::from_slice(&data, &[3], COL).unwrap();
-    let d = einsum::<Complex64, CS, CpuBackend>(&mut ctx, "i->ii", &[&v], None).unwrap();
+    let d = einsum::<CS, CpuBackend>(&mut ctx, "i->ii", &[&v], None).unwrap();
     assert_eq!(d.dims(), &[3, 3]);
 
     for i in 0..3 {
@@ -1587,7 +1573,7 @@ fn einsum_complex_trace() {
         .map(|x| Complex64::new(x as f64, 0.5 * x as f64))
         .collect();
     let a = Tensor::<Complex64>::from_slice(&data, &[2, 2], COL).unwrap();
-    let tr = einsum::<Complex64, CS, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
+    let tr = einsum::<CS, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
     assert!(tr.dims().is_empty());
 
     // Column-major 2x2: a[0,0] + a[1,1]
@@ -1610,7 +1596,7 @@ fn einsum_error_rank_mismatch() {
     // Subscripts say "ij" (rank 2) but tensor is rank 1
     let mut ctx = CpuContext::new(1);
     let v = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0], &[3], COL).unwrap();
-    let result = einsum::<f64, S, CpuBackend>(&mut ctx, "ij->i", &[&v], None);
+    let result = einsum::<S, CpuBackend>(&mut ctx, "ij->i", &[&v], None);
     assert!(result.is_err(), "should fail for rank mismatch");
 }
 
@@ -1619,7 +1605,7 @@ fn einsum_error_empty_inputs() {
     // No input tensors
     let mut ctx = CpuContext::new(1);
     let empty: &[&Tensor<f64>] = &[];
-    let result = einsum::<f64, S, CpuBackend>(&mut ctx, "->", empty, None);
+    let result = einsum::<S, CpuBackend>(&mut ctx, "->", empty, None);
     assert!(result.is_err(), "should fail for empty inputs");
 }
 
@@ -1628,7 +1614,7 @@ fn einsum_error_output_label_not_in_input() {
     // Output references label 'k' which is not in any input
     let mut ctx = CpuContext::new(1);
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
-    let result = einsum::<f64, S, CpuBackend>(&mut ctx, "ij->ik", &[&a], None);
+    let result = einsum::<S, CpuBackend>(&mut ctx, "ij->ik", &[&a], None);
     assert!(
         result.is_err(),
         "should fail when output label not in input"
@@ -1640,7 +1626,7 @@ fn einsum_error_non_square_trace() {
     // Trace "ii->" but matrix is 2x3 (non-square), so label 'i' has conflicting sizes
     let mut ctx = CpuContext::new(1);
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
-    let result = einsum::<f64, S, CpuBackend>(&mut ctx, "ii->", &[&a], None);
+    let result = einsum::<S, CpuBackend>(&mut ctx, "ii->", &[&a], None);
     assert!(
         matches!(result, Err(tenferro_device::Error::ShapeMismatch { .. })),
         "expected ShapeMismatch for non-square trace, got: {:?}",
@@ -1665,14 +1651,14 @@ fn einsum_auto_propagates_fw_grad() {
     a.set_fw_grad(da.clone());
 
     // C = einsum("ij,jk->ik", A, B)
-    let c = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+    let c = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
 
     // C should have fw_grad = einsum_frule result
     assert!(c.has_fw_grad(), "output should carry fw_grad");
 
     // Compare with explicit frule
     let expected =
-        einsum_frule::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &[Some(&da), None])
+        einsum_frule::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &[Some(&da), None])
             .unwrap();
 
     let cg = c.fw_grad().unwrap();
@@ -1695,7 +1681,7 @@ fn einsum_no_fw_grad_unchanged() {
     let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
     let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], COL).unwrap();
 
-    let c = einsum::<f64, S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+    let c = einsum::<S, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
     assert!(
         !c.has_fw_grad(),
         "output should NOT carry fw_grad when inputs have none"
@@ -1738,14 +1724,14 @@ fn hvp_via_fw_grad_composition() {
     let a_id = a.node_id().unwrap();
 
     // loss = sum_{ij} C_{ij}^2 where C = A @ B
-    let c = tracked_einsum::<f64, S, CpuBackend>(ctx.clone(), "ij,jk->ik", &[&a, &b]).unwrap();
-    let loss = tracked_einsum::<f64, S, CpuBackend>(ctx.clone(), "ij,ij->", &[&c, &c]).unwrap();
+    let c = tracked_einsum::<S, CpuBackend>(ctx.clone(), "ij,jk->ik", &[&a, &b]).unwrap();
+    let loss = tracked_einsum::<S, CpuBackend>(ctx.clone(), "ij,ij->", &[&c, &c]).unwrap();
 
     let grads = tape.pullback(&loss).unwrap();
     let ga = grads.get(a_id).unwrap();
 
     // grad_A should match 2*C @ B^T
-    let c_val = einsum::<f64, S, CpuBackend>(
+    let c_val = einsum::<S, CpuBackend>(
         &mut ctx.borrow_mut(),
         "ij,jk->ik",
         &[&a_data, &b_data],
@@ -1754,10 +1740,9 @@ fn hvp_via_fw_grad_composition() {
     .unwrap();
     let two = Tensor::<f64>::from_slice(&[2.0], &[], COL).unwrap();
     let two_c =
-        einsum::<f64, S, CpuBackend>(&mut ctx.borrow_mut(), "ij,->ij", &[&c_val, &two], None)
-            .unwrap();
+        einsum::<S, CpuBackend>(&mut ctx.borrow_mut(), "ij,->ij", &[&c_val, &two], None).unwrap();
     let expected_ga =
-        einsum::<f64, S, CpuBackend>(&mut ctx.borrow_mut(), "ik,jk->ij", &[&two_c, &b_data], None)
+        einsum::<S, CpuBackend>(&mut ctx.borrow_mut(), "ik,jk->ij", &[&two_c, &b_data], None)
             .unwrap();
 
     // Verify grad_A primal
@@ -1775,14 +1760,12 @@ fn hvp_via_fw_grad_composition() {
     // HVP: d(grad_A)/dt = 2*(dA@B)@B^T where dA = ones
     // dA@B = ones @ B = einsum("ij,jk->ik", ones, B)
     let ones = Tensor::<f64>::ones(&[2, 2], MEM, COL);
-    let da_b =
-        einsum::<f64, S, CpuBackend>(&mut ctx.borrow_mut(), "ij,jk->ik", &[&ones, &b_data], None)
-            .unwrap();
+    let da_b = einsum::<S, CpuBackend>(&mut ctx.borrow_mut(), "ij,jk->ik", &[&ones, &b_data], None)
+        .unwrap();
     // 2*(dA@B)@B^T = einsum("ik,jk->ij", 2*dA_B, B)
     let two_da_b =
-        einsum::<f64, S, CpuBackend>(&mut ctx.borrow_mut(), "ij,->ij", &[&da_b, &two], None)
-            .unwrap();
-    let expected_hvp = einsum::<f64, S, CpuBackend>(
+        einsum::<S, CpuBackend>(&mut ctx.borrow_mut(), "ij,->ij", &[&da_b, &two], None).unwrap();
+    let expected_hvp = einsum::<S, CpuBackend>(
         &mut ctx.borrow_mut(),
         "ik,jk->ij",
         &[&two_da_b, &b_data],

--- a/tenferro-prims/src/cpu.rs
+++ b/tenferro-prims/src/cpu.rs
@@ -991,20 +991,20 @@ fn execute_contract<T: Scalar>(
 // ===========================================================================
 
 impl<S: Scalar> TensorPrims<Standard<S>> for CpuBackend {
-    type Plan<T: Scalar> = CpuPlan<T>;
+    type Plan = CpuPlan<S>;
     type Context = CpuContext;
 
-    fn plan<T: Scalar>(
+    fn plan(
         ctx: &mut CpuContext,
         desc: &PrimDescriptor,
         shapes: &[&[usize]],
-    ) -> Result<CpuPlan<T>> {
+    ) -> Result<CpuPlan<S>> {
         // Check cache first
-        if let Some(cached) = ctx.plan_cache.get::<CpuPlan<T>>(desc, shapes) {
+        if let Some(cached) = ctx.plan_cache.get::<CpuPlan<S>>(desc, shapes) {
             return Ok(cached);
         }
 
-        let plan = Self::build_plan::<T>(desc, shapes)?;
+        let plan = Self::build_plan::<S>(desc, shapes)?;
 
         // Store in cache for future reuse
         ctx.plan_cache.insert(desc, shapes, plan.clone());
@@ -1012,20 +1012,20 @@ impl<S: Scalar> TensorPrims<Standard<S>> for CpuBackend {
         Ok(plan)
     }
 
-    fn execute<T: Scalar>(
+    fn execute(
         _ctx: &mut CpuContext,
-        plan: &CpuPlan<T>,
-        alpha: T,
-        inputs: &[&Tensor<T>],
-        beta: T,
-        output: &mut Tensor<T>,
+        plan: &CpuPlan<S>,
+        alpha: S,
+        inputs: &[&Tensor<S>],
+        beta: S,
+        output: &mut Tensor<S>,
     ) -> Result<()> {
         // Convert Tensor inputs to StridedView for internal dispatch
-        let views: Vec<StridedView<T>> = inputs
+        let views: Vec<StridedView<S>> = inputs
             .iter()
             .map(|t| tensor_to_view(t))
             .collect::<Result<Vec<_>>>()?;
-        let view_refs: Vec<&StridedView<T>> = views.iter().collect();
+        let view_refs: Vec<&StridedView<S>> = views.iter().collect();
         let mut out_view = tensor_to_view_mut(output)?;
 
         match plan {
@@ -1151,7 +1151,7 @@ impl<S: Scalar> TensorPrims<Standard<S>> for CpuBackend {
         }
     }
 
-    fn has_extension_for<T: Scalar>(_ext: Extension) -> bool {
+    fn has_extension_for(_ext: Extension) -> bool {
         // CPU backend supports both Contract and ElementwiseMul
         true
     }

--- a/tenferro-prims/src/gpu_stubs.rs
+++ b/tenferro-prims/src/gpu_stubs.rs
@@ -75,33 +75,33 @@ impl CudaBackend {
 
 #[cfg(not(feature = "cuda"))]
 impl<S: Scalar> TensorPrims<Standard<S>> for CudaBackend {
-    type Plan<T: Scalar> = CudaPlan<T>;
+    type Plan = CudaPlan<S>;
     type Context = CudaContext;
 
-    fn plan<T: Scalar>(
+    fn plan(
         _ctx: &mut CudaContext,
         _desc: &PrimDescriptor,
         _shapes: &[&[usize]],
-    ) -> Result<CudaPlan<T>> {
+    ) -> Result<CudaPlan<S>> {
         Err(Error::DeviceError(
             "CUDA backend not available: load cuTENSOR library first".into(),
         ))
     }
 
-    fn execute<T: Scalar>(
+    fn execute(
         _ctx: &mut CudaContext,
-        _plan: &CudaPlan<T>,
-        _alpha: T,
-        _inputs: &[&Tensor<T>],
-        _beta: T,
-        _output: &mut Tensor<T>,
+        _plan: &CudaPlan<S>,
+        _alpha: S,
+        _inputs: &[&Tensor<S>],
+        _beta: S,
+        _output: &mut Tensor<S>,
     ) -> Result<()> {
         Err(Error::DeviceError(
             "CUDA backend not available: load cuTENSOR library first".into(),
         ))
     }
 
-    fn has_extension_for<T: Scalar>(_ext: Extension) -> bool {
+    fn has_extension_for(_ext: Extension) -> bool {
         false
     }
 }
@@ -192,33 +192,33 @@ impl RocmBackend {
 }
 
 impl<S: Scalar> TensorPrims<Standard<S>> for RocmBackend {
-    type Plan<T: Scalar> = RocmPlan<T>;
+    type Plan = RocmPlan<S>;
     type Context = RocmContext;
 
-    fn plan<T: Scalar>(
+    fn plan(
         _ctx: &mut RocmContext,
         _desc: &PrimDescriptor,
         _shapes: &[&[usize]],
-    ) -> Result<RocmPlan<T>> {
+    ) -> Result<RocmPlan<S>> {
         Err(Error::DeviceError(
             "ROCm backend not available: load hipTENSOR library first".into(),
         ))
     }
 
-    fn execute<T: Scalar>(
+    fn execute(
         _ctx: &mut RocmContext,
-        _plan: &RocmPlan<T>,
-        _alpha: T,
-        _inputs: &[&Tensor<T>],
-        _beta: T,
-        _output: &mut Tensor<T>,
+        _plan: &RocmPlan<S>,
+        _alpha: S,
+        _inputs: &[&Tensor<S>],
+        _beta: S,
+        _output: &mut Tensor<S>,
     ) -> Result<()> {
         Err(Error::DeviceError(
             "ROCm backend not available: load hipTENSOR library first".into(),
         ))
     }
 
-    fn has_extension_for<T: Scalar>(_ext: Extension) -> bool {
+    fn has_extension_for(_ext: Extension) -> bool {
         // Not yet implemented. When available, hipTENSOR will support
         // Contract and ElementwiseMul for f32/f64/Complex.
         false

--- a/tenferro-prims/src/lib.rs
+++ b/tenferro-prims/src/lib.rs
@@ -121,7 +121,7 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use tenferro_algebra::Scalar;
+use tenferro_algebra::{Algebra, Scalar};
 use tenferro_device::{Error, Result};
 use tenferro_tensor::Tensor;
 
@@ -194,7 +194,7 @@ pub enum UnaryOp {
 /// use tenferro_prims::{CpuBackend, TensorPrims, Extension};
 ///
 /// // Check if element-wise multiplication is available for f64
-/// let available = CpuBackend::has_extension_for::<f64>(Extension::ElementwiseMul);
+/// let available = <CpuBackend as TensorPrims<Standard<f64>>>::has_extension_for(Extension::ElementwiseMul);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Extension {
@@ -329,7 +329,7 @@ pub enum PrimDescriptor {
     /// strategy). Maps to `cutensorContract` on GPU backends
     /// (not yet implemented).
     ///
-    /// Available when `has_extension_for::<T>(Extension::Contract)` returns true.
+    /// Available when `has_extension_for(Extension::Contract)` returns true.
     Contract {
         /// Mode labels for input tensor A.
         modes_a: Vec<u32>,
@@ -341,7 +341,7 @@ pub enum PrimDescriptor {
 
     /// Element-wise multiplication of two tensors.
     ///
-    /// Available when `has_extension_for::<T>(Extension::ElementwiseMul)` returns true.
+    /// Available when `has_extension_for(Extension::ElementwiseMul)` returns true.
     ElementwiseMul,
 
     // ====================================================================
@@ -386,12 +386,12 @@ pub enum PrimDescriptor {
 /// let desc = PrimDescriptor::BatchedGemm {
 ///     batch_dims: vec![], m: 3, n: 5, k: 4,
 /// };
-/// let plan = CpuBackend::plan::<f64>(&mut ctx, &desc, &[&[3, 4], &[4, 5], &[3, 5]]).unwrap();
-/// CpuBackend::execute(&mut ctx, &plan, 1.0, &[&a.view(), &b.view()], 0.0, &mut c.view_mut()).unwrap();
+/// let plan = <CpuBackend as TensorPrims<Standard<f64>>>::plan(&mut ctx, &desc, &[&[3, 4], &[4, 5], &[3, 5]]).unwrap();
+/// <CpuBackend as TensorPrims<Standard<f64>>>::execute(&mut ctx, &plan, 1.0, &[&a.view(), &b.view()], 0.0, &mut c.view_mut()).unwrap();
 /// ```
-pub trait TensorPrims<Alg> {
-    /// Backend-specific plan type (no type erasure).
-    type Plan<T: Scalar>;
+pub trait TensorPrims<Alg: Algebra> {
+    /// Backend-specific plan type.
+    type Plan;
 
     /// Backend-specific execution context.
     ///
@@ -405,33 +405,34 @@ pub trait TensorPrims<Alg> {
     /// The plan pre-computes kernel selection and workspace sizes.
     /// `shapes` contains the shape of each tensor involved in the operation
     /// (inputs first, then output).
-    fn plan<T: Scalar>(
+    fn plan(
         ctx: &mut Self::Context,
         desc: &PrimDescriptor,
         shapes: &[&[usize]],
-    ) -> Result<Self::Plan<T>>;
+    ) -> Result<Self::Plan>;
 
     /// Execute a plan with the given tensors and scaling factors.
     ///
     /// Follows the BLAS/cuTENSOR pattern:
     /// `output = alpha * op(inputs) + beta * output`
     ///
-    /// Operations receive `Tensor<T>` directly (PyTorch-aligned). CPU backends
-    /// convert to strided views internally; GPU backends extract device pointers.
-    fn execute<T: Scalar>(
+    /// Operations receive `Tensor<Alg::Scalar>` directly (PyTorch-aligned).
+    /// CPU backends convert to strided views internally; GPU backends
+    /// extract device pointers.
+    fn execute(
         ctx: &mut Self::Context,
-        plan: &Self::Plan<T>,
-        alpha: T,
-        inputs: &[&Tensor<T>],
-        beta: T,
-        output: &mut Tensor<T>,
+        plan: &Self::Plan,
+        alpha: Alg::Scalar,
+        inputs: &[&Tensor<Alg::Scalar>],
+        beta: Alg::Scalar,
+        output: &mut Tensor<Alg::Scalar>,
     ) -> Result<()>;
 
-    /// Query whether an extended operation is available for scalar type `T`.
+    /// Query whether an extended operation is available for this algebra.
     ///
     /// Returns `true` if the backend supports the given extended operation
-    /// for the specified scalar type.
-    fn has_extension_for<T: Scalar>(ext: Extension) -> bool;
+    /// for the algebra's scalar type.
+    fn has_extension_for(ext: Extension) -> bool;
 }
 
 // ===========================================================================

--- a/tenferro-prims/tests/prims_tests.rs
+++ b/tenferro-prims/tests/prims_tests.rs
@@ -18,7 +18,7 @@ fn cpu_plan<T: Scalar>(
     desc: &PrimDescriptor,
     shapes: &[&[usize]],
 ) -> tenferro_device::Result<CpuPlan<T>> {
-    <CpuBackend as TensorPrims<Standard<T>>>::plan::<T>(ctx, desc, shapes)
+    <CpuBackend as TensorPrims<Standard<T>>>::plan(ctx, desc, shapes)
 }
 
 fn cpu_execute<T: Scalar>(
@@ -33,7 +33,7 @@ fn cpu_execute<T: Scalar>(
 }
 
 fn cpu_has_ext<T: Scalar>(ext: Extension) -> bool {
-    <CpuBackend as TensorPrims<Standard<T>>>::has_extension_for::<T>(ext)
+    <CpuBackend as TensorPrims<Standard<T>>>::has_extension_for(ext)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `Algebra` trait to `tenferro-algebra` with `type Scalar: Scalar`, making `Semiring` extend `Algebra`
- Remove the independent `T: Scalar` type parameter from `TensorPrims` methods (`plan`, `execute`, `has_extension_for`), replacing it with `Alg::Scalar` derived from the algebra
- Remove the GAT `type Plan<T: Scalar>` in favor of a concrete `type Plan` (scalar type is now determined by the algebra)
- Update all backend implementations (CpuBackend, CUDA/ROCm stubs, tropical), einsum, capi, and all test files
- Fix pre-existing type-mismatch bug in f32 tropical tests that used f64 algebra markers (previously masked by the old design's separate T parameter)

## Motivation

The old design had a type-level hole: `TensorPrims<Alg>` methods were generic over `T: Scalar` independently of `Alg`, allowing mismatches like `T = f32` with `Alg = Standard<f64>`. The new design enforces `Alg: Algebra` where `Alg::Scalar` determines the scalar type, making such mismatches a compile-time error.

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` -- all tests pass (0 failures)
- [x] Coverage check -- same results as main (no regression)

Generated with [Claude Code](https://claude.com/claude-code)