### PR TITLE
docs(design): specify paired-axis prim semantics and unary lowering pipeline

### DIFF
--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -342,6 +342,58 @@ the `permute_view + MakeContiguous + BatchedGemm` pipeline.
 | `i→ii` (embed diagonal) | `anti_diag(A, [(0,1)])` |
 | `ij→i` (sum axis) | `reduce(A, axis=1, ReduceOp::Sum)` |
 
+### Systematic Unary Lowering with TensorPrims
+
+To support trace and generative output patterns uniformly, unary lowering should
+follow a fixed classification and rewrite pipeline.
+
+1. Parse one-input subscripts and build `size_dict` (including optional user
+   sizes for labels not present in input).
+2. Count input/output occurrences per label.
+3. Classify labels:
+   - `extract_labels`: repeated in input and present in output
+   - `trace_labels`: repeated in input and absent from output
+   - `generative_labels`: absent from input and present in output
+   - `duplicate_output_labels`: repeated in output
+4. Lower in stages:
+   - `diag` (Tensor view op) for `extract_labels`
+   - `trace` (`PrimDescriptor::Trace`) for `trace_labels`
+   - `reduce` (`PrimDescriptor::Reduce`) for non-output residual labels
+   - `permute` (`PrimDescriptor::Permute`) to canonical output order
+   - `repeat` (Tensor broadcast) for non-duplicate generative labels
+   - `anti_diag` / `anti_trace` for output duplication and scalar-to-diagonal
+     materialization
+
+This keeps TensorPrims usage explicit while preserving zero-copy
+transformations (`diag`, `repeat`) at the Tensor layer.
+
+### Pattern-to-Primitive Mapping
+
+| Pattern | Expected semantics | Lowering |
+|--------|---------------------|----------|
+| `ii->` | `sum_i A[i,i]` | `Trace(paired=[(0,1)])` |
+| `iijj->` | `sum_{i,j} A[i,i,j,j]` | `Trace` with two independent components |
+| `ii->i` | diagonal extraction | `diag([(0,1)])` |
+| `iij->j` | partial trace | `diag([(0,1)])` then `Reduce` |
+| `i->ii` | vector to diagonal matrix | `AntiDiag(paired=[(0,1)])` |
+| `->ii` | scalar to identity-like diagonal | scalar input + generative diagonal via `AntiTrace`/`AntiDiag` with unanchored component |
+| `->iii` | scalar to superdiagonal 3-tensor | scalar input + one 3-axis equality component |
+
+### End-to-End Unary Flow
+
+```
+subscripts + operand + optional size_dict
+    -> classify labels (extract / trace / generative / duplicate)
+    -> normalize with Tensor view ops (diag, repeat where applicable)
+    -> execute prim plans (Trace, Reduce, Permute, AntiDiag, AntiTrace)
+    -> final tensor with requested output label multiplicities
+```
+
+The critical requirement is that `Trace`, `AntiTrace`, and `AntiDiag` execute
+one loop variable per equality-component, not one global diagonal index.
+Without that, multi-pair trace (`iijj->`) and generative diagonal (`->ii`,
+`->iii`) are under-specified.
+
 ---
 
 ## Algebra Dispatch

--- a/docs/design/tensor-prims.md
+++ b/docs/design/tensor-prims.md
@@ -74,6 +74,92 @@ The core operations form adjoint pairs, enabling clean VJP/JVP rules:
 
 ---
 
+## Formal Semantics for Paired-Axis Operations
+
+`Trace`, `AntiTrace`, and `AntiDiag` are defined by equality constraints over
+output/input axes encoded in `paired`.
+
+### Constraint Graph and Components
+
+Given a rank-`r` tensor, build an undirected graph:
+
+- Vertices: axis positions `V = {0, ..., r-1}`
+- Edges: each pair `(a, b)` in `paired`
+
+Connected components define independent diagonal indices. Let components be
+`C_0, ..., C_{q-1}` with axis-to-component map `comp(axis)`.
+
+For each component `C_t`, all member axes must have the same dimension:
+
+`dim[a] = dim[b]` for all `a, b in C_t`
+
+This gives an independent diagonal index `d_t in [0, D_t)` per component.
+
+### Trace
+
+`Trace` contracts paired axes and sums over each component index:
+
+`Y[f] = sum_{d_0,...,d_{q-1}} X[j(f, d)]`
+
+where `j(f, d)` is built by:
+
+- free axis `a`: copy value from output index `f`
+- paired axis `a`: `j_a = d_{comp(a)}`
+
+This is the key generalization from "single `d`" to "one `d_t` per component".
+It is required for cases like `iijj->`:
+
+`sum_{i,j} X[i, i, j, j]`
+
+not `sum_d X[d, d, d, d]`.
+
+### AntiTrace (Adjoint of Trace)
+
+`AntiTrace` scatters a cotangent back to all constrained diagonal positions:
+
+`Z[j] = G[pi(j)] * prod_{(a,b) in paired} delta(j_a, j_b)`
+
+Equivalent loop form:
+
+`for each free index f:`
+`  for each component index tuple d:`
+`    Z[j(f, d)] += G[f]`
+
+with alpha/beta scaling in the standard `execute` contract.
+
+### AntiDiag (Adjoint of Diagonal Extraction)
+
+`AntiDiag` writes cotangents to constrained output positions:
+
+`Z[j] = sum_i G[i]`
+`       * prod_u delta(j_{phi(u)}, i_u)`
+`       * prod_{(a,b) in paired} delta(j_a, j_b)`
+
+`phi(u)` maps each input axis `u` to its output axis in `modes_c`.
+
+Two component classes appear in practice:
+
+- Anchored component: at least one axis comes from `modes_a`; value is fixed by
+  the corresponding `i_u`
+- Generative component: no axis from `modes_a`; must be looped independently
+  over `d_t in [0, D_t)`
+
+Generative components are required for scalar-to-diagonal patterns such as
+`->ii` and `->iii`.
+
+### Plan-Time Metadata (Recommended)
+
+To keep execution loops simple, precompute in `plan`:
+
+- `axis_to_comp: Vec<Option<usize>>`
+- `comp_dims: Vec<usize>`
+- component class (`anchored` vs `generative`) for `AntiDiag`
+
+Then `execute_*` can iterate over a Cartesian product of `comp_dims` instead of
+assuming a single shared diagonal loop variable.
+
+---
+
 ## Key Types
 
 ```rust


### PR DESCRIPTION
## Summary

- Add formal mathematical semantics for `Trace`, `AntiTrace`, and `AntiDiag` in `docs/design/tensor-prims.md`.
- Define the equality-constraint component model (paired-axis graph -> connected components) and recommended plan-time metadata.
- Add a systematic unary lowering pipeline in `docs/design/einsum.md`, including pattern-to-primitive mapping for:
  - `ii->`, `iijj->`, `ii->i`, `iij->j`, `i->ii`, `->ii`, `->iii`.
- Open implementation tracking issue: Closes #200.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo llvm-cov --workspace --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` (fails on existing baseline files unrelated to this docs-only PR):
  - `extension/tenferro-tropical/src/prims.rs: 79.9% < 80%`
  - `tenferro-prims/src/gpu_stubs.rs: 0.0% < 80%`

Generated with [Claude Code](https://claude.com/claude-code)
