### PR TITLE
ci(docs): restore pandoc install for API index rendering

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install Quarto
         uses: quarto-dev/quarto-actions/setup@v2
 
-      - name: Install graphviz
-        run: sudo apt-get update && sudo apt-get install -y graphviz
+      - name: Install pandoc and graphviz
+        run: sudo apt-get update && sudo apt-get install -y pandoc graphviz
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary

- Restore pandoc install in docs CI workflow alongside graphviz
- build_docs_site.sh step 3 calls pandoc directly to convert api_index.md to HTML, before Quarto runs in step 4
- Quarto bundled pandoc is not on PATH until quarto is invoked, so system pandoc is needed

## Test plan

- [ ] Deploy Documentation workflow succeeds
- [ ] tensor4all.org/tenferro-rs/ loads correctly with both API and design doc links working

Generated with [Claude Code](https://claude.com/claude-code)