### PR TITLE
chore: workspace metadata inheritance + README influences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,13 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+authors = ["Hiroshi Shinaoka <h.shinaoka@gmail.com>", "GiggleLiu <cacate0129@gmail.com>"]
+publish = false
+
 [workspace.dependencies]
 num-complex = "0.4"
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,36 @@ A general-purpose tensor computation library in Rust with CPU/GPU support.
 
 Built on top of [strided-rs](https://github.com/tensor4all/strided-rs) for cache-optimized strided array operations.
 
+### Influences
+
+The API and internal architecture are strongly influenced by
+[PyTorch / libtorch](https://github.com/pytorch/pytorch):
+
+- **Tensor type** — `Tensor<T>` with reference-counted storage and zero-copy
+  view operations (permute, broadcast, diagonal, narrow, select) mirrors
+  `at::Tensor` / `c10::Storage`.
+- **Plan-based execution** — The `TensorPrims<A>` describe-plan-execute
+  protocol follows the cuTENSOR / BLAS pattern used by PyTorch's GPU backend.
+- **Automatic differentiation** — Tape-based reverse mode (VJP) and
+  dual-number forward mode (JVP) follow PyTorch's autograd and `torch.func`
+  design, factored into standalone `chainrules-core` / `chainrules` crates
+  (inspired by Julia's
+  [ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl)).
+- **Einsum** — Ported from Julia's
+  [OMEinsum.jl](https://github.com/under-Peter/OMEinsum.jl); string notation
+  (`"ij,jk->ik"`) is compatible with `torch.einsum`, with N-ary contraction
+  tree optimization.
+- **Linear algebra** — `tenferro-linalg` mirrors `torch.linalg` (SVD, QR, LU,
+  eigen, Cholesky, solve) with differentiable decompositions.
+
+Key differences from PyTorch: column-major default layout with `(m, n, *)`
+batch convention, compile-time generics (`Tensor<T>`) instead of runtime dtype
+dispatch, and algebra parameterization (`TensorPrims<A>`) enabling custom
+semirings (e.g., tropical).
+
+For a detailed feature-by-feature mapping, see
+[`docs/design/reference/libtorch.md`](docs/design/reference/libtorch.md).
+
 ## Design
 
 See [`docs/design/`](docs/design/) for architecture and design documents, including:

--- a/extension/tenferro-burn/Cargo.toml
+++ b/extension/tenferro-burn/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tenferro-burn"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "Bridge between Burn deep learning framework and tenferro tensor network operations."
-publish = false
 
 [dependencies]
 tenferro-tensor = { path = "../../tenferro-tensor" }

--- a/extension/tenferro-mdarray/Cargo.toml
+++ b/extension/tenferro-mdarray/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "tenferro-mdarray"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 rust-version = "1.89"
-license = "MIT OR Apache-2.0"
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "Bridge between mdarray multidimensional arrays and tenferro tensors."
-publish = false
 
 [dependencies]
 tenferro-tensor = { path = "../../tenferro-tensor" }

--- a/extension/tenferro-tropical-capi/Cargo.toml
+++ b/extension/tenferro-tropical-capi/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tenferro-tropical-capi"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "C-API (FFI) for tropical semiring tensor operations (MaxPlus, MinPlus, MaxMul einsum)."
-publish = false
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/extension/tenferro-tropical/Cargo.toml
+++ b/extension/tenferro-tropical/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tenferro-tropical"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "Tropical semiring tensor operations (MaxPlus, MinPlus, MaxMul) for the tenferro workspace."
-publish = false
 
 [dependencies]
 tenferro-device = { path = "../../tenferro-device" }

--- a/extern/chainrules-core/Cargo.toml
+++ b/extern/chainrules-core/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "chainrules-core"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "Generic automatic differentiation framework (ChainRulesCore.jl-style). Defines Differentiable trait, TrackedTensor, DualTensor, and rule traits."
-publish = false
 
 [dependencies]
 thiserror.workspace = true

--- a/extern/chainrules/Cargo.toml
+++ b/extern/chainrules/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "chainrules"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "AD engine: TrackedTensor, DualTensor, pullback, hvp."
-publish = false
 
 [dependencies]
 chainrules-core = { path = "../chainrules-core" }

--- a/tenferro-algebra/Cargo.toml
+++ b/tenferro-algebra/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tenferro-algebra"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "Algebra traits (HasAlgebra, Semiring, Standard) for the tenferro workspace."
-publish = false
 
 [dependencies]
 num-complex.workspace = true

--- a/tenferro-capi/Cargo.toml
+++ b/tenferro-capi/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tenferro-capi"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "C-API (FFI) for tenferro: exposes einsum and SVD (with AD rules) to Julia, Python, and other languages."
-publish = false
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]

--- a/tenferro-device/Cargo.toml
+++ b/tenferro-device/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tenferro-device"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "Device abstraction and shared error types for the tenferro workspace."
-publish = false
 
 [dependencies]
 thiserror.workspace = true

--- a/tenferro-einsum/Cargo.toml
+++ b/tenferro-einsum/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tenferro-einsum"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "High-level einsum with N-ary contraction tree optimization for the tenferro workspace."
-publish = false
 
 [dependencies]
 tenferro-device = { path = "../tenferro-device" }

--- a/tenferro-linalg/Cargo.toml
+++ b/tenferro-linalg/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tenferro-linalg"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "Batched matrix linear algebra decompositions (SVD, QR, LU, eigen) with AD rules for the tenferro workspace."
-publish = false
 
 [features]
 default = ["faer"]

--- a/tenferro-prims/Cargo.toml
+++ b/tenferro-prims/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tenferro-prims"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "Tensor primitive operations (TensorPrims trait) for the tenferro workspace."
-publish = false
 
 [features]
 default = []

--- a/tenferro-tensor/Cargo.toml
+++ b/tenferro-tensor/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tenferro-tensor"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 description = "Dense tensor type with CPU/GPU support for the tenferro workspace."
-publish = false
 
 [dependencies]
 tenferro-device = { path = "../tenferro-device" }


### PR DESCRIPTION
## Summary

- Add `[workspace.package]` to root `Cargo.toml` with shared `version`, `edition`, `license`, `authors`, `publish` fields
- All 13 crates now inherit these via `.workspace = true` instead of duplicating values (`tenferro-mdarray` keeps its own `edition = "2024"`)
- Add "Influences" section to README documenting PyTorch/libtorch and OMEinsum.jl heritage, with key differences and link to `docs/design/reference/libtorch.md`

## Test plan

- [x] `cargo check --workspace` passes (excluding burn/mdarray due to rustc version)

Generated with [Claude Code](https://claude.com/claude-code)