### PR TITLE
feat(einsum): expose binary APIs and explicit contraction-path entrypoints

### DIFF
--- a/tenferro-einsum/src/api.rs
+++ b/tenferro-einsum/src/api.rs
@@ -118,6 +118,52 @@ where
     einsum_with_plan::<Alg, Backend>(ctx, &tree, operands, size_dict)
 }
 
+/// Execute N-ary einsum with an explicit pairwise contraction path.
+///
+/// This is a convenience wrapper around [`ContractionTree::from_pairs`]
+/// + [`einsum_with_plan`]. It makes the "N-ary = binary composition along a
+/// path" model explicit in the public API.
+///
+/// # Arguments
+///
+/// * `subscripts` — Einsum subscripts
+/// * `pairs` — Ordered pairwise contraction path
+/// * `operands` — Input tensors
+/// * `size_dict` — Optional size overrides for output-only labels
+///
+/// # Errors
+///
+/// Returns an error if the path is invalid for the provided subscripts/shapes.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_einsum::{einsum_with_path, Subscripts};
+/// use tenferro_prims::{CpuBackend, CpuContext};
+///
+/// let mut ctx = CpuContext::new(1);
+/// let subs = Subscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]);
+/// // Path: contract B*C first, then A*(BC)
+/// let pairs = vec![(1, 2), (0, 3)];
+/// let d = einsum_with_path::<_, CpuBackend>(&mut ctx, &subs, &pairs, &[&a, &b, &c], None).unwrap();
+/// ```
+pub fn einsum_with_path<Alg, Backend>(
+    ctx: &mut Backend::Context,
+    subscripts: &Subscripts,
+    pairs: &[(usize, usize)],
+    operands: &[&Tensor<Alg::Scalar>],
+    size_dict: Option<&HashMap<u32, usize>>,
+) -> Result<Tensor<Alg::Scalar>>
+where
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
+{
+    let shapes: Vec<&[usize]> = operands.iter().map(|t| t.dims()).collect();
+    let tree = ContractionTree::from_pairs(subscripts, &shapes, pairs)?;
+    einsum_with_plan::<Alg, Backend>(ctx, &tree, operands, size_dict)
+}
+
 /// Execute einsum with a pre-optimized [`ContractionTree`].
 ///
 /// Avoids both subscript parsing and contraction order optimization.
@@ -389,6 +435,44 @@ where
 {
     let shapes: Vec<&[usize]> = operands.iter().map(|t| t.dims()).collect();
     let tree = ContractionTree::optimize(subscripts, &shapes)?;
+    einsum_with_plan_into::<Alg, Backend>(ctx, &tree, operands, alpha, beta, output, size_dict)
+}
+
+/// Execute N-ary einsum with an explicit pairwise contraction path, accumulating
+/// into an existing output tensor.
+///
+/// Computes `output = alpha * einsum_path(operands) + beta * output`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_einsum::{einsum_with_path_into, Subscripts};
+/// use tenferro_prims::{CpuBackend, CpuContext};
+///
+/// let mut ctx = CpuContext::new(1);
+/// let subs = Subscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]);
+/// let pairs = vec![(1, 2), (0, 3)];
+/// einsum_with_path_into::<_, CpuBackend>(
+///     &mut ctx, &subs, &pairs, &[&a, &b, &c], 1.0, 0.0, &mut out, None
+/// ).unwrap();
+/// ```
+pub fn einsum_with_path_into<Alg, Backend>(
+    ctx: &mut Backend::Context,
+    subscripts: &Subscripts,
+    pairs: &[(usize, usize)],
+    operands: &[&Tensor<Alg::Scalar>],
+    alpha: Alg::Scalar,
+    beta: Alg::Scalar,
+    output: &mut Tensor<Alg::Scalar>,
+    size_dict: Option<&HashMap<u32, usize>>,
+) -> Result<()>
+where
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
+{
+    let shapes: Vec<&[usize]> = operands.iter().map(|t| t.dims()).collect();
+    let tree = ContractionTree::from_pairs(subscripts, &shapes, pairs)?;
     einsum_with_plan_into::<Alg, Backend>(ctx, &tree, operands, alpha, beta, output, size_dict)
 }
 

--- a/tenferro-einsum/src/binary.rs
+++ b/tenferro-einsum/src/binary.rs
@@ -1,0 +1,243 @@
+use std::collections::HashMap;
+
+use tenferro_algebra::{Algebra, HasAlgebra, Scalar};
+use tenferro_device::{Error, Result};
+use tenferro_prims::TensorPrims;
+use tenferro_tensor::Tensor;
+
+use crate::api::{einsum_with_subscripts, einsum_with_subscripts_into};
+use crate::subscripts::Subscripts;
+
+fn ensure_binary_subscripts(subscripts: &Subscripts) -> Result<()> {
+    if subscripts.inputs.len() != 2 {
+        return Err(Error::InvalidArgument(format!(
+            "binary einsum requires exactly 2 inputs, got {}",
+            subscripts.inputs.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Execute a binary einsum from string notation.
+///
+/// This is the two-input specialization of [`crate::einsum`]. It is intended as
+/// a reusable primitive for building explicit contraction paths at higher layers.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_einsum::einsum_binary;
+/// use tenferro_prims::{CpuBackend, CpuContext};
+///
+/// let mut ctx = CpuContext::new(1);
+/// let c = einsum_binary::<_, CpuBackend>(&mut ctx, "ij,jk->ik", &a, &b, None).unwrap();
+/// ```
+pub fn einsum_binary<Alg, Backend>(
+    ctx: &mut Backend::Context,
+    subscripts: &str,
+    left: &Tensor<Alg::Scalar>,
+    right: &Tensor<Alg::Scalar>,
+    size_dict: Option<&HashMap<u32, usize>>,
+) -> Result<Tensor<Alg::Scalar>>
+where
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
+{
+    let subs = Subscripts::parse(subscripts)?;
+    einsum_binary_with_subscripts::<Alg, Backend>(ctx, &subs, left, right, size_dict)
+}
+
+/// Execute a binary einsum from pre-parsed subscripts.
+///
+/// # Errors
+///
+/// Returns an error if `subscripts` does not contain exactly two inputs.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_einsum::{einsum_binary_with_subscripts, Subscripts};
+/// use tenferro_prims::{CpuBackend, CpuContext};
+///
+/// let mut ctx = CpuContext::new(1);
+/// let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+/// let c = einsum_binary_with_subscripts::<_, CpuBackend>(&mut ctx, &subs, &a, &b, None).unwrap();
+/// ```
+pub fn einsum_binary_with_subscripts<Alg, Backend>(
+    ctx: &mut Backend::Context,
+    subscripts: &Subscripts,
+    left: &Tensor<Alg::Scalar>,
+    right: &Tensor<Alg::Scalar>,
+    size_dict: Option<&HashMap<u32, usize>>,
+) -> Result<Tensor<Alg::Scalar>>
+where
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
+{
+    ensure_binary_subscripts(subscripts)?;
+    einsum_with_subscripts::<Alg, Backend>(ctx, subscripts, &[left, right], size_dict)
+}
+
+/// Execute a binary einsum and accumulate into an existing output buffer.
+///
+/// Computes `output = alpha * einsum(left, right) + beta * output`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_einsum::einsum_binary_into;
+/// use tenferro_prims::{CpuBackend, CpuContext};
+///
+/// let mut ctx = CpuContext::new(1);
+/// einsum_binary_into::<_, CpuBackend>(&mut ctx, "ij,jk->ik", &a, &b, 1.0, 0.0, &mut c, None).unwrap();
+/// ```
+pub fn einsum_binary_into<Alg, Backend>(
+    ctx: &mut Backend::Context,
+    subscripts: &str,
+    left: &Tensor<Alg::Scalar>,
+    right: &Tensor<Alg::Scalar>,
+    alpha: Alg::Scalar,
+    beta: Alg::Scalar,
+    output: &mut Tensor<Alg::Scalar>,
+    size_dict: Option<&HashMap<u32, usize>>,
+) -> Result<()>
+where
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
+{
+    let subs = Subscripts::parse(subscripts)?;
+    einsum_binary_with_subscripts_into::<Alg, Backend>(
+        ctx, &subs, left, right, alpha, beta, output, size_dict,
+    )
+}
+
+/// Execute a binary einsum from pre-parsed subscripts, accumulating into output.
+///
+/// Computes `output = alpha * einsum(left, right) + beta * output`.
+///
+/// # Errors
+///
+/// Returns an error if `subscripts` does not contain exactly two inputs.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_einsum::{einsum_binary_with_subscripts_into, Subscripts};
+/// use tenferro_prims::{CpuBackend, CpuContext};
+///
+/// let mut ctx = CpuContext::new(1);
+/// let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+/// einsum_binary_with_subscripts_into::<_, CpuBackend>(
+///     &mut ctx, &subs, &a, &b, 1.0, 0.0, &mut c, None
+/// ).unwrap();
+/// ```
+pub fn einsum_binary_with_subscripts_into<Alg, Backend>(
+    ctx: &mut Backend::Context,
+    subscripts: &Subscripts,
+    left: &Tensor<Alg::Scalar>,
+    right: &Tensor<Alg::Scalar>,
+    alpha: Alg::Scalar,
+    beta: Alg::Scalar,
+    output: &mut Tensor<Alg::Scalar>,
+    size_dict: Option<&HashMap<u32, usize>>,
+) -> Result<()>
+where
+    Alg: Algebra,
+    Alg::Scalar: Scalar + HasAlgebra<Algebra = Alg>,
+    Backend: TensorPrims<Alg>,
+{
+    ensure_binary_subscripts(subscripts)?;
+    einsum_with_subscripts_into::<Alg, Backend>(
+        ctx,
+        subscripts,
+        &[left, right],
+        alpha,
+        beta,
+        output,
+        size_dict,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use tenferro_algebra::Standard;
+    use tenferro_device::LogicalMemorySpace;
+    use tenferro_prims::{CpuBackend, CpuContext};
+    use tenferro_tensor::{MemoryOrder, Tensor};
+
+    use super::{einsum_binary, einsum_binary_into};
+
+    const COL: MemoryOrder = MemoryOrder::ColumnMajor;
+    const MEM: LogicalMemorySpace = LogicalMemorySpace::MainMemory;
+
+    fn mat(data: &[f64], dims: &[usize]) -> Tensor<f64> {
+        Tensor::from_slice(data, dims, COL).unwrap()
+    }
+
+    #[test]
+    fn binary_matmul_matches_expected_values() {
+        let mut ctx = CpuContext::new(1);
+        let a = mat(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+        let b = mat(&[5.0, 6.0, 7.0, 8.0], &[2, 2]);
+        let c = einsum_binary::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &a, &b, None)
+            .unwrap();
+        let data = c.buffer().as_slice().unwrap();
+        assert_eq!(
+            data[c.offset() as usize..c.offset() as usize + 4],
+            [23.0, 34.0, 31.0, 46.0]
+        );
+    }
+
+    #[test]
+    fn binary_into_accumulates_with_alpha_beta() {
+        let mut ctx = CpuContext::new(1);
+        let a = mat(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+        let b = mat(&[5.0, 6.0, 7.0, 8.0], &[2, 2]);
+        let mut out = Tensor::<f64>::zeros(&[2, 2], MEM, COL);
+        einsum_binary_into::<Standard<f64>, CpuBackend>(
+            &mut ctx,
+            "ij,jk->ik",
+            &a,
+            &b,
+            1.0,
+            0.0,
+            &mut out,
+            None,
+        )
+        .unwrap();
+        einsum_binary_into::<Standard<f64>, CpuBackend>(
+            &mut ctx,
+            "ij,jk->ik",
+            &a,
+            &b,
+            1.0,
+            1.0,
+            &mut out,
+            None,
+        )
+        .unwrap();
+        let data = out.buffer().as_slice().unwrap();
+        assert_eq!(
+            data[out.offset() as usize..out.offset() as usize + 4],
+            [46.0, 68.0, 62.0, 92.0]
+        );
+    }
+
+    #[test]
+    fn binary_rejects_non_binary_notation() {
+        let mut ctx = CpuContext::new(1);
+        let a = Tensor::<f64>::zeros(&[2, 2], MEM, COL);
+        let b = Tensor::<f64>::zeros(&[2, 2], MEM, COL);
+        let result =
+            einsum_binary::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk,kl->il", &a, &b, None);
+        match result {
+            Ok(_) => panic!("expected binary notation validation error"),
+            Err(err) => {
+                assert!(format!("{err}").contains("binary einsum requires exactly 2 inputs"))
+            }
+        }
+    }
+}

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -9,6 +9,8 @@
 //! - **Integer label notation**: omeinsum-rs compatible, using `u32` labels
 //! - **N-ary contraction**: Automatic or manual optimization of pairwise
 //!   contraction order via [`ContractionTree`]
+//! - **Binary primitive**: Public two-input einsum APIs (`einsum_binary*`) for
+//!   composing explicit contraction paths in higher layers
 //! - **Accumulating variants**: [`einsum_into`], [`einsum_with_subscripts_into`],
 //!   [`einsum_with_plan_into`] write into a pre-allocated output buffer with
 //!   BLAS-style `alpha`/`beta` scaling, avoiding allocation in hot loops
@@ -223,6 +225,7 @@
 // Internal modules
 pub(crate) mod ad;
 pub(crate) mod api;
+mod binary;
 mod classify;
 mod dispatch;
 mod execute;
@@ -244,9 +247,13 @@ pub use tree::ContractionTree;
 
 // Public re-exports: functions
 pub use api::{
-    einsum, einsum_into, einsum_owned, einsum_with_plan, einsum_with_plan_into,
-    einsum_with_plan_owned, einsum_with_subscripts, einsum_with_subscripts_into,
-    einsum_with_subscripts_owned,
+    einsum, einsum_into, einsum_owned, einsum_with_path, einsum_with_path_into, einsum_with_plan,
+    einsum_with_plan_into, einsum_with_plan_owned, einsum_with_subscripts,
+    einsum_with_subscripts_into, einsum_with_subscripts_owned,
+};
+pub use binary::{
+    einsum_binary, einsum_binary_into, einsum_binary_with_subscripts,
+    einsum_binary_with_subscripts_into,
 };
 
 pub use ad::{dual_einsum, einsum_frule, einsum_hvp, einsum_rrule, tracked_einsum};

--- a/tenferro-einsum/tests/einsum_tests.rs
+++ b/tenferro-einsum/tests/einsum_tests.rs
@@ -7,8 +7,10 @@
 use tenferro_algebra::Standard;
 use tenferro_device::LogicalMemorySpace;
 use tenferro_einsum::{
-    dual_einsum, einsum, einsum_frule, einsum_into, einsum_owned, einsum_rrule, einsum_with_plan,
-    einsum_with_subscripts, tracked_einsum, ContractionTree, Subscripts,
+    dual_einsum, einsum, einsum_frule, einsum_into, einsum_owned, einsum_rrule, einsum_with_path,
+    einsum_with_path_into, einsum_with_plan, einsum_with_plan_owned, einsum_with_subscripts,
+    einsum_with_subscripts_into, einsum_with_subscripts_owned, tracked_einsum, ContractionTree,
+    Subscripts,
 };
 use tenferro_prims::{CpuBackend, CpuContext};
 use tenferro_tensor::{MemoryOrder, Tensor};
@@ -490,6 +492,150 @@ fn einsum_owned_matmul() {
     .unwrap();
     let c = einsum_owned::<S, CpuBackend>(&mut ctx, "ij,jk->ik", vec![a, b], None).unwrap();
     assert_eq!(c.dims(), &[2, 4]);
+}
+
+#[test]
+fn einsum_with_subscripts_owned_matches_borrowed() {
+    let mut ctx = CpuContext::new(1);
+    let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
+    let b = Tensor::<f64>::from_slice(
+        &[
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ],
+        &[3, 4],
+        COL,
+    )
+    .unwrap();
+
+    let expected =
+        einsum_with_subscripts::<S, CpuBackend>(&mut ctx, &subs, &[&a, &b], None).unwrap();
+    let got =
+        einsum_with_subscripts_owned::<S, CpuBackend>(&mut ctx, &subs, vec![a, b], None).unwrap();
+    assert_tensors_close(&got, &expected, "with_subscripts_owned");
+}
+
+#[test]
+fn einsum_with_plan_owned_matches_borrowed() {
+    let mut ctx = CpuContext::new(1);
+    let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+    let shapes: &[&[usize]] = &[&[2, 3], &[3, 4]];
+    let tree = ContractionTree::optimize(&subs, shapes).unwrap();
+
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], COL).unwrap();
+    let b = Tensor::<f64>::from_slice(
+        &[
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ],
+        &[3, 4],
+        COL,
+    )
+    .unwrap();
+
+    let expected = einsum_with_plan::<S, CpuBackend>(&mut ctx, &tree, &[&a, &b], None).unwrap();
+    let got = einsum_with_plan_owned::<S, CpuBackend>(&mut ctx, &tree, vec![a, b], None).unwrap();
+    assert_tensors_close(&got, &expected, "with_plan_owned");
+}
+
+#[test]
+fn einsum_with_path_matches_flat_nary() {
+    let mut ctx = CpuContext::new(1);
+    let subs = Subscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]);
+    let pairs = vec![(1, 2), (0, 3)];
+
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
+    let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], COL).unwrap();
+    let c = Tensor::<f64>::from_slice(&[9.0, 10.0, 11.0, 12.0], &[2, 2], COL).unwrap();
+
+    let via_path =
+        einsum_with_path::<S, CpuBackend>(&mut ctx, &subs, &pairs, &[&a, &b, &c], None).unwrap();
+    let flat = einsum::<S, CpuBackend>(&mut ctx, "ij,jk,kl->il", &[&a, &b, &c], None).unwrap();
+    assert_tensors_close(&via_path, &flat, "with_path");
+}
+
+#[test]
+fn einsum_with_path_invalid_pairs_errors() {
+    let mut ctx = CpuContext::new(1);
+    let subs = Subscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]);
+    let bad_pairs = vec![(0, 99), (0, 3)];
+
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
+    let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], COL).unwrap();
+    let c = Tensor::<f64>::from_slice(&[9.0, 10.0, 11.0, 12.0], &[2, 2], COL).unwrap();
+
+    let result =
+        einsum_with_path::<S, CpuBackend>(&mut ctx, &subs, &bad_pairs, &[&a, &b, &c], None);
+    assert!(result.is_err(), "invalid contraction path must error");
+}
+
+#[test]
+fn einsum_with_subscripts_into_accumulate() {
+    let mut ctx = CpuContext::new(1);
+    let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
+    let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], COL).unwrap();
+    let expected_mm =
+        einsum_with_subscripts::<S, CpuBackend>(&mut ctx, &subs, &[&a, &b], None).unwrap();
+
+    let mut out = Tensor::<f64>::ones(&[2, 2], MEM, COL);
+    einsum_with_subscripts_into::<S, CpuBackend>(
+        &mut ctx,
+        &subs,
+        &[&a, &b],
+        2.0,
+        3.0,
+        &mut out,
+        None,
+    )
+    .unwrap();
+
+    let got = out.buffer().as_slice().unwrap();
+    let mm = expected_mm.buffer().as_slice().unwrap();
+    for i in 0..got.len() {
+        let expected = 2.0 * mm[i] + 3.0;
+        assert!(
+            (got[i] - expected).abs() < 1e-10,
+            "with_subscripts_into[{i}] got={}, expected={expected}",
+            got[i]
+        );
+    }
+}
+
+#[test]
+fn einsum_with_path_into_accumulate() {
+    let mut ctx = CpuContext::new(1);
+    let subs = Subscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]);
+    let pairs = vec![(1, 2), (0, 3)];
+
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
+    let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], COL).unwrap();
+    let c = Tensor::<f64>::from_slice(&[9.0, 10.0, 11.0, 12.0], &[2, 2], COL).unwrap();
+    let base =
+        einsum_with_path::<S, CpuBackend>(&mut ctx, &subs, &pairs, &[&a, &b, &c], None).unwrap();
+
+    let mut out = Tensor::<f64>::ones(&[2, 2], MEM, COL);
+    einsum_with_path_into::<S, CpuBackend>(
+        &mut ctx,
+        &subs,
+        &pairs,
+        &[&a, &b, &c],
+        2.0,
+        3.0,
+        &mut out,
+        None,
+    )
+    .unwrap();
+
+    let got = out.buffer().as_slice().unwrap();
+    let base_data = base.buffer().as_slice().unwrap();
+    for i in 0..got.len() {
+        let expected = 2.0 * base_data[i] + 3.0;
+        assert!(
+            (got[i] - expected).abs() < 1e-10,
+            "with_path_into[{i}] got={}, expected={expected}",
+            got[i]
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add public binary einsum APIs (`einsum_binary*`) to make two-operand contraction an explicit reusable primitive
- add explicit path APIs for N-ary einsum (`einsum_with_path`, `einsum_with_path_into`) built on `ContractionTree::from_pairs`
- export the new APIs from `tenferro-einsum` and extend tests to cover owned/into/path variants

## Validation
- cargo fmt --all --check
- cargo test --workspace
- cargo llvm-cov --workspace --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json

Generated with [Claude Code](https://claude.com/claude-code)
