### PR TITLE
einsum: optimize prepare fallback copy path for partial fusions

### DIFF
--- a/tenferro-einsum/src/prepare.rs
+++ b/tenferro-einsum/src/prepare.rs
@@ -27,6 +27,14 @@ pub(crate) fn print_and_reset_prepare_profile() {
     eprintln!("[prepare profile] zero_copy={zc}  fallback_copy={fb}  fallback_elems={elems}");
 }
 
+#[cfg(feature = "profile-dispatch")]
+#[inline]
+fn record_prepare_fallback(dims: &[usize]) {
+    PREPARE_FALLBACK.fetch_add(1, Ordering::Relaxed);
+    let n_elems: usize = dims.iter().product();
+    PREPARE_FALLBACK_ELEMS.fetch_add(n_elems as u64, Ordering::Relaxed);
+}
+
 /// Prepare a single operand for GEMM: permute and try to fuse dimension groups.
 pub(crate) fn prepare_one_operand<A, B>(
     ctx: &mut B::Context,
@@ -63,39 +71,76 @@ where
     let g1_strides = &strides[..n_group1];
     let g2_dims = &dims[n_group1..n_group1 + n_group2];
     let g2_strides = &strides[n_group1..n_group1 + n_group2];
+    let batch_dims = &dims[n_group1 + n_group2..];
+    let batch_strides = &strides[n_group1 + n_group2..];
 
     let fused_g1 = try_fuse_group(g1_dims, g1_strides);
     let fused_g2 = try_fuse_group(g2_dims, g2_strides);
 
-    if let (Some((size1, stride1)), Some((size2, stride2))) = (fused_g1, fused_g2) {
-        // Zero-copy: construct fused view [fused_g1, fused_g2, batch...]
-        #[cfg(feature = "profile-dispatch")]
-        PREPARE_ZEROCOPY.fetch_add(1, Ordering::Relaxed);
-        let mut fused_dims = Vec::with_capacity(nb + 2);
-        let mut fused_strides = Vec::with_capacity(nb + 2);
-        fused_dims.push(size1);
-        fused_strides.push(stride1);
-        fused_dims.push(size2);
-        fused_strides.push(stride2);
-        fused_dims.extend_from_slice(&dims[n_group1 + n_group2..]);
-        fused_strides.extend_from_slice(&strides[n_group1 + n_group2..]);
-        return permuted.view_as_strided(fused_dims, fused_strides);
+    match (fused_g1, fused_g2) {
+        (Some((size1, stride1)), Some((size2, stride2))) => {
+            // Zero-copy: construct fused view [fused_g1, fused_g2, batch...]
+            #[cfg(feature = "profile-dispatch")]
+            PREPARE_ZEROCOPY.fetch_add(1, Ordering::Relaxed);
+            let mut fused_dims = Vec::with_capacity(nb + 2);
+            let mut fused_strides = Vec::with_capacity(nb + 2);
+            fused_dims.push(size1);
+            fused_strides.push(stride1);
+            fused_dims.push(size2);
+            fused_strides.push(stride2);
+            fused_dims.extend_from_slice(batch_dims);
+            fused_strides.extend_from_slice(batch_strides);
+            permuted.view_as_strided(fused_dims, fused_strides)
+        }
+        (Some((size1, stride1)), None) => {
+            // Partial fallback: g1 is already fusable, so preserve it and
+            // materialize contiguity for the failing g2 side only.
+            #[cfg(feature = "profile-dispatch")]
+            record_prepare_fallback(dims);
+            let mut partial_dims = Vec::with_capacity(1 + n_group2 + nb);
+            let mut partial_strides = Vec::with_capacity(1 + n_group2 + nb);
+            partial_dims.push(size1);
+            partial_strides.push(stride1);
+            partial_dims.extend_from_slice(g2_dims);
+            partial_dims.extend_from_slice(batch_dims);
+            partial_strides.extend_from_slice(g2_strides);
+            partial_strides.extend_from_slice(batch_strides);
+            let partial = permuted.view_as_strided(partial_dims, partial_strides)?;
+            let contiguous = make_contiguous_if_needed::<A, B>(ctx, &partial, pool)?;
+            contiguous.reshape(fallback_shape)
+        }
+        (None, Some((size2, stride2))) => {
+            // Partial fallback: g2 is already fusable, so preserve it and
+            // materialize contiguity for the failing g1 side only.
+            #[cfg(feature = "profile-dispatch")]
+            record_prepare_fallback(dims);
+            let mut partial_dims = Vec::with_capacity(n_group1 + 1 + nb);
+            let mut partial_strides = Vec::with_capacity(n_group1 + 1 + nb);
+            partial_dims.extend_from_slice(g1_dims);
+            partial_dims.push(size2);
+            partial_dims.extend_from_slice(batch_dims);
+            partial_strides.extend_from_slice(g1_strides);
+            partial_strides.push(stride2);
+            partial_strides.extend_from_slice(batch_strides);
+            let partial = permuted.view_as_strided(partial_dims, partial_strides)?;
+            let contiguous = make_contiguous_if_needed::<A, B>(ctx, &partial, pool)?;
+            contiguous.reshape(fallback_shape)
+        }
+        (None, None) => {
+            // Full fallback: both groups are non-fusable; materialize full target
+            // layout, then reshape for GEMM.
+            #[cfg(feature = "profile-dispatch")]
+            record_prepare_fallback(dims);
+            let contiguous = make_contiguous_if_needed::<A, B>(ctx, &permuted, pool)?;
+            contiguous.reshape(fallback_shape)
+        }
     }
-
-    // Fallback: copy to contiguous, then reshape
-    #[cfg(feature = "profile-dispatch")]
-    {
-        PREPARE_FALLBACK.fetch_add(1, Ordering::Relaxed);
-        let n_elems: usize = dims.iter().product();
-        PREPARE_FALLBACK_ELEMS.fetch_add(n_elems as u64, Ordering::Relaxed);
-    }
-    let contiguous = permute_or_copy::<A, B>(ctx, tensor, current_subs, target_subs, pool)?;
-    contiguous.reshape(fallback_shape)
 }
 
 /// Uses `Tensor::permute` (zero-copy view) first; copies to a pooled buffer
 /// only when the result is non-contiguous. Falls back to MakeContiguous when
 /// `current_subs == target_subs`.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn permute_or_copy<A, B>(
     ctx: &mut B::Context,
     tensor: &Tensor<A::Scalar>,
@@ -184,10 +229,27 @@ mod tests {
     use tenferro_tensor::MemoryOrder;
 
     use super::*;
-    use crate::util::tensor_get;
+    use crate::util::{tensor_get, unflatten_index};
 
     fn tensor(data: &[f64], dims: &[usize]) -> Tensor<f64> {
         Tensor::from_slice(data, dims, MemoryOrder::ColumnMajor).unwrap()
+    }
+
+    fn assert_tensor_close(lhs: &Tensor<f64>, rhs: &Tensor<f64>) {
+        assert_eq!(lhs.dims(), rhs.dims());
+        let numel: usize = lhs.dims().iter().product();
+        for flat in 0..numel {
+            let idx = unflatten_index(flat, lhs.dims());
+            let l = tensor_get(lhs, &idx);
+            let r = tensor_get(rhs, &idx);
+            assert!(
+                (l - r).abs() < 1e-10,
+                "mismatch at {:?}: left={} right={}",
+                idx,
+                l,
+                r
+            );
+        }
     }
 
     #[test]
@@ -211,6 +273,80 @@ mod tests {
 
         assert_eq!(prepared.dims(), &[2, 2]);
         assert_eq!(prepared.buffer().as_ptr(), input.buffer().as_ptr());
+    }
+
+    #[test]
+    fn prepare_one_operand_partial_fallback_when_group2_nonfusable() {
+        let mut ctx = CpuContext::new(1);
+        let mut pool = BufferPool::new();
+        let mut ref_pool = BufferPool::new();
+        let data: Vec<f64> = (1..=24).map(|x| x as f64).collect();
+        let input = tensor(&data, &[2, 3, 4]);
+        let fallback_shape = [3, 8];
+
+        let prepared = prepare_one_operand::<Standard<f64>, CpuBackend>(
+            &mut ctx,
+            &input,
+            &[0, 1, 2],
+            &[1, 2, 0],
+            0,
+            1,
+            2,
+            &fallback_shape,
+            &mut pool,
+        )
+        .unwrap();
+        let expected = permute_or_copy::<Standard<f64>, CpuBackend>(
+            &mut ctx,
+            &input,
+            &[0, 1, 2],
+            &[1, 2, 0],
+            &mut ref_pool,
+        )
+        .unwrap()
+        .reshape(&fallback_shape)
+        .unwrap();
+
+        assert_eq!(prepared.dims(), &fallback_shape);
+        assert!(prepared.is_contiguous());
+        assert_tensor_close(&prepared, &expected);
+    }
+
+    #[test]
+    fn prepare_one_operand_partial_fallback_when_group1_nonfusable() {
+        let mut ctx = CpuContext::new(1);
+        let mut pool = BufferPool::new();
+        let mut ref_pool = BufferPool::new();
+        let data: Vec<f64> = (1..=24).map(|x| x as f64).collect();
+        let input = tensor(&data, &[2, 3, 4]);
+        let fallback_shape = [8, 3];
+
+        let prepared = prepare_one_operand::<Standard<f64>, CpuBackend>(
+            &mut ctx,
+            &input,
+            &[0, 1, 2],
+            &[2, 0, 1],
+            0,
+            2,
+            1,
+            &fallback_shape,
+            &mut pool,
+        )
+        .unwrap();
+        let expected = permute_or_copy::<Standard<f64>, CpuBackend>(
+            &mut ctx,
+            &input,
+            &[0, 1, 2],
+            &[2, 0, 1],
+            &mut ref_pool,
+        )
+        .unwrap()
+        .reshape(&fallback_shape)
+        .unwrap();
+
+        assert_eq!(prepared.dims(), &fallback_shape);
+        assert!(prepared.is_contiguous());
+        assert_tensor_close(&prepared, &expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- optimize `prepare_one_operand` fallback by handling `(Some, None)` and `(None, Some)` fuse cases separately
- keep fallback materialization on permuted view and factor fallback profiling into a helper
- add regression tests for both partial-fallback branches in `prepare.rs`

## Benchmark (1 thread)
- gm_queen5_5_3.wcsp: opt_size 2969.487 -> 2915.376 ms (-1.82%)
- lm_batch_likelihood_brackets_4_4d: opt_size 48.083 -> 34.831 ms (-27.56%)
- tensornetwork_permutation_light_415: opt_size 607.592 -> 577.477 ms (-4.96%)

## Test Plan
- cargo fmt --all --check
- cargo test --workspace
- cargo llvm-cov --workspace --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- ../tenferro-einsum-benchmark/scripts/run_all.sh 1

Generated with [Claude Code](https://claude.com/claude-code)
