### PR TITLE
einsum: speed up prepare fallback with CPU direct contiguous copy

### DIFF
--- a/tenferro-einsum/src/prepare.rs
+++ b/tenferro-einsum/src/prepare.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use num_traits::{One, Zero};
 use tenferro_algebra::{Algebra, HasAlgebra, Scalar};
-use tenferro_device::Result;
+use tenferro_device::{Error, LogicalMemorySpace, Result};
 use tenferro_prims::{PrimDescriptor, TensorPrims};
 use tenferro_tensor::Tensor;
 
@@ -205,6 +205,39 @@ where
     if tensor.is_contiguous() {
         return Ok(tensor.clone());
     }
+
+    // CPU fast-path: avoid PrimDescriptor/plan/execute overhead for pure host
+    // copies by using strided-perm directly while still reusing pooled buffers.
+    if tensor.logical_memory_space() == LogicalMemorySpace::MainMemory {
+        if let Some(src_data) = tensor.buffer().as_slice() {
+            let dims = tensor.dims();
+            let mut result =
+                alloc_tensor_from_pool::<A::Scalar>(dims, LogicalMemorySpace::MainMemory, pool);
+
+            let src =
+                strided_view::StridedView::new(src_data, dims, tensor.strides(), tensor.offset())
+                    .map_err(|e| Error::StrideError(e.to_string()))?;
+
+            // alloc_tensor_from_pool always returns column-major contiguous layout.
+            let mut dst_strides = Vec::with_capacity(dims.len());
+            let mut s = 1isize;
+            for &d in dims {
+                dst_strides.push(s);
+                s *= d as isize;
+            }
+
+            let dst_data = result.buffer_mut().as_mut_slice().ok_or_else(|| {
+                Error::DeviceError("CPU tensor expected in host copy path".into())
+            })?;
+            let mut dst = strided_view::StridedViewMut::new(dst_data, dims, &dst_strides, 0)
+                .map_err(|e| Error::StrideError(e.to_string()))?;
+
+            strided_perm::copy_into(&mut dst, &src)
+                .map_err(|e| Error::StrideError(e.to_string()))?;
+            return Ok(result);
+        }
+    }
+
     let memory_space = tensor.logical_memory_space();
     let mut result = alloc_tensor_from_pool::<A::Scalar>(tensor.dims(), memory_space, pool);
     let desc = PrimDescriptor::MakeContiguous;


### PR DESCRIPTION
## Summary
- add a CPU fast path in `make_contiguous_if_needed` for host tensors in the einsum prepare stage
- bypass `PrimDescriptor::MakeContiguous` plan/execute overhead by copying directly with `strided-perm` into pooled contiguous buffers
- keep existing backend-dispatch path as fallback for non-host / non-CPU-copy cases

## Benchmark (1 thread, targeted #236 cases)
Measured via `BENCH_INSTANCE=... RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 cargo run --release --manifest-path ../tenferro-einsum-benchmark/Cargo.toml`.

Compared to previous main baseline used in issue tracking:

- `gm_queen5_5_3.wcsp`
  - opt_flops: `7986.361 -> 7744.949 ms` (**-3.02%**)
  - opt_size: `2915.376 -> 2896.142 ms` (**-0.66%**)
- `lm_batch_likelihood_brackets_4_4d`
  - opt_flops: `48.563 -> 33.665 ms` (**-30.68%**)
  - opt_size: `34.831 -> 29.666 ms` (**-14.83%**)
- `tensornetwork_permutation_light_415`
  - opt_flops: `615.823 -> 572.868 ms` (**-6.98%**)
  - opt_size: `577.477 -> 572.772 ms` (**-0.81%**)

## Test Plan
- cargo fmt --all --check
- cargo test --workspace
- cargo llvm-cov --workspace --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- BENCH_INSTANCE=gm_queen5_5_3.wcsp RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 cargo run --release --manifest-path ../tenferro-einsum-benchmark/Cargo.toml
- BENCH_INSTANCE=lm_batch_likelihood_brackets_4_4d RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 cargo run --release --manifest-path ../tenferro-einsum-benchmark/Cargo.toml
- BENCH_INSTANCE=tensornetwork_permutation_light_415 RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 cargo run --release --manifest-path ../tenferro-einsum-benchmark/Cargo.toml

Generated with [Claude Code](https://claude.com/claude-code)
