### PR TITLE
Issue #261: scalar AD rules and dyadtensor eager AD API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     # extern (general-purpose, non-tenferro)
     "extern/chainrules-core",
     "extern/chainrules",
+    "extern/chainrules-scalarops",
 ]
 resolver = "2"
 

--- a/docs/AD/index.md
+++ b/docs/AD/index.md
@@ -34,3 +34,4 @@ verification procedures (reconstruction checks, finite-difference gradient check
 | [pinv.md](./pinv.md) | Pseudoinverse (`pinv_rrule`) | AD rules for Moore-Penrose pseudoinverse |
 | [matrix_exp.md](./matrix_exp.md) | Matrix exponential (`matrix_exp_rrule`) | AD rules for `exp(A)` |
 | [norm.md](./norm.md) | Norm (`norm_rrule`) | AD rules for matrix and vector norms |
+| [scalar_ops.md](./scalar_ops.md) | Scalar ops (`conj`, `sqrt`, `powf`, `powi`) | PyTorch-aligned scalar rrule/frule conventions and `handle_r_to_c` projection note |

--- a/docs/AD/scalar_ops.md
+++ b/docs/AD/scalar_ops.md
@@ -1,0 +1,95 @@
+# Scalar AD Rules (`conj`, `sqrt`, `powf`, `powi`)
+
+This note records the scalar AD formulas we align with before implementing
+`chainrules-scalarops` and exposing `AdScalar` APIs in `tenferro-dyadtensor`.
+
+## Scope
+
+Target operations:
+
+- `conj`
+- `sqrt`
+- `powf` (scalar exponent)
+- `powi` (integer exponent; a restricted `pow` case)
+
+Target scalar domains:
+
+- `f32`, `f64`
+- `Complex32`, `Complex64`
+
+## PyTorch Baseline (Local Snapshot)
+
+Reference repository: `../pytorch`  
+Commit used for this note: `8dd3b7637abd04433bafe77765de59df6388f9f9`
+
+Primary source files:
+
+- `tools/autograd/derivatives.yaml`
+- `torch/csrc/autograd/FunctionsManual.cpp`
+- `docs/source/notes/autograd.rst`
+
+Key lines:
+
+- `_conj` backward: `derivatives.yaml:477-479`
+- `sqrt` backward: `derivatives.yaml:1622-1624`
+- `pow.Tensor_Scalar` / `pow.Tensor_Tensor`: `derivatives.yaml:1385-1392`
+- `pow_backward*` implementation: `FunctionsManual.cpp:473-557`
+- `handle_r_to_c`: `FunctionsManual.cpp:169-183`
+- Complex AD convention statement: `notes/autograd.rst:601-607`
+
+## Complex Gradient Convention
+
+We follow PyTorch's convention for real-valued losses:
+
+- gradients are conjugate-Wirtinger (`dL/dz*`) style
+- VJP formulas include complex conjugation where required
+- if input is real and an intermediate gradient is complex, project back to real
+  (`handle_r_to_c` behavior)
+
+## Rule Summary
+
+Let `g` be output cotangent, `x` input primal, `y = f(x)` output primal.
+
+### `conj`
+
+- Primal: `y = conj(x)`
+- rrule: `dx = conj(g)`
+- frule: `dy = conj(dx)`
+
+### `sqrt`
+
+- Primal: `y = sqrt(x)`
+- rrule: `dx = g / (2 * conj(y))`
+- frule: `dy = dx / (2 * conj(y))`
+
+### `powf` (fixed scalar exponent `a`)
+
+- Primal: `y = x^a`
+- rrule (self gradient): `dx = g * conj(a * x^(a - 1))`
+- frule (self tangent): `dy = dx * conj(a * x^(a - 1))`
+
+### `powi` (fixed integer exponent `n`)
+
+This is `powf` with integer exponent semantics.
+
+- Primal: `y = x^n`
+- rrule: `dx = g * conj(n * x^(n - 1))`
+- frule: `dy = dx * conj(n * x^(n - 1))`
+
+## Edge Cases
+
+Aligned with PyTorch:
+
+- `pow` with exponent `0` gives zero self-gradient.
+- Real-input/complex-intermediate gradients are projected back to real
+  (`handle_r_to_c` equivalent).
+
+## API Placement
+
+Implementation placement:
+
+- formulas and helper projection (`handle_r_to_c` equivalent):
+  `extern/chainrules-scalarops`
+- user-facing scalar AD API:
+  `extension/tenferro-dyadtensor::AdScalar`
+

--- a/docs/design/autodiff.md
+++ b/docs/design/autodiff.md
@@ -37,6 +37,7 @@ tenferro-linalg          ← Linalg + linalg AD rules (depends on chainrules-cor
 Operation-specific AD rules live with their operations:
 - Einsum AD in `tenferro-einsum`
 - Linalg AD in `tenferro-linalg`
+- Scalar elementary AD rules in `chainrules-scalarops` (extension crate)
 - Future operations in their own crates
 
 ---
@@ -86,6 +87,36 @@ Linalg uses only stateless `_rrule`/`_frule` functions — no `tracked_*` or
 - `qr_rrule`, `qr_frule` — QR AD
 - `lu_rrule`, `lu_frule` — LU AD
 - `eigen_rrule`, `eigen_frule` — Eigen AD
+
+**Scalar AD helpers (in `chainrules-scalarops`):**
+
+- `conj`, `sqrt`, `powf`, `powi` primal/frule/rrule helpers for scalar types
+- complex convention follows PyTorch conjugate-Wirtinger + `handle_r_to_c` style projection
+- math details are documented in [AD Formula Notes: scalar ops](../AD/scalar_ops.md)
+
+**Dyadtensor AD eager aliases (in `tenferro-dyadtensor::ad`):**
+
+- integration-facing eager functions without `_ad` suffix:
+  `ad::einsum`, `ad::svd`, `ad::qr`, `ad::lu`, `ad::eigen`, `ad::lstsq`,
+  `ad::cholesky`, `ad::solve`, `ad::inv`, `ad::det`, `ad::slogdet`,
+  `ad::eig`, `ad::pinv`, `ad::matrix_exp`, `ad::solve_triangular`, `ad::norm`
+- each alias is an explicit eager wrapper around existing builder paths
+  (`*_ad(...).run()`), so no tape handle is exposed at call sites
+  and no implicit `Drop`-driven execution is used
+
+### Dyadtensor HVP Support Matrix (Current)
+
+| Surface | HVP status | Current behavior |
+|---------|------------|------------------|
+| `chainrules::Tape::hvp` | Supported | Use tape-level forward-over-reverse API |
+| `tenferro-einsum::einsum_hvp` | Supported | Local einsum HVP helper exists |
+| `tenferro-dyadtensor::ad::*` eager API | Not yet exposed | No dedicated dyadtensor HVP entry point yet |
+| `tenferro-dyadtensor::solve_triangular_ad` (fwd/rev) | Not supported | Returns `Error::UnsupportedAdOp { op: "solve_triangular_ad" }` |
+
+For migration work, dyadtensor-facing HVP is staged:
+1. Document currently available low-level paths (`Tape::hvp`, `einsum_hvp`).
+2. Keep explicit unsupported errors for missing AD/HVP paths.
+3. Add dyadtensor-level HVP entry points incrementally per operation family.
 
 ---
 

--- a/extension/tenferro-dyadtensor/Cargo.toml
+++ b/extension/tenferro-dyadtensor/Cargo.toml
@@ -12,6 +12,7 @@ num-complex.workspace = true
 num-traits.workspace = true
 thiserror.workspace = true
 chainrules-core = { path = "../../extern/chainrules-core" }
+chainrules-scalarops = { path = "../../extern/chainrules-scalarops" }
 tenferro-algebra = { path = "../../tenferro-algebra" }
 tenferro-device = { path = "../../tenferro-device" }
 tenferro-einsum = { path = "../../tenferro-einsum" }

--- a/extension/tenferro-dyadtensor/src/ad_value.rs
+++ b/extension/tenferro-dyadtensor/src/ad_value.rs
@@ -1,3 +1,4 @@
+use chainrules_scalarops as scalarops;
 use tenferro_algebra::Scalar;
 use tenferro_tensor::Tensor;
 
@@ -372,6 +373,26 @@ impl<T> AdScalar<T> {
         self.0
     }
 
+    /// Consumes this wrapper and returns only the primal scalar value.
+    ///
+    /// This is an explicit AD-drop API for intentional metadata discard.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_dyadtensor::AdScalar;
+    ///
+    /// let x = AdScalar::new_forward(2.0_f64, 1.0_f64);
+    /// assert_eq!(x.into_primal(), 2.0);
+    /// ```
+    pub fn into_primal(self) -> T {
+        match self.0 {
+            AdValue::Primal(primal) => primal,
+            AdValue::Forward { primal, .. } => primal,
+            AdValue::Reverse { primal, .. } => primal,
+        }
+    }
+
     /// Returns primal scalar reference.
     ///
     /// # Examples
@@ -398,6 +419,167 @@ impl<T> AdScalar<T> {
     /// ```
     pub fn tangent(&self) -> Option<&T> {
         self.0.tangent_ref()
+    }
+
+    /// Applies scalar conjugation with AD propagation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use num_complex::Complex64;
+    /// use tenferro_dyadtensor::AdScalar;
+    ///
+    /// let x = AdScalar::new_forward(Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0));
+    /// let y = x.conj();
+    /// assert_eq!(*y.primal(), Complex64::new(1.0, -2.0));
+    /// assert_eq!(*y.tangent().unwrap(), Complex64::new(3.0, 4.0));
+    /// ```
+    pub fn conj(self) -> Self
+    where
+        T: scalarops::ScalarAd,
+    {
+        match self.0 {
+            AdValue::Primal(primal) => Self::new_primal(scalarops::conj(primal)),
+            AdValue::Forward { primal, tangent } => {
+                let (primal, tangent) = scalarops::conj_frule(primal, tangent);
+                Self::new_forward(primal, tangent)
+            }
+            AdValue::Reverse {
+                primal,
+                node,
+                tape,
+                tangent,
+            } => {
+                let (primal, tangent) = match tangent {
+                    Some(tangent) => {
+                        let (primal, tangent) = scalarops::conj_frule(primal, tangent);
+                        (primal, Some(tangent))
+                    }
+                    None => (scalarops::conj(primal), None),
+                };
+                Self::new_reverse(primal, node, tape, tangent)
+            }
+        }
+    }
+
+    /// Applies scalar square-root with AD propagation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_dyadtensor::AdScalar;
+    ///
+    /// let x = AdScalar::new_forward(9.0_f64, 1.0_f64);
+    /// let y = x.sqrt();
+    /// assert!((*y.primal() - 3.0).abs() < 1e-12);
+    /// assert!((*y.tangent().unwrap() - 1.0 / 6.0).abs() < 1e-12);
+    /// ```
+    pub fn sqrt(self) -> Self
+    where
+        T: scalarops::ScalarAd,
+    {
+        match self.0 {
+            AdValue::Primal(primal) => Self::new_primal(scalarops::sqrt(primal)),
+            AdValue::Forward { primal, tangent } => {
+                let (primal, tangent) = scalarops::sqrt_frule(primal, tangent);
+                Self::new_forward(primal, tangent)
+            }
+            AdValue::Reverse {
+                primal,
+                node,
+                tape,
+                tangent,
+            } => {
+                let (primal, tangent) = match tangent {
+                    Some(tangent) => {
+                        let (primal, tangent) = scalarops::sqrt_frule(primal, tangent);
+                        (primal, Some(tangent))
+                    }
+                    None => (scalarops::sqrt(primal), None),
+                };
+                Self::new_reverse(primal, node, tape, tangent)
+            }
+        }
+    }
+
+    /// Applies scalar real-exponent power with AD propagation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_dyadtensor::AdScalar;
+    ///
+    /// let x = AdScalar::new_forward(2.0_f64, 1.0_f64);
+    /// let y = x.powf(3.0);
+    /// assert_eq!(*y.primal(), 8.0);
+    /// assert_eq!(*y.tangent().unwrap(), 12.0);
+    /// ```
+    pub fn powf(self, exponent: <T as scalarops::ScalarAd>::Real) -> Self
+    where
+        T: scalarops::ScalarAd,
+    {
+        match self.0 {
+            AdValue::Primal(primal) => Self::new_primal(scalarops::powf(primal, exponent)),
+            AdValue::Forward { primal, tangent } => {
+                let (primal, tangent) = scalarops::powf_frule(primal, exponent, tangent);
+                Self::new_forward(primal, tangent)
+            }
+            AdValue::Reverse {
+                primal,
+                node,
+                tape,
+                tangent,
+            } => {
+                let (primal, tangent) = match tangent {
+                    Some(tangent) => {
+                        let (primal, tangent) = scalarops::powf_frule(primal, exponent, tangent);
+                        (primal, Some(tangent))
+                    }
+                    None => (scalarops::powf(primal, exponent), None),
+                };
+                Self::new_reverse(primal, node, tape, tangent)
+            }
+        }
+    }
+
+    /// Applies scalar integer-exponent power with AD propagation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_dyadtensor::AdScalar;
+    ///
+    /// let x = AdScalar::new_forward(2.0_f64, 1.0_f64);
+    /// let y = x.powi(4);
+    /// assert_eq!(*y.primal(), 16.0);
+    /// assert_eq!(*y.tangent().unwrap(), 32.0);
+    /// ```
+    pub fn powi(self, exponent: i32) -> Self
+    where
+        T: scalarops::ScalarAd,
+    {
+        match self.0 {
+            AdValue::Primal(primal) => Self::new_primal(scalarops::powi(primal, exponent)),
+            AdValue::Forward { primal, tangent } => {
+                let (primal, tangent) = scalarops::powi_frule(primal, exponent, tangent);
+                Self::new_forward(primal, tangent)
+            }
+            AdValue::Reverse {
+                primal,
+                node,
+                tape,
+                tangent,
+            } => {
+                let (primal, tangent) = match tangent {
+                    Some(tangent) => {
+                        let (primal, tangent) = scalarops::powi_frule(primal, exponent, tangent);
+                        (primal, Some(tangent))
+                    }
+                    None => (scalarops::powi(primal, exponent), None),
+                };
+                Self::new_reverse(primal, node, tape, tangent)
+            }
+        }
     }
 }
 
@@ -656,6 +838,7 @@ impl<T: Scalar> From<AdTensor<T>> for AdValue<Tensor<T>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use num_complex::Complex64;
     use tenferro_tensor::MemoryOrder;
 
     #[test]
@@ -676,5 +859,43 @@ mod tests {
         assert_eq!(ad.dims(), &[2]);
         assert_eq!(ad.ndim(), 1);
         assert_eq!(ad.len(), 2);
+    }
+
+    #[test]
+    fn ad_scalar_into_primal_drops_metadata() {
+        let x = AdScalar::new_forward(2.5_f64, 0.1_f64);
+        assert_eq!(x.into_primal(), 2.5_f64);
+    }
+
+    #[test]
+    fn ad_scalar_sqrt_forward_propagates_tangent() {
+        let x = AdScalar::new_forward(9.0_f64, 1.0_f64);
+        let y = x.sqrt();
+        assert!((*y.primal() - 3.0).abs() < 1e-12);
+        assert!((*y.tangent().unwrap() - (1.0 / 6.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn ad_scalar_powi_forward_propagates_tangent() {
+        let x = AdScalar::new_forward(2.0_f64, 1.0_f64);
+        let y = x.powi(4);
+        assert_eq!(*y.primal(), 16.0);
+        assert_eq!(*y.tangent().unwrap(), 32.0);
+    }
+
+    #[test]
+    fn ad_scalar_conj_reverse_preserves_tape_metadata() {
+        let x = AdScalar::new_reverse(
+            Complex64::new(1.0, 2.0),
+            NodeId(11),
+            TapeId(7),
+            Some(Complex64::new(-1.0, 0.5)),
+        );
+        let y = x.conj();
+        assert_eq!(y.mode(), AdMode::Reverse);
+        assert_eq!(y.as_value().node_id(), Some(NodeId(11)));
+        assert_eq!(y.as_value().tape_id(), Some(TapeId(7)));
+        assert_eq!(*y.primal(), Complex64::new(1.0, -2.0));
+        assert_eq!(*y.tangent().unwrap(), Complex64::new(-1.0, -0.5));
     }
 }

--- a/extension/tenferro-dyadtensor/src/api/ad.rs
+++ b/extension/tenferro-dyadtensor/src/api/ad.rs
@@ -1,0 +1,379 @@
+//! Eager AD entry points without `_ad` suffix.
+//!
+//! These functions are thin wrappers around the existing builder APIs
+//! (`*_ad(...).run()`) and are intended for integration code paths that prefer
+//! explicit eager execution.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use tenferro_dyadtensor::{ad, set_default_runtime, AdTensor, RuntimeContext};
+//! use tenferro_prims::CpuContext;
+//! use tenferro_tensor::{MemoryOrder, Tensor};
+//!
+//! let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+//! let a = Tensor::<f64>::from_slice(&[1.0, 0.0, 0.0, 1.0], &[2, 2], MemoryOrder::ColumnMajor)
+//!     .unwrap();
+//! let ad_a = AdTensor::new_primal(a);
+//! let out = ad::qr(&ad_a).unwrap();
+//! assert_eq!(out.q.dims(), &[2, 2]);
+//! ```
+
+use num_complex::Complex;
+use num_traits::Float;
+use tenferro_algebra::{HasAlgebra, Scalar, Standard};
+use tenferro_linalg::backend::CpuLinalgScalar;
+use tenferro_linalg::{LinalgScalar, NormKind};
+use tenferro_prims::{CpuBackend, CpuContext, TensorPrims};
+
+use crate::{AdTensor, Result};
+
+use super::{
+    AdEigResult, AdEigenResult, AdLstsqResult, AdLuResult, AdQrResult, AdSlogdetResult, AdSvdResult,
+};
+
+/// Eager AD einsum.
+///
+/// Equivalent to `crate::einsum_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::einsum("ij,jk->ik", &[&a, &b])?;
+/// ```
+pub fn einsum<'a, T>(subscripts: &'a str, operands: &'a [&'a AdTensor<T>]) -> Result<AdTensor<T>>
+where
+    T: Scalar + HasAlgebra<Algebra = Standard<T>>,
+    CpuBackend: TensorPrims<Standard<T>, Context = CpuContext>,
+{
+    super::einsum_ad(subscripts, operands).run()
+}
+
+/// Eager AD SVD.
+///
+/// Equivalent to `crate::svd_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::svd(&a)?;
+/// ```
+pub fn svd<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdSvdResult<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::svd_ad(tensor).run()
+}
+
+/// Eager AD QR.
+///
+/// Equivalent to `crate::qr_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::qr(&a)?;
+/// ```
+pub fn qr<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdQrResult<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::qr_ad(tensor).run()
+}
+
+/// Eager AD LU (partial pivot by default).
+///
+/// Equivalent to `crate::lu_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::lu(&a)?;
+/// ```
+pub fn lu<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdLuResult<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::lu_ad(tensor).run()
+}
+
+/// Eager AD symmetric/Hermitian eigen decomposition.
+///
+/// Equivalent to `crate::eigen_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::eigen(&a)?;
+/// ```
+pub fn eigen<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdEigenResult<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::eigen_ad(tensor).run()
+}
+
+/// Eager AD least-squares solve.
+///
+/// Equivalent to `crate::lstsq_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::lstsq(&a, &b)?;
+/// ```
+pub fn lstsq<T: Scalar>(a: &AdTensor<T>, b: &AdTensor<T>) -> Result<AdLstsqResult<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::lstsq_ad(a, b).run()
+}
+
+/// Eager AD Cholesky.
+///
+/// Equivalent to `crate::cholesky_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::cholesky(&a)?;
+/// ```
+pub fn cholesky<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdTensor<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::cholesky_ad(tensor).run()
+}
+
+/// Eager AD linear solve.
+///
+/// Equivalent to `crate::solve_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::solve(&a, &b)?;
+/// ```
+pub fn solve<T: Scalar>(a: &AdTensor<T>, b: &AdTensor<T>) -> Result<AdTensor<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::solve_ad(a, b).run()
+}
+
+/// Eager AD inverse.
+///
+/// Equivalent to `crate::inv_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::inv(&a)?;
+/// ```
+pub fn inv<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdTensor<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::inv_ad(tensor).run()
+}
+
+/// Eager AD determinant.
+///
+/// Equivalent to `crate::det_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::det(&a)?;
+/// ```
+pub fn det<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdTensor<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::det_ad(tensor).run()
+}
+
+/// Eager AD slogdet.
+///
+/// Equivalent to `crate::slogdet_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::slogdet(&a)?;
+/// ```
+pub fn slogdet<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdSlogdetResult<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::slogdet_ad(tensor).run()
+}
+
+/// Eager AD general eigendecomposition.
+///
+/// Equivalent to `crate::eig_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::eig(&a)?;
+/// ```
+pub fn eig<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdEigResult<T>>
+where
+    T: LinalgScalar<Real = T, Complex = Complex<T>> + Float + CpuLinalgScalar,
+    Complex<T>: Scalar,
+{
+    super::eig_ad(tensor).run()
+}
+
+/// Eager AD pseudoinverse.
+///
+/// Equivalent to `crate::pinv_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::pinv(&a)?;
+/// ```
+pub fn pinv<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdTensor<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::pinv_ad(tensor).run()
+}
+
+/// Eager AD matrix exponential.
+///
+/// Equivalent to `crate::matrix_exp_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::matrix_exp(&a)?;
+/// ```
+pub fn matrix_exp<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdTensor<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::matrix_exp_ad(tensor).run()
+}
+
+/// Eager AD triangular solve (upper=true by default).
+///
+/// Equivalent to `crate::solve_triangular_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::solve_triangular(&a, &b)?;
+/// ```
+pub fn solve_triangular<T: Scalar>(a: &AdTensor<T>, b: &AdTensor<T>) -> Result<AdTensor<T>>
+where
+    T: LinalgScalar + CpuLinalgScalar,
+{
+    super::solve_triangular_ad(a, b).run()
+}
+
+/// Eager AD norm (Frobenius by default).
+///
+/// Equivalent to `crate::norm_ad(...).run()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = tenferro_dyadtensor::ad::norm(&a)?;
+/// ```
+pub fn norm<T: Scalar>(tensor: &AdTensor<T>) -> Result<AdTensor<T>>
+where
+    T: LinalgScalar<Real = T> + Float + CpuLinalgScalar,
+{
+    super::norm_ad(tensor).kind(NormKind::Fro).run()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AdValue, NodeId, RuntimeContext, TapeId};
+    use tenferro_prims::CpuContext;
+    use tenferro_tensor::{MemoryOrder, Tensor};
+
+    fn f64_2x2(values: [f64; 4]) -> Tensor<f64> {
+        Tensor::<f64>::from_slice(&values, &[2, 2], MemoryOrder::ColumnMajor).unwrap()
+    }
+
+    #[test]
+    fn eager_ad_linalg_and_einsum_cover_all_ops() {
+        let _guard = crate::set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+        let a = f64_2x2([4.0, 1.0, 1.0, 3.0]);
+        let b = Tensor::<f64>::from_slice(&[1.0, 2.0], &[2], MemoryOrder::ColumnMajor).unwrap();
+        let tri = f64_2x2([2.0, 0.0, 1.0, 3.0]);
+        let general = f64_2x2([0.0, 1.0, -1.0, 0.0]);
+        let rect = Tensor::<f64>::from_slice(
+            &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            &[2, 3],
+            MemoryOrder::ColumnMajor,
+        )
+        .unwrap();
+        let a_ls = Tensor::<f64>::from_slice(
+            &[1.0, 0.0, 1.0, 0.0, 1.0, 1.0],
+            &[3, 2],
+            MemoryOrder::ColumnMajor,
+        )
+        .unwrap();
+        let b_ls =
+            Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0], &[3], MemoryOrder::ColumnMajor).unwrap();
+
+        let ad_a = AdTensor::new_primal(a.clone());
+        let ad_b = AdTensor::new_primal(b);
+        let _ad_tri = AdTensor::new_primal(tri);
+        let ad_general = AdTensor::new_primal(general);
+        let ad_rect = AdTensor::new_primal(rect);
+        let ad_ls_a = AdTensor::new_primal(a_ls);
+        let ad_ls_b = AdTensor::new_primal(b_ls);
+
+        let out_einsum = einsum("ij,jk->ik", &[&ad_a, &ad_a]).unwrap();
+        assert_eq!(out_einsum.dims(), &[2, 2]);
+        let out_svd = svd(&ad_a).unwrap();
+        assert_eq!(out_svd.s.dims(), &[2]);
+        let out_qr = qr(&ad_a).unwrap();
+        assert_eq!(out_qr.q.dims(), &[2, 2]);
+        let out_lu = lu(&ad_a).unwrap();
+        assert_eq!(out_lu.l.dims(), &[2, 2]);
+        let out_eigen = eigen(&ad_a).unwrap();
+        assert_eq!(out_eigen.values.dims(), &[2]);
+        let out_lstsq = lstsq(&ad_ls_a, &ad_ls_b).unwrap();
+        assert_eq!(out_lstsq.x.dims(), &[2]);
+        assert_eq!(cholesky(&ad_a).unwrap().dims(), &[2, 2]);
+        assert_eq!(solve(&ad_a, &ad_b).unwrap().dims(), &[2]);
+        assert_eq!(inv(&ad_a).unwrap().dims(), &[2, 2]);
+        assert_eq!(det(&ad_a).unwrap().dims(), &[]);
+        let out_slogdet = slogdet(&ad_a).unwrap();
+        assert_eq!(out_slogdet.sign.dims(), &[]);
+        let out_eig = eig(&ad_general).unwrap();
+        assert_eq!(out_eig.values.dims(), &[2]);
+        assert_eq!(pinv(&ad_rect).unwrap().dims(), &[3, 2]);
+        assert_eq!(matrix_exp(&ad_a).unwrap().dims(), &[2, 2]);
+        assert_eq!(solve_triangular(&ad_a, &ad_b).unwrap().dims(), &[2]);
+        assert_eq!(norm(&ad_a).unwrap().dims(), &[]);
+    }
+
+    #[test]
+    fn eager_ad_preserves_mode_propagation() {
+        let _guard = crate::set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+        let a = f64_2x2([4.0, 1.0, 1.0, 3.0]);
+        let da = f64_2x2([0.1, 0.0, 0.0, 0.1]);
+        let b = Tensor::<f64>::from_slice(&[1.0, 2.0], &[2], MemoryOrder::ColumnMajor).unwrap();
+
+        let ad_a_fwd = AdTensor::new_forward(a.clone(), da);
+        let ad_b = AdTensor::new_primal(b);
+        let out_fwd = solve(&ad_a_fwd, &ad_b).unwrap();
+        assert!(matches!(out_fwd.as_value(), AdValue::Forward { .. }));
+
+        let ad_a_rev = AdTensor::new_reverse(a.clone(), NodeId(1), TapeId(11), None);
+        let ad_b_rev = AdTensor::new_reverse(a, NodeId(2), TapeId(11), None);
+        let out_rev = einsum("ij,jk->ik", &[&ad_a_rev, &ad_b_rev]).unwrap();
+        assert!(matches!(out_rev.as_value(), AdValue::Reverse { tape, .. } if *tape == TapeId(11)));
+    }
+}

--- a/extension/tenferro-dyadtensor/src/api/mod.rs
+++ b/extension/tenferro-dyadtensor/src/api/mod.rs
@@ -19,6 +19,7 @@ use crate::ad_value::{AdValue, NodeId};
 use crate::runtime::{with_default_runtime, RuntimeContext};
 use crate::{AdTensor, Error, Result, TapeId};
 
+pub mod ad;
 mod ad_results;
 
 pub use ad_results::{
@@ -1990,6 +1991,7 @@ pub fn norm_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> NormAdBuilder<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tenferro_prims::{CudaContext, RocmContext};
     use tenferro_tensor::MemoryOrder;
 
     fn as_slice<T: Scalar>(t: &Tensor<T>) -> &[T] {
@@ -2004,6 +2006,36 @@ mod tests {
             .unwrap();
         let err = qr(&t).run().err();
         assert!(matches!(err, Some(Error::RuntimeNotConfigured)));
+    }
+
+    #[test]
+    fn run_with_cuda_runtime_returns_unsupported_runtime_error() {
+        let _guard = crate::set_default_runtime(RuntimeContext::Cuda(CudaContext::new()));
+        let t = Tensor::<f64>::from_slice(&[1.0, 0.0, 0.0, 1.0], &[2, 2], MemoryOrder::ColumnMajor)
+            .unwrap();
+        let err = qr(&t).run().err();
+        assert!(matches!(
+            err,
+            Some(Error::UnsupportedRuntimeOp {
+                op: "qr",
+                runtime: "cuda"
+            })
+        ));
+    }
+
+    #[test]
+    fn run_with_rocm_runtime_returns_unsupported_runtime_error() {
+        let _guard = crate::set_default_runtime(RuntimeContext::Rocm(RocmContext::new()));
+        let t = Tensor::<f64>::from_slice(&[1.0, 0.0, 0.0, 1.0], &[2, 2], MemoryOrder::ColumnMajor)
+            .unwrap();
+        let err = qr(&t).run().err();
+        assert!(matches!(
+            err,
+            Some(Error::UnsupportedRuntimeOp {
+                op: "qr",
+                runtime: "rocm"
+            })
+        ));
     }
 
     #[test]

--- a/extension/tenferro-dyadtensor/src/lib.rs
+++ b/extension/tenferro-dyadtensor/src/lib.rs
@@ -10,6 +10,7 @@ pub mod runtime;
 pub mod traits;
 
 pub use ad_value::{AdMode, AdScalar, AdTensor, AdValue, NodeId, TapeId};
+pub use api::ad;
 pub use api::{
     cholesky, cholesky_ad, det, det_ad, eig, eig_ad, eigen, eigen_ad, einsum, einsum_ad, inv,
     inv_ad, lstsq, lstsq_ad, lu, lu_ad, matrix_exp, matrix_exp_ad, norm, norm_ad, pinv, pinv_ad,

--- a/extension/tenferro-dyadtensor/src/runtime.rs
+++ b/extension/tenferro-dyadtensor/src/runtime.rs
@@ -4,6 +4,12 @@ use tenferro_prims::{CpuContext, CudaContext, RocmContext};
 
 /// Runtime execution context used by builder `.run()` entry points.
 ///
+/// Current status:
+///
+/// - `Cpu`: supported by builder `.run()` paths.
+/// - `Cuda`/`Rocm`: accepted as context values, but current builder execution
+///   paths return [`Error::UnsupportedRuntimeOp`].
+///
 /// # Examples
 ///
 /// ```rust

--- a/extern/chainrules-scalarops/Cargo.toml
+++ b/extern/chainrules-scalarops/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "chainrules-scalarops"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
+description = "Scalar AD helpers (primal/frule/rrule) for conj, sqrt, powf, powi."
+
+[dependencies]
+chainrules-core = { path = "../chainrules-core" }
+num-complex.workspace = true
+num-traits.workspace = true

--- a/extern/chainrules-scalarops/src/lib.rs
+++ b/extern/chainrules-scalarops/src/lib.rs
@@ -1,0 +1,413 @@
+//! Scalar AD helper rules for elementary operations.
+//!
+//! This crate provides stateless primal/frule/rrule helpers for scalar ops
+//! used by wrapper-level AD APIs.
+//!
+//! Supported operations:
+//!
+//! - `conj`
+//! - `sqrt`
+//! - `powf` (fixed real exponent)
+//! - `powi` (fixed integer exponent)
+//!
+//! # Examples
+//!
+//! ```rust
+//! use chainrules_scalarops::{powf_frule, powf_rrule};
+//!
+//! // y = x^3 at x=2, dx=1
+//! let (y, dy) = powf_frule(2.0_f64, 3.0, 1.0);
+//! assert_eq!(y, 8.0);
+//! assert_eq!(dy, 12.0);
+//!
+//! // Reverse-mode: dL/dx = dL/dy * 3*x^2
+//! let dx = powf_rrule(2.0_f64, 3.0, 1.0);
+//! assert_eq!(dx, 12.0);
+//! ```
+
+use core::ops::{Add, Div, Mul, Sub};
+use num_complex::{Complex32, Complex64};
+use num_traits::{Float, One, Zero};
+
+/// Scalar trait used by elementary AD rule helpers.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::ScalarAd;
+///
+/// fn takes_scalar<S: ScalarAd>(_x: S) {}
+/// takes_scalar(1.0_f32);
+/// takes_scalar(1.0_f64);
+/// ```
+pub trait ScalarAd:
+    Copy + Add<Output = Self> + Sub<Output = Self> + Mul<Output = Self> + Div<Output = Self>
+{
+    /// Real exponent type for `powf`.
+    type Real: Copy + Float;
+
+    /// Complex conjugate (identity for real scalars).
+    fn conj(self) -> Self;
+
+    /// Square root.
+    fn sqrt(self) -> Self;
+
+    /// Power by real exponent.
+    fn powf(self, exponent: Self::Real) -> Self;
+
+    /// Power by integer exponent.
+    fn powi(self, exponent: i32) -> Self;
+
+    /// Convert real scalar to this scalar type.
+    fn from_real(value: Self::Real) -> Self;
+
+    /// Convert signed integer to this scalar type.
+    fn from_i32(value: i32) -> Self;
+}
+
+impl ScalarAd for f32 {
+    type Real = f32;
+
+    fn conj(self) -> Self {
+        self
+    }
+
+    fn sqrt(self) -> Self {
+        f32::sqrt(self)
+    }
+
+    fn powf(self, exponent: Self::Real) -> Self {
+        f32::powf(self, exponent)
+    }
+
+    fn powi(self, exponent: i32) -> Self {
+        f32::powi(self, exponent)
+    }
+
+    fn from_real(value: Self::Real) -> Self {
+        value
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as f32
+    }
+}
+
+impl ScalarAd for f64 {
+    type Real = f64;
+
+    fn conj(self) -> Self {
+        self
+    }
+
+    fn sqrt(self) -> Self {
+        f64::sqrt(self)
+    }
+
+    fn powf(self, exponent: Self::Real) -> Self {
+        f64::powf(self, exponent)
+    }
+
+    fn powi(self, exponent: i32) -> Self {
+        f64::powi(self, exponent)
+    }
+
+    fn from_real(value: Self::Real) -> Self {
+        value
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as f64
+    }
+}
+
+impl ScalarAd for Complex32 {
+    type Real = f32;
+
+    fn conj(self) -> Self {
+        Complex32::conj(&self)
+    }
+
+    fn sqrt(self) -> Self {
+        Complex32::sqrt(self)
+    }
+
+    fn powf(self, exponent: Self::Real) -> Self {
+        Complex32::powf(self, exponent)
+    }
+
+    fn powi(self, exponent: i32) -> Self {
+        Complex32::powi(&self, exponent)
+    }
+
+    fn from_real(value: Self::Real) -> Self {
+        Complex32::new(value, 0.0)
+    }
+
+    fn from_i32(value: i32) -> Self {
+        Complex32::new(value as f32, 0.0)
+    }
+}
+
+impl ScalarAd for Complex64 {
+    type Real = f64;
+
+    fn conj(self) -> Self {
+        Complex64::conj(&self)
+    }
+
+    fn sqrt(self) -> Self {
+        Complex64::sqrt(self)
+    }
+
+    fn powf(self, exponent: Self::Real) -> Self {
+        Complex64::powf(self, exponent)
+    }
+
+    fn powi(self, exponent: i32) -> Self {
+        Complex64::powi(&self, exponent)
+    }
+
+    fn from_real(value: Self::Real) -> Self {
+        Complex64::new(value, 0.0)
+    }
+
+    fn from_i32(value: i32) -> Self {
+        Complex64::new(value as f64, 0.0)
+    }
+}
+
+/// PyTorch-style real-input / complex-gradient projection helper (`handle_r_to_c`).
+///
+/// This is equivalent to taking the real part when a gradient for real input
+/// becomes complex during intermediate algebra.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::handle_r_to_c_f64;
+/// use num_complex::Complex64;
+///
+/// let g = Complex64::new(1.25, -3.0);
+/// assert_eq!(handle_r_to_c_f64(g), 1.25);
+/// ```
+pub fn handle_r_to_c_f64(gradient: Complex64) -> f64 {
+    gradient.re
+}
+
+/// `f32` variant of [`handle_r_to_c_f64`].
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::handle_r_to_c_f32;
+/// use num_complex::Complex32;
+///
+/// let g = Complex32::new(2.0, 4.0);
+/// assert_eq!(handle_r_to_c_f32(g), 2.0);
+/// ```
+pub fn handle_r_to_c_f32(gradient: Complex32) -> f32 {
+    gradient.re
+}
+
+/// Primal `conj`.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::conj;
+/// use num_complex::Complex64;
+///
+/// assert_eq!(conj(3.0_f64), 3.0);
+/// assert_eq!(conj(Complex64::new(1.0, 2.0)), Complex64::new(1.0, -2.0));
+/// ```
+pub fn conj<S: ScalarAd>(x: S) -> S {
+    x.conj()
+}
+
+/// Forward rule for `conj`.
+///
+/// Returns `(primal, tangent)`.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::conj_frule;
+/// use num_complex::Complex64;
+///
+/// let (y, dy) = conj_frule(Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0));
+/// assert_eq!(y, Complex64::new(1.0, -2.0));
+/// assert_eq!(dy, Complex64::new(3.0, 4.0));
+/// ```
+pub fn conj_frule<S: ScalarAd>(x: S, dx: S) -> (S, S) {
+    (x.conj(), dx.conj())
+}
+
+/// Reverse rule for `conj`.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::conj_rrule;
+/// use num_complex::Complex64;
+///
+/// let dx = conj_rrule(Complex64::new(1.0, 2.0));
+/// assert_eq!(dx, Complex64::new(1.0, -2.0));
+/// ```
+pub fn conj_rrule<S: ScalarAd>(cotangent: S) -> S {
+    cotangent.conj()
+}
+
+/// Primal `sqrt`.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::sqrt;
+///
+/// assert_eq!(sqrt(9.0_f64), 3.0);
+/// ```
+pub fn sqrt<S: ScalarAd>(x: S) -> S {
+    x.sqrt()
+}
+
+/// Forward rule for `sqrt`.
+///
+/// Returns `(primal, tangent)`.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::sqrt_frule;
+///
+/// let (_y, dy) = sqrt_frule(9.0_f64, 1.0);
+/// assert!((dy - (1.0 / 6.0)).abs() < 1e-12);
+/// ```
+pub fn sqrt_frule<S: ScalarAd>(x: S, dx: S) -> (S, S) {
+    let y = x.sqrt();
+    let dy = dx / (S::from_i32(2) * y.conj());
+    (y, dy)
+}
+
+/// Reverse rule for `sqrt`.
+///
+/// `result` is the primal output `sqrt(x)`.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::sqrt_rrule;
+///
+/// let result = 3.0_f64;
+/// let dx = sqrt_rrule(result, 1.0_f64);
+/// assert!((dx - (1.0 / 6.0)).abs() < 1e-12);
+/// ```
+pub fn sqrt_rrule<S: ScalarAd>(result: S, cotangent: S) -> S {
+    cotangent / (S::from_i32(2) * result.conj())
+}
+
+/// Primal `powf`.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::powf;
+///
+/// assert_eq!(powf(2.0_f64, 3.0), 8.0);
+/// ```
+pub fn powf<S: ScalarAd>(x: S, exponent: S::Real) -> S {
+    x.powf(exponent)
+}
+
+/// Forward rule for `powf` with fixed exponent.
+///
+/// Returns `(primal, tangent)`.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::powf_frule;
+///
+/// let (y, dy) = powf_frule(2.0_f64, 3.0, 1.0);
+/// assert_eq!(y, 8.0);
+/// assert_eq!(dy, 12.0);
+/// ```
+pub fn powf_frule<S: ScalarAd>(x: S, exponent: S::Real, dx: S) -> (S, S) {
+    let y = x.powf(exponent);
+    let dy = if exponent == S::Real::zero() {
+        S::from_real(S::Real::zero())
+    } else {
+        dx * (S::from_real(exponent) * x.powf(exponent - S::Real::one())).conj()
+    };
+    (y, dy)
+}
+
+/// Reverse rule for `powf` with fixed exponent.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::powf_rrule;
+///
+/// let dx = powf_rrule(2.0_f64, 3.0, 1.0);
+/// assert_eq!(dx, 12.0);
+/// ```
+pub fn powf_rrule<S: ScalarAd>(x: S, exponent: S::Real, cotangent: S) -> S {
+    if exponent == S::Real::zero() {
+        return S::from_real(S::Real::zero());
+    }
+    cotangent * (S::from_real(exponent) * x.powf(exponent - S::Real::one())).conj()
+}
+
+/// Primal `powi`.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::powi;
+///
+/// assert_eq!(powi(2.0_f64, 4), 16.0);
+/// ```
+pub fn powi<S: ScalarAd>(x: S, exponent: i32) -> S {
+    x.powi(exponent)
+}
+
+/// Forward rule for `powi` with fixed integer exponent.
+///
+/// Returns `(primal, tangent)`.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::powi_frule;
+///
+/// let (y, dy) = powi_frule(2.0_f64, 4, 1.0);
+/// assert_eq!(y, 16.0);
+/// assert_eq!(dy, 32.0);
+/// ```
+pub fn powi_frule<S: ScalarAd>(x: S, exponent: i32, dx: S) -> (S, S) {
+    let y = x.powi(exponent);
+    let dy = if exponent == 0 {
+        S::from_i32(0)
+    } else {
+        dx * (S::from_i32(exponent) * x.powi(exponent - 1)).conj()
+    };
+    (y, dy)
+}
+
+/// Reverse rule for `powi` with fixed integer exponent.
+///
+/// # Examples
+///
+/// ```rust
+/// use chainrules_scalarops::powi_rrule;
+///
+/// let dx = powi_rrule(2.0_f64, 4, 1.0);
+/// assert_eq!(dx, 32.0);
+/// ```
+pub fn powi_rrule<S: ScalarAd>(x: S, exponent: i32, cotangent: S) -> S {
+    if exponent == 0 {
+        return S::from_i32(0);
+    }
+    cotangent * (S::from_i32(exponent) * x.powi(exponent - 1)).conj()
+}

--- a/extern/chainrules-scalarops/tests/scalarops_tests.rs
+++ b/extern/chainrules-scalarops/tests/scalarops_tests.rs
@@ -1,0 +1,130 @@
+use chainrules_scalarops::{
+    conj, conj_frule, conj_rrule, handle_r_to_c_f32, handle_r_to_c_f64, powf, powf_frule,
+    powf_rrule, powi, powi_frule, powi_rrule, sqrt, sqrt_frule, sqrt_rrule,
+};
+use num_complex::{Complex32, Complex64};
+
+#[test]
+fn handle_r_to_c_projects_real_part() {
+    let g32 = Complex32::new(1.25, -9.0);
+    let g64 = Complex64::new(-3.5, 2.0);
+    assert_eq!(handle_r_to_c_f32(g32), 1.25_f32);
+    assert_eq!(handle_r_to_c_f64(g64), -3.5_f64);
+}
+
+#[test]
+fn conj_rules_match_formula_complex64() {
+    let x = Complex64::new(2.0, -3.0);
+    let dx = Complex64::new(-0.5, 4.0);
+    let g = Complex64::new(1.5, -2.0);
+
+    let (y, dy) = conj_frule(x, dx);
+    assert_eq!(y, Complex64::new(2.0, 3.0));
+    assert_eq!(dy, Complex64::new(-0.5, -4.0));
+
+    let grad = conj_rrule(g);
+    assert_eq!(grad, Complex64::new(1.5, 2.0));
+}
+
+#[test]
+fn sqrt_rules_match_formula_f64() {
+    let x = 9.0_f64;
+    let dx = 1.0_f64;
+    let g = 1.0_f64;
+
+    let (y, dy) = sqrt_frule(x, dx);
+    assert!((y - 3.0).abs() < 1e-12);
+    assert!((dy - (1.0 / 6.0)).abs() < 1e-12);
+
+    let grad = sqrt_rrule(y, g);
+    assert!((grad - (1.0 / 6.0)).abs() < 1e-12);
+}
+
+#[test]
+fn powf_rules_match_formula_f64() {
+    let x = 2.0_f64;
+    let exponent = 3.0_f64;
+    let dx = 1.0_f64;
+    let g = 1.0_f64;
+
+    let (y, dy) = powf_frule(x, exponent, dx);
+    assert!((y - 8.0).abs() < 1e-12);
+    assert!((dy - 12.0).abs() < 1e-12);
+
+    let grad = powf_rrule(x, exponent, g);
+    assert!((grad - 12.0).abs() < 1e-12);
+}
+
+#[test]
+fn powi_rules_match_formula_complex64() {
+    let x = Complex64::new(1.0, 2.0);
+    let exponent = 3_i32;
+    let dx = Complex64::new(-1.0, 0.5);
+    let g = Complex64::new(0.25, -0.75);
+
+    let (y, dy) = powi_frule(x, exponent, dx);
+    let expected_y = x * x * x;
+    assert!((y - expected_y).norm() < 1e-12);
+
+    let expected_scale = (Complex64::new(3.0, 0.0) * x.powi(2)).conj();
+    assert!((dy - (dx * expected_scale)).norm() < 1e-12);
+
+    let grad = powi_rrule(x, exponent, g);
+    assert!((grad - (g * expected_scale)).norm() < 1e-12);
+}
+
+#[test]
+fn pow_zero_exponent_returns_zero_gradients() {
+    let x = 0.0_f64;
+
+    let (_y_f, dy_f) = powf_frule(x, 0.0, 1.0);
+    assert_eq!(dy_f, 0.0);
+    assert_eq!(powf_rrule(x, 0.0, 1.0), 0.0);
+
+    let (_y_i, dy_i) = powi_frule(x, 0, 1.0);
+    assert_eq!(dy_i, 0.0);
+    assert_eq!(powi_rrule(x, 0, 1.0), 0.0);
+}
+
+#[test]
+fn primal_wrappers_cover_real_and_complex() {
+    assert_eq!(conj(3.0_f32), 3.0_f32);
+    assert!((sqrt(16.0_f32) - 4.0_f32).abs() < 1e-6);
+    assert!((powf(2.0_f32, 3.5_f32) - 2.0_f32.powf(3.5_f32)).abs() < 1e-6);
+    assert!((powi(2.0_f32, -2) - 0.25_f32).abs() < 1e-6);
+
+    let z32 = Complex32::new(3.0, 4.0);
+    assert_eq!(conj(z32), Complex32::new(3.0, -4.0));
+    let z32_sqrt = sqrt(z32);
+    assert!((z32_sqrt * z32_sqrt - z32).norm() < 1e-5);
+    assert!((powf(z32, 1.25_f32) - z32.powf(1.25_f32)).norm() < 1e-5);
+    assert!((powi(z32, 3) - z32.powi(3)).norm() < 1e-5);
+
+    let z64 = Complex64::new(2.0, -1.5);
+    assert_eq!(conj(z64), Complex64::new(2.0, 1.5));
+    let z64_sqrt = sqrt(z64);
+    assert!((z64_sqrt * z64_sqrt - z64).norm() < 1e-12);
+    assert!((powf(z64, 2.5_f64) - z64.powf(2.5_f64)).norm() < 1e-12);
+    assert!((powi(z64, -3) - z64.powi(-3)).norm() < 1e-12);
+}
+
+#[test]
+fn complex_frules_and_rrules_cover_from_real_paths() {
+    let x32 = Complex32::new(1.2, -0.3);
+    let dx32 = Complex32::new(-0.4, 0.7);
+    let g32 = Complex32::new(0.6, -0.2);
+    let (_y32, dy32) = powf_frule(x32, 2.0_f32, dx32);
+    let grad32 = powf_rrule(x32, 2.0_f32, g32);
+    let expected_scale32 = (Complex32::new(2.0, 0.0) * x32.powf(1.0_f32)).conj();
+    assert!((dy32 - dx32 * expected_scale32).norm() < 1e-5);
+    assert!((grad32 - g32 * expected_scale32).norm() < 1e-5);
+
+    let x64 = Complex64::new(-0.8, 1.1);
+    let dx64 = Complex64::new(0.9, -0.4);
+    let g64 = Complex64::new(0.3, 0.2);
+    let (_y64, dy64) = powi_frule(x64, 4, dx64);
+    let grad64 = powi_rrule(x64, 4, g64);
+    let expected_scale64 = (Complex64::new(4.0, 0.0) * x64.powi(3)).conj();
+    assert!((dy64 - dx64 * expected_scale64).norm() < 1e-12);
+    assert!((grad64 - g64 * expected_scale64).norm() < 1e-12);
+}


### PR DESCRIPTION
## Summary
- add new workspace crate `extern/chainrules-scalarops` with scalar AD helpers for `conj/sqrt/powf/powi`
- document PyTorch-compatible complex convention and `handle_r_to_c` projection in AD notes
- extend `AdScalar` with scalar ops and explicit `into_primal()` for intentional AD metadata drop
- add dyadtensor eager AD aliases under `tenferro_dyadtensor::ad` (no `_ad` suffix, no terminal `.run()`)
- document dyadtensor HVP support matrix and staged policy in design docs
- add tests for scalar rules, eager AD entry points, mode propagation, runtime behavior, and coverage thresholds

## Verification
- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo llvm-cov --workspace --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`

Closes #261

Generated with [Claude Code](https://claude.com/claude-code)
