### PR TITLE
fix(dyadtensor): repair mixed reverse bridges

### DIFF
--- a/extension/tenferro-dyadtensor/src/ad_value.rs
+++ b/extension/tenferro-dyadtensor/src/ad_value.rs
@@ -1,5 +1,5 @@
 use chainrules_scalarops as scalarops;
-use core::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Neg, Sub};
 use std::sync::atomic::{AtomicU64, Ordering};
 use tenferro_algebra::Scalar;
 use tenferro_tensor::Tensor;
@@ -239,7 +239,12 @@ impl<T> AdValue<T> {
         }
     }
 
-    /// Maps the payload type while preserving AD mode.
+    /// Maps the payload type while preserving AD metadata.
+    ///
+    /// In reverse mode this preserves the existing `node` / `tape` metadata, so
+    /// it is only appropriate for identity-same-cotangent-space transforms.
+    /// Dtype-changing or otherwise graph-changing reverse transforms must
+    /// register explicit pullback rules instead of using this helper directly.
     ///
     /// # Examples
     ///
@@ -247,11 +252,11 @@ impl<T> AdValue<T> {
     /// use tenferro_dyadtensor::AdValue;
     ///
     /// let x = AdValue::forward(2_i32, 3_i32);
-    /// let y = x.map(|v| v as f64);
+    /// let y = x.map_preserving_metadata(|v| v as f64);
     /// assert_eq!(y.primal_ref(), &2.0_f64);
     /// assert_eq!(y.tangent_ref(), Some(&3.0_f64));
     /// ```
-    pub fn map<U>(self, mut f: impl FnMut(T) -> U) -> AdValue<U> {
+    pub fn map_preserving_metadata<U>(self, mut f: impl FnMut(T) -> U) -> AdValue<U> {
         match self {
             Self::Primal(value) => AdValue::Primal(f(value)),
             Self::Forward { primal, tangent } => AdValue::Forward {
@@ -597,6 +602,89 @@ where
     }
 }
 
+pub(crate) fn map_ad_value_same_type_linear<T, M>(
+    value: AdValue<T>,
+    op_name: &'static str,
+    map: M,
+) -> AdValue<T>
+where
+    T: scalarops::ScalarAd + 'static,
+    M: Fn(T) -> T + Copy + 'static,
+{
+    match value {
+        AdValue::Primal(primal) => AdValue::Primal(map(primal)),
+        AdValue::Forward { primal, tangent } => AdValue::Forward {
+            primal: map(primal),
+            tangent: map(tangent),
+        },
+        AdValue::Reverse {
+            primal,
+            node: input_node,
+            tape,
+            tangent,
+        } => {
+            let output_primal = map(primal);
+            let output_tangent = tangent.map(map);
+            let output_node = NodeId(NEXT_AD_SCALAR_NODE_ID.fetch_add(1, Ordering::Relaxed));
+            reverse_tape::register_scalar_rule(
+                tape,
+                output_node,
+                Box::new(move |cotangent| Ok(vec![(input_node, map(*cotangent))])),
+            )
+            .unwrap_or_else(|e| panic!("{op_name}: {e}"));
+            AdValue::Reverse {
+                primal: output_primal,
+                node: output_node,
+                tape,
+                tangent: output_tangent,
+            }
+        }
+    }
+}
+
+pub(crate) fn map_ad_value_mixed_linear<TIn, TOut, P, R>(
+    value: AdValue<TIn>,
+    op_name: &'static str,
+    primal_map: P,
+    reverse_map: R,
+) -> AdValue<TOut>
+where
+    TIn: scalarops::ScalarAd + 'static,
+    TOut: scalarops::ScalarAd + 'static,
+    P: Fn(TIn) -> TOut + Copy,
+    R: Fn(TOut) -> TIn + Copy + 'static,
+{
+    match value {
+        AdValue::Primal(primal) => AdValue::Primal(primal_map(primal)),
+        AdValue::Forward { primal, tangent } => AdValue::Forward {
+            primal: primal_map(primal),
+            tangent: primal_map(tangent),
+        },
+        AdValue::Reverse {
+            primal,
+            node: input_node,
+            tape,
+            tangent,
+        } => {
+            let output_primal = primal_map(primal);
+            let output_tangent = tangent.map(primal_map);
+            let output_node = NodeId(NEXT_AD_SCALAR_NODE_ID.fetch_add(1, Ordering::Relaxed));
+            reverse_tape::register_scalar_mixed_rule(
+                tape,
+                output_node,
+                Box::new(move |cotangent| Ok(vec![(input_node, reverse_map(*cotangent))])),
+            )
+            .unwrap_or_else(|e| panic!("{op_name}: {e}"));
+            AdValue::Reverse {
+                primal: output_primal,
+                node: output_node,
+                tape,
+                tangent: output_tangent,
+            }
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 struct BinaryScalarState<T> {
     primal: T,
@@ -853,6 +941,23 @@ where
     }
 }
 
+impl<T> Neg for AdScalar<T>
+where
+    T: scalarops::ScalarAd + Neg<Output = T> + 'static,
+{
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        unary_ad_scalar_op(
+            self,
+            "neg",
+            |primal| -primal,
+            |primal, tangent| (-primal, -tangent),
+            |_input, _output, cotangent| -cotangent,
+        )
+    }
+}
+
 /// Tensor newtype carrying AD mode information.
 ///
 /// # Examples
@@ -1094,9 +1199,9 @@ mod tests {
     use tenferro_tensor::MemoryOrder;
 
     #[test]
-    fn ad_value_map_preserves_mode() {
+    fn ad_value_map_preserving_metadata_preserves_mode() {
         let x = AdValue::forward(2_i32, 3_i32);
-        let y = x.map(|v| v as f64);
+        let y = x.map_preserving_metadata(|v| v as f64);
         assert_eq!(y.mode(), AdMode::Forward);
         assert_eq!(y.primal_ref(), &2.0_f64);
         assert_eq!(y.tangent_ref(), Some(&3.0_f64));

--- a/extension/tenferro-dyadtensor/src/dyn_types.rs
+++ b/extension/tenferro-dyadtensor/src/dyn_types.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tenferro_algebra::Scalar;
 use tenferro_tensor::{MemoryOrder, Tensor};
 
+use crate::ad_value::{map_ad_value_mixed_linear, map_ad_value_same_type_linear};
 use crate::{reverse_tape, AdMode, AdScalar, AdTensor, AdValue, Error, NodeId, Result, TapeId};
 
 static NEXT_AD_TENSOR_NODE_ID: AtomicU64 = AtomicU64::new(1_u64 << 61);
@@ -760,12 +761,20 @@ impl BinaryOp {
     }
 }
 
-fn promote_f32_to_c32(value: AdValue<f32>) -> AdValue<Complex32> {
-    value.map(|x| Complex32::new(x, 0.0))
+fn promote_f32_to_c32(value: AdValue<f32>, op_name: &'static str) -> AdValue<Complex32> {
+    map_ad_value_mixed_linear(value, op_name, |x| Complex32::new(x, 0.0), |z| z.re)
 }
 
-fn promote_f64_to_c64(value: AdValue<f64>) -> AdValue<Complex64> {
-    value.map(|x| Complex64::new(x, 0.0))
+fn promote_f64_to_c64(value: AdValue<f64>, op_name: &'static str) -> AdValue<Complex64> {
+    map_ad_value_mixed_linear(value, op_name, |x| Complex64::new(x, 0.0), |z| z.re)
+}
+
+fn embed_f32_to_c32_imag(value: AdValue<f32>, op_name: &'static str) -> AdValue<Complex32> {
+    map_ad_value_mixed_linear(value, op_name, |y| Complex32::new(0.0, y), |z| z.im)
+}
+
+fn embed_f64_to_c64_imag(value: AdValue<f64>, op_name: &'static str) -> AdValue<Complex64> {
+    map_ad_value_mixed_linear(value, op_name, |y| Complex64::new(0.0, y), |z| z.im)
 }
 
 fn apply_binary_ad<T: ScalarAd + 'static>(
@@ -836,16 +845,16 @@ fn try_binary_dyn(lhs: DynAdScalar, rhs: DynAdScalar, op: BinaryOp) -> Result<Dy
             Ok(DynAdScalar::C64(checked_apply_binary_ad(a, b, op)?))
         }
         (DynAdScalar::F32(a), DynAdScalar::C32(b)) => Ok(DynAdScalar::C32(
-            checked_apply_binary_ad(promote_f32_to_c32(a), b, op)?,
+            checked_apply_binary_ad(promote_f32_to_c32(a, op.name()), b, op)?,
         )),
         (DynAdScalar::C32(a), DynAdScalar::F32(b)) => Ok(DynAdScalar::C32(
-            checked_apply_binary_ad(a, promote_f32_to_c32(b), op)?,
+            checked_apply_binary_ad(a, promote_f32_to_c32(b, op.name()), op)?,
         )),
         (DynAdScalar::F64(a), DynAdScalar::C64(b)) => Ok(DynAdScalar::C64(
-            checked_apply_binary_ad(promote_f64_to_c64(a), b, op)?,
+            checked_apply_binary_ad(promote_f64_to_c64(a, op.name()), b, op)?,
         )),
         (DynAdScalar::C64(a), DynAdScalar::F64(b)) => Ok(DynAdScalar::C64(
-            checked_apply_binary_ad(a, promote_f64_to_c64(b), op)?,
+            checked_apply_binary_ad(a, promote_f64_to_c64(b, op.name()), op)?,
         )),
         _ => Err(unsupported_binary_pair(op, lhs_ty, rhs_ty)),
     }
@@ -1167,7 +1176,7 @@ impl DynAdScalar {
                 if *v.primal_ref() >= 0.0 {
                     Self::F32(AdScalar::from(v).sqrt().into_value())
                 } else {
-                    let promoted = v.map(|x| Complex32::new(x, 0.0));
+                    let promoted = promote_f32_to_c32(v, "sqrt");
                     Self::C32(AdScalar::from(promoted).sqrt().into_value())
                 }
             }
@@ -1175,7 +1184,7 @@ impl DynAdScalar {
                 if *v.primal_ref() >= 0.0 {
                     Self::F64(AdScalar::from(v).sqrt().into_value())
                 } else {
-                    let promoted = v.map(|x| Complex64::new(x, 0.0));
+                    let promoted = promote_f64_to_c64(v, "sqrt");
                     Self::C64(AdScalar::from(promoted).sqrt().into_value())
                 }
             }
@@ -1193,7 +1202,7 @@ impl DynAdScalar {
                 if *v.primal_ref() >= 0.0 {
                     Self::F32(AdScalar::from(v).powf(exponent as f32).into_value())
                 } else {
-                    let promoted = v.map(|x| Complex32::new(x, 0.0));
+                    let promoted = promote_f32_to_c32(v, "powf");
                     Self::C32(AdScalar::from(promoted).powf(exponent as f32).into_value())
                 }
             }
@@ -1201,7 +1210,7 @@ impl DynAdScalar {
                 if *v.primal_ref() >= 0.0 {
                     Self::F64(AdScalar::from(v).powf(exponent).into_value())
                 } else {
-                    let promoted = v.map(|x| Complex64::new(x, 0.0));
+                    let promoted = promote_f64_to_c64(v, "powf");
                     Self::C64(AdScalar::from(promoted).powf(exponent).into_value())
                 }
             }
@@ -1228,8 +1237,18 @@ impl DynAdScalar {
         match self.clone() {
             Self::F32(v) => Self::F32(v),
             Self::F64(v) => Self::F64(v),
-            Self::C32(v) => Self::F32(v.map(|z| z.re)),
-            Self::C64(v) => Self::F64(v.map(|z| z.re)),
+            Self::C32(v) => Self::F32(map_ad_value_mixed_linear(
+                v,
+                "real_part",
+                |z| z.re,
+                |cotangent| Complex32::new(cotangent, 0.0),
+            )),
+            Self::C64(v) => Self::F64(map_ad_value_mixed_linear(
+                v,
+                "real_part",
+                |z| z.re,
+                |cotangent| Complex64::new(cotangent, 0.0),
+            )),
         }
     }
 
@@ -1239,10 +1258,20 @@ impl DynAdScalar {
     /// - Complex dtype: returns real dtype (`C32->F32`, `C64->F64`).
     pub fn imag_part(&self) -> Self {
         match self.clone() {
-            Self::F32(v) => Self::F32(v.map(|_| 0.0_f32)),
-            Self::F64(v) => Self::F64(v.map(|_| 0.0_f64)),
-            Self::C32(v) => Self::F32(v.map(|z| z.im)),
-            Self::C64(v) => Self::F64(v.map(|z| z.im)),
+            Self::F32(v) => Self::F32(map_ad_value_same_type_linear(v, "imag_part", |_| 0.0_f32)),
+            Self::F64(v) => Self::F64(map_ad_value_same_type_linear(v, "imag_part", |_| 0.0_f64)),
+            Self::C32(v) => Self::F32(map_ad_value_mixed_linear(
+                v,
+                "imag_part",
+                |z| z.im,
+                |cotangent| Complex32::new(0.0, cotangent),
+            )),
+            Self::C64(v) => Self::F64(map_ad_value_mixed_linear(
+                v,
+                "imag_part",
+                |z| z.im,
+                |cotangent| Complex64::new(0.0, cotangent),
+            )),
         }
     }
 
@@ -1252,13 +1281,13 @@ impl DynAdScalar {
     pub fn compose_complex(real: Self, imag: Self) -> Result<Self> {
         match (real, imag) {
             (Self::F32(re), Self::F32(im)) => Ok(Self::C32(checked_apply_binary_ad(
-                re.map(|x| Complex32::new(x, 0.0)),
-                im.map(|y| Complex32::new(0.0, y)),
+                promote_f32_to_c32(re, "compose_complex"),
+                embed_f32_to_c32_imag(im, "compose_complex"),
                 BinaryOp::Add,
             )?)),
             (Self::F64(re), Self::F64(im)) => Ok(Self::C64(checked_apply_binary_ad(
-                re.map(|x| Complex64::new(x, 0.0)),
-                im.map(|y| Complex64::new(0.0, y)),
+                promote_f64_to_c64(re, "compose_complex"),
+                embed_f64_to_c64_imag(im, "compose_complex"),
                 BinaryOp::Add,
             )?)),
             (lhs, rhs) => Err(Error::InvalidAdScalar {
@@ -1431,10 +1460,10 @@ impl Neg for DynAdScalar {
 
     fn neg(self) -> Self::Output {
         match self {
-            DynAdScalar::F32(v) => DynAdScalar::F32(v.map(|x| -x)),
-            DynAdScalar::F64(v) => DynAdScalar::F64(v.map(|x| -x)),
-            DynAdScalar::C32(v) => DynAdScalar::C32(v.map(|x| -x)),
-            DynAdScalar::C64(v) => DynAdScalar::C64(v.map(|x| -x)),
+            DynAdScalar::F32(v) => DynAdScalar::F32((-AdScalar::from(v)).into_value()),
+            DynAdScalar::F64(v) => DynAdScalar::F64((-AdScalar::from(v)).into_value()),
+            DynAdScalar::C32(v) => DynAdScalar::C32((-AdScalar::from(v)).into_value()),
+            DynAdScalar::C64(v) => DynAdScalar::C64((-AdScalar::from(v)).into_value()),
         }
     }
 }
@@ -1593,32 +1622,100 @@ pub enum DynAdTensor {
     C64(AdTensor<Complex64>),
 }
 
-fn map_ad_tensor_unary_typed<T, U, F>(input: &AdTensor<T>, f: F) -> Result<AdTensor<U>>
+fn map_ad_tensor_same_type_linear_typed<T, F>(
+    input: &AdTensor<T>,
+    op_name: &'static str,
+    map: F,
+) -> Result<AdTensor<T>>
 where
-    T: Scalar + Copy,
-    U: Scalar + Copy,
-    F: Fn(T) -> U + Copy,
+    T: Scalar + ScalarAd + Copy + 'static,
+    F: Fn(T) -> T + Copy + 'static,
 {
     let mapped = match input.as_value().clone() {
-        AdValue::Primal(primal) => AdValue::Primal(tensor_map_unary_typed(&primal, f)?),
+        AdValue::Primal(primal) => AdValue::Primal(tensor_map_unary_typed(&primal, map)?),
         AdValue::Forward { primal, tangent } => AdValue::Forward {
-            primal: tensor_map_unary_typed(&primal, f)?,
-            tangent: tensor_map_unary_typed(&tangent, f)?,
+            primal: tensor_map_unary_typed(&primal, map)?,
+            tangent: tensor_map_unary_typed(&tangent, map)?,
         },
         AdValue::Reverse {
             primal,
-            node,
+            node: input_node,
             tape,
             tangent,
-        } => AdValue::Reverse {
-            primal: tensor_map_unary_typed(&primal, f)?,
-            node,
-            tape,
-            tangent: tangent
+        } => {
+            let output_primal = tensor_map_unary_typed(&primal, map)?;
+            let output_tangent = tangent
                 .as_ref()
-                .map(|t| tensor_map_unary_typed(t, f))
-                .transpose()?,
+                .map(|t| tensor_map_unary_typed(t, map))
+                .transpose()?;
+            let output_node = NodeId(NEXT_AD_TENSOR_NODE_ID.fetch_add(1, Ordering::Relaxed));
+            reverse_tape::register_rule::<T>(
+                tape,
+                output_node,
+                Box::new(move |cotangent| {
+                    Ok(vec![(input_node, tensor_map_unary_typed(cotangent, map)?)])
+                }),
+            )
+            .unwrap_or_else(|e| panic!("{op_name}: {e}"));
+            AdValue::Reverse {
+                primal: output_primal,
+                node: output_node,
+                tape,
+                tangent: output_tangent,
+            }
+        }
+    };
+    Ok(AdTensor(mapped))
+}
+
+fn map_ad_tensor_mixed_linear_typed<TIn, TOut, P, R>(
+    input: &AdTensor<TIn>,
+    op_name: &'static str,
+    primal_map: P,
+    reverse_map: R,
+) -> Result<AdTensor<TOut>>
+where
+    TIn: Scalar + ScalarAd + Copy + 'static,
+    TOut: Scalar + ScalarAd + Copy + 'static,
+    P: Fn(TIn) -> TOut + Copy,
+    R: Fn(TOut) -> TIn + Copy + 'static,
+{
+    let mapped = match input.as_value().clone() {
+        AdValue::Primal(primal) => AdValue::Primal(tensor_map_unary_typed(&primal, primal_map)?),
+        AdValue::Forward { primal, tangent } => AdValue::Forward {
+            primal: tensor_map_unary_typed(&primal, primal_map)?,
+            tangent: tensor_map_unary_typed(&tangent, primal_map)?,
         },
+        AdValue::Reverse {
+            primal,
+            node: input_node,
+            tape,
+            tangent,
+        } => {
+            let output_primal = tensor_map_unary_typed(&primal, primal_map)?;
+            let output_tangent = tangent
+                .as_ref()
+                .map(|t| tensor_map_unary_typed(t, primal_map))
+                .transpose()?;
+            let output_node = NodeId(NEXT_AD_TENSOR_NODE_ID.fetch_add(1, Ordering::Relaxed));
+            reverse_tape::register_bridge_rule::<TOut, TIn>(
+                tape,
+                output_node,
+                Box::new(move |cotangent| {
+                    Ok(vec![(
+                        input_node,
+                        tensor_map_unary_typed(cotangent, reverse_map)?,
+                    )])
+                }),
+            )
+            .unwrap_or_else(|e| panic!("{op_name}: {e}"));
+            AdValue::Reverse {
+                primal: output_primal,
+                node: output_node,
+                tape,
+                tangent: output_tangent,
+            }
+        }
     };
     Ok(AdTensor(mapped))
 }
@@ -2146,8 +2243,18 @@ impl DynAdTensor {
         match self {
             Self::F32(v) => Ok(Self::F32(v.clone())),
             Self::F64(v) => Ok(Self::F64(v.clone())),
-            Self::C32(v) => Ok(Self::F32(map_ad_tensor_unary_typed(v, |z| z.re)?)),
-            Self::C64(v) => Ok(Self::F64(map_ad_tensor_unary_typed(v, |z| z.re)?)),
+            Self::C32(v) => Ok(Self::F32(map_ad_tensor_mixed_linear_typed(
+                v,
+                "real_part",
+                |z| z.re,
+                |cotangent| Complex32::new(cotangent, 0.0),
+            )?)),
+            Self::C64(v) => Ok(Self::F64(map_ad_tensor_mixed_linear_typed(
+                v,
+                "real_part",
+                |z| z.re,
+                |cotangent| Complex64::new(cotangent, 0.0),
+            )?)),
         }
     }
 
@@ -2157,10 +2264,28 @@ impl DynAdTensor {
     /// - Complex dtype: returns real dtype (`C32->F32`, `C64->F64`).
     pub fn imag_part(&self) -> Result<Self> {
         match self {
-            Self::F32(v) => Ok(Self::F32(map_ad_tensor_unary_typed(v, |_| 0.0_f32)?)),
-            Self::F64(v) => Ok(Self::F64(map_ad_tensor_unary_typed(v, |_| 0.0_f64)?)),
-            Self::C32(v) => Ok(Self::F32(map_ad_tensor_unary_typed(v, |z| z.im)?)),
-            Self::C64(v) => Ok(Self::F64(map_ad_tensor_unary_typed(v, |z| z.im)?)),
+            Self::F32(v) => Ok(Self::F32(map_ad_tensor_same_type_linear_typed(
+                v,
+                "imag_part",
+                |_| 0.0_f32,
+            )?)),
+            Self::F64(v) => Ok(Self::F64(map_ad_tensor_same_type_linear_typed(
+                v,
+                "imag_part",
+                |_| 0.0_f64,
+            )?)),
+            Self::C32(v) => Ok(Self::F32(map_ad_tensor_mixed_linear_typed(
+                v,
+                "imag_part",
+                |z| z.im,
+                |cotangent| Complex32::new(0.0, cotangent),
+            )?)),
+            Self::C64(v) => Ok(Self::F64(map_ad_tensor_mixed_linear_typed(
+                v,
+                "imag_part",
+                |z| z.im,
+                |cotangent| Complex64::new(0.0, cotangent),
+            )?)),
         }
     }
 
@@ -2170,14 +2295,34 @@ impl DynAdTensor {
     pub fn compose_complex(real: Self, imag: Self) -> Result<Self> {
         match (real, imag) {
             (Self::F32(re), Self::F32(im)) => {
-                let re_c = map_ad_tensor_unary_typed(&re, |x| Complex32::new(x, 0.0))?;
-                let im_c = map_ad_tensor_unary_typed(&im, |y| Complex32::new(0.0, y))?;
+                let re_c = map_ad_tensor_mixed_linear_typed(
+                    &re,
+                    "compose_complex",
+                    |x| Complex32::new(x, 0.0),
+                    |cotangent| cotangent.re,
+                )?;
+                let im_c = map_ad_tensor_mixed_linear_typed(
+                    &im,
+                    "compose_complex",
+                    |y| Complex32::new(0.0, y),
+                    |cotangent| cotangent.im,
+                )?;
                 let merged = merge_add_ad_tensors(re_c.into_value(), im_c.into_value())?;
                 Ok(Self::C32(AdTensor(merged)))
             }
             (Self::F64(re), Self::F64(im)) => {
-                let re_c = map_ad_tensor_unary_typed(&re, |x| Complex64::new(x, 0.0))?;
-                let im_c = map_ad_tensor_unary_typed(&im, |y| Complex64::new(0.0, y))?;
+                let re_c = map_ad_tensor_mixed_linear_typed(
+                    &re,
+                    "compose_complex",
+                    |x| Complex64::new(x, 0.0),
+                    |cotangent| cotangent.re,
+                )?;
+                let im_c = map_ad_tensor_mixed_linear_typed(
+                    &im,
+                    "compose_complex",
+                    |y| Complex64::new(0.0, y),
+                    |cotangent| cotangent.im,
+                )?;
                 let merged = merge_add_ad_tensors(re_c.into_value(), im_c.into_value())?;
                 Ok(Self::C64(AdTensor(merged)))
             }
@@ -2218,8 +2363,16 @@ impl DynAdTensor {
             (Self::C32(tensor), DynAdScalar::C32(alpha)) => {
                 Ok(Self::C32(scale_ad_tensor_typed(tensor, alpha)?))
             }
+            (Self::C32(tensor), DynAdScalar::F32(alpha)) => {
+                let promoted = promote_f32_to_c32(alpha.clone(), "scale");
+                Ok(Self::C32(scale_ad_tensor_typed(tensor, &promoted)?))
+            }
             (Self::C64(tensor), DynAdScalar::C64(alpha)) => {
                 Ok(Self::C64(scale_ad_tensor_typed(tensor, alpha)?))
+            }
+            (Self::C64(tensor), DynAdScalar::F64(alpha)) => {
+                let promoted = promote_f64_to_c64(alpha.clone(), "scale");
+                Ok(Self::C64(scale_ad_tensor_typed(tensor, &promoted)?))
             }
             _ => Err(Error::InvalidAdTensor {
                 message: format!(
@@ -2304,8 +2457,16 @@ impl DynAdTensor {
             (Self::C32(tensor), DynAdScalar::C32(alpha)) => {
                 Ok(Self::C32(div_ad_tensor_typed(tensor, alpha)?))
             }
+            (Self::C32(tensor), DynAdScalar::F32(alpha)) => {
+                let promoted = promote_f32_to_c32(alpha.clone(), "div_scalar");
+                Ok(Self::C32(div_ad_tensor_typed(tensor, &promoted)?))
+            }
             (Self::C64(tensor), DynAdScalar::C64(alpha)) => {
                 Ok(Self::C64(div_ad_tensor_typed(tensor, alpha)?))
+            }
+            (Self::C64(tensor), DynAdScalar::F64(alpha)) => {
+                let promoted = promote_f64_to_c64(alpha.clone(), "div_scalar");
+                Ok(Self::C64(div_ad_tensor_typed(tensor, &promoted)?))
             }
             _ => Err(Error::InvalidAdTensor {
                 message: format!(

--- a/extension/tenferro-dyadtensor/src/reverse_tape.rs
+++ b/extension/tenferro-dyadtensor/src/reverse_tape.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use chainrules_core::Differentiable as _;
 use chainrules_scalarops::ScalarAd;
+use num_complex::{Complex32, Complex64};
 use tenferro_algebra::Scalar;
 use tenferro_tensor::Tensor;
 
@@ -14,6 +15,7 @@ type BridgeRule<TOut, TIn> =
     Box<dyn Fn(&Tensor<TOut>) -> Result<Vec<(NodeId, Tensor<TIn>)>> + 'static>;
 type ScalarBridgeRule<TOut, TIn> =
     Box<dyn Fn(&Tensor<TOut>) -> Result<Vec<(NodeId, TIn)>> + 'static>;
+type ScalarMixedRule<TOut, TIn> = Box<dyn Fn(&TOut) -> Result<Vec<(NodeId, TIn)>> + 'static>;
 type ScalarPullbackRule<T> = Box<dyn Fn(&T) -> Result<Vec<(NodeId, T)>> + 'static>;
 
 struct TapeRules<T: Scalar> {
@@ -52,6 +54,18 @@ impl<TOut: Scalar, TIn: ScalarAd> TapeScalarBridgeRules<TOut, TIn> {
     }
 }
 
+struct TapeScalarMixedRules<TOut: ScalarAd, TIn: ScalarAd> {
+    rules: HashMap<NodeId, ScalarMixedRule<TOut, TIn>>,
+}
+
+impl<TOut: ScalarAd, TIn: ScalarAd> TapeScalarMixedRules<TOut, TIn> {
+    fn new() -> Self {
+        Self {
+            rules: HashMap::new(),
+        }
+    }
+}
+
 struct TapeScalarRules<T: ScalarAd> {
     rules: HashMap<NodeId, ScalarPullbackRule<T>>,
 }
@@ -67,12 +81,14 @@ impl<T: ScalarAd> TapeScalarRules<T> {
 type RuleRegistry = HashMap<(u64, TypeId), Box<dyn Any>>;
 type BridgeRegistry = HashMap<(u64, TypeId, TypeId), Box<dyn Any>>;
 type ScalarBridgeRegistry = HashMap<(u64, TypeId, TypeId), Box<dyn Any>>;
+type ScalarMixedRegistry = HashMap<(u64, TypeId, TypeId), Box<dyn Any>>;
 type ScalarRuleRegistry = HashMap<(u64, TypeId), Box<dyn Any>>;
 
 thread_local! {
     static REVERSE_RULE_REGISTRY: RefCell<RuleRegistry> = RefCell::new(HashMap::new());
     static REVERSE_BRIDGE_REGISTRY: RefCell<BridgeRegistry> = RefCell::new(HashMap::new());
     static REVERSE_SCALAR_BRIDGE_REGISTRY: RefCell<ScalarBridgeRegistry> = RefCell::new(HashMap::new());
+    static REVERSE_SCALAR_MIXED_REGISTRY: RefCell<ScalarMixedRegistry> = RefCell::new(HashMap::new());
     static REVERSE_SCALAR_RULE_REGISTRY: RefCell<ScalarRuleRegistry> = RefCell::new(HashMap::new());
 }
 
@@ -139,6 +155,27 @@ pub(crate) fn register_scalar_bridge_rule<TOut: Scalar + 'static, TIn: ScalarAd 
     })
 }
 
+pub(crate) fn register_scalar_mixed_rule<TOut: ScalarAd + 'static, TIn: ScalarAd + 'static>(
+    tape: TapeId,
+    node: NodeId,
+    rule: ScalarMixedRule<TOut, TIn>,
+) -> Result<()> {
+    REVERSE_SCALAR_MIXED_REGISTRY.with(|registry| {
+        let mut registry = registry.borrow_mut();
+        let key = (tape.0, TypeId::of::<TOut>(), TypeId::of::<TIn>());
+        let entry = registry
+            .entry(key)
+            .or_insert_with(|| Box::new(TapeScalarMixedRules::<TOut, TIn>::new()));
+        let typed = entry
+            .downcast_mut::<TapeScalarMixedRules<TOut, TIn>>()
+            .ok_or_else(|| Error::InvalidAdScalar {
+                message: "reverse scalar mixed registry type mismatch".to_string(),
+            })?;
+        typed.rules.insert(node, rule);
+        Ok(())
+    })
+}
+
 pub(crate) fn register_scalar_rule<T: ScalarAd + 'static>(
     tape: TapeId,
     node: NodeId,
@@ -199,6 +236,29 @@ fn bridge_pullback_scalar<TOut: Scalar + 'static, TIn: ScalarAd + 'static>(
             .downcast_ref::<TapeScalarBridgeRules<TOut, TIn>>()
             .ok_or_else(|| Error::InvalidAdScalar {
                 message: "reverse scalar bridge registry type mismatch".to_string(),
+            })?;
+        let Some(rule) = state.rules.get(&output_node) else {
+            return Ok(Vec::new());
+        };
+        rule(cotangent)
+    })
+}
+
+fn bridge_pullback_scalar_mixed<TOut: ScalarAd + 'static, TIn: ScalarAd + 'static>(
+    tape: TapeId,
+    output_node: NodeId,
+    cotangent: &TOut,
+) -> Result<Vec<(NodeId, TIn)>> {
+    REVERSE_SCALAR_MIXED_REGISTRY.with(|registry| {
+        let registry = registry.borrow();
+        let key = (tape.0, TypeId::of::<TOut>(), TypeId::of::<TIn>());
+        let Some(state_any) = registry.get(&key) else {
+            return Ok(Vec::new());
+        };
+        let state = state_any
+            .downcast_ref::<TapeScalarMixedRules<TOut, TIn>>()
+            .ok_or_else(|| Error::InvalidAdScalar {
+                message: "reverse scalar mixed registry type mismatch".to_string(),
             })?;
         let Some(rule) = state.rules.get(&output_node) else {
             return Ok(Vec::new());
@@ -346,17 +406,52 @@ pub(crate) fn pullback_wrt_scalars<TOut: Scalar + 'static, TIn: ScalarAd + 'stat
         Err(e) => return Err(e),
     };
 
+    let mut all_in_grads: HashMap<NodeId, TIn> = HashMap::new();
+    let direct_seed_in = collect_tensor_scalar_bridge_seeds::<TOut, TIn>(tape, &all_out_grads)?;
+    for (node, grad) in propagate_scalar_seeds(tape, direct_seed_in)? {
+        accumulate_scalar_into(&mut all_in_grads, node, grad);
+    }
+
+    accumulate_tensor_scalar_mixed_path::<TOut, f32, TIn>(tape, &all_out_grads, &mut all_in_grads)?;
+    accumulate_tensor_scalar_mixed_path::<TOut, f64, TIn>(tape, &all_out_grads, &mut all_in_grads)?;
+    accumulate_tensor_scalar_mixed_path::<TOut, Complex32, TIn>(
+        tape,
+        &all_out_grads,
+        &mut all_in_grads,
+    )?;
+    accumulate_tensor_scalar_mixed_path::<TOut, Complex64, TIn>(
+        tape,
+        &all_out_grads,
+        &mut all_in_grads,
+    )?;
+
+    Ok(wrt_nodes
+        .iter()
+        .map(|node| node.and_then(|n| all_in_grads.get(&n).copied()))
+        .collect())
+}
+
+fn collect_tensor_scalar_bridge_seeds<TOut: Scalar + 'static, TIn: ScalarAd + 'static>(
+    tape: TapeId,
+    all_out_grads: &HashMap<NodeId, Tensor<TOut>>,
+) -> Result<HashMap<NodeId, TIn>> {
     let mut seed_in: HashMap<NodeId, TIn> = HashMap::new();
-    for (node, delta_out) in &all_out_grads {
+    for (node, delta_out) in all_out_grads {
         let bridged = bridge_pullback_scalar::<TOut, TIn>(tape, *node, delta_out)?;
         for (in_node, in_delta) in bridged {
             accumulate_scalar_into(&mut seed_in, in_node, in_delta);
         }
     }
+    Ok(seed_in)
+}
 
-    let mut all_in_grads: HashMap<NodeId, TIn> = HashMap::new();
+fn propagate_scalar_seeds<T: ScalarAd + 'static>(
+    tape: TapeId,
+    seed_in: HashMap<NodeId, T>,
+) -> Result<HashMap<NodeId, T>> {
+    let mut all_in_grads: HashMap<NodeId, T> = HashMap::new();
     for (seed_node, seed_delta) in seed_in {
-        let propagated = match pullback_scalar::<TIn>(tape, seed_node, &seed_delta) {
+        let propagated = match pullback_scalar::<T>(tape, seed_node, &seed_delta) {
             Ok(grads) => grads,
             Err(Error::InvalidAdScalar { message })
                 if message.starts_with("no reverse scalar rules registered for tape")
@@ -372,11 +467,59 @@ pub(crate) fn pullback_wrt_scalars<TOut: Scalar + 'static, TIn: ScalarAd + 'stat
             accumulate_scalar_into(&mut all_in_grads, node, grad);
         }
     }
+    Ok(all_in_grads)
+}
 
-    Ok(wrt_nodes
-        .iter()
-        .map(|node| node.and_then(|n| all_in_grads.get(&n).copied()))
-        .collect())
+fn pullback_scalar_wrt_mixed<TOut: ScalarAd + 'static, TIn: ScalarAd + 'static>(
+    tape: TapeId,
+    output_node: NodeId,
+    cotangent: &TOut,
+) -> Result<HashMap<NodeId, TIn>> {
+    let all_out_grads = match pullback_scalar::<TOut>(tape, output_node, cotangent) {
+        Ok(grads) => grads,
+        Err(Error::InvalidAdScalar { message })
+            if message.starts_with("no reverse scalar rules registered for tape")
+                || message.starts_with("no reverse scalar rule registered for output node") =>
+        {
+            let mut seed = HashMap::new();
+            seed.insert(output_node, *cotangent);
+            seed
+        }
+        Err(e) => return Err(e),
+    };
+
+    let mut seed_in: HashMap<NodeId, TIn> = HashMap::new();
+    for (node, delta_out) in &all_out_grads {
+        let bridged = bridge_pullback_scalar_mixed::<TOut, TIn>(tape, *node, delta_out)?;
+        for (in_node, in_delta) in bridged {
+            accumulate_scalar_into(&mut seed_in, in_node, in_delta);
+        }
+    }
+
+    propagate_scalar_seeds(tape, seed_in)
+}
+
+fn accumulate_tensor_scalar_mixed_path<
+    TOut: Scalar + 'static,
+    TSeed: ScalarAd + 'static,
+    TIn: ScalarAd + 'static,
+>(
+    tape: TapeId,
+    all_out_grads: &HashMap<NodeId, Tensor<TOut>>,
+    all_in_grads: &mut HashMap<NodeId, TIn>,
+) -> Result<()> {
+    if TypeId::of::<TSeed>() == TypeId::of::<TIn>() {
+        return Ok(());
+    }
+
+    let seed_in = collect_tensor_scalar_bridge_seeds::<TOut, TSeed>(tape, all_out_grads)?;
+    for (seed_node, seed_delta) in seed_in {
+        let propagated = pullback_scalar_wrt_mixed::<TSeed, TIn>(tape, seed_node, &seed_delta)?;
+        for (node, grad) in propagated {
+            accumulate_scalar_into(all_in_grads, node, grad);
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn pullback_scalar<T: ScalarAd + 'static>(

--- a/extension/tenferro-dyadtensor/tests/mixed_complex_real_scalar_tests.rs
+++ b/extension/tenferro-dyadtensor/tests/mixed_complex_real_scalar_tests.rs
@@ -1,0 +1,156 @@
+use num_complex::Complex64;
+use tenferro_dyadtensor::{
+    ad, AdMode, AdScalar, AdTensor, AdValue, DynAdScalar, DynAdTensor, NodeId, TapeId,
+};
+use tenferro_tensor::{MemoryOrder, Tensor};
+
+fn c64_vec(values: &[Complex64]) -> Tensor<Complex64> {
+    Tensor::<Complex64>::from_slice(values, &[values.len()], MemoryOrder::ColumnMajor).unwrap()
+}
+
+fn scalar_f64(value: &DynAdScalar) -> AdScalar<f64> {
+    AdScalar::from(value.as_f64().unwrap().clone())
+}
+
+#[test]
+fn c64_tensor_scale_accepts_f64_scalar_in_forward_mode() {
+    let x: DynAdTensor = AdTensor::new_forward(
+        c64_vec(&[Complex64::new(1.0, 0.0), Complex64::new(-3.0, 0.0)]),
+        c64_vec(&[Complex64::new(0.5, 0.0), Complex64::new(1.5, 0.0)]),
+    )
+    .into();
+    let a = DynAdScalar::from(AdValue::forward(2.0_f64, 0.25_f64));
+
+    let out = x.scale(&a).unwrap();
+    assert_eq!(out.mode(), AdMode::Forward);
+
+    let out_t = out.as_c64().unwrap();
+    assert_eq!(
+        out_t.primal().buffer().as_slice().unwrap(),
+        &[Complex64::new(2.0, 0.0), Complex64::new(-6.0, 0.0)]
+    );
+    assert_eq!(
+        out_t.tangent().unwrap().buffer().as_slice().unwrap(),
+        &[Complex64::new(1.25, 0.0), Complex64::new(2.25, 0.0)]
+    );
+}
+
+#[test]
+fn c64_tensor_div_scalar_accepts_f64_scalar_in_forward_mode() {
+    let x: DynAdTensor = AdTensor::new_forward(
+        c64_vec(&[Complex64::new(4.0, 0.0), Complex64::new(-6.0, 0.0)]),
+        c64_vec(&[Complex64::new(0.5, 0.0), Complex64::new(1.5, 0.0)]),
+    )
+    .into();
+    let a = DynAdScalar::from(AdValue::forward(2.0_f64, 0.5_f64));
+
+    let out = x.div_scalar(&a).unwrap();
+    assert_eq!(out.mode(), AdMode::Forward);
+
+    let out_t = out.as_c64().unwrap();
+    assert_eq!(
+        out_t.primal().buffer().as_slice().unwrap(),
+        &[Complex64::new(2.0, 0.0), Complex64::new(-3.0, 0.0)]
+    );
+    assert_eq!(
+        out_t.tangent().unwrap().buffer().as_slice().unwrap(),
+        &[Complex64::new(-0.25, 0.0), Complex64::new(1.5, 0.0)]
+    );
+}
+
+#[test]
+fn c64_tensor_axpby_accepts_real_coefficients() {
+    let x: DynAdTensor = AdTensor::new_forward(
+        c64_vec(&[Complex64::new(1.0, 0.0), Complex64::new(-3.0, 0.0)]),
+        c64_vec(&[Complex64::new(0.5, 0.0), Complex64::new(1.5, 0.0)]),
+    )
+    .into();
+    let y: DynAdTensor = AdTensor::new_forward(
+        c64_vec(&[Complex64::new(0.5, 0.0), Complex64::new(2.0, 0.0)]),
+        c64_vec(&[Complex64::new(-0.5, 0.0), Complex64::new(0.25, 0.0)]),
+    )
+    .into();
+    let a = DynAdScalar::from(AdValue::forward(2.0_f64, 0.25_f64));
+    let b = DynAdScalar::from(AdValue::forward(-0.5_f64, 1.0_f64));
+
+    let out = x.axpby(&a, &y, &b).unwrap();
+    assert_eq!(out.mode(), AdMode::Forward);
+
+    let out_t = out.as_c64().unwrap();
+    assert_eq!(
+        out_t.primal().buffer().as_slice().unwrap(),
+        &[Complex64::new(1.75, 0.0), Complex64::new(-7.0, 0.0)]
+    );
+    assert_eq!(
+        out_t.tangent().unwrap().buffer().as_slice().unwrap(),
+        &[Complex64::new(2.0, 0.0), Complex64::new(4.125, 0.0)]
+    );
+}
+
+#[test]
+fn c64_tensor_scale_pullback_reaches_real_scalar_input() {
+    let x: DynAdTensor = AdTensor::new_reverse(
+        c64_vec(&[Complex64::new(1.0, 0.0), Complex64::new(-3.0, 0.0)]),
+        NodeId(21),
+        TapeId(91),
+        None,
+    )
+    .into();
+    let a = DynAdScalar::from(AdValue::reverse(2.0_f64, NodeId(22), TapeId(91), None));
+
+    let out = x.scale(&a).unwrap();
+    let cotangent = AdTensor::new_primal(c64_vec(&[
+        Complex64::new(0.5, 0.0),
+        Complex64::new(1.0, 0.0),
+    ]));
+
+    let tensor_grads =
+        ad::pullback_wrt(out.as_c64().unwrap(), &cotangent, &[x.as_c64().unwrap()]).unwrap();
+    let scalar_grads =
+        ad::pullback_wrt_scalars(out.as_c64().unwrap(), &cotangent, &[&scalar_f64(&a)]).unwrap();
+
+    assert_eq!(
+        tensor_grads[0]
+            .as_ref()
+            .unwrap()
+            .buffer()
+            .as_slice()
+            .unwrap(),
+        &[Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)]
+    );
+    assert_eq!(scalar_grads, vec![Some(-2.5)]);
+}
+
+#[test]
+fn c64_tensor_div_scalar_pullback_reaches_real_scalar_input() {
+    let x: DynAdTensor = AdTensor::new_reverse(
+        c64_vec(&[Complex64::new(4.0, 0.0), Complex64::new(-6.0, 0.0)]),
+        NodeId(31),
+        TapeId(92),
+        None,
+    )
+    .into();
+    let a = DynAdScalar::from(AdValue::reverse(2.0_f64, NodeId(32), TapeId(92), None));
+
+    let out = x.div_scalar(&a).unwrap();
+    let cotangent = AdTensor::new_primal(c64_vec(&[
+        Complex64::new(0.5, 0.0),
+        Complex64::new(1.0, 0.0),
+    ]));
+
+    let tensor_grads =
+        ad::pullback_wrt(out.as_c64().unwrap(), &cotangent, &[x.as_c64().unwrap()]).unwrap();
+    let scalar_grads =
+        ad::pullback_wrt_scalars(out.as_c64().unwrap(), &cotangent, &[&scalar_f64(&a)]).unwrap();
+
+    assert_eq!(
+        tensor_grads[0]
+            .as_ref()
+            .unwrap()
+            .buffer()
+            .as_slice()
+            .unwrap(),
+        &[Complex64::new(0.25, 0.0), Complex64::new(0.5, 0.0)]
+    );
+    assert_eq!(scalar_grads, vec![Some(1.0)]);
+}

--- a/extension/tenferro-dyadtensor/tests/mixed_primitives_reverse_tests.rs
+++ b/extension/tenferro-dyadtensor/tests/mixed_primitives_reverse_tests.rs
@@ -1,3 +1,4 @@
+use num_complex::Complex64;
 use tenferro_dyadtensor::{
     ad, AdMode, AdScalar, AdTensor, AdValue, DynAdScalar, DynAdTensor, NodeId, TapeId,
 };
@@ -5,6 +6,10 @@ use tenferro_tensor::{MemoryOrder, Tensor};
 
 fn f64_vec(values: &[f64]) -> Tensor<f64> {
     Tensor::<f64>::from_slice(values, &[values.len()], MemoryOrder::ColumnMajor).unwrap()
+}
+
+fn c64_vec(values: &[Complex64]) -> Tensor<Complex64> {
+    Tensor::<Complex64>::from_slice(values, &[values.len()], MemoryOrder::ColumnMajor).unwrap()
 }
 
 fn scalar_from_dyn(value: &DynAdScalar) -> AdScalar<f64> {
@@ -143,4 +148,45 @@ fn scale_propagates_reverse_gradients_through_unary_scalar_coefficients() {
         &[1.0, 2.5]
     );
     assert_eq!(scalar_grads, vec![Some(0.75)]);
+}
+
+#[test]
+fn scale_propagates_reverse_gradients_through_negated_scalar_coefficients() {
+    let x: DynAdTensor = AdTensor::new_primal(f64_vec(&[2.0, -1.0])).into();
+    let a = DynAdScalar::from(AdValue::reverse(3.0_f64, NodeId(41), TapeId(61), None));
+    let coeff = -a.clone();
+
+    let out = x.scale(&coeff).unwrap();
+    assert_eq!(out.mode(), AdMode::Reverse);
+
+    let out_t = out.as_f64().unwrap();
+    let cotangent = AdTensor::new_primal(f64_vec(&[0.5, -1.25]));
+    let scalar_grads =
+        ad::pullback_wrt_scalars(out_t, &cotangent, &[&scalar_from_dyn(&a)]).unwrap();
+
+    assert_eq!(scalar_grads, vec![Some(-2.25)]);
+}
+
+#[test]
+fn scale_propagates_reverse_gradients_through_negative_real_sqrt_promotion() {
+    let x: DynAdTensor = AdTensor::new_primal(c64_vec(&[
+        Complex64::new(1.0, 0.0),
+        Complex64::new(2.0, 0.0),
+    ]))
+    .into();
+    let a = DynAdScalar::from(AdValue::reverse(-4.0_f64, NodeId(51), TapeId(62), None));
+    let coeff = a.sqrt();
+
+    let out = x.scale(&coeff).unwrap();
+    assert_eq!(out.mode(), AdMode::Reverse);
+
+    let out_t = out.as_c64().unwrap();
+    let cotangent = AdTensor::new_primal(c64_vec(&[
+        Complex64::new(0.0, 1.0),
+        Complex64::new(0.0, 2.0),
+    ]));
+    let scalar_grads =
+        ad::pullback_wrt_scalars(out_t, &cotangent, &[&scalar_from_dyn(&a)]).unwrap();
+
+    assert_eq!(scalar_grads, vec![Some(-1.25)]);
 }

--- a/extension/tenferro-dyadtensor/tests/projection_reverse_tests.rs
+++ b/extension/tenferro-dyadtensor/tests/projection_reverse_tests.rs
@@ -1,0 +1,163 @@
+use num_complex::Complex64;
+use tenferro_dyadtensor::{
+    ad, AdScalar, AdTensor, AdValue, DynAdScalar, DynAdTensor, NodeId, TapeId,
+};
+use tenferro_tensor::{MemoryOrder, Tensor};
+
+fn f64_vec(values: &[f64]) -> Tensor<f64> {
+    Tensor::<f64>::from_slice(values, &[values.len()], MemoryOrder::ColumnMajor).unwrap()
+}
+
+fn c64_vec(values: &[Complex64]) -> Tensor<Complex64> {
+    Tensor::<Complex64>::from_slice(values, &[values.len()], MemoryOrder::ColumnMajor).unwrap()
+}
+
+fn scalar_f64(value: &DynAdScalar) -> AdScalar<f64> {
+    AdScalar::from(value.as_f64().unwrap().clone())
+}
+
+fn scalar_c64(value: &DynAdScalar) -> AdScalar<Complex64> {
+    AdScalar::from(value.as_c64().unwrap().clone())
+}
+
+#[test]
+fn scalar_complex_real_part_reverse_flows_into_real_lane() {
+    let x: DynAdTensor = AdTensor::new_primal(f64_vec(&[2.0, -1.0])).into();
+    let z = DynAdScalar::from(AdValue::reverse(
+        Complex64::new(3.0, -4.0),
+        NodeId(1),
+        TapeId(71),
+        None,
+    ));
+
+    let out = x.scale(&z.real_part()).unwrap();
+    let cotangent = AdTensor::new_primal(f64_vec(&[0.5, -1.25]));
+    let grads =
+        ad::pullback_wrt_scalars(out.as_f64().unwrap(), &cotangent, &[&scalar_c64(&z)]).unwrap();
+
+    assert_eq!(grads, vec![Some(Complex64::new(2.25, 0.0))]);
+}
+
+#[test]
+fn scalar_complex_imag_part_reverse_flows_into_imag_lane() {
+    let x: DynAdTensor = AdTensor::new_primal(f64_vec(&[2.0, -1.0])).into();
+    let z = DynAdScalar::from(AdValue::reverse(
+        Complex64::new(3.0, -4.0),
+        NodeId(2),
+        TapeId(72),
+        None,
+    ));
+
+    let out = x.scale(&z.imag_part()).unwrap();
+    let cotangent = AdTensor::new_primal(f64_vec(&[0.5, -1.25]));
+    let grads =
+        ad::pullback_wrt_scalars(out.as_f64().unwrap(), &cotangent, &[&scalar_c64(&z)]).unwrap();
+
+    assert_eq!(grads, vec![Some(Complex64::new(0.0, 2.25))]);
+}
+
+#[test]
+fn scalar_real_imag_part_reverse_returns_zero_gradient() {
+    let x: DynAdTensor = AdTensor::new_primal(f64_vec(&[2.0, -1.0])).into();
+    let a = DynAdScalar::from(AdValue::reverse(3.0_f64, NodeId(3), TapeId(73), None));
+
+    let out = x.scale(&a.imag_part()).unwrap();
+    let cotangent = AdTensor::new_primal(f64_vec(&[0.5, -1.25]));
+    let grads =
+        ad::pullback_wrt_scalars(out.as_f64().unwrap(), &cotangent, &[&scalar_f64(&a)]).unwrap();
+
+    assert_eq!(grads, vec![Some(0.0)]);
+}
+
+#[test]
+fn scalar_compose_complex_reverse_splits_complex_cotangent() {
+    let x: DynAdTensor = AdTensor::new_primal(c64_vec(&[Complex64::new(1.0, 0.0); 2])).into();
+    let re = DynAdScalar::from(AdValue::reverse(2.0_f64, NodeId(4), TapeId(74), None));
+    let im = DynAdScalar::from(AdValue::reverse(-3.0_f64, NodeId(5), TapeId(74), None));
+    let z = DynAdScalar::compose_complex(re.clone(), im.clone()).unwrap();
+
+    let out = x.scale(&z).unwrap();
+    let cotangent = AdTensor::new_primal(c64_vec(&[
+        Complex64::new(0.5, -0.25),
+        Complex64::new(1.0, 0.75),
+    ]));
+    let grads = ad::pullback_wrt_scalars(
+        out.as_c64().unwrap(),
+        &cotangent,
+        &[&scalar_f64(&re), &scalar_f64(&im)],
+    )
+    .unwrap();
+
+    assert_eq!(grads, vec![Some(1.5), Some(0.5)]);
+}
+
+#[test]
+fn tensor_complex_real_part_reverse_via_pullback_wrt_mixed() {
+    let x: DynAdTensor = AdTensor::new_reverse(
+        c64_vec(&[Complex64::new(1.0, 2.0), Complex64::new(-3.0, 4.0)]),
+        NodeId(11),
+        TapeId(81),
+        None,
+    )
+    .into();
+
+    let out = x.real_part().unwrap();
+    let cotangent = AdTensor::new_primal(f64_vec(&[0.5, -1.25]));
+    let grads =
+        ad::pullback_wrt_mixed(out.as_f64().unwrap(), &cotangent, &[x.as_c64().unwrap()]).unwrap();
+
+    assert_eq!(
+        grads[0].as_ref().unwrap().buffer().as_slice().unwrap(),
+        &[Complex64::new(0.5, 0.0), Complex64::new(-1.25, 0.0)]
+    );
+}
+
+#[test]
+fn tensor_complex_imag_part_reverse_via_pullback_wrt_mixed() {
+    let x: DynAdTensor = AdTensor::new_reverse(
+        c64_vec(&[Complex64::new(1.0, 2.0), Complex64::new(-3.0, 4.0)]),
+        NodeId(12),
+        TapeId(82),
+        None,
+    )
+    .into();
+
+    let out = x.imag_part().unwrap();
+    let cotangent = AdTensor::new_primal(f64_vec(&[0.5, -1.25]));
+    let grads =
+        ad::pullback_wrt_mixed(out.as_f64().unwrap(), &cotangent, &[x.as_c64().unwrap()]).unwrap();
+
+    assert_eq!(
+        grads[0].as_ref().unwrap().buffer().as_slice().unwrap(),
+        &[Complex64::new(0.0, 0.5), Complex64::new(0.0, -1.25)]
+    );
+}
+
+#[test]
+fn tensor_compose_complex_reverse_via_pullback_wrt_mixed() {
+    let re: DynAdTensor =
+        AdTensor::new_reverse(f64_vec(&[1.0, -3.0]), NodeId(13), TapeId(83), None).into();
+    let im: DynAdTensor =
+        AdTensor::new_reverse(f64_vec(&[2.0, 4.0]), NodeId(14), TapeId(83), None).into();
+
+    let out = DynAdTensor::compose_complex(re.clone(), im.clone()).unwrap();
+    let cotangent = AdTensor::new_primal(c64_vec(&[
+        Complex64::new(0.5, -0.25),
+        Complex64::new(1.0, 0.75),
+    ]));
+    let grads = ad::pullback_wrt_mixed(
+        out.as_c64().unwrap(),
+        &cotangent,
+        &[re.as_f64().unwrap(), im.as_f64().unwrap()],
+    )
+    .unwrap();
+
+    assert_eq!(
+        grads[0].as_ref().unwrap().buffer().as_slice().unwrap(),
+        &[0.5, 1.0]
+    );
+    assert_eq!(
+        grads[1].as_ref().unwrap().buffer().as_slice().unwrap(),
+        &[-0.25, 0.75]
+    );
+}


### PR DESCRIPTION
Fixes #277
Fixes #278

## Summary
- repair reverse-mode bridges for scalar and tensor `real_part` / `imag_part` / `compose_complex`
- route complex-tensor mixed primitives through real-to-complex scalar promotion so `scale`, `div_scalar`, and `axpby` accept `F32 -> C32` and `F64 -> C64`
- rename `AdValue::map` to `map_preserving_metadata` and keep graph-changing reverse transforms on explicit helper paths

## Testing
- cargo fmt --all --check
- cargo test --workspace
- cargo llvm-cov --workspace --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo nextest run --release -p tenferro-dyadtensor

Generated with [Claude Code](https://claude.com/claude-code)
