### PR TITLE
fix(burn,mdarray): fix Cargo.toml settings and improve documentation (#349-#354)

### DIFF
--- a/extension/tenferro-burn/src/convert.rs
+++ b/extension/tenferro-burn/src/convert.rs
@@ -1,9 +1,20 @@
 //! Conversion utilities between Burn tensor primitives and tenferro tensors.
+//!
+//! # Current Limitations
+//!
+//! These conversion functions currently only support `f64` element type.
+//! Support for `f32` and other numeric types will be added in future versions.
 
 use burn::tensor::backend::Backend;
 use burn::tensor::ops::FloatTensor;
 
 /// Convert a Burn backend tensor primitive into a tenferro `Tensor<f64>`.
+///
+/// # Current Limitations
+///
+/// This function currently always returns `Tensor<f64>` regardless of the
+/// backend's float element type. Support for other element types (e.g., `f32`)
+/// will be added in future versions.
 ///
 /// # Examples
 ///
@@ -21,14 +32,25 @@ pub fn burn_to_tenferro<B: Backend>(_tensor: FloatTensor<B>) -> tenferro_tensor:
 
 /// Convert a tenferro `Tensor<f64>` into a Burn backend tensor primitive.
 ///
+/// The `device` parameter specifies which Burn device the resulting tensor
+/// should be placed on. For the `NdArray` backend this is typically
+/// `NdArrayDevice::Cpu`, obtainable via `Default::default()`.
+///
+/// # Current Limitations
+///
+/// This function currently only accepts `Tensor<f64>`. Support for other
+/// element types will be added in future versions.
+///
 /// # Examples
 ///
 /// ```ignore
 /// use burn::backend::NdArray;
+/// use burn::backend::ndarray::NdArrayDevice;
 /// use tenferro_burn::convert::tenferro_to_burn;
 ///
 /// let tenferro_t: tenferro_tensor::Tensor<f64> = todo!();
-/// let burn_prim = tenferro_to_burn::<NdArray<f64>>(tenferro_t, &Default::default());
+/// let device = NdArrayDevice::Cpu;
+/// let burn_prim = tenferro_to_burn::<NdArray<f64>>(tenferro_t, &device);
 /// ```
 pub fn tenferro_to_burn<B: Backend>(
     _tensor: tenferro_tensor::Tensor<f64>,

--- a/extension/tenferro-burn/src/forward.rs
+++ b/extension/tenferro-burn/src/forward.rs
@@ -1,5 +1,11 @@
 //! Forward-mode (inference) implementation of [`TensorNetworkOps`] for the
 //! NdArray backend.
+//!
+//! # Current Limitations
+//!
+//! `TensorNetworkOps` is currently only implemented for `NdArray<f64>`.
+//! Implementations for other backends (e.g., `Wgpu`, `LibTorch`) and element
+//! types (e.g., `f32`) will be added in future versions.
 
 use burn::backend::NdArray;
 use burn::tensor::ops::FloatTensor;

--- a/extension/tenferro-burn/src/lib.rs
+++ b/extension/tenferro-burn/src/lib.rs
@@ -22,6 +22,8 @@ pub mod backward;
 pub mod convert;
 pub mod forward;
 
+pub use convert::{burn_to_tenferro, tenferro_to_burn};
+
 use burn::tensor::backend::Backend;
 use burn::tensor::ops::FloatTensor;
 use burn::tensor::Tensor;

--- a/extension/tenferro-mdarray/Cargo.toml
+++ b/extension/tenferro-mdarray/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "tenferro-mdarray"
 version.workspace = true
-edition = "2024"
-rust-version = "1.89"
+edition.workspace = true
 license.workspace = true
 authors.workspace = true
 publish.workspace = true


### PR DESCRIPTION
## Summary
- Fix invalid `edition = "2024"` to `edition.workspace = true` in tenferro-mdarray (#349)
- Remove speculative `rust-version = "1.89"` from tenferro-mdarray (#350)
- Document `burn_to_tenferro` f64 limitation and add module-level docs (#351)
- Document `TensorNetworkOps` NdArray<f64> backend limitation (#352)
- Fix `tenferro_to_burn` device parameter documentation with correct usage pattern (#353)
- Add `pub use` re-export for `burn_to_tenferro` and `tenferro_to_burn` (#354)

## Test plan
- [x] `cargo check -p tenferro-burn -p tenferro-mdarray` passes
- [x] `cargo fmt --all --check` passes

Closes #349, Closes #350, Closes #351, Closes #352, Closes #353, Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)