### PR TITLE
fix: tenferro-burn is not externally consumable with current dependency...

### DIFF
--- a/extension/tenferro-burn/Cargo.toml
+++ b/extension/tenferro-burn/Cargo.toml
@@ -14,4 +14,4 @@ tenferro-prims = { path = "../../tenferro-prims" }
 tenferro-device = { path = "../../tenferro-device" }
 tenferro-algebra = { path = "../../tenferro-algebra" }
 
-burn = { version = "0.21.0-pre.1", default-features = false, features = ["ndarray", "autodiff"] }
+burn = { version = "=0.21.0-pre.1", default-features = false, features = ["ndarray", "autodiff"] }


### PR DESCRIPTION
## Summary
Closes #376

The `tenferro-burn` extension was not externally consumable because its dependency on `burn` used a semver-compatible version range instead of an exact version. This caused dependency resolution conflicts when external crates attempted to use the extension.

## Changes
- Pinned the `burn` dependency to exact version `=0.21.0-pre.1` in `extension/tenferro-burn/Cargo.toml` to ensure consistent and conflict-free dependency resolution for external consumers.user
Write a concise, professional GitHub PR description for this fix.

Issue #376: Bug: tenferro-burn is not externally consumable with current dependency resolution

Patch:
```diff
diff --git a/extension/tenferro-burn/Cargo.toml b/extension/tenferro-burn/Cargo.toml
index 4137a5f..6ea40a1 100644
--- a/extension/tenferro-burn

Let me analyze this PR:

1. **Issue**: The `tenferro-burn` extension is not externally consumable due to dependency resolution problems.

2. **The fix**: Adding `=` prefix to the burn version constraint, changing from `version = "0.21.0-pre.1"` to `version = "=0.21.0-pre.1"`.

3. **Why this matters**: In Cargo, the `=` prefix forces an exact version match. Without it, Cargo uses semver-compatible ranges (e.g., `0.21.0-pre.1` could resolve to `0.21.0-pre.2` or higher). This can cause:
   - Dependency conflicts when external crates try to use `tenferro-burn`
   - Inconsistent builds across different environments
   - Transitive dependency resolution failures

4. **Changes made**: Only one line in `extension/tenferro-burn/Cargo.toml`

5. **No test changes**: The patch doesn't modify any test files.

Now I'll write a concise, professional PR description following the requested format.

<response>
## Summary
Closes #376

The `tenferro-burn` extension was not externally consumable because its dependency on `burn` used a semver-compatible version range instead of an exact version. This caused dependency resolution conflicts when external crates attempted to use the extension.

## Changes
- Pinned the `burn` dependency to exact version `=0.21.0-pre.1` in `extension/tenferro-burn/Cargo.toml` to ensure consistent and conflict-free dependency resolution for external consumers.
</response>

This gives us the final answer: ```markdown
## Summary
Closes #376

The `tenferro-burn` extension was not externally consumable because its dependency on `burn` used a semver-compatible version range instead of an exact version. This caused dependency resolution conflicts when external crates attempted to use the extension.

## Changes
- Pinned the `burn` dependency to exact version `=0.21.0-pre.1` in `extension/tenferro-burn/Cargo.toml` to ensure consistent and conflict-free dependency resolution for external consumers.
```