### PR TITLE
fix: implement minimal CUDA allocation and transfer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,11 @@ The workspace contains active implementations alongside evolving APIs. Implement
 
 ### GPU Status
 
-GPU support is currently stubbed and not implemented. CUDA/HIP-facing types,
-traits, and C API entrypoints may exist to preserve the intended future API
-shape, but they should not be treated as working execution paths yet. Outside
-explicit bug exploration or GPU implementation tasks, do not assume a GPU path
-works just because the symbol is present.
+GPU support is still partial and experimental. CUDA-only allocation,
+CPU<->GPU transfer, and limited cuTENSOR-backed primitive execution now exist,
+but broader GPU coverage is incomplete and HIP remains stubbed. Outside
+explicit GPU implementation tasks, do not assume a GPU path works just because
+the symbol is present.
 
 ### Documentation Requirements
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,4 @@ blas-src = { version = "0.14", default-features = false }
 lapack = "0.20"
 lapack-src = "0.13"
 lapack-inject = "0.1.0"
+cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "dynamic-loading", "cuda-12000"] }

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 A general-purpose tensor computation library in Rust with CPU support today and planned GPU support later.
 
 > [!WARNING]
-> GPU support is currently stubbed and not implemented. The repository contains
-> CUDA/HIP-facing types and API surfaces, but production GPU allocation,
-> transfer, and execution are still future work.
+> GPU support is still partial and experimental. CUDA-only allocation,
+> CPU<->GPU transfer, and limited cuTENSOR-backed primitive execution exist,
+> but broad GPU coverage is incomplete and HIP remains stubbed.
 
 ## Overview
 
@@ -21,9 +21,10 @@ Built on top of [strided-rs](https://github.com/tensor4all/strided-rs) for cache
 
 ## GPU Status
 
-CPU functionality is actively implemented and tested. GPU-facing modules exist
-to stabilize the future API shape, but the current CUDA/HIP path is still a
-stub. Outside explicit bug exploration or implementation work, do not assume a
+CPU functionality is actively implemented and tested. The CUDA path now has
+basic allocation, CPU<->GPU transfer, and a small set of runtime-loaded
+primitive execution paths, but broader GPU coverage is still incomplete and
+HIP remains a stub. Outside explicit GPU implementation tasks, do not assume a
 GPU code path works just because the type, trait, or FFI entrypoint exists.
 
 ### Influences

--- a/tenferro-prims/Cargo.toml
+++ b/tenferro-prims/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tensor primitive operations (TensorPrims trait) for the tenferro 
 
 [features]
 default = ["gemm-faer"]
-cuda = ["dep:cudarc"]
+cuda = ["dep:cudarc", "tenferro-tensor/cuda"]
 gemm-faer = ["dep:faer"]
 gemm-blas = ["dep:cblas-sys"]
 # Backward-compatible alias: use `--no-default-features --features gemm-openblas`.
@@ -42,6 +42,6 @@ cblas-sys = { workspace = true, optional = true }
 cblas-src = { workspace = true, optional = true }
 cblas-inject = { workspace = true, optional = true }
 blas-src = { workspace = true, optional = true }
-cudarc = { version = "0.19", optional = true, default-features = false, features = ["driver", "dynamic-loading", "cuda-12060"] }
+cudarc = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/tenferro-prims/src/cuda.rs
+++ b/tenferro-prims/src/cuda.rs
@@ -19,6 +19,8 @@ use std::marker::PhantomData;
 use std::ptr;
 use std::sync::Arc;
 
+#[cfg(unix)]
+use libloading::os::unix::{Library as UnixLibrary, RTLD_GLOBAL, RTLD_NOW};
 use num_complex::{Complex32, Complex64};
 use tenferro_algebra::{Conjugate, Scalar, Standard};
 use tenferro_device::{Error, Result};
@@ -141,7 +143,7 @@ pub(crate) trait CutensorType: Scalar {
 
 impl CutensorType for f32 {
     fn data_type() -> CutensorDataType {
-        CutensorDataType::R_32F
+        CUTENSOR_R_32F
     }
     fn compute_descriptor(vtable: &CutensorVtable) -> cutensorComputeDescriptor_t {
         vtable.compute_desc_32f
@@ -150,7 +152,7 @@ impl CutensorType for f32 {
 
 impl CutensorType for f64 {
     fn data_type() -> CutensorDataType {
-        CutensorDataType::R_64F
+        CUTENSOR_R_64F
     }
     fn compute_descriptor(vtable: &CutensorVtable) -> cutensorComputeDescriptor_t {
         vtable.compute_desc_64f
@@ -159,7 +161,7 @@ impl CutensorType for f64 {
 
 impl CutensorType for Complex32 {
     fn data_type() -> CutensorDataType {
-        CutensorDataType::C_32F
+        CUTENSOR_C_32F
     }
     fn compute_descriptor(vtable: &CutensorVtable) -> cutensorComputeDescriptor_t {
         vtable.compute_desc_32f
@@ -168,7 +170,7 @@ impl CutensorType for Complex32 {
 
 impl CutensorType for Complex64 {
     fn data_type() -> CutensorDataType {
-        CutensorDataType::C_64F
+        CUTENSOR_C_64F
     }
     fn compute_descriptor(vtable: &CutensorVtable) -> cutensorComputeDescriptor_t {
         vtable.compute_desc_64f
@@ -238,8 +240,8 @@ fn build_cutensor_plan(
         (vtable.create_plan_preference)(
             handle,
             &mut pref_raw,
-            CutensorAlgo::Default,
-            CutensorJitMode::None,
+            CUTENSOR_ALGO_DEFAULT,
+            CUTENSOR_JIT_MODE_NONE,
         )
     };
     check_status(status, "cutensorCreatePlanPreference")?;
@@ -255,7 +257,7 @@ fn build_cutensor_plan(
             handle,
             op_desc.raw,
             _pref.raw,
-            CutensorWorksizePref::Recommended,
+            CUTENSOR_WORKSPACE_DEFAULT,
             &mut workspace_size,
         )
     };
@@ -289,13 +291,13 @@ fn scalar_data_type<T: Scalar>() -> Result<CutensorDataType> {
     use std::any::TypeId;
     let tid = TypeId::of::<T>();
     if tid == TypeId::of::<f32>() {
-        Ok(CutensorDataType::R_32F)
+        Ok(CUTENSOR_R_32F)
     } else if tid == TypeId::of::<f64>() {
-        Ok(CutensorDataType::R_64F)
+        Ok(CUTENSOR_R_64F)
     } else if tid == TypeId::of::<Complex32>() {
-        Ok(CutensorDataType::C_32F)
+        Ok(CUTENSOR_C_32F)
     } else if tid == TypeId::of::<Complex64>() {
-        Ok(CutensorDataType::C_64F)
+        Ok(CUTENSOR_C_64F)
     } else {
         Err(Error::DeviceError(
             "Unsupported scalar type for CUDA backend".into(),
@@ -354,13 +356,13 @@ fn plan_contraction(
             &mut op_raw,
             desc_a.raw,
             modes_a.as_ptr(),
-            CutensorOperator::Identity,
+            CUTENSOR_OP_IDENTITY,
             desc_b.raw,
             modes_b.as_ptr(),
-            CutensorOperator::Identity,
+            CUTENSOR_OP_IDENTITY,
             desc_c.raw,
             modes_c.as_ptr(),
-            CutensorOperator::Identity,
+            CUTENSOR_OP_IDENTITY,
             desc_d.raw,
             modes_c.as_ptr(),
             compute,
@@ -400,7 +402,7 @@ fn plan_permutation(
             &mut op_raw,
             desc_a.raw,
             modes_a.as_ptr(),
-            CutensorOperator::Identity,
+            CUTENSOR_OP_IDENTITY,
             desc_b.raw,
             modes_b.as_ptr(),
             compute,
@@ -425,7 +427,7 @@ fn plan_reduction(
     modes_c: &[i32],
     shape_c: &[usize],
     strides_c: &[isize],
-    reduce_op: CutensorReduceOp,
+    reduce_op: CutensorOperator,
 ) -> Result<(PlanWrapper, u64)> {
     let vtable = &ctx.vtable;
     let handle = ctx.handle.raw;
@@ -441,10 +443,10 @@ fn plan_reduction(
             &mut op_raw,
             desc_a.raw,
             modes_a.as_ptr(),
-            CutensorOperator::Identity,
+            CUTENSOR_OP_IDENTITY,
             desc_c.raw,
             modes_c.as_ptr(),
-            CutensorOperator::Identity,
+            CUTENSOR_OP_IDENTITY,
             desc_d.raw,
             modes_c.as_ptr(),
             reduce_op,
@@ -482,13 +484,13 @@ fn plan_elementwise_binary(
             &mut op_raw,
             desc_a.raw,
             modes.as_ptr(),
-            CutensorOperator::Identity,
+            CUTENSOR_OP_IDENTITY,
             desc_c.raw,
             modes.as_ptr(),
-            CutensorOperator::Identity,
+            CUTENSOR_OP_IDENTITY,
             desc_d.raw,
             modes.as_ptr(),
-            CutensorReduceOp::Add,
+            CUTENSOR_OP_MUL,
             compute,
         )
     };
@@ -531,14 +533,14 @@ fn plan_elementwise_trinary(
             op_a,
             desc_b.raw,
             modes.as_ptr(),
-            CutensorOperator::Identity,
+            CUTENSOR_OP_IDENTITY,
             desc_c.raw,
             modes.as_ptr(),
-            CutensorOperator::Identity,
+            CUTENSOR_OP_IDENTITY,
             desc_d.raw,
             modes.as_ptr(),
-            CutensorReduceOp::Add, // op_ab
-            CutensorReduceOp::Add, // op_abc
+            CUTENSOR_OP_ADD, // op_ab
+            CUTENSOR_OP_ADD, // op_abc
             compute,
         )
     };
@@ -568,8 +570,8 @@ fn plan_elementwise_trinary(
 pub struct CudaContext {
     /// cuTENSOR library handle (RAII — Drop calls cutensorDestroy).
     handle: HandleWrapper,
-    /// cudarc stream handle for GPU memory and stream management.
-    stream: Arc<cudarc::driver::CudaStream>,
+    /// CUDA device ordinal used for runtime API calls.
+    device_id: usize,
     /// cuTENSOR function pointer vtable loaded via libloading.
     vtable: Arc<CutensorVtable>,
     /// GPU workspace buffer for cuTENSOR operations.
@@ -612,7 +614,10 @@ pub struct CudaPlan<T: Scalar> {
 /// registry.load_cutensor("/usr/lib/libcutensor.so").unwrap();
 /// ```
 pub struct CudaBackend {
-    _lib: libloading::Library,
+    #[cfg(unix)]
+    _cudart_global: UnixLibrary,
+    #[cfg(unix)]
+    _lib: DynamicLibrary,
 }
 
 impl CudaBackend {
@@ -630,16 +635,41 @@ impl CudaBackend {
     /// let (backend, ctx) = CudaBackend::load("/usr/lib/libcutensor.so").unwrap();
     /// ```
     pub fn load(path: &str) -> Result<(Self, CudaContext)> {
+        #[cfg(unix)]
+        let cudart_global = {
+            let candidates = [
+                "/usr/lib/x86_64-linux-gnu/libcudart.so.12",
+                "/usr/lib/x86_64-linux-gnu/libcudart.so",
+            ];
+            let mut loaded = None;
+            for candidate in candidates {
+                match unsafe { UnixLibrary::open(Some(candidate), RTLD_NOW | RTLD_GLOBAL) } {
+                    Ok(lib) => {
+                        loaded = Some(lib);
+                        break;
+                    }
+                    Err(_) => continue,
+                }
+            }
+            loaded.ok_or_else(|| {
+                Error::DeviceError("Failed to load libcudart with RTLD_GLOBAL for cuTENSOR".into())
+            })?
+        };
+
         // 1. Open shared library
-        let lib = unsafe { libloading::Library::new(path) }
+        let lib = unsafe { DynamicLibrary::open(path, RTLD_NOW) }
             .map_err(|e| Error::DeviceError(format!("Failed to load cuTENSOR: {e}")))?;
 
         // 2. Populate vtable
-        let vtable = unsafe { CutensorVtable::load(&lib) }
+        let vtable = unsafe { CutensorVtable::load(lib.handle()) }
             .map_err(|e| Error::DeviceError(format!("Failed to load cuTENSOR symbols: {e}")))?;
         let vtable = Arc::new(vtable);
 
-        // 3. Initialize cuTENSOR handle
+        // 3. Initialize CUDA runtime state before creating the cuTENSOR handle.
+        cudarc::runtime::result::device::set(0)
+            .map_err(|e| Error::DeviceError(format!("CUDA runtime init failed: {e:?}")))?;
+
+        // 4. Initialize cuTENSOR handle now that the CUDA context is active.
         let mut handle_raw: cutensorHandle_t = ptr::null_mut();
         let status = unsafe { (vtable.create)(&mut handle_raw) };
         check_status(status, "cutensorCreate")?;
@@ -648,20 +678,23 @@ impl CudaBackend {
             vtable: Arc::clone(&vtable),
         };
 
-        // 4. Initialize CUDA device and stream via cudarc
-        let cuda_ctx = cudarc::driver::CudaContext::new(0)
-            .map_err(|e| Error::DeviceError(format!("CUDA device init failed: {e:?}")))?;
-        let stream = cuda_ctx.default_stream();
-
         let ctx = CudaContext {
             handle,
-            stream,
+            device_id: 0,
             vtable: Arc::clone(&vtable),
             workspace: Vec::new(),
             plan_cache: PlanCache::new(),
         };
 
-        Ok((CudaBackend { _lib: lib }, ctx))
+        Ok((
+            CudaBackend {
+                #[cfg(unix)]
+                _cudart_global: cudart_global,
+                #[cfg(unix)]
+                _lib: lib,
+            },
+            ctx,
+        ))
     }
 
     /// Materialize a lazily-conjugated tensor on GPU.
@@ -696,6 +729,8 @@ impl<S: Scalar> TensorPrims<Standard<S>> for CudaBackend {
         desc: &PrimDescriptor,
         shapes: &[&[usize]],
     ) -> Result<CudaPlan<S>> {
+        cudarc::runtime::result::device::set(ctx.device_id as i32)
+            .map_err(|e| Error::DeviceError(format!("CUDA runtime set-device failed: {e:?}")))?;
         // Resolve cuTENSOR data type and compute descriptor for the algebra scalar.
         // This uses TypeId dispatch since the trait bound is Scalar (not CutensorType).
         let data_type = scalar_data_type::<S>()?;
@@ -841,9 +876,9 @@ impl<S: Scalar> TensorPrims<Standard<S>> for CudaBackend {
             } => {
                 validate_shape_count(shapes, 2, "Reduce")?;
                 let reduce_op = match op {
-                    ReduceOp::Sum => CutensorReduceOp::Add,
-                    ReduceOp::Max => CutensorReduceOp::Max,
-                    ReduceOp::Min => CutensorReduceOp::Min,
+                    ReduceOp::Sum => CUTENSOR_OP_ADD,
+                    ReduceOp::Max => CUTENSOR_OP_MAX,
+                    ReduceOp::Min => CUTENSOR_OP_MIN,
                 };
                 let modes_a_i32: Vec<i32> = modes_a.iter().map(|&m| m as i32).collect();
                 let modes_c_i32: Vec<i32> = modes_c.iter().map(|&m| m as i32).collect();
@@ -872,8 +907,8 @@ impl<S: Scalar> TensorPrims<Standard<S>> for CudaBackend {
             PrimDescriptor::ElementwiseUnary { op } => {
                 validate_shape_count(shapes, 2, "ElementwiseUnary")?;
                 let op_a = match op {
-                    UnaryOp::Conj => CutensorOperator::Conj,
-                    _ => CutensorOperator::Identity,
+                    UnaryOp::Conj => CUTENSOR_OP_CONJ,
+                    _ => CUTENSOR_OP_IDENTITY,
                 };
                 let ndim = shapes[0].len();
                 let modes: Vec<i32> = (0..ndim as i32).collect();
@@ -916,6 +951,8 @@ impl<S: Scalar> TensorPrims<Standard<S>> for CudaBackend {
     ) -> Result<()> {
         use std::ffi::c_void;
 
+        cudarc::runtime::result::device::set(ctx.device_id as i32)
+            .map_err(|e| Error::DeviceError(format!("CUDA runtime set-device failed: {e:?}")))?;
         let handle = ctx.handle.raw;
         // Use null stream (default CUDA stream)
         let stream: *mut c_void = ptr::null_mut();

--- a/tenferro-prims/src/cuda/tests/mod.rs
+++ b/tenferro-prims/src/cuda/tests/mod.rs
@@ -1,5 +1,7 @@
 use tenferro_algebra::Standard;
+use tenferro_device::LogicalMemorySpace;
 use tenferro_device::Result;
+use tenferro_tensor::MemoryOrder;
 use tenferro_tensor::Tensor;
 
 use super::*;
@@ -20,5 +22,80 @@ fn cuda_backend_feature_surface_matches_tensor_prims_contract() {
     assert!(<CudaBackend as TensorPrims<Standard<f64>>>::has_extension_for(Extension::Contract));
     assert!(
         <CudaBackend as TensorPrims<Standard<f64>>>::has_extension_for(Extension::ElementwiseMul)
+    );
+}
+
+fn available_cutensor_library_path() -> Option<&'static str> {
+    [
+        "/usr/lib/x86_64-linux-gnu/libcutensor.so",
+        "/usr/lib/x86_64-linux-gnu/libcutensor.so.2",
+        "/usr/lib/x86_64-linux-gnu/libcutensor/12/libcutensor.so",
+        "/usr/lib/x86_64-linux-gnu/libcutensor/12/libcutensor.so.2",
+    ]
+    .into_iter()
+    .find(|path| std::path::Path::new(path).exists())
+}
+
+fn cuda_device_zero_is_available() -> bool {
+    std::panic::catch_unwind(|| {
+        cudarc::runtime::result::device::get_count()
+            .map(|count| count > 0)
+            .unwrap_or(false)
+    })
+    .unwrap_or(false)
+}
+
+#[test]
+fn cuda_permute_smoke_runs_on_device_tensors_when_runtime_is_available() {
+    let Some(path) = available_cutensor_library_path() else {
+        return;
+    };
+
+    if !cuda_device_zero_is_available() {
+        return;
+    }
+
+    let (_backend, mut ctx) = CudaBackend::load(path).unwrap();
+    let input = Tensor::<f32>::from_slice(
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        &[2, 3],
+        MemoryOrder::ColumnMajor,
+    )
+    .unwrap();
+    let desc = PrimDescriptor::Permute {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+    };
+    let plan =
+        <CudaBackend as TensorPrims<Standard<f32>>>::plan(&mut ctx, &desc, &[&[2, 3], &[3, 2]])
+            .unwrap();
+    let input_gpu = input
+        .to_memory_space_async(LogicalMemorySpace::GpuMemory { device_id: 0 })
+        .unwrap();
+    let mut output_gpu = Tensor::<f32>::zeros(
+        &[3, 2],
+        LogicalMemorySpace::GpuMemory { device_id: 0 },
+        MemoryOrder::ColumnMajor,
+    );
+
+    <CudaBackend as TensorPrims<Standard<f32>>>::execute(
+        &mut ctx,
+        &plan,
+        1.0,
+        &[&input_gpu],
+        0.0,
+        &mut output_gpu,
+    )
+    .unwrap();
+
+    let output_cpu = output_gpu
+        .to_memory_space_async(LogicalMemorySpace::MainMemory)
+        .unwrap();
+
+    assert!(output_cpu.is_contiguous());
+    assert_eq!(output_cpu.dims(), &[3, 2]);
+    assert_eq!(
+        output_cpu.buffer().as_slice(),
+        Some(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0][..])
     );
 }

--- a/tenferro-prims/src/cuda_ffi.rs
+++ b/tenferro-prims/src/cuda_ffi.rs
@@ -14,7 +14,16 @@
 //! let vtable = unsafe { CutensorVtable::load(&lib) }.unwrap();
 //! ```
 
-use std::ffi::c_void;
+use std::ffi::{c_void, CStr, CString};
+
+#[cfg(unix)]
+#[link(name = "dl")]
+unsafe extern "C" {
+    fn dlopen(filename: *const std::os::raw::c_char, flags: i32) -> *mut c_void;
+    fn dlclose(handle: *mut c_void) -> i32;
+    fn dlsym(handle: *mut c_void, symbol: *const std::os::raw::c_char) -> *mut c_void;
+    fn dlerror() -> *const std::os::raw::c_char;
+}
 
 // ============================================================================
 // cuTENSOR status codes
@@ -47,82 +56,50 @@ pub type cutensorComputeDescriptor_t = *const c_void;
 // Enums
 // ============================================================================
 
-/// cuTENSOR data type (mirrors `cutensorDataType_t`).
-///
-/// Maps Rust scalar types to cuTENSOR's internal type identifiers.
-/// Values must match the cuTENSOR v2 header exactly.
-///
-/// # Examples
-///
-/// ```ignore
-/// use tenferro_prims::CutensorDataType;
-/// let dt = CutensorDataType::R_64F;
-/// ```
-#[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CutensorDataType {
-    /// 32-bit float (`float`).
-    R_32F = 0,
-    /// 64-bit float (`double`).
-    R_64F = 1,
-    /// 32-bit complex (`cuComplex`).
-    C_32F = 4,
-    /// 64-bit complex (`cuDoubleComplex`).
-    C_64F = 5,
-}
+/// cuTENSOR data type (mirrors `cutensorDataType_t` / `cudaDataType_t`).
+pub type CutensorDataType = i32;
+/// 32-bit float (`float`).
+pub const CUTENSOR_R_32F: CutensorDataType = 0;
+/// 64-bit float (`double`).
+pub const CUTENSOR_R_64F: CutensorDataType = 1;
+/// 32-bit complex (`cuComplex`).
+pub const CUTENSOR_C_32F: CutensorDataType = 4;
+/// 64-bit complex (`cuDoubleComplex`).
+pub const CUTENSOR_C_64F: CutensorDataType = 5;
 
-/// cuTENSOR unary element-wise operator (mirrors `cutensorOperator_t`).
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CutensorOperator {
-    /// Identity (no transformation).
-    Identity = 1,
-    /// Complex conjugate.
-    Conj = 2,
-}
+/// cuTENSOR unary/binary operator (mirrors `cutensorOperator_t`).
+pub type CutensorOperator = i32;
+/// Identity (no transformation).
+pub const CUTENSOR_OP_IDENTITY: CutensorOperator = 1;
+/// Addition.
+pub const CUTENSOR_OP_ADD: CutensorOperator = 3;
+/// Multiplication.
+pub const CUTENSOR_OP_MUL: CutensorOperator = 5;
+/// Maximum.
+pub const CUTENSOR_OP_MAX: CutensorOperator = 6;
+/// Minimum.
+pub const CUTENSOR_OP_MIN: CutensorOperator = 7;
+/// Complex conjugate.
+pub const CUTENSOR_OP_CONJ: CutensorOperator = 9;
 
 /// cuTENSOR algorithm selection (mirrors `cutensorAlgo_t`).
-#[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CutensorAlgo {
-    /// Let cuTENSOR choose the best algorithm.
-    Default = -1,
-}
+pub type CutensorAlgo = i32;
+/// Let cuTENSOR choose the best algorithm.
+pub const CUTENSOR_ALGO_DEFAULT: CutensorAlgo = -1;
 
 /// cuTENSOR JIT compilation mode (mirrors `cutensorJitMode_t`).
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CutensorJitMode {
-    /// Disable JIT compilation.
-    None = 0,
-}
+pub type CutensorJitMode = i32;
+/// Disable JIT compilation.
+pub const CUTENSOR_JIT_MODE_NONE: CutensorJitMode = 0;
 
 /// cuTENSOR workspace size preference (mirrors `cutensorWorksizePreference_t`).
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CutensorWorksizePref {
-    /// Minimum workspace.
-    Min = 1,
-    /// Recommended workspace (balance of speed and memory).
-    Recommended = 2,
-    /// Maximum workspace (fastest execution).
-    Max = 3,
-}
-
-/// Reduction operator for `cutensorCreateReduction`.
-///
-/// Mirrors the cuTENSOR v2 `cutensorOperator_t` values used in
-/// reduction contexts.
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CutensorReduceOp {
-    /// Addition (sum) reduction.
-    Add = 3,
-    /// Maximum value reduction.
-    Max = 5,
-    /// Minimum value reduction.
-    Min = 6,
-}
+pub type CutensorWorksizePref = i32;
+/// Minimum workspace.
+pub const CUTENSOR_WORKSPACE_MIN: CutensorWorksizePref = 1;
+/// Recommended workspace (balance of speed and memory).
+pub const CUTENSOR_WORKSPACE_DEFAULT: CutensorWorksizePref = 2;
+/// Maximum workspace (fastest execution).
+pub const CUTENSOR_WORKSPACE_MAX: CutensorWorksizePref = 3;
 
 // ============================================================================
 // Function pointer type aliases
@@ -186,7 +163,7 @@ pub type FnCreateReduction = unsafe extern "C" fn(
     CutensorOperator, // C
     cutensorTensorDescriptor_t,
     *const i32, // D
-    CutensorReduceOp,
+    CutensorOperator,
     cutensorComputeDescriptor_t,
 ) -> cutensorStatus_t;
 
@@ -201,7 +178,7 @@ pub type FnCreateElementwiseBinary = unsafe extern "C" fn(
     CutensorOperator, // C
     cutensorTensorDescriptor_t,
     *const i32,       // D
-    CutensorReduceOp, // op_ac
+    CutensorOperator, // op_ac
     cutensorComputeDescriptor_t,
 ) -> cutensorStatus_t;
 
@@ -219,8 +196,8 @@ pub type FnCreateElementwiseTrinary = unsafe extern "C" fn(
     CutensorOperator, // C
     cutensorTensorDescriptor_t,
     *const i32,       // D
-    CutensorReduceOp, // op_ab
-    CutensorReduceOp, // op_abc
+    CutensorOperator, // op_ab
+    CutensorOperator, // op_abc
     cutensorComputeDescriptor_t,
 ) -> cutensorStatus_t;
 
@@ -371,6 +348,85 @@ pub struct CutensorVtable {
     pub compute_desc_64f: cutensorComputeDescriptor_t,
 }
 
+#[cfg(unix)]
+fn dlerror_string() -> String {
+    unsafe {
+        let err = dlerror();
+        if err.is_null() {
+            "unknown dlerror".into()
+        } else {
+            CStr::from_ptr(err).to_string_lossy().into_owned()
+        }
+    }
+}
+
+#[cfg(unix)]
+unsafe fn load_symbol<T: Copy>(
+    handle: *mut c_void,
+    symbol: &str,
+) -> std::result::Result<T, String> {
+    let symbol = CString::new(symbol).map_err(|e| e.to_string())?;
+    let ptr = dlsym(handle, symbol.as_ptr());
+    if ptr.is_null() {
+        Err(dlerror_string())
+    } else {
+        Ok(std::mem::transmute_copy(&ptr))
+    }
+}
+
+#[cfg(unix)]
+unsafe fn load_data_symbol<T: Copy>(
+    handle: *mut c_void,
+    symbol: &str,
+) -> std::result::Result<T, String> {
+    let symbol = CString::new(symbol).map_err(|e| e.to_string())?;
+    let ptr = dlsym(handle, symbol.as_ptr());
+    if ptr.is_null() {
+        Err(dlerror_string())
+    } else {
+        Ok(*(ptr as *const T))
+    }
+}
+
+#[cfg(unix)]
+pub(crate) struct DynamicLibrary {
+    handle: *mut c_void,
+}
+
+#[cfg(unix)]
+unsafe impl Send for DynamicLibrary {}
+
+#[cfg(unix)]
+unsafe impl Sync for DynamicLibrary {}
+
+#[cfg(unix)]
+impl DynamicLibrary {
+    pub unsafe fn open(path: &str, flags: i32) -> std::result::Result<Self, String> {
+        let path = CString::new(path).map_err(|e| e.to_string())?;
+        let handle = dlopen(path.as_ptr(), flags);
+        if handle.is_null() {
+            Err(dlerror_string())
+        } else {
+            Ok(Self { handle })
+        }
+    }
+
+    pub fn handle(&self) -> *mut c_void {
+        self.handle
+    }
+}
+
+#[cfg(unix)]
+impl Drop for DynamicLibrary {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                let _ = dlclose(self.handle);
+            }
+        }
+    }
+}
+
 impl CutensorVtable {
     /// Load all cuTENSOR v2 function pointers from a libloading Library.
     ///
@@ -379,32 +435,34 @@ impl CutensorVtable {
     /// The caller must ensure `lib` points to a valid cuTENSOR v2 shared
     /// library. Function pointer signatures must match the loaded library
     /// version.
-    pub unsafe fn load(lib: &libloading::Library) -> std::result::Result<Self, libloading::Error> {
+    #[cfg(unix)]
+    pub unsafe fn load(handle: *mut c_void) -> std::result::Result<Self, String> {
         Ok(Self {
-            create: *lib.get(b"cutensorCreate\0")?,
-            destroy: *lib.get(b"cutensorDestroy\0")?,
-            create_tensor_descriptor: *lib.get(b"cutensorCreateTensorDescriptor\0")?,
-            destroy_tensor_descriptor: *lib.get(b"cutensorDestroyTensorDescriptor\0")?,
-            create_contraction: *lib.get(b"cutensorCreateContraction\0")?,
-            create_permutation: *lib.get(b"cutensorCreatePermutation\0")?,
-            create_reduction: *lib.get(b"cutensorCreateReduction\0")?,
-            create_elementwise_binary: *lib.get(b"cutensorCreateElementwiseBinary\0")?,
-            create_elementwise_trinary: *lib.get(b"cutensorCreateElementwiseTrinary\0")?,
-            destroy_operation_descriptor: *lib.get(b"cutensorDestroyOperationDescriptor\0")?,
-            create_plan_preference: *lib.get(b"cutensorCreatePlanPreference\0")?,
-            destroy_plan_preference: *lib.get(b"cutensorDestroyPlanPreference\0")?,
-            estimate_workspace_size: *lib.get(b"cutensorEstimateWorkspaceSize\0")?,
-            create_plan: *lib.get(b"cutensorCreatePlan\0")?,
-            destroy_plan: *lib.get(b"cutensorDestroyPlan\0")?,
-            contract: *lib.get(b"cutensorContract\0")?,
-            permute: *lib.get(b"cutensorPermute\0")?,
-            reduce: *lib.get(b"cutensorReduce\0")?,
-            elementwise_binary_execute: *lib.get(b"cutensorElementwiseBinaryExecute\0")?,
-            elementwise_trinary_execute: *lib.get(b"cutensorElementwiseTrinaryExecute\0")?,
-            compute_desc_32f: *lib
-                .get::<cutensorComputeDescriptor_t>(b"CUTENSOR_COMPUTE_DESC_32F\0")?,
-            compute_desc_64f: *lib
-                .get::<cutensorComputeDescriptor_t>(b"CUTENSOR_COMPUTE_DESC_64F\0")?,
+            create: load_symbol(handle, "cutensorCreate")?,
+            destroy: load_symbol(handle, "cutensorDestroy")?,
+            create_tensor_descriptor: load_symbol(handle, "cutensorCreateTensorDescriptor")?,
+            destroy_tensor_descriptor: load_symbol(handle, "cutensorDestroyTensorDescriptor")?,
+            create_contraction: load_symbol(handle, "cutensorCreateContraction")?,
+            create_permutation: load_symbol(handle, "cutensorCreatePermutation")?,
+            create_reduction: load_symbol(handle, "cutensorCreateReduction")?,
+            create_elementwise_binary: load_symbol(handle, "cutensorCreateElementwiseBinary")?,
+            create_elementwise_trinary: load_symbol(handle, "cutensorCreateElementwiseTrinary")?,
+            destroy_operation_descriptor: load_symbol(
+                handle,
+                "cutensorDestroyOperationDescriptor",
+            )?,
+            create_plan_preference: load_symbol(handle, "cutensorCreatePlanPreference")?,
+            destroy_plan_preference: load_symbol(handle, "cutensorDestroyPlanPreference")?,
+            estimate_workspace_size: load_symbol(handle, "cutensorEstimateWorkspaceSize")?,
+            create_plan: load_symbol(handle, "cutensorCreatePlan")?,
+            destroy_plan: load_symbol(handle, "cutensorDestroyPlan")?,
+            contract: load_symbol(handle, "cutensorContract")?,
+            permute: load_symbol(handle, "cutensorPermute")?,
+            reduce: load_symbol(handle, "cutensorReduce")?,
+            elementwise_binary_execute: load_symbol(handle, "cutensorElementwiseBinaryExecute")?,
+            elementwise_trinary_execute: load_symbol(handle, "cutensorElementwiseTrinaryExecute")?,
+            compute_desc_32f: load_data_symbol(handle, "CUTENSOR_COMPUTE_DESC_32F")?,
+            compute_desc_64f: load_data_symbol(handle, "CUTENSOR_COMPUTE_DESC_64F")?,
         })
     }
 }

--- a/tenferro-tensor/Cargo.toml
+++ b/tenferro-tensor/Cargo.toml
@@ -7,8 +7,12 @@ authors.workspace = true
 publish.workspace = true
 description = "Dense tensor type with CPU/GPU support for the tenferro workspace."
 
+[features]
+cuda = ["dep:cudarc"]
+
 [dependencies]
 tenferro-device = { path = "../tenferro-device" }
 tenferro-algebra = { path = "../tenferro-algebra" }
 chainrules-core = { path = "../extern/chainrules-core" }
 num-traits.workspace = true
+cudarc = { workspace = true, optional = true }

--- a/tenferro-tensor/src/cuda_runtime.rs
+++ b/tenferro-tensor/src/cuda_runtime.rs
@@ -1,0 +1,150 @@
+use std::sync::Arc;
+
+use cudarc::driver::{result as cuda_result, CudaContext};
+
+use super::*;
+
+fn cuda_error(operation: &str, err: impl std::fmt::Debug) -> Error {
+    Error::DeviceError(format!("{operation} failed: {err:?}"))
+}
+
+fn init_cuda_context(device_id: usize) -> Result<Arc<CudaContext>> {
+    std::panic::catch_unwind(|| CudaContext::new(device_id))
+        .map_err(|_| Error::DeviceError("CUDA driver initialization panicked".into()))?
+        .map_err(|err| cuda_error("CUDA device init", err))
+}
+
+fn copy_host_buffer_to_gpu<T: Scalar>(
+    host_data: &[T],
+    target: LogicalMemorySpace,
+) -> Result<DataBuffer<T>> {
+    let LogicalMemorySpace::GpuMemory { device_id } = target else {
+        return Err(Error::DeviceError(format!(
+            "unsupported CUDA allocation target: {target:?}"
+        )));
+    };
+
+    let ctx = init_cuda_context(device_id)?;
+    ctx.bind_to_thread()
+        .map_err(|err| cuda_error("CUDA context bind", err))?;
+
+    let num_bytes = std::mem::size_of_val(host_data);
+    let device_ptr = unsafe { cuda_result::malloc_sync(num_bytes) }
+        .map_err(|err| cuda_error("cudaMalloc", err))?;
+
+    if !host_data.is_empty() {
+        if let Err(err) = unsafe { cuda_result::memcpy_htod_sync(device_ptr, host_data) } {
+            let _ = unsafe { cuda_result::free_sync(device_ptr) };
+            return Err(cuda_error("cudaMemcpyHtoD", err));
+        }
+    }
+
+    let release_ctx = Arc::clone(&ctx);
+    let release = move || {
+        let _ = release_ctx.bind_to_thread();
+        let _ = unsafe { cuda_result::free_sync(device_ptr) };
+    };
+
+    Ok(DataBuffer {
+        inner: Arc::new(BufferInner::Gpu {
+            device_ptr: device_ptr as *mut T,
+            len: host_data.len(),
+            space: target,
+            release: Some(Box::new(release)),
+        }),
+    })
+}
+
+fn copy_gpu_buffer_to_host<T: Scalar>(
+    buffer: &DataBuffer<T>,
+    source: LogicalMemorySpace,
+) -> Result<Vec<T>> {
+    let LogicalMemorySpace::GpuMemory { device_id } = source else {
+        return Err(Error::DeviceError(format!(
+            "unsupported CUDA transfer source: {source:?}"
+        )));
+    };
+
+    let ctx = init_cuda_context(device_id)?;
+    ctx.bind_to_thread()
+        .map_err(|err| cuda_error("CUDA context bind", err))?;
+
+    let mut host_data = vec![T::zero(); buffer.len()];
+    if host_data.is_empty() {
+        return Ok(host_data);
+    }
+
+    let device_ptr = buffer
+        .as_device_ptr()
+        .ok_or_else(|| Error::DeviceError("tensor buffer is not resident on GPU".into()))?;
+
+    unsafe {
+        cuda_result::memcpy_dtoh_sync(&mut host_data, device_ptr as usize as _)
+            .map_err(|err| cuda_error("cudaMemcpyDtoH", err))?;
+    }
+
+    Ok(host_data)
+}
+
+fn transferred_fw_grad<T: Scalar>(
+    source: &Option<Box<Tensor<T>>>,
+    target: LogicalMemorySpace,
+) -> Result<Option<Box<Tensor<T>>>> {
+    source
+        .as_ref()
+        .map(|fw_grad| fw_grad.to_memory_space_async(target).map(Box::new))
+        .transpose()
+}
+
+fn rebuild_tensor_in_space<T: Scalar>(
+    source: &Tensor<T>,
+    buffer: DataBuffer<T>,
+    target: LogicalMemorySpace,
+) -> Result<Tensor<T>> {
+    Ok(Tensor {
+        buffer,
+        dims: source.dims.clone(),
+        strides: source.strides.clone(),
+        offset: source.offset,
+        logical_memory_space: target,
+        preferred_compute_device: source.preferred_compute_device,
+        event: None,
+        conjugated: source.conjugated,
+        fw_grad: transferred_fw_grad(&source.fw_grad, target)?,
+    })
+}
+
+pub(super) fn transfer_tensor<T: Scalar>(
+    source: &Tensor<T>,
+    target: LogicalMemorySpace,
+) -> Result<Tensor<T>> {
+    match (source.logical_memory_space, target) {
+        (LogicalMemorySpace::MainMemory, LogicalMemorySpace::GpuMemory { .. }) => {
+            let host_data = source
+                .buffer
+                .as_slice()
+                .ok_or_else(|| Error::DeviceError("CPU tensor is not host-accessible".into()))?;
+            let buffer = copy_host_buffer_to_gpu(host_data, target)?;
+            rebuild_tensor_in_space(source, buffer, target)
+        }
+        (LogicalMemorySpace::GpuMemory { .. }, LogicalMemorySpace::MainMemory) => {
+            let host_data = copy_gpu_buffer_to_host(&source.buffer, source.logical_memory_space)?;
+            rebuild_tensor_in_space(source, DataBuffer::from_vec(host_data), target)
+        }
+        (LogicalMemorySpace::GpuMemory { .. }, LogicalMemorySpace::GpuMemory { .. }) => Err(
+            Error::DeviceError("GPU-to-GPU transfer not yet implemented".into()),
+        ),
+        (_, LogicalMemorySpace::PinnedMemory) => Err(Error::DeviceError(
+            "pinned-memory transfer not yet implemented".into(),
+        )),
+        (_, LogicalMemorySpace::ManagedMemory) => Err(Error::DeviceError(
+            "managed-memory transfer not yet implemented".into(),
+        )),
+        (_, LogicalMemorySpace::MainMemory) => Err(Error::DeviceError(
+            "unsupported transfer source memory space".into(),
+        )),
+        (_, LogicalMemorySpace::GpuMemory { .. }) => Err(Error::DeviceError(
+            "unsupported transfer source memory space".into(),
+        )),
+    }
+}

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -104,6 +104,9 @@ use tenferro_device::{
     preferred_compute_devices, ComputeDevice, Error, LogicalMemorySpace, OpKind, Result,
 };
 
+#[cfg(feature = "cuda")]
+mod cuda_runtime;
+
 // ============================================================================
 // Private helpers
 // ============================================================================
@@ -866,22 +869,28 @@ impl<T: Scalar> Tensor<T> {
     /// );
     /// ```
     pub fn zeros(dims: &[usize], memory_space: LogicalMemorySpace, order: MemoryOrder) -> Self {
-        assert!(
-            memory_space == LogicalMemorySpace::MainMemory,
-            "GPU memory allocation not yet implemented"
-        );
         let n_elements: usize = dims.iter().product();
         let strides = compute_contiguous_strides(dims, order);
-        Tensor {
+        let tensor = Tensor {
             buffer: DataBuffer::from_vec(vec![T::zero(); n_elements]),
             dims: Arc::from(dims),
             strides: Arc::from(strides),
             offset: 0,
-            logical_memory_space: memory_space,
+            logical_memory_space: LogicalMemorySpace::MainMemory,
             preferred_compute_device: None,
             event: None,
             conjugated: false,
             fw_grad: None,
+        };
+
+        if memory_space == LogicalMemorySpace::MainMemory {
+            tensor
+        } else {
+            tensor
+                .to_memory_space_async(memory_space)
+                .unwrap_or_else(|err| {
+                    panic!("tensor allocation for {memory_space:?} failed: {err}")
+                })
         }
     }
 
@@ -903,22 +912,28 @@ impl<T: Scalar> Tensor<T> {
     ///     LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
     /// ```
     pub fn ones(dims: &[usize], memory_space: LogicalMemorySpace, order: MemoryOrder) -> Self {
-        assert!(
-            memory_space == LogicalMemorySpace::MainMemory,
-            "GPU memory allocation not yet implemented"
-        );
         let n_elements: usize = dims.iter().product();
         let strides = compute_contiguous_strides(dims, order);
-        Tensor {
+        let tensor = Tensor {
             buffer: DataBuffer::from_vec(vec![T::one(); n_elements]),
             dims: Arc::from(dims),
             strides: Arc::from(strides),
             offset: 0,
-            logical_memory_space: memory_space,
+            logical_memory_space: LogicalMemorySpace::MainMemory,
             preferred_compute_device: None,
             event: None,
             conjugated: false,
             fw_grad: None,
+        };
+
+        if memory_space == LogicalMemorySpace::MainMemory {
+            tensor
+        } else {
+            tensor
+                .to_memory_space_async(memory_space)
+                .unwrap_or_else(|err| {
+                    panic!("tensor allocation for {memory_space:?} failed: {err}")
+                })
         }
     }
 
@@ -1072,10 +1087,6 @@ impl<T: Scalar> Tensor<T> {
     /// assert_eq!(id.dims(), &[3, 3]);
     /// ```
     pub fn eye(n: usize, memory_space: LogicalMemorySpace, order: MemoryOrder) -> Self {
-        assert!(
-            memory_space == LogicalMemorySpace::MainMemory,
-            "GPU memory allocation not yet implemented"
-        );
         let dims = [n, n];
         let strides = compute_contiguous_strides(&dims, order);
         let n_elements = n * n;
@@ -1084,16 +1095,26 @@ impl<T: Scalar> Tensor<T> {
             let pos = (i as isize * strides[0] + i as isize * strides[1]) as usize;
             data[pos] = T::one();
         }
-        Tensor {
+        let tensor = Tensor {
             buffer: DataBuffer::from_vec(data),
             dims: Arc::from(dims.as_slice()),
             strides: Arc::from(strides),
             offset: 0,
-            logical_memory_space: memory_space,
+            logical_memory_space: LogicalMemorySpace::MainMemory,
             preferred_compute_device: None,
             event: None,
             conjugated: false,
             fw_grad: None,
+        };
+
+        if memory_space == LogicalMemorySpace::MainMemory {
+            tensor
+        } else {
+            tensor
+                .to_memory_space_async(memory_space)
+                .unwrap_or_else(|err| {
+                    panic!("tensor allocation for {memory_space:?} failed: {err}")
+                })
         }
     }
 
@@ -2210,7 +2231,9 @@ impl<T: Scalar> Tensor<T> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the transfer is not supported.
+    /// Returns an error if the transfer is not supported. With the `cuda`
+    /// feature enabled, `MainMemory <-> GpuMemory { device_id }` is supported.
+    /// Pinned, managed, and GPU-to-GPU transfers remain unsupported.
     ///
     /// # Examples
     ///
@@ -2225,9 +2248,19 @@ impl<T: Scalar> Tensor<T> {
         if target == self.logical_memory_space {
             return Ok(self.clone());
         }
-        Err(Error::DeviceError(
-            "GPU memory transfer not yet implemented".into(),
-        ))
+
+        #[cfg(feature = "cuda")]
+        {
+            return cuda_runtime::transfer_tensor(self, target);
+        }
+
+        #[cfg(not(feature = "cuda"))]
+        {
+            Err(Error::DeviceError(
+                "GPU memory transfer not available: rebuild with `tenferro-tensor --features cuda`"
+                    .into(),
+            ))
+        }
     }
 
     // ========================================================================

--- a/tenferro-tensor/src/tests/cuda.rs
+++ b/tenferro-tensor/src/tests/cuda.rs
@@ -1,0 +1,68 @@
+use super::*;
+
+fn cuda_device_zero_is_available() -> bool {
+    std::panic::catch_unwind(|| cudarc::driver::CudaContext::new(0).is_ok()).unwrap_or(false)
+}
+
+#[test]
+fn gpu_zeros_allocates_device_buffer_when_cuda_is_available() {
+    if !cuda_device_zero_is_available() {
+        return;
+    }
+
+    let tensor = Tensor::<f32>::zeros(
+        &[2, 3],
+        LogicalMemorySpace::GpuMemory { device_id: 0 },
+        MemoryOrder::ColumnMajor,
+    );
+
+    assert_eq!(
+        tensor.logical_memory_space(),
+        LogicalMemorySpace::GpuMemory { device_id: 0 }
+    );
+    assert!(tensor.buffer().is_gpu());
+    assert_eq!(
+        tensor.buffer().gpu_memory_space(),
+        Some(LogicalMemorySpace::GpuMemory { device_id: 0 })
+    );
+    assert_eq!(tensor.buffer().len(), 6);
+    assert!(tensor.buffer().as_device_ptr().is_some());
+    assert!(tensor.buffer().as_slice().is_none());
+}
+
+#[test]
+fn gpu_round_trip_preserves_view_layout_and_values_when_cuda_is_available() {
+    if !cuda_device_zero_is_available() {
+        return;
+    }
+
+    let data: Vec<f32> = (1..=24).map(|value| value as f32).collect();
+    let base = Tensor::<f32>::from_slice(&data, &[2, 3, 4], MemoryOrder::ColumnMajor).unwrap();
+    let view = base.permute(&[2, 0, 1]).unwrap();
+    assert!(!view.is_contiguous());
+
+    let gpu = view
+        .to_memory_space_async(LogicalMemorySpace::GpuMemory { device_id: 0 })
+        .unwrap();
+    let round_trip = gpu
+        .to_memory_space_async(LogicalMemorySpace::MainMemory)
+        .unwrap();
+
+    assert_eq!(round_trip.dims(), view.dims());
+    assert_eq!(round_trip.strides(), view.strides());
+    assert_eq!(round_trip.offset(), view.offset());
+    assert_eq!(round_trip.buffer().len(), view.buffer().len());
+    assert_eq!(
+        round_trip.logical_memory_space(),
+        LogicalMemorySpace::MainMemory
+    );
+    assert_eq!(
+        round_trip
+            .contiguous(MemoryOrder::ColumnMajor)
+            .buffer()
+            .as_slice(),
+        view.contiguous(MemoryOrder::ColumnMajor)
+            .buffer()
+            .as_slice(),
+    );
+}

--- a/tenferro-tensor/src/tests/mod.rs
+++ b/tenferro-tensor/src/tests/mod.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(feature = "cuda")]
+mod cuda;
+
 #[test]
 fn tensor_debug_is_summary_style() {
     let tensor = Tensor::<f32>::zeros(

--- a/tenferro-tensor/tests/tensor_tests.rs
+++ b/tenferro-tensor/tests/tensor_tests.rs
@@ -784,13 +784,19 @@ fn to_memory_space_same_space() {
 }
 
 #[test]
-fn to_memory_space_gpu_fails() {
+fn to_memory_space_gpu_behavior_matches_feature_support() {
     let t = Tensor::<f64>::zeros(&[2, 3], MEM, COL);
+    let result = t.to_memory_space_async(LogicalMemorySpace::GpuMemory { device_id: 0 });
+
+    #[cfg(feature = "cuda")]
     assert!(
-        matches!(
-            t.to_memory_space_async(LogicalMemorySpace::GpuMemory { device_id: 0 }),
-            Err(tenferro_device::Error::DeviceError(_))
-        ),
+        result.is_ok(),
+        "expected CUDA feature build to allow GPU transfer"
+    );
+
+    #[cfg(not(feature = "cuda"))]
+    assert!(
+        matches!(result, Err(tenferro_device::Error::DeviceError(_))),
         "expected DeviceError for GPU memory transfer"
     );
 }


### PR DESCRIPTION
## Summary
- implement CUDA-only tensor allocation and CPU<->GPU transfer in `tenferro-tensor`, including round-trip tests for non-contiguous views
- wire `tenferro-prims --features cuda` through the tensor CUDA feature and harden cuTENSOR runtime loading so a device-backed permute smoke test runs end-to-end
- document the new partial GPU status in `README.md` and `AGENTS.md`

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace --release`
- [x] `cargo llvm-cov --workspace --json --output-path coverage.json`
- [x] `python3 scripts/check-coverage.py coverage.json`
- [x] `cargo doc --workspace --no-deps`
- [x] `python3 scripts/check-docs-site.py`
- [x] `cargo test -p tenferro-tensor --features cuda`
- [x] `cargo test -p tenferro-prims --features cuda`

Closes #397
Closes #398

Generated with [Claude Code](https://claude.com/claude-code)
