### PR TITLE
docs: realign public API docs and header generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,45 @@ primitive execution paths, but broader GPU coverage is still incomplete and
 HIP remains a stub. Outside explicit GPU implementation tasks, do not assume a
 GPU code path works just because the type, trait, or FFI entrypoint exists.
 
+## Quickstart
+
+For a local checkout, a minimal CPU-only downstream crate needs these
+workspace members:
+
+```toml
+[dependencies]
+tenferro-algebra = { path = "../tenferro-rs/tenferro-algebra" }
+tenferro-device = { path = "../tenferro-rs/tenferro-device" }
+tenferro-tensor = { path = "../tenferro-rs/tenferro-tensor" }
+tenferro-prims = { path = "../tenferro-rs/tenferro-prims" }
+tenferro-einsum = { path = "../tenferro-rs/tenferro-einsum" }
+```
+
+```rust
+use tenferro_algebra::Standard;
+use tenferro_device::LogicalMemorySpace;
+use tenferro_einsum::einsum;
+use tenferro_prims::{CpuBackend, CpuContext};
+use tenferro_tensor::{MemoryOrder, Tensor};
+
+fn main() {
+    let col = MemoryOrder::ColumnMajor;
+    let mem = LogicalMemorySpace::MainMemory;
+    let mut ctx = CpuContext::new(4);
+
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
+    let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
+    let c = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None)
+        .unwrap();
+
+    assert_eq!(c.dims(), &[2, 2]);
+    assert_eq!(c.logical_memory_space(), mem);
+}
+```
+
+If you want autodiff, start from `extension/tenferro-dyadtensor`. For more
+examples, see the crate docs for `tenferro-einsum` and `tenferro-tensor`.
+
 ### Influences
 
 The API and internal architecture are strongly influenced by
@@ -98,6 +137,13 @@ Generate a unified local docs site (design docs + Rust API docs):
 bash scripts/build_docs_site.sh
 python3 scripts/check-docs-site.py
 ```
+
+Extra local tools:
+
+- `quarto` is required for `target/docs-site/design/`
+- Graphviz `dot` is required for the dependency graph assets
+- without those tools, the script still generates `target/docs-site/api/` and
+  `target/docs-site/index.html`
 
 Output:
 

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,0 +1,13 @@
+language = "C"
+pragma_once = true
+cpp_compat = true
+usize_is_size_t = true
+documentation = true
+style = "Both"
+include_guard = "TENFERRO_H"
+sort_by = "Name"
+sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
+
+[parse]
+clean = true
+parse_deps = false

--- a/docs/design/algebra.md
+++ b/docs/design/algebra.md
@@ -83,12 +83,15 @@ algebra extension mechanism works for external crates.
 
 ```rust
 // tenferro-tropical crate
-pub struct MaxPlus<T>(PhantomData<T>);
+pub struct MaxPlus<T>(pub T);
+pub struct MaxPlusAlgebra<T>(PhantomData<T>);
 
-impl HasAlgebra for MaxPlus<f64> { type Algebra = MaxPlus<f64>; }
+impl HasAlgebra for MaxPlus<f64> {
+    type Algebra = MaxPlusAlgebra<f64>;
+}
 
-impl TensorPrims<MaxPlus<f64>> for CpuBackend {
-    fn has_extension_for<T: ScalarBase>(ext: Extension) -> bool {
+impl TensorPrims<MaxPlusAlgebra<f64>> for CpuBackend {
+    fn has_extension_for(ext: Extension) -> bool {
         false  // tropical uses core ops decomposition
     }
     ...

--- a/docs/design/capi.md
+++ b/docs/design/capi.md
@@ -307,8 +307,17 @@ See [testing.md](./testing.md) for the workspace-level testing strategy.
 ## ABI Policy
 
 ### Header Generation
-C header generated via `cbindgen` from `tenferro-capi/src/lib.rs`.
-Run `cbindgen --config cbindgen.toml --output tenferro.h` after API changes.
+C headers are generated via `cbindgen` from the two FFI crates:
+
+```bash
+cbindgen --config cbindgen.toml --crate tenferro-capi --output tenferro.h
+cbindgen \
+  --config extension/tenferro-tropical-capi/cbindgen.toml \
+  --crate tenferro-tropical-capi \
+  --output tenferro_tropical.h
+```
+
+`tenferro_tropical.h` is the extension header and includes `tenferro.h`.
 
 ### Symbol Naming
 All public symbols use the `tfe_` prefix. Tropical extension uses `tfe_tropical_` prefix.

--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -223,35 +223,44 @@ let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
 let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
 
 // Matrix multiplication
-let c = einsum::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+let c = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
 
 // Trace
-let tr = einsum::<_, _, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
+let tr = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
 
 // Batch matrix multiplication
 let ba = Tensor::<f64>::zeros(&[10, 3, 4], LogicalMemorySpace::MainMemory, col);
 let bb = Tensor::<f64>::zeros(&[10, 4, 5], LogicalMemorySpace::MainMemory, col);
-let bc = einsum::<_, _, CpuBackend>(&mut ctx, "bij,bjk->bik", &[&ba, &bb], None).unwrap();
+let bc =
+    einsum::<Standard<f64>, CpuBackend>(&mut ctx, "bij,bjk->bik", &[&ba, &bb], None).unwrap();
 
 // Explicit contraction order via parentheses
-let d = einsum::<_, _, CpuBackend>(
+let d = einsum::<Standard<f64>, CpuBackend>(
     &mut ctx, "ij,(jk,kl)->il", &[&a, &b, &c], None,
 ).unwrap();
 
 // Integer label notation (for programmatic use)
 let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
-let c = einsum_with_subscripts::<_, _, CpuBackend>(&mut ctx, &subs, &[&a, &b], None).unwrap();
+let c = einsum_with_subscripts::<Standard<f64>, CpuBackend>(
+    &mut ctx,
+    &subs,
+    &[&a, &b],
+    None,
+)
+.unwrap();
 
 // Pre-optimized tree (hot loops)
 let tree = ContractionTree::optimize(&subs, &[&[2, 2], &[2, 2]]).unwrap();
 for _ in 0..n_steps {
-    let c = einsum_with_plan::<_, _, CpuBackend>(&mut ctx, &tree, &[&a, &b], None).unwrap();
+    let c = einsum_with_plan::<Standard<f64>, CpuBackend>(&mut ctx, &tree, &[&a, &b], None)
+        .unwrap();
 }
 
 // Consuming variant: operands moved, buffers reused
 let x = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
 let y = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
-let z = einsum_owned::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", vec![x, y], None).unwrap();
+let z =
+    einsum_owned::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", vec![x, y], None).unwrap();
 ```
 
 ---
@@ -290,10 +299,10 @@ where
 
 For each binary contraction, the engine chooses between:
 
-**Path A — Extended Contract available** (`has_extension_for::<T>(Contract)`):
+**Path A — Extended Contract available** (`has_extension_for(Contract)`):
 ```
 let desc = PrimDescriptor::Contract { modes_a, modes_b, modes_c };
-let plan = B::plan::<T>(&mut ctx, &desc, &shapes)?;
+let plan = B::plan(&mut ctx, &desc, &shapes)?;
 B::execute(&mut ctx, &plan, alpha, &[&a, &b], beta, &mut c)?;
 → backend handles diag, trace, permute, GEMM internally
 ```

--- a/docs/design/linalg.md
+++ b/docs/design/linalg.md
@@ -86,12 +86,14 @@ when the caller wants to control exactly where memory copies occur.
 
 ### Notes
 
-- `lu(..., LuPivot::NoPivot)` returns `Error::InvalidArgument` (not implemented).
+- `lu(..., LuPivot::NoPivot)` is implemented for the supported CPU paths and
+  returns an LU factorization with `p: None`.
 - `eig()` always returns `EigResult` with `Complex<T>` eigenvalues and eigenvectors,
   even for real input. This avoids branching on whether eigenvalues happen to be real.
 - `norm(...)` implements `Fro`, `Nuclear`, and `Spectral` only; other variants
   return `Error::InvalidArgument`.
-- `solve_triangular` has no AD rules (forward-only utility).
+- `solve_triangular` has public reverse- and forward-mode AD rules via
+  `solve_triangular_rrule` and `solve_triangular_frule`.
 
 ---
 

--- a/docs/design/reference/einsum-algorithm-comparison.md
+++ b/docs/design/reference/einsum-algorithm-comparison.md
@@ -275,7 +275,7 @@ not in `TensorPrims` (no computation needed).
 | 1 | `contract` | omeinsum-rs + strided-rs | Fused permute + batched_gemm + unpermute (cuTENSOR's `cutensorContract`) |
 | 2 | `elementwise_mul` | strided-rs | Hadamard product bypass (strided-rs's `zip_map2_into`) |
 
-**Dispatch rule**: If `has_extension_for::<T>(Extension::Contract)` returns
+**Dispatch rule**: If `has_extension_for(Extension::Contract)` returns
 `true` → use the fused operation via `PrimDescriptor::Contract`. Otherwise →
 `tenferro-einsum` decomposes into core ops:
 `diag → trace/reduce → permute → batched_gemm → permute`.

--- a/docs/design/tensor-prims.md
+++ b/docs/design/tensor-prims.md
@@ -20,7 +20,7 @@ tenferro-einsum (engine)
     │  T: HasAlgebra (UX sugar) → infers A = T::Algebra automatically
     │  A: Semiring → A::Scalar is the canonical scalar type
     │
-    ├── [has_extension_for::<T>(Contract)?]
+    ├── [has_extension_for(Contract)?]
     │   YES → execute Contract plan (fused permute+GEMM)
     │
     └── [otherwise]
@@ -28,8 +28,9 @@ tenferro-einsum (engine)
         diag → trace/reduce → permute_view → make_contiguous → batched_gemm
 ```
 
-**Dispatch is dynamic**: `has_extension_for::<T>(ext)` queries at runtime
-whether a specific extended operation is available for scalar type `T`.
+**Dispatch is dynamic**: `has_extension_for(ext)` queries at runtime
+whether a specific extended operation is available for the algebra-specific
+backend implementation.
 This is important because:
 - GPU backends are loaded at runtime (dlopen)
 - cuTENSOR supports `f32`/`f64`/Complex but not tropical types
@@ -85,7 +86,7 @@ needed independently of a GEMM.
 
 Extended operations are in the same `PrimDescriptor` enum as core ops.
 Whether a backend supports them is queried at runtime via
-`has_extension_for::<T>(Extension::Contract)`.
+`has_extension_for(Extension::Contract)`.
 
 ---
 

--- a/extension/tenferro-tropical-capi/cbindgen.toml
+++ b/extension/tenferro-tropical-capi/cbindgen.toml
@@ -1,0 +1,14 @@
+language = "C"
+pragma_once = true
+cpp_compat = true
+usize_is_size_t = true
+documentation = true
+style = "Both"
+include_guard = "TENFERRO_TROPICAL_H"
+sort_by = "Name"
+sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
+includes = ["tenferro.h"]
+
+[parse]
+clean = true
+parse_deps = false

--- a/extension/tenferro-tropical-capi/src/lib.rs
+++ b/extension/tenferro-tropical-capi/src/lib.rs
@@ -29,6 +29,17 @@
 //! tfe_tensor_f64 *c = tfe_tropical_einsum_maxplus_f64("ij,jk->ik", ops, 2, &status);
 //! ```
 //!
+//! # Header generation
+//!
+//! Generate the extension header from a workspace checkout with:
+//!
+//! ```text
+//! cbindgen \
+//!   --config extension/tenferro-tropical-capi/cbindgen.toml \
+//!   --crate tenferro-tropical-capi \
+//!   --output tenferro_tropical.h
+//! ```
+//!
 //! # Example (C pseudocode)
 //!
 //! ```c

--- a/extension/tenferro-tropical/src/lib.rs
+++ b/extension/tenferro-tropical/src/lib.rs
@@ -61,17 +61,39 @@
 //! ## Plan-based tropical contraction
 //!
 //! ```ignore
+//! use tenferro_algebra::Standard;
+//! use tenferro_device::LogicalMemorySpace;
 //! use tenferro_prims::{CpuBackend, TensorPrims, PrimDescriptor};
+//! use tenferro_prims::CpuContext;
+//! use tenferro_tensor::{MemoryOrder, Tensor};
 //! use tenferro_tropical::MaxPlusAlgebra;
 //!
+//! let mut ctx = CpuContext::new(1);
+//! let col = MemoryOrder::ColumnMajor;
+//! let mem = LogicalMemorySpace::MainMemory;
+//! let a = Tensor::<f64>::zeros(&[3, 4], mem, col);
+//! let b = Tensor::<f64>::zeros(&[4, 5], mem, col);
+//! let mut c = Tensor::<f64>::zeros(&[3, 5], mem, col);
 //! let desc = PrimDescriptor::BatchedGemm {
 //!     batch_dims: vec![], m: 3, n: 5, k: 4,
 //! };
 //! // Under MaxPlusAlgebra<f64>, GEMM computes:
 //! //   C[i,j] = max_k (A[i,k] + B[k,j])
-//! let plan = <CpuBackend as TensorPrims<MaxPlusAlgebra<f64>>>::plan::<f64>(
-//!     &desc, &[&[3, 4], &[4, 5], &[3, 5]],
-//! ).unwrap();
+//! let plan = <CpuBackend as TensorPrims<MaxPlusAlgebra<f64>>>::plan(
+//!     &mut ctx,
+//!     &desc,
+//!     &[&[3, 4], &[4, 5], &[3, 5]],
+//! )
+//! .unwrap();
+//! <CpuBackend as TensorPrims<MaxPlusAlgebra<f64>>>::execute(
+//!     &mut ctx,
+//!     &plan,
+//!     1.0,
+//!     &[&a, &b],
+//!     0.0,
+//!     &mut c,
+//! )
+//! .unwrap();
 //! ```
 
 pub mod ad;

--- a/extension/tenferro-tropical/src/prims.rs
+++ b/extension/tenferro-tropical/src/prims.rs
@@ -55,18 +55,33 @@ fn tensor_to_view_mut<T: Scalar>(t: &mut Tensor<T>) -> Result<StridedViewMut<'_,
 /// # Examples
 ///
 /// ```ignore
-/// use tenferro_prims::{CpuBackend, CpuContext, TensorPrims, PrimDescriptor, ReduceOp};
+/// use tenferro_device::LogicalMemorySpace;
+/// use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, ReduceOp, TensorPrims};
+/// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_tropical::{MaxPlusAlgebra, TropicalPlan};
 ///
 /// let mut ctx = CpuContext::new(1);
+/// let col = MemoryOrder::ColumnMajor;
+/// let mem = LogicalMemorySpace::MainMemory;
+/// let a = Tensor::<f64>::zeros(&[3, 4], mem, col);
+/// let mut c = Tensor::<f64>::zeros(&[3], mem, col);
 /// let desc = PrimDescriptor::Reduce {
 ///     modes_a: vec![0, 1],
 ///     modes_c: vec![0],
 ///     op: ReduceOp::Sum,
 /// };
-/// let plan = <CpuBackend as TensorPrims<MaxPlusAlgebra<f64>>>::plan::<f64>(
-///     &mut ctx, &desc, &[&[3, 4], &[3]],
-/// ).unwrap();
+/// let plan =
+///     <CpuBackend as TensorPrims<MaxPlusAlgebra<f64>>>::plan(&mut ctx, &desc, &[&[3, 4], &[3]])
+///         .unwrap();
+/// <CpuBackend as TensorPrims<MaxPlusAlgebra<f64>>>::execute(
+///     &mut ctx,
+///     &plan,
+///     1.0,
+///     &[&a],
+///     0.0,
+///     &mut c,
+/// )
+/// .unwrap();
 /// ```
 #[derive(Debug)]
 pub enum TropicalPlan<T: Scalar> {

--- a/tenferro-capi/src/lib.rs
+++ b/tenferro-capi/src/lib.rs
@@ -23,6 +23,14 @@
 //!   copies the caller's data into a Rust-owned buffer. For zero-copy, use
 //!   DLPack.
 //!
+//! # Header generation
+//!
+//! Generate the public C header from a workspace checkout with:
+//!
+//! ```text
+//! cbindgen --config cbindgen.toml --crate tenferro-capi --output tenferro.h
+//! ```
+//!
 //! # Memory ownership
 //!
 //! | Allocation | Freed by |

--- a/tenferro-einsum/src/ad.rs
+++ b/tenferro-einsum/src/ad.rs
@@ -164,24 +164,29 @@ where
 /// use std::cell::RefCell;
 /// use std::rc::Rc;
 /// use chainrules::Tape;
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::tracked_einsum;
+/// use tenferro_prims::{CpuBackend, CpuContext};
 /// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_device::LogicalMemorySpace;
 ///
+/// let col = MemoryOrder::ColumnMajor;
 /// let ctx = Rc::new(RefCell::new(CpuContext::new(1)));
 /// let tape = Tape::<Tensor<f64>>::new();
 /// let a = tape.leaf(Tensor::ones(
 ///     &[2, 3],
 ///     LogicalMemorySpace::MainMemory,
-///     MemoryOrder::ColumnMajor,
+///     col,
 /// ));
 /// let b = tape.leaf(Tensor::ones(
 ///     &[3, 4],
 ///     LogicalMemorySpace::MainMemory,
-///     MemoryOrder::ColumnMajor,
+///     col,
 /// ));
-/// let c = tracked_einsum::<_, _, CpuBackend>(ctx.clone(), "ij,jk->ik", &[&a, &b]).unwrap();
-/// let loss = tracked_einsum::<_, _, CpuBackend>(ctx.clone(), "ij,ij->", &[&c, &c]).unwrap();
+/// let c =
+///     tracked_einsum::<Standard<f64>, CpuBackend>(ctx.clone(), "ij,jk->ik", &[&a, &b]).unwrap();
+/// let loss =
+///     tracked_einsum::<Standard<f64>, CpuBackend>(ctx.clone(), "ij,ij->", &[&c, &c]).unwrap();
 /// let grads = tape.pullback(&loss).unwrap();
 /// let _ga = grads.get(a.node_id().unwrap()).unwrap();
 /// ```
@@ -261,6 +266,7 @@ where
 /// use std::rc::Rc;
 /// use std::sync::Arc;
 /// use chainrules::{autograd, AutogradContext, BackwardOptions, Variable};
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::variable_einsum;
 /// use tenferro_prims::{CpuBackend, CpuContext};
 /// use tenferro_tensor::{MemoryOrder, Tensor};
@@ -275,8 +281,10 @@ where
 ///     Tensor::ones(&[3, 4], tenferro_device::LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor),
 ///     Arc::clone(&ad_ctx),
 /// ).requires_grad_(true).unwrap();
-/// let c = variable_einsum::<_, CpuBackend>(ctx.clone(), "ij,jk->ik", &[&a, &b]).unwrap();
-/// let loss = variable_einsum::<_, CpuBackend>(ctx.clone(), "ij,ij->", &[&c, &c]).unwrap();
+/// let c = variable_einsum::<Standard<f64>, CpuBackend>(ctx.clone(), "ij,jk->ik", &[&a, &b])
+///     .unwrap();
+/// let loss =
+///     variable_einsum::<Standard<f64>, CpuBackend>(ctx.clone(), "ij,ij->", &[&c, &c]).unwrap();
 /// loss.backward(BackwardOptions::default()).unwrap();
 /// ```
 pub fn variable_einsum<Alg: 'static, Backend>(
@@ -335,19 +343,24 @@ where
 ///
 /// ```ignore
 /// use chainrules::DualTensor;
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::dual_einsum;
+/// use tenferro_prims::{CpuBackend, CpuContext};
 /// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_device::LogicalMemorySpace;
 ///
 /// let col = MemoryOrder::ColumnMajor;
 /// let mem = LogicalMemorySpace::MainMemory;
+/// let mut ctx = CpuContext::new(1);
 /// let a = Tensor::<f64>::ones(&[2, 3], mem, col);
 /// let da = Tensor::<f64>::ones(&[2, 3], mem, col);
 /// let b = Tensor::<f64>::ones(&[3, 4], mem, col);
 ///
 /// let a_dual = DualTensor::with_tangent(a, da).unwrap();
 /// let b_dual = DualTensor::new(b);
-/// let c_dual = dual_einsum::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a_dual, &b_dual]).unwrap();
+/// let c_dual =
+///     dual_einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a_dual, &b_dual])
+///         .unwrap();
 /// let _tangent = c_dual.tangent();
 /// ```
 pub fn dual_einsum<Alg, Backend>(
@@ -393,17 +406,21 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::einsum_rrule;
+/// use tenferro_prims::{CpuBackend, CpuContext};
 /// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_device::LogicalMemorySpace;
 ///
 /// let col = MemoryOrder::ColumnMajor;
 /// let mem = LogicalMemorySpace::MainMemory;
+/// let mut ctx = CpuContext::new(1);
 /// let a = Tensor::<f64>::ones(&[2, 3], mem, col);
 /// let b = Tensor::<f64>::ones(&[3, 4], mem, col);
 /// let grad_c = Tensor::<f64>::ones(&[2, 4], mem, col);
 ///
-/// let grads = einsum_rrule::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &grad_c).unwrap();
+/// let grads = einsum_rrule::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &grad_c)
+///     .unwrap();
 /// assert_eq!(grads.len(), 2);
 /// ```
 pub fn einsum_rrule<Alg, Backend>(
@@ -457,17 +474,26 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::einsum_frule;
+/// use tenferro_prims::{CpuBackend, CpuContext};
 /// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_device::LogicalMemorySpace;
 ///
 /// let col = MemoryOrder::ColumnMajor;
 /// let mem = LogicalMemorySpace::MainMemory;
+/// let mut ctx = CpuContext::new(1);
 /// let a = Tensor::<f64>::ones(&[2, 3], mem, col);
 /// let b = Tensor::<f64>::ones(&[3, 4], mem, col);
 /// let da = Tensor::<f64>::ones(&[2, 3], mem, col);
 ///
-/// let dc = einsum_frule::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], &[Some(&da), None]).unwrap();
+/// let dc = einsum_frule::<Standard<f64>, CpuBackend>(
+///     &mut ctx,
+///     "ij,jk->ik",
+///     &[&a, &b],
+///     &[Some(&da), None],
+/// )
+/// .unwrap();
 /// ```
 pub fn einsum_frule<Alg, Backend>(
     ctx: &mut Backend::Context,
@@ -563,12 +589,15 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::einsum_hvp;
+/// use tenferro_prims::{CpuBackend, CpuContext};
 /// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_device::LogicalMemorySpace;
 ///
 /// let col = MemoryOrder::ColumnMajor;
 /// let mem = LogicalMemorySpace::MainMemory;
+/// let mut ctx = CpuContext::new(1);
 /// let a = Tensor::<f64>::ones(&[2, 3], mem, col);
 /// let b = Tensor::<f64>::ones(&[3, 4], mem, col);
 /// let da = Tensor::<f64>::ones(&[2, 3], mem, col);
@@ -576,7 +605,7 @@ where
 /// let grad_c = Tensor::<f64>::ones(&[2, 4], mem, col);
 /// let dgrad_c = Tensor::<f64>::ones(&[2, 4], mem, col);
 ///
-/// let results = einsum_hvp::<_, _, CpuBackend>(
+/// let results = einsum_hvp::<Standard<f64>, CpuBackend>(
 ///     &mut ctx,
 ///     "ij,jk->ik",
 ///     &[&a, &b],

--- a/tenferro-einsum/src/api.rs
+++ b/tenferro-einsum/src/api.rs
@@ -47,20 +47,23 @@ fn canonicalize_col_major_operands<T: Scalar>(operands: &[&Tensor<T>]) -> Vec<Te
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_prims::{CpuBackend, CpuContext};
 /// let mut ctx = CpuContext::new(4);
 ///
 /// // Matrix multiplication
-/// let c = einsum::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+/// let c = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
 ///
 /// // Trace
-/// let tr = einsum::<_, _, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
+/// let tr = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
 ///
 /// // Batch matrix multiplication
-/// let c = einsum::<_, _, CpuBackend>(&mut ctx, "bij,bjk->bik", &[&a, &b], None).unwrap();
+/// let c =
+///     einsum::<Standard<f64>, CpuBackend>(&mut ctx, "bij,bjk->bik", &[&a, &b], None).unwrap();
 ///
 /// // Explicit contraction order: contract B*C first, then A
-/// let d = einsum::<_, _, CpuBackend>(&mut ctx, "ij,(jk,kl)->il", &[&a, &b, &c], None).unwrap();
+/// let d = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ij,(jk,kl)->il", &[&a, &b, &c], None)
+///     .unwrap();
 /// ```
 ///
 /// # Errors
@@ -151,14 +154,22 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::{einsum_with_path, Subscripts};
+/// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_prims::{CpuBackend, CpuContext};
 ///
 /// let mut ctx = CpuContext::new(1);
+/// let col = MemoryOrder::ColumnMajor;
 /// let subs = Subscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]);
+/// let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
+/// let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
+/// let c = Tensor::<f64>::from_slice(&[9.0, 10.0, 11.0, 12.0], &[2, 2], col).unwrap();
 /// // Path: contract B*C first, then A*(BC)
 /// let pairs = vec![(1, 2), (0, 3)];
-/// let d = einsum_with_path::<_, CpuBackend>(&mut ctx, &subs, &pairs, &[&a, &b, &c], None).unwrap();
+/// let d =
+///     einsum_with_path::<Standard<f64>, CpuBackend>(&mut ctx, &subs, &pairs, &[&a, &b, &c], None)
+///         .unwrap();
 /// ```
 pub fn einsum_with_path<Alg, Backend>(
     ctx: &mut Backend::Context,
@@ -242,6 +253,7 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::einsum_owned;
 /// use tenferro_tensor::{Tensor, MemoryOrder};
 /// use tenferro_prims::{CpuBackend, CpuContext};
@@ -252,7 +264,9 @@ where
 /// let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
 ///
 /// // `a` and `b` are consumed; their buffers may be reused
-/// let c = einsum_owned::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", vec![a, b], None).unwrap();
+/// let c =
+///     einsum_owned::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", vec![a, b], None)
+///         .unwrap();
 /// ```
 ///
 /// # Errors
@@ -346,6 +360,7 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::einsum_into;
 /// use tenferro_tensor::{Tensor, MemoryOrder};
 /// use tenferro_device::LogicalMemorySpace;
@@ -358,10 +373,10 @@ where
 /// let mut c = Tensor::<f64>::zeros(&[2, 2], LogicalMemorySpace::MainMemory, col);
 ///
 /// // Overwrite: C = A @ B
-/// einsum_into::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], 1.0, 0.0, &mut c, None).unwrap();
+/// einsum_into::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], 1.0, 0.0, &mut c, None).unwrap();
 ///
 /// // Accumulate: C += A @ B
-/// einsum_into::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], 1.0, 1.0, &mut c, None).unwrap();
+/// einsum_into::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], 1.0, 1.0, &mut c, None).unwrap();
 /// ```
 ///
 /// # Errors
@@ -415,17 +430,31 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::{einsum_with_subscripts_into, Subscripts};
 /// use tenferro_tensor::{Tensor, MemoryOrder};
 /// use tenferro_device::LogicalMemorySpace;
 /// use tenferro_prims::{CpuBackend, CpuContext};
 ///
 /// let mut ctx = CpuContext::new(4);
+/// let col = MemoryOrder::ColumnMajor;
 /// let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
-/// let mut c = Tensor::<f64>::zeros(&[3, 5], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
+/// let a = Tensor::<f64>::from_slice(
+///     &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+///     &[3, 2],
+///     col,
+/// )
+/// .unwrap();
+/// let b = Tensor::<f64>::from_slice(
+///     &[7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+///     &[2, 5],
+///     col,
+/// )
+/// .unwrap();
+/// let mut c = Tensor::<f64>::zeros(&[3, 5], LogicalMemorySpace::MainMemory, col);
 ///
 /// // C = 1.0 * (A @ B) + 0.0 * C
-/// einsum_with_subscripts_into::<_, _, CpuBackend>(
+/// einsum_with_subscripts_into::<Standard<f64>, CpuBackend>(
 ///     &mut ctx, &subs, &[&a, &b], 1.0, 0.0, &mut c, None,
 /// ).unwrap();
 /// ```
@@ -461,13 +490,21 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::{einsum_with_path_into, Subscripts};
+/// use tenferro_device::LogicalMemorySpace;
 /// use tenferro_prims::{CpuBackend, CpuContext};
+/// use tenferro_tensor::{MemoryOrder, Tensor};
 ///
 /// let mut ctx = CpuContext::new(1);
+/// let col = MemoryOrder::ColumnMajor;
 /// let subs = Subscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]);
+/// let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
+/// let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
+/// let c = Tensor::<f64>::from_slice(&[9.0, 10.0, 11.0, 12.0], &[2, 2], col).unwrap();
 /// let pairs = vec![(1, 2), (0, 3)];
-/// einsum_with_path_into::<_, CpuBackend>(
+/// let mut out = Tensor::<f64>::zeros(&[2, 2], LogicalMemorySpace::MainMemory, col);
+/// einsum_with_path_into::<Standard<f64>, CpuBackend>(
 ///     &mut ctx, &subs, &pairs, &[&a, &b, &c], 1.0, 0.0, &mut out, None
 /// ).unwrap();
 /// ```
@@ -501,6 +538,7 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::{einsum_with_plan_into, ContractionTree, Subscripts};
 /// use tenferro_tensor::{Tensor, MemoryOrder};
 /// use tenferro_device::LogicalMemorySpace;
@@ -510,11 +548,13 @@ where
 /// let mut ctx = CpuContext::new(4);
 /// let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
 /// let tree = ContractionTree::optimize(&subs, &[&[3, 4], &[4, 5]]).unwrap();
+/// let a = Tensor::<f64>::zeros(&[3, 4], LogicalMemorySpace::MainMemory, col);
+/// let b = Tensor::<f64>::zeros(&[4, 5], LogicalMemorySpace::MainMemory, col);
 /// let mut c = Tensor::<f64>::zeros(&[3, 5], LogicalMemorySpace::MainMemory, col);
 ///
 /// // Hot loop: reuse output buffer, no allocation per iteration
 /// for _ in 0..1000 {
-///     einsum_with_plan_into::<_, _, CpuBackend>(
+///     einsum_with_plan_into::<Standard<f64>, CpuBackend>(
 ///         &mut ctx, &tree, &[&a, &b], 1.0, 0.0, &mut c, None,
 ///     ).unwrap();
 /// }

--- a/tenferro-einsum/src/binary.rs
+++ b/tenferro-einsum/src/binary.rs
@@ -26,11 +26,17 @@ fn ensure_binary_subscripts(subscripts: &Subscripts) -> Result<()> {
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::einsum_binary;
+/// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_prims::{CpuBackend, CpuContext};
 ///
 /// let mut ctx = CpuContext::new(1);
-/// let c = einsum_binary::<_, CpuBackend>(&mut ctx, "ij,jk->ik", &a, &b, None).unwrap();
+/// let col = MemoryOrder::ColumnMajor;
+/// let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
+/// let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
+/// let c =
+///     einsum_binary::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &a, &b, None).unwrap();
 /// ```
 pub fn einsum_binary<Alg, Backend>(
     ctx: &mut Backend::Context,
@@ -57,12 +63,19 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::{einsum_binary_with_subscripts, Subscripts};
+/// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_prims::{CpuBackend, CpuContext};
 ///
 /// let mut ctx = CpuContext::new(1);
+/// let col = MemoryOrder::ColumnMajor;
 /// let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
-/// let c = einsum_binary_with_subscripts::<_, CpuBackend>(&mut ctx, &subs, &a, &b, None).unwrap();
+/// let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
+/// let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
+/// let c =
+///     einsum_binary_with_subscripts::<Standard<f64>, CpuBackend>(&mut ctx, &subs, &a, &b, None)
+///         .unwrap();
 /// ```
 pub fn einsum_binary_with_subscripts<Alg, Backend>(
     ctx: &mut Backend::Context,
@@ -87,11 +100,21 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::einsum_binary_into;
+/// use tenferro_device::LogicalMemorySpace;
+/// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_prims::{CpuBackend, CpuContext};
 ///
 /// let mut ctx = CpuContext::new(1);
-/// einsum_binary_into::<_, CpuBackend>(&mut ctx, "ij,jk->ik", &a, &b, 1.0, 0.0, &mut c, None).unwrap();
+/// let col = MemoryOrder::ColumnMajor;
+/// let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
+/// let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
+/// let mut c = Tensor::<f64>::zeros(&[2, 2], LogicalMemorySpace::MainMemory, col);
+/// einsum_binary_into::<Standard<f64>, CpuBackend>(
+///     &mut ctx, "ij,jk->ik", &a, &b, 1.0, 0.0, &mut c, None
+/// )
+/// .unwrap();
 /// ```
 pub fn einsum_binary_into<Alg, Backend>(
     ctx: &mut Backend::Context,
@@ -125,12 +148,19 @@ where
 /// # Examples
 ///
 /// ```ignore
+/// use tenferro_algebra::Standard;
 /// use tenferro_einsum::{einsum_binary_with_subscripts_into, Subscripts};
+/// use tenferro_device::LogicalMemorySpace;
+/// use tenferro_tensor::{MemoryOrder, Tensor};
 /// use tenferro_prims::{CpuBackend, CpuContext};
 ///
 /// let mut ctx = CpuContext::new(1);
+/// let col = MemoryOrder::ColumnMajor;
 /// let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
-/// einsum_binary_with_subscripts_into::<_, CpuBackend>(
+/// let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
+/// let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
+/// let mut c = Tensor::<f64>::zeros(&[2, 2], LogicalMemorySpace::MainMemory, col);
+/// einsum_binary_with_subscripts_into::<Standard<f64>, CpuBackend>(
 ///     &mut ctx, &subs, &a, &b, 1.0, 0.0, &mut c, None
 /// ).unwrap();
 /// ```

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -33,6 +33,7 @@
 //! ## Common operations
 //!
 //! ```ignore
+//! use tenferro_algebra::Standard;
 //! use tenferro_einsum::einsum;
 //! use tenferro_tensor::{Tensor, MemoryOrder};
 //! use tenferro_device::LogicalMemorySpace;
@@ -46,81 +47,92 @@
 //! let v = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0], &[3], col).unwrap();
 //!
 //! // Matrix multiplication: C = A @ B
-//! let c = einsum::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+//! let c = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
 //!
 //! // Trace: tr(A)
-//! let tr = einsum::<_, _, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
+//! let tr = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
 //!
 //! // Outer product: v_i * v_j -> M_{ij}
-//! let outer = einsum::<_, _, CpuBackend>(&mut ctx, "i,j->ij", &[&v, &v], None).unwrap();
+//! let outer =
+//!     einsum::<Standard<f64>, CpuBackend>(&mut ctx, "i,j->ij", &[&v, &v], None).unwrap();
 //!
 //! // Dot product: v . v
-//! let dot = einsum::<_, _, CpuBackend>(&mut ctx, "i,i->", &[&v, &v], None).unwrap();
+//! let dot = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "i,i->", &[&v, &v], None).unwrap();
 //!
 //! // Matrix-vector product: A @ v
-//! let mv = einsum::<_, _, CpuBackend>(&mut ctx, "ij,j->i", &[&a, &v], None).unwrap();
+//! let mv = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ij,j->i", &[&a, &v], None).unwrap();
 //!
 //! // Diagonal embedding: vector -> diagonal matrix
 //! // v = [1, 2, 3] -> [[1,0,0],[0,2,0],[0,0,3]]
-//! let diag = einsum::<_, _, CpuBackend>(&mut ctx, "i->ii", &[&v], None).unwrap();
+//! let diag = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "i->ii", &[&v], None).unwrap();
 //! assert_eq!(diag.dims(), &[3, 3]);
 //!
 //! // Diagonal extraction: matrix -> diagonal vector
-//! let d = einsum::<_, _, CpuBackend>(&mut ctx, "ii->i", &[&a], None).unwrap();
+//! let d = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ii->i", &[&a], None).unwrap();
 //!
 //! // Higher-order diagonal: 3D tensor with repeated index
 //! // Creates T_{iii} from v_i
-//! let t = einsum::<_, _, CpuBackend>(&mut ctx, "i->iii", &[&v], None).unwrap();
+//! let t = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "i->iii", &[&v], None).unwrap();
 //! assert_eq!(t.dims(), &[3, 3, 3]);
 //!
 //! // Consuming variant: operands are moved (buffer reuse not yet implemented)
 //! use tenferro_einsum::einsum_owned;
 //! let x = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
 //! let y = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
-//! let z = einsum_owned::<_, _, CpuBackend>(&mut ctx, "ij,jk->ik", vec![x, y], None).unwrap();
+//! let z =
+//!     einsum_owned::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", vec![x, y], None)
+//!         .unwrap();
 //! ```
 //!
 //! ## Batch operations
 //!
 //! ```ignore
+//! use tenferro_algebra::Standard;
 //! // Batched GEMM: 10 independent matrix multiplications in one call
 //! // A: (batch=10, m=3, k=4), B: (batch=10, k=4, n=5) -> C: (batch=10, m=3, n=5)
 //! let a = Tensor::<f64>::zeros(&[10, 3, 4], LogicalMemorySpace::MainMemory, col);
 //! let b = Tensor::<f64>::zeros(&[10, 4, 5], LogicalMemorySpace::MainMemory, col);
-//! let c = einsum::<_, _, CpuBackend>(&mut ctx, "bij,bjk->bik", &[&a, &b], None).unwrap();
+//! let c =
+//!     einsum::<Standard<f64>, CpuBackend>(&mut ctx, "bij,bjk->bik", &[&a, &b], None).unwrap();
 //! assert_eq!(c.dims(), &[10, 3, 5]);
 //!
 //! // Multiple batch dimensions: (batch1=2, batch2=3, m, k) x (batch1=2, batch2=3, k, n)
 //! let a = Tensor::<f64>::zeros(&[2, 3, 4, 5], LogicalMemorySpace::MainMemory, col);
 //! let b = Tensor::<f64>::zeros(&[2, 3, 5, 6], LogicalMemorySpace::MainMemory, col);
-//! let c = einsum::<_, _, CpuBackend>(&mut ctx, "abij,abjk->abik", &[&a, &b], None).unwrap();
+//! let c = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "abij,abjk->abik", &[&a, &b], None)
+//!     .unwrap();
 //! assert_eq!(c.dims(), &[2, 3, 4, 6]);
 //!
 //! // Broadcast batch: A has batch dim, B is shared across batch
 //! // A: (batch=10, m=3, k=4), B: (k=4, n=5) -> C: (batch=10, m=3, n=5)
 //! let a = Tensor::<f64>::zeros(&[10, 3, 4], LogicalMemorySpace::MainMemory, col);
 //! let b = Tensor::<f64>::zeros(&[4, 5], LogicalMemorySpace::MainMemory, col);
-//! let c = einsum::<_, _, CpuBackend>(&mut ctx, "bij,jk->bik", &[&a, &b], None).unwrap();
+//! let c = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "bij,jk->bik", &[&a, &b], None)
+//!     .unwrap();
 //! assert_eq!(c.dims(), &[10, 3, 5]);
 //! ```
 //!
 //! ## Integer label notation
 //!
 //! ```ignore
+//! use tenferro_algebra::Standard;
 //! use tenferro_einsum::{einsum_with_subscripts, Subscripts};
 //!
 //! // Same as "ij,jk->ik" but with integer labels
 //! // Useful when indices exceed 52 (a-z, A-Z) or are computed programmatically
 //! let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
-//! let c = einsum_with_subscripts::<_, _, CpuBackend>(&mut ctx, &subs, &[&a, &b], None).unwrap();
+//! let c = einsum_with_subscripts::<Standard<f64>, CpuBackend>(&mut ctx, &subs, &[&a, &b], None)
+//!     .unwrap();
 //! ```
 //!
 //! ## Contraction order control
 //!
 //! ```ignore
+//! use tenferro_algebra::Standard;
 //! // Three matrices: D = A @ B @ C
 //! // Parentheses specify: contract B*C first, then A*(BC)
-//! let d = einsum::<_, _, CpuBackend>(&mut ctx, "ij,(jk,kl)->il", &[&a, &b, &c], None).unwrap();
+//! let d = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ij,(jk,kl)->il", &[&a, &b, &c], None)
+//!     .unwrap();
 //!
 //! // Or use ContractionTree for programmatic control
 //! use tenferro_einsum::ContractionTree;
@@ -130,12 +142,14 @@
 //!     &[&[3, 4], &[4, 5], &[5, 6]],
 //!     &[(1, 2), (0, 3)],  // B*C first (avoids large intermediate)
 //! ).unwrap();
-//! let d = einsum_with_plan::<_, _, CpuBackend>(&mut ctx, &tree, &[&a, &b, &c], None).unwrap();
+//! let d = einsum_with_plan::<Standard<f64>, CpuBackend>(&mut ctx, &tree, &[&a, &b, &c], None)
+//!     .unwrap();
 //! ```
 //!
 //! ## Accumulating into a pre-allocated output
 //!
 //! ```ignore
+//! use tenferro_algebra::Standard;
 //! use tenferro_einsum::{einsum_with_plan_into, ContractionTree, Subscripts};
 //! use tenferro_tensor::{Tensor, MemoryOrder};
 //! use tenferro_device::LogicalMemorySpace;
@@ -152,7 +166,7 @@
 //! // Hot loop: reuse output buffer, zero allocation per iteration
 //! for _ in 0..1000 {
 //!     // C = 1.0 * (A @ B) + 0.0 * C  (overwrite)
-//!     einsum_with_plan_into::<_, _, CpuBackend>(
+//!     einsum_with_plan_into::<Standard<f64>, CpuBackend>(
 //!         &mut ctx, &tree, &[&a, &b], 1.0, 0.0, &mut c, None,
 //!     ).unwrap();
 //! }
@@ -174,6 +188,7 @@
 //! - For CPU tensors, `event` is always `None` (zero overhead)
 //!
 //! ```ignore
+//! use tenferro_algebra::Standard;
 //! use tenferro_einsum::einsum;
 //! use tenferro_tensor::{Tensor, MemoryOrder};
 //! use tenferro_device::LogicalMemorySpace;
@@ -189,8 +204,10 @@
 //!
 //! // Both einsum calls submit work to the GPU and return immediately.
 //! // The second call detects c's pending event and chains on the stream.
-//! let c = einsum::<_, _, CudaBackend>(&mut gpu_ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
-//! let d = einsum::<_, _, CudaBackend>(&mut gpu_ctx, "ij,jk->ik", &[&c, &b], None).unwrap();
+//! let c = einsum::<Standard<f64>, CudaBackend>(&mut gpu_ctx, "ij,jk->ik", &[&a, &b], None)
+//!     .unwrap();
+//! let d = einsum::<Standard<f64>, CudaBackend>(&mut gpu_ctx, "ij,jk->ik", &[&c, &b], None)
+//!     .unwrap();
 //!
 //! // wait() blocks until GPU computation completes
 //! d.wait();
@@ -222,7 +239,8 @@
 //! b.set_preferred_compute_device(Some(ComputeDevice::Cuda { device_id: 1 }));
 //!
 //! // einsum dispatches to the specified CUDA device
-//! let c = einsum::<_, _, CudaBackend>(&mut gpu_ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
+//! let c = einsum::<Standard<f64>, CudaBackend>(&mut gpu_ctx, "ij,jk->ik", &[&a, &b], None)
+//!     .unwrap();
 //!
 //! // Clear override — revert to automatic device selection
 //! // a.set_preferred_compute_device(None);

--- a/tenferro-prims/src/cpu.rs
+++ b/tenferro-prims/src/cpu.rs
@@ -617,18 +617,32 @@ impl CpuContext {
 /// # Examples
 ///
 /// ```ignore
-/// use tenferro_prims::{CpuBackend, CpuContext, TensorPrims, PrimDescriptor};
-/// use strided_view::StridedArray;
+/// use tenferro_algebra::Standard;
+/// use tenferro_device::LogicalMemorySpace;
+/// use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+/// use tenferro_tensor::{MemoryOrder, Tensor};
 ///
 /// let mut ctx = CpuContext::new(4);
+/// let col = MemoryOrder::ColumnMajor;
+/// let mem = LogicalMemorySpace::MainMemory;
+/// let a = Tensor::<f64>::zeros(&[3, 4], mem, col);
+/// let mut b = Tensor::<f64>::zeros(&[4, 3], mem, col);
 /// let desc = PrimDescriptor::Permute {
 ///     modes_a: vec![0, 1],
 ///     modes_b: vec![1, 0],
 /// };
-/// let plan = CpuBackend::plan::<f64>(&mut ctx, &desc, &[&[3, 4], &[4, 3]]).unwrap();
-/// let a = StridedArray::<f64>::col_major(&[3, 4]);
-/// let mut b = StridedArray::<f64>::col_major(&[4, 3]);
-/// CpuBackend::execute(&mut ctx, &plan, 1.0, &[&a.view()], 0.0, &mut b.view_mut()).unwrap();
+/// let plan =
+///     <CpuBackend as TensorPrims<Standard<f64>>>::plan(&mut ctx, &desc, &[&[3, 4], &[4, 3]])
+///         .unwrap();
+/// <CpuBackend as TensorPrims<Standard<f64>>>::execute(
+///     &mut ctx,
+///     &plan,
+///     1.0,
+///     &[&a],
+///     0.0,
+///     &mut b,
+/// )
+/// .unwrap();
 /// ```
 pub struct CpuBackend;
 

--- a/tenferro-prims/src/cuda.rs
+++ b/tenferro-prims/src/cuda.rs
@@ -585,10 +585,17 @@ pub struct CudaContext {
 /// # Examples
 ///
 /// ```ignore
-/// use tenferro_prims::{CudaBackend, CudaContext, TensorPrims, PrimDescriptor};
+/// use tenferro_algebra::Standard;
+/// use tenferro_prims::{CudaBackend, PrimDescriptor, TensorPrims};
 ///
 /// let (_, mut ctx) = CudaBackend::load("/usr/lib/libcutensor.so").unwrap();
-/// let plan = CudaBackend::plan::<f64>(&mut ctx, &desc, &shapes).unwrap();
+/// let desc = PrimDescriptor::Permute {
+///     modes_a: vec![0, 1],
+///     modes_b: vec![1, 0],
+/// };
+/// let plan =
+///     <CudaBackend as TensorPrims<Standard<f64>>>::plan(&mut ctx, &desc, &[&[2, 3], &[3, 2]])
+///         .unwrap();
 /// ```
 pub struct CudaPlan<T: Scalar> {
     /// Compiled cuTENSOR plan (RAII — Drop calls cutensorDestroyPlan).

--- a/tenferro-prims/src/lib.rs
+++ b/tenferro-prims/src/lib.rs
@@ -51,7 +51,7 @@
 //! # Algebra parameterization
 //!
 //! [`TensorPrims<Alg>`] is parameterized by algebra `Alg` (e.g.,
-//! [`Standard<f64>`](Standard), `MaxPlusAlgebra`). The algebra type carries
+//! [`Standard<f64>`](tenferro_algebra::Standard), `MaxPlusAlgebra`). The algebra type carries
 //! its scalar type via `Alg::Scalar` (see [`Semiring`](tenferro_algebra::Semiring)).
 //! External crates implement `TensorPrims<MyAlgebra> for CpuBackend` (orphan rule
 //! compatible). The [`HasAlgebra`](tenferro_algebra::HasAlgebra) trait on scalar types
@@ -62,50 +62,110 @@
 //! ## Plan-based GEMM
 //!
 //! ```ignore
-//! use tenferro_prims::{CpuBackend, CpuContext, TensorPrims, PrimDescriptor};
-//! use strided_view::StridedArray;
+//! use tenferro_algebra::Standard;
+//! use tenferro_device::LogicalMemorySpace;
+//! use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+//! use tenferro_tensor::{MemoryOrder, Tensor};
 //!
 //! let mut ctx = CpuContext::new(4);
-//! let a = StridedArray::<f64>::col_major(&[3, 4]);
-//! let b = StridedArray::<f64>::col_major(&[4, 5]);
-//! let mut c = StridedArray::<f64>::col_major(&[3, 5]);
+//! let col = MemoryOrder::ColumnMajor;
+//! let mem = LogicalMemorySpace::MainMemory;
+//! let a = Tensor::<f64>::zeros(&[3, 4], mem, col);
+//! let b = Tensor::<f64>::zeros(&[4, 5], mem, col);
+//! let mut c = Tensor::<f64>::zeros(&[3, 5], mem, col);
 //!
 //! let desc = PrimDescriptor::BatchedGemm {
-//!     batch_dims: vec![], m: 3, n: 5, k: 4,
+//!     batch_dims: vec![],
+//!     m: 3,
+//!     n: 5,
+//!     k: 4,
 //! };
-//! let plan = CpuBackend::plan::<f64>(&mut ctx, &desc, &[&[3, 4], &[4, 5], &[3, 5]]).unwrap();
-//! CpuBackend::execute(&mut ctx, &plan, 1.0, &[&a.view(), &b.view()], 0.0, &mut c.view_mut()).unwrap();
+//! let plan = <CpuBackend as TensorPrims<Standard<f64>>>::plan(
+//!     &mut ctx,
+//!     &desc,
+//!     &[&[3, 4], &[4, 5], &[3, 5]],
+//! )
+//! .unwrap();
+//! <CpuBackend as TensorPrims<Standard<f64>>>::execute(
+//!     &mut ctx,
+//!     &plan,
+//!     1.0,
+//!     &[&a, &b],
+//!     0.0,
+//!     &mut c,
+//! )
+//! .unwrap();
 //! ```
 //!
 //! ## Reduction (sum over an axis)
 //!
 //! ```ignore
-//! use tenferro_prims::{CpuBackend, CpuContext, TensorPrims, PrimDescriptor, ReduceOp};
+//! use tenferro_algebra::Standard;
+//! use tenferro_device::LogicalMemorySpace;
+//! use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, ReduceOp, TensorPrims};
+//! use tenferro_tensor::{MemoryOrder, Tensor};
 //!
 //! let mut ctx = CpuContext::new(4);
-//! // Sum over columns: c_i = Σ_j A_{i,j}
+//! let col = MemoryOrder::ColumnMajor;
+//! let mem = LogicalMemorySpace::MainMemory;
+//! let a = Tensor::<f64>::zeros(&[3, 4], mem, col);
+//! let mut c = Tensor::<f64>::zeros(&[3], mem, col);
+//!
 //! let desc = PrimDescriptor::Reduce {
-//!     modes_a: vec![0, 1], modes_c: vec![0], op: ReduceOp::Sum,
+//!     modes_a: vec![0, 1],
+//!     modes_c: vec![0],
+//!     op: ReduceOp::Sum,
 //! };
-//! let plan = CpuBackend::plan::<f64>(&mut ctx, &desc, &[&[3, 4], &[3]]).unwrap();
-//! CpuBackend::execute(&mut ctx, &plan, 1.0, &[&a.view()], 0.0, &mut c.view_mut()).unwrap();
+//! let plan =
+//!     <CpuBackend as TensorPrims<Standard<f64>>>::plan(&mut ctx, &desc, &[&[3, 4], &[3]])
+//!         .unwrap();
+//! <CpuBackend as TensorPrims<Standard<f64>>>::execute(
+//!     &mut ctx,
+//!     &plan,
+//!     1.0,
+//!     &[&a],
+//!     0.0,
+//!     &mut c,
+//! )
+//! .unwrap();
 //! ```
 //!
 //! ## Contraction (extended operation)
 //!
 //! ```ignore
-//! use tenferro_prims::{CpuBackend, CpuContext, TensorPrims, PrimDescriptor, Extension};
+//! use tenferro_algebra::Standard;
+//! use tenferro_device::LogicalMemorySpace;
+//! use tenferro_prims::{CpuBackend, CpuContext, Extension, PrimDescriptor, TensorPrims};
+//! use tenferro_tensor::{MemoryOrder, Tensor};
 //!
 //! let mut ctx = CpuContext::new(4);
-//! // Contract is an extended operation — check availability first
-//! if CpuBackend::has_extension_for::<f64>(Extension::Contract) {
+//! let col = MemoryOrder::ColumnMajor;
+//! let mem = LogicalMemorySpace::MainMemory;
+//! let a = Tensor::<f64>::zeros(&[3, 4], mem, col);
+//! let b = Tensor::<f64>::zeros(&[4, 5], mem, col);
+//! let mut c = Tensor::<f64>::zeros(&[3, 5], mem, col);
+//!
+//! if <CpuBackend as TensorPrims<Standard<f64>>>::has_extension_for(Extension::Contract) {
 //!     let desc = PrimDescriptor::Contract {
-//!         modes_a: vec![0, 1], modes_b: vec![1, 2], modes_c: vec![0, 2],
+//!         modes_a: vec![0, 1],
+//!         modes_b: vec![1, 2],
+//!         modes_c: vec![0, 2],
 //!     };
-//!     let plan = CpuBackend::plan::<f64>(&mut ctx, &desc, &[&[3, 4], &[4, 5], &[3, 5]]).unwrap();
-//!     CpuBackend::execute(
-//!         &ctx, &plan, 1.0, &[&a.view(), &b.view()], 0.0, &mut c.view_mut(),
-//!     ).unwrap();
+//!     let plan = <CpuBackend as TensorPrims<Standard<f64>>>::plan(
+//!         &mut ctx,
+//!         &desc,
+//!         &[&[3, 4], &[4, 5], &[3, 5]],
+//!     )
+//!     .unwrap();
+//!     <CpuBackend as TensorPrims<Standard<f64>>>::execute(
+//!         &mut ctx,
+//!         &plan,
+//!         1.0,
+//!         &[&a, &b],
+//!         0.0,
+//!         &mut c,
+//!     )
+//!     .unwrap();
 //! }
 //! ```
 
@@ -478,15 +538,39 @@ pub enum PrimDescriptor {
 /// # Examples
 ///
 /// ```ignore
-/// use tenferro_prims::{CpuBackend, CpuContext, TensorPrims, PrimDescriptor};
+/// use tenferro_algebra::Standard;
+/// use tenferro_device::LogicalMemorySpace;
+/// use tenferro_prims::{CpuBackend, CpuContext, PrimDescriptor, TensorPrims};
+/// use tenferro_tensor::{MemoryOrder, Tensor};
 ///
-/// let mut ctx = CpuContext::new(4); // 4 threads
+/// let mut ctx = CpuContext::new(4);
+/// let col = MemoryOrder::ColumnMajor;
+/// let mem = LogicalMemorySpace::MainMemory;
+/// let a = Tensor::<f64>::zeros(&[3, 4], mem, col);
+/// let b = Tensor::<f64>::zeros(&[4, 5], mem, col);
+/// let mut c = Tensor::<f64>::zeros(&[3, 5], mem, col);
 ///
 /// let desc = PrimDescriptor::BatchedGemm {
-///     batch_dims: vec![], m: 3, n: 5, k: 4,
+///     batch_dims: vec![],
+///     m: 3,
+///     n: 5,
+///     k: 4,
 /// };
-/// let plan = <CpuBackend as TensorPrims<Standard<f64>>>::plan(&mut ctx, &desc, &[&[3, 4], &[4, 5], &[3, 5]]).unwrap();
-/// <CpuBackend as TensorPrims<Standard<f64>>>::execute(&mut ctx, &plan, 1.0, &[&a.view(), &b.view()], 0.0, &mut c.view_mut()).unwrap();
+/// let plan = <CpuBackend as TensorPrims<Standard<f64>>>::plan(
+///     &mut ctx,
+///     &desc,
+///     &[&[3, 4], &[4, 5], &[3, 5]],
+/// )
+/// .unwrap();
+/// <CpuBackend as TensorPrims<Standard<f64>>>::execute(
+///     &mut ctx,
+///     &plan,
+///     1.0,
+///     &[&a, &b],
+///     0.0,
+///     &mut c,
+/// )
+/// .unwrap();
 /// ```
 pub trait TensorPrims<Alg: Algebra> {
     /// Backend-specific plan type.

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -716,9 +716,14 @@ impl<T> DataBuffer<T> {
 /// # Examples
 ///
 /// ```ignore
-/// use tenferro_tensor::Tensor;
+/// use tenferro_device::LogicalMemorySpace;
+/// use tenferro_tensor::{MemoryOrder, Tensor};
 ///
-/// let t = Tensor::<f64>::zeros(&[2, 3]);
+/// let t = Tensor::<f64>::zeros(
+///     &[2, 3],
+///     LogicalMemorySpace::MainMemory,
+///     MemoryOrder::ColumnMajor,
+/// );
 /// assert_eq!(t.dims(), &[2, 3]);
 /// assert_eq!(t.len(), 6);
 /// ```
@@ -1127,7 +1132,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// assert_eq!(t.dims(), &[3, 4]);
     /// ```
     pub fn dims(&self) -> &[usize] {
@@ -1139,7 +1151,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// let strides = t.strides();
     /// ```
     pub fn strides(&self) -> &[isize] {
@@ -1151,7 +1170,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// assert_eq!(t.offset(), 0);
     /// ```
     pub fn offset(&self) -> isize {
@@ -1163,7 +1189,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// let buf = t.buffer();
     /// ```
     pub fn buffer(&self) -> &DataBuffer<T> {
@@ -1175,7 +1208,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let mut t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let mut t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// let buf = t.buffer_mut();
     /// ```
     pub fn buffer_mut(&mut self) -> &mut DataBuffer<T> {
@@ -1187,7 +1227,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// assert_eq!(t.ndim(), 2);
     /// ```
     pub fn ndim(&self) -> usize {
@@ -1199,7 +1246,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// assert_eq!(t.len(), 12);
     /// ```
     pub fn len(&self) -> usize {
@@ -1211,7 +1265,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[0, 4], mem, col);
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[0, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// assert!(t.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
@@ -1224,8 +1285,13 @@ impl<T: Scalar> Tensor<T> {
     ///
     /// ```ignore
     /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
     ///
-    /// let t = Tensor::<f64>::zeros(&[3, 4], LogicalMemorySpace::MainMemory, col);
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// assert_eq!(t.logical_memory_space(), LogicalMemorySpace::MainMemory);
     /// ```
     pub fn logical_memory_space(&self) -> LogicalMemorySpace {
@@ -1237,7 +1303,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// assert!(t.preferred_compute_device().is_none());
     /// ```
     pub fn preferred_compute_device(&self) -> Option<ComputeDevice> {
@@ -1248,15 +1321,21 @@ impl<T: Scalar> Tensor<T> {
     ///
     /// When set, this device will be used for operations on this tensor
     /// instead of the default device selected by
-    /// [`preferred_compute_devices`](tenferro_device::preferred_compute_devices).
+    /// [`preferred_compute_devices`].
     /// Pass `None` to clear the override and revert to automatic selection.
     ///
     /// # Examples
     ///
     /// ```ignore
     /// use tenferro_device::ComputeDevice;
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
     ///
-    /// let mut t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// let mut t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// t.set_preferred_compute_device(Some(ComputeDevice::Cpu { device_id: 0 }));
     /// ```
     pub fn set_preferred_compute_device(&mut self, device: Option<ComputeDevice>) {
@@ -1271,7 +1350,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// assert!(!t.is_conjugated());
     /// ```
     pub fn is_conjugated(&self) -> bool {
@@ -1347,7 +1433,7 @@ impl<T: Scalar> Tensor<T> {
     /// If a preferred compute device is set, returns a single-element vector
     /// containing that device when it is compatible with the tensor's logical
     /// memory space for the requested operation. Otherwise, delegates to
-    /// [`preferred_compute_devices`](tenferro_device::preferred_compute_devices).
+    /// [`preferred_compute_devices`].
     ///
     /// # Errors
     ///
@@ -1357,8 +1443,14 @@ impl<T: Scalar> Tensor<T> {
     ///
     /// ```ignore
     /// use tenferro_device::OpKind;
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
     ///
-    /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col);
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// let devices = t.effective_compute_devices(OpKind::BatchedGemm).unwrap();
     /// ```
     pub fn effective_compute_devices(
@@ -1400,7 +1492,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[3, 4], mem, col); // [3, 4]
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[3, 4],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// let transposed = t.permute(&[1, 0]).unwrap();    // [4, 3]
     /// ```
     pub fn permute(&self, perm: &[usize]) -> Result<Tensor<T>> {
@@ -1922,9 +2021,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// use tenferro_tensor::Tensor;
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
     ///
-    /// let t = Tensor::<f64>::zeros(&[2, 3]);
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[2, 3],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// assert!(t.is_contiguous());
     /// ```
     pub fn is_contiguous(&self) -> bool {
@@ -1992,9 +2096,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// use tenferro_tensor::Tensor;
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
     ///
-    /// let t = Tensor::<f64>::zeros(&[2, 3]);
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[2, 3],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// let tc = t.into_conj();
     /// assert!(tc.is_conjugated());
     /// ```
@@ -2238,10 +2347,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// use tenferro_tensor::Tensor;
     /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
     ///
-    /// let t = Tensor::<f64>::zeros(&[2, 3]);
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[2, 3],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// let t2 = t.to_memory_space_async(LogicalMemorySpace::MainMemory).unwrap();
     /// ```
     pub fn to_memory_space_async(&self, target: LogicalMemorySpace) -> Result<Tensor<T>> {
@@ -2303,9 +2416,14 @@ impl<T: Scalar> Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// use tenferro_tensor::Tensor;
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
     ///
-    /// let t = Tensor::<f64>::zeros(&[2, 3]);
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[2, 3],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// // CPU tensors are always ready.
     /// assert!(t.is_ready());
     /// ```
@@ -2326,10 +2444,15 @@ impl<T: Scalar> chainrules_core::Differentiable for Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// use tenferro_tensor::Tensor;
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
     /// use chainrules_core::Differentiable;
     ///
-    /// let t = Tensor::<f64>::zeros(&[2, 3]);
+    /// let t = Tensor::<f64>::zeros(
+    ///     &[2, 3],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// let zt = t.zero_tangent();
     /// ```
     fn zero_tangent(&self) -> Tensor<T> {
@@ -2345,11 +2468,20 @@ impl<T: Scalar> chainrules_core::Differentiable for Tensor<T> {
     /// # Examples
     ///
     /// ```ignore
-    /// use tenferro_tensor::Tensor;
+    /// use tenferro_device::LogicalMemorySpace;
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
     /// use chainrules_core::Differentiable;
     ///
-    /// let mut t = Tensor::<f64>::zeros(&[2, 3]);
-    /// let tangent = Tensor::<f64>::zeros(&[2, 3]);
+    /// let mut t = Tensor::<f64>::zeros(
+    ///     &[2, 3],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
+    /// let tangent = Tensor::<f64>::zeros(
+    ///     &[2, 3],
+    ///     LogicalMemorySpace::MainMemory,
+    ///     MemoryOrder::ColumnMajor,
+    /// );
     /// t.accumulate_tangent(&tangent);
     /// ```
     fn num_elements(&self) -> usize {


### PR DESCRIPTION
## Summary
- add a root quickstart and docs-site prerequisite notes so the public docs match the current local-consumption flow
- refresh stale `TensorPrims`/`einsum`/`Tensor`/tropical examples to the current API and make key examples self-contained
- add `cbindgen` configs plus documented header-generation commands for `tenferro-capi` and `tenferro-tropical-capi`

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace --release`
- [x] `cargo llvm-cov --workspace --json --output-path coverage.json`
- [x] `python3 scripts/check-coverage.py coverage.json`
- [x] `cargo doc --workspace --no-deps`
- [x] `python3 scripts/check-docs-site.py`

Closes #371
Closes #372
Closes #373
Closes #406
Closes #409
Closes #410
Closes #411
Closes #412

Generated with [Claude Code](https://claude.com/claude-code)
