### PR TITLE
fix: consume rejected DLPack imports and stabilize tropical tie routing

### DIFF
--- a/docs/design/capi.md
+++ b/docs/design/capi.md
@@ -48,7 +48,8 @@ if a caller were to invoke such a path internally, it would surface as
 4. **f64 only** in POC phase. All functions carry the `_f64` suffix.
 
 5. **DLPack v1.0.** Zero-copy tensor exchange across language boundaries
-   (NumPy, PyTorch, JAX, DLPack.jl). Supports CPU and GPU memory.
+   (NumPy, PyTorch, JAX, DLPack.jl). Export preserves CPU/GPU logical memory
+   spaces; import currently accepts only `KDLCPU` with `device_id = 0`.
 
 6. **Copy semantics for convenience.** `tfe_tensor_f64_from_data` copies
    caller data. For zero-copy, use DLPack.
@@ -95,7 +96,8 @@ The returned `DLManagedTensorVersioned` must be consumed by the host
 language, which calls the `deleter` callback when done.
 
 **Import**: takes ownership of `DLManagedTensorVersioned`. The deleter
-is called when the returned tensor is released.
+is called exactly once, either when the returned tensor is released or
+immediately if import validation rejects the input.
 
 ### Einsum
 
@@ -193,6 +195,10 @@ DLPack device types map to `LogicalMemorySpace`:
 | `KDLCUDA_HOST`, `KDLROCM_HOST` | `PinnedMemory` |
 | `KDLCUDA`, `KDLROCM` | `GpuMemory { device_id }` |
 | `KDLCUDA_MANAGED` | `ManagedMemory` |
+
+Current import support is narrower than the full mapping above:
+`tfe_tensor_f64_from_dlpack` only accepts `KDLCPU` with `device_id = 0`
+and `float64` dtype today.
 
 ---
 

--- a/extension/tenferro-tropical-capi/src/tests/mod.rs
+++ b/extension/tenferro-tropical-capi/src/tests/mod.rs
@@ -3,12 +3,58 @@ use tenferro_tensor::{MemoryOrder, Tensor};
 
 use super::*;
 
+type TropicalRruleFn = unsafe extern "C" fn(
+    *const std::ffi::c_char,
+    *const *const TfeTensorF64,
+    usize,
+    *const TfeTensorF64,
+    *mut *mut TfeTensorF64,
+    *mut tfe_status_t,
+);
+
 fn tensor_handle(data: &[f64], dims: &[usize]) -> *mut TfeTensorF64 {
     tensor_to_handle(Tensor::from_slice(data, dims, MemoryOrder::ColumnMajor).unwrap())
 }
 
 unsafe fn read_tensor(handle: *const TfeTensorF64) -> Vec<f64> {
     handle_to_ref(handle).buffer().as_slice().unwrap().to_vec()
+}
+
+fn assert_rrule_prefers_smallest_linear_index(
+    rrule: TropicalRruleFn,
+    a_data: &[f64],
+    b_data: &[f64],
+    expected_da: &[f64],
+    expected_db: &[f64],
+) {
+    let a = tensor_handle(a_data, &[2]);
+    let b = tensor_handle(b_data, &[2]);
+    let cot = tensor_handle(&[1.0], &[]);
+    let ops = [a as *const TfeTensorF64, b as *const TfeTensorF64];
+    let mut grads = [std::ptr::null_mut(); 2];
+    let mut status = TFE_INTERNAL_ERROR;
+
+    unsafe {
+        rrule(
+            c"i,i->".as_ptr(),
+            ops.as_ptr(),
+            2,
+            cot,
+            grads.as_mut_ptr(),
+            &mut status,
+        )
+    };
+    assert_eq!(status, TFE_SUCCESS);
+    assert_eq!(unsafe { read_tensor(grads[0]) }, expected_da);
+    assert_eq!(unsafe { read_tensor(grads[1]) }, expected_db);
+
+    unsafe {
+        tfe_tensor_f64_release(grads[0]);
+        tfe_tensor_f64_release(grads[1]);
+        tfe_tensor_f64_release(cot);
+        tfe_tensor_f64_release(b);
+        tfe_tensor_f64_release(a);
+    }
 }
 
 #[test]
@@ -177,4 +223,37 @@ fn maxmul_entrypoints_produce_expected_values() {
         tfe_tensor_f64_release(b);
         tfe_tensor_f64_release(a);
     }
+}
+
+#[test]
+fn maxplus_rrule_tie_prefers_smallest_linear_index() {
+    assert_rrule_prefers_smallest_linear_index(
+        tfe_tropical_einsum_rrule_maxplus_f64,
+        &[1.0, 1.0],
+        &[2.0, 2.0],
+        &[1.0, 0.0],
+        &[1.0, 0.0],
+    );
+}
+
+#[test]
+fn minplus_rrule_tie_prefers_smallest_linear_index() {
+    assert_rrule_prefers_smallest_linear_index(
+        tfe_tropical_einsum_rrule_minplus_f64,
+        &[1.0, 1.0],
+        &[2.0, 2.0],
+        &[1.0, 0.0],
+        &[1.0, 0.0],
+    );
+}
+
+#[test]
+fn maxmul_rrule_tie_prefers_smallest_linear_index() {
+    assert_rrule_prefers_smallest_linear_index(
+        tfe_tropical_einsum_rrule_maxmul_f64,
+        &[2.0, 2.0],
+        &[3.0, 3.0],
+        &[3.0, 0.0],
+        &[2.0, 0.0],
+    );
 }

--- a/extension/tenferro-tropical/src/ad.rs
+++ b/extension/tenferro-tropical/src/ad.rs
@@ -509,7 +509,9 @@ fn tropical_forward_with_argmax<T: TropicalScalar>(
             }
 
             let new_sum = best + product;
-            if k_flat == 0 || product.inner() == new_sum.inner() {
+            // Keep the first winner on ties so gradients route to the
+            // smallest linear contraction index deterministically.
+            if k_flat == 0 || new_sum.inner() != best.inner() {
                 best_k = k_flat;
             }
             best = new_sum;

--- a/extension/tenferro-tropical/tests/ad_tests.rs
+++ b/extension/tenferro-tropical/tests/ad_tests.rs
@@ -195,7 +195,7 @@ fn maxplus_matmul_backward_mixed_winners() {
     .unwrap();
 
     // C[i,k] = max_j(A[i,j] + B[j,k])
-    // C[0,0] = max(10+1, 1+10) = max(11, 11) = 11  → winner j=1 (last one wins tie)
+    // C[0,0] = max(10+1, 1+10) = max(11, 11) = 11  → winner j=0 (smallest index wins tie)
     // C[1,0] = max(0+1, 5+10) = max(1, 15) = 15    → winner j=1
     // C[0,1] = max(10+0, 1+1) = max(10, 2) = 10    → winner j=0
     // C[1,1] = max(0+0, 5+1) = max(0, 6) = 6       → winner j=1
@@ -212,24 +212,24 @@ fn maxplus_matmul_backward_mixed_winners() {
     let da = grads[0].buffer().as_slice().unwrap();
     let db = grads[1].buffer().as_slice().unwrap();
 
-    // Winners: C[0,0]→j=1, C[1,0]→j=1, C[0,1]→j=0, C[1,1]→j=1
+    // Winners: C[0,0]→j=0, C[1,0]→j=1, C[0,1]→j=0, C[1,1]→j=1
     // dA[i,j] gets dC[i,k] when j was the winner for (i,k)
-    // dA[0,0] = dC[0,1] = 1  (j=0 won for (0,1))
+    // dA[0,0] = dC[0,0] + dC[0,1] = 2  (j=0 won for both outputs in row 0)
     // dA[1,0] = 0             (j=0 never won for i=1)
-    // dA[0,1] = dC[0,0] = 1  (j=1 won for (0,0))
+    // dA[0,1] = 0             (j=1 never won for i=0)
     // dA[1,1] = dC[1,0] + dC[1,1] = 2  (j=1 won for (1,0) and (1,1))
-    assert_eq!(da[0], 1.0); // dA[0,0]
+    assert_eq!(da[0], 2.0); // dA[0,0]
     assert_eq!(da[1], 0.0); // dA[1,0]
-    assert_eq!(da[2], 1.0); // dA[0,1]
+    assert_eq!(da[2], 0.0); // dA[0,1]
     assert_eq!(da[3], 2.0); // dA[1,1]
 
     // dB[j,k] gets dC[i,k] when j was the winner for (i,k)
-    // dB[0,0] = 0             (j=0 never won for k=0)
-    // dB[1,0] = dC[0,0] + dC[1,0] = 2  (j=1 won for k=0)
+    // dB[0,0] = dC[0,0] = 1  (j=0 won for (0,0))
+    // dB[1,0] = dC[1,0] = 1  (j=1 won for (1,0))
     // dB[0,1] = dC[0,1] = 1  (j=0 won for (0,1))
     // dB[1,1] = dC[1,1] = 1  (j=1 won for (1,1))
-    assert_eq!(db[0], 0.0); // dB[0,0]
-    assert_eq!(db[1], 2.0); // dB[1,0]
+    assert_eq!(db[0], 1.0); // dB[0,0]
+    assert_eq!(db[1], 1.0); // dB[1,0]
     assert_eq!(db[2], 1.0); // dB[0,1]
     assert_eq!(db[3], 1.0); // dB[1,1]
 }

--- a/tenferro-capi/src/lib.rs
+++ b/tenferro-capi/src/lib.rs
@@ -16,9 +16,10 @@
 //!   (ChainRules.jl, PyTorch autograd, JAX custom_vjp).
 //! - **f64 only** in this POC phase. All functions carry the `_f64` suffix.
 //! - **DLPack interop**: Zero-copy tensor exchange with Julia, Python, and
-//!   other frameworks via [`DLManagedTensorVersioned`]. Supports CPU and
-//!   GPU memory. Use [`tfe_tensor_f64_to_dlpack`] (export) and
-//!   [`tfe_tensor_f64_from_dlpack`] (import).
+//!   other frameworks via [`DLManagedTensorVersioned`]. Export preserves the
+//!   tensor's logical memory space, while import currently accepts only
+//!   `kDLCPU device_id=0` float64 tensors. Use [`tfe_tensor_f64_to_dlpack`]
+//!   (export) and [`tfe_tensor_f64_from_dlpack`] (import).
 //! - **Copy semantics** for convenience functions: `tfe_tensor_f64_from_data`
 //!   copies the caller's data into a Rust-owned buffer. For zero-copy, use
 //!   DLPack.
@@ -339,6 +340,44 @@ struct ExportedDLPackTensor {
     tensor: Box<Tensor<f64>>,
     shape: Box<[i64]>,
     strides: Box<[i64]>,
+}
+
+struct ImportedDLPackGuard {
+    managed: *mut DLManagedTensorVersioned,
+    armed: bool,
+}
+
+impl ImportedDLPackGuard {
+    unsafe fn new(managed: *mut DLManagedTensorVersioned) -> Self {
+        Self {
+            managed,
+            armed: true,
+        }
+    }
+
+    fn as_ptr(&self) -> *mut DLManagedTensorVersioned {
+        self.managed
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ImportedDLPackGuard {
+    fn drop(&mut self) {
+        if !self.armed || self.managed.is_null() {
+            return;
+        }
+
+        unsafe {
+            if let Some(deleter) = (*self.managed).deleter {
+                deleter(self.managed);
+            } else {
+                drop(Box::from_raw(self.managed));
+            }
+        }
+    }
 }
 
 // ============================================================================
@@ -1301,6 +1340,8 @@ pub unsafe extern "C" fn tfe_tensor_f64_to_dlpack(
 /// Takes ownership of the `DLManagedTensorVersioned`. The deleter
 /// callback will be called when the returned tensor is released
 /// via `tfe_tensor_f64_release`.
+/// For every non-null input, ownership is consumed even when validation
+/// fails, so rejected imports still trigger the producer deleter exactly once.
 ///
 /// The tensor data is NOT copied. The returned tensor references
 /// the same memory as the DLPack tensor.
@@ -1340,7 +1381,8 @@ pub unsafe extern "C" fn tfe_tensor_f64_from_dlpack(
                 return Err(TFE_INVALID_ARGUMENT);
             }
 
-            let managed_ref = &*managed;
+            let mut guard = ImportedDLPackGuard::new(managed);
+            let managed_ref = &*guard.as_ptr();
             if managed_ref.version.major != 1 {
                 set_last_error("from_dlpack: unsupported DLPack major version");
                 return Err(TFE_INVALID_ARGUMENT);
@@ -1411,7 +1453,7 @@ pub unsafe extern "C" fn tfe_tensor_f64_from_dlpack(
                 return Err(TFE_INVALID_ARGUMENT);
             }
 
-            let managed_addr = managed as usize;
+            let managed_addr = guard.as_ptr() as usize;
             let release = move || unsafe {
                 let managed = managed_addr as *mut DLManagedTensorVersioned;
                 if let Some(deleter) = (*managed).deleter {
@@ -1422,6 +1464,7 @@ pub unsafe extern "C" fn tfe_tensor_f64_from_dlpack(
             };
             let tensor = Tensor::from_external_parts(data, len, &dims, &strides, offset, release)
                 .map_err(|err| map_device_error(&err))?;
+            guard.disarm();
             Ok(tensor_to_handle(tensor))
         },
     ));

--- a/tenferro-capi/src/tests/mod.rs
+++ b/tenferro-capi/src/tests/mod.rs
@@ -21,6 +21,48 @@ unsafe extern "C" fn import_fixture_deleter(managed: *mut DLManagedTensorVersion
     fixture.calls.fetch_add(1, Ordering::SeqCst);
 }
 
+fn import_fixture_managed(
+    device_type: i32,
+    device_id: i32,
+) -> (*mut DLManagedTensorVersioned, Arc<AtomicUsize>) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut fixture = Box::new(ImportFixture {
+        data: vec![1.0, 2.0, 3.0, 4.0],
+        shape: vec![2, 2].into_boxed_slice(),
+        strides: vec![2, 1].into_boxed_slice(),
+        calls: calls.clone(),
+    });
+    let data_ptr = fixture.data.as_mut_ptr();
+    let shape_ptr = fixture.shape.as_mut_ptr();
+    let strides_ptr = fixture.strides.as_mut_ptr();
+    let manager_ctx = Box::into_raw(fixture);
+
+    let managed = Box::into_raw(Box::new(DLManagedTensorVersioned {
+        version: DLPackVersion { major: 1, minor: 0 },
+        manager_ctx: manager_ctx as *mut c_void,
+        deleter: Some(import_fixture_deleter),
+        flags: 0,
+        dl_tensor: DLTensor {
+            data: data_ptr as *mut c_void,
+            device: DLDevice {
+                device_type,
+                device_id,
+            },
+            ndim: 2,
+            dtype: DLDataType {
+                code: KDLFLOAT,
+                bits: 64,
+                lanes: 1,
+            },
+            shape: shape_ptr,
+            strides: strides_ptr,
+            byte_offset: 0,
+        },
+    }));
+
+    (managed, calls)
+}
+
 #[test]
 fn dlpack_export_import_roundtrip_preserves_strides_and_values() {
     let base = Tensor::from_slice(
@@ -68,40 +110,7 @@ fn dlpack_export_import_roundtrip_preserves_strides_and_values() {
 
 #[test]
 fn dlpack_import_calls_producer_deleter_on_release() {
-    let calls = Arc::new(AtomicUsize::new(0));
-    let mut fixture = Box::new(ImportFixture {
-        data: vec![1.0, 2.0, 3.0, 4.0],
-        shape: vec![2, 2].into_boxed_slice(),
-        strides: vec![2, 1].into_boxed_slice(),
-        calls: calls.clone(),
-    });
-    let data_ptr = fixture.data.as_mut_ptr();
-    let shape_ptr = fixture.shape.as_mut_ptr();
-    let strides_ptr = fixture.strides.as_mut_ptr();
-    let manager_ctx = Box::into_raw(fixture);
-
-    let managed = Box::into_raw(Box::new(DLManagedTensorVersioned {
-        version: DLPackVersion { major: 1, minor: 0 },
-        manager_ctx: manager_ctx as *mut c_void,
-        deleter: Some(import_fixture_deleter),
-        flags: 0,
-        dl_tensor: DLTensor {
-            data: data_ptr as *mut c_void,
-            device: DLDevice {
-                device_type: KDLCPU,
-                device_id: 0,
-            },
-            ndim: 2,
-            dtype: DLDataType {
-                code: KDLFLOAT,
-                bits: 64,
-                lanes: 1,
-            },
-            shape: shape_ptr,
-            strides: strides_ptr,
-            byte_offset: 0,
-        },
-    }));
+    let (managed, calls) = import_fixture_managed(KDLCPU, 0);
 
     let mut status = TFE_INTERNAL_ERROR;
     let handle = unsafe { tfe_tensor_f64_from_dlpack(managed, &mut status) };
@@ -115,5 +124,16 @@ fn dlpack_import_calls_producer_deleter_on_release() {
     assert_eq!(tensor.buffer().as_slice().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
 
     unsafe { tfe_tensor_f64_release(handle) };
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn dlpack_import_rejects_unsupported_device_and_consumes_input() {
+    let (managed, calls) = import_fixture_managed(KDLCUDA, 0);
+
+    let mut status = TFE_INTERNAL_ERROR;
+    let handle = unsafe { tfe_tensor_f64_from_dlpack(managed, &mut status) };
+    assert!(handle.is_null());
+    assert_eq!(status, TFE_INVALID_ARGUMENT);
     assert_eq!(calls.load(Ordering::SeqCst), 1);
 }


### PR DESCRIPTION
## Summary

- consume rejected `DLManagedTensorVersioned` imports immediately so `tfe_tensor_f64_from_dlpack` honors the ownership contract on all non-null inputs
- keep tropical argmax routing stable on ties so the smallest linear contraction index wins in both the core rule and the C-API entrypoints
- narrow the DLPack documentation to the currently supported import surface while keeping export semantics documented

Closes #415
Closes #416

## Verification

- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/tmp/tenferro-capi-tropical-batch-target CARGO_BUILD_JOBS=1 cargo test --workspace --release`
- `CARGO_TARGET_DIR=/tmp/tenferro-capi-tropical-batch-cov-target cargo llvm-cov --workspace --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `CARGO_TARGET_DIR=/tmp/tenferro-capi-tropical-batch-doc-target cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Generated with [Claude Code](https://claude.com/claude-code)
