### PR TITLE
docs: clean rustdoc warnings

### DIFF
--- a/extension/tenferro-dyadtensor/src/api/mod.rs
+++ b/extension/tenferro-dyadtensor/src/api/mod.rs
@@ -447,7 +447,7 @@ where
 /// Builder for primal einsum.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `EinsumBuilder` via its corresponding operation constructor.
 /// ```
 pub struct EinsumBuilder<'a, T>
@@ -525,7 +525,7 @@ where
 /// Builder for AD einsum.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `EinsumAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct EinsumAdBuilder<'a, T>
@@ -844,7 +844,7 @@ where
 /// Builder for SVD.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `SvdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct SvdBuilder<'a, T: LinalgScalar> {
@@ -897,7 +897,7 @@ pub fn svd<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> SvdBuilder<'a, T> {
 /// Builder for QR.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `QrBuilder` via its corresponding operation constructor.
 /// ```
 pub struct QrBuilder<'a, T: LinalgScalar> {
@@ -934,7 +934,7 @@ pub fn qr<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> QrBuilder<'a, T> {
 /// Builder for LU.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `LuBuilder` via its corresponding operation constructor.
 /// ```
 pub struct LuBuilder<'a, T: LinalgScalar> {
@@ -986,7 +986,7 @@ pub fn lu<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> LuBuilder<'a, T> {
 /// Builder for eigen decomposition.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `EigenBuilder` via its corresponding operation constructor.
 /// ```
 pub struct EigenBuilder<'a, T: LinalgScalar> {
@@ -1023,7 +1023,7 @@ pub fn eigen<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> EigenBuilder<'a, T> 
 /// Builder for least squares solve.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `LstsqBuilder` via its corresponding operation constructor.
 /// ```
 pub struct LstsqBuilder<'a, T: LinalgScalar> {
@@ -1061,7 +1061,7 @@ pub fn lstsq<'a, T: LinalgScalar>(a: &'a Tensor<T>, b: &'a Tensor<T>) -> LstsqBu
 /// Builder for Cholesky.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `CholeskyBuilder` via its corresponding operation constructor.
 /// ```
 pub struct CholeskyBuilder<'a, T: LinalgScalar> {
@@ -1098,7 +1098,7 @@ pub fn cholesky<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> CholeskyBuilder<'
 /// Builder for solve.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `SolveBuilder` via its corresponding operation constructor.
 /// ```
 pub struct SolveBuilder<'a, T: LinalgScalar> {
@@ -1136,7 +1136,7 @@ pub fn solve<'a, T: LinalgScalar>(a: &'a Tensor<T>, b: &'a Tensor<T>) -> SolveBu
 /// Builder for matrix inverse.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `InvBuilder` via its corresponding operation constructor.
 /// ```
 pub struct InvBuilder<'a, T: LinalgScalar> {
@@ -1173,7 +1173,7 @@ pub fn inv<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> InvBuilder<'a, T> {
 /// Builder for determinant.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `DetBuilder` via its corresponding operation constructor.
 /// ```
 pub struct DetBuilder<'a, T: LinalgScalar> {
@@ -1210,7 +1210,7 @@ pub fn det<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> DetBuilder<'a, T> {
 /// Builder for slogdet.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `SlogdetBuilder` via its corresponding operation constructor.
 /// ```
 pub struct SlogdetBuilder<'a, T: LinalgScalar> {
@@ -1247,7 +1247,7 @@ pub fn slogdet<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> SlogdetBuilder<'a,
 /// Builder for general eigendecomposition.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `EigBuilder` via its corresponding operation constructor.
 /// ```
 pub struct EigBuilder<'a, T: LinalgScalar> {
@@ -1284,7 +1284,7 @@ pub fn eig<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> EigBuilder<'a, T> {
 /// Builder for pseudoinverse.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `PinvBuilder` via its corresponding operation constructor.
 /// ```
 pub struct PinvBuilder<'a, T: LinalgScalar> {
@@ -1337,7 +1337,7 @@ pub fn pinv<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> PinvBuilder<'a, T> {
 /// Builder for matrix exponential.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `MatrixExpBuilder` via its corresponding operation constructor.
 /// ```
 pub struct MatrixExpBuilder<'a, T: LinalgScalar> {
@@ -1374,7 +1374,7 @@ pub fn matrix_exp<'a, T: LinalgScalar>(tensor: &'a Tensor<T>) -> MatrixExpBuilde
 /// Builder for triangular solve.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `SolveTriangularBuilder` via its corresponding operation constructor.
 /// ```
 pub struct SolveTriangularBuilder<'a, T: LinalgScalar> {
@@ -1428,7 +1428,7 @@ pub fn solve_triangular<'a, T: LinalgScalar>(
 /// Builder for norm.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `NormBuilder` via its corresponding operation constructor.
 /// ```
 pub struct NormBuilder<'a, T: LinalgScalar> {
@@ -1642,7 +1642,7 @@ where
 /// Builder for AD SVD.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `SvdAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct SvdAdBuilder<'a, T: Scalar> {
@@ -1826,7 +1826,7 @@ pub fn svd_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> SvdAdBuilder<'a, T> {
 /// Builder for AD QR.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `QrAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct QrAdBuilder<'a, T: Scalar> {
@@ -1951,7 +1951,7 @@ pub fn qr_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> QrAdBuilder<'a, T> {
 /// Builder for AD LU.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `LuAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct LuAdBuilder<'a, T: Scalar> {
@@ -2101,7 +2101,7 @@ pub fn lu_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> LuAdBuilder<'a, T> {
 /// Builder for AD eigen decomposition.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `EigenAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct EigenAdBuilder<'a, T: Scalar> {
@@ -2229,7 +2229,7 @@ pub fn eigen_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> EigenAdBuilder<'a, T>
 /// Builder for AD least squares.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `LstsqAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct LstsqAdBuilder<'a, T: Scalar> {
@@ -2365,7 +2365,7 @@ pub fn lstsq_ad<'a, T: Scalar>(a: &'a AdTensor<T>, b: &'a AdTensor<T>) -> LstsqA
 /// Builder for AD Cholesky.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `CholeskyAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct CholeskyAdBuilder<'a, T: Scalar> {
@@ -2407,7 +2407,7 @@ pub fn cholesky_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> CholeskyAdBuilder<
 /// Builder for AD solve.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `SolveAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct SolveAdBuilder<'a, T: Scalar> {
@@ -2454,7 +2454,7 @@ pub fn solve_ad<'a, T: Scalar>(a: &'a AdTensor<T>, b: &'a AdTensor<T>) -> SolveA
 /// Builder for AD inverse.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `InvAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct InvAdBuilder<'a, T: Scalar> {
@@ -2496,7 +2496,7 @@ pub fn inv_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> InvAdBuilder<'a, T> {
 /// Builder for AD det.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `DetAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct DetAdBuilder<'a, T: Scalar> {
@@ -2538,7 +2538,7 @@ pub fn det_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> DetAdBuilder<'a, T> {
 /// Builder for AD slogdet.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `SlogdetAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct SlogdetAdBuilder<'a, T: Scalar> {
@@ -2654,7 +2654,7 @@ pub fn slogdet_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> SlogdetAdBuilder<'a
 /// Builder for AD eig.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `EigAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct EigAdBuilder<'a, T: Scalar> {
@@ -2786,7 +2786,7 @@ pub fn eig_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> EigAdBuilder<'a, T> {
 /// Builder for AD pinv.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `PinvAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct PinvAdBuilder<'a, T: Scalar> {
@@ -2847,7 +2847,7 @@ pub fn pinv_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> PinvAdBuilder<'a, T> {
 /// Builder for AD matrix exponential.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `MatrixExpAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct MatrixExpAdBuilder<'a, T: Scalar> {
@@ -2891,7 +2891,7 @@ pub fn matrix_exp_ad<'a, T: Scalar>(tensor: &'a AdTensor<T>) -> MatrixExpAdBuild
 /// Builder for AD solve_triangular.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `SolveTriangularAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct SolveTriangularAdBuilder<'a, T: Scalar> {
@@ -3017,7 +3017,7 @@ pub fn solve_triangular_ad<'a, T: Scalar>(
 /// Builder for AD norm.
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Construct `NormAdBuilder` via its corresponding operation constructor.
 /// ```
 pub struct NormAdBuilder<'a, T: Scalar> {

--- a/extension/tenferro-tropical/src/ad.rs
+++ b/extension/tenferro-tropical/src/ad.rs
@@ -14,11 +14,11 @@
 //!
 //! ## Architecture
 //!
-//! - [`tropical_forward_with_argmax`]: runs tropical einsum forward and records
-//!   winner indices in an [`ArgmaxTracker`](crate::ArgmaxTracker)
+//! - `tropical_forward_with_argmax`: runs tropical einsum forward and records
+//!   winner indices in an [`ArgmaxTracker`]
 //! - [`tropical_einsum_rrule`]: standalone reverse-mode rule (pullback)
-//! - [`TropicalEinsumReverseRule`]: implements
-//!   [`ReverseRule<Tensor<T::Inner>>`](chainrules::ReverseRule) for tape integration
+//! - [`TropicalEinsumReverseRule`]: tape integration via
+//!   [`ReverseRule<Tensor<T::Inner>>`](chainrules::ReverseRule)
 //! - [`tracked_tropical_einsum`]: tape-aware tracked einsum for tropical ops
 //!
 //! ## Backward rules by semiring
@@ -26,11 +26,11 @@
 //! For a GEMM `C[i,j] = opt_k (A[i,k] (x) B[k,j])` where `opt` = max/min
 //! and `(x)` is tropical multiplication:
 //!
-//! | Semiring | opt | (x) | dA[i,k*] | dB[k*,j] |
+//! | Semiring | opt | (x) | `dA[i,k*]` | `dB[k*,j]` |
 //! |----------|-----|-----|----------|----------|
-//! | MaxPlus | max | + | dC[i,j] | dC[i,j] |
-//! | MinPlus | min | + | dC[i,j] | dC[i,j] |
-//! | MaxMul | max | x | dC[i,j] * B.0[k*,j] | dC[i,j] * A.0[i,k*] |
+//! | MaxPlus | max | + | `dC[i,j]` | `dC[i,j]` |
+//! | MinPlus | min | + | `dC[i,j]` | `dC[i,j]` |
+//! | MaxMul | max | x | `dC[i,j] * B.0[k*,j]` | `dC[i,j] * A.0[i,k*]` |
 //!
 //! where `k*` is the winner index from the forward pass.
 //!
@@ -955,7 +955,7 @@ fn tropical_backward_binary<T: TropicalScalar>(
 // Tape-integrated tropical AD
 // ============================================================================
 
-/// Reverse-mode rule for tropical einsum, for integration with [`Tape`].
+/// Reverse-mode rule for tropical einsum, for integration with [`chainrules::Tape`].
 ///
 /// This rule stores the tropical primal tensors and the argmax tracker from
 /// the forward pass. The pullback computes standard real gradients.

--- a/extension/tenferro-tropical/src/prims.rs
+++ b/extension/tenferro-tropical/src/prims.rs
@@ -115,7 +115,7 @@ pub enum TropicalPlan<T: Scalar> {
     },
     /// Plan for permutation.
     Permute {
-        /// Permutation mapping: perm[out_axis] = in_axis.
+        /// Permutation mapping: `perm[out_axis] = in_axis`.
         perm: Vec<usize>,
         _marker: PhantomData<T>,
     },

--- a/extern/chainrules/src/lib.rs
+++ b/extern/chainrules/src/lib.rs
@@ -1896,7 +1896,7 @@ pub mod autograd {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```text
     /// // Intended for operation implementations:
     /// // let out = autograd::record_op(value, &[&x, &y], Box::new(rule), tangent)?;
     /// ```

--- a/tenferro-algebra/src/lib.rs
+++ b/tenferro-algebra/src/lib.rs
@@ -163,7 +163,7 @@ impl HasAlgebra for Complex64 {
 
 /// Associates an algebra marker with its scalar type.
 ///
-/// This is the minimal trait required by [`TensorPrims`] — it provides
+/// This is the minimal trait required by `TensorPrims` — it provides
 /// the scalar type without requiring semiring operations.
 ///
 /// [`Semiring`] extends `Algebra` with zero/one/add/mul.

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -6,7 +6,7 @@
 
 //! High-level einsum with N-ary contraction tree optimization.
 //!
-//! This crate provides Einstein summation notation for [`Tensor`]
+//! This crate provides Einstein summation notation for [`tenferro_tensor::Tensor`]
 //! values. It supports:
 //!
 //! - **String notation**: `"ij,jk->ik"` (NumPy/PyTorch compatible)

--- a/tenferro-einsum/src/subscripts.rs
+++ b/tenferro-einsum/src/subscripts.rs
@@ -56,8 +56,8 @@ impl Subscripts {
     /// from the output.
     ///
     /// Parentheses in the notation are accepted but stripped during parsing.
-    /// To respect parenthesized contraction order, use [`NestedEinsum::parse`]
-    /// or pass the parenthesized string directly to [`einsum`].
+    /// To respect parenthesized contraction order, use [`crate::NestedEinsum::parse`]
+    /// or pass the parenthesized string directly to [`crate::einsum`].
     ///
     /// # Examples
     ///

--- a/tenferro-prims/src/cpu.rs
+++ b/tenferro-prims/src/cpu.rs
@@ -322,7 +322,7 @@ pub enum CpuPlan<T: Scalar> {
     },
     /// Plan for permutation.
     Permute {
-        /// Permutation mapping (perm[out_axis] = in_axis).
+        /// Permutation mapping (`perm[out_axis] = in_axis`).
         perm: Vec<usize>,
         _marker: PhantomData<T>,
     },

--- a/tenferro-prims/src/gpu_stubs.rs
+++ b/tenferro-prims/src/gpu_stubs.rs
@@ -202,7 +202,7 @@ pub struct RocmPlan<T: Scalar> {
 /// **Status: Not yet implemented.** All methods currently return errors.
 /// The type exists to define the intended API surface. `plan()` and
 /// `execute()` return `Err(DeviceError)`. `load_hiptensor()` on
-/// [`BackendRegistry`] also returns an error.
+/// [`crate::BackendRegistry`] also returns an error.
 ///
 /// When implemented, will be loaded at runtime from a user-provided `.so`
 /// path with no compile-time ROCm SDK dependency. Will implement


### PR DESCRIPTION
## Summary
- fix broken intra-doc links that fail `cargo doc` with `-D warnings`
- convert placeholder comment-only doc blocks from `ignore` to `text`
- keep the batch scoped to rustdoc warning cleanup only

Closes #374

Generated with [Claude Code](https://claude.com/claude-code)