### PR TITLE
fix: correct linalg AD formulas and edge cases

### DIFF
--- a/docs/AD/qr.md
+++ b/docs/AD/qr.md
@@ -84,43 +84,77 @@ The key insight is that $R\bar{R}^\dagger - \bar{Q}^\dagger Q$ encodes
 the cotangent information, and `copyltu` extracts the Hermitian part
 consistent with the $Q$ orthogonality constraint.
 
-## QR Case 2: Wide $R$ ($M < N$, $K = M$)
+## QR Case 2: Wide Reduced QR ($M < N$, $K = M$)
 
-When $R$ has more columns than rows, partition:
-
-$$
-R = [U \mid D], \quad U \in \mathbb{C}^{K \times K} \text{ upper triangular}, \quad D \in \mathbb{C}^{K \times (N - K)}
-$$
-
-and correspondingly:
+When $M < N$, the reduced QR still has
 
 $$
-A = Q [U \mid D] = [QU \mid QD]
+Q \in \mathbb{C}^{K \times K}, \qquad R \in \mathbb{C}^{K \times N},
 $$
 
-Let $A_1 = A_{:, 1:K}$ and $A_2 = A_{:, K+1:N}$.
-Note $A_2 = QD$, so $D = Q^\dagger A_2$.
-
-### Backward
-
-Partition $\bar{R} = [\bar{U} \mid \bar{D}]$.
-
-**From $D = Q^\dagger A_2$:**
-- $\bar{Q} \leftarrow \bar{Q} + A_2 \bar{D}^\dagger$ (chain rule for $Q$ through $D = Q^\dagger A_2$)
-- $\bar{A}_2 = Q \bar{D}$ (chain rule for $A_2$)
-
-**For $A_1 = QU$:**
-Apply the full-rank QR backward with the augmented cotangent:
+with the leading square block
 
 $$
-\bar{A}_1 = \mathrm{qr\_back\_fullrank}(Q, U, \bar{Q} + A_2 \bar{D}^\dagger, \bar{U})
+R_1 = R_{:, 1:K} \in \mathbb{C}^{K \times K}.
 $$
 
-**Combine:**
+The reverse rule is most convenient to write directly in terms of
+$Q$, $R$, $\bar{Q}$, and $\bar{R}$, without repartitioning the primal
+matrix.
+
+### Step 1: Build the square auxiliary matrix
 
 $$
-\bar{A} = [\bar{A}_1 \mid \bar{A}_2]
+X = Q^\dagger \bar{Q} - \bar{R} R^\dagger \in \mathbb{C}^{K \times K}
 $$
+
+### Step 2: Project to the lower-triangular skew part
+
+Define the adjoint helper used in the wide reduced-QR backward:
+
+$$
+\mathrm{trilImInvAdjSkew}(X) =
+\begin{cases}
+\mathrm{tril}(X - X^\top) & \text{real case}, \\
+\mathrm{tril}(X - X^\dagger)\ \text{with imaginary diagonal halved} & \text{complex case}.
+\end{cases}
+$$
+
+For the current `tenferro-linalg` implementation, the real-valued
+specialization is the one in use.
+
+### Step 3: Solve for the leading block
+
+$$
+\bar{A}_{\mathrm{lead}} = Q \, \mathrm{trilImInvAdjSkew}(X)\, R_1^{-\dagger}
+$$
+
+This produces the cotangent for the leading $K$ columns only.
+
+### Step 4: Embed and add the direct $R$ path
+
+Let $\pi^\*(Y)$ embed a $K \times K$ block back into the full-width
+$K \times N$ matrix by padding trailing zero columns:
+
+$$
+\pi^\*(Y) = [Y \mid 0].
+$$
+
+Then the full reverse rule is
+
+$$
+\bar{A} = \pi^\*(\bar{A}_{\mathrm{lead}}) + Q \bar{R}.
+$$
+
+The first term accounts for the orthogonality constraint on $Q$ together
+with the triangular structure of the leading block of $R$. The second term
+is the direct cotangent flow through the explicit $Q \bar{R}$ contribution.
+
+### Implementation note
+
+This is the formula used by the current `tenferro-linalg::qr_rrule`
+implementation, and it matches the reduced-QR backward written in
+PyTorch's manual autograd formulas for the real case.
 
 ---
 

--- a/tenferro-linalg/src/backend/cpu_tensor_impl.rs
+++ b/tenferro-linalg/src/backend/cpu_tensor_impl.rs
@@ -280,6 +280,16 @@ where
 {
     let (n, batch_dims) = validate_square(a)?;
     let bc = batch_count(batch_dims);
+    if n == 0 || bc == 0 {
+        let mut val_shape = vec![n];
+        val_shape.extend_from_slice(batch_dims);
+        let mut vec_shape = vec![n, n];
+        vec_shape.extend_from_slice(batch_dims);
+        return Ok(EigenTensorResult {
+            values: tensor_from_data(Vec::new(), &val_shape)?,
+            vectors: tensor_from_data(Vec::new(), &vec_shape)?,
+        });
+    }
 
     let a_contig = ensure_col_major(a);
     let a_data = extract_contiguous_slice(&a_contig)?;

--- a/tenferro-linalg/src/backend/tensor_helpers.rs
+++ b/tenferro-linalg/src/backend/tensor_helpers.rs
@@ -53,7 +53,11 @@ pub(crate) fn ensure_col_major<T: LinalgScalar>(a: &Tensor<T>) -> Tensor<T> {
 
 /// Compute the total number of elements in batch dimensions.
 pub(crate) fn batch_count(batch_dims: &[usize]) -> usize {
-    batch_dims.iter().product::<usize>().max(1)
+    if batch_dims.is_empty() {
+        1
+    } else {
+        batch_dims.iter().product()
+    }
 }
 
 /// Extract the underlying buffer slice from a tensor. Returns an error if

--- a/tenferro-linalg/src/backend/tensor_helpers/tests/mod.rs
+++ b/tenferro-linalg/src/backend/tensor_helpers/tests/mod.rs
@@ -44,6 +44,12 @@ fn batch_count_nonempty() {
 }
 
 #[test]
+fn batch_count_zero_dim_batch_is_zero() {
+    assert_eq!(batch_count(&[0]), 0);
+    assert_eq!(batch_count(&[2, 0, 3]), 0);
+}
+
+#[test]
 fn ensure_col_major_contiguous() {
     let a = make(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
     let b = ensure_col_major(&a);

--- a/tenferro-linalg/src/lib.rs
+++ b/tenferro-linalg/src/lib.rs
@@ -604,7 +604,11 @@ fn to_ad_err(e: Error) -> chainrules_core::AutodiffError {
 
 /// Compute batch count from batch dims (product, or 1 if empty).
 fn batch_count(batch_dims: &[usize]) -> usize {
-    batch_dims.iter().product::<usize>().max(1)
+    if batch_dims.is_empty() {
+        1
+    } else {
+        batch_dims.iter().product()
+    }
 }
 
 /// Build output dims: [mat_dims..., batch_dims...].
@@ -2924,8 +2928,8 @@ where
             let ut_du = backend_mat_mul(ctx, &transpose(u_b, m, k), k, m, du_b, k)?;
             for i in 0..k {
                 for j in 0..k {
-                    let sym = ut_du[i + j * k] + ut_du[j + i * k];
-                    gamma[i + j * k] = gamma[i + j * k] + f_mat[i + j * k] * sym * s_b[j];
+                    let skew = ut_du[i + j * k] - ut_du[j + i * k];
+                    gamma[i + j * k] = gamma[i + j * k] + f_mat[i + j * k] * skew * s_b[j];
                 }
             }
         }
@@ -2940,8 +2944,8 @@ where
             let vt_dv = backend_mat_mul(ctx, &transpose(&v_b, n, k), k, n, &dv_b, k)?;
             for i in 0..k {
                 for j in 0..k {
-                    let sym = vt_dv[i + j * k] + vt_dv[j + i * k];
-                    gamma[i + j * k] = gamma[i + j * k] + s_b[i] * f_mat[i + j * k] * sym;
+                    let skew = vt_dv[i + j * k] - vt_dv[j + i * k];
+                    gamma[i + j * k] = gamma[i + j * k] + s_b[i] * f_mat[i + j * k] * skew;
                 }
             }
         }
@@ -3082,58 +3086,62 @@ where
             vec![T::zero(); k * n]
         };
 
-        // For thin QR (m >= n): A = QR where Q is m×k, R is k×n
-        // W = R dR^T - dQ^T Q (k×k)
-        let r_drt = backend_mat_mul(ctx, r_b, k, n, &transpose(&dr_b, k, n), k)?;
-        let dqt_q = backend_mat_mul(ctx, &transpose(&dq_b, m, k), k, m, q_b, k)?;
-        let w = sub_vec(&r_drt, &dqt_q);
+        if m >= n {
+            // For thin QR (m >= n): A = QR where Q is m×k, R is k×n.
+            // Match PyTorch's reduced-QR backward for the real case.
+            let r_drt = backend_mat_mul(ctx, r_b, k, n, &transpose(&dr_b, k, n), k)?;
+            let dqt_q = backend_mat_mul(ctx, &transpose(&dq_b, m, k), k, m, q_b, k)?;
+            let w = sub_vec(&r_drt, &dqt_q);
 
-        // H = copyltu(W) — symmetrize from lower triangle
-        let h = copyltu(&w, k);
+            let h = copyltu(&w, k);
+            let qh = backend_mat_mul(ctx, q_b, m, k, &h, k)?;
+            let rhs = add_vec(&dq_b, &qh);
 
-        // B = dQ + Q H (m×k)
-        let qh = backend_mat_mul(ctx, q_b, m, k, &h, k)?;
-        let rhs = add_vec(&dq_b, &qh);
+            let r_square = r_b[..k * n].to_vec();
+            let rhs_t = transpose(&rhs, m, k);
+            let da_t = backend_solve_tri(ctx, &r_square, &rhs_t, k, m, true)?;
+            let da_first_k = transpose(&da_t, k, m);
 
-        // dA = B R^{-T} = solve R^T x = B^T, then transpose
-        // R is k×k upper triangular (first k columns)
-        let r_square = if n > k {
-            // Extract first k columns of R (k×n → k×k)
-            let mut rs = vec![T::zero(); k * k];
-            for j in 0..k {
-                for i in 0..k {
-                    rs[i + j * k] = r_b[i + j * k];
+            for j in 0..k.min(n) {
+                for i in 0..m {
+                    grad_a[b * m * n + i + j * m] = da_first_k[i + j * m];
                 }
             }
-            rs
         } else {
-            // When n <= k, we have k = min(m,n) = n, so k*n == k*k
-            // and the full R block is already the square factor.
-            r_b[..k * n].to_vec()
-        };
+            // Wide reduced QR follows the PyTorch backward:
+            // gA = pi*(Q trilImInvAdjSkew(Q^T gQ - gR R^T) R1^{-T}) + Q gR
+            let qtgq = backend_mat_mul(ctx, &transpose(q_b, m, k), k, m, &dq_b, k)?;
+            let gr_rt = backend_mat_mul(ctx, &dr_b, k, n, &transpose(r_b, k, n), k)?;
+            let wide_inner = sub_vec(&qtgq, &gr_rt);
 
-        // dA[:, :k] = B R_square^{-T} (m×k solve)
-        let rhs_t = transpose(&rhs, m, k);
-        let da_t = backend_solve_tri(ctx, &r_square, &rhs_t, k, m, true)?;
-        let da_first_k = transpose(&da_t, k, m);
-
-        // Copy first k columns
-        for j in 0..k.min(n) {
-            for i in 0..m {
-                grad_a[b * m * n + i + j * m] = da_first_k[i + j * m];
+            let mut lower_skew = vec![T::zero(); k * k];
+            for j in 0..k {
+                for i in j..k {
+                    lower_skew[i + j * k] = wide_inner[i + j * k] - wide_inner[j + i * k];
+                }
             }
-        }
 
-        // For wide case (n > k), handle remaining columns via dR
-        if n > k {
-            // dA[:, k:] = Q dR[:, k:]
-            for j in k..n {
+            let q_lower = backend_mat_mul(ctx, q_b, m, k, &lower_skew, k)?;
+            let q_lower_t = transpose(&q_lower, m, k);
+            let mut r1 = vec![T::zero(); k * k];
+            for j in 0..k {
+                for i in 0..k {
+                    r1[i + j * k] = r_b[i + j * k];
+                }
+            }
+            let leading_t = backend_solve_tri(ctx, &r1, &q_lower_t, k, m, true)?;
+            let leading = transpose(&leading_t, k, m);
+
+            for j in 0..k {
                 for i in 0..m {
-                    let mut val = T::zero();
-                    for l in 0..k {
-                        val = val + q_b[i + l * m] * dr_b[l + j * k];
-                    }
-                    grad_a[b * m * n + i + j * m] = val;
+                    grad_a[b * m * n + i + j * m] = leading[i + j * m];
+                }
+            }
+
+            let qgr = backend_mat_mul(ctx, q_b, m, k, &dr_b, n)?;
+            for j in 0..n {
+                for i in 0..m {
+                    grad_a[b * m * n + i + j * m] = grad_a[b * m * n + i + j * m] + qgr[i + j * m];
                 }
             }
         }
@@ -3461,8 +3469,8 @@ where
             let half: T = scalar_from(0.5).map_err(to_ad_err)?;
             for i in 0..n {
                 for j in 0..n {
-                    let sym = half * (vt_dv[i + j * n] + vt_dv[j + i * n]);
-                    d_mat[i + j * n] = d_mat[i + j * n] + f_mat[i + j * n] * sym;
+                    let skew = half * (vt_dv[i + j * n] - vt_dv[j + i * n]);
+                    d_mat[i + j * n] = d_mat[i + j * n] + f_mat[i + j * n] * skew;
                 }
             }
         }
@@ -4643,7 +4651,7 @@ where
         let mut st_c_plus_ct_s = vec![T::zero(); k * k];
         for i in 0..k {
             for j in 0..k {
-                st_c_plus_ct_s[i + j * k] = s_b[j] * c[i + j * k] + c[j + i * k] * s_b[i];
+                st_c_plus_ct_s[i + j * k] = -(s_b[i] * c[i + j * k] + c[j + i * k] * s_b[j]);
             }
         }
         let f_inner2 = hadamard(&f_mat, &st_c_plus_ct_s);
@@ -5016,7 +5024,7 @@ where
         for i in 0..n {
             for j in 0..n {
                 if i != j {
-                    let denom = e_b[i] - e_b[j];
+                    let denom = e_b[j] - e_b[i];
                     let f_ij = T::one()
                         / (denom
                             + eta

--- a/tenferro-linalg/tests/linalg_tests.rs
+++ b/tenferro-linalg/tests/linalg_tests.rs
@@ -619,6 +619,15 @@ fn eigen_nonsymmetric_returns_error() {
     assert!(eigen(&mut ctx, &a).is_err());
 }
 
+#[test]
+fn eigen_0x0_returns_empty_values_and_vectors() {
+    let mut ctx = CpuContext::new(1);
+    let a: Tensor<f64> = Tensor::from_vec(vec![], &[0, 0], &[1, 0], 0).unwrap();
+    let result = eigen(&mut ctx, &a).unwrap();
+    assert_eq!(result.values.dims(), &[0]);
+    assert_eq!(result.vectors.dims(), &[0, 0]);
+}
+
 // ============================================================================
 // Solve tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- correct linalg AD formula signs for QR, SVD, pinv, and eig/eigen paths
- handle zero-sized batch/eigen cases consistently in tensor linalg helpers
- update the QR AD note to match the current wide reduced-QR backward implementation

## Verification
- cargo fmt --all --check
- cargo test --workspace --release
- cargo llvm-cov --workspace --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py

Generated with [Claude Code](https://claude.com/claude-code)
