### PR TITLE
docs: sync vendored template-rs network filesystem rules

### DIFF
--- a/ai/vendor/template-rs/common-agent-rules.md
+++ b/ai/vendor/template-rs/common-agent-rules.md
@@ -28,6 +28,21 @@
 - Use `thiserror` for public API error types.
 - Use `anyhow` only for internal glue where typed errors are not part of the public contract.
 
+## Build Environment
+
+- Do not treat NFS or other network filesystems as a normal location for Rust
+  development worktrees. Strongly prefer putting the repository or worktree
+  itself on local disk.
+- If a repository is on NFS or another network filesystem, explicitly warn the
+  user before running heavy Rust commands. State that compile and link times
+  can degrade severely and that local-disk worktrees are strongly preferred.
+- Continue on NFS only if the user explicitly wants to proceed anyway.
+- When proceeding on NFS, place Cargo build artifacts on local disk rather than
+  inside the repository checkout.
+- Prefer a stable repo-specific local target directory such as
+  `CARGO_TARGET_DIR=/tmp/<repo>-target` for `cargo build`, `cargo test`,
+  `cargo llvm-cov`, and similar heavy commands.
+
 ## File Organization
 
 Keep source files small and focused. Split by behavior or abstraction boundary, not by arbitrary line count.


### PR DESCRIPTION
## Summary
- sync the vendored `template-rs` common agent rules after upstream PR #9
- add the warning-first policy for Rust work on network filesystems
- document the local-disk `CARGO_TARGET_DIR` fallback for explicit NFS continuation

## Test Plan
- `env CARGO_TARGET_DIR=/tmp/tenferro-vendor-sync-target cargo fmt --all --check`
- `env CARGO_TARGET_DIR=/tmp/tenferro-vendor-sync-target cargo test --workspace --release`
- `env CARGO_TARGET_DIR=/tmp/tenferro-vendor-sync-target cargo llvm-cov --workspace --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `env CARGO_TARGET_DIR=/tmp/tenferro-vendor-sync-target cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py --doc-root /tmp/tenferro-vendor-sync-target/doc`

Generated with [Claude Code](https://claude.com/claude-code)
