### PR TITLE
Refactor dyadtensor runtime dispatch toward generic/DRY contracts

### DIFF
--- a/docs/AD/scalar_ops.md
+++ b/docs/AD/scalar_ops.md
@@ -26,6 +26,10 @@ The tensor wrappers now share a centralized runtime-dispatch contract layer in
 repeating backend-specific `Cpu/Cuda/Rocm` bounds at each eager or builder
 entrypoint.
 
+Scalar reduction helpers also use transfer-aware rank-0 extraction and scalar
+broadcast utilities. That keeps reduction pullbacks on the same generic
+runtime path instead of introducing one-off CPU-only builder branches.
+
 Tensor-level wrappers built on top of those formulas:
 
 - pointwise binary:

--- a/docs/design/supported-ops.md
+++ b/docs/design/supported-ops.md
@@ -129,6 +129,11 @@ The following public primal ops do not yet have stateless linalg AD rules:
 
 ## `tenferro-dyadtensor`
 
+### Structured tensor helpers
+
+- `StructuredTensor::to_dense`
+- `StructuredTensor::einsum_with_subscripts`
+
 ### Eager AD tensor entrypoints
 
 `tenferro_dyadtensor::ad::*` currently includes:
@@ -161,6 +166,7 @@ Builder APIs are implemented for:
 
 - API contract: runtime-generic across CPU, CUDA, and ROCm
 - `chainrules_api::einsum` is backend-parametric over `tenferro-einsum::EinsumBackend`; callers choose the backend via the runtime context type
+- Structured tensor materialization and compressed einsum reuse the same einsum runtime-dispatch layer rather than maintaining separate CPU/CUDA/ROCm builder paths
 - Actual execution today:
   - CPU paths are implemented for the operations listed above
   - CUDA and ROCm dispatch report unsupported capability for scalar/analytic and most linalg families rather than assuming CPU-only execution

--- a/extension/tenferro-dyadtensor/src/api/ad_builders/reduction.rs
+++ b/extension/tenferro-dyadtensor/src/api/ad_builders/reduction.rs
@@ -70,16 +70,10 @@ where
                     let Some(input_node) = input_node else {
                         return Ok(Vec::new());
                     };
-                    with_runtime(
-                        |_ctx| {
-                            let scalar = scalar_from_rank0_tensor(cotangent, "sum_ad")?;
-                            let payload = broadcast_scalar_like(scalar, input_layout.payload())?;
-                            let grad = input_layout.with_payload_like(payload)?;
-                            Ok(vec![(input_node, grad.into_payload())])
-                        },
-                        |_ctx| Err(unsupported_runtime_capability("sum_ad_pullback", "cuda")),
-                        |_ctx| Err(unsupported_runtime_capability("sum_ad_pullback", "rocm")),
-                    )
+                    let scalar = scalar_from_rank0_tensor(cotangent, "sum_ad")?;
+                    let payload = broadcast_scalar_like(scalar, input_layout.payload())?;
+                    let grad = input_layout.with_payload_like(payload)?;
+                    Ok(vec![(input_node, grad.into_payload())])
                 }),
             )?;
         }

--- a/extension/tenferro-dyadtensor/src/api/contracts.rs
+++ b/extension/tenferro-dyadtensor/src/api/contracts.rs
@@ -12,11 +12,27 @@ use tenferro_prims::{
 };
 
 #[doc(hidden)]
+/// Hidden bound for values that participate in the standard dyadtensor runtime.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn require_standard<T: tenferro_dyadtensor::api::contracts::StandardRuntimeValue>() {}
+/// require_standard::<f64>();
+/// ```
 pub trait StandardRuntimeValue: Scalar + HasAlgebra<Algebra = Standard<Self>> + 'static {}
 
 impl<T> StandardRuntimeValue for T where T: Scalar + HasAlgebra<Algebra = Standard<T>> + 'static {}
 
 #[doc(hidden)]
+/// Hidden bound for values that can run through the einsum runtime dispatch layer.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn require_einsum<T: tenferro_dyadtensor::api::contracts::EinsumRuntimeValue>() {}
+/// require_einsum::<f64>();
+/// ```
 pub trait EinsumRuntimeValue: StandardRuntimeValue {}
 
 impl<T> EinsumRuntimeValue for T
@@ -29,6 +45,14 @@ where
 }
 
 #[doc(hidden)]
+/// Hidden bound for values that support scalar pointwise and reduction primitives.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn require_scalar<T: tenferro_dyadtensor::api::contracts::ScalarRuntimeValue>() {}
+/// require_scalar::<f64>();
+/// ```
 pub trait ScalarRuntimeValue: StandardRuntimeValue + Copy {}
 
 impl<T> ScalarRuntimeValue for T
@@ -41,6 +65,14 @@ where
 }
 
 #[doc(hidden)]
+/// Hidden bound for values that support analytic pointwise and reduction primitives.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn require_analytic<T: tenferro_dyadtensor::api::contracts::AnalyticRuntimeValue>() {}
+/// require_analytic::<f64>();
+/// ```
 pub trait AnalyticRuntimeValue: ScalarRuntimeValue {}
 
 impl<T> AnalyticRuntimeValue for T
@@ -53,6 +85,14 @@ where
 }
 
 #[doc(hidden)]
+/// Hidden shorthand for values that support einsum, scalar, and analytic runtime families.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn require_all<T: tenferro_dyadtensor::api::contracts::ScalarAnalyticRuntimeValue>() {}
+/// require_all::<f64>();
+/// ```
 pub trait ScalarAnalyticRuntimeValue:
     EinsumRuntimeValue + ScalarRuntimeValue + AnalyticRuntimeValue
 {
@@ -64,16 +104,40 @@ impl<T> ScalarAnalyticRuntimeValue for T where
 }
 
 #[doc(hidden)]
+/// Hidden shorthand for scalar/analytic runtime values with scalar AD formulas attached.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn require_generic_ad<T: tenferro_dyadtensor::api::contracts::GenericAdRuntimeValue>() {}
+/// require_generic_ad::<f64>();
+/// ```
 pub trait GenericAdRuntimeValue: ScalarAnalyticRuntimeValue + ScalarAd {}
 
 impl<T> GenericAdRuntimeValue for T where T: ScalarAnalyticRuntimeValue + ScalarAd {}
 
 #[doc(hidden)]
+/// Hidden shorthand for real-valued generic AD runtime values.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn require_real_ad<T: tenferro_dyadtensor::api::contracts::RealAdRuntimeValue>() {}
+/// require_real_ad::<f64>();
+/// ```
 pub trait RealAdRuntimeValue: GenericAdRuntimeValue + ScalarAd<Real = Self> + Float {}
 
 impl<T> RealAdRuntimeValue for T where T: GenericAdRuntimeValue + ScalarAd<Real = T> + Float {}
 
 #[doc(hidden)]
+/// Hidden bound for values that can execute linalg families through the runtime dispatch layer.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn require_linalg<T: tenferro_dyadtensor::api::contracts::LinalgRuntimeValue>() {}
+/// require_linalg::<f64>();
+/// ```
 pub trait LinalgRuntimeValue:
     EinsumRuntimeValue + LinalgScalar + CpuLinalgScalar + 'static
 {
@@ -95,6 +159,14 @@ where
 }
 
 #[doc(hidden)]
+/// Hidden shorthand for real-valued linalg runtime values.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn require_real_linalg<T: tenferro_dyadtensor::api::contracts::RealLinalgRuntimeValue>() {}
+/// require_real_linalg::<f64>();
+/// ```
 pub trait RealLinalgRuntimeValue:
     LinalgRuntimeValue + HasAlgebra<Algebra = Standard<Self>> + LinalgScalar<Real = Self> + Float
 {
@@ -106,6 +178,14 @@ impl<T> RealLinalgRuntimeValue for T where
 }
 
 #[doc(hidden)]
+/// Hidden shorthand for complex-capable linalg runtime values.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn require_complex_linalg<T: tenferro_dyadtensor::api::contracts::ComplexLinalgRuntimeValue>() {}
+/// require_complex_linalg::<f64>();
+/// ```
 pub trait ComplexLinalgRuntimeValue:
     RealLinalgRuntimeValue + LinalgScalar<Complex = Complex<Self>>
 where

--- a/extension/tenferro-dyadtensor/src/api/runtime.rs
+++ b/extension/tenferro-dyadtensor/src/api/runtime.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tenferro_device::LogicalMemorySpace;
 
 pub(crate) fn has_forward<S: Scalar>(operands: &[&AdTensor<S>]) -> bool {
     operands
@@ -186,25 +187,7 @@ pub(crate) fn dense_input_snapshot_in_runtime<T>(
 where
     T: EinsumRuntimeValue,
 {
-    dispatch_einsum_runtime!(T, op_name, |ctx, Backend, runtime| {
-        if std::any::TypeId::of::<Backend>() != std::any::TypeId::of::<CpuBackend>() {
-            if !input.is_dense() {
-                return Err(unsupported_runtime_capability(op_name, runtime));
-            }
-            let primal = input.primal().clone().contiguous(MemoryOrder::ColumnMajor);
-            let tangent = if needs_tangent {
-                Some(
-                    input
-                        .tangent()
-                        .cloned()
-                        .unwrap_or_else(|| zero_like(&primal))
-                        .contiguous(MemoryOrder::ColumnMajor),
-                )
-            } else {
-                None
-            };
-            return Ok((primal, tangent));
-        }
+    dispatch_einsum_runtime!(T, op_name, |ctx, Backend| {
         dense_input_snapshot_in_backend::<Backend, _, T>(ctx, input, needs_tangent)
     })
 }
@@ -222,11 +205,9 @@ where
         return Ok(dense);
     }
 
-    with_runtime(
-        |ctx| compress_pullback_like_in_backend::<CpuBackend, _, T>(ctx, op_name, dense, layout),
-        |_ctx| Err(unsupported_runtime_capability(op_name, "cuda")),
-        |_ctx| Err(unsupported_runtime_capability(op_name, "rocm")),
-    )
+    dispatch_einsum_runtime!(T, op_name, |ctx, Backend| {
+        compress_pullback_like_in_backend::<Backend, _, T>(ctx, op_name, dense.clone(), layout)
+    })
 }
 
 pub(crate) fn compress_pullback_like_in_backend<B, C, T>(
@@ -269,6 +250,13 @@ where
         });
     }
     let contiguous = tensor.contiguous(MemoryOrder::ColumnMajor);
+    let contiguous = if contiguous.logical_memory_space() == LogicalMemorySpace::MainMemory {
+        contiguous
+    } else {
+        contiguous
+            .to_memory_space_async(LogicalMemorySpace::MainMemory)
+            .map_err(Error::from)?
+    };
     let off = contiguous.offset() as usize;
     contiguous
         .buffer()
@@ -276,7 +264,7 @@ where
         .and_then(|values| values.get(off))
         .copied()
         .ok_or_else(|| Error::InvalidAdTensor {
-            message: format!("{op_name} expects CPU-backed scalar cotangent"),
+            message: format!("{op_name} could not materialize rank-0 cotangent on host memory"),
         })
 }
 
@@ -286,7 +274,15 @@ where
 {
     let len = template.len();
     let data = vec![value; len];
-    Tensor::from_slice(&data, template.dims(), MemoryOrder::ColumnMajor).map_err(Error::from)
+    let dense = Tensor::from_slice(&data, template.dims(), MemoryOrder::ColumnMajor)
+        .map_err(Error::from)?;
+    if template.logical_memory_space() == LogicalMemorySpace::MainMemory {
+        Ok(dense)
+    } else {
+        dense
+            .to_memory_space_async(template.logical_memory_space())
+            .map_err(Error::from)
+    }
 }
 
 pub(crate) fn wrap_dense_ad_output<TIn: Scalar, TOut: Scalar>(

--- a/extension/tenferro-dyadtensor/src/api/tests/runtime_dispatch.rs
+++ b/extension/tenferro-dyadtensor/src/api/tests/runtime_dispatch.rs
@@ -13,6 +13,10 @@ fn repo_files(paths: &[&str]) -> String {
         .join("\n")
 }
 
+// IMPORTANT: Do not delete or weaken these runtime-dispatch structure tests.
+// They guard the generic/capability-driven architecture that keeps dyadtensor
+// extensible as more scalar, analytic, and linalg families are added.
+
 #[test]
 fn unary_and_reduction_entrypoints_route_through_runtime_dispatch() {
     let scalar_builders = [
@@ -99,5 +103,36 @@ fn structured_einsum_uses_shared_runtime_dispatch_path() {
     assert!(
         !structured_einsum.contains("with_runtime_cpu_only("),
         "structured einsum should share the same runtime-dispatch path as the rest of dyadtensor"
+    );
+    assert!(
+        !structured_einsum.contains("CpuBackend")
+            && !structured_einsum.contains("CudaBackend")
+            && !structured_einsum.contains("RocmBackend"),
+        "structured einsum should dispatch through shared generic helpers rather than spelling out backend triples"
+    );
+    assert!(
+        !structured_einsum.contains("CpuContext")
+            && !structured_einsum.contains("CudaContext")
+            && !structured_einsum.contains("RocmContext"),
+        "structured einsum should not hard-code runtime context triples once shared dispatch exists"
+    );
+}
+
+#[test]
+fn runtime_helpers_stay_capability_driven() {
+    let runtime_helpers = repo_file("src/api/runtime.rs");
+    let reduction_builders = repo_file("src/api/ad_builders/reduction.rs");
+
+    assert!(
+        !runtime_helpers.contains("TypeId::of::<Backend>()"),
+        "runtime helpers should dispatch through capability-aware generic helpers rather than backend type checks"
+    );
+    assert!(
+        !runtime_helpers.contains("compress_pullback_like_in_backend::<CpuBackend"),
+        "runtime helpers should not hard-code CPU-only compression paths once einsum runtime dispatch exists"
+    );
+    assert!(
+        !reduction_builders.contains("unsupported_runtime_capability(\"sum_ad_pullback\""),
+        "sum_ad pullback should rely on transfer-aware runtime helpers rather than hard-coded CPU-only runtime failures"
     );
 }

--- a/extension/tenferro-dyadtensor/src/structured/einsum.rs
+++ b/extension/tenferro-dyadtensor/src/structured/einsum.rs
@@ -3,12 +3,10 @@ use std::collections::{HashMap, HashSet};
 use chainrules_core::Differentiable as _;
 use tenferro_algebra::{HasAlgebra, Scalar, Standard};
 use tenferro_einsum::{self as tf_einsum, Subscripts};
-use tenferro_prims::{
-    CpuBackend, CpuContext, CudaBackend, CudaContext, RocmBackend, RocmContext, TensorPrims,
-};
+use tenferro_prims::TensorPrims;
 use tenferro_tensor::Tensor;
 
-use crate::api::with_einsum_runtime;
+use crate::api::{dispatch_einsum_runtime, EinsumRuntimeValue};
 use crate::{Error, Result};
 
 use super::meta::{plan_axis_classes_for_subscripts, OperandAxisClasses};
@@ -16,10 +14,7 @@ use super::StructuredTensor;
 
 impl<T> StructuredTensor<T>
 where
-    T: Scalar + HasAlgebra<Algebra = Standard<T>>,
-    CpuBackend: TensorPrims<Standard<T>, Context = CpuContext>,
-    CudaBackend: TensorPrims<Standard<T>, Context = CudaContext>,
-    RocmBackend: TensorPrims<Standard<T>, Context = RocmContext>,
+    T: EinsumRuntimeValue,
 {
     /// Materialize this structured tensor into a dense payload tensor.
     ///
@@ -34,12 +29,9 @@ where
             return Ok(self.payload().clone());
         }
 
-        with_einsum_runtime::<T, _>(
-            "structured_to_dense",
-            |ctx| to_dense_in_ctx::<CpuBackend, _, T>(ctx, self),
-            |ctx| to_dense_in_ctx::<CudaBackend, _, T>(ctx, self),
-            |ctx| to_dense_in_ctx::<RocmBackend, _, T>(ctx, self),
-        )
+        dispatch_einsum_runtime!(T, "structured_to_dense", |ctx, Backend| {
+            to_dense_in_ctx::<Backend, _, T>(ctx, self)
+        })
     }
 
     /// Contract/einsum structured operands while preserving compressed metadata.
@@ -59,12 +51,9 @@ where
             });
         }
 
-        with_einsum_runtime::<T, _>(
-            "structured_einsum",
-            |ctx| einsum_with_subscripts_in_ctx::<CpuBackend, _, T>(ctx, subscripts, operands),
-            |ctx| einsum_with_subscripts_in_ctx::<CudaBackend, _, T>(ctx, subscripts, operands),
-            |ctx| einsum_with_subscripts_in_ctx::<RocmBackend, _, T>(ctx, subscripts, operands),
-        )
+        dispatch_einsum_runtime!(T, "structured_einsum", |ctx, Backend| {
+            einsum_with_subscripts_in_ctx::<Backend, _, T>(ctx, subscripts, operands)
+        })
     }
 }
 

--- a/extension/tenferro-dyadtensor/src/structured/einsum/tests/mod.rs
+++ b/extension/tenferro-dyadtensor/src/structured/einsum/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{set_default_runtime, RuntimeContext};
-use tenferro_prims::{CpuContext, CudaContext};
+use tenferro_prims::{CpuBackend, CpuContext, CudaContext};
 use tenferro_tensor::MemoryOrder;
 
 fn vector(values: &[f64]) -> Tensor<f64> {


### PR DESCRIPTION
## Summary
- remove ad hoc backend type checks and backend triples from dyadtensor runtime/structured einsum paths
- make scalar reduction helper paths transfer-aware so sum pullbacks stay on the generic runtime path
- document hidden runtime contracts and update supported-ops / AD docs for the current runtime story

## Verification
- cargo fmt --all --check
- env CARGO_TARGET_DIR=/tmp/tenferro-refactor-generic-dry-kiss-audit-target cargo test -p tenferro-dyadtensor --lib
- env CARGO_TARGET_DIR=/tmp/tenferro-refactor-generic-dry-kiss-audit-release-target cargo test --workspace --release
- env CARGO_TARGET_DIR=/tmp/tenferro-refactor-generic-dry-kiss-audit-cov-target cargo llvm-cov --workspace --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- env CARGO_TARGET_DIR=/tmp/tenferro-refactor-generic-dry-kiss-audit-docs-target cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py --doc-root /tmp/tenferro-refactor-generic-dry-kiss-audit-docs-target/doc

Generated with [Claude Code](https://claude.com/claude-code)