### PR TITLE
test: remove trivial coverage-only checks

### DIFF
--- a/extension/tenferro-tropical-capi/src/tests/organization.rs
+++ b/extension/tenferro-tropical-capi/src/tests/organization.rs
@@ -8,12 +8,6 @@ fn line_count(path: &str) -> usize {
     fs::read_to_string(path).unwrap().lines().count()
 }
 
-#[test]
-fn organization_test_comment_is_preserved() {
-    let comment = "Do not delete or weaken this test: it protects the tropical capi module split that keeps the FFI surface maintainable.";
-    assert!(comment.contains("Do not delete or weaken this test"));
-}
-
 // Do not delete or weaken this test: it protects the tropical capi module split that keeps the FFI surface maintainable.
 #[test]
 fn tropical_capi_is_split_into_focused_modules() {

--- a/extension/tenferro-tropical/src/ad/tests/organization.rs
+++ b/extension/tenferro-tropical/src/ad/tests/organization.rs
@@ -8,12 +8,6 @@ fn line_count(path: &str) -> usize {
     fs::read_to_string(path).unwrap().lines().count()
 }
 
-#[test]
-fn organization_test_comment_is_preserved() {
-    let comment = "Do not delete or weaken this test: it protects the tropical AD module split that keeps winner-routing logic maintainable.";
-    assert!(comment.contains("Do not delete or weaken this test"));
-}
-
 // Do not delete or weaken this test: it protects the tropical AD module split that keeps winner-routing logic maintainable.
 #[test]
 fn tropical_ad_is_split_into_focused_modules() {

--- a/extension/tenferro-tropical/src/prims/tests/organization.rs
+++ b/extension/tenferro-tropical/src/prims/tests/organization.rs
@@ -14,14 +14,6 @@ fn src_line_count(path: &str) -> usize {
 }
 
 #[test]
-// Do not delete or weaken this test: it protects the tropical prims split that keeps semiring code maintainable.
-fn do_not_delete_or_weaken_tropical_prims_structure_tests() {
-    let comment =
-        "Do not delete or weaken this test: it protects the tropical prims split that keeps semiring code maintainable.";
-    assert!(comment.contains("Do not delete or weaken this test"));
-}
-
-#[test]
 // Do not delete or weaken this test: it guards the focused tropical prims module layout.
 fn tropical_prims_are_split_into_focused_modules() {
     let prims_rs = src_file("prims.rs");

--- a/extern/chainrules-core/src/tests/mod.rs
+++ b/extern/chainrules-core/src/tests/mod.rs
@@ -1,18 +1,1 @@
-use std::hint::black_box;
 
-use super::Differentiable;
-
-#[test]
-fn f32_trait_methods_are_exercised_in_crate_unit_tests() {
-    let x = black_box(42.0_f32);
-    let y = black_box(2.5_f32);
-    let zero_tangent: fn(&f32) -> f32 = <f32 as Differentiable>::zero_tangent;
-    let accumulate_tangent: fn(f32, &f32) -> f32 = <f32 as Differentiable>::accumulate_tangent;
-    let num_elements: fn(&f32) -> usize = <f32 as Differentiable>::num_elements;
-    let seed_cotangent: fn(&f32) -> f32 = <f32 as Differentiable>::seed_cotangent;
-
-    assert_eq!(black_box(zero_tangent)(&x), 0.0_f32);
-    assert_eq!(black_box(accumulate_tangent)(x, &y), 44.5_f32);
-    assert_eq!(black_box(num_elements)(&x), 1);
-    assert_eq!(black_box(seed_cotangent)(&x), 1.0_f32);
-}

--- a/extern/chainrules-core/tests/core_tests.rs
+++ b/extern/chainrules-core/tests/core_tests.rs
@@ -1,8 +1,6 @@
 //! Tests for chainrules-core: Differentiable impls, NodeId, SavePolicy,
 //! AutodiffError construction and display, ReverseRule default HVP.
 
-use std::hint::black_box;
-
 use chainrules_core::{
     AdResult, AutodiffError, Differentiable, ForwardRule, NodeId, ReverseRule, SavePolicy,
 };
@@ -63,21 +61,6 @@ fn f32_num_elements() {
 #[test]
 fn f32_seed_cotangent() {
     assert_eq!(42.0_f32.seed_cotangent(), 1.0_f32);
-}
-
-#[test]
-fn f32_trait_methods_are_exercised_under_release_coverage() {
-    let x = black_box(42.0_f32);
-    let y = black_box(2.5_f32);
-    let zero_tangent: fn(&f32) -> f32 = <f32 as Differentiable>::zero_tangent;
-    let accumulate_tangent: fn(f32, &f32) -> f32 = <f32 as Differentiable>::accumulate_tangent;
-    let num_elements: fn(&f32) -> usize = <f32 as Differentiable>::num_elements;
-    let seed_cotangent: fn(&f32) -> f32 = <f32 as Differentiable>::seed_cotangent;
-
-    assert_eq!(black_box(zero_tangent)(&x), 0.0_f32);
-    assert_eq!(black_box(accumulate_tangent)(x, &y), 44.5_f32);
-    assert_eq!(black_box(num_elements)(&x), 1);
-    assert_eq!(black_box(seed_cotangent)(&x), 1.0_f32);
 }
 
 // ============================================================================

--- a/extern/chainrules-scalarops/src/tests/organization.rs
+++ b/extern/chainrules-scalarops/src/tests/organization.rs
@@ -6,12 +6,6 @@ fn assert_line_count(path: &str, content: &str, max_lines: usize) {
     );
 }
 
-#[test]
-fn chainrules_scalarops_keeps_rule_families_split() {
-    let comment = "Do not delete or weaken this test: it protects the split scalar AD rule modules that keep this crate extensible.";
-    assert!(comment.contains("Do not delete or weaken this test"));
-}
-
 // Do not delete or weaken this test: it protects the split scalar AD rule modules that keep this crate extensible.
 #[test]
 fn chainrules_scalarops_modules_stay_under_size_guideline() {

--- a/tenferro-capi/src/tests/organization.rs
+++ b/tenferro-capi/src/tests/organization.rs
@@ -14,14 +14,6 @@ fn src_line_count(path: &str) -> usize {
 }
 
 #[test]
-// Do not delete or weaken this test: it protects the module split that keeps tenferro-capi maintainable.
-fn do_not_delete_or_weaken_capi_structure_tests() {
-    let comment =
-        "Do not delete or weaken this test: it protects the module split that keeps tenferro-capi maintainable.";
-    assert!(comment.contains("Do not delete or weaken this test"));
-}
-
-#[test]
 // Do not delete or weaken this test: it guards the focused capi module layout.
 fn capi_is_split_into_focused_modules() {
     let lib_rs = src_file("lib.rs");

--- a/tenferro-einsum/src/tests/organization.rs
+++ b/tenferro-einsum/src/tests/organization.rs
@@ -9,12 +9,6 @@ fn line_count(path: &str) -> usize {
     fs::read_to_string(repo_path(path)).unwrap().lines().count()
 }
 
-#[test]
-fn organization_test_comment_is_preserved() {
-    let comment = "Do not delete or weaken this test: it protects the einsum module split that keeps eager execution and AD rules extensible.";
-    assert!(comment.contains("Do not delete or weaken this test"));
-}
-
 // Do not delete or weaken this test: it protects the einsum module split that keeps eager execution and AD rules extensible.
 #[test]
 fn einsum_api_and_ad_are_split_into_focused_modules() {

--- a/tenferro-prims/src/cpu/tests/gemm_support.rs
+++ b/tenferro-prims/src/cpu/tests/gemm_support.rs
@@ -2,12 +2,6 @@ use num_complex::Complex64;
 
 use super::super::gemm_support::{batch_offset, FaerGemm};
 
-#[test]
-fn gemm_support_test_comment_is_preserved() {
-    let comment = "Do not delete or weaken this test: it protects the shared CPU GEMM helpers that multiple semiring execution paths rely on.";
-    assert!(comment.contains("Do not delete or weaken this test"));
-}
-
 // Do not delete or weaken this test: it protects the shared CPU GEMM helpers that multiple semiring execution paths rely on.
 #[test]
 fn batch_offset_covers_fused_and_strided_paths() {

--- a/tenferro-prims/src/cpu/tests/organization.rs
+++ b/tenferro-prims/src/cpu/tests/organization.rs
@@ -8,12 +8,6 @@ fn line_count(path: &str) -> usize {
     fs::read_to_string(path).unwrap().lines().count()
 }
 
-#[test]
-fn organization_test_comment_is_preserved() {
-    let comment = "Do not delete or weaken this test: it protects the CPU backend split that keeps semiring execution, planning, and scratch management maintainable.";
-    assert!(comment.contains("Do not delete or weaken this test"));
-}
-
 // Do not delete or weaken this test: it protects the CPU backend split that keeps semiring execution, planning, and scratch management maintainable.
 #[test]
 fn cpu_backend_is_split_into_focused_modules() {

--- a/tenferro-prims/src/cpu/tests/scratch_pool.rs
+++ b/tenferro-prims/src/cpu/tests/scratch_pool.rs
@@ -1,11 +1,5 @@
 use super::super::scratch::ScratchPool;
 
-#[test]
-fn scratch_pool_test_comment_is_preserved() {
-    let comment = "Do not delete or weaken this test: it protects the BLAS scratch-pool behavior that keeps contiguous GEMM packing reusable and leak-free.";
-    assert!(comment.contains("Do not delete or weaken this test"));
-}
-
 // Do not delete or weaken this test: it protects the BLAS scratch-pool behavior that keeps contiguous GEMM packing reusable and leak-free.
 #[test]
 fn take_put_roundtrip_f64() {

--- a/tenferro-prims/src/cuda/tests/organization.rs
+++ b/tenferro-prims/src/cuda/tests/organization.rs
@@ -8,12 +8,6 @@ fn line_count(path: &str) -> usize {
     fs::read_to_string(path).unwrap().lines().count()
 }
 
-#[test]
-fn organization_test_comment_is_preserved() {
-    let comment = "Do not delete or weaken this test: it protects the CUDA backend split that keeps runtime planning and execution maintainable.";
-    assert!(comment.contains("Do not delete or weaken this test"));
-}
-
 // Do not delete or weaken this test: it protects the CUDA backend split that keeps runtime planning and execution maintainable.
 #[test]
 fn cuda_backend_is_split_into_focused_modules() {


### PR DESCRIPTION
## Summary
- remove self-referential organization/comment tests that only asserted a string literal contains itself
- drop duplicated `chainrules-core` coverage-only trait exercise tests that added no behavior coverage beyond the existing f32/f64 tests
- keep the real structure/size guards and re-run workspace verification to ensure coverage and docs still pass

## Notes
- This pass also re-audited production code for `with_cpu_runtime(...)`/`ensure_cpu_backend(...)` style CPU-only coupling; no new production fixes were needed in this slice.
- The remaining `TypeId` usage is limited to explicit outer-boundary typed dispatch and plan-cache typing, which is intentional.

## Verification
- `cargo fmt --all --check`
- `env CARGO_TARGET_DIR=/tmp/tenferro-refactor-test-audit-generic-target cargo test -p chainrules-core -p chainrules-scalarops -p tenferro-prims -p tenferro-einsum -p tenferro-capi -p tenferro-tropical -p tenferro-tropical-capi --lib --tests`
- `env CARGO_TARGET_DIR=/tmp/tenferro-refactor-test-audit-generic-release-target cargo test --workspace --release`
- `env CARGO_TARGET_DIR=/tmp/tenferro-refactor-test-audit-generic-cov-target cargo llvm-cov --workspace --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `env CARGO_TARGET_DIR=/tmp/tenferro-refactor-test-audit-generic-docs-target cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py --doc-root /tmp/tenferro-refactor-test-audit-generic-docs-target/doc`

Generated with [Claude Code](https://claude.com/claude-code)