### PR TITLE
test: rename coverage-oriented test surfaces

### DIFF
--- a/extern/chainrules-scalarops/src/tests/behavior.rs
+++ b/extern/chainrules-scalarops/src/tests/behavior.rs
@@ -30,7 +30,7 @@ fn assert_close_c64(actual: Complex64, expected: Complex64) {
 }
 
 #[test]
-fn scalar_ad_real_impls_cover_remaining_methods() {
+fn scalar_ad_real_impls_match_std_real_ops() {
     let x32 = 0.25_f32;
     assert_close_f32(<f32 as ScalarAd>::expm1(x32), x32.exp_m1());
     assert_close_f32(<f32 as ScalarAd>::log1p(x32), x32.ln_1p());
@@ -55,7 +55,7 @@ fn scalar_ad_real_impls_cover_remaining_methods() {
 }
 
 #[test]
-fn scalar_ad_complex_impls_cover_remaining_methods() {
+fn scalar_ad_complex_impls_match_std_complex_ops() {
     let x32 = Complex32::new(0.25, -0.5);
     assert_close_c32(<Complex32 as ScalarAd>::conj(x32), x32.conj());
     assert_close_c32(<Complex32 as ScalarAd>::sqrt(x32), x32.sqrt());
@@ -112,7 +112,7 @@ fn scalar_ad_complex_impls_cover_remaining_methods() {
 }
 
 #[test]
-fn handle_r_to_c_and_real_ops_cover_direct_entrypoints() {
+fn direct_entrypoints_match_real_projection_and_atan2_formulas() {
     assert_eq!(handle_r_to_c_f32(Complex32::new(2.0, -5.0)), 2.0);
     assert_eq!(handle_r_to_c_f64(Complex64::new(-3.0, 1.5)), -3.0);
 
@@ -125,7 +125,7 @@ fn handle_r_to_c_and_real_ops_cover_direct_entrypoints() {
 }
 
 #[test]
-fn unary_helpers_cover_remaining_forward_and_reverse_paths() {
+fn unary_entrypoints_match_forward_and_reverse_formulas() {
     let complex = Complex32::new(1.0, -2.0);
     assert_eq!(conj(complex), complex.conj());
     let (_y, dy) = conj_frule(complex, Complex32::new(3.0, 4.0));

--- a/extern/chainrules-scalarops/src/tests/mod.rs
+++ b/extern/chainrules-scalarops/src/tests/mod.rs
@@ -1,8 +1,8 @@
-mod coverage;
+mod behavior;
 mod organization;
 
 #[test]
-fn phase1_scalar_rules_cover_exp_log_and_atan2() {
+fn exp_log_and_atan2_rules_match_expected_derivatives() {
     let (exp_y, exp_dy) = crate::exp_frule(1.0_f64, 0.25_f64);
     assert!((exp_y - std::f64::consts::E).abs() < 1.0e-12);
     assert!((exp_dy - 0.25_f64 * std::f64::consts::E).abs() < 1.0e-12);

--- a/extern/chainrules/tests/autodiff_next_api_tests.rs
+++ b/extern/chainrules/tests/autodiff_next_api_tests.rs
@@ -63,7 +63,7 @@ fn variable_api_surface_exists() {
 }
 
 #[test]
-fn tape_and_variable_surfaces_cover_remaining_public_entry_points() {
+fn tape_pullback_returns_leaf_gradient_for_tracked_variable() {
     let tape = Tape::<f64>::new();
     let x = tape.leaf(3.0_f64);
     assert!(x.requires_grad());

--- a/tenferro-linalg/src/backend/faer_backend/tests/mod.rs
+++ b/tenferro-linalg/src/backend/faer_backend/tests/mod.rs
@@ -937,7 +937,7 @@ fn faer_backend_eig_general_complex64_nan_returns_error() {
 }
 
 // ========================================================================
-// Complex32 coverage and additional complex error paths migrated from
+// Complex32 behavior and additional complex error paths migrated from
 // integration tests so the public API does not need to expose these cases.
 // ========================================================================
 

--- a/tenferro-linalg/src/tests/mod.rs
+++ b/tenferro-linalg/src/tests/mod.rs
@@ -16,7 +16,7 @@ fn tensor_data(tensor: &Tensor<f64>) -> Vec<f64> {
 }
 
 #[test]
-fn vector_norm_paths_are_covered_in_crate_unit_tests() {
+fn vector_norm_primal_rrule_and_frule_match_expected_values() {
     let mut ctx = CpuContext::new(1);
     let x = Tensor::from_slice(&[3.0_f64, -4.0], &[2], MemoryOrder::ColumnMajor).unwrap();
     let dx = Tensor::from_slice(&[0.25_f64, -0.5], &[2], MemoryOrder::ColumnMajor).unwrap();
@@ -36,7 +36,7 @@ fn vector_norm_paths_are_covered_in_crate_unit_tests() {
 }
 
 #[test]
-fn private_scalar_and_validation_helpers_are_covered_in_crate_unit_tests() {
+fn linalg_scalar_helpers_and_validation_accept_valid_inputs() {
     assert_eq!(<f64 as LinalgScalar>::abs_real(&black_box(-1.5_f64)), 1.5);
     assert_eq!(<f32 as LinalgScalar>::abs_real(&black_box(-1.5_f32)), 1.5);
     assert!(black_box(<f32 as LinalgScalar>::real_epsilon()) > 0.0);
@@ -85,14 +85,14 @@ fn private_scalar_and_validation_helpers_are_covered_in_crate_unit_tests() {
     let scalar = scalar_from::<f32>(1.25).unwrap();
     assert_eq!(scalar, 1.25_f32);
 
-    let ad_err = to_ad_err(Error::InvalidArgument("coverage".into()));
+    let ad_err = to_ad_err(Error::InvalidArgument("invalid shape".into()));
     assert!(
-        matches!(ad_err, chainrules_core::AutodiffError::InvalidArgument(msg) if msg.contains("coverage"))
+        matches!(ad_err, chainrules_core::AutodiffError::InvalidArgument(msg) if msg.contains("invalid shape"))
     );
 }
 
 #[test]
-fn private_validation_helpers_cover_remaining_error_paths() {
+fn validation_helpers_reject_invalid_shapes_and_axes() {
     let wrong_rank_rhs =
         Tensor::from_slice(&[1.0_f64, 2.0, 3.0], &[3], MemoryOrder::ColumnMajor).unwrap();
     let err = validate_lstsq_rhs(&wrong_rank_rhs, 2, &[2]).unwrap_err();

--- a/tenferro-linalg/tests/linalg_tests.rs
+++ b/tenferro-linalg/tests/linalg_tests.rs
@@ -3265,7 +3265,7 @@ fn norm_fro_frule_fd() {
 }
 
 // ============================================================================
-// Coverage: f32 forward tests
+// f32 forward tests
 // ============================================================================
 
 /// Create a column-major tensor from a flat vec of f32 and shape.
@@ -3516,7 +3516,7 @@ fn slogdet_f32() {
 }
 
 // ============================================================================
-// Coverage: Complex32 backend tests
+// Complex32 backend tests
 // ============================================================================
 
 /// Create a column-major tensor from Complex32.
@@ -3722,7 +3722,7 @@ fn solve_triangular_complex32() {
 }
 
 // ============================================================================
-// Coverage: Additional Complex64 backend tests (operations not yet tested)
+// Additional Complex64 backend tests (operations not yet tested)
 // ============================================================================
 
 #[test]
@@ -3802,7 +3802,7 @@ fn matrix_exp_complex64() {
 }
 
 // ============================================================================
-// Coverage: solve_triangular forward (upper and lower)
+// solve_triangular forward (upper and lower)
 // ============================================================================
 
 #[test]
@@ -3850,7 +3850,7 @@ fn solve_triangular_upper_multi_rhs() {
 }
 
 // ============================================================================
-// Coverage: norm Nuclear and Spectral forward + AD
+// norm Nuclear and Spectral forward + AD
 // ============================================================================
 
 #[test]
@@ -3932,7 +3932,7 @@ fn norm_spectral_frule_fd() {
 }
 
 // ============================================================================
-// Coverage: SVD with cutoff option
+// SVD with cutoff option
 // ============================================================================
 
 #[test]
@@ -3966,7 +3966,7 @@ fn svd_with_default_options() {
 }
 
 // ============================================================================
-// Coverage: batch dimension tests
+// batch dimension tests
 // ============================================================================
 
 #[test]
@@ -4076,7 +4076,7 @@ fn norm_batched_fro() {
 }
 
 // ============================================================================
-// Coverage: lstsq forward happy path
+// lstsq forward happy path
 // ============================================================================
 
 #[test]
@@ -4102,7 +4102,7 @@ fn lstsq_underdetermined_returns_error() {
 }
 
 // ============================================================================
-// Coverage: error paths for validation functions
+// error paths for validation functions
 // ============================================================================
 
 #[test]
@@ -4233,7 +4233,7 @@ fn norm_vector_error_cases_return_errors() {
 }
 
 // ============================================================================
-// Coverage: Non-square SVD rrule with full cotangent (dU, dS, dVt)
+// Non-square SVD rrule with full cotangent (dU, dS, dVt)
 // ============================================================================
 
 #[test]
@@ -4286,7 +4286,7 @@ fn svd_rrule_wide_with_dvt_cotangent() {
 }
 
 // ============================================================================
-// Coverage: SVD frule for non-square (tall m>k and wide n>k)
+// SVD frule for non-square (tall m>k and wide n>k)
 // ============================================================================
 
 #[test]
@@ -4320,7 +4320,7 @@ fn svd_frule_wide_matrix() {
 }
 
 // ============================================================================
-// Coverage: QR frule and rrule for non-square
+// QR frule and rrule for non-square
 // ============================================================================
 
 #[test]
@@ -4365,7 +4365,7 @@ fn qr_frule_wide_matrix() {
 // faer's LU backend panics on non-square input (faer requires m == n).
 
 // ============================================================================
-// Coverage: lstsq rrule
+// lstsq rrule
 // ============================================================================
 
 #[test]
@@ -4384,7 +4384,7 @@ fn lstsq_rrule_basic() {
 }
 
 // ============================================================================
-// Coverage: eigen rrule with vectors cotangent
+// eigen rrule with vectors cotangent
 // ============================================================================
 
 #[test]
@@ -4412,7 +4412,7 @@ fn eigen_rrule_with_vectors_cotangent() {
 }
 
 // ============================================================================
-// Coverage: matrix_exp edge cases
+// matrix_exp edge cases
 // ============================================================================
 
 #[test]
@@ -4441,7 +4441,7 @@ fn matrix_exp_f32() {
 }
 
 // ============================================================================
-// Coverage: pinv forward with threshold
+// pinv forward with threshold
 // ============================================================================
 
 #[test]
@@ -4462,7 +4462,7 @@ fn pinv_with_threshold() {
 }
 
 // ============================================================================
-// Coverage: eig forward for general non-symmetric (covers interleaved ri)
+// eig forward for a general non-symmetric matrix with complex-valued eigenpairs
 // ============================================================================
 
 #[test]
@@ -4489,7 +4489,7 @@ fn eig_3x3_general() {
 }
 
 // ============================================================================
-// Coverage: norm_rrule cotangent shape validation
+// norm_rrule cotangent shape validation
 // ============================================================================
 
 #[test]
@@ -4511,7 +4511,7 @@ fn norm_rrule_cotangent_batch_mismatch() {
 }
 
 // ============================================================================
-// Coverage: norm_rrule for batched Nuclear and Spectral
+// norm_rrule for batched Nuclear and Spectral
 // ============================================================================
 
 #[test]
@@ -4544,7 +4544,7 @@ fn norm_spectral_batched() {
 }
 
 // ============================================================================
-// Coverage: solve with vector RHS (nrhs=1 path)
+// solve with vector RHS (nrhs=1 path)
 // ============================================================================
 
 #[test]
@@ -4559,7 +4559,7 @@ fn solve_vector_rhs() {
 }
 
 // ============================================================================
-// Coverage: solve_triangular with vector RHS
+// solve_triangular with vector RHS
 // ============================================================================
 
 #[test]
@@ -4575,7 +4575,7 @@ fn solve_triangular_vector_rhs() {
 }
 
 // ============================================================================
-// Coverage: solve_triangular batched
+// solve_triangular batched
 // ============================================================================
 
 #[test]
@@ -4591,7 +4591,7 @@ fn solve_triangular_batched() {
 }
 
 // ============================================================================
-// Coverage: lstsq batched
+// lstsq batched
 // ============================================================================
 
 #[test]
@@ -4611,7 +4611,7 @@ fn lstsq_batched() {
 }
 
 // ============================================================================
-// Coverage: pinv batched
+// pinv batched
 // ============================================================================
 
 #[test]
@@ -4631,7 +4631,7 @@ fn pinv_batched() {
 // faer's LU backend panics on non-square input (faer requires m == n).
 
 // ============================================================================
-// Coverage: lu_rrule execution (covers ~120 lines in lib.rs)
+// lu_rrule execution across representative cotangent combinations
 // ============================================================================
 
 #[test]
@@ -4770,7 +4770,7 @@ fn lu_rrule_rejects_u_cotangent_shape_mismatch() {
 }
 
 // ============================================================================
-// Coverage: eig_rrule with vectors cotangent (EigCotangent)
+// eig_rrule with vectors cotangent (EigCotangent)
 // ============================================================================
 
 #[test]
@@ -4835,7 +4835,7 @@ fn eig_rrule_with_both_values_and_vectors() {
 }
 
 // ============================================================================
-// Coverage: solve_rrule and solve_frule with multi-RHS
+// solve_rrule and solve_frule with multi-RHS
 // ============================================================================
 
 fn assert_close_slices(label: &str, got: &[f64], expected: &[f64], atol: f64) {
@@ -5260,7 +5260,7 @@ fn solve_rrule_complex64_matches_manual_formula() {
 }
 
 // ============================================================================
-// Coverage: lstsq_frule
+// lstsq_frule
 // ============================================================================
 
 #[test]
@@ -5282,12 +5282,12 @@ fn lstsq_frule_basic() {
 }
 
 // ============================================================================
-// Coverage: pinv_rrule and pinv_frule
+// pinv_rrule and pinv_frule
 // ============================================================================
 
 #[test]
 fn pinv_rrule_execution() {
-    // Exercise pinv_rrule (covers ~50 lines in lib.rs).
+    // Exercise pinv_rrule for the singular-value thresholding path.
     let mut ctx = CpuContext::new(1);
     let a = make_tensor(vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0], &[3, 2]);
     let ap = pinv(&mut ctx, &a, None).unwrap();
@@ -5302,7 +5302,7 @@ fn pinv_rrule_execution() {
 
 #[test]
 fn pinv_frule_execution() {
-    // Exercise pinv_frule (covers ~50 lines in lib.rs).
+    // Exercise pinv_frule for the singular-value thresholding path.
     let mut ctx = CpuContext::new(1);
     let a = make_tensor(vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0], &[3, 2]);
     let da = make_tensor(vec![0.1; 6], &[3, 2]);
@@ -5316,12 +5316,12 @@ fn pinv_frule_execution() {
 }
 
 // ============================================================================
-// Coverage: norm_rrule Nuclear & Spectral
+// norm_rrule Nuclear & Spectral
 // ============================================================================
 
 #[test]
 fn norm_nuclear_rrule_execution() {
-    // Exercise norm_rrule Nuclear path (covers ~10 lines).
+    // Exercise norm_rrule for the nuclear norm path.
     let mut ctx = CpuContext::new(1);
     let a = make_tensor(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]);
     let co = make_tensor(vec![1.0], &[]);
@@ -5335,7 +5335,7 @@ fn norm_nuclear_rrule_execution() {
 
 #[test]
 fn norm_spectral_rrule_execution() {
-    // Exercise norm_rrule Spectral path (covers ~10 lines).
+    // Exercise norm_rrule for the spectral norm path.
     let mut ctx = CpuContext::new(1);
     let a = make_tensor(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]);
     let co = make_tensor(vec![1.0], &[]);
@@ -5351,7 +5351,7 @@ fn norm_spectral_rrule_execution() {
 }
 
 // ============================================================================
-// Coverage: norm_frule Nuclear & Spectral
+// norm_frule Nuclear & Spectral
 // ============================================================================
 
 #[test]
@@ -5381,7 +5381,7 @@ fn norm_spectral_frule_execution() {
 }
 
 // ============================================================================
-// Coverage: qr_frule and qr_rrule execution (to cover non-square projector terms)
+// qr_frule and qr_rrule execution for non-square projector terms
 // ============================================================================
 
 #[test]
@@ -5426,7 +5426,7 @@ fn qr_frule_tall_execution() {
 }
 
 // ============================================================================
-// Coverage: svd_rrule non-square correction paths
+// svd_rrule non-square correction paths
 // ============================================================================
 
 #[test]
@@ -5480,7 +5480,7 @@ fn svd_rrule_wide_with_all_cotangents() {
 }
 
 // ============================================================================
-// Coverage: svd_frule non-square paths
+// svd_frule non-square paths
 // ============================================================================
 
 #[test]
@@ -5514,7 +5514,7 @@ fn svd_frule_wide_all_outputs() {
 }
 
 // ============================================================================
-// Coverage: lu_frule execution
+// lu_frule execution
 // ============================================================================
 
 #[test]
@@ -5537,7 +5537,7 @@ fn lu_frule_square_execution() {
 }
 
 // ============================================================================
-// Coverage: cholesky_rrule and cholesky_frule execution
+// cholesky_rrule and cholesky_frule execution
 // ============================================================================
 
 #[test]
@@ -5569,7 +5569,7 @@ fn cholesky_frule_execution() {
 }
 
 // ============================================================================
-// Coverage: eigen_frule execution
+// eigen_frule execution
 // ============================================================================
 
 #[test]
@@ -5587,7 +5587,7 @@ fn eigen_frule_execution() {
 }
 
 // ============================================================================
-// Coverage: slogdet_rrule execution
+// slogdet_rrule execution
 // ============================================================================
 
 #[test]
@@ -5607,7 +5607,7 @@ fn slogdet_rrule_execution() {
 }
 
 // ============================================================================
-// Coverage: slogdet_frule execution
+// slogdet_frule execution
 // ============================================================================
 
 #[test]
@@ -5621,7 +5621,7 @@ fn slogdet_frule_execution() {
 }
 
 // ============================================================================
-// Coverage: det_rrule and det_frule execution
+// det_rrule and det_frule execution
 // ============================================================================
 
 #[test]
@@ -5648,7 +5648,7 @@ fn det_frule_execution() {
 }
 
 // ============================================================================
-// Coverage: inv_rrule and inv_frule execution
+// inv_rrule and inv_frule execution
 // ============================================================================
 
 #[test]
@@ -5679,7 +5679,7 @@ fn inv_frule_execution() {
 }
 
 // ============================================================================
-// Coverage: matrix_exp_rrule and matrix_exp_frule execution
+// matrix_exp_rrule and matrix_exp_frule execution
 // ============================================================================
 
 #[test]
@@ -5710,7 +5710,7 @@ fn matrix_exp_frule_execution() {
 }
 
 // ============================================================================
-// Coverage: eig_frule execution
+// eig_frule execution
 // ============================================================================
 
 #[test]
@@ -5724,12 +5724,12 @@ fn eig_frule_execution() {
 }
 
 // ============================================================================
-// Coverage: lstsq_rrule full execution
+// lstsq_rrule full execution
 // ============================================================================
 
 #[test]
 fn lstsq_rrule_full_execution() {
-    // Exercise lstsq_rrule with a tall matrix to cover all lines.
+    // Exercise lstsq_rrule on a tall matrix with both gradient outputs.
     let mut ctx = CpuContext::new(1);
     let a = make_tensor(vec![1.0, 0.0, 0.5, 0.0, 1.0, 0.5], &[3, 2]);
     let b = make_tensor(vec![1.0, 2.0, 3.0], &[3]);
@@ -5754,7 +5754,7 @@ fn lstsq_rrule_full_execution() {
 // Note: solve_triangular now has frule support, but rrule is still not exposed.
 
 // ============================================================================
-// Coverage: additional validation error paths and branch coverage
+// additional validation and edge-case paths
 // ============================================================================
 
 #[test]
@@ -5803,7 +5803,7 @@ fn solve_rhs_2d_batch_mismatch() {
 
 #[test]
 fn solve_triangular_rhs_2d_batch_mismatch() {
-    // Also covers lines 321-325 via solve_triangular path.
+    // Exercise the same RHS batch validation path through solve_triangular.
     let mut ctx = CpuContext::new(1);
     let a = make_tensor(vec![1.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0, 2.0], &[2, 2, 2]);
     let b = make_tensor(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 1, 3]);
@@ -6013,7 +6013,7 @@ fn norm_rrule_batched_fro_correct_cotangent() {
 
 #[test]
 fn norm_frule_batched_fro() {
-    // Exercise norm_frule with batched input to cover batched paths.
+    // Exercise norm_frule with batched input.
     let mut ctx = CpuContext::new(1);
     let a = make_tensor(vec![1.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0, 2.0], &[2, 2, 2]);
     let da = make_tensor(vec![0.1, 0.0, 0.0, 0.1, 0.2, 0.0, 0.0, 0.2], &[2, 2, 2]);
@@ -6045,7 +6045,7 @@ fn norm_frule_zero_matrix() {
 
 #[test]
 fn svd_rrule_no_cotangent() {
-    // Covers svd_rrule with all cotangents None.
+    // svd_rrule with all cotangents omitted should return a zero gradient.
     let mut ctx = CpuContext::new(1);
     let a = make_tensor(vec![1.0, 0.0, 0.0, 1.0], &[2, 2]);
     let co = SvdCotangent {
@@ -6065,7 +6065,7 @@ fn svd_rrule_no_cotangent() {
 
 #[test]
 fn qr_rrule_r_only_cotangent() {
-    // Covers qr_rrule with q=None.
+    // qr_rrule should accept an R-only cotangent.
     let mut ctx = CpuContext::new(1);
     let a = make_tensor(vec![1.0, 0.5, 0.5, 1.0], &[2, 2]);
     let result = qr(&mut ctx, &a).unwrap();

--- a/tenferro-prims/src/cpu/tests/gemm_support.rs
+++ b/tenferro-prims/src/cpu/tests/gemm_support.rs
@@ -4,13 +4,13 @@ use super::super::gemm_support::{batch_offset, FaerGemm};
 
 // Do not delete or weaken this test: it protects the shared CPU GEMM helpers that multiple semiring execution paths rely on.
 #[test]
-fn batch_offset_covers_fused_and_strided_paths() {
+fn batch_offset_handles_fused_and_strided_batches() {
     assert_eq!(batch_offset(3, &[0, 0], Some((8, 7)), &[11, 13]), 21);
     assert_eq!(batch_offset(0, &[2, 3], None, &[5, 11]), 43);
 }
 
 #[test]
-fn faer_strided_gemm_covers_replace_and_scaled_add_paths() {
+fn faer_strided_gemm_replaces_or_accumulates_output() {
     unsafe fn run<T>(alpha: T, beta: T, a: &[T], b: &[T], c: &mut [T])
     where
         T: FaerGemm + tenferro_algebra::Scalar,

--- a/tenferro-prims/tests/prims_tests.rs
+++ b/tenferro-prims/tests/prims_tests.rs
@@ -778,7 +778,7 @@ fn contract_generic_fallback_with_b_only_mode() {
     }
 }
 
-// (elementwise_unary_conj_identity standalone test covered by typed_prims_tests! macro)
+// (elementwise_unary_conj_identity standalone test is exercised by the typed_prims_tests! macro)
 
 // ============================================================================
 // ElementwiseUnary -- Conj for complex types


### PR DESCRIPTION
## Summary\n- rename test modules and functions so they describe behavior instead of coverage intent\n- drop residual coverage-oriented comments in linalg and prims tests\n- keep the structural guard tests while making their purpose explicit\n\n## Verification\n- cargo fmt --all --check\n- env CARGO_TARGET_DIR=/tmp/tenferro-refactor-test-behavior-names-release-target cargo test --workspace --release\n- env CARGO_TARGET_DIR=/tmp/tenferro-refactor-test-behavior-names-cov-target cargo llvm-cov --workspace --json --output-path coverage.json\n- python3 scripts/check-coverage.py coverage.json\n- env CARGO_TARGET_DIR=/tmp/tenferro-refactor-test-behavior-names-docs-target cargo doc --workspace --no-deps\n- python3 scripts/check-docs-site.py --doc-root /tmp/tenferro-refactor-test-behavior-names-docs-target/doc\n\nGenerated with [Claude Code](https://claude.com/claude-code)