### PR TITLE
refactor: centralize typed scalar dispatch

### DIFF
--- a/extension/tenferro-tropical/src/prims_impls.rs
+++ b/extension/tenferro-tropical/src/prims_impls.rs
@@ -24,32 +24,38 @@ use crate::scalar::{MaxMul, MaxPlus, MinPlus};
 /// All tropical scalar types are #[repr(transparent)] over their inner type,
 /// so the transmute is sound.
 macro_rules! try_simd_dispatch {
-    ($T:ty, $concrete_ty:ty, $inputs:expr, $alpha:expr, $beta:expr,
-     $output:expr, $batch_dims:expr, $m:expr, $n:expr, $k:expr) => {
-        if TypeId::of::<$T>() == TypeId::of::<$concrete_ty>() {
-            let a = unsafe {
-                &*($inputs[0] as *const StridedView<$T> as *const StridedView<$concrete_ty>)
-            };
-            let b = unsafe {
-                &*($inputs[1] as *const StridedView<$T> as *const StridedView<$concrete_ty>)
-            };
-            let out = unsafe {
-                &mut *($output as *mut StridedViewMut<$T> as *mut StridedViewMut<$concrete_ty>)
-            };
-            let alpha = unsafe { *(&$alpha as *const $T as *const $concrete_ty) };
-            let beta = unsafe { *(&$beta as *const $T as *const $concrete_ty) };
-            return execute_batched_gemm_optimized(
-                alpha,
-                &[a, b],
-                beta,
-                out,
-                $batch_dims,
-                $m,
-                $n,
-                $k,
-            );
-        }
-    };
+    ($T:ty, [$($concrete_ty:ty),+ $(,)?], $inputs:expr, $alpha:expr, $beta:expr,
+     $output:expr, $batch_dims:expr, $m:expr, $n:expr, $k:expr) => {{
+        let tid = TypeId::of::<$T>();
+        $(
+            if tid == TypeId::of::<$concrete_ty>() {
+                let a = unsafe {
+                    &*($inputs[0] as *const StridedView<$T> as *const StridedView<$concrete_ty>)
+                };
+                let b = unsafe {
+                    &*($inputs[1] as *const StridedView<$T> as *const StridedView<$concrete_ty>)
+                };
+                let out = unsafe {
+                    &mut *(
+                        $output as *mut StridedViewMut<$T>
+                            as *mut StridedViewMut<$concrete_ty>
+                    )
+                };
+                let alpha = unsafe { *(&$alpha as *const $T as *const $concrete_ty) };
+                let beta = unsafe { *(&$beta as *const $T as *const $concrete_ty) };
+                return execute_batched_gemm_optimized(
+                    alpha,
+                    &[a, b],
+                    beta,
+                    out,
+                    $batch_dims,
+                    $m,
+                    $n,
+                    $k,
+                );
+            }
+        )+
+    }};
 }
 
 macro_rules! impl_tropical_prims {
@@ -100,19 +106,7 @@ macro_rules! impl_tropical_prims {
                     }
                     try_simd_dispatch!(
                         $wrapper<S>,
-                        $wrapper<f64>,
-                        &view_refs,
-                        alpha,
-                        beta,
-                        &mut out_view,
-                        batch_dims,
-                        *m,
-                        *n,
-                        *k
-                    );
-                    try_simd_dispatch!(
-                        $wrapper<S>,
-                        $wrapper<f32>,
+                        [$wrapper<f64>, $wrapper<f32>],
                         &view_refs,
                         alpha,
                         beta,

--- a/tenferro-prims/src/family_cpu_common.rs
+++ b/tenferro-prims/src/family_cpu_common.rs
@@ -8,6 +8,7 @@ use strided_view::{StridedView, StridedViewMut};
 use tenferro_algebra::Scalar;
 use tenferro_device::{Error, Result};
 
+use crate::typed_dispatch::matches_any_type_id;
 use crate::{for_each_index, validate_rank, validate_shape_count, validate_shape_eq};
 
 pub(crate) trait CpuScalarValue:
@@ -174,13 +175,10 @@ where
 
 pub(crate) fn is_supported_scalar_type<T: Scalar + 'static>() -> bool {
     let tid = TypeId::of::<T>();
-    tid == TypeId::of::<f32>()
-        || tid == TypeId::of::<f64>()
-        || tid == TypeId::of::<Complex32>()
-        || tid == TypeId::of::<Complex64>()
+    matches_any_type_id!(tid; f32, f64, Complex32, Complex64)
 }
 
 pub(crate) fn is_supported_ordered_real_type<T: Scalar + 'static>() -> bool {
     let tid = TypeId::of::<T>();
-    tid == TypeId::of::<f32>() || tid == TypeId::of::<f64>()
+    matches_any_type_id!(tid; f32, f64)
 }

--- a/tenferro-prims/src/typed_dispatch.rs
+++ b/tenferro-prims/src/typed_dispatch.rs
@@ -1,3 +1,24 @@
+macro_rules! matches_any_type_id {
+    ($tid:expr; $($ty:ty),+ $(,)?) => {{
+        false $(|| $tid == std::any::TypeId::of::<$ty>())+
+    }};
+}
+
+pub(crate) use matches_any_type_id;
+
+macro_rules! dispatch_type_id {
+    ($tid:expr, $concrete:ident, [$($ty:ty),+ $(,)?], $body:block) => {{
+        $(
+            if $tid == std::any::TypeId::of::<$ty>() {
+                type $concrete = $ty;
+                $body
+            }
+        ) else+
+    }};
+}
+
+pub(crate) use dispatch_type_id;
+
 macro_rules! cast_strided_view {
     ($view:expr, $from:ty, $to:ty) => {{
         unsafe {
@@ -31,22 +52,12 @@ pub(crate) use cast_scalar_value;
 macro_rules! dispatch_standard_scalar_type {
     ($generic:ty, $concrete:ident, $body:block) => {{
         let tid = std::any::TypeId::of::<$generic>();
-        if tid == std::any::TypeId::of::<f64>() {
-            type $concrete = f64;
+        $crate::typed_dispatch::dispatch_type_id!(
+            tid,
+            $concrete,
+            [f64, f32, num_complex::Complex64, num_complex::Complex32],
             $body
-        }
-        if tid == std::any::TypeId::of::<f32>() {
-            type $concrete = f32;
-            $body
-        }
-        if tid == std::any::TypeId::of::<num_complex::Complex64>() {
-            type $concrete = num_complex::Complex64;
-            $body
-        }
-        if tid == std::any::TypeId::of::<num_complex::Complex32>() {
-            type $concrete = num_complex::Complex32;
-            $body
-        }
+        )
     }};
 }
 
@@ -55,14 +66,7 @@ pub(crate) use dispatch_standard_scalar_type;
 macro_rules! dispatch_real_scalar_type {
     ($generic:ty, $concrete:ident, $body:block) => {{
         let tid = std::any::TypeId::of::<$generic>();
-        if tid == std::any::TypeId::of::<f64>() {
-            type $concrete = f64;
-            $body
-        }
-        if tid == std::any::TypeId::of::<f32>() {
-            type $concrete = f32;
-            $body
-        }
+        $crate::typed_dispatch::dispatch_type_id!(tid, $concrete, [f64, f32], $body)
     }};
 }
 
@@ -71,14 +75,12 @@ pub(crate) use dispatch_real_scalar_type;
 macro_rules! dispatch_complex_scalar_type {
     ($generic:ty, $concrete:ident, $body:block) => {{
         let tid = std::any::TypeId::of::<$generic>();
-        if tid == std::any::TypeId::of::<num_complex::Complex64>() {
-            type $concrete = num_complex::Complex64;
+        $crate::typed_dispatch::dispatch_type_id!(
+            tid,
+            $concrete,
+            [num_complex::Complex64, num_complex::Complex32],
             $body
-        }
-        if tid == std::any::TypeId::of::<num_complex::Complex32>() {
-            type $concrete = num_complex::Complex32;
-            $body
-        }
+        )
     }};
 }
 


### PR DESCRIPTION
## Summary
- centralize the known scalar TypeId lists in `tenferro-prims::typed_dispatch`
- reuse that shared typed-dispatch vocabulary for CPU scalar support predicates
- collapse tropical SIMD dispatch into one typed branch instead of ad hoc repeated checks

## Verification
- cargo fmt --all --check
- env CARGO_TARGET_DIR=/tmp/tenferro-refactor-typed-dispatch-cleanup-release-target cargo test --workspace --release
- env CARGO_TARGET_DIR=/tmp/tenferro-refactor-typed-dispatch-cleanup-cov-target cargo llvm-cov --workspace --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- env CARGO_TARGET_DIR=/tmp/tenferro-refactor-typed-dispatch-cleanup-docs-target cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py --doc-root /tmp/tenferro-refactor-typed-dispatch-cleanup-docs-target/doc

Generated with [Claude Code](https://claude.com/claude-code)
