### PR TITLE
refactor: remove cpu-named linalg scalar leakage

### DIFF
--- a/docs/design/linalg-prims.md
+++ b/docs/design/linalg-prims.md
@@ -90,7 +90,12 @@ backend-facing linalg contract. Some concrete backends still use local helper
 modules internally, but those helpers now sit behind `tenferro-linalg-prims`
 instead of acting as a competing public abstraction.
 
-One important current debt is that `LinalgScalar` still carries
-LAPACK-oriented eigendecomposition helper requirements. That helper surface is
-more specific than the true backend-generic scalar contract and should be
-isolated into a narrower CPU-oriented trait.
+The scalar side is intentionally split:
+
+- `LinalgScalar` describes the general scalar behavior shared by linalg code
+- `KernelLinalgScalar` marks the dtypes that backend kernel contracts currently
+  support
+- `LapackEigScalar` isolates the narrower CPU eig buffer conversion helpers
+
+That separation keeps public/high-level linalg APIs backend-generic without
+leaking CPU-specific scalar trait names.

--- a/docs/design/reference/pytorch-dense-cpu-parity.md
+++ b/docs/design/reference/pytorch-dense-cpu-parity.md
@@ -44,7 +44,7 @@ Status labels in the matrix use:
 | Semiring core / fast path (`tenferro-prims`) | Yes | Partial | Partial | Yes | Partial | Yes | `einsum` is strong, `Permute` is gone from the prim surface, and semiring execution now routes directly through the family contracts; the remaining gap is GPU capability breadth, not legacy layering |
 | Scalar (`TensorScalarPrims`) | Partial | Partial | Partial | No | Partial | Partial | CPU phase 1 now executes unary `Neg/Conj/Abs/Reciprocal/Real/Imag/Square`, binary `Add/Sub/Mul/Div/Maximum/Minimum/Clamp*`, and reductions `Sum/Prod/Mean/Max/Min`; predicate/select tensor ops such as `where` are still absent |
 | Analytic (`TensorAnalyticPrims`) | Partial | Partial | Partial | No | Partial | Partial | CPU phase 1 now executes unary `Sqrt/Rsqrt/Exp/Expm1/Log/Log1p/Sin/Cos/Tan/Tanh/Asin/Acos/Atan/Sinh/Cosh/Asinh/Acosh/Atanh`, binary `Pow/Atan2/Hypot/Xlogy`, and reductions `Var/Std`; GPU custom-kernel coverage is still absent |
-| Linalg kernel (`tenferro-linalg-prims`) | Yes | Partial | Partial | Partial | Partial | Partial | Solve/factorization kernels exist, but CPU eig helpers still leak through `LinalgScalar` and some execution still routes through CPU-local helpers |
+| Linalg kernel (`tenferro-linalg-prims`) | Yes | Partial | Partial | Partial | Partial | Partial | Solve/factorization kernels exist and now gate on backend-generic `KernelLinalgScalar`; the remaining gap is backend breadth, not CPU-named scalar contracts |
 | Linalg composite (`tenferro-linalg`) | Yes | Partial | Partial | Partial | Partial | Partial | Public coverage is broad and production entrypoints are capability-driven; the remaining gap is that several composites still bottom out in CPU-only kernels because broader backend support is missing |
 | Dyadtensor / AD surface | Partial | Partial | Partial | Partial | Partial | Partial | Eager builders now cover scalar/analytic unary, binary, and reduction families including `add`, `atan2`, `pow`, `hypot`, `exp`, `log`, `sin`, `cos`, `tanh`, `asin`, `acos`, `atan`, hyperbolic families, `sum`, `mean`, `var`, and `std`; predicate/select families are still missing and some AD families remain CPU-complete only |
 
@@ -167,12 +167,16 @@ capability-driven. The remaining issue is not legacy layering; it is that some
 composite paths still bottom out in CPU-only kernels because broader backend
 coverage has not landed yet.
 
-### 4. `tenferro-linalg-prims` still mixes generic scalar semantics with LAPACK-specific helpers
+### 4. `tenferro-linalg-prims` now separates backend-generic kernel scalars from LAPACK-specific helpers
 
-`LinalgScalar` currently carries eigendecomposition buffer conversion helpers
-that only make sense for the current CPU LAPACK-style path. That makes the
-trait broader than the true cross-backend contract. This is the concrete layer
-problem addressed by `#445`.
+The backend contract now distinguishes:
+
+- `KernelLinalgScalar` for dtypes supported by backend kernel implementations
+- `LapackEigScalar` for the narrower CPU eig helper path
+
+That keeps public/high-level linalg and dyadtensor bounds free of CPU-specific
+names while still allowing the CPU backend to own its concrete eig buffer
+conversion details.
 
 ### 5. Dyadtensor runtime is generic at the API boundary, but backend coverage is still mixed
 
@@ -209,7 +213,7 @@ still unsupported, including `det`, `eig`, `eigvals`, `eigvalsh`,
   dyadtensor runtime surface
 - Keep composite linalg paths lowering through capability-driven contracts as
   more backends land
-- Split LAPACK eig helpers out of `LinalgScalar`
+- Keep `KernelLinalgScalar` and `LapackEigScalar` separate as backend breadth grows
 
 ### Public API and family gaps
 

--- a/docs/design/supported-ops.md
+++ b/docs/design/supported-ops.md
@@ -67,6 +67,9 @@ contracts used by `tenferro-linalg`:
 - `solve`
 - `solve_triangular`
 
+The backend-facing dtype contract is `KernelLinalgScalar`, with LAPACK-specific
+eig helpers isolated behind `LapackEigScalar`.
+
 ## `tenferro-einsum`
 
 ### Primal

--- a/extension/tenferro-dyadtensor/src/api/contracts.rs
+++ b/extension/tenferro-dyadtensor/src/api/contracts.rs
@@ -4,7 +4,7 @@ use chainrules_scalarops::ScalarAd;
 use num_complex::Complex;
 use num_traits::Float;
 use tenferro_algebra::{HasAlgebra, Scalar, Standard};
-use tenferro_linalg::{backend::CpuLinalgScalar, LinalgScalar};
+use tenferro_linalg::{KernelLinalgScalar, LinalgScalar};
 
 #[doc(hidden)]
 /// Hidden bound for values that participate in the standard dyadtensor runtime.
@@ -112,15 +112,9 @@ impl<T> RealAdRuntimeValue for T where T: GenericAdRuntimeValue + ScalarAd<Real 
 /// fn require_linalg<T: tenferro_dyadtensor::api::contracts::LinalgRuntimeValue>() {}
 /// require_linalg::<f64>();
 /// ```
-pub trait LinalgRuntimeValue:
-    EinsumRuntimeValue + LinalgScalar + CpuLinalgScalar + 'static
-{
-}
+pub trait LinalgRuntimeValue: EinsumRuntimeValue + KernelLinalgScalar + 'static {}
 
-impl<T> LinalgRuntimeValue for T where
-    T: EinsumRuntimeValue + LinalgScalar + CpuLinalgScalar + 'static
-{
-}
+impl<T> LinalgRuntimeValue for T where T: EinsumRuntimeValue + KernelLinalgScalar + 'static {}
 
 #[doc(hidden)]
 /// Hidden shorthand for real-valued linalg runtime values.

--- a/extension/tenferro-dyadtensor/src/api/tests/runtime_dispatch.rs
+++ b/extension/tenferro-dyadtensor/src/api/tests/runtime_dispatch.rs
@@ -150,6 +150,10 @@ fn runtime_helpers_stay_capability_driven() {
         "semantic runtime value traits should not hard-code runtime context triples"
     );
     assert!(
+        !contracts.contains("CpuLinalgScalar"),
+        "semantic runtime value traits should not leak CPU-specific scalar contracts into the generic dyadtensor surface"
+    );
+    assert!(
         runtime_dispatch.contains("trait RuntimeSlot"),
         "runtime dispatch should centralize concrete runtime slot metadata instead of repeating ad hoc backend/context wiring"
     );

--- a/tenferro-linalg-prims/src/lib.rs
+++ b/tenferro-linalg-prims/src/lib.rs
@@ -49,6 +49,21 @@ pub trait LinalgScalar:
     fn conj(&self) -> Self;
 }
 
+/// Scalar types with concrete backend kernel support in the current workspace.
+///
+/// This marker keeps public/high-level linalg bounds generic over backends
+/// without leaking provider-specific names such as `Cpu*` into higher layers.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_linalg_prims::KernelLinalgScalar;
+///
+/// fn needs_kernel_scalar<T: KernelLinalgScalar>(x: T) -> T { x }
+/// assert_eq!(needs_kernel_scalar(1.0_f64), 1.0);
+/// ```
+pub trait KernelLinalgScalar: LinalgScalar {}
+
 /// LAPACK-oriented eigen helper contract for CPU eigendecomposition paths.
 ///
 /// This trait is intentionally narrower than [`LinalgScalar`]. It exists so
@@ -78,149 +93,94 @@ pub trait LapackEigScalar: LinalgScalar {
     );
 }
 
-impl LinalgScalar for f64 {
-    type Real = f64;
-    type Complex = Complex64;
+macro_rules! impl_real_linalg_scalar {
+    ($ty:ty, $complex:ty) => {
+        impl LinalgScalar for $ty {
+            type Real = $ty;
+            type Complex = $complex;
 
-    fn abs_real(&self) -> f64 {
-        num_traits::Float::abs(*self)
-    }
+            fn abs_real(&self) -> $ty {
+                num_traits::Float::abs(*self)
+            }
 
-    fn real_epsilon() -> f64 {
-        <f64 as num_traits::Float>::epsilon()
-    }
+            fn real_epsilon() -> $ty {
+                <$ty as num_traits::Float>::epsilon()
+            }
 
-    fn conj(&self) -> f64 {
-        *self
-    }
-}
-
-impl LapackEigScalar for f64 {
-    fn eig_buffer_sizes(n: usize) -> (usize, usize) {
-        (2 * n, 2 * n * n)
-    }
-
-    fn eig_ri_to_complex(
-        n: usize,
-        val_ri: &[Self],
-        vec_ri: &[Self],
-        values_out: &mut [Complex64],
-        vectors_out: &mut [Complex64],
-    ) {
-        for i in 0..n {
-            values_out[i] = Complex64::new(val_ri[2 * i], val_ri[2 * i + 1]);
+            fn conj(&self) -> $ty {
+                *self
+            }
         }
-        for k in 0..(n * n) {
-            vectors_out[k] = Complex64::new(vec_ri[2 * k], vec_ri[2 * k + 1]);
+
+        impl KernelLinalgScalar for $ty {}
+
+        impl LapackEigScalar for $ty {
+            fn eig_buffer_sizes(n: usize) -> (usize, usize) {
+                (2 * n, 2 * n * n)
+            }
+
+            fn eig_ri_to_complex(
+                n: usize,
+                val_ri: &[Self],
+                vec_ri: &[Self],
+                values_out: &mut [$complex],
+                vectors_out: &mut [$complex],
+            ) {
+                for i in 0..n {
+                    values_out[i] = <$complex>::new(val_ri[2 * i], val_ri[2 * i + 1]);
+                }
+                for k in 0..(n * n) {
+                    vectors_out[k] = <$complex>::new(vec_ri[2 * k], vec_ri[2 * k + 1]);
+                }
+            }
         }
-    }
+    };
 }
 
-impl LinalgScalar for f32 {
-    type Real = f32;
-    type Complex = Complex32;
+macro_rules! impl_complex_linalg_scalar {
+    ($ty:ty, $real:ty) => {
+        impl LinalgScalar for $ty {
+            type Real = $real;
+            type Complex = $ty;
 
-    fn abs_real(&self) -> f32 {
-        num_traits::Float::abs(*self)
-    }
+            fn abs_real(&self) -> $real {
+                self.norm()
+            }
 
-    fn real_epsilon() -> f32 {
-        <f32 as num_traits::Float>::epsilon()
-    }
+            fn real_epsilon() -> $real {
+                <$real as num_traits::Float>::epsilon()
+            }
 
-    fn conj(&self) -> f32 {
-        *self
-    }
-}
-
-impl LapackEigScalar for f32 {
-    fn eig_buffer_sizes(n: usize) -> (usize, usize) {
-        (2 * n, 2 * n * n)
-    }
-
-    fn eig_ri_to_complex(
-        n: usize,
-        val_ri: &[Self],
-        vec_ri: &[Self],
-        values_out: &mut [Complex32],
-        vectors_out: &mut [Complex32],
-    ) {
-        for i in 0..n {
-            values_out[i] = Complex32::new(val_ri[2 * i], val_ri[2 * i + 1]);
+            fn conj(&self) -> $ty {
+                self.conj()
+            }
         }
-        for k in 0..(n * n) {
-            vectors_out[k] = Complex32::new(vec_ri[2 * k], vec_ri[2 * k + 1]);
+
+        impl KernelLinalgScalar for $ty {}
+
+        impl LapackEigScalar for $ty {
+            fn eig_buffer_sizes(n: usize) -> (usize, usize) {
+                (n, n * n)
+            }
+
+            fn eig_ri_to_complex(
+                _n: usize,
+                val_ri: &[Self],
+                vec_ri: &[Self],
+                values_out: &mut [$ty],
+                vectors_out: &mut [$ty],
+            ) {
+                values_out.copy_from_slice(val_ri);
+                vectors_out.copy_from_slice(vec_ri);
+            }
         }
-    }
+    };
 }
 
-impl LinalgScalar for Complex64 {
-    type Real = f64;
-    type Complex = Complex64;
-
-    fn abs_real(&self) -> f64 {
-        self.norm()
-    }
-
-    fn real_epsilon() -> f64 {
-        <f64 as num_traits::Float>::epsilon()
-    }
-
-    fn conj(&self) -> Complex64 {
-        self.conj()
-    }
-}
-
-impl LapackEigScalar for Complex64 {
-    fn eig_buffer_sizes(n: usize) -> (usize, usize) {
-        (n, n * n)
-    }
-
-    fn eig_ri_to_complex(
-        _n: usize,
-        val_ri: &[Self],
-        vec_ri: &[Self],
-        values_out: &mut [Complex64],
-        vectors_out: &mut [Complex64],
-    ) {
-        values_out.copy_from_slice(val_ri);
-        vectors_out.copy_from_slice(vec_ri);
-    }
-}
-
-impl LinalgScalar for Complex32 {
-    type Real = f32;
-    type Complex = Complex32;
-
-    fn abs_real(&self) -> f32 {
-        self.norm()
-    }
-
-    fn real_epsilon() -> f32 {
-        <f32 as num_traits::Float>::epsilon()
-    }
-
-    fn conj(&self) -> Complex32 {
-        self.conj()
-    }
-}
-
-impl LapackEigScalar for Complex32 {
-    fn eig_buffer_sizes(n: usize) -> (usize, usize) {
-        (n, n * n)
-    }
-
-    fn eig_ri_to_complex(
-        _n: usize,
-        val_ri: &[Self],
-        vec_ri: &[Self],
-        values_out: &mut [Complex32],
-        vectors_out: &mut [Complex32],
-    ) {
-        values_out.copy_from_slice(val_ri);
-        vectors_out.copy_from_slice(vec_ri);
-    }
-}
+impl_real_linalg_scalar!(f64, Complex64);
+impl_real_linalg_scalar!(f32, Complex32);
+impl_complex_linalg_scalar!(Complex64, f64);
+impl_complex_linalg_scalar!(Complex32, f32);
 
 /// Result of a tensor-level QR decomposition.
 ///
@@ -332,7 +292,7 @@ pub enum LinalgCapabilityOp {
     Norm,
 }
 
-pub trait TensorLinalgPrims<T: LinalgScalar> {
+pub trait TensorLinalgPrims<T: KernelLinalgScalar> {
     type Context;
 
     fn has_linalg_support(op: LinalgCapabilityOp) -> bool;

--- a/tenferro-linalg/src/ad_helpers/backend_ops.rs
+++ b/tenferro-linalg/src/ad_helpers/backend_ops.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Mat mul via LinalgBackend, returning `Vec` for convenience in AD code.
-pub(crate) fn backend_mat_mul<T: LinalgScalar, C>(
+pub(crate) fn backend_mat_mul<T: KernelLinalgScalar, C>(
     _ctx: &mut C,
     a: &[T],
     m: usize,
@@ -10,13 +10,13 @@ pub(crate) fn backend_mat_mul<T: LinalgScalar, C>(
     n: usize,
 ) -> AdResult<Vec<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     prims_bridge::batched_gemm_via_prims(a, m, k, b, n).map_err(to_ad_err)
 }
 
 /// Solve via LinalgBackend, returning `Vec` for convenience in AD code.
-pub(crate) fn backend_solve<T: LinalgScalar, C>(
+pub(crate) fn backend_solve<T: KernelLinalgScalar, C>(
     _ctx: &mut C,
     a: &[T],
     b: &[T],
@@ -24,7 +24,7 @@ pub(crate) fn backend_solve<T: LinalgScalar, C>(
     nrhs: usize,
 ) -> AdResult<Vec<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let mut x = vec![T::zero(); n * nrhs];
     backend::cpu::solve_slices(a, b, n, nrhs, &mut x).map_err(to_ad_err)?;
@@ -32,7 +32,7 @@ where
 }
 
 /// Solve triangular via LinalgBackend, returning `Vec` for convenience in AD code.
-pub(crate) fn backend_solve_tri<T: LinalgScalar, C>(
+pub(crate) fn backend_solve_tri<T: KernelLinalgScalar, C>(
     _ctx: &mut C,
     a: &[T],
     b: &[T],
@@ -41,7 +41,7 @@ pub(crate) fn backend_solve_tri<T: LinalgScalar, C>(
     upper: bool,
 ) -> AdResult<Vec<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let mut x = vec![T::zero(); n * nrhs];
     backend::cpu::solve_triangular_slices(a, b, n, nrhs, upper, &mut x).map_err(to_ad_err)?;
@@ -49,14 +49,14 @@ where
 }
 
 /// Thin SVD via LinalgBackend, returning `(U, S, V)` for convenience in AD code.
-pub(crate) fn backend_thin_svd<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub(crate) fn backend_thin_svd<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     _ctx: &mut C,
     a: &[T],
     m: usize,
     n: usize,
 ) -> AdResult<(Vec<T>, Vec<T>, Vec<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let k = m.min(n);
     let mut u = vec![T::zero(); m * k];
@@ -68,14 +68,14 @@ where
 }
 
 /// QR decomposition via LinalgBackend, returning `(Q, R)` for convenience in AD code.
-pub(crate) fn backend_qr<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub(crate) fn backend_qr<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     _ctx: &mut C,
     a: &[T],
     m: usize,
     n: usize,
 ) -> AdResult<(Vec<T>, Vec<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let k = m.min(n);
     let mut q = vec![T::zero(); m * k];

--- a/tenferro-linalg/src/ad_helpers/complex_ops.rs
+++ b/tenferro-linalg/src/ad_helpers/complex_ops.rs
@@ -38,14 +38,14 @@ where
 }
 
 /// Solve `A X = B` for complex square matrices.
-pub(crate) fn complex_solve_nn<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub(crate) fn complex_solve_nn<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     _ctx: &mut C,
     a: &[Cx<T>],
     b: &[Cx<T>],
     n: usize,
 ) -> AdResult<Vec<Cx<T>>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let nn = 2 * n;
     let mut a_real = vec![T::zero(); nn * nn];

--- a/tenferro-linalg/src/ad_helpers/lu.rs
+++ b/tenferro-linalg/src/ad_helpers/lu.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) fn lu_factor_impl<T: LinalgScalar, C>(
+pub(crate) fn lu_factor_impl<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
 ) -> Result<LuFactorExResult<T>>
@@ -77,14 +77,14 @@ pub(crate) fn pack_lu_factors<T: LinalgScalar>(
     tensor_from_data(packed, &output_dims(&[m, n], batch_dims))
 }
 
-pub(crate) fn lu_solve_impl<T: LinalgScalar, C>(
+pub(crate) fn lu_solve_impl<T: KernelLinalgScalar, C>(
     _ctx: &mut C,
     factors: &Tensor<T>,
     pivots: &[usize],
     b: &Tensor<T>,
 ) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
 {
     let (n, batch_dims) = validate_square(factors)?;

--- a/tenferro-linalg/src/ad_helpers/matrix_exp.rs
+++ b/tenferro-linalg/src/ad_helpers/matrix_exp.rs
@@ -37,14 +37,14 @@ pub(crate) fn matrix_1_norm<T: LinalgScalar>(a: &[T], n: usize) -> T::Real {
 }
 
 /// Multiply two n x n column-major matrices using the backend.
-pub(crate) fn backend_mat_mul_nn<T: LinalgScalar, C>(
+pub(crate) fn backend_mat_mul_nn<T: KernelLinalgScalar, C>(
     _ctx: &mut C,
     a: &[T],
     b: &[T],
     n: usize,
 ) -> Result<Vec<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     prims_bridge::batched_gemm_via_prims(a, n, n, b, n)
 }
@@ -82,13 +82,13 @@ pub(crate) fn mat_add<T: LinalgScalar>(a: &[T], b: &[T]) -> Vec<T> {
 }
 
 /// Compute matrix exponential of a single n x n column-major matrix.
-pub(crate) fn matrix_exp_single<T: LinalgScalar, C>(
+pub(crate) fn matrix_exp_single<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     a: &[T],
     n: usize,
 ) -> Result<Vec<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     if n == 0 {
         return Ok(Vec::new());
@@ -174,14 +174,14 @@ where
     Ok(result)
 }
 
-pub(crate) fn matrix_power_single<T: LinalgScalar, C>(
+pub(crate) fn matrix_power_single<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     a: &[T],
     n: usize,
     exponent: u64,
 ) -> Result<Vec<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     if exponent == 1 {
         return Ok(a.to_vec());

--- a/tenferro-linalg/src/ad_helpers/mod.rs
+++ b/tenferro-linalg/src/ad_helpers/mod.rs
@@ -6,7 +6,7 @@ mod matrix_exp;
 mod matrix_ops;
 mod validation;
 
-use crate::{backend, prims_bridge, LuFactorExResult, NormKind};
+use crate::{backend, prims_bridge, KernelLinalgScalar, LuFactorExResult, NormKind};
 use chainrules_core::AdResult;
 use tenferro_algebra::Scalar;
 use tenferro_device::{Error, Result};

--- a/tenferro-linalg/src/backend/cpu.rs
+++ b/tenferro-linalg/src/backend/cpu.rs
@@ -3,8 +3,10 @@
 //! The actual provider implementation is selected at compile time via
 //! `linalg-faer` or `linalg-lapack` features.
 
+use std::any::TypeId;
+
 use num_complex::{Complex32, Complex64};
-use tenferro_linalg_prims::LapackEigScalar;
+use tenferro_linalg_prims::{KernelLinalgScalar, LapackEigScalar};
 
 use super::tensor_api::TensorLinalgBackend;
 use super::tensor_context::TensorLinalgContextFor;
@@ -25,10 +27,10 @@ mod private {
     use num_complex::{Complex32, Complex64};
 
     use super::{LinalgBackend, SelectedCpuSliceBackend};
-    use crate::LinalgScalar;
+    use crate::KernelLinalgScalar;
     use tenferro_device::Result;
 
-    pub trait CpuLinalgOps: LinalgScalar {
+    pub trait CpuLinalgOps: KernelLinalgScalar + super::LapackEigScalar {
         fn solve_slices(
             a: &[Self],
             b: &[Self],
@@ -163,25 +165,58 @@ mod private {
     impl_cpu_linalg_ops!(Complex32);
 }
 
-/// Scalar types supported by the CPU linalg provider selected at build time.
-pub trait CpuLinalgScalar: private::CpuLinalgOps + LapackEigScalar {}
+macro_rules! cast_slice {
+    ($slice:expr, $from:ty, $to:ty) => {{
+        unsafe { &*($slice as *const [$from] as *const [$to]) }
+    }};
+}
 
-impl CpuLinalgScalar for f64 {}
-impl CpuLinalgScalar for f32 {}
-impl CpuLinalgScalar for Complex64 {}
-impl CpuLinalgScalar for Complex32 {}
+macro_rules! cast_slice_mut {
+    ($slice:expr, $from:ty, $to:ty) => {{
+        unsafe { &mut *($slice as *mut [$from] as *mut [$to]) }
+    }};
+}
 
-pub(crate) fn solve_slices<T: CpuLinalgScalar>(
+macro_rules! dispatch_kernel_linalg_scalar_type {
+    ($generic:ty, $concrete:ident, $body:block) => {{
+        let tid = TypeId::of::<$generic>();
+        if tid == TypeId::of::<f64>() {
+            type $concrete = f64;
+            $body
+        } else if tid == TypeId::of::<f32>() {
+            type $concrete = f32;
+            $body
+        } else if tid == TypeId::of::<Complex64>() {
+            type $concrete = Complex64;
+            $body
+        } else if tid == TypeId::of::<Complex32>() {
+            type $concrete = Complex32;
+            $body
+        } else {
+            unreachable!("KernelLinalgScalar must be one of the standard linalg dtypes")
+        }
+    }};
+}
+
+pub(crate) fn solve_slices<T: KernelLinalgScalar>(
     a: &[T],
     b: &[T],
     n: usize,
     nrhs: usize,
     x: &mut [T],
 ) -> Result<()> {
-    <T as private::CpuLinalgOps>::solve_slices(a, b, n, nrhs, x)
+    dispatch_kernel_linalg_scalar_type!(T, Concrete, {
+        <Concrete as private::CpuLinalgOps>::solve_slices(
+            cast_slice!(a, T, Concrete),
+            cast_slice!(b, T, Concrete),
+            n,
+            nrhs,
+            cast_slice_mut!(x, T, Concrete),
+        )
+    })
 }
 
-pub(crate) fn solve_triangular_slices<T: CpuLinalgScalar>(
+pub(crate) fn solve_triangular_slices<T: KernelLinalgScalar>(
     a: &[T],
     b: &[T],
     n: usize,
@@ -189,10 +224,19 @@ pub(crate) fn solve_triangular_slices<T: CpuLinalgScalar>(
     upper: bool,
     x: &mut [T],
 ) -> Result<()> {
-    <T as private::CpuLinalgOps>::solve_triangular_slices(a, b, n, nrhs, upper, x)
+    dispatch_kernel_linalg_scalar_type!(T, Concrete, {
+        <Concrete as private::CpuLinalgOps>::solve_triangular_slices(
+            cast_slice!(a, T, Concrete),
+            cast_slice!(b, T, Concrete),
+            n,
+            nrhs,
+            upper,
+            cast_slice_mut!(x, T, Concrete),
+        )
+    })
 }
 
-pub(crate) fn thin_svd_slices<T: CpuLinalgScalar>(
+pub(crate) fn thin_svd_slices<T: KernelLinalgScalar>(
     a: &[T],
     m: usize,
     n: usize,
@@ -200,20 +244,38 @@ pub(crate) fn thin_svd_slices<T: CpuLinalgScalar>(
     s: &mut [T::Real],
     vt: &mut [T],
 ) -> Result<()> {
-    <T as private::CpuLinalgOps>::thin_svd_slices(a, m, n, u, s, vt)
+    dispatch_kernel_linalg_scalar_type!(T, Concrete, {
+        type ConcreteReal = <Concrete as crate::LinalgScalar>::Real;
+        <Concrete as private::CpuLinalgOps>::thin_svd_slices(
+            cast_slice!(a, T, Concrete),
+            m,
+            n,
+            cast_slice_mut!(u, T, Concrete),
+            cast_slice_mut!(s, T::Real, ConcreteReal),
+            cast_slice_mut!(vt, T, Concrete),
+        )
+    })
 }
 
-pub(crate) fn qr_slices<T: CpuLinalgScalar>(
+pub(crate) fn qr_slices<T: KernelLinalgScalar>(
     a: &[T],
     m: usize,
     n: usize,
     q: &mut [T],
     r: &mut [T],
 ) -> Result<()> {
-    <T as private::CpuLinalgOps>::qr_slices(a, m, n, q, r)
+    dispatch_kernel_linalg_scalar_type!(T, Concrete, {
+        <Concrete as private::CpuLinalgOps>::qr_slices(
+            cast_slice!(a, T, Concrete),
+            m,
+            n,
+            cast_slice_mut!(q, T, Concrete),
+            cast_slice_mut!(r, T, Concrete),
+        )
+    })
 }
 
-pub(crate) fn lu_slices<T: CpuLinalgScalar>(
+pub(crate) fn lu_slices<T: KernelLinalgScalar>(
     a: &[T],
     m: usize,
     n: usize,
@@ -221,29 +283,84 @@ pub(crate) fn lu_slices<T: CpuLinalgScalar>(
     l: &mut [T],
     u_out: &mut [T],
 ) -> Result<()> {
-    <T as private::CpuLinalgOps>::lu_slices(a, m, n, perm, l, u_out)
+    dispatch_kernel_linalg_scalar_type!(T, Concrete, {
+        <Concrete as private::CpuLinalgOps>::lu_slices(
+            cast_slice!(a, T, Concrete),
+            m,
+            n,
+            perm,
+            cast_slice_mut!(l, T, Concrete),
+            cast_slice_mut!(u_out, T, Concrete),
+        )
+    })
 }
 
-pub(crate) fn cholesky_slices<T: CpuLinalgScalar>(a: &[T], n: usize, l: &mut [T]) -> Result<()> {
-    <T as private::CpuLinalgOps>::cholesky_slices(a, n, l)
+pub(crate) fn cholesky_slices<T: KernelLinalgScalar>(a: &[T], n: usize, l: &mut [T]) -> Result<()> {
+    dispatch_kernel_linalg_scalar_type!(T, Concrete, {
+        <Concrete as private::CpuLinalgOps>::cholesky_slices(
+            cast_slice!(a, T, Concrete),
+            n,
+            cast_slice_mut!(l, T, Concrete),
+        )
+    })
 }
 
-pub(crate) fn eigen_sym_slices<T: CpuLinalgScalar>(
+pub(crate) fn eigen_sym_slices<T: KernelLinalgScalar>(
     a: &[T],
     n: usize,
     values: &mut [T::Real],
     vectors: &mut [T],
 ) -> Result<()> {
-    <T as private::CpuLinalgOps>::eigen_sym_slices(a, n, values, vectors)
+    dispatch_kernel_linalg_scalar_type!(T, Concrete, {
+        type ConcreteReal = <Concrete as crate::LinalgScalar>::Real;
+        <Concrete as private::CpuLinalgOps>::eigen_sym_slices(
+            cast_slice!(a, T, Concrete),
+            n,
+            cast_slice_mut!(values, T::Real, ConcreteReal),
+            cast_slice_mut!(vectors, T, Concrete),
+        )
+    })
 }
 
-pub(crate) fn eig_slices<T: CpuLinalgScalar>(
+pub(crate) fn eig_slices<T: KernelLinalgScalar>(
     a: &[T],
     n: usize,
     values_ri: &mut [T],
     vectors_ri: &mut [T],
 ) -> Result<()> {
-    <T as private::CpuLinalgOps>::eig_slices(a, n, values_ri, vectors_ri)
+    dispatch_kernel_linalg_scalar_type!(T, Concrete, {
+        <Concrete as private::CpuLinalgOps>::eig_slices(
+            cast_slice!(a, T, Concrete),
+            n,
+            cast_slice_mut!(values_ri, T, Concrete),
+            cast_slice_mut!(vectors_ri, T, Concrete),
+        )
+    })
+}
+
+pub(crate) fn eig_buffer_sizes<T: KernelLinalgScalar>(n: usize) -> (usize, usize) {
+    dispatch_kernel_linalg_scalar_type!(T, Concrete, {
+        <Concrete as LapackEigScalar>::eig_buffer_sizes(n)
+    })
+}
+
+pub(crate) fn eig_ri_to_complex<T: KernelLinalgScalar>(
+    n: usize,
+    val_ri: &[T],
+    vec_ri: &[T],
+    values_out: &mut [T::Complex],
+    vectors_out: &mut [T::Complex],
+) {
+    dispatch_kernel_linalg_scalar_type!(T, Concrete, {
+        type ConcreteComplex = <Concrete as crate::LinalgScalar>::Complex;
+        <Concrete as LapackEigScalar>::eig_ri_to_complex(
+            n,
+            cast_slice!(val_ri, T, Concrete),
+            cast_slice!(vec_ri, T, Concrete),
+            cast_slice_mut!(values_out, T::Complex, ConcreteComplex),
+            cast_slice_mut!(vectors_out, T::Complex, ConcreteComplex),
+        )
+    })
 }
 
 /// Marker type for the CPU tensor linalg backend.
@@ -264,7 +381,7 @@ pub struct CpuTensorLinalgBackend;
 
 impl<T> TensorLinalgBackend<T> for CpuTensorLinalgBackend
 where
-    T: CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     type Context = tenferro_prims::CpuContext;
 
@@ -334,7 +451,7 @@ where
 
 impl<T> TensorLinalgContextFor<T> for tenferro_prims::CpuContext
 where
-    T: CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     type Backend = CpuTensorLinalgBackend;
 }

--- a/tenferro-linalg/src/backend/cpu/tests/mod.rs
+++ b/tenferro-linalg/src/backend/cpu/tests/mod.rs
@@ -1,9 +1,9 @@
 use super::*;
-use crate::LinalgScalar;
+use crate::KernelLinalgScalar;
 use tenferro_tensor::{MemoryOrder, Tensor};
 
 /// Convert a slice of f64 pairs into scalar type T for test matrices.
-trait TestScalar: LinalgScalar {
+trait TestScalar: KernelLinalgScalar {
     fn from_f64(v: f64) -> Self;
 }
 
@@ -185,7 +185,7 @@ cpu_backend_tests!(complex32_tests, num_complex::Complex32);
 fn run_generic_backend_solve_smoke<B, T>()
 where
     B: TensorLinalgBackend<T, Context = tenferro_prims::CpuContext>,
-    T: TestScalar + CpuLinalgScalar,
+    T: TestScalar,
 {
     let mut ctx = tenferro_prims::CpuContext::new(1);
     let a = make::<T>(&[2.0, 1.0, 1.0, 3.0], &[2, 2]);
@@ -197,7 +197,7 @@ where
 fn run_generic_backend_qr_smoke<B, T>()
 where
     B: TensorLinalgBackend<T, Context = tenferro_prims::CpuContext>,
-    T: TestScalar + CpuLinalgScalar,
+    T: TestScalar,
 {
     let mut ctx = tenferro_prims::CpuContext::new(1);
     let a = make::<T>(&[1.0, 0.0, 0.0, 1.0], &[2, 2]);

--- a/tenferro-linalg/src/backend/cpu_tensor_impl.rs
+++ b/tenferro-linalg/src/backend/cpu_tensor_impl.rs
@@ -16,7 +16,7 @@ use super::tensor_helpers::{
     batch_count, ensure_col_major, extract_contiguous_slice, validate_matrix_shape,
     validate_solve_rhs_shape, validate_square,
 };
-use crate::LinalgScalar;
+use crate::KernelLinalgScalar;
 
 /// Create a tensor from data in column-major layout.
 fn tensor_from_data<T: Scalar>(data: Vec<T>, dims: &[usize]) -> Result<Tensor<T>> {
@@ -31,8 +31,7 @@ pub(crate) fn solve<T>(
     b: &Tensor<T>,
 ) -> Result<Tensor<T>>
 where
-    T: LinalgScalar,
-    T: super::cpu::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let (n, batch_dims) = validate_square(a)?;
     let rhs = validate_solve_rhs_shape(b, n, batch_dims, "solve")?;
@@ -68,8 +67,7 @@ pub(crate) fn solve_triangular<T>(
     upper: bool,
 ) -> Result<Tensor<T>>
 where
-    T: LinalgScalar,
-    T: super::cpu::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let (n, batch_dims) = validate_square(a)?;
     let rhs = validate_solve_rhs_shape(b, n, batch_dims, "solve_triangular")?;
@@ -103,8 +101,7 @@ pub(crate) fn qr<T>(
     a: &Tensor<T>,
 ) -> Result<QrTensorResult<T>>
 where
-    T: LinalgScalar,
-    T: super::cpu::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let (m, n, batch_dims) = validate_matrix_shape(a)?;
     let k = m.min(n);
@@ -147,8 +144,7 @@ pub(crate) fn thin_svd<T>(
     a: &Tensor<T>,
 ) -> Result<SvdTensorResult<T>>
 where
-    T: LinalgScalar,
-    T: super::cpu::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let (m, n, batch_dims) = validate_matrix_shape(a)?;
     let k = m.min(n);
@@ -195,8 +191,7 @@ pub(crate) fn lu_factor<T>(
     a: &Tensor<T>,
 ) -> Result<LuTensorResult<T>>
 where
-    T: LinalgScalar,
-    T: super::cpu::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let (m, n, batch_dims) = validate_matrix_shape(a)?;
     let k = m.min(n);
@@ -243,8 +238,7 @@ where
 /// Cholesky decomposition via the selected CPU slice backend.
 pub(crate) fn cholesky<T>(_ctx: &mut tenferro_prims::CpuContext, a: &Tensor<T>) -> Result<Tensor<T>>
 where
-    T: LinalgScalar,
-    T: super::cpu::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let (n, batch_dims) = validate_square(a)?;
     let bc = batch_count(batch_dims);
@@ -275,8 +269,7 @@ pub(crate) fn eigen_sym<T>(
     a: &Tensor<T>,
 ) -> Result<EigenTensorResult<T>>
 where
-    T: LinalgScalar,
-    T: super::cpu::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let (n, batch_dims) = validate_square(a)?;
     let bc = batch_count(batch_dims);
@@ -326,8 +319,7 @@ pub(crate) fn eig<T>(
     a: &Tensor<T>,
 ) -> Result<EigTensorResult<T>>
 where
-    T: LinalgScalar,
-    T: super::cpu::CpuLinalgScalar,
+    T: KernelLinalgScalar,
 {
     let (n, batch_dims) = validate_square(a)?;
     let bc = batch_count(batch_dims);
@@ -337,7 +329,7 @@ where
     let a_off = a_contig.offset() as usize;
     let mat_size = n * n;
 
-    let (val_ri_len, vec_ri_len) = T::eig_buffer_sizes(n);
+    let (val_ri_len, vec_ri_len) = super::cpu::eig_buffer_sizes::<T>(n);
 
     let mut val_ri = vec![T::zero(); val_ri_len];
     let mut vec_ri = vec![T::zero(); vec_ri_len];
@@ -349,7 +341,7 @@ where
         let a_slice = &a_data[a_off + i * mat_size..a_off + (i + 1) * mat_size];
         super::cpu::eig_slices(a_slice, n, &mut val_ri, &mut vec_ri)?;
 
-        T::eig_ri_to_complex(
+        super::cpu::eig_ri_to_complex::<T>(
             n,
             &val_ri,
             &vec_ri,

--- a/tenferro-linalg/src/backend/cuda.rs
+++ b/tenferro-linalg/src/backend/cuda.rs
@@ -8,7 +8,7 @@ use super::tensor_api::{
     TensorLinalgBackend,
 };
 use super::tensor_context::TensorLinalgContextFor;
-use crate::LinalgScalar;
+use crate::KernelLinalgScalar;
 use tenferro_device::{Error, Result};
 use tenferro_tensor::Tensor;
 
@@ -30,7 +30,7 @@ fn unsupported<T>() -> Result<T> {
     ))
 }
 
-impl<T: LinalgScalar> TensorLinalgBackend<T> for CudaTensorLinalgBackend {
+impl<T: KernelLinalgScalar> TensorLinalgBackend<T> for CudaTensorLinalgBackend {
     type Context = tenferro_prims::CudaContext;
 
     fn has_linalg_support(_op: super::tensor_api::LinalgCapabilityOp) -> bool {
@@ -68,7 +68,7 @@ impl<T: LinalgScalar> TensorLinalgBackend<T> for CudaTensorLinalgBackend {
     }
 }
 
-impl<T: LinalgScalar> TensorLinalgContextFor<T> for tenferro_prims::CudaContext {
+impl<T: KernelLinalgScalar> TensorLinalgContextFor<T> for tenferro_prims::CudaContext {
     type Backend = CudaTensorLinalgBackend;
 }
 

--- a/tenferro-linalg/src/backend/hip.rs
+++ b/tenferro-linalg/src/backend/hip.rs
@@ -8,7 +8,7 @@ use super::tensor_api::{
     TensorLinalgBackend,
 };
 use super::tensor_context::TensorLinalgContextFor;
-use crate::LinalgScalar;
+use crate::KernelLinalgScalar;
 use tenferro_device::{Error, Result};
 use tenferro_tensor::Tensor;
 
@@ -30,7 +30,7 @@ fn unsupported<T>() -> Result<T> {
     ))
 }
 
-impl<T: LinalgScalar> TensorLinalgBackend<T> for HipTensorLinalgBackend {
+impl<T: KernelLinalgScalar> TensorLinalgBackend<T> for HipTensorLinalgBackend {
     type Context = tenferro_prims::RocmContext;
 
     fn has_linalg_support(_op: super::tensor_api::LinalgCapabilityOp) -> bool {
@@ -68,7 +68,7 @@ impl<T: LinalgScalar> TensorLinalgBackend<T> for HipTensorLinalgBackend {
     }
 }
 
-impl<T: LinalgScalar> TensorLinalgContextFor<T> for tenferro_prims::RocmContext {
+impl<T: KernelLinalgScalar> TensorLinalgContextFor<T> for tenferro_prims::RocmContext {
     type Backend = HipTensorLinalgBackend;
 }
 

--- a/tenferro-linalg/src/backend/mod.rs
+++ b/tenferro-linalg/src/backend/mod.rs
@@ -83,7 +83,6 @@ pub use tensor_context::TensorLinalgContextFor;
 // CPU backend (public)
 #[cfg(feature = "linalg-lapack")]
 pub use blas_lapack_backend::BlasLapackBackend;
-pub use cpu::CpuLinalgScalar;
 pub use cpu::CpuTensorLinalgBackend;
 
 // GPU backend stubs (public)

--- a/tenferro-linalg/src/backend/tensor_api.rs
+++ b/tenferro-linalg/src/backend/tensor_api.rs
@@ -7,8 +7,8 @@
 
 #[doc(inline)]
 pub use tenferro_linalg_prims::{
-    EigTensorResult, EigenTensorResult, LinalgCapabilityOp, LinalgScalar, LuTensorResult,
-    QrTensorResult, SvdTensorResult, TensorLinalgPrims as TensorLinalgBackend,
+    EigTensorResult, EigenTensorResult, KernelLinalgScalar, LinalgCapabilityOp, LinalgScalar,
+    LuTensorResult, QrTensorResult, SvdTensorResult, TensorLinalgPrims as TensorLinalgBackend,
 };
 
 #[cfg(test)]

--- a/tenferro-linalg/src/backend/tensor_context.rs
+++ b/tenferro-linalg/src/backend/tensor_context.rs
@@ -5,7 +5,7 @@
 //! backend-marker pattern from [`TensorLinalgBackend`].
 
 use super::tensor_api::TensorLinalgBackend;
-use crate::LinalgScalar;
+use crate::KernelLinalgScalar;
 
 /// Bridge trait that maps a context type to its backend.
 ///
@@ -25,13 +25,13 @@ use crate::LinalgScalar;
 ///
 /// fn do_work<T, C>(ctx: &mut C)
 /// where
-///     T: tenferro_linalg::LinalgScalar,
+///     T: tenferro_linalg::KernelLinalgScalar,
 ///     C: TensorLinalgContextFor<T>,
 /// {
 ///     // dispatch through the backend
 /// }
 /// ```
-pub trait TensorLinalgContextFor<T: LinalgScalar> {
+pub trait TensorLinalgContextFor<T: KernelLinalgScalar> {
     /// The backend type that this context is associated with.
     type Backend: TensorLinalgBackend<T, Context = Self>;
 }

--- a/tenferro-linalg/src/frules/least_squares.rs
+++ b/tenferro-linalg/src/frules/least_squares.rs
@@ -19,7 +19,7 @@ use super::*;
 /// let db = Tensor::<f64>::ones(&[3], mem, col);
 /// let (result, dresult) = lstsq_frule(&mut ctx, &a, &b, &da, &db).unwrap();
 /// ```
-pub fn lstsq_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn lstsq_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
@@ -27,7 +27,7 @@ pub fn lstsq_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
     tangent_b: &Tensor<T>,
 ) -> AdResult<(LstsqResult<T>, LstsqResult<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -101,13 +101,13 @@ where
 /// let da = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let (l, dl) = cholesky_frule(&mut ctx, &a, &da).unwrap();
 /// ```
-pub fn cholesky_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn cholesky_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
 ) -> AdResult<(Tensor<T>, Tensor<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/frules/linear_systems.rs
+++ b/tenferro-linalg/src/frules/linear_systems.rs
@@ -19,7 +19,7 @@ use super::*;
 /// let db = Tensor::<f64>::ones(&[3], mem, col);
 /// let (x, dx) = solve_frule(&mut ctx, &a, &b, &da, &db).unwrap();
 /// ```
-pub fn solve_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn solve_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
@@ -27,7 +27,7 @@ pub fn solve_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
     tangent_b: &Tensor<T>,
 ) -> AdResult<(Tensor<T>, Tensor<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -77,7 +77,7 @@ where
 ///
 /// where `proj(dA)` keeps only the active triangular part
 /// (`triu` when `upper=true`, `tril` when `upper=false`).
-pub fn solve_triangular_frule<T: LinalgScalar, C>(
+pub fn solve_triangular_frule<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
@@ -86,7 +86,7 @@ pub fn solve_triangular_frule<T: LinalgScalar, C>(
     upper: bool,
 ) -> AdResult<(Tensor<T>, Tensor<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -175,13 +175,13 @@ where
 /// let da = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let (a_inv, da_inv) = inv_frule(&mut ctx, &a, &da).unwrap();
 /// ```
-pub fn inv_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn inv_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
 ) -> AdResult<(Tensor<T>, Tensor<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -233,13 +233,13 @@ where
 /// let da = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let (d, dd) = det_frule(&mut ctx, &a, &da).unwrap();
 /// ```
-pub fn det_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn det_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
 ) -> AdResult<(Tensor<T>, Tensor<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -295,13 +295,13 @@ where
 /// let da = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let (result, dresult) = slogdet_frule(&mut ctx, &a, &da).unwrap();
 /// ```
-pub fn slogdet_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn slogdet_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
 ) -> AdResult<(SlogdetResult<T>, SlogdetResult<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/frules/lu_eigen.rs
+++ b/tenferro-linalg/src/frules/lu_eigen.rs
@@ -20,14 +20,14 @@ use super::*;
 /// let da = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let (result, dresult) = lu_frule(&mut ctx, &a, &da, LuPivot::Partial).unwrap();
 /// ```
-pub fn lu_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn lu_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
     pivot: LuPivot,
 ) -> AdResult<(LuResult<T>, LuResult<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -155,13 +155,13 @@ where
 /// let da = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let (result, dresult) = eigen_frule(&mut ctx, &a, &da).unwrap();
 /// ```
-pub fn eigen_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn eigen_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
 ) -> AdResult<(EigenResult<T>, EigenResult<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/frules/matrix_functions.rs
+++ b/tenferro-linalg/src/frules/matrix_functions.rs
@@ -26,13 +26,13 @@ use super::*;
 /// let da = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let (exp_a, dexp_a) = matrix_exp_frule(&mut ctx, &a, &da).unwrap();
 /// ```
-pub fn matrix_exp_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn matrix_exp_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
 ) -> AdResult<(Tensor<T>, Tensor<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/frules/norms.rs
+++ b/tenferro-linalg/src/frules/norms.rs
@@ -17,14 +17,14 @@ use super::*;
 /// let da = Tensor::<f64>::ones(&[3, 4], mem, col);
 /// let (n, dn) = norm_frule(&mut ctx, &a, &da, NormKind::Fro).unwrap();
 /// ```
-pub fn norm_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn norm_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
     kind: NormKind,
 ) -> AdResult<(Tensor<T>, Tensor<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/frules/spectral.rs
+++ b/tenferro-linalg/src/frules/spectral.rs
@@ -25,7 +25,7 @@ use super::*;
 /// let (result, dresult) = eig_frule(&mut ctx, &a, &da).unwrap();
 /// ```
 pub fn eig_frule<
-    T: LinalgScalar<Real = T, Complex = num_complex::Complex<T>> + num_traits::Float,
+    T: KernelLinalgScalar<Real = T, Complex = num_complex::Complex<T>> + num_traits::Float,
     C,
 >(
     ctx: &mut C,
@@ -33,7 +33,7 @@ pub fn eig_frule<
     tangent: &Tensor<T>,
 ) -> AdResult<(EigResult<T>, EigResult<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -119,14 +119,14 @@ where
 /// let da = Tensor::<f64>::ones(&[3, 4], mem, col);
 /// let (pinv_a, dpinv_a) = pinv_frule(&mut ctx, &a, &da, None).unwrap();
 /// ```
-pub fn pinv_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn pinv_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
     rcond: Option<f64>,
 ) -> AdResult<(Tensor<T>, Tensor<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/frules/svd_qr.rs
+++ b/tenferro-linalg/src/frules/svd_qr.rs
@@ -24,14 +24,14 @@ use super::*;
 /// let da = Tensor::<f64>::ones(&[3, 4], mem, col);
 /// let (result, dresult) = svd_frule(&mut ctx, &a, &da, None).unwrap();
 /// ```
-pub fn svd_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn svd_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
     options: Option<&SvdOptions>,
 ) -> AdResult<(SvdResult<T>, SvdResult<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -205,13 +205,13 @@ where
 /// let da = Tensor::<f64>::ones(&[4, 3], mem, col);
 /// let (result, dresult) = qr_frule(&mut ctx, &a, &da).unwrap();
 /// ```
-pub fn qr_frule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn qr_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
 ) -> AdResult<(QrResult<T>, QrResult<T>)>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/lib.rs
+++ b/tenferro-linalg/src/lib.rs
@@ -3,7 +3,9 @@
 //! Batched matrix linear algebra decompositions with AD rules.
 //!
 //! CPU decompositions and solvers are fully implemented via the
-//! [`faer`](https://crates.io/crates/faer) backend. GPU backends are planned.
+//! [`faer`](https://crates.io/crates/faer) backend. CUDA/HIP linalg contracts
+//! are already part of the public surface, but backend coverage there remains
+//! partial and capability-gated.
 //!
 //! This crate provides SVD, QR, LU, eigendecomposition, Cholesky, least squares,
 //! linear solve, matrix inverse, determinant, pseudoinverse, matrix exponential,
@@ -220,7 +222,7 @@ pub use primal::*;
 pub use result_types::*;
 pub use rrules::*;
 #[doc(inline)]
-pub use tenferro_linalg_prims::{LinalgCapabilityOp, LinalgScalar};
+pub use tenferro_linalg_prims::{KernelLinalgScalar, LinalgCapabilityOp, LinalgScalar};
 
 #[cfg(test)]
 mod tests;

--- a/tenferro-linalg/src/primal/decompositions.rs
+++ b/tenferro-linalg/src/primal/decompositions.rs
@@ -35,7 +35,7 @@ use super::*;
 /// # Errors
 ///
 /// Returns an error if the input has fewer than 2 dimensions.
-pub fn svd<T: LinalgScalar, C>(
+pub fn svd<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     options: Option<&SvdOptions>,
@@ -144,7 +144,7 @@ where
 /// # Errors
 ///
 /// Returns an error if the input has fewer than 2 dimensions.
-pub fn qr<T: LinalgScalar, C>(ctx: &mut C, tensor: &Tensor<T>) -> Result<QrResult<T>>
+pub fn qr<T: KernelLinalgScalar, C>(ctx: &mut C, tensor: &Tensor<T>) -> Result<QrResult<T>>
 where
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
@@ -182,7 +182,7 @@ where
 /// let no_pivot = lu(&mut ctx, &a, LuPivot::NoPivot).unwrap();
 /// assert!(no_pivot.p.is_none());
 /// ```
-pub fn lu<T: LinalgScalar, C>(
+pub fn lu<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     pivot: LuPivot,
@@ -271,7 +271,10 @@ where
 }
 
 /// Compute the packed LU factorization of a batched matrix.
-pub fn lu_factor<T: LinalgScalar, C>(ctx: &mut C, tensor: &Tensor<T>) -> Result<LuFactorResult<T>>
+pub fn lu_factor<T: KernelLinalgScalar, C>(
+    ctx: &mut C,
+    tensor: &Tensor<T>,
+) -> Result<LuFactorResult<T>>
 where
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
@@ -284,7 +287,7 @@ where
 }
 
 /// Compute the packed LU factorization with numerical status information.
-pub fn lu_factor_ex<T: LinalgScalar, C>(
+pub fn lu_factor_ex<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
 ) -> Result<LuFactorExResult<T>>
@@ -296,14 +299,14 @@ where
 }
 
 /// Solve `A x = b` from a packed LU factorization.
-pub fn lu_solve<T: LinalgScalar, C>(
+pub fn lu_solve<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     factors: &Tensor<T>,
     pivots: &[usize],
     b: &Tensor<T>,
 ) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -314,7 +317,10 @@ where
 /// Compute the eigendecomposition of a batched square matrix.
 ///
 /// Input shape: `(n, n, *)`.
-pub fn eigen<T: LinalgScalar, C>(ctx: &mut C, tensor: &Tensor<T>) -> Result<EigenResult<T, T::Real>>
+pub fn eigen<T: KernelLinalgScalar, C>(
+    ctx: &mut C,
+    tensor: &Tensor<T>,
+) -> Result<EigenResult<T, T::Real>>
 where
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,

--- a/tenferro-linalg/src/primal/least_squares.rs
+++ b/tenferro-linalg/src/primal/least_squares.rs
@@ -1,13 +1,13 @@
 use super::*;
 
 /// Solve the least squares problem: `x = argmin ||Ax - b||²`.
-pub fn lstsq<T: LinalgScalar, C>(
+pub fn lstsq<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
 ) -> Result<LstsqResult<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -80,7 +80,7 @@ where
 }
 
 /// Compute the Cholesky decomposition of a Hermitian positive-definite matrix.
-pub fn cholesky<T: LinalgScalar, C>(ctx: &mut C, tensor: &Tensor<T>) -> Result<Tensor<T>>
+pub fn cholesky<T: KernelLinalgScalar, C>(ctx: &mut C, tensor: &Tensor<T>) -> Result<Tensor<T>>
 where
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
@@ -89,12 +89,12 @@ where
 }
 
 /// Compute the Cholesky decomposition with numerical status information.
-pub fn cholesky_ex<T: LinalgScalar, C>(
+pub fn cholesky_ex<T: KernelLinalgScalar, C>(
     _ctx: &mut C,
     tensor: &Tensor<T>,
 ) -> Result<CholeskyExResult<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/primal/linear_systems.rs
+++ b/tenferro-linalg/src/primal/linear_systems.rs
@@ -1,7 +1,11 @@
 use super::*;
 
 /// Solve a square linear system `A x = b`.
-pub fn solve<T: LinalgScalar, C>(ctx: &mut C, a: &Tensor<T>, b: &Tensor<T>) -> Result<Tensor<T>>
+pub fn solve<T: KernelLinalgScalar, C>(
+    ctx: &mut C,
+    a: &Tensor<T>,
+    b: &Tensor<T>,
+) -> Result<Tensor<T>>
 where
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
@@ -10,13 +14,13 @@ where
 }
 
 /// Solve a square linear system with numerical status information.
-pub fn solve_ex<T: LinalgScalar, C>(
+pub fn solve_ex<T: KernelLinalgScalar, C>(
     _ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
 ) -> Result<SolveExResult<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -57,9 +61,9 @@ where
 }
 
 /// Compute the inverse of a square matrix.
-pub fn inv<T: LinalgScalar, C>(_ctx: &mut C, tensor: &Tensor<T>) -> Result<Tensor<T>>
+pub fn inv<T: KernelLinalgScalar, C>(_ctx: &mut C, tensor: &Tensor<T>) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -91,9 +95,9 @@ where
 }
 
 /// Compute the inverse with numerical status information.
-pub fn inv_ex<T: LinalgScalar, C>(ctx: &mut C, tensor: &Tensor<T>) -> Result<InvExResult<T>>
+pub fn inv_ex<T: KernelLinalgScalar, C>(ctx: &mut C, tensor: &Tensor<T>) -> Result<InvExResult<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -113,12 +117,12 @@ where
 }
 
 /// Compute the determinant of a square matrix.
-pub fn det<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn det<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     _ctx: &mut C,
     tensor: &Tensor<T>,
 ) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -181,12 +185,12 @@ where
 }
 
 /// Compute sign and log-absolute-determinant of a square matrix.
-pub fn slogdet<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn slogdet<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     _ctx: &mut C,
     tensor: &Tensor<T>,
 ) -> Result<SlogdetResult<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/primal/matrix_functions.rs
+++ b/tenferro-linalg/src/primal/matrix_functions.rs
@@ -1,13 +1,13 @@
 use super::*;
 
 /// Raise a square matrix to an integer power.
-pub fn matrix_power<T: LinalgScalar, C>(
+pub fn matrix_power<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     exponent: i64,
 ) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/primal/norms.rs
+++ b/tenferro-linalg/src/primal/norms.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Solve a triangular linear system `A x = b`.
-pub fn solve_triangular<T: LinalgScalar, C>(
+pub fn solve_triangular<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
@@ -15,13 +15,13 @@ where
 }
 
 /// Compute a norm.
-pub fn norm<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn norm<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     kind: NormKind,
 ) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -166,13 +166,13 @@ where
 }
 
 /// Compute the matrix condition number with a selected norm convention.
-pub fn cond<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn cond<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     kind: NormKind,
 ) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/primal/spectral.rs
+++ b/tenferro-linalg/src/primal/spectral.rs
@@ -1,7 +1,10 @@
 use super::*;
 
 /// Compute the eigendecomposition of a general (non-symmetric) square matrix.
-pub fn eig<T: LinalgScalar<Real = T, Complex = num_complex::Complex<T>> + num_traits::Float, C>(
+pub fn eig<
+    T: KernelLinalgScalar<Real = T, Complex = num_complex::Complex<T>> + num_traits::Float,
+    C,
+>(
     ctx: &mut C,
     tensor: &Tensor<T>,
 ) -> Result<EigResult<T>>
@@ -16,7 +19,7 @@ where
     })
 }
 
-pub(crate) fn require_linalg_support<T: LinalgScalar, C>(
+pub(crate) fn require_linalg_support<T: KernelLinalgScalar, C>(
     capability: backend::LinalgCapabilityOp,
     op: &str,
 ) -> Result<()>
@@ -34,13 +37,13 @@ where
 }
 
 /// Compute the Moore-Penrose pseudoinverse of a matrix.
-pub fn pinv<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn pinv<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     rcond: Option<f64>,
 ) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -102,9 +105,9 @@ where
 }
 
 /// Compute the matrix exponential `exp(A)` of a square matrix.
-pub fn matrix_exp<T: LinalgScalar, C>(ctx: &mut C, tensor: &Tensor<T>) -> Result<Tensor<T>>
+pub fn matrix_exp<T: KernelLinalgScalar, C>(ctx: &mut C, tensor: &Tensor<T>) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/primal/tensor_ops.rs
+++ b/tenferro-linalg/src/primal/tensor_ops.rs
@@ -1,7 +1,11 @@
 use super::*;
 
 /// Compute the cross product along the leading vector axis.
-pub fn cross<T: LinalgScalar, C>(_ctx: &mut C, a: &Tensor<T>, b: &Tensor<T>) -> Result<Tensor<T>>
+pub fn cross<T: KernelLinalgScalar, C>(
+    _ctx: &mut C,
+    a: &Tensor<T>,
+    b: &Tensor<T>,
+) -> Result<Tensor<T>>
 where
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
@@ -92,7 +96,7 @@ where
 }
 
 /// Form the explicit product of Householder reflectors.
-pub fn householder_product<T: LinalgScalar, C>(
+pub fn householder_product<T: KernelLinalgScalar, C>(
     _ctx: &mut C,
     a: &Tensor<T>,
     tau: &Tensor<T>,
@@ -177,7 +181,7 @@ where
 }
 
 /// Build a Vandermonde matrix from leading-dimension vectors.
-pub fn vander<T: LinalgScalar, C>(
+pub fn vander<T: KernelLinalgScalar, C>(
     _ctx: &mut C,
     x: &Tensor<T>,
     columns: Option<usize>,
@@ -230,13 +234,13 @@ where
 }
 
 /// Invert a tensorized square operator.
-pub fn tensorinv<T: LinalgScalar, C>(
+pub fn tensorinv<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     ind: usize,
 ) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -272,14 +276,14 @@ where
 }
 
 /// Solve a tensorized linear system.
-pub fn tensorsolve<T: LinalgScalar, C>(
+pub fn tensorsolve<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
     dims: Option<&[usize]>,
 ) -> Result<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/rrules/least_squares.rs
+++ b/tenferro-linalg/src/rrules/least_squares.rs
@@ -21,14 +21,14 @@ use super::*;
 /// let grad = lstsq_rrule(&mut ctx, &a, &b, &dx).unwrap();
 /// // grad.a: cotangent for A, grad.b: cotangent for b
 /// ```
-pub fn lstsq_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn lstsq_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
     cotangent_x: &Tensor<T>,
 ) -> AdResult<LstsqGrad<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -105,13 +105,13 @@ where
 /// let cotangent = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let grad_a = cholesky_rrule(&mut ctx, &a, &cotangent).unwrap();
 /// ```
-pub fn cholesky_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn cholesky_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &Tensor<T>,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/rrules/linear_systems.rs
+++ b/tenferro-linalg/src/rrules/linear_systems.rs
@@ -20,14 +20,14 @@ use super::*;
 /// let cotangent = Tensor::<f64>::ones(&[3], mem, col);
 /// let grad = solve_rrule(&mut ctx, &a, &b, &cotangent).unwrap();
 /// ```
-pub fn solve_rrule<T: LinalgScalar, C>(
+pub fn solve_rrule<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
     cotangent: &Tensor<T>,
 ) -> AdResult<SolveGrad<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -84,7 +84,7 @@ where
 /// - `G = A^{-H} x̄` solved with conjugate-transposed triangular structure
 /// - `b̄ = G`
 /// - `Ā = proj(-G x^H)` where `proj = triu` for upper, `tril` for lower
-pub fn solve_triangular_rrule<T: LinalgScalar, C>(
+pub fn solve_triangular_rrule<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
@@ -92,7 +92,7 @@ pub fn solve_triangular_rrule<T: LinalgScalar, C>(
     upper: bool,
 ) -> AdResult<SolveGrad<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -170,13 +170,13 @@ where
 /// let cotangent = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let grad_a = inv_rrule(&mut ctx, &a, &cotangent).unwrap();
 /// ```
-pub fn inv_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn inv_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &Tensor<T>,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -230,13 +230,13 @@ where
 /// let cotangent = Tensor::<f64>::ones(&[], mem, col);
 /// let grad_a = det_rrule(&mut ctx, &a, &cotangent).unwrap();
 /// ```
-pub fn det_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn det_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &Tensor<T>,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -296,13 +296,13 @@ where
 /// };
 /// let grad_a = slogdet_rrule(&mut ctx, &a, &cotangent).unwrap();
 /// ```
-pub fn slogdet_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn slogdet_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &SlogdetCotangent<T>,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/rrules/lu_eigen.rs
+++ b/tenferro-linalg/src/rrules/lu_eigen.rs
@@ -23,14 +23,14 @@ use super::*;
 /// };
 /// let grad_a = lu_rrule(&mut ctx, &a, &cotangent, LuPivot::Partial).unwrap();
 /// ```
-pub fn lu_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn lu_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &LuCotangent<T>,
     pivot: LuPivot,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -247,13 +247,13 @@ where
 /// };
 /// let grad_a = eigen_rrule(&mut ctx, &a, &cotangent).unwrap();
 /// ```
-pub fn eigen_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn eigen_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &EigenCotangent<T>,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/rrules/matrix_functions.rs
+++ b/tenferro-linalg/src/rrules/matrix_functions.rs
@@ -25,13 +25,13 @@ use super::*;
 /// let cotangent = Tensor::<f64>::ones(&[3, 3], mem, col);
 /// let grad_a = matrix_exp_rrule(&mut ctx, &a, &cotangent).unwrap();
 /// ```
-pub fn matrix_exp_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn matrix_exp_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &Tensor<T>,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/rrules/norms.rs
+++ b/tenferro-linalg/src/rrules/norms.rs
@@ -17,14 +17,14 @@ use super::*;
 /// let cotangent = Tensor::<f64>::ones(&[], mem, col);
 /// let grad_a = norm_rrule(&mut ctx, &a, &cotangent, NormKind::Fro).unwrap();
 /// ```
-pub fn norm_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn norm_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &Tensor<T>,
     kind: NormKind,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/rrules/spectral.rs
+++ b/tenferro-linalg/src/rrules/spectral.rs
@@ -29,7 +29,7 @@ use super::*;
 /// let grad_a = eig_rrule(&mut ctx, &a, &cotangent).unwrap();
 /// ```
 pub fn eig_rrule<
-    T: LinalgScalar<Real = T, Complex = num_complex::Complex<T>> + num_traits::Float,
+    T: KernelLinalgScalar<Real = T, Complex = num_complex::Complex<T>> + num_traits::Float,
     C,
 >(
     ctx: &mut C,
@@ -37,7 +37,7 @@ pub fn eig_rrule<
     cotangent: &EigCotangent<T>,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -122,14 +122,14 @@ where
 /// let cotangent = Tensor::<f64>::ones(&[4, 3], mem, col);
 /// let grad_a = pinv_rrule(&mut ctx, &a, &cotangent, None).unwrap();
 /// ```
-pub fn pinv_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn pinv_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &Tensor<T>,
     rcond: Option<f64>,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/rrules/svd_qr.rs
+++ b/tenferro-linalg/src/rrules/svd_qr.rs
@@ -25,14 +25,14 @@ use super::*;
 /// };
 /// let grad_a = svd_rrule(&mut ctx, &a, &cotangent, None).unwrap();
 /// ```
-pub fn svd_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn svd_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &SvdCotangent<T>,
     options: Option<&SvdOptions>,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {
@@ -226,13 +226,13 @@ where
 /// };
 /// let grad_a = qr_rrule(&mut ctx, &a, &cotangent).unwrap();
 /// ```
-pub fn qr_rrule<T: LinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn qr_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &QrCotangent<T>,
 ) -> AdResult<Tensor<T>>
 where
-    T: backend::CpuLinalgScalar,
+    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro-linalg/src/tests/runtime_capability.rs
+++ b/tenferro-linalg/src/tests/runtime_capability.rs
@@ -33,3 +33,25 @@ fn cpu_only_kernel_paths_fail_through_capability_not_backend_name() {
         "primal linalg paths should not identify unsupported runtimes through direct backend type checks"
     );
 }
+
+#[test]
+fn public_linalg_layers_do_not_spell_cpu_scalar_contracts() {
+    let public_layers = [
+        "src/lib.rs",
+        "src/primal/mod.rs",
+        "src/frules/mod.rs",
+        "src/rrules/mod.rs",
+        "src/ad_helpers/mod.rs",
+        "src/backend/tensor_api.rs",
+        "src/backend/tensor_context.rs",
+    ]
+    .into_iter()
+    .map(repo_file)
+    .collect::<Vec<_>>()
+    .join("\n");
+
+    assert!(
+        !public_layers.contains("CpuLinalgScalar"),
+        "public linalg layers should depend on backend-generic kernel scalar contracts rather than CPU-specific scalar names"
+    );
+}


### PR DESCRIPTION
## Summary
- replace public and runtime-facing `CpuLinalgScalar` bounds with backend-generic `KernelLinalgScalar`
- keep LAPACK eig helpers isolated behind `LapackEigScalar` and document the split
- add regression tests and docs updates so CPU-specific scalar names do not leak back into active layers

## Verification
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py --doc-root /tmp/tenferro-refactor-remove-cpu-linalg-leakage-doc-target/doc`

Generated with [Claude Code](https://claude.com/claude-code)