### PR TITLE
Fix integer overflow in Tensor::narrow offset calculation

### DIFF
--- a/tenferro-tensor/src/tensor/views.rs
+++ b/tenferro-tensor/src/tensor/views.rs
@@ -262,7 +262,14 @@ impl<T: Scalar> Tensor<T> {
             )));
         }
 
-        let offset = self.offset + start as isize * self.strides[dim];
+        let offset = (start as isize)
+            .checked_mul(self.strides[dim])
+            .and_then(|delta| self.offset.checked_add(delta))
+            .ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "narrow offset overflow for start {start} in dimension {dim}"
+                ))
+            })?;
         let mut new_dims = self.dims.to_vec();
         new_dims[dim] = length;
         Ok(self.shared_view_with(Arc::from(new_dims), self.strides.clone(), offset))


### PR DESCRIPTION
## Summary

- Fix integer overflow vulnerability in `Tensor::narrow()` by using checked arithmetic
- The fix follows the same pattern already used in `Tensor::select()` (lines 223-230)
- Prevents panics in debug mode and silent wraparound in release mode that could lead to memory safety issues

## Details

The `narrow` function was calculating offset without using checked arithmetic:

```rust
let offset = self.offset + start as isize * self.strides[dim];
```

This has been updated to use checked arithmetic with proper error handling:

```rust
let offset = (start as isize)
    .checked_mul(self.strides[dim])
    .and_then(|delta| self.offset.checked_add(delta))
    .ok_or_else(|| {
        Error::InvalidArgument(format!(
            "narrow offset overflow for start {start} in dimension {dim}"
        ))
    })?;
```

Fixes #460

Generated with [Claude Code](https://claude.ai/claude-code)