### PR TITLE
fix: harden buffer pool initialization and batch offsets

### DIFF
--- a/tenferro-capi/src/tests/mod.rs
+++ b/tenferro-capi/src/tests/mod.rs
@@ -23,6 +23,15 @@ unsafe extern "C" fn import_fixture_deleter(managed: *mut DLManagedTensorVersion
     fixture.calls.fetch_add(1, Ordering::SeqCst);
 }
 
+unsafe extern "C" fn boxed_i64_slice_deleter(managed: *mut DLManagedTensorVersioned) {
+    let managed = unsafe { Box::from_raw(managed) };
+    if !managed.manager_ctx.is_null() {
+        unsafe {
+            drop(Box::from_raw(managed.manager_ctx as *mut [i64; 1]));
+        }
+    }
+}
+
 fn import_fixture_managed(
     device_type: i32,
     device_id: i32,
@@ -63,6 +72,20 @@ fn import_fixture_managed(
     }));
 
     (managed, calls)
+}
+
+fn import_fixture_with_tensor(
+    dl_tensor: DLTensor,
+    deleter: Option<unsafe extern "C" fn(*mut DLManagedTensorVersioned)>,
+    manager_ctx: *mut c_void,
+) -> *mut DLManagedTensorVersioned {
+    Box::into_raw(Box::new(DLManagedTensorVersioned {
+        version: DLPackVersion { major: 1, minor: 0 },
+        manager_ctx,
+        deleter,
+        flags: 0,
+        dl_tensor,
+    }))
 }
 
 #[test]
@@ -138,4 +161,96 @@ fn dlpack_import_rejects_unsupported_device_and_consumes_input() {
     assert!(handle.is_null());
     assert_eq!(status, TFE_INVALID_ARGUMENT);
     assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn dlpack_export_rejects_null_tensor_pointer() {
+    let mut status = TFE_INTERNAL_ERROR;
+    let managed = unsafe { tfe_tensor_f64_to_dlpack(std::ptr::null_mut(), &mut status) };
+    assert!(managed.is_null());
+    assert_eq!(status, TFE_INVALID_ARGUMENT);
+}
+
+#[test]
+fn dlpack_import_rejects_negative_ndim() {
+    let managed = import_fixture_with_tensor(
+        DLTensor {
+            data: std::ptr::dangling_mut::<f64>() as *mut c_void,
+            device: DLDevice {
+                device_type: KDLCPU,
+                device_id: 0,
+            },
+            ndim: -1,
+            dtype: DLDataType {
+                code: KDLFLOAT,
+                bits: 64,
+                lanes: 1,
+            },
+            shape: std::ptr::null_mut(),
+            strides: std::ptr::null_mut(),
+            byte_offset: 0,
+        },
+        None,
+        std::ptr::null_mut(),
+    );
+
+    let mut status = TFE_INTERNAL_ERROR;
+    let handle = unsafe { tfe_tensor_f64_from_dlpack(managed, &mut status) };
+    assert!(handle.is_null());
+    assert_eq!(status, TFE_INVALID_ARGUMENT);
+}
+
+#[test]
+fn dlpack_import_rejects_null_shape_and_null_data_for_non_empty_tensor() {
+    let managed_missing_shape = import_fixture_with_tensor(
+        DLTensor {
+            data: std::ptr::dangling_mut::<f64>() as *mut c_void,
+            device: DLDevice {
+                device_type: KDLCPU,
+                device_id: 0,
+            },
+            ndim: 1,
+            dtype: DLDataType {
+                code: KDLFLOAT,
+                bits: 64,
+                lanes: 1,
+            },
+            shape: std::ptr::null_mut(),
+            strides: std::ptr::null_mut(),
+            byte_offset: 0,
+        },
+        None,
+        std::ptr::null_mut(),
+    );
+
+    let mut status = TFE_INTERNAL_ERROR;
+    let handle = unsafe { tfe_tensor_f64_from_dlpack(managed_missing_shape, &mut status) };
+    assert!(handle.is_null());
+    assert_eq!(status, TFE_INVALID_ARGUMENT);
+
+    let mut shape = Box::new([1_i64]);
+    let managed_missing_data = import_fixture_with_tensor(
+        DLTensor {
+            data: std::ptr::null_mut(),
+            device: DLDevice {
+                device_type: KDLCPU,
+                device_id: 0,
+            },
+            ndim: 1,
+            dtype: DLDataType {
+                code: KDLFLOAT,
+                bits: 64,
+                lanes: 1,
+            },
+            shape: shape.as_mut_ptr(),
+            strides: std::ptr::null_mut(),
+            byte_offset: 0,
+        },
+        Some(boxed_i64_slice_deleter),
+        Box::into_raw(shape) as *mut c_void,
+    );
+
+    let handle = unsafe { tfe_tensor_f64_from_dlpack(managed_missing_data, &mut status) };
+    assert!(handle.is_null());
+    assert_eq!(status, TFE_INVALID_ARGUMENT);
 }

--- a/tenferro-einsum/src/pool.rs
+++ b/tenferro-einsum/src/pool.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use tenferro_algebra::Scalar;
+
 const MAX_POOLED_BYTES: usize = 64 * 1024 * 1024; // 64 MB
 
 /// Typed buffer pool using BTreeMap for O(log n) best-fit allocation.
@@ -9,7 +11,7 @@ pub(crate) struct BufferPool<T> {
     total_bytes: usize,
 }
 
-impl<T> BufferPool<T> {
+impl<T: Scalar> BufferPool<T> {
     pub fn new() -> Self {
         Self {
             buffers: BTreeMap::new(),
@@ -17,9 +19,7 @@ impl<T> BufferPool<T> {
         }
     }
 
-    /// Take a buffer of at least `len` elements from the pool.
-    /// Returns an uninitialized buffer (caller must fill before reading).
-    #[allow(clippy::uninit_vec)]
+    /// Take a zero-initialized buffer of at least `len` elements from the pool.
     pub fn take(&mut self, len: usize) -> Vec<T> {
         // Find smallest buffer with capacity >= len
         let mut found_cap = None;
@@ -35,13 +35,10 @@ impl<T> BufferPool<T> {
                 self.buffers.remove(&cap);
             }
             self.total_bytes -= cap * std::mem::size_of::<T>();
-            // Safety: capacity >= len; caller writes all elements before reading.
-            unsafe { buf.set_len(len) };
+            buf.resize(len, T::zero());
             return buf;
         }
-        let mut buf = Vec::with_capacity(len);
-        unsafe { buf.set_len(len) };
-        buf
+        vec![T::zero(); len]
     }
 
     /// Return a buffer to the pool for reuse.
@@ -57,7 +54,7 @@ impl<T> BufferPool<T> {
     }
 }
 
-impl<T> Default for BufferPool<T> {
+impl<T: Scalar> Default for BufferPool<T> {
     fn default() -> Self {
         Self::new()
     }

--- a/tenferro-einsum/src/pool/tests/mod.rs
+++ b/tenferro-einsum/src/pool/tests/mod.rs
@@ -6,17 +6,20 @@ fn take_returns_correct_length() {
     let buf = pool.take(100);
     assert_eq!(buf.len(), 100);
     assert!(buf.capacity() >= 100);
+    assert!(buf.iter().all(|&x| x == 0.0));
 }
 
 #[test]
 fn return_and_reuse() {
     let mut pool = BufferPool::<f64>::new();
-    let buf = pool.take(100);
+    let mut buf = pool.take(100);
+    buf.fill(7.0);
     let ptr = buf.as_ptr();
     pool.return_buf(buf);
     let buf2 = pool.take(50);
     assert_eq!(buf2.as_ptr(), ptr);
     assert_eq!(buf2.len(), 50);
+    assert!(buf2.iter().all(|&x| x == 0.0));
 }
 
 #[test]

--- a/tenferro-prims/src/cpu/batched_gemm.rs
+++ b/tenferro-prims/src/cpu/batched_gemm.rs
@@ -8,7 +8,7 @@ use crate::typed_dispatch::{
 };
 
 use super::context::CpuContext;
-use super::gemm_support::batch_offset;
+use super::gemm_support::{advance_batch_offset, batch_iteration_count, batch_offset};
 
 #[cfg(feature = "gemm-faer")]
 use super::gemm_support::FaerGemm;
@@ -130,7 +130,7 @@ pub(super) fn execute_batched_gemm_contiguous<T: Scalar + 'static>(
         let a_fused = try_fuse_group(batch_dims, a_batch);
         let b_fused = try_fuse_group(batch_dims, b_batch);
         let c_fused = try_fuse_group(batch_dims, c_batch);
-        let total: usize = batch_dims.iter().product();
+        let total = batch_iteration_count(batch_dims)?;
 
         if let (Some((_, a_step)), Some((_, b_step)), Some((_, c_step))) =
             (a_fused, b_fused, c_fused)
@@ -143,16 +143,28 @@ pub(super) fn execute_batched_gemm_contiguous<T: Scalar + 'static>(
                     result = Err(e);
                     break;
                 }
-                a_off += a_step;
-                b_off += b_step;
-                c_off += c_step;
+                match (
+                    advance_batch_offset(a_off, a_step),
+                    advance_batch_offset(b_off, b_step),
+                    advance_batch_offset(c_off, c_step),
+                ) {
+                    (Ok(next_a), Ok(next_b), Ok(next_c)) => {
+                        a_off = next_a;
+                        b_off = next_b;
+                        c_off = next_c;
+                    }
+                    _ => {
+                        result = Err(Error::InvalidArgument("batch offset overflow".into()));
+                        break;
+                    }
+                }
             }
         } else {
             let mut idx = vec![0usize; nb];
             for flat in 0..total {
-                let a_off = batch_offset(flat, &idx, a_fused, a_batch);
-                let b_off = batch_offset(flat, &idx, b_fused, b_batch);
-                let c_off = batch_offset(flat, &idx, c_fused, c_batch);
+                let a_off = batch_offset(flat, &idx, a_fused, a_batch)?;
+                let b_off = batch_offset(flat, &idx, b_fused, b_batch)?;
+                let c_off = batch_offset(flat, &idx, c_fused, c_batch)?;
                 if let Err(e) = do_batch(a_off, b_off, c_off, &mut a_mat, &mut b_mat, &mut c_mat) {
                     result = Err(e);
                     break;
@@ -237,7 +249,7 @@ pub(super) fn execute_batched_gemm_strided<T: FaerGemm>(
         let a_fused = try_fuse_group(batch_dims, a_batch);
         let b_fused = try_fuse_group(batch_dims, b_batch);
         let c_fused = try_fuse_group(batch_dims, c_batch);
-        let total: usize = batch_dims.iter().product();
+        let total = batch_iteration_count(batch_dims)?;
 
         if let (Some((_, a_step)), Some((_, b_step)), Some((_, c_step))) =
             (a_fused, b_fused, c_fused)
@@ -247,16 +259,16 @@ pub(super) fn execute_batched_gemm_strided<T: FaerGemm>(
             let mut c_off = 0isize;
             for _ in 0..total {
                 do_batch(a_off, b_off, c_off);
-                a_off += a_step;
-                b_off += b_step;
-                c_off += c_step;
+                a_off = advance_batch_offset(a_off, a_step)?;
+                b_off = advance_batch_offset(b_off, b_step)?;
+                c_off = advance_batch_offset(c_off, c_step)?;
             }
         } else {
             let mut idx = vec![0usize; nb];
             for flat in 0..total {
-                let a_off = batch_offset(flat, &idx, a_fused, a_batch);
-                let b_off = batch_offset(flat, &idx, b_fused, b_batch);
-                let c_off = batch_offset(flat, &idx, c_fused, c_batch);
+                let a_off = batch_offset(flat, &idx, a_fused, a_batch)?;
+                let b_off = batch_offset(flat, &idx, b_fused, b_batch)?;
+                let c_off = batch_offset(flat, &idx, c_fused, c_batch)?;
                 do_batch(a_off, b_off, c_off);
 
                 if flat + 1 < total {

--- a/tenferro-prims/src/cpu/gemm_support.rs
+++ b/tenferro-prims/src/cpu/gemm_support.rs
@@ -1,6 +1,5 @@
 use num_complex::{Complex32, Complex64};
 use tenferro_algebra::Scalar;
-#[cfg(feature = "gemm-blas")]
 use tenferro_device::{Error, Result};
 
 /// Trait for types that support strided GEMM via faer (zero-copy, zero-allocation).
@@ -115,15 +114,42 @@ pub(super) fn batch_offset(
     idx: &[usize],
     fused: Option<(usize, isize)>,
     batch_strides: &[isize],
-) -> isize {
+) -> Result<isize> {
     if let Some((_, step)) = fused {
-        flat as isize * step
+        checked_mul_offset(flat, step)
     } else {
         idx.iter()
             .zip(batch_strides)
-            .map(|(&i, &s)| i as isize * s)
-            .sum()
+            .try_fold(0isize, |acc, (&i, &s)| {
+                let term = checked_mul_offset(i, s)?;
+                acc.checked_add(term)
+                    .ok_or_else(|| Error::InvalidArgument("batch offset overflow".into()))
+            })
     }
+}
+
+#[inline]
+pub(super) fn advance_batch_offset(offset: isize, step: isize) -> Result<isize> {
+    offset
+        .checked_add(step)
+        .ok_or_else(|| Error::InvalidArgument("batch offset overflow".into()))
+}
+
+#[inline]
+pub(super) fn batch_iteration_count(batch_dims: &[usize]) -> Result<usize> {
+    batch_dims.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| Error::InvalidArgument("batch iteration count overflow".into()))
+    })
+}
+
+#[inline]
+fn checked_mul_offset(index: usize, stride: isize) -> Result<isize> {
+    let index = isize::try_from(index)
+        .map_err(|_| Error::InvalidArgument("batch index too large for isize".into()))?;
+    index
+        .checked_mul(stride)
+        .ok_or_else(|| Error::InvalidArgument("batch offset overflow".into()))
 }
 
 #[cfg(feature = "gemm-blas")]

--- a/tenferro-prims/src/cpu/tests/context.rs
+++ b/tenferro-prims/src/cpu/tests/context.rs
@@ -1,0 +1,41 @@
+use num_complex::Complex64;
+use tenferro_tensor::{MemoryOrder, Tensor};
+
+use super::super::context::{CpuBackend, CpuContext};
+
+// Do not delete or weaken this test: it keeps CpuContext constructor and accessor coverage tied to the public execution contract.
+#[test]
+fn cpu_context_try_new_rejects_zero_threads_and_exposes_accessors() {
+    let err = CpuContext::try_new(0)
+        .err()
+        .expect("zero-thread context should fail");
+    assert!(err.to_string().contains("num_threads >= 1"));
+
+    let mut ctx = CpuContext::try_new(2).unwrap();
+    assert_eq!(ctx.num_threads(), 2);
+    assert_eq!(ctx.thread_pool().current_num_threads(), 2);
+    ctx.plan_cache_mut().clear();
+}
+
+#[test]
+fn cpu_backend_resolve_conj_covers_both_fast_and_materializing_paths() {
+    let mut ctx = CpuContext::new(1);
+
+    let plain = Tensor::from_slice(&[1.0_f64, 2.0], &[2], MemoryOrder::ColumnMajor).unwrap();
+    let resolved_plain = CpuBackend::resolve_conj(&mut ctx, &plain);
+    assert_eq!(resolved_plain.buffer().as_slice().unwrap(), &[1.0, 2.0]);
+
+    let complex = Tensor::from_slice(
+        &[Complex64::new(1.0, 2.0), Complex64::new(-3.0, 4.0)],
+        &[2],
+        MemoryOrder::ColumnMajor,
+    )
+    .unwrap()
+    .into_conj();
+    let resolved_complex = CpuBackend::resolve_conj(&mut ctx, &complex);
+    assert!(!resolved_complex.is_conjugated());
+    assert_eq!(
+        resolved_complex.buffer().as_slice().unwrap(),
+        &[Complex64::new(1.0, -2.0), Complex64::new(-3.0, -4.0)]
+    );
+}

--- a/tenferro-prims/src/cpu/tests/gemm_support.rs
+++ b/tenferro-prims/src/cpu/tests/gemm_support.rs
@@ -1,12 +1,38 @@
 use num_complex::Complex64;
 
-use super::super::gemm_support::{batch_offset, FaerGemm};
+use super::super::gemm_support::{
+    advance_batch_offset, batch_iteration_count, batch_offset, FaerGemm,
+};
 
 // Do not delete or weaken this test: it protects the shared CPU GEMM helpers that multiple semiring execution paths rely on.
 #[test]
 fn batch_offset_handles_fused_and_strided_batches() {
-    assert_eq!(batch_offset(3, &[0, 0], Some((8, 7)), &[11, 13]), 21);
-    assert_eq!(batch_offset(0, &[2, 3], None, &[5, 11]), 43);
+    assert_eq!(
+        batch_offset(3, &[0, 0], Some((8, 7)), &[11, 13]).unwrap(),
+        21
+    );
+    assert_eq!(batch_offset(0, &[2, 3], None, &[5, 11]).unwrap(), 43);
+}
+
+#[test]
+fn batch_offset_rejects_overflow() {
+    let err = batch_offset(2, &[], Some((1, isize::MAX)), &[]).unwrap_err();
+    assert!(err.to_string().contains("batch offset overflow"));
+
+    let err = batch_offset(0, &[usize::MAX], None, &[2]).unwrap_err();
+    assert!(err.to_string().contains("batch index too large"));
+}
+
+#[test]
+fn advance_batch_offset_rejects_overflow() {
+    let err = advance_batch_offset(isize::MAX, 1).unwrap_err();
+    assert!(err.to_string().contains("batch offset overflow"));
+}
+
+#[test]
+fn batch_iteration_count_rejects_overflow() {
+    let err = batch_iteration_count(&[usize::MAX, 2]).unwrap_err();
+    assert!(err.to_string().contains("batch iteration count overflow"));
 }
 
 #[test]

--- a/tenferro-prims/src/cpu/tests/mod.rs
+++ b/tenferro-prims/src/cpu/tests/mod.rs
@@ -1,3 +1,4 @@
+mod context;
 mod organization;
 
 #[cfg(feature = "gemm-faer")]


### PR DESCRIPTION
## Summary
- make `tenferro-einsum` buffer pool return zero-initialized buffers instead of exposing an implicit uninitialized contract
- harden CPU batched GEMM batch-offset math with checked multiplication, checked accumulation, and checked batch iteration counts
- add focused tests that lock in the new hardening behavior and keep coverage green

Closes #462
Closes #471

Generated with [Claude Code](https://claude.com/claude-code)
