### PR TITLE
Add tensor placement frontend APIs

### DIFF
--- a/docs/api_index.md
+++ b/docs/api_index.md
@@ -224,8 +224,11 @@ object; rank-0 tensors act as scalar coefficients, and diagonal or
 multi-equivalence-class layouts are created through frontend methods such as
 `Tensor::diag`, `Tensor::diag_embed`, and `Tensor::with_axis_classes`.
 
-The crate exposes PyTorch-like eager tensor methods on top of the core typed
+The crate exposes PyTorch-like direct tensor methods on top of the core typed
 tenferro crates. Reverse entrypoints use `set_requires_grad`, `grad`, and
 `backward`, while forward-mode uses scoped `forward_ad::dual_level(...)`.
 Explicit numeric casts use `Tensor::to_scalar_type(...)`, while mixed-dtype
-ops apply implicit result-type promotion internally.
+ops apply implicit result-type promotion internally. Placement and transfer
+stay on `Tensor` through `memory_space`, `preferred_compute_device`,
+`to_memory_space`, `to_cpu`, and `to_gpu`, while explicit runtime choice stays
+under `tenferro::runtime`.

--- a/tenferro/README.upstream.md
+++ b/tenferro/README.upstream.md
@@ -13,18 +13,27 @@ This repository currently provides:
   - `RuntimeContext`
   - `set_default_runtime`
   - `with_default_runtime`
-- PyTorch-like eager methods on `Tensor`:
+- PyTorch-like direct methods on `Tensor`:
   - scalar/analytic: `exp`, `sqrt`, `sin`, `cos`, `tanh`, `add`, `pow`, `mean`, `sum`, `var`, `std`, ...
   - tensor: `einsum`
   - linalg: `svd`, `qr`, `lu`, `eigen`, `eig`, `lstsq`, `solve`, `det`, `slogdet`, ...
 
-The preferred public surface is `Tensor` plus its eager methods. Runtime
+The preferred public surface is `Tensor` plus its direct methods. Runtime
 selection uses an explicit runtime holder, reverse-mode graphs stay
 homogeneous over one runtime-typed tensor payload, and rank-0 tensors carry
 scalar AD values. Mixed-dtype tensor ops apply implicit result-type promotion
 internally (`complex` beats `real`, `64-bit` beats `32-bit`), and reverse-mode
 pullbacks cast gradients back to each input dtype. Explicit numeric casts use
 `Tensor::to_scalar_type`.
+
+Placement and transfer stay on the tensor object:
+
+- `Tensor::memory_space()`
+- `Tensor::preferred_compute_device()`
+- `Tensor::to_memory_space(...)`
+- `Tensor::to_cpu()` / `Tensor::to_gpu()`
+
+Explicit runtime choice remains separate via `tenferro::runtime::with_runtime(...)`.
 
 ```rust
 use tenferro::{set_default_runtime, RuntimeContext, Tensor};

--- a/tenferro/src/core/dynamic/dyn_ad_tensor/mod.rs
+++ b/tenferro/src/core/dynamic/dyn_ad_tensor/mod.rs
@@ -6,6 +6,7 @@ mod eager_scalar;
 mod eager_tensor;
 mod layout;
 mod merge;
+mod placement;
 mod promotion;
 mod pullback;
 mod scalar_ops;

--- a/tenferro/src/core/dynamic/dyn_ad_tensor/placement.rs
+++ b/tenferro/src/core/dynamic/dyn_ad_tensor/placement.rs
@@ -1,0 +1,222 @@
+use tenferro_device::{ComputeDevice, LogicalMemorySpace};
+
+use super::Tensor;
+use crate::Result;
+
+impl Tensor {
+    /// Returns the logical memory space holding the primal payload.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro::{LogicalMemorySpace, Tensor};
+    ///
+    /// let x = Tensor::from_slice(&[1.0_f64, 2.0], &[2]).unwrap();
+    /// assert_eq!(x.memory_space(), LogicalMemorySpace::MainMemory);
+    /// ```
+    pub fn memory_space(&self) -> LogicalMemorySpace {
+        match self {
+            Self::F32(value) => value.memory_space(),
+            Self::F64(value) => value.memory_space(),
+            Self::C32(value) => value.memory_space(),
+            Self::C64(value) => value.memory_space(),
+        }
+    }
+
+    /// Returns the preferred compute-device override for this tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro::{ComputeDevice, Tensor};
+    ///
+    /// let mut x = Tensor::from_slice(&[1.0_f64], &[1]).unwrap();
+    /// x.set_preferred_compute_device(Some(ComputeDevice::Cpu { device_id: 0 }));
+    /// assert_eq!(x.preferred_compute_device(), Some(ComputeDevice::Cpu { device_id: 0 }));
+    /// ```
+    pub fn preferred_compute_device(&self) -> Option<ComputeDevice> {
+        match self {
+            Self::F32(value) => value.preferred_compute_device(),
+            Self::F64(value) => value.preferred_compute_device(),
+            Self::C32(value) => value.preferred_compute_device(),
+            Self::C64(value) => value.preferred_compute_device(),
+        }
+    }
+
+    /// Sets the preferred compute-device override for this tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro::{ComputeDevice, Tensor};
+    ///
+    /// let mut x = Tensor::from_slice(&[1.0_f64], &[1]).unwrap();
+    /// x.set_preferred_compute_device(Some(ComputeDevice::Cpu { device_id: 0 }));
+    /// assert_eq!(x.preferred_compute_device(), Some(ComputeDevice::Cpu { device_id: 0 }));
+    /// ```
+    pub fn set_preferred_compute_device(&mut self, device: Option<ComputeDevice>) {
+        match self {
+            Self::F32(value) => value.set_preferred_compute_device(device),
+            Self::F64(value) => value.set_preferred_compute_device(device),
+            Self::C32(value) => value.set_preferred_compute_device(device),
+            Self::C64(value) => value.set_preferred_compute_device(device),
+        }
+    }
+
+    /// Asynchronously transfers this tensor to a target memory space.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro::{LogicalMemorySpace, Tensor};
+    ///
+    /// let x = Tensor::from_slice(&[1.0_f64, 2.0], &[2]).unwrap();
+    /// let y = x.to_memory_space_async(LogicalMemorySpace::MainMemory).unwrap();
+    /// assert_eq!(y.memory_space(), LogicalMemorySpace::MainMemory);
+    /// ```
+    pub fn to_memory_space_async(&self, target: LogicalMemorySpace) -> Result<Self> {
+        match self {
+            Self::F32(value) => Ok(Self::F32(value.to_memory_space_async(target)?)),
+            Self::F64(value) => Ok(Self::F64(value.to_memory_space_async(target)?)),
+            Self::C32(value) => Ok(Self::C32(value.to_memory_space_async(target)?)),
+            Self::C64(value) => Ok(Self::C64(value.to_memory_space_async(target)?)),
+        }
+    }
+
+    /// Transfers this tensor to a target memory space and waits for readiness.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro::{LogicalMemorySpace, Tensor};
+    ///
+    /// let x = Tensor::from_slice(&[1.0_f64, 2.0], &[2]).unwrap();
+    /// let y = x.to_memory_space(LogicalMemorySpace::MainMemory).unwrap();
+    /// assert_eq!(y.memory_space(), LogicalMemorySpace::MainMemory);
+    /// ```
+    pub fn to_memory_space(&self, target: LogicalMemorySpace) -> Result<Self> {
+        let moved = self.to_memory_space_async(target)?;
+        moved.wait();
+        Ok(moved)
+    }
+
+    /// Waits for pending transfers or device work associated with this tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro::Tensor;
+    ///
+    /// let x = Tensor::from_slice(&[1.0_f64], &[1]).unwrap();
+    /// x.wait();
+    /// ```
+    pub fn wait(&self) {
+        match self {
+            Self::F32(value) => value.wait(),
+            Self::F64(value) => value.wait(),
+            Self::C32(value) => value.wait(),
+            Self::C64(value) => value.wait(),
+        }
+    }
+
+    /// Returns `true` when tensor data is ready without blocking.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro::Tensor;
+    ///
+    /// let x = Tensor::from_slice(&[1.0_f64], &[1]).unwrap();
+    /// assert!(x.is_ready());
+    /// ```
+    pub fn is_ready(&self) -> bool {
+        match self {
+            Self::F32(value) => value.is_ready(),
+            Self::F64(value) => value.is_ready(),
+            Self::C32(value) => value.is_ready(),
+            Self::C64(value) => value.is_ready(),
+        }
+    }
+
+    /// Convenience wrapper for synchronous transfer to CPU-visible main memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro::{LogicalMemorySpace, Tensor};
+    ///
+    /// let x = Tensor::from_slice(&[1.0_f64], &[1]).unwrap();
+    /// let y = x.to_cpu().unwrap();
+    /// assert_eq!(y.memory_space(), LogicalMemorySpace::MainMemory);
+    /// ```
+    pub fn to_cpu(&self) -> Result<Self> {
+        self.to_memory_space(LogicalMemorySpace::MainMemory)
+    }
+
+    /// Convenience wrapper for asynchronous transfer to CPU-visible main memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro::{LogicalMemorySpace, Tensor};
+    ///
+    /// let x = Tensor::from_slice(&[1.0_f64], &[1]).unwrap();
+    /// let y = x.to_cpu_async().unwrap();
+    /// assert_eq!(y.memory_space(), LogicalMemorySpace::MainMemory);
+    /// ```
+    pub fn to_cpu_async(&self) -> Result<Self> {
+        self.to_memory_space_async(LogicalMemorySpace::MainMemory)
+    }
+
+    /// Convenience wrapper for synchronous transfer to the default GPU device.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let gpu = x.to_gpu()?;
+    /// assert_eq!(gpu.memory_space(), tenferro::LogicalMemorySpace::GpuMemory { device_id: 0 });
+    /// # Ok::<(), tenferro::Error>(())
+    /// ```
+    pub fn to_gpu(&self) -> Result<Self> {
+        self.to_gpu_on(0)
+    }
+
+    /// Convenience wrapper for asynchronous transfer to the default GPU device.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let gpu = x.to_gpu_async()?;
+    /// assert_eq!(gpu.memory_space(), tenferro::LogicalMemorySpace::GpuMemory { device_id: 0 });
+    /// # Ok::<(), tenferro::Error>(())
+    /// ```
+    pub fn to_gpu_async(&self) -> Result<Self> {
+        self.to_gpu_async_on(0)
+    }
+
+    /// Convenience wrapper for synchronous transfer to a specific GPU device.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let gpu = x.to_gpu_on(1)?;
+    /// assert_eq!(gpu.memory_space(), tenferro::LogicalMemorySpace::GpuMemory { device_id: 1 });
+    /// # Ok::<(), tenferro::Error>(())
+    /// ```
+    pub fn to_gpu_on(&self, device_id: usize) -> Result<Self> {
+        self.to_memory_space(LogicalMemorySpace::GpuMemory { device_id })
+    }
+
+    /// Convenience wrapper for asynchronous transfer to a specific GPU device.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let gpu = x.to_gpu_async_on(1)?;
+    /// assert_eq!(gpu.memory_space(), tenferro::LogicalMemorySpace::GpuMemory { device_id: 1 });
+    /// # Ok::<(), tenferro::Error>(())
+    /// ```
+    pub fn to_gpu_async_on(&self, device_id: usize) -> Result<Self> {
+        self.to_memory_space_async(LogicalMemorySpace::GpuMemory { device_id })
+    }
+}

--- a/tenferro/src/core/value/tensor.rs
+++ b/tenferro/src/core/value/tensor.rs
@@ -9,6 +9,7 @@ use crate::structured::StructuredTensor;
 use crate::{Error, Result};
 
 mod accessors;
+mod placement;
 mod reverse_api;
 
 #[derive(Clone)]

--- a/tenferro/src/core/value/tensor/placement.rs
+++ b/tenferro/src/core/value/tensor/placement.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use tenferro_algebra::Scalar;
+use tenferro_device::{ComputeDevice, LogicalMemorySpace};
+
+use super::{AdTensor, Result, TensorAdState};
+
+impl<T: Scalar> AdTensor<T> {
+    pub fn memory_space(&self) -> LogicalMemorySpace {
+        self.structured_primal().memory_space()
+    }
+
+    pub fn preferred_compute_device(&self) -> Option<ComputeDevice> {
+        self.structured_primal().preferred_compute_device()
+    }
+
+    pub fn set_preferred_compute_device(&mut self, device: Option<ComputeDevice>) {
+        match &mut self.0 {
+            TensorAdState::Primal(primal) => primal.set_preferred_compute_device(device),
+            TensorAdState::Forward { primal, tangent } => {
+                primal.set_preferred_compute_device(device);
+                tangent.set_preferred_compute_device(device);
+            }
+            TensorAdState::Reverse {
+                primal, tangent, ..
+            } => {
+                primal.set_preferred_compute_device(device);
+                if let Some(tangent) = tangent {
+                    tangent.set_preferred_compute_device(device);
+                }
+            }
+        }
+    }
+
+    pub fn to_memory_space_async(&self, target: LogicalMemorySpace) -> Result<Self> {
+        match &self.0 {
+            TensorAdState::Primal(primal) => {
+                Ok(Self::new_primal(primal.to_memory_space_async(target)?))
+            }
+            TensorAdState::Forward { primal, tangent } => Self::new_forward(
+                primal.to_memory_space_async(target)?,
+                tangent.to_memory_space_async(target)?,
+            ),
+            TensorAdState::Reverse {
+                primal,
+                tangent,
+                state,
+            } => Ok(Self(TensorAdState::Reverse {
+                primal: primal.to_memory_space_async(target)?,
+                tangent: tangent
+                    .as_ref()
+                    .map(|value| value.to_memory_space_async(target))
+                    .transpose()?,
+                state: Arc::clone(state),
+            })),
+        }
+    }
+
+    pub fn to_memory_space(&self, target: LogicalMemorySpace) -> Result<Self> {
+        let moved = self.to_memory_space_async(target)?;
+        moved.wait();
+        Ok(moved)
+    }
+
+    pub fn wait(&self) {
+        self.structured_primal().wait();
+        if let Some(tangent) = self.structured_tangent() {
+            tangent.wait();
+        }
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.structured_primal().is_ready()
+            && self
+                .structured_tangent()
+                .map(|tangent| tangent.is_ready())
+                .unwrap_or(true)
+    }
+}

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! Builder `.run()` execution is configured through [`set_default_runtime`].
 //! The primary public frontend is [`Tensor`], with rank-0 tensor scalar
-//! semantics and eager tensor methods.
+//! semantics and direct tensor methods.
 //!
 //! Module map:
 //!
@@ -49,3 +49,4 @@ pub(crate) use core::{AdTensor, AdValue, DynTensor};
 pub use error::{Error, Result};
 pub use runtime::{set_default_runtime, with_default_runtime, DefaultRuntimeGuard, RuntimeContext};
 pub use scalar_value::ScalarValue;
+pub use tenferro_device::{ComputeDevice, LogicalMemorySpace};

--- a/tenferro/src/runtime/mod.rs
+++ b/tenferro/src/runtime/mod.rs
@@ -85,6 +85,29 @@ pub fn set_default_runtime(ctx: RuntimeContext) -> DefaultRuntimeGuard {
     context::set_runtime_context(ctx)
 }
 
+/// Runs `f` with an explicitly supplied runtime installed for the duration of
+/// the closure.
+///
+/// Any previously configured default runtime is restored afterwards, even when
+/// `f` returns an error.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro::{runtime, RuntimeContext, Tensor};
+/// use tenferro_prims::CpuContext;
+///
+/// let out = runtime::with_runtime(RuntimeContext::Cpu(CpuContext::new(1)), || {
+///     let x = Tensor::from_slice(&[1.0_f64, 2.0], &[2])?;
+///     x.sum()
+/// });
+/// assert!(out.is_ok());
+/// ```
+pub fn with_runtime<R>(ctx: RuntimeContext, f: impl FnOnce() -> Result<R>) -> Result<R> {
+    let _guard = context::set_runtime_context(ctx);
+    f()
+}
+
 /// Runs `f` with the default runtime context.
 ///
 /// Returns [`crate::Error::RuntimeNotConfigured`] when runtime is not

--- a/tenferro/src/runtime/tests/mod.rs
+++ b/tenferro/src/runtime/tests/mod.rs
@@ -1,4 +1,5 @@
 mod organization;
+mod scope;
 
 use super::*;
 

--- a/tenferro/src/runtime/tests/scope.rs
+++ b/tenferro/src/runtime/tests/scope.rs
@@ -1,0 +1,40 @@
+use tenferro_prims::CpuContext;
+
+use crate::{runtime, Error, RuntimeContext, Tensor};
+
+#[test]
+fn with_runtime_installs_scope_and_restores_previous_default() {
+    assert!(matches!(
+        crate::with_default_runtime(|ctx| Ok(ctx.name())),
+        Err(Error::RuntimeNotConfigured)
+    ));
+
+    let out = runtime::with_runtime(RuntimeContext::Cpu(CpuContext::new(1)), || {
+        let x = Tensor::from_slice(&[1.0_f64, 2.0], &[2])?;
+        x.sum()
+    })
+    .unwrap();
+
+    assert_eq!(out.dims(), &[]);
+    assert!(matches!(
+        crate::with_default_runtime(|ctx| Ok(ctx.name())),
+        Err(Error::RuntimeNotConfigured)
+    ));
+}
+
+#[test]
+fn with_runtime_restores_outer_default_runtime_after_nested_scope() {
+    let _guard = crate::set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let outer_before = crate::with_default_runtime(|ctx| Ok(ctx.name())).unwrap();
+    assert_eq!(outer_before, "cpu");
+
+    let nested = runtime::with_runtime(RuntimeContext::Cpu(CpuContext::new(2)), || {
+        crate::with_default_runtime(|ctx| Ok(ctx.name()))
+    })
+    .unwrap();
+    assert_eq!(nested, "cpu");
+
+    let outer_after = crate::with_default_runtime(|ctx| Ok(ctx.name())).unwrap();
+    assert_eq!(outer_after, "cpu");
+}

--- a/tenferro/src/structured/mod.rs
+++ b/tenferro/src/structured/mod.rs
@@ -2,6 +2,7 @@ mod autodiff;
 mod einsum;
 mod layout;
 pub mod meta;
+mod placement;
 
 pub(crate) use einsum::{
     accumulate_tangent as accumulate_structured_tangent, compress_dense_to_layout_in_ctx,

--- a/tenferro/src/structured/placement.rs
+++ b/tenferro/src/structured/placement.rs
@@ -1,0 +1,41 @@
+use tenferro_algebra::Scalar;
+use tenferro_device::{ComputeDevice, LogicalMemorySpace};
+
+use super::StructuredTensor;
+use crate::{Error, Result};
+
+impl<T: Scalar> StructuredTensor<T> {
+    pub fn memory_space(&self) -> LogicalMemorySpace {
+        self.payload().logical_memory_space()
+    }
+
+    pub fn preferred_compute_device(&self) -> Option<ComputeDevice> {
+        self.payload().preferred_compute_device()
+    }
+
+    pub fn set_preferred_compute_device(&mut self, device: Option<ComputeDevice>) {
+        let mut payload = self.payload().clone();
+        payload.set_preferred_compute_device(device);
+        *self = self.with_payload_like(payload).unwrap_or_else(|err| {
+            unreachable!(
+                "StructuredTensor::set_preferred_compute_device should preserve layout: {err}"
+            )
+        });
+    }
+
+    pub fn to_memory_space_async(&self, target: LogicalMemorySpace) -> Result<Self> {
+        let payload = self
+            .payload()
+            .to_memory_space_async(target)
+            .map_err(Error::from)?;
+        self.with_payload_like(payload)
+    }
+
+    pub fn wait(&self) {
+        self.payload().wait();
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.payload().is_ready()
+    }
+}

--- a/tenferro/tests/tensor_placement_surface_tests.rs
+++ b/tenferro/tests/tensor_placement_surface_tests.rs
@@ -1,0 +1,173 @@
+use tenferro::{
+    backward, forward_ad, runtime, AdMode, BackwardOptions, ComputeDevice, LogicalMemorySpace,
+    RuntimeContext, Tensor,
+};
+use tenferro_prims::CpuContext;
+
+#[test]
+fn tensor_reports_memory_space_and_device_preference() {
+    let mut x = Tensor::from_slice(&[1.0_f64, 2.0], &[2]).unwrap();
+    assert_eq!(x.memory_space(), LogicalMemorySpace::MainMemory);
+    assert_eq!(x.preferred_compute_device(), None);
+
+    x.set_preferred_compute_device(Some(ComputeDevice::Cpu { device_id: 0 }));
+    assert_eq!(
+        x.preferred_compute_device(),
+        Some(ComputeDevice::Cpu { device_id: 0 })
+    );
+}
+
+#[test]
+fn placement_surface_covers_all_frontend_dtypes_and_gpu_sugar() {
+    let mut f32_tensor = Tensor::from_slice(&[1.0_f32, 2.0], &[2]).unwrap();
+    let mut f64_tensor = Tensor::from_slice(&[1.0_f64, 2.0], &[2]).unwrap();
+    let mut c32_tensor =
+        Tensor::from_slice(&[num_complex::Complex32::new(1.0, 0.5)], &[1]).unwrap();
+    let mut c64_tensor =
+        Tensor::from_slice(&[num_complex::Complex64::new(1.0, -0.5)], &[1]).unwrap();
+
+    for tensor in [
+        &mut f32_tensor,
+        &mut f64_tensor,
+        &mut c32_tensor,
+        &mut c64_tensor,
+    ] {
+        assert_eq!(tensor.memory_space(), LogicalMemorySpace::MainMemory);
+        tensor.set_preferred_compute_device(Some(ComputeDevice::Cpu { device_id: 0 }));
+        assert_eq!(
+            tensor.preferred_compute_device(),
+            Some(ComputeDevice::Cpu { device_id: 0 })
+        );
+
+        let sync = tensor.to_cpu().unwrap();
+        let async_copy = tensor.to_cpu_async().unwrap();
+        sync.wait();
+        async_copy.wait();
+        assert!(sync.is_ready());
+        assert!(async_copy.is_ready());
+    }
+
+    let gpu_sync = f64_tensor.to_gpu();
+    let gpu_async = f64_tensor.to_gpu_async();
+    let gpu_sync_on = f64_tensor.to_gpu_on(1);
+    let gpu_async_on = f64_tensor.to_gpu_async_on(1);
+
+    assert!(
+        matches!(
+            gpu_sync,
+            Ok(ref tensor)
+                if tensor.memory_space() == LogicalMemorySpace::GpuMemory { device_id: 0 }
+        ) || matches!(gpu_sync, Err(tenferro::Error::Backend(_)))
+    );
+    assert!(
+        matches!(
+            gpu_async,
+            Ok(ref tensor)
+                if tensor.memory_space() == LogicalMemorySpace::GpuMemory { device_id: 0 }
+        ) || matches!(gpu_async, Err(tenferro::Error::Backend(_)))
+    );
+    assert!(
+        matches!(
+            gpu_sync_on,
+            Ok(ref tensor)
+                if tensor.memory_space() == LogicalMemorySpace::GpuMemory { device_id: 1 }
+        ) || matches!(gpu_sync_on, Err(tenferro::Error::Backend(_)))
+    );
+    assert!(
+        matches!(
+            gpu_async_on,
+            Ok(ref tensor)
+                if tensor.memory_space() == LogicalMemorySpace::GpuMemory { device_id: 1 }
+        ) || matches!(gpu_async_on, Err(tenferro::Error::Backend(_)))
+    );
+}
+
+#[test]
+fn to_memory_space_preserves_forward_mode_and_tangent() {
+    let x = Tensor::from_slice(&[1.0_f64, 2.0], &[2]).unwrap();
+    let dx = Tensor::from_slice(&[0.5_f64, -0.25], &[2]).unwrap();
+
+    let (_, tangent) = forward_ad::dual_level(|fw| {
+        let dual = fw.make_dual(&x, &dx)?;
+        let moved = dual.to_memory_space(LogicalMemorySpace::MainMemory)?;
+        assert_eq!(moved.mode(), AdMode::Forward);
+        assert_eq!(moved.memory_space(), LogicalMemorySpace::MainMemory);
+        fw.unpack_dual(&moved)
+    })
+    .unwrap();
+
+    let tangent = tangent.unwrap();
+    assert_eq!(tangent.mode(), AdMode::Primal);
+    assert_eq!(tangent.dims(), &[2]);
+    assert_eq!(
+        tangent
+            .as_f64()
+            .unwrap()
+            .primal()
+            .buffer()
+            .as_slice()
+            .unwrap(),
+        &[0.5, -0.25]
+    );
+}
+
+#[test]
+fn forward_mode_device_preference_updates_primal_and_tangent() {
+    let x = Tensor::from_slice(&[1.0_f64, 2.0], &[2]).unwrap();
+    let dx = Tensor::from_slice(&[0.5_f64, -0.25], &[2]).unwrap();
+
+    let (_, tangent) = forward_ad::dual_level(|fw| {
+        let mut dual = fw.make_dual(&x, &dx)?;
+        dual.set_preferred_compute_device(Some(ComputeDevice::Cpu { device_id: 0 }));
+        assert_eq!(
+            dual.preferred_compute_device(),
+            Some(ComputeDevice::Cpu { device_id: 0 })
+        );
+        fw.unpack_dual(&dual)
+    })
+    .unwrap();
+
+    let tangent = tangent.unwrap();
+    assert_eq!(
+        tangent.preferred_compute_device(),
+        Some(ComputeDevice::Cpu { device_id: 0 })
+    );
+}
+
+#[test]
+fn to_memory_space_preserves_reverse_mode_and_grad_flow() {
+    let _guard = runtime::with_runtime(RuntimeContext::Cpu(CpuContext::new(1)), || {
+        let mut x = Tensor::from_slice(&[2.0_f64], &[])?;
+        x.set_requires_grad(true)?;
+        x.set_preferred_compute_device(Some(ComputeDevice::Cpu { device_id: 0 }));
+
+        let moved = x.to_memory_space(LogicalMemorySpace::MainMemory)?;
+        assert_eq!(moved.mode(), AdMode::Reverse);
+        assert!(moved.requires_grad());
+        assert_eq!(
+            moved.preferred_compute_device(),
+            Some(ComputeDevice::Cpu { device_id: 0 })
+        );
+
+        let out = moved.exp()?;
+        backward(&[&out], None, &[&moved], BackwardOptions::default())?;
+        assert!(moved.grad().is_some());
+        Ok::<(), tenferro::Error>(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn to_cpu_surface_and_readiness_are_available_on_tensor() {
+    let x = Tensor::from_slice(&[1.0_f64, 2.0, 3.0], &[3]).unwrap();
+
+    let sync = x.to_cpu().unwrap();
+    let async_copy = x.to_cpu_async().unwrap();
+
+    assert_eq!(sync.memory_space(), LogicalMemorySpace::MainMemory);
+    assert_eq!(async_copy.memory_space(), LogicalMemorySpace::MainMemory);
+    sync.wait();
+    async_copy.wait();
+    assert!(sync.is_ready());
+    assert!(async_copy.is_ready());
+}


### PR DESCRIPTION
## Summary
- add placement, readiness, and transfer APIs to `tenferro::Tensor`
- add `tenferro::runtime::with_runtime(...)` for scoped explicit runtime execution
- document the new cpu/gpu-oriented frontend surface and add integration coverage

## Testing
- cargo fmt --all --check
- env CARGO_TARGET_DIR=/tmp/tenferro-placement-api-release-target cargo test --workspace --release
- env CARGO_TARGET_DIR=/tmp/tenferro-placement-api-cov-target cargo llvm-cov --workspace --release --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- env CARGO_TARGET_DIR=/tmp/tenferro-placement-api-doc-target cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py --doc-root /tmp/tenferro-placement-api-doc-target/doc

Closes #509

Generated with [Claude Code](https://claude.com/claude-code)