### PR TITLE
Add ndarray interop bridge crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "extension/tenferro-tropical-capi",
     "extension/tenferro-burn",
     "extension/tenferro-mdarray",
+    "extension/tenferro-ndarray",
     "tenferro",
     # extern (general-purpose, non-tenferro)
     "extern/chainrules-core",
@@ -50,3 +51,4 @@ lapack = "0.20"
 lapack-src = "0.13"
 lapack-inject = "0.1.0"
 cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "dynamic-loading", "cuda-12000"] }
+ndarray = "0.17.2"

--- a/docs/api_index.md
+++ b/docs/api_index.md
@@ -216,6 +216,16 @@ arrays and tenferro tensors. Provides checked
 (`mdarray_to_tensor`, `tensor_to_mdarray`) conversion functions for
 bidirectional data exchange between `Array<T, DynRank>` and `Tensor<T>`.
 
+<a id="tenferro-ndarray"></a>
+### [tenferro-ndarray](tenferro_ndarray/index.html) <small>(Extension)</small>
+
+Bridge between [ndarray](https://docs.rs/ndarray) arrays and tenferro tensors.
+Provides checked (`try_ndarray_to_tensor`, `try_tensor_to_ndarray`) and
+convenience (`ndarray_to_tensor`, `tensor_to_ndarray`) conversion functions for
+bidirectional data exchange between dense `ndarray` values and
+`tenferro_tensor::Tensor<T>`. The optional `frontend` feature adds
+`try_ndarray_to_frontend(...)` for direct conversion into `tenferro::Tensor`.
+
 <a id="tenferro"></a>
 ### [tenferro](tenferro/index.html) <small>(Extension)</small>
 

--- a/extension/tenferro-ndarray/Cargo.toml
+++ b/extension/tenferro-ndarray/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tenferro-ndarray"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
+description = "Bridge between ndarray arrays and tenferro tensors."
+
+[features]
+default = []
+frontend = ["dep:tenferro"]
+
+[dependencies]
+ndarray.workspace = true
+num-complex.workspace = true
+tenferro = { path = "../../tenferro", optional = true }
+tenferro-algebra = { path = "../../tenferro-algebra" }
+tenferro-device = { path = "../../tenferro-device" }
+tenferro-tensor = { path = "../../tenferro-tensor" }

--- a/extension/tenferro-ndarray/src/lib.rs
+++ b/extension/tenferro-ndarray/src/lib.rs
@@ -1,0 +1,267 @@
+//! Bridge between [ndarray](https://docs.rs/ndarray) arrays and tenferro tensors.
+//!
+//! This crate provides typed canonical conversion helpers between generic
+//! `ndarray::ArrayBase<S, D>` inputs and [`tenferro_tensor::Tensor<T>`], plus
+//! export back to owned `ndarray::ArrayD<T>`. An optional `frontend` feature
+//! adds a convenience conversion into `tenferro::Tensor`.
+//!
+//! # Examples
+//!
+//! ```ignore
+//! use ndarray::Array2;
+//! use tenferro_ndarray::{ndarray_to_tensor, tensor_to_ndarray};
+//! use tenferro_tensor::{MemoryOrder, Tensor};
+//!
+//! let array = Array2::from_shape_vec((2, 2), vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+//! let tensor = ndarray_to_tensor(array);
+//! let roundtrip = tensor_to_ndarray(tensor);
+//! assert_eq!(roundtrip.shape(), &[2, 2]);
+//! ```
+
+use ndarray::{ArrayBase, ArrayD, Data, Dimension, IxDyn, ShapeBuilder};
+use tenferro_algebra::Scalar;
+use tenferro_device::{Error, LogicalMemorySpace, Result};
+use tenferro_tensor::{MemoryOrder, Tensor};
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "frontend")]
+mod frontend {
+    use num_complex::{Complex32, Complex64};
+
+    pub trait Sealed {}
+
+    impl Sealed for f32 {}
+    impl Sealed for f64 {}
+    impl Sealed for Complex32 {}
+    impl Sealed for Complex64 {}
+}
+
+fn shape_error(err: ndarray::ShapeError) -> Error {
+    Error::InvalidArgument(format!("ndarray layout conversion failed: {err}"))
+}
+
+fn ensure_main_memory(space: LogicalMemorySpace) -> Result<()> {
+    if space != LogicalMemorySpace::MainMemory {
+        return Err(Error::InvalidArgument(
+            "tenferro-ndarray currently supports CPU/main-memory tensors only".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn usize_strides(strides: &[isize]) -> Result<Vec<usize>> {
+    strides
+        .iter()
+        .map(|&stride| {
+            usize::try_from(stride).map_err(|_| {
+                Error::InvalidArgument(format!(
+                    "negative ndarray/tenferro stride {stride} is not supported by the bridge"
+                ))
+            })
+        })
+        .collect()
+}
+
+fn can_zero_copy_tensor_to_ndarray<T: Scalar>(tensor: &Tensor<T>) -> bool {
+    tensor.logical_memory_space() == LogicalMemorySpace::MainMemory
+        && !tensor.is_conjugated()
+        && tensor.offset() == 0
+        && tensor.buffer().is_owned()
+        && tensor.buffer().is_unique()
+        && tensor
+            .strides()
+            .iter()
+            .all(|&stride| stride > 0 || tensor.len() <= 1)
+}
+
+fn into_owned_data<T: Scalar>(tensor: Tensor<T>, context: &str) -> Result<Vec<T>> {
+    tensor
+        .try_into_data_vec()
+        .ok_or_else(|| Error::InvalidArgument(context.into()))
+}
+
+/// Fallibly converts an ndarray array into a typed tenferro tensor.
+///
+/// This is the canonical interop entry point. The bridge preserves shape,
+/// strides, and offset. Owned ndarray inputs use best-effort zero-copy by
+/// moving CPU storage into the target tensor; borrowed or shared inputs fall
+/// back to `into_owned()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ndarray::Array2;
+/// use tenferro_ndarray::try_ndarray_to_tensor;
+///
+/// let array = Array2::from_shape_vec((1, 2), vec![1.0_f64, 2.0]).unwrap();
+/// let tensor = try_ndarray_to_tensor(array).unwrap();
+/// assert_eq!(tensor.dims(), &[1, 2]);
+/// ```
+pub fn try_ndarray_to_tensor<T, S, D>(array: ArrayBase<S, D>) -> Result<Tensor<T>>
+where
+    T: Scalar + Clone,
+    S: Data<Elem = T>,
+    D: Dimension,
+{
+    let array = array.into_dyn().into_owned();
+    let dims = array.shape().to_vec();
+    let strides = array.strides().to_vec();
+    let (data, offset) = array.into_raw_vec_and_offset();
+    Tensor::from_vec(data, &dims, &strides, offset.unwrap_or(0) as isize)
+}
+
+/// Converts an owned ndarray array into a typed tenferro tensor, panicking on
+/// conversion failure.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ndarray::Array2;
+/// use tenferro_ndarray::ndarray_to_tensor;
+///
+/// let array = Array2::from_shape_vec((1, 2), vec![1.0_f64, 2.0]).unwrap();
+/// let tensor = ndarray_to_tensor(array);
+/// assert_eq!(tensor.dims(), &[1, 2]);
+/// ```
+pub fn ndarray_to_tensor<T, S, D>(array: ArrayBase<S, D>) -> Tensor<T>
+where
+    T: Scalar + Clone,
+    S: Data<Elem = T>,
+    D: Dimension,
+{
+    try_ndarray_to_tensor(array).unwrap_or_else(|err| panic!("{err}"))
+}
+
+/// Fallibly converts a typed tenferro tensor into an owned ndarray array.
+///
+/// The bridge attempts zero-copy for unique owned CPU buffers whose layout can
+/// be expressed by ndarray. Otherwise it materializes a row-major CPU copy.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_device::LogicalMemorySpace;
+/// use tenferro_ndarray::try_tensor_to_ndarray;
+/// use tenferro_tensor::{MemoryOrder, Tensor};
+///
+/// let tensor = Tensor::<f64>::zeros(&[2, 2], LogicalMemorySpace::MainMemory, MemoryOrder::RowMajor);
+/// let array = try_tensor_to_ndarray(tensor).unwrap();
+/// assert_eq!(array.shape(), &[2, 2]);
+/// ```
+pub fn try_tensor_to_ndarray<T: Scalar>(tensor: Tensor<T>) -> Result<ArrayD<T>> {
+    ensure_main_memory(tensor.logical_memory_space())?;
+
+    if can_zero_copy_tensor_to_ndarray(&tensor) {
+        let dims = tensor.dims().to_vec();
+        let strides = usize_strides(tensor.strides())?;
+        let data = into_owned_data(
+            tensor,
+            "expected unique owned CPU tensor buffer for zero-copy ndarray export",
+        )?;
+        return ArrayD::from_shape_vec(IxDyn(&dims).strides(IxDyn(&strides)), data)
+            .map_err(shape_error);
+    }
+
+    let row_major = tensor.into_contiguous(MemoryOrder::RowMajor);
+    let dims = row_major.dims().to_vec();
+    let data = into_owned_data(
+        row_major,
+        "into_contiguous(RowMajor) must yield an owned CPU buffer for ndarray export",
+    )?;
+    ArrayD::from_shape_vec(IxDyn(&dims), data).map_err(shape_error)
+}
+
+/// Converts a typed tenferro tensor into an owned ndarray array, panicking on
+/// conversion failure.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_device::LogicalMemorySpace;
+/// use tenferro_ndarray::tensor_to_ndarray;
+/// use tenferro_tensor::{MemoryOrder, Tensor};
+///
+/// let tensor = Tensor::<f64>::zeros(&[2], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
+/// let array = tensor_to_ndarray(tensor);
+/// assert_eq!(array.shape(), &[2]);
+/// ```
+pub fn tensor_to_ndarray<T: Scalar>(tensor: Tensor<T>) -> ArrayD<T> {
+    try_tensor_to_ndarray(tensor).unwrap_or_else(|err| panic!("{err}"))
+}
+
+/// Marker trait for scalar dtypes supported by the optional frontend helper.
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ndarray::Array2;
+/// use tenferro_ndarray::try_ndarray_to_frontend;
+///
+/// let array = Array2::from_shape_vec((1, 2), vec![1.0_f64, 2.0]).unwrap();
+/// let tensor = try_ndarray_to_frontend(array).unwrap();
+/// assert_eq!(tensor.dims(), &[1, 2]);
+/// ```
+#[cfg(feature = "frontend")]
+pub trait FrontendScalar: Scalar + frontend::Sealed {
+    fn into_frontend_tensor(tensor: Tensor<Self>) -> tenferro::Tensor;
+}
+
+#[cfg(feature = "frontend")]
+impl FrontendScalar for f32 {
+    fn into_frontend_tensor(tensor: Tensor<Self>) -> tenferro::Tensor {
+        tenferro::Tensor::from_tensor(tensor)
+    }
+}
+
+#[cfg(feature = "frontend")]
+impl FrontendScalar for f64 {
+    fn into_frontend_tensor(tensor: Tensor<Self>) -> tenferro::Tensor {
+        tenferro::Tensor::from_tensor(tensor)
+    }
+}
+
+#[cfg(feature = "frontend")]
+impl FrontendScalar for num_complex::Complex32 {
+    fn into_frontend_tensor(tensor: Tensor<Self>) -> tenferro::Tensor {
+        tenferro::Tensor::from_tensor(tensor)
+    }
+}
+
+#[cfg(feature = "frontend")]
+impl FrontendScalar for num_complex::Complex64 {
+    fn into_frontend_tensor(tensor: Tensor<Self>) -> tenferro::Tensor {
+        tenferro::Tensor::from_tensor(tensor)
+    }
+}
+
+/// Fallibly converts an owned ndarray array into the public `tenferro::Tensor`
+/// frontend.
+///
+/// This helper is enabled by the `frontend` feature and is intentionally thin:
+/// it converts through the canonical typed `ndarray -> tenferro_tensor::Tensor`
+/// path first.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ndarray::Array2;
+/// use tenferro_ndarray::try_ndarray_to_frontend;
+///
+/// let array = Array2::from_shape_vec((1, 2), vec![1.0_f64, 2.0]).unwrap();
+/// let tensor = try_ndarray_to_frontend(array).unwrap();
+/// assert_eq!(tensor.dims(), &[1, 2]);
+/// ```
+#[cfg(feature = "frontend")]
+pub fn try_ndarray_to_frontend<T, S, D>(array: ArrayBase<S, D>) -> Result<tenferro::Tensor>
+where
+    T: FrontendScalar + Clone,
+    S: Data<Elem = T>,
+    D: Dimension,
+{
+    let tensor = try_ndarray_to_tensor(array)?;
+    Ok(T::into_frontend_tensor(tensor))
+}

--- a/extension/tenferro-ndarray/src/tests/conversions.rs
+++ b/extension/tenferro-ndarray/src/tests/conversions.rs
@@ -1,0 +1,178 @@
+use ndarray::{Array2, ArrayD, IxDyn, ShapeBuilder};
+use num_complex::Complex64;
+use tenferro_device::{Error, LogicalMemorySpace};
+use tenferro_tensor::{MemoryOrder, Tensor};
+
+use crate::{
+    can_zero_copy_tensor_to_ndarray, ensure_main_memory, into_owned_data, ndarray_to_tensor,
+    shape_error, tensor_to_ndarray, try_ndarray_to_tensor, try_tensor_to_ndarray, usize_strides,
+};
+
+#[test]
+fn owned_ndarray_to_tensor_preserves_shape_and_values() {
+    let array = ArrayD::from_shape_vec(IxDyn(&[2, 2]), vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let tensor = try_ndarray_to_tensor(array).unwrap();
+    assert_eq!(tensor.dims(), &[2, 2]);
+    assert_eq!(tensor.buffer().as_slice().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn owned_ndarray_to_tensor_reuses_owned_buffer_when_layout_is_representable() {
+    let array = ArrayD::from_shape_vec(IxDyn(&[2, 2]), vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let ptr = array.as_ptr();
+    let tensor = try_ndarray_to_tensor(array).unwrap();
+    assert_eq!(tensor.buffer().as_slice().unwrap().as_ptr(), ptr);
+}
+
+#[test]
+fn generic_owned_ndarray_input_reuses_owned_buffer_when_layout_is_representable() {
+    let array = Array2::from_shape_vec((2, 2), vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let ptr = array.as_ptr();
+    let tensor = try_ndarray_to_tensor(array).unwrap();
+    assert_eq!(tensor.buffer().as_slice().unwrap().as_ptr(), ptr);
+}
+
+#[test]
+fn ndarray_to_tensor_wrapper_matches_checked_conversion() {
+    let array = Array2::from_shape_vec((1, 3), vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let tensor = ndarray_to_tensor(array);
+    assert_eq!(tensor.dims(), &[1, 3]);
+    assert_eq!(tensor.buffer().as_slice().unwrap(), &[1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn borrowed_ndarray_view_falls_back_to_owned_tensor_materialization() {
+    let array = Array2::from_shape_vec((2, 2), vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let view = array.view().reversed_axes();
+    let tensor = try_ndarray_to_tensor(view).unwrap();
+    let roundtrip = tensor_to_ndarray(tensor);
+    assert_eq!(roundtrip.shape(), &[2, 2]);
+    assert_eq!(roundtrip, view.into_owned().into_dyn());
+}
+
+#[test]
+fn tensor_to_ndarray_reuses_owned_cpu_buffer_when_layout_is_representable() {
+    let tensor = Tensor::from_vec(vec![1.0_f64, 2.0, 3.0, 4.0], &[2, 2], &[2, 1], 0).unwrap();
+    let ptr = tensor.buffer().as_slice().unwrap().as_ptr();
+    let array = try_tensor_to_ndarray(tensor).unwrap();
+    assert_eq!(array.as_ptr(), ptr);
+    assert_eq!(array.shape(), &[2, 2]);
+}
+
+#[test]
+fn tensor_to_ndarray_wrapper_matches_checked_conversion() {
+    let tensor = Tensor::from_slice(&[1.0_f64, 2.0, 3.0], &[3], MemoryOrder::ColumnMajor).unwrap();
+    let array = tensor_to_ndarray(tensor);
+    assert_eq!(array.shape(), &[3]);
+    assert_eq!(
+        array.iter().copied().collect::<Vec<_>>(),
+        vec![1.0, 2.0, 3.0]
+    );
+}
+
+#[test]
+fn tensor_to_ndarray_materializes_permuted_views_when_zero_copy_is_not_possible() {
+    let tensor = Tensor::from_slice(&[1.0_f64, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::ColumnMajor)
+        .unwrap()
+        .narrow(0, 1, 1)
+        .unwrap();
+
+    let array = tensor_to_ndarray(tensor);
+    assert_eq!(array.shape(), &[1, 2]);
+    assert_eq!(array.iter().copied().collect::<Vec<_>>(), vec![2.0, 4.0]);
+}
+
+#[test]
+fn usize_strides_rejects_negative_values() {
+    let err = usize_strides(&[-1]).unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(msg) if msg.contains("negative ndarray/tenferro stride -1"))
+    );
+}
+
+#[test]
+fn shape_error_wraps_ndarray_layout_failures() {
+    let source = ArrayD::from_shape_vec(
+        IxDyn(&[2, 2]).strides(IxDyn(&[1, 1])),
+        vec![1.0_f64, 2.0, 3.0],
+    )
+    .unwrap_err();
+    let err = shape_error(source);
+    assert!(
+        matches!(err, Error::InvalidArgument(msg) if msg.contains("ndarray layout conversion failed"))
+    );
+}
+
+#[test]
+fn zero_copy_helper_rejects_shared_views_and_conjugated_tensors() {
+    let shared = Tensor::from_slice(&[1.0_f64, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::ColumnMajor)
+        .unwrap()
+        .narrow(0, 1, 1)
+        .unwrap();
+    assert!(!can_zero_copy_tensor_to_ndarray(&shared));
+
+    let complex = Tensor::from_slice(
+        &[Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
+        &[2],
+        MemoryOrder::ColumnMajor,
+    )
+    .unwrap()
+    .conj();
+    assert!(!can_zero_copy_tensor_to_ndarray(&complex));
+}
+
+#[test]
+fn tensor_to_ndarray_rejects_negative_singleton_stride_layout() {
+    let tensor = Tensor::from_vec(vec![1.0_f64], &[1], &[-1], 0).unwrap();
+    let err = try_tensor_to_ndarray(tensor).unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(msg) if msg.contains("negative ndarray/tenferro stride -1"))
+    );
+}
+
+#[test]
+fn tensor_to_ndarray_reports_layout_errors_for_overlapping_zero_copy_views() {
+    let tensor = Tensor::from_vec(vec![1.0_f64, 2.0, 3.0], &[2, 2], &[1, 1], 0).unwrap();
+    let err = try_tensor_to_ndarray(tensor).unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(msg) if msg.contains("ndarray layout conversion failed"))
+    );
+}
+
+#[test]
+fn zero_copy_helper_requires_main_memory() {
+    let tensor = Tensor::<f64>::zeros(
+        &[2],
+        LogicalMemorySpace::MainMemory,
+        MemoryOrder::ColumnMajor,
+    );
+    assert!(can_zero_copy_tensor_to_ndarray(&tensor));
+}
+
+#[test]
+fn ensure_main_memory_rejects_gpu_spaces() {
+    let err = ensure_main_memory(LogicalMemorySpace::GpuMemory { device_id: 0 }).unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(msg) if msg.contains("CPU/main-memory tensors only"))
+    );
+}
+
+#[test]
+fn into_owned_data_rejects_shared_views() {
+    let data = vec![1.0_f64, 2.0, 3.0, 4.0];
+    let ptr = data.as_ptr();
+    let tensor = unsafe {
+        Tensor::from_external_parts(ptr, data.len(), &[2, 2], &[2, 1], 0, move || drop(data))
+    }
+    .unwrap();
+    let err = into_owned_data(tensor, "shared view is not owned").unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(msg) if msg.contains("shared view is not owned")));
+}
+
+#[cfg(feature = "frontend")]
+#[test]
+fn frontend_helper_builds_public_tensor() {
+    let array = ArrayD::from_shape_vec(IxDyn(&[2]), vec![1.0_f64, 2.0]).unwrap();
+    let tensor = crate::try_ndarray_to_frontend(array).unwrap();
+    assert_eq!(tensor.dims(), &[2]);
+}

--- a/extension/tenferro-ndarray/src/tests/mod.rs
+++ b/extension/tenferro-ndarray/src/tests/mod.rs
@@ -1,0 +1,2 @@
+mod conversions;
+mod organization;

--- a/extension/tenferro-ndarray/src/tests/organization.rs
+++ b/extension/tenferro-ndarray/src/tests/organization.rs
@@ -1,0 +1,25 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn ndarray_bridge_exposes_checked_conversion_helpers() {
+    let lib = fs::read_to_string(crate_root().join("src/lib.rs")).unwrap();
+    assert!(
+        lib.contains("pub fn try_ndarray_to_tensor")
+            && lib.contains("pub fn try_tensor_to_ndarray"),
+        "tenferro-ndarray should expose explicit checked conversion helpers alongside convenience wrappers",
+    );
+}
+
+#[test]
+fn ndarray_bridge_library_code_does_not_use_expect() {
+    let lib = fs::read_to_string(crate_root().join("src/lib.rs")).unwrap();
+    assert!(
+        !lib.contains(".expect("),
+        "tenferro-ndarray library code should avoid expect(...) and route fallible conversions through checked helpers",
+    );
+}


### PR DESCRIPTION
## Summary
- add `extension/tenferro-ndarray` as the canonical ndarray interop layer for typed tensors
- support best-effort zero-copy in both directions for dense CPU/primal conversions
- add an optional `frontend` helper that lifts converted typed tensors into `tenferro::Tensor`

## Testing
- cargo fmt --all --check
- env CARGO_TARGET_DIR=/tmp/tenferro-ndarray-interop-release-target cargo test --workspace --release
- env CARGO_TARGET_DIR=/tmp/tenferro-ndarray-interop-cov-target cargo llvm-cov --workspace --release --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- env CARGO_TARGET_DIR=/tmp/tenferro-ndarray-interop-doc-target cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py --doc-root /tmp/tenferro-ndarray-interop-doc-target/doc

Closes #512

Generated with [Claude Code](https://claude.com/claude-code)