### PR TITLE
feat: expand complex linalg tensor frontend

### DIFF
--- a/tenferro-linalg/src/frules/linear_systems.rs
+++ b/tenferro-linalg/src/frules/linear_systems.rs
@@ -19,7 +19,7 @@ use super::*;
 /// let db = Tensor::<f64>::ones(&[3], mem, col);
 /// let (x, dx) = solve_frule(&mut ctx, &a, &b, &da, &db).unwrap();
 /// ```
-pub fn solve_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn solve_frule<T: KernelLinalgScalar, C>(
     ctx: &mut C,
     a: &Tensor<T>,
     b: &Tensor<T>,
@@ -27,7 +27,6 @@ pub fn solve_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
     tangent_b: &Tensor<T>,
 ) -> AdResult<(Tensor<T>, Tensor<T>)>
 where
-    T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>,
     C::Backend: 'static,
 {

--- a/tenferro/src/core/dynamic/dyn_ad_tensor/eager_linalg/extra.rs
+++ b/tenferro/src/core/dynamic/dyn_ad_tensor/eager_linalg/extra.rs
@@ -1,0 +1,567 @@
+use super::{
+    same_dtype_error, CholeskyExResult, InvExResult, LuFactorExResult, LuFactorResult,
+    SolveExResult, Tensor,
+};
+use crate::{AdTensor, DynTensorTyped, Result};
+use tenferro_algebra::Scalar;
+
+fn with_dense_primal<T, R, F>(value: &AdTensor<T>, op: &'static str, f: F) -> Result<R>
+where
+    T: Scalar + DynTensorTyped + crate::runtime::contracts::LinalgRuntimeValue,
+    F: FnOnce(&tenferro_tensor::Tensor<T>) -> Result<R>,
+{
+    let dense = Tensor::dense_primal_only(value, op)?;
+    f(&dense)
+}
+
+fn with_dense_primal_pair<T, R, F>(
+    lhs: &AdTensor<T>,
+    rhs: &AdTensor<T>,
+    op: &'static str,
+    f: F,
+) -> Result<R>
+where
+    T: Scalar + DynTensorTyped + crate::runtime::contracts::LinalgRuntimeValue,
+    F: FnOnce(&tenferro_tensor::Tensor<T>, &tenferro_tensor::Tensor<T>) -> Result<R>,
+{
+    let lhs = Tensor::dense_primal_only(lhs, op)?;
+    let rhs = Tensor::dense_primal_only(rhs, op)?;
+    f(&lhs, &rhs)
+}
+
+fn map_lu_factor_result<T>(out: tenferro_linalg::LuFactorResult<T>) -> LuFactorResult
+where
+    T: Scalar + DynTensorTyped,
+    AdTensor<T>: Into<Tensor>,
+{
+    LuFactorResult {
+        factors: Tensor::from_tensor(out.factors),
+        pivots: out.pivots,
+    }
+}
+
+fn map_lu_factor_ex_result<T>(out: tenferro_linalg::LuFactorExResult<T>) -> LuFactorExResult
+where
+    T: Scalar + DynTensorTyped,
+    AdTensor<T>: Into<Tensor>,
+{
+    LuFactorExResult {
+        factors: Tensor::from_tensor(out.factors),
+        pivots: out.pivots,
+        info: out.info,
+    }
+}
+
+fn map_solve_ex_result<T>(out: tenferro_linalg::SolveExResult<T>) -> SolveExResult
+where
+    T: Scalar + DynTensorTyped,
+    AdTensor<T>: Into<Tensor>,
+{
+    SolveExResult {
+        solution: Tensor::from_tensor(out.solution),
+        info: out.info,
+    }
+}
+
+fn map_inv_ex_result<T>(out: tenferro_linalg::InvExResult<T>) -> InvExResult
+where
+    T: Scalar + DynTensorTyped,
+    AdTensor<T>: Into<Tensor>,
+{
+    InvExResult {
+        inverse: Tensor::from_tensor(out.inverse),
+        info: out.info,
+    }
+}
+
+fn map_cholesky_ex_result<T>(out: tenferro_linalg::CholeskyExResult<T>) -> CholeskyExResult
+where
+    T: Scalar + DynTensorTyped,
+    AdTensor<T>: Into<Tensor>,
+{
+    CholeskyExResult {
+        l: Tensor::from_tensor(out.l),
+        info: out.info,
+    }
+}
+
+impl Tensor {
+    /// Computes an LU factorization and returns the packed factors plus pivots.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let out = x.lu_factor()?;
+    /// let _pivots = &out.pivots;
+    /// ```
+    pub fn lu_factor(&self) -> Result<LuFactorResult> {
+        match self {
+            Self::F32(value) => with_dense_primal(value, "lu_factor", |dense| {
+                Ok(map_lu_factor_result(crate::ops::lu_factor(dense).run()?))
+            }),
+            Self::F64(value) => with_dense_primal(value, "lu_factor", |dense| {
+                Ok(map_lu_factor_result(crate::ops::lu_factor(dense).run()?))
+            }),
+            Self::C32(value) => with_dense_primal(value, "lu_factor", |dense| {
+                Ok(map_lu_factor_result(crate::ops::lu_factor(dense).run()?))
+            }),
+            Self::C64(value) => with_dense_primal(value, "lu_factor", |dense| {
+                Ok(map_lu_factor_result(crate::ops::lu_factor(dense).run()?))
+            }),
+        }
+    }
+
+    /// Computes an LU factorization with numerical status information.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let out = x.lu_factor_ex()?;
+    /// let _info = &out.info;
+    /// ```
+    pub fn lu_factor_ex(&self) -> Result<LuFactorExResult> {
+        match self {
+            Self::F32(value) => with_dense_primal(value, "lu_factor_ex", |dense| {
+                Ok(map_lu_factor_ex_result(
+                    crate::ops::lu_factor_ex(dense).run()?,
+                ))
+            }),
+            Self::F64(value) => with_dense_primal(value, "lu_factor_ex", |dense| {
+                Ok(map_lu_factor_ex_result(
+                    crate::ops::lu_factor_ex(dense).run()?,
+                ))
+            }),
+            Self::C32(value) => with_dense_primal(value, "lu_factor_ex", |dense| {
+                Ok(map_lu_factor_ex_result(
+                    crate::ops::lu_factor_ex(dense).run()?,
+                ))
+            }),
+            Self::C64(value) => with_dense_primal(value, "lu_factor_ex", |dense| {
+                Ok(map_lu_factor_ex_result(
+                    crate::ops::lu_factor_ex(dense).run()?,
+                ))
+            }),
+        }
+    }
+
+    /// Solves `LU x = b` using pre-factorized packed LU factors and pivots.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let x = factors.lu_solve(&rhs, &pivots)?;
+    /// ```
+    pub fn lu_solve(&self, rhs: &Self, pivots: &[usize]) -> Result<Self> {
+        match (self, rhs) {
+            (Self::F32(lhs), Self::F32(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "lu_solve", |factors, rhs| {
+                    Ok(Self::from_tensor(
+                        crate::ops::lu_solve(factors, rhs).pivots(pivots).run()?,
+                    ))
+                })
+            }
+            (Self::F64(lhs), Self::F64(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "lu_solve", |factors, rhs| {
+                    Ok(Self::from_tensor(
+                        crate::ops::lu_solve(factors, rhs).pivots(pivots).run()?,
+                    ))
+                })
+            }
+            (Self::C32(lhs), Self::C32(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "lu_solve", |factors, rhs| {
+                    Ok(Self::from_tensor(
+                        crate::ops::lu_solve(factors, rhs).pivots(pivots).run()?,
+                    ))
+                })
+            }
+            (Self::C64(lhs), Self::C64(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "lu_solve", |factors, rhs| {
+                    Ok(Self::from_tensor(
+                        crate::ops::lu_solve(factors, rhs).pivots(pivots).run()?,
+                    ))
+                })
+            }
+            (lhs, rhs) => Err(same_dtype_error(
+                "lu_solve",
+                lhs.scalar_type(),
+                rhs.scalar_type(),
+            )),
+        }
+    }
+
+    /// Solves a linear system and returns numerical status information.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let out = a.solve_ex(&b)?;
+    /// let _solution = &out.solution;
+    /// ```
+    pub fn solve_ex(&self, rhs: &Self) -> Result<SolveExResult> {
+        match (self, rhs) {
+            (Self::F32(lhs), Self::F32(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "solve_ex", |a, b| {
+                    Ok(map_solve_ex_result(crate::ops::solve_ex(a, b).run()?))
+                })
+            }
+            (Self::F64(lhs), Self::F64(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "solve_ex", |a, b| {
+                    Ok(map_solve_ex_result(crate::ops::solve_ex(a, b).run()?))
+                })
+            }
+            (Self::C32(lhs), Self::C32(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "solve_ex", |a, b| {
+                    Ok(map_solve_ex_result(crate::ops::solve_ex(a, b).run()?))
+                })
+            }
+            (Self::C64(lhs), Self::C64(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "solve_ex", |a, b| {
+                    Ok(map_solve_ex_result(crate::ops::solve_ex(a, b).run()?))
+                })
+            }
+            (lhs, rhs) => Err(same_dtype_error(
+                "solve_ex",
+                lhs.scalar_type(),
+                rhs.scalar_type(),
+            )),
+        }
+    }
+
+    /// Computes an inverse with numerical status information.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let out = x.inv_ex()?;
+    /// let _inverse = &out.inverse;
+    /// ```
+    pub fn inv_ex(&self) -> Result<InvExResult> {
+        match self {
+            Self::F32(value) => with_dense_primal(value, "inv_ex", |dense| {
+                Ok(map_inv_ex_result(crate::ops::inv_ex(dense).run()?))
+            }),
+            Self::F64(value) => with_dense_primal(value, "inv_ex", |dense| {
+                Ok(map_inv_ex_result(crate::ops::inv_ex(dense).run()?))
+            }),
+            Self::C32(value) => with_dense_primal(value, "inv_ex", |dense| {
+                Ok(map_inv_ex_result(crate::ops::inv_ex(dense).run()?))
+            }),
+            Self::C64(value) => with_dense_primal(value, "inv_ex", |dense| {
+                Ok(map_inv_ex_result(crate::ops::inv_ex(dense).run()?))
+            }),
+        }
+    }
+
+    /// Computes a Cholesky factorization with numerical status information.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let out = x.cholesky_ex()?;
+    /// let _factor = &out.l;
+    /// ```
+    pub fn cholesky_ex(&self) -> Result<CholeskyExResult> {
+        match self {
+            Self::F32(value) => with_dense_primal(value, "cholesky_ex", |dense| {
+                Ok(map_cholesky_ex_result(
+                    crate::ops::cholesky_ex(dense).run()?,
+                ))
+            }),
+            Self::F64(value) => with_dense_primal(value, "cholesky_ex", |dense| {
+                Ok(map_cholesky_ex_result(
+                    crate::ops::cholesky_ex(dense).run()?,
+                ))
+            }),
+            Self::C32(value) => with_dense_primal(value, "cholesky_ex", |dense| {
+                Ok(map_cholesky_ex_result(
+                    crate::ops::cholesky_ex(dense).run()?,
+                ))
+            }),
+            Self::C64(value) => with_dense_primal(value, "cholesky_ex", |dense| {
+                Ok(map_cholesky_ex_result(
+                    crate::ops::cholesky_ex(dense).run()?,
+                ))
+            }),
+        }
+    }
+
+    /// Raises a square matrix to an integer power.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let squared = x.matrix_power(2)?;
+    /// ```
+    pub fn matrix_power(&self, exponent: i64) -> Result<Self> {
+        match self {
+            Self::F32(value) => with_dense_primal(value, "matrix_power", |dense| {
+                Ok(Self::from_tensor(
+                    crate::ops::matrix_power(dense).exponent(exponent).run()?,
+                ))
+            }),
+            Self::F64(value) => with_dense_primal(value, "matrix_power", |dense| {
+                Ok(Self::from_tensor(
+                    crate::ops::matrix_power(dense).exponent(exponent).run()?,
+                ))
+            }),
+            Self::C32(value) => with_dense_primal(value, "matrix_power", |dense| {
+                Ok(Self::from_tensor(
+                    crate::ops::matrix_power(dense).exponent(exponent).run()?,
+                ))
+            }),
+            Self::C64(value) => with_dense_primal(value, "matrix_power", |dense| {
+                Ok(Self::from_tensor(
+                    crate::ops::matrix_power(dense).exponent(exponent).run()?,
+                ))
+            }),
+        }
+    }
+
+    /// Computes the matrix condition number with the default spectral norm.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let value = x.cond()?;
+    /// ```
+    pub fn cond(&self) -> Result<Self> {
+        match self {
+            Self::F32(value) => with_dense_primal(value, "cond", |dense| {
+                Ok(Self::from_tensor(crate::ops::cond(dense).run()?))
+            }),
+            Self::F64(value) => with_dense_primal(value, "cond", |dense| {
+                Ok(Self::from_tensor(crate::ops::cond(dense).run()?))
+            }),
+            _ => Err(super::real_only_error("cond", self.scalar_type())),
+        }
+    }
+
+    /// Computes the vector cross product.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let z = x.cross(&y)?;
+    /// ```
+    pub fn cross(&self, rhs: &Self) -> Result<Self> {
+        match (self, rhs) {
+            (Self::F32(lhs), Self::F32(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "cross", |a, b| {
+                    Ok(Self::from_tensor(crate::ops::cross(a, b).run()?))
+                })
+            }
+            (Self::F64(lhs), Self::F64(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "cross", |a, b| {
+                    Ok(Self::from_tensor(crate::ops::cross(a, b).run()?))
+                })
+            }
+            (Self::C32(lhs), Self::C32(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "cross", |a, b| {
+                    Ok(Self::from_tensor(crate::ops::cross(a, b).run()?))
+                })
+            }
+            (Self::C64(lhs), Self::C64(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "cross", |a, b| {
+                    Ok(Self::from_tensor(crate::ops::cross(a, b).run()?))
+                })
+            }
+            (lhs, rhs) => Err(same_dtype_error(
+                "cross",
+                lhs.scalar_type(),
+                rhs.scalar_type(),
+            )),
+        }
+    }
+
+    /// Forms the orthogonal/unitary matrix from Householder reflectors and `tau`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let q = reflectors.householder_product(&tau)?;
+    /// ```
+    pub fn householder_product(&self, tau: &Self) -> Result<Self> {
+        match (self, tau) {
+            (Self::F32(lhs), Self::F32(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "householder_product", |a, b| {
+                    Ok(Self::from_tensor(
+                        crate::ops::householder_product(a, b).run()?,
+                    ))
+                })
+            }
+            (Self::F64(lhs), Self::F64(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "householder_product", |a, b| {
+                    Ok(Self::from_tensor(
+                        crate::ops::householder_product(a, b).run()?,
+                    ))
+                })
+            }
+            (Self::C32(lhs), Self::C32(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "householder_product", |a, b| {
+                    Ok(Self::from_tensor(
+                        crate::ops::householder_product(a, b).run()?,
+                    ))
+                })
+            }
+            (Self::C64(lhs), Self::C64(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "householder_product", |a, b| {
+                    Ok(Self::from_tensor(
+                        crate::ops::householder_product(a, b).run()?,
+                    ))
+                })
+            }
+            (lhs, rhs) => Err(same_dtype_error(
+                "householder_product",
+                lhs.scalar_type(),
+                rhs.scalar_type(),
+            )),
+        }
+    }
+
+    /// Builds a Vandermonde matrix using the default options.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let v = x.vander()?;
+    /// ```
+    pub fn vander(&self) -> Result<Self> {
+        self.vander_with(None, false)
+    }
+
+    /// Builds a Vandermonde matrix with explicit column-count and order controls.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let v = x.vander_with(Some(4), true)?;
+    /// ```
+    pub fn vander_with(&self, columns: Option<usize>, increasing: bool) -> Result<Self> {
+        match self {
+            Self::F32(value) => with_dense_primal(value, "vander", |dense| {
+                let mut builder = crate::ops::vander(dense).increasing(increasing);
+                if let Some(columns) = columns {
+                    builder = builder.columns(columns);
+                }
+                Ok(Self::from_tensor(builder.run()?))
+            }),
+            Self::F64(value) => with_dense_primal(value, "vander", |dense| {
+                let mut builder = crate::ops::vander(dense).increasing(increasing);
+                if let Some(columns) = columns {
+                    builder = builder.columns(columns);
+                }
+                Ok(Self::from_tensor(builder.run()?))
+            }),
+            Self::C32(value) => with_dense_primal(value, "vander", |dense| {
+                let mut builder = crate::ops::vander(dense).increasing(increasing);
+                if let Some(columns) = columns {
+                    builder = builder.columns(columns);
+                }
+                Ok(Self::from_tensor(builder.run()?))
+            }),
+            Self::C64(value) => with_dense_primal(value, "vander", |dense| {
+                let mut builder = crate::ops::vander(dense).increasing(increasing);
+                if let Some(columns) = columns {
+                    builder = builder.columns(columns);
+                }
+                Ok(Self::from_tensor(builder.run()?))
+            }),
+        }
+    }
+
+    /// Inverts a tensorized linear map by splitting the first `ind` axes to the left.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let inv = x.tensorinv(2)?;
+    /// ```
+    pub fn tensorinv(&self, ind: usize) -> Result<Self> {
+        match self {
+            Self::F32(value) => with_dense_primal(value, "tensorinv", |dense| {
+                Ok(Self::from_tensor(
+                    crate::ops::tensorinv(dense).ind(ind).run()?,
+                ))
+            }),
+            Self::F64(value) => with_dense_primal(value, "tensorinv", |dense| {
+                Ok(Self::from_tensor(
+                    crate::ops::tensorinv(dense).ind(ind).run()?,
+                ))
+            }),
+            Self::C32(value) => with_dense_primal(value, "tensorinv", |dense| {
+                Ok(Self::from_tensor(
+                    crate::ops::tensorinv(dense).ind(ind).run()?,
+                ))
+            }),
+            Self::C64(value) => with_dense_primal(value, "tensorinv", |dense| {
+                Ok(Self::from_tensor(
+                    crate::ops::tensorinv(dense).ind(ind).run()?,
+                ))
+            }),
+        }
+    }
+
+    /// Solves a tensorized linear system using the default axis ordering.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let x = a.tensorsolve(&b)?;
+    /// ```
+    pub fn tensorsolve(&self, rhs: &Self) -> Result<Self> {
+        self.tensorsolve_with_dims(rhs, &[])
+    }
+
+    /// Solves a tensorized linear system after moving the listed axes before solving.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let x = a.tensorsolve_with_dims(&b, &[3, 2])?;
+    /// ```
+    pub fn tensorsolve_with_dims(&self, rhs: &Self, dims: &[usize]) -> Result<Self> {
+        match (self, rhs) {
+            (Self::F32(lhs), Self::F32(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "tensorsolve", |a, b| {
+                    let mut builder = crate::ops::tensorsolve(a, b);
+                    if !dims.is_empty() {
+                        builder = builder.dims(dims);
+                    }
+                    Ok(Self::from_tensor(builder.run()?))
+                })
+            }
+            (Self::F64(lhs), Self::F64(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "tensorsolve", |a, b| {
+                    let mut builder = crate::ops::tensorsolve(a, b);
+                    if !dims.is_empty() {
+                        builder = builder.dims(dims);
+                    }
+                    Ok(Self::from_tensor(builder.run()?))
+                })
+            }
+            (Self::C32(lhs), Self::C32(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "tensorsolve", |a, b| {
+                    let mut builder = crate::ops::tensorsolve(a, b);
+                    if !dims.is_empty() {
+                        builder = builder.dims(dims);
+                    }
+                    Ok(Self::from_tensor(builder.run()?))
+                })
+            }
+            (Self::C64(lhs), Self::C64(rhs)) => {
+                with_dense_primal_pair(lhs, rhs, "tensorsolve", |a, b| {
+                    let mut builder = crate::ops::tensorsolve(a, b);
+                    if !dims.is_empty() {
+                        builder = builder.dims(dims);
+                    }
+                    Ok(Self::from_tensor(builder.run()?))
+                })
+            }
+            (lhs, rhs) => Err(same_dtype_error(
+                "tensorsolve",
+                lhs.scalar_type(),
+                rhs.scalar_type(),
+            )),
+        }
+    }
+}

--- a/tenferro/src/core/dynamic/dyn_ad_tensor/eager_linalg/mod.rs
+++ b/tenferro/src/core/dynamic/dyn_ad_tensor/eager_linalg/mod.rs
@@ -1,39 +1,54 @@
 use super::Tensor;
 use crate::ops::ad;
 use crate::{AdMode, Error, Result, ScalarType};
-use num_complex::{Complex32, Complex64};
+use tenferro_algebra::Scalar;
 
+mod extra;
 mod results;
 
 pub use results::{
-    EigResult, EigenResult, LstsqResult, LuResult, QrResult, SlogdetResult, SvdResult,
+    CholeskyExResult, EigResult, EigenResult, InvExResult, LstsqResult, LuFactorExResult,
+    LuFactorResult, LuResult, QrResult, SlogdetResult, SolveExResult, SvdResult,
 };
 
-fn real_only_error(op: &'static str, dtype: ScalarType) -> Error {
+pub(super) fn real_only_error(op: &'static str, dtype: ScalarType) -> Error {
     Error::InvalidAdTensor {
         message: format!("{op} currently requires a real Tensor input, got {dtype:?}"),
     }
 }
 
-fn primal_complex_only_error(op: &'static str) -> Error {
+pub(super) fn primal_only_error(op: &'static str) -> Error {
+    Error::InvalidAdTensor {
+        message: format!("{op} currently supports only primal tensors"),
+    }
+}
+
+pub(super) fn primal_complex_only_error(op: &'static str) -> Error {
     Error::InvalidAdTensor {
         message: format!("{op} currently supports complex tensors only in primal mode"),
     }
 }
 
-fn same_dtype_error(op: &'static str, lhs: ScalarType, rhs: ScalarType) -> Error {
+pub(super) fn same_dtype_error(op: &'static str, lhs: ScalarType, rhs: ScalarType) -> Error {
     Error::InvalidAdTensor {
         message: format!("{op} requires matching dtypes, got lhs={lhs:?}, rhs={rhs:?}"),
     }
 }
 
 impl Tensor {
-    fn dense_primal_c32(
-        value: &crate::AdTensor<Complex32>,
+    fn dense_primal_with_mode_error<T>(
+        value: &crate::AdTensor<T>,
         op: &'static str,
-    ) -> Result<tenferro_tensor::Tensor<Complex32>> {
+        mode_error: fn(&'static str) -> Error,
+    ) -> Result<tenferro_tensor::Tensor<T>>
+    where
+        T: Scalar + crate::DynTensorTyped + crate::runtime::contracts::LinalgRuntimeValue,
+    {
+        if !value.is_dense() {
+            return Err(Error::UnsupportedStructuredLinalg { op });
+        }
         if value.mode() != AdMode::Primal {
-            return Err(primal_complex_only_error(op));
+            return Err(mode_error(op));
         }
         value
             .structured_primal()
@@ -43,19 +58,24 @@ impl Tensor {
             })
     }
 
-    fn dense_primal_c64(
-        value: &crate::AdTensor<Complex64>,
+    pub(super) fn dense_primal_only<T>(
+        value: &crate::AdTensor<T>,
         op: &'static str,
-    ) -> Result<tenferro_tensor::Tensor<Complex64>> {
-        if value.mode() != AdMode::Primal {
-            return Err(primal_complex_only_error(op));
-        }
-        value
-            .structured_primal()
-            .to_dense()
-            .map_err(|e| Error::InvalidAdTensor {
-                message: format!("{op} failed to densify structured complex input: {e}"),
-            })
+    ) -> Result<tenferro_tensor::Tensor<T>>
+    where
+        T: Scalar + crate::DynTensorTyped + crate::runtime::contracts::LinalgRuntimeValue,
+    {
+        Self::dense_primal_with_mode_error(value, op, primal_only_error)
+    }
+
+    pub(super) fn dense_primal_complex_only<T>(
+        value: &crate::AdTensor<T>,
+        op: &'static str,
+    ) -> Result<tenferro_tensor::Tensor<T>>
+    where
+        T: Scalar + crate::DynTensorTyped + crate::runtime::contracts::LinalgRuntimeValue,
+    {
+        Self::dense_primal_with_mode_error(value, op, primal_complex_only_error)
     }
 
     /// Runs eager AD SVD on a dynamic tensor.
@@ -85,21 +105,19 @@ impl Tensor {
                 })
             }
             Self::C32(value) => {
-                let dense = Self::dense_primal_c32(value, "svd")?;
-                let out = crate::ops::svd(&dense).run()?;
+                let out = ad::svd(value)?;
                 Ok(SvdResult {
-                    u: Tensor::from_tensor(out.u),
-                    s: Tensor::from_tensor(out.s),
-                    vt: Tensor::from_tensor(out.vt),
+                    u: out.u.into(),
+                    s: out.s.into(),
+                    vt: out.vt.into(),
                 })
             }
             Self::C64(value) => {
-                let dense = Self::dense_primal_c64(value, "svd")?;
-                let out = crate::ops::svd(&dense).run()?;
+                let out = ad::svd(value)?;
                 Ok(SvdResult {
-                    u: Tensor::from_tensor(out.u),
-                    s: Tensor::from_tensor(out.s),
-                    vt: Tensor::from_tensor(out.vt),
+                    u: out.u.into(),
+                    s: out.s.into(),
+                    vt: out.vt.into(),
                 })
             }
         }
@@ -130,7 +148,7 @@ impl Tensor {
                 })
             }
             Self::C32(value) => {
-                let dense = Self::dense_primal_c32(value, "qr")?;
+                let dense = Self::dense_primal_complex_only(value, "qr")?;
                 let out = crate::ops::qr(&dense).run()?;
                 Ok(QrResult {
                     q: Tensor::from_tensor(out.q),
@@ -138,7 +156,7 @@ impl Tensor {
                 })
             }
             Self::C64(value) => {
-                let dense = Self::dense_primal_c64(value, "qr")?;
+                let dense = Self::dense_primal_complex_only(value, "qr")?;
                 let out = crate::ops::qr(&dense).run()?;
                 Ok(QrResult {
                     q: Tensor::from_tensor(out.q),
@@ -174,7 +192,24 @@ impl Tensor {
                     u: out.u.into(),
                 })
             }
-            _ => Err(real_only_error("lu", self.scalar_type())),
+            Self::C32(value) => {
+                let dense = Self::dense_primal_complex_only(value, "lu")?;
+                let out = crate::ops::lu(&dense).run()?;
+                Ok(LuResult {
+                    p: out.p,
+                    l: Tensor::from_tensor(out.l),
+                    u: Tensor::from_tensor(out.u),
+                })
+            }
+            Self::C64(value) => {
+                let dense = Self::dense_primal_complex_only(value, "lu")?;
+                let out = crate::ops::lu(&dense).run()?;
+                Ok(LuResult {
+                    p: out.p,
+                    l: Tensor::from_tensor(out.l),
+                    u: Tensor::from_tensor(out.u),
+                })
+            }
         }
     }
 
@@ -202,7 +237,22 @@ impl Tensor {
                     vectors: out.vectors.into(),
                 })
             }
-            _ => Err(real_only_error("eigen", self.scalar_type())),
+            Self::C32(value) => {
+                let dense = Self::dense_primal_complex_only(value, "eigen")?;
+                let out = crate::ops::eigen(&dense).run()?;
+                Ok(EigenResult {
+                    values: Tensor::from_tensor(out.values),
+                    vectors: Tensor::from_tensor(out.vectors),
+                })
+            }
+            Self::C64(value) => {
+                let dense = Self::dense_primal_complex_only(value, "eigen")?;
+                let out = crate::ops::eigen(&dense).run()?;
+                Ok(EigenResult {
+                    values: Tensor::from_tensor(out.values),
+                    vectors: Tensor::from_tensor(out.vectors),
+                })
+            }
         }
     }
 
@@ -277,7 +327,14 @@ impl Tensor {
         match self {
             Self::F32(value) => Ok(Self::F32(ad::cholesky(value)?)),
             Self::F64(value) => Ok(Self::F64(ad::cholesky(value)?)),
-            _ => Err(real_only_error("cholesky", self.scalar_type())),
+            Self::C32(value) => {
+                let dense = Self::dense_primal_complex_only(value, "cholesky")?;
+                Ok(Self::from_tensor(crate::ops::cholesky(&dense).run()?))
+            }
+            Self::C64(value) => {
+                let dense = Self::dense_primal_complex_only(value, "cholesky")?;
+                Ok(Self::from_tensor(crate::ops::cholesky(&dense).run()?))
+            }
         }
     }
 
@@ -292,6 +349,8 @@ impl Tensor {
         match (self, rhs) {
             (Self::F32(lhs), Self::F32(rhs)) => Ok(Self::F32(ad::solve(lhs, rhs)?)),
             (Self::F64(lhs), Self::F64(rhs)) => Ok(Self::F64(ad::solve(lhs, rhs)?)),
+            (Self::C32(lhs), Self::C32(rhs)) => Ok(Self::C32(ad::solve(lhs, rhs)?)),
+            (Self::C64(lhs), Self::C64(rhs)) => Ok(Self::C64(ad::solve(lhs, rhs)?)),
             (lhs, rhs) => Err(same_dtype_error(
                 "solve",
                 lhs.scalar_type(),
@@ -332,7 +391,14 @@ impl Tensor {
         match self {
             Self::F32(value) => Ok(Self::F32(ad::inv(value)?)),
             Self::F64(value) => Ok(Self::F64(ad::inv(value)?)),
-            _ => Err(real_only_error("inv", self.scalar_type())),
+            Self::C32(value) => {
+                let dense = Self::dense_primal_complex_only(value, "inv")?;
+                Ok(Self::from_tensor(crate::ops::inv(&dense).run()?))
+            }
+            Self::C64(value) => {
+                let dense = Self::dense_primal_complex_only(value, "inv")?;
+                Ok(Self::from_tensor(crate::ops::inv(&dense).run()?))
+            }
         }
     }
 
@@ -405,7 +471,14 @@ impl Tensor {
         match self {
             Self::F32(value) => Ok(Self::F32(ad::matrix_exp(value)?)),
             Self::F64(value) => Ok(Self::F64(ad::matrix_exp(value)?)),
-            _ => Err(real_only_error("matrix_exp", self.scalar_type())),
+            Self::C32(value) => {
+                let dense = Self::dense_primal_complex_only(value, "matrix_exp")?;
+                Ok(Self::from_tensor(crate::ops::matrix_exp(&dense).run()?))
+            }
+            Self::C64(value) => {
+                let dense = Self::dense_primal_complex_only(value, "matrix_exp")?;
+                Ok(Self::from_tensor(crate::ops::matrix_exp(&dense).run()?))
+            }
         }
     }
 

--- a/tenferro/src/core/dynamic/dyn_ad_tensor/eager_linalg/results.rs
+++ b/tenferro/src/core/dynamic/dyn_ad_tensor/eager_linalg/results.rs
@@ -123,3 +123,85 @@ pub struct LstsqResult {
     /// Residual tensor.
     pub residual: Tensor,
 }
+
+/// Dynamic AD-aware LU factorization result.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = x.lu_factor()?;
+/// let _factors = &out.factors;
+/// ```
+#[derive(Clone)]
+pub struct LuFactorResult {
+    /// Packed LU factors.
+    pub factors: Tensor,
+    /// Flattened forward row permutations.
+    pub pivots: Vec<usize>,
+}
+
+/// Dynamic AD-aware LU factorization result with status codes.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = x.lu_factor_ex()?;
+/// let _info = &out.info;
+/// ```
+#[derive(Clone)]
+pub struct LuFactorExResult {
+    /// Packed LU factors.
+    pub factors: Tensor,
+    /// Flattened forward row permutations.
+    pub pivots: Vec<usize>,
+    /// Per-batch numerical status.
+    pub info: Vec<i32>,
+}
+
+/// Dynamic AD-aware solve result with status codes.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = a.solve_ex(&b)?;
+/// let _solution = &out.solution;
+/// ```
+#[derive(Clone)]
+pub struct SolveExResult {
+    /// Solution tensor.
+    pub solution: Tensor,
+    /// Per-batch numerical status.
+    pub info: Vec<i32>,
+}
+
+/// Dynamic AD-aware inverse result with status codes.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = x.inv_ex()?;
+/// let _inverse = &out.inverse;
+/// ```
+#[derive(Clone)]
+pub struct InvExResult {
+    /// Inverse tensor.
+    pub inverse: Tensor,
+    /// Per-batch numerical status.
+    pub info: Vec<i32>,
+}
+
+/// Dynamic AD-aware Cholesky result with status codes.
+///
+/// # Examples
+///
+/// ```ignore
+/// let out = x.cholesky_ex()?;
+/// let _l = &out.l;
+/// ```
+#[derive(Clone)]
+pub struct CholeskyExResult {
+    /// Lower-triangular factor.
+    pub l: Tensor,
+    /// Per-batch numerical status.
+    pub info: Vec<i32>,
+}

--- a/tenferro/src/core/dynamic/dyn_ad_tensor/mod.rs
+++ b/tenferro/src/core/dynamic/dyn_ad_tensor/mod.rs
@@ -13,10 +13,13 @@ mod scalar_ops;
 mod shape;
 mod snapshot;
 
+use std::fmt;
+
 use num_complex::{Complex32, Complex64};
 
 pub use eager_linalg::{
-    EigResult, EigenResult, LstsqResult, LuResult, QrResult, SlogdetResult, SvdResult,
+    CholeskyExResult, EigResult, EigenResult, InvExResult, LstsqResult, LuFactorExResult,
+    LuFactorResult, LuResult, QrResult, SlogdetResult, SolveExResult, SvdResult,
 };
 
 /// Runtime AD tensor wrapper.
@@ -60,4 +63,17 @@ pub enum Tensor {
     F64(crate::AdTensor<f64>),
     C32(crate::AdTensor<Complex32>),
     C64(crate::AdTensor<Complex64>),
+}
+
+impl fmt::Debug for Tensor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Tensor")
+            .field("scalar_type", &self.scalar_type())
+            .field("dims", &self.dims())
+            .field("axis_classes", &self.axis_classes())
+            .field("mode", &self.mode())
+            .field("is_dense", &self.is_dense())
+            .field("is_diag", &self.is_diag())
+            .finish()
+    }
 }

--- a/tenferro/src/core/dynamic/mod.rs
+++ b/tenferro/src/core/dynamic/mod.rs
@@ -5,7 +5,8 @@ mod scalar_type;
 mod tensor_ops;
 
 pub use dyn_ad_tensor::{
-    EigResult, EigenResult, LstsqResult, LuResult, QrResult, SlogdetResult, SvdResult, Tensor,
+    CholeskyExResult, EigResult, EigenResult, InvExResult, LstsqResult, LuFactorExResult,
+    LuFactorResult, LuResult, QrResult, SlogdetResult, SolveExResult, SvdResult, Tensor,
 };
 pub use dyn_tensor::DynTensor;
 #[doc(hidden)]

--- a/tenferro/src/core/mod.rs
+++ b/tenferro/src/core/mod.rs
@@ -5,7 +5,8 @@ pub use dynamic::DynTensor;
 #[doc(hidden)]
 pub use dynamic::DynTensorTyped;
 pub use dynamic::{
-    EigResult, EigenResult, LstsqResult, LuResult, QrResult, ScalarType, SlogdetResult, SvdResult,
+    CholeskyExResult, EigResult, EigenResult, InvExResult, LstsqResult, LuFactorExResult,
+    LuFactorResult, LuResult, QrResult, ScalarType, SlogdetResult, SolveExResult, SvdResult,
     Tensor,
 };
 pub(crate) use value::AdTensorSnapshot;

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -42,8 +42,9 @@ mod tape;
 pub use autograd_api::{backward, grad, BackwardOptions, GradOptions};
 pub(crate) use core::DynTensorTyped;
 pub use core::{
-    AdMode, EigResult, EigenResult, LstsqResult, LuResult, QrResult, ScalarType, SlogdetResult,
-    SvdResult, Tensor,
+    AdMode, CholeskyExResult, EigResult, EigenResult, InvExResult, LstsqResult, LuFactorExResult,
+    LuFactorResult, LuResult, QrResult, ScalarType, SlogdetResult, SolveExResult, SvdResult,
+    Tensor,
 };
 pub(crate) use core::{AdTensor, AdValue, DynTensor};
 pub use error::{Error, Result};

--- a/tenferro/src/ops/linalg/ad/eager.rs
+++ b/tenferro/src/ops/linalg/ad/eager.rs
@@ -37,9 +37,10 @@ eager_unary!(
     /// ```ignore
     /// let out = tenferro::ad::svd(&a)?;
     /// ```
-    fn svd -> TypedSvdResult<T> => svd_ad;
+    fn svd -> TypedSvdResult<T, T::Real> => svd_ad;
     where {
-        T: RealLinalgRuntimeValue,
+        T: LinalgRuntimeValue,
+        T::Real: DynTensorTyped,
     }
 );
 
@@ -135,7 +136,7 @@ eager_binary!(
     /// ```
     fn solve -> AdTensor<T> => solve_ad;
     where {
-        T: RealLinalgRuntimeValue,
+        T: LinalgRuntimeValue,
     }
 );
 

--- a/tenferro/src/ops/linalg/ad/single.rs
+++ b/tenferro/src/ops/linalg/ad/single.rs
@@ -64,7 +64,7 @@ pub struct SolveAdBuilder<'a, T: Scalar> {
 
 impl<'a, T> SolveAdBuilder<'a, T>
 where
-    T: RealLinalgRuntimeValue,
+    T: LinalgRuntimeValue,
 {
     /// Executes AD solve.
     /// # Examples

--- a/tenferro/src/ops/linalg/ad/svd_qr.rs
+++ b/tenferro/src/ops/linalg/ad/svd_qr.rs
@@ -1,5 +1,46 @@
 use super::super::super::*;
 use super::common::dispatch_linalg_ad_runtime;
+use crate::DynTensorTyped;
+
+fn wrap_mixed_dense_linalg_output<TIn, TOut>(
+    op_name: &'static str,
+    inputs: &[&AdTensor<TIn>],
+    primal: Tensor<TOut>,
+    tangent: Option<Tensor<TOut>>,
+) -> Result<AdTensor<TOut>>
+where
+    TIn: Scalar + DynTensorTyped,
+    TOut: Scalar + DynTensorTyped,
+{
+    let tangent = tangent
+        .map(|tangent| normalize_output_tangent_shape(tangent, primal.dims(), op_name))
+        .transpose()?;
+
+    if has_reverse(inputs) {
+        let tape = derive_reverse_tape_handle(inputs)?.ok_or_else(|| Error::InvalidAdTensor {
+            message: "reverse-mode output requested but no reverse tape found".to_string(),
+        })?;
+        return AdTensor::new_reverse_output(
+            crate::structured::StructuredTensor::from_dense(primal),
+            &tape,
+            tangent.map(crate::structured::StructuredTensor::from_dense),
+        );
+    }
+
+    if has_forward(inputs) {
+        let tangent = tangent.ok_or_else(|| Error::InvalidAdTensor {
+            message: "forward-mode inputs must provide tangent output".to_string(),
+        })?;
+        return AdTensor::new_forward(
+            crate::structured::StructuredTensor::from_dense(primal),
+            crate::structured::StructuredTensor::from_dense(tangent),
+        );
+    }
+
+    Ok(AdTensor::new_primal(
+        crate::structured::StructuredTensor::from_dense(primal),
+    ))
+}
 
 /// Builder for AD SVD.
 /// # Examples
@@ -14,7 +55,8 @@ pub struct SvdAdBuilder<'a, T: Scalar> {
 
 impl<'a, T> SvdAdBuilder<'a, T>
 where
-    T: RealLinalgRuntimeValue,
+    T: LinalgRuntimeValue,
+    T::Real: DynTensorTyped,
 {
     /// Sets optional SVD options.
     /// # Examples
@@ -33,7 +75,7 @@ where
     /// ```ignore
     /// let _out = builder.run();
     /// ```
-    pub fn run(self) -> Result<TypedSvdResult<T>> {
+    pub fn run(self) -> Result<TypedSvdResult<T, T::Real>> {
         let operands = [self.tensor];
         ensure_dense_linalg_inputs("svd", &operands)?;
         let needs_tangent = has_forward(&operands) || has_any_tangent(&operands);
@@ -82,7 +124,7 @@ where
         };
 
         let out_u = wrap_same_type_dense_ad_output("svd_ad", &operands, primal.u, du)?;
-        let out_s = wrap_same_type_dense_ad_output("svd_ad", &operands, primal.s, ds)?;
+        let out_s = wrap_mixed_dense_linalg_output("svd_ad", &operands, primal.s, ds)?;
         let out_vt = wrap_same_type_dense_ad_output("svd_ad", &operands, primal.vt, dvt)?;
 
         let input_spec = collect_reverse_input_specs(&operands)
@@ -132,7 +174,7 @@ where
                 let spec = spec.clone();
                 let options = options.clone();
                 let a_primal = input_primal.clone();
-                tape::register_rule::<T>(
+                tape::register_mixed_rule::<T::Real, T>(
                     &tape,
                     node,
                     Box::new(move |cotangent| {

--- a/tenferro/src/ops/linalg/primal/spectral.rs
+++ b/tenferro/src/ops/linalg/primal/spectral.rs
@@ -99,7 +99,7 @@ unary_linalg_builder!(
     returns = Tensor<T>,
     capability = tenferro_linalg::backend::LinalgCapabilityOp::MatrixExp,
     op = "matrix_exp",
-    bounds = (T: RealLinalgRuntimeValue),
+    bounds = (T: LinalgRuntimeValue),
     call = |ctx, builder| tenferro_linalg::matrix_exp::<T, _>(ctx, builder.tensor).map_err(Error::from)
 );
 

--- a/tenferro/src/ops/linalg/results.rs
+++ b/tenferro/src/ops/linalg/results.rs
@@ -19,11 +19,15 @@ use crate::{AdTensor, DynTensorTyped};
 /// assert_eq!(out.s.dims(), &[2]);
 /// ```
 #[derive(Clone)]
-pub struct TypedSvdResult<T: Scalar + DynTensorTyped> {
+pub struct TypedSvdResult<T, R = T>
+where
+    T: Scalar + DynTensorTyped,
+    R: Scalar + DynTensorTyped,
+{
     /// Left singular vectors.
     pub u: AdTensor<T>,
     /// Singular values.
-    pub s: AdTensor<T>,
+    pub s: AdTensor<R>,
     /// Right singular vectors transposed.
     pub vt: AdTensor<T>,
 }

--- a/tenferro/tests/autograd_surface_error_tests.rs
+++ b/tenferro/tests/autograd_surface_error_tests.rs
@@ -28,7 +28,7 @@ fn c64_vector(values: &[Complex64]) -> Tensor {
 fn grad_and_backward_reject_create_graph() {
     let x = Tensor::from_slice(&[1.0_f64], &[1]).unwrap();
 
-    let grad_err = match grad(
+    let grad_err = grad(
         &[&x],
         &[&x],
         None,
@@ -36,10 +36,8 @@ fn grad_and_backward_reject_create_graph() {
             create_graph: true,
             ..GradOptions::default()
         },
-    ) {
-        Ok(_) => panic!("grad(create_graph=true) should fail"),
-        Err(err) => err,
-    };
+    )
+    .unwrap_err();
     assert!(matches!(
         grad_err,
         Error::UnsupportedAdOp {
@@ -47,7 +45,7 @@ fn grad_and_backward_reject_create_graph() {
         }
     ));
 
-    let backward_err = match backward(
+    let backward_err = backward(
         &[&x],
         None,
         &[&x],
@@ -55,10 +53,8 @@ fn grad_and_backward_reject_create_graph() {
             create_graph: true,
             ..BackwardOptions::default()
         },
-    ) {
-        Ok(_) => panic!("backward(create_graph=true) should fail"),
-        Err(err) => err,
-    };
+    )
+    .unwrap_err();
     assert!(matches!(
         backward_err,
         Error::UnsupportedAdOp {
@@ -73,15 +69,13 @@ fn grad_rejects_grad_output_length_mismatch() {
     let grad_output = Tensor::from_slice(&[1.0_f64], &[1]).unwrap();
     let extra = Tensor::from_slice(&[2.0_f64], &[1]).unwrap();
 
-    let err = match grad(
+    let err = grad(
         &[&output],
         &[&output],
         Some(&[grad_output, extra]),
         GradOptions::default(),
-    ) {
-        Ok(_) => panic!("grad should reject mismatched grad_outputs"),
-        Err(err) => err,
-    };
+    )
+    .unwrap_err();
     assert!(matches!(err, Error::InvalidAdTensor { .. }));
 }
 
@@ -97,10 +91,7 @@ fn grad_rejects_outputs_from_distinct_reverse_graphs() {
     let out_x = x.exp().unwrap().sum().unwrap();
     let out_y = y.exp().unwrap().sum().unwrap();
 
-    let err = match grad(&[&out_x, &out_y], &[&x, &y], None, GradOptions::default()) {
-        Ok(_) => panic!("grad should reject outputs from different reverse graphs"),
-        Err(err) => err,
-    };
+    let err = grad(&[&out_x, &out_y], &[&x, &y], None, GradOptions::default()).unwrap_err();
     assert!(matches!(err, Error::MixedReverseTape { .. }));
 }
 

--- a/tenferro/tests/dynamic_wrapper_coverage_tests.rs
+++ b/tenferro/tests/dynamic_wrapper_coverage_tests.rs
@@ -465,7 +465,7 @@ fn tensor_dynamic_linalg_wrappers_cover_success_and_error_paths() {
     assert_eq!(complex32_qr.q.scalar_type(), ScalarType::C32);
     assert_eq!(complex32_qr.r.scalar_type(), ScalarType::C32);
 
-    let complex_err = match reverse!(matrix_c64(
+    let mut reverse_complex_svd = reverse!(matrix_c64(
         &[
             Complex64::new(4.0, 0.5),
             Complex64::new(1.0, -0.25),
@@ -473,15 +473,19 @@ fn tensor_dynamic_linalg_wrappers_cover_success_and_error_paths() {
             Complex64::new(3.0, 1.0),
         ],
         &[2, 2],
-    ))
-    .svd()
-    {
-        Ok(_) => panic!("complex reverse-mode svd should stay rejected by the dynamic wrapper"),
-        Err(err) => err,
-    };
-    assert!(
-        matches!(complex_err, tenferro::Error::InvalidAdTensor { message } if message.contains("supports complex tensors only in primal mode"))
-    );
+    ));
+    reverse_complex_svd.set_requires_grad(true).unwrap();
+    let reverse_svd_loss = reverse_complex_svd.svd().unwrap().s.sum().unwrap();
+    let reverse_svd_grads = grad(
+        &[&reverse_svd_loss],
+        &[&reverse_complex_svd],
+        None,
+        GradOptions::default(),
+    )
+    .unwrap();
+    let reverse_svd_grad = reverse_svd_grads[0].as_ref().unwrap();
+    assert_eq!(reverse_svd_grad.scalar_type(), ScalarType::C64);
+    assert_eq!(reverse_svd_grad.dims(), &[2, 2]);
 
     let complex32_err = match reverse!(matrix_c32(
         &[
@@ -501,10 +505,7 @@ fn tensor_dynamic_linalg_wrappers_cover_success_and_error_paths() {
         matches!(complex32_err, tenferro::Error::InvalidAdTensor { message } if message.contains("supports complex tensors only in primal mode"))
     );
 
-    let mismatch_err = match matrix32.solve(&rhs64) {
-        Ok(_) => panic!("solve should reject mixed dtypes"),
-        Err(err) => err,
-    };
+    let mismatch_err = matrix32.solve(&rhs64).unwrap_err();
     assert!(
         matches!(mismatch_err, tenferro::Error::InvalidAdTensor { message } if message.contains("requires matching dtypes"))
     );
@@ -515,6 +516,42 @@ fn tensor_dynamic_linalg_wrappers_cover_success_and_error_paths() {
     };
     assert!(
         matches!(lstsq_err, tenferro::Error::InvalidAdTensor { message } if message.contains("requires matching dtypes"))
+    );
+
+    let complex_solve = complex.solve(&make_c64_rhs()).unwrap();
+    assert_eq!(complex_solve.scalar_type(), ScalarType::C64);
+
+    let mut reverse_solve_a = primal!(matrix_c64(
+        &[
+            Complex64::new(4.0, 0.5),
+            Complex64::new(1.0, -0.25),
+            Complex64::new(1.0, 0.25),
+            Complex64::new(3.0, 1.0),
+        ],
+        &[2, 2],
+    ));
+    reverse_solve_a.set_requires_grad(true).unwrap();
+    let mut reverse_solve_b = make_c64_rhs();
+    reverse_solve_b.set_requires_grad(true).unwrap();
+    let solve_out = reverse_solve_a.solve(&reverse_solve_b).unwrap();
+    let solve_cotangent = primal!(vector_c64(&[
+        Complex64::new(1.0, -0.5),
+        Complex64::new(-0.25, 0.75),
+    ]));
+    let reverse_solve_grads = grad(
+        &[&solve_out],
+        &[&reverse_solve_a, &reverse_solve_b],
+        Some(&[solve_cotangent]),
+        GradOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        reverse_solve_grads[0].as_ref().unwrap().scalar_type(),
+        ScalarType::C64
+    );
+    assert_eq!(
+        reverse_solve_grads[1].as_ref().unwrap().scalar_type(),
+        ScalarType::C64
     );
 }
 

--- a/tenferro/tests/linalg_frontend_gap_tests.rs
+++ b/tenferro/tests/linalg_frontend_gap_tests.rs
@@ -1,0 +1,471 @@
+use num_complex::{Complex32, Complex64};
+use tenferro::{forward_ad, set_default_runtime, RuntimeContext, ScalarType, Tensor};
+use tenferro_prims::CpuContext;
+use tenferro_tensor::{MemoryOrder, Tensor as DenseTensor};
+
+fn matrix_f32(values: &[f32], dims: &[usize]) -> Tensor {
+    Tensor::from_tensor(DenseTensor::from_slice(values, dims, MemoryOrder::ColumnMajor).unwrap())
+}
+
+fn matrix_f64(values: &[f64], dims: &[usize]) -> Tensor {
+    Tensor::from_tensor(DenseTensor::from_slice(values, dims, MemoryOrder::ColumnMajor).unwrap())
+}
+
+fn matrix_c32(values: &[Complex32], dims: &[usize]) -> Tensor {
+    Tensor::from_tensor(DenseTensor::from_slice(values, dims, MemoryOrder::ColumnMajor).unwrap())
+}
+
+fn matrix_c64(values: &[Complex64], dims: &[usize]) -> Tensor {
+    Tensor::from_tensor(DenseTensor::from_slice(values, dims, MemoryOrder::ColumnMajor).unwrap())
+}
+
+fn vector_f32(values: &[f32]) -> Tensor {
+    Tensor::from_tensor(
+        DenseTensor::<f32>::from_slice(values, &[values.len()], MemoryOrder::ColumnMajor).unwrap(),
+    )
+}
+
+fn vector_f64(values: &[f64]) -> Tensor {
+    Tensor::from_tensor(
+        DenseTensor::<f64>::from_slice(values, &[values.len()], MemoryOrder::ColumnMajor).unwrap(),
+    )
+}
+
+fn vector_c32(values: &[Complex32]) -> Tensor {
+    Tensor::from_tensor(
+        DenseTensor::<Complex32>::from_slice(values, &[values.len()], MemoryOrder::ColumnMajor)
+            .unwrap(),
+    )
+}
+
+fn vector_c64(values: &[Complex64]) -> Tensor {
+    Tensor::from_tensor(
+        DenseTensor::<Complex64>::from_slice(values, &[values.len()], MemoryOrder::ColumnMajor)
+            .unwrap(),
+    )
+}
+
+fn tensor_f64(values: &[f64], dims: &[usize]) -> Tensor {
+    Tensor::from_tensor(DenseTensor::from_slice(values, dims, MemoryOrder::ColumnMajor).unwrap())
+}
+
+fn tensor_f32(values: &[f32], dims: &[usize]) -> Tensor {
+    Tensor::from_tensor(DenseTensor::from_slice(values, dims, MemoryOrder::ColumnMajor).unwrap())
+}
+
+fn tensor_c32(values: &[Complex32], dims: &[usize]) -> Tensor {
+    Tensor::from_tensor(DenseTensor::from_slice(values, dims, MemoryOrder::ColumnMajor).unwrap())
+}
+
+#[test]
+fn complex_forward_wrappers_cover_supported_svd_and_solve_paths() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let a = matrix_c64(
+        &[
+            Complex64::new(4.0, 0.5),
+            Complex64::new(1.0, -0.25),
+            Complex64::new(1.0, 0.25),
+            Complex64::new(3.0, 1.0),
+        ],
+        &[2, 2],
+    );
+    let da = matrix_c64(
+        &[
+            Complex64::new(0.1, 0.0),
+            Complex64::new(-0.2, 0.05),
+            Complex64::new(0.3, -0.1),
+            Complex64::new(-0.4, 0.2),
+        ],
+        &[2, 2],
+    );
+    let b = vector_c64(&[Complex64::new(1.0, 0.5), Complex64::new(-2.0, 1.0)]);
+    let db = vector_c64(&[Complex64::new(0.2, -0.1), Complex64::new(-0.3, 0.4)]);
+
+    let (svd_primal, svd_tangent) = forward_ad::dual_level(|fw| {
+        let dual_a = fw.make_dual(&a, &da)?;
+        let singular_values = dual_a.svd()?.s.sum()?;
+        fw.unpack_dual(&singular_values)
+    })
+    .unwrap();
+    assert_eq!(svd_primal.scalar_type(), ScalarType::F64);
+    assert_eq!(svd_tangent.unwrap().scalar_type(), ScalarType::F64);
+
+    let (solve_primal, solve_tangent) = forward_ad::dual_level(|fw| {
+        let dual_a = fw.make_dual(&a, &da)?;
+        let dual_b = fw.make_dual(&b, &db)?;
+        let solution = dual_a.solve(&dual_b)?;
+        fw.unpack_dual(&solution)
+    })
+    .unwrap();
+    assert_eq!(solve_primal.scalar_type(), ScalarType::C64);
+    assert_eq!(solve_tangent.unwrap().scalar_type(), ScalarType::C64);
+}
+
+#[test]
+fn tensor_frontend_exposes_missing_primal_linalg_wrappers() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let matrix = matrix_f64(&[4.0, 1.0, 1.0, 3.0], &[2, 2]);
+    let rhs = vector_f64(&[1.0, 2.0]);
+
+    let lu_factor = matrix.lu_factor().unwrap();
+    assert_eq!(lu_factor.factors.dims(), &[2, 2]);
+    assert_eq!(lu_factor.pivots.len(), 2);
+
+    let lu_factor_ex = matrix.lu_factor_ex().unwrap();
+    assert_eq!(lu_factor_ex.factors.dims(), &[2, 2]);
+    assert_eq!(lu_factor_ex.pivots.len(), 2);
+    assert_eq!(lu_factor_ex.info, vec![0]);
+
+    let lu_solved = lu_factor.factors.lu_solve(&rhs, &lu_factor.pivots).unwrap();
+    assert_eq!(lu_solved.dims(), &[2]);
+
+    let solve_ex = matrix.solve_ex(&rhs).unwrap();
+    assert_eq!(solve_ex.solution.dims(), &[2]);
+    assert_eq!(solve_ex.info, vec![0]);
+
+    let inv_ex = matrix.inv_ex().unwrap();
+    assert_eq!(inv_ex.inverse.dims(), &[2, 2]);
+    assert_eq!(inv_ex.info, vec![0]);
+
+    let cholesky_ex = matrix.cholesky_ex().unwrap();
+    assert_eq!(cholesky_ex.l.dims(), &[2, 2]);
+    assert_eq!(cholesky_ex.info, vec![0]);
+
+    let squared = matrix.matrix_power(2).unwrap();
+    assert_eq!(squared.dims(), &[2, 2]);
+
+    let cond = matrix.cond().unwrap();
+    assert_eq!(cond.dims(), &[]);
+
+    let cross = vector_f64(&[1.0, 0.0, 0.0])
+        .cross(&vector_f64(&[0.0, 1.0, 0.0]))
+        .unwrap();
+    assert_eq!(cross.dims(), &[3]);
+
+    let reflectors = matrix_f64(&[1.0, 0.0, 0.0, 1.0], &[2, 2]);
+    let tau = vector_f64(&[2.0]);
+    let householder = reflectors.householder_product(&tau).unwrap();
+    assert_eq!(householder.dims(), &[2, 2]);
+
+    let x = vector_f64(&[2.0, 3.0]);
+    let default_vander = x.vander().unwrap();
+    assert_eq!(default_vander.dims(), &[2, 2]);
+    let custom_vander = x.vander_with(Some(4), true).unwrap();
+    assert_eq!(custom_vander.dims(), &[2, 4]);
+
+    let tensorized = tensor_f64(
+        &[
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0,
+        ],
+        &[2, 2, 2, 2],
+    );
+    let tensor_inverse = tensorized.tensorinv(2).unwrap();
+    assert_eq!(tensor_inverse.dims(), &[2, 2, 2, 2]);
+
+    let tensor_rhs = matrix_f64(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+    let tensor_solve = tensorized.tensorsolve(&tensor_rhs).unwrap();
+    assert_eq!(tensor_solve.dims(), &[2, 2]);
+    let reordered_tensor_solve = tensorized
+        .tensorsolve_with_dims(&tensor_rhs, &[3, 2])
+        .unwrap();
+    assert_eq!(reordered_tensor_solve.dims(), &[2, 2]);
+}
+
+#[test]
+fn complex_primal_frontend_support_extends_beyond_svd_and_qr() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let hermitian = matrix_c64(
+        &[
+            Complex64::new(4.0, 0.0),
+            Complex64::new(1.0, -0.5),
+            Complex64::new(1.0, 0.5),
+            Complex64::new(3.0, 0.0),
+        ],
+        &[2, 2],
+    );
+    let rhs = vector_c64(&[Complex64::new(1.0, 0.5), Complex64::new(-2.0, 1.0)]);
+
+    let lu = hermitian.lu().unwrap();
+    assert_eq!(lu.l.scalar_type(), ScalarType::C64);
+
+    let eigen = hermitian.eigen().unwrap();
+    assert_eq!(eigen.values.scalar_type(), ScalarType::F64);
+    assert_eq!(eigen.vectors.scalar_type(), ScalarType::C64);
+
+    let cholesky = hermitian.cholesky().unwrap();
+    assert_eq!(cholesky.scalar_type(), ScalarType::C64);
+
+    let solved = hermitian.solve(&rhs).unwrap();
+    assert_eq!(solved.scalar_type(), ScalarType::C64);
+
+    let inverse = hermitian.inv().unwrap();
+    assert_eq!(inverse.scalar_type(), ScalarType::C64);
+
+    let matrix_exp = hermitian.matrix_exp().unwrap();
+    assert_eq!(matrix_exp.scalar_type(), ScalarType::C64);
+
+    let lu_factor = hermitian.lu_factor().unwrap();
+    assert_eq!(lu_factor.factors.scalar_type(), ScalarType::C64);
+
+    let solve_ex = hermitian.solve_ex(&rhs).unwrap();
+    assert_eq!(solve_ex.solution.scalar_type(), ScalarType::C64);
+
+    let inv_ex = hermitian.inv_ex().unwrap();
+    assert_eq!(inv_ex.inverse.scalar_type(), ScalarType::C64);
+
+    let matrix_power = hermitian.matrix_power(2).unwrap();
+    assert_eq!(matrix_power.scalar_type(), ScalarType::C64);
+}
+
+#[test]
+fn tensor_frontend_extra_wrappers_cover_remaining_f32_c32_and_error_paths() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let matrix32 = matrix_f32(&[4.0, 1.0, 1.0, 3.0], &[2, 2]);
+    let rhs32 = vector_f32(&[1.0, 2.0]);
+    let lu_factor32 = matrix32.lu_factor().unwrap();
+    assert_eq!(lu_factor32.factors.scalar_type(), ScalarType::F32);
+    assert_eq!(
+        matrix32.lu_factor_ex().unwrap().factors.scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(
+        lu_factor32
+            .factors
+            .lu_solve(&rhs32, &lu_factor32.pivots)
+            .unwrap()
+            .scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(
+        matrix32.solve_ex(&rhs32).unwrap().solution.scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(
+        matrix32.inv_ex().unwrap().inverse.scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(
+        matrix32.cholesky_ex().unwrap().l.scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(
+        matrix32.matrix_power(3).unwrap().scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(matrix32.cond().unwrap().scalar_type(), ScalarType::F32);
+    assert_eq!(
+        vector_f32(&[1.0, 0.0, 0.0])
+            .cross(&vector_f32(&[0.0, 1.0, 0.0]))
+            .unwrap()
+            .scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(
+        matrix_f32(&[1.0, 0.0, 0.0, 1.0], &[2, 2])
+            .householder_product(&vector_f32(&[2.0]))
+            .unwrap()
+            .scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(
+        vector_f32(&[2.0, 3.0]).vander().unwrap().scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(
+        vector_f32(&[2.0, 3.0])
+            .vander_with(Some(3), true)
+            .unwrap()
+            .scalar_type(),
+        ScalarType::F32
+    );
+    let tensorized32 = tensor_f32(
+        &[
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0,
+        ],
+        &[2, 2, 2, 2],
+    );
+    assert_eq!(
+        tensorized32.tensorinv(2).unwrap().scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(
+        tensorized32
+            .tensorsolve(&matrix_f32(&[1.0, 2.0, 3.0, 4.0], &[2, 2]))
+            .unwrap()
+            .scalar_type(),
+        ScalarType::F32
+    );
+    assert_eq!(
+        tensorized32
+            .tensorsolve_with_dims(&matrix_f32(&[1.0, 2.0, 3.0, 4.0], &[2, 2]), &[3, 2])
+            .unwrap()
+            .scalar_type(),
+        ScalarType::F32
+    );
+
+    let hermitian32 = matrix_c32(
+        &[
+            Complex32::new(4.0, 0.0),
+            Complex32::new(1.0, -0.5),
+            Complex32::new(1.0, 0.5),
+            Complex32::new(3.0, 0.0),
+        ],
+        &[2, 2],
+    );
+    let rhs_c32 = vector_c32(&[Complex32::new(1.0, 0.5), Complex32::new(-2.0, 1.0)]);
+    let lu_factor_c32 = hermitian32.lu_factor().unwrap();
+    assert_eq!(lu_factor_c32.factors.scalar_type(), ScalarType::C32);
+    assert_eq!(
+        hermitian32.lu_factor_ex().unwrap().factors.scalar_type(),
+        ScalarType::C32
+    );
+    assert_eq!(
+        lu_factor_c32
+            .factors
+            .lu_solve(&rhs_c32, &lu_factor_c32.pivots)
+            .unwrap()
+            .scalar_type(),
+        ScalarType::C32
+    );
+    assert_eq!(
+        hermitian32
+            .solve_ex(&rhs_c32)
+            .unwrap()
+            .solution
+            .scalar_type(),
+        ScalarType::C32
+    );
+    assert_eq!(
+        hermitian32.inv_ex().unwrap().inverse.scalar_type(),
+        ScalarType::C32
+    );
+    assert_eq!(
+        hermitian32.cholesky_ex().unwrap().l.scalar_type(),
+        ScalarType::C32
+    );
+    assert_eq!(
+        hermitian32.matrix_power(3).unwrap().scalar_type(),
+        ScalarType::C32
+    );
+    let cond_err = hermitian32.cond().unwrap_err();
+    assert!(matches!(cond_err, tenferro::Error::InvalidAdTensor { .. }));
+    assert_eq!(
+        vector_c32(&[
+            Complex32::new(1.0, 0.0),
+            Complex32::new(0.0, 1.0),
+            Complex32::new(0.0, 0.0),
+        ])
+        .cross(&vector_c32(&[
+            Complex32::new(0.0, 0.0),
+            Complex32::new(1.0, 0.0),
+            Complex32::new(0.0, 1.0),
+        ]))
+        .unwrap()
+        .scalar_type(),
+        ScalarType::C32
+    );
+    assert_eq!(
+        matrix_c32(
+            &[
+                Complex32::new(1.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(1.0, 0.0),
+            ],
+            &[2, 2],
+        )
+        .householder_product(&vector_c32(&[Complex32::new(2.0, 0.0)]))
+        .unwrap()
+        .scalar_type(),
+        ScalarType::C32
+    );
+    assert_eq!(
+        vector_c32(&[Complex32::new(2.0, 0.0), Complex32::new(3.0, 1.0)])
+            .vander()
+            .unwrap()
+            .scalar_type(),
+        ScalarType::C32
+    );
+    assert_eq!(
+        vector_c32(&[Complex32::new(2.0, 0.0), Complex32::new(3.0, 1.0)])
+            .vander_with(Some(3), true)
+            .unwrap()
+            .scalar_type(),
+        ScalarType::C32
+    );
+    let tensorized_c32 = tensor_c32(
+        &[
+            Complex32::new(1.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(1.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(1.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(1.0, 0.0),
+        ],
+        &[2, 2, 2, 2],
+    );
+    assert_eq!(
+        tensorized_c32.tensorinv(2).unwrap().scalar_type(),
+        ScalarType::C32
+    );
+    let tensor_rhs_c32 = matrix_c32(
+        &[
+            Complex32::new(1.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(3.0, 0.0),
+            Complex32::new(4.0, 0.0),
+        ],
+        &[2, 2],
+    );
+    assert_eq!(
+        tensorized_c32
+            .tensorsolve(&tensor_rhs_c32)
+            .unwrap()
+            .scalar_type(),
+        ScalarType::C32
+    );
+    assert_eq!(
+        tensorized_c32
+            .tensorsolve_with_dims(&tensor_rhs_c32, &[3, 2])
+            .unwrap()
+            .scalar_type(),
+        ScalarType::C32
+    );
+
+    assert!(matrix32.solve_ex(&rhs_c32).is_err());
+    assert!(lu_factor32
+        .factors
+        .lu_solve(&rhs_c32, &lu_factor32.pivots)
+        .is_err());
+    assert!(vector_f32(&[1.0, 0.0, 0.0])
+        .cross(&vector_c32(&[
+            Complex32::new(0.0, 0.0),
+            Complex32::new(1.0, 0.0),
+            Complex32::new(0.0, 1.0),
+        ]))
+        .is_err());
+    assert!(matrix32
+        .householder_product(&vector_c32(&[Complex32::new(2.0, 0.0)]))
+        .is_err());
+    assert!(tensorized32.tensorsolve(&tensor_rhs_c32).is_err());
+}

--- a/tenferro/tests/public_surface_tests.rs
+++ b/tenferro/tests/public_surface_tests.rs
@@ -112,6 +112,19 @@ fn tensor_public_primal_constructor_handles_dense_and_diag() {
 }
 
 #[test]
+fn tensor_debug_prints_semantic_summary() {
+    let x = Tensor::from_tensor(vector_f64(&[1.0, 2.0]));
+    let rendered = format!("{x:?}");
+    assert!(rendered.contains("Tensor"));
+    assert!(rendered.contains("scalar_type: F64"));
+    assert!(rendered.contains("dims: [2]"));
+    assert!(rendered.contains("axis_classes: [0]"));
+    assert!(rendered.contains("mode: Primal"));
+    assert!(rendered.contains("is_dense: true"));
+    assert!(rendered.contains("is_diag: true"));
+}
+
+#[test]
 fn tensor_public_forward_constructor_preserves_tangent() {
     let x = Tensor::from_tensor(vector_f64(&[1.0, 2.0]));
     let dx = Tensor::from_tensor(vector_f64(&[0.5, -0.5]));


### PR DESCRIPTION
## Summary
- expand the `tenferro::Tensor` linalg frontend with missing wrappers and broader complex-mode support
- enable complex `solve` forward-mode AD and mixed-output dynamic `svd` wrapping
- add a semantic-summary `Debug` impl for `Tensor` and simplify error-path tests that can now use `unwrap_err()`

## Testing
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py --doc-root /tmp/tenferro-complex-op-capability-wave-doc-target/doc`

Generated with [Claude Code](https://claude.com/claude-code)
