### PR TITLE
fix transposed einsum fusion for scalar contractions

### DIFF
--- a/tenferro-einsum/src/execution/dispatch.rs
+++ b/tenferro-einsum/src/execution/dispatch.rs
@@ -16,7 +16,7 @@ use crate::execution::pool::BufferPool;
 use crate::execution::util::alloc_tensor_from_pool;
 use crate::planning::classify::compute_permutation;
 use crate::planning::plan::{GemmPlan, ReducePlan, StepPlan};
-use crate::planning::prepare::prepare_one_operand;
+use crate::planning::prepare::{prepare_one_operand, try_fuse_group_in_target_order};
 
 #[cfg(feature = "profile-dispatch")]
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -315,9 +315,11 @@ where
     let c_direct = !plan.needs_final_permute && {
         let c_dims = output.dims();
         let c_strides = output.strides();
-        let g1 = strided_perm::try_fuse_group(&c_dims[..n_lo], &c_strides[..n_lo]);
-        let g2 =
-            strided_perm::try_fuse_group(&c_dims[n_lo..n_lo + n_ro], &c_strides[n_lo..n_lo + n_ro]);
+        let g1 = try_fuse_group_in_target_order(&c_dims[..n_lo], &c_strides[..n_lo]);
+        let g2 = try_fuse_group_in_target_order(
+            &c_dims[n_lo..n_lo + n_ro],
+            &c_strides[n_lo..n_lo + n_ro],
+        );
         g1.is_some() && g2.is_some()
     };
 
@@ -332,10 +334,12 @@ where
         let c_dims = output.dims().to_vec();
         let c_strides = output.strides().to_vec();
         let (_, m_stride) =
-            strided_perm::try_fuse_group(&c_dims[..n_lo], &c_strides[..n_lo]).unwrap();
-        let (_, n_stride) =
-            strided_perm::try_fuse_group(&c_dims[n_lo..n_lo + n_ro], &c_strides[n_lo..n_lo + n_ro])
-                .unwrap();
+            try_fuse_group_in_target_order(&c_dims[..n_lo], &c_strides[..n_lo]).unwrap();
+        let (_, n_stride) = try_fuse_group_in_target_order(
+            &c_dims[n_lo..n_lo + n_ro],
+            &c_strides[n_lo..n_lo + n_ro],
+        )
+        .unwrap();
         let mut fused_dims = Vec::with_capacity(2 + nb);
         let mut fused_strides = Vec::with_capacity(2 + nb);
         fused_dims.push(plan.m);

--- a/tenferro-einsum/src/planning/manual/tests.rs
+++ b/tenferro-einsum/src/planning/manual/tests.rs
@@ -43,3 +43,27 @@ fn manual_einsum_trace_returns_scalar() {
     assert!(result.dims().is_empty());
     assert!((data[result.offset() as usize] - 4.0).abs() < 1e-10);
 }
+
+#[test]
+fn manual_einsum_transposed_scalar_contraction_matches_backend() {
+    let mut ctx = CpuContext::new(1);
+    let subs = Subscripts::parse("ab,ba->").unwrap();
+    let lhs = tensor(&[1.0, -0.5, 2.0, 0.3, 1.2, -0.8], &[2, 3]);
+    let rhs = tensor(&[0.5, 1.0, -1.2, 0.7, 0.2, -0.4], &[3, 2]);
+    let size_dict = HashMap::from([('a' as u32, 2usize), ('b' as u32, 3usize)]);
+
+    let manual = manual_einsum(&subs, &[lhs.clone(), rhs.clone()], &size_dict).unwrap();
+    let backend =
+        einsum_with_subscripts::<Standard<f64>, CpuBackend>(&mut ctx, &subs, &[&lhs, &rhs], None)
+            .unwrap();
+
+    let manual_data = manual.buffer().as_slice().unwrap();
+    let backend_data = backend.buffer().as_slice().unwrap();
+    let manual_value = manual_data[manual.offset() as usize];
+    let backend_value = backend_data[backend.offset() as usize];
+
+    assert!(
+        (manual_value - backend_value).abs() < 1e-10,
+        "manual={manual_value}, backend={backend_value}"
+    );
+}

--- a/tenferro-einsum/src/planning/prepare.rs
+++ b/tenferro-einsum/src/planning/prepare.rs
@@ -35,6 +35,40 @@ fn record_prepare_fallback(dims: &[usize]) {
     PREPARE_FALLBACK_ELEMS.fetch_add(n_elems as u64, Ordering::Relaxed);
 }
 
+pub(crate) fn try_fuse_group_in_target_order(
+    dims: &[usize],
+    strides: &[isize],
+) -> Option<(usize, isize)> {
+    match dims.len() {
+        0 => Some((1, 0)),
+        1 => Some((dims[0], strides[0])),
+        _ => {
+            if dims.len() != strides.len() {
+                return None;
+            }
+
+            let first_non_singleton = dims.iter().position(|&d| d > 1);
+            let Some(base_idx) = first_non_singleton else {
+                return Some((dims.iter().product(), *strides.first().unwrap_or(&0)));
+            };
+
+            let base_stride = strides[base_idx];
+            let mut expected_abs = base_stride.unsigned_abs();
+            for (&dim, &stride) in dims.iter().zip(strides.iter()) {
+                if dim <= 1 {
+                    continue;
+                }
+                if stride.unsigned_abs() != expected_abs {
+                    return None;
+                }
+                expected_abs = expected_abs.checked_mul(dim)?;
+            }
+
+            Some((dims.iter().product(), base_stride))
+        }
+    }
+}
+
 /// Prepare a single operand for GEMM: permute and try to fuse dimension groups.
 pub(crate) fn prepare_one_operand<A, B>(
     ctx: &mut BackendContext<A, B>,
@@ -52,8 +86,6 @@ where
     A::Scalar: Scalar + HasAlgebra<Algebra = A>,
     B: TensorSemiringCore<A>,
 {
-    use strided_perm::try_fuse_group;
-
     // Step 1: Permute (metadata-only, zero-copy)
     let permuted = if current_subs == target_subs {
         tensor.clone()
@@ -75,8 +107,8 @@ where
     let batch_dims = &dims[n_group1 + n_group2..];
     let batch_strides = &strides[n_group1 + n_group2..];
 
-    let fused_g1 = try_fuse_group(g1_dims, g1_strides);
-    let fused_g2 = try_fuse_group(g2_dims, g2_strides);
+    let fused_g1 = try_fuse_group_in_target_order(g1_dims, g1_strides);
+    let fused_g2 = try_fuse_group_in_target_order(g2_dims, g2_strides);
 
     match (fused_g1, fused_g2) {
         (Some((size1, stride1)), Some((size2, stride2))) => {
@@ -171,7 +203,7 @@ where
     let view = tensor.permute(&perm)?;
 
     // If the view happens to be contiguous, return it directly (zero allocation)
-    if view.is_contiguous() {
+    if view.is_col_major_contiguous() {
         return Ok(view);
     }
 
@@ -203,7 +235,7 @@ where
     A::Scalar: Scalar + HasAlgebra<Algebra = A>,
     B: TensorSemiringCore<A>,
 {
-    if tensor.is_contiguous() {
+    if tensor.is_col_major_contiguous() {
         return Ok(tensor.clone());
     }
 

--- a/tenferro-einsum/src/planning/prepare/tests.rs
+++ b/tenferro-einsum/src/planning/prepare/tests.rs
@@ -89,6 +89,48 @@ fn prepare_one_operand_partial_fallback_when_group2_nonfusable() {
 }
 
 #[test]
+fn permute_or_copy_transposed_scalar_contraction_materializes_target_order() {
+    let mut ctx = CpuContext::new(1);
+    let mut pool = BufferPool::new();
+    let rhs = tensor(&[0.5, 1.0, -1.2, 0.7, 0.2, -0.4], &[3, 2]);
+    let expected = tensor(&[0.5, 0.7, 1.0, 0.2, -1.2, -0.4], &[2, 3]);
+
+    let prepared =
+        permute_or_copy::<Standard<f64>, CpuBackend>(&mut ctx, &rhs, &[1, 0], &[0, 1], &mut pool)
+            .unwrap();
+
+    assert_eq!(prepared.dims(), &[2, 3]);
+    assert!(prepared.is_col_major_contiguous());
+    assert_tensor_close(&prepared, &expected);
+}
+
+#[test]
+fn prepare_one_operand_transposed_scalar_contraction_materializes_target_order() {
+    let mut ctx = CpuContext::new(1);
+    let mut pool = BufferPool::new();
+    let rhs = tensor(&[0.5, 1.0, -1.2, 0.7, 0.2, -0.4], &[3, 2]);
+    let fallback_shape = [6, 1];
+    let expected = tensor(&[0.5, 0.7, 1.0, 0.2, -1.2, -0.4], &fallback_shape);
+
+    let prepared = prepare_one_operand::<Standard<f64>, CpuBackend>(
+        &mut ctx,
+        &rhs,
+        &[1, 0],
+        &[0, 1],
+        0,
+        2,
+        0,
+        &fallback_shape,
+        &mut pool,
+    )
+    .unwrap();
+
+    assert_eq!(prepared.dims(), &fallback_shape);
+    assert!(prepared.is_col_major_contiguous());
+    assert_tensor_close(&prepared, &expected);
+}
+
+#[test]
 fn prepare_one_operand_partial_fallback_when_group1_nonfusable() {
     let mut ctx = CpuContext::new(1);
     let mut pool = BufferPool::new();

--- a/tenferro-prims/src/cpu/batched_gemm.rs
+++ b/tenferro-prims/src/cpu/batched_gemm.rs
@@ -1,4 +1,3 @@
-use strided_perm::try_fuse_group;
 use strided_view::{StridedView, StridedViewMut};
 use tenferro_algebra::Scalar;
 use tenferro_device::{Error, Result};
@@ -9,6 +8,7 @@ use crate::infra::typed_dispatch::{
 
 use super::context::CpuContext;
 use super::gemm_support::{advance_batch_offset, batch_iteration_count, batch_offset};
+use super::layout_fusion::try_fuse_group_in_order;
 
 #[cfg(feature = "gemm-faer")]
 use super::gemm_support::FaerGemm;
@@ -127,9 +127,9 @@ pub(super) fn execute_batched_gemm_contiguous<T: Scalar + 'static>(
     if nb == 0 {
         result = do_batch(0, 0, 0, &mut a_mat, &mut b_mat, &mut c_mat);
     } else {
-        let a_fused = try_fuse_group(batch_dims, a_batch);
-        let b_fused = try_fuse_group(batch_dims, b_batch);
-        let c_fused = try_fuse_group(batch_dims, c_batch);
+        let a_fused = try_fuse_group_in_order(batch_dims, a_batch);
+        let b_fused = try_fuse_group_in_order(batch_dims, b_batch);
+        let c_fused = try_fuse_group_in_order(batch_dims, c_batch);
         let total = batch_iteration_count(batch_dims)?;
 
         if let (Some((_, a_step)), Some((_, b_step)), Some((_, c_step))) =
@@ -246,9 +246,9 @@ pub(super) fn execute_batched_gemm_strided<T: FaerGemm>(
     if nb == 0 {
         do_batch(0, 0, 0);
     } else {
-        let a_fused = try_fuse_group(batch_dims, a_batch);
-        let b_fused = try_fuse_group(batch_dims, b_batch);
-        let c_fused = try_fuse_group(batch_dims, c_batch);
+        let a_fused = try_fuse_group_in_order(batch_dims, a_batch);
+        let b_fused = try_fuse_group_in_order(batch_dims, b_batch);
+        let c_fused = try_fuse_group_in_order(batch_dims, c_batch);
         let total = batch_iteration_count(batch_dims)?;
 
         if let (Some((_, a_step)), Some((_, b_step)), Some((_, c_step))) =

--- a/tenferro-prims/src/cpu/contract.rs
+++ b/tenferro-prims/src/cpu/contract.rs
@@ -1,4 +1,3 @@
-use strided_perm::try_fuse_group;
 use strided_view::{StridedView, StridedViewMut};
 use tenferro_algebra::Scalar;
 use tenferro_device::{Error, Result};
@@ -8,6 +7,7 @@ use crate::infra::typed_dispatch::{
 };
 use crate::SemiringBinaryOp;
 
+use super::layout_fusion::try_fuse_group_in_order;
 use super::plan::{build_contract_gemm_spec, ContractGemmSpec};
 
 #[cfg(feature = "gemm-faer")]
@@ -236,9 +236,9 @@ fn try_execute_contract_gemm<T: Scalar + 'static>(
         let (batch_total, a_bs, b_bs, c_bs) = if nb == 0 {
             (1usize, 0isize, 0isize, 0isize)
         } else {
-            let (ta, sa) = try_fuse_group(&a_dims[..nb], &a_strides[..nb])?;
-            let (tb, sb) = try_fuse_group(&b_dims[..nb], &b_strides[..nb])?;
-            let (tc, sc) = try_fuse_group(&c_dims[..nb], &c_strides[..nb])?;
+            let (ta, sa) = try_fuse_group_in_order(&a_dims[..nb], &a_strides[..nb])?;
+            let (tb, sb) = try_fuse_group_in_order(&b_dims[..nb], &b_strides[..nb])?;
+            let (tc, sc) = try_fuse_group_in_order(&c_dims[..nb], &c_strides[..nb])?;
             if ta != tb || ta != tc {
                 return None;
             }
@@ -248,12 +248,12 @@ fn try_execute_contract_gemm<T: Scalar + 'static>(
         let (m_raw, a_ms) = if nm == 0 {
             (1usize, 0isize)
         } else {
-            try_fuse_group(&a_dims[nb..nb + nm], &a_strides[nb..nb + nm])?
+            try_fuse_group_in_order(&a_dims[nb..nb + nm], &a_strides[nb..nb + nm])?
         };
         let (m_chk, c_ms) = if nm == 0 {
             (1usize, 0isize)
         } else {
-            try_fuse_group(&c_dims[nb..nb + nm], &c_strides[nb..nb + nm])?
+            try_fuse_group_in_order(&c_dims[nb..nb + nm], &c_strides[nb..nb + nm])?
         };
         if m_raw != m_chk {
             return None;
@@ -262,7 +262,7 @@ fn try_execute_contract_gemm<T: Scalar + 'static>(
         let (k_raw, a_ks) = if nk == 0 {
             (1usize, 0isize)
         } else {
-            try_fuse_group(
+            try_fuse_group_in_order(
                 &a_dims[nb + nm..nb + nm + nk],
                 &a_strides[nb + nm..nb + nm + nk],
             )?
@@ -270,7 +270,7 @@ fn try_execute_contract_gemm<T: Scalar + 'static>(
         let (k_chk, b_ks) = if nk == 0 {
             (1usize, 0isize)
         } else {
-            try_fuse_group(&b_dims[nb..nb + nk], &b_strides[nb..nb + nk])?
+            try_fuse_group_in_order(&b_dims[nb..nb + nk], &b_strides[nb..nb + nk])?
         };
         if k_raw != k_chk {
             return None;
@@ -279,7 +279,7 @@ fn try_execute_contract_gemm<T: Scalar + 'static>(
         let (n_raw, b_ns) = if nn == 0 {
             (1usize, 0isize)
         } else {
-            try_fuse_group(
+            try_fuse_group_in_order(
                 &b_dims[nb + nk..nb + nk + nn],
                 &b_strides[nb + nk..nb + nk + nn],
             )?
@@ -287,7 +287,7 @@ fn try_execute_contract_gemm<T: Scalar + 'static>(
         let (n_chk, c_ns) = if nn == 0 {
             (1usize, 0isize)
         } else {
-            try_fuse_group(
+            try_fuse_group_in_order(
                 &c_dims[nb + nm..nb + nm + nn],
                 &c_strides[nb + nm..nb + nm + nn],
             )?

--- a/tenferro-prims/src/cpu/layout_fusion.rs
+++ b/tenferro-prims/src/cpu/layout_fusion.rs
@@ -1,0 +1,30 @@
+pub(super) fn try_fuse_group_in_order(dims: &[usize], strides: &[isize]) -> Option<(usize, isize)> {
+    match dims.len() {
+        0 => Some((1, 0)),
+        1 => Some((dims[0], strides[0])),
+        _ => {
+            if dims.len() != strides.len() {
+                return None;
+            }
+
+            let first_non_singleton = dims.iter().position(|&d| d > 1);
+            let Some(base_idx) = first_non_singleton else {
+                return Some((dims.iter().product(), *strides.first().unwrap_or(&0)));
+            };
+
+            let base_stride = strides[base_idx];
+            let mut expected_abs = base_stride.unsigned_abs();
+            for (&dim, &stride) in dims.iter().zip(strides.iter()) {
+                if dim <= 1 {
+                    continue;
+                }
+                if stride.unsigned_abs() != expected_abs {
+                    return None;
+                }
+                expected_abs = expected_abs.checked_mul(dim)?;
+            }
+
+            Some((dims.iter().product(), base_stride))
+        }
+    }
+}

--- a/tenferro-prims/src/cpu/mod.rs
+++ b/tenferro-prims/src/cpu/mod.rs
@@ -11,6 +11,7 @@ mod contract;
 mod execution;
 mod family_reduction;
 mod gemm_support;
+mod layout_fusion;
 mod plan;
 mod planning;
 mod reduction;

--- a/tenferro-prims/src/cpu/tests/organization.rs
+++ b/tenferro-prims/src/cpu/tests/organization.rs
@@ -18,6 +18,7 @@ fn cpu_backend_is_split_into_focused_modules() {
         "mod contract;",
         "mod execution;",
         "mod gemm_support;",
+        "mod layout_fusion;",
         "mod plan;",
         "mod planning;",
     ] {
@@ -41,6 +42,7 @@ fn split_cpu_modules_stay_under_size_guideline() {
         format!("{ROOT}/contract.rs"),
         format!("{ROOT}/batched_gemm.rs"),
         format!("{ROOT}/gemm_support.rs"),
+        format!("{ROOT}/layout_fusion.rs"),
     ] {
         assert!(
             Path::new(&path).exists(),

--- a/tenferro-prims/tests/prims_tests.rs
+++ b/tenferro-prims/tests/prims_tests.rs
@@ -91,10 +91,21 @@ fn cpu_has_fast_path<T: Scalar>(desc: SemiringFastPathDescriptor) -> bool {
 /// Create a Tensor from a closure, column-major order.
 /// Equivalent to the old `StridedArray::from_fn_col_major`.
 fn tensor_from_fn<T: Scalar>(dims: &[usize], f: impl Fn(&[usize]) -> T) -> Tensor<T> {
+    tensor_from_fn_with_order(dims, MemoryOrder::ColumnMajor, f)
+}
+
+fn tensor_from_fn_with_order<T: Scalar>(
+    dims: &[usize],
+    order: MemoryOrder,
+    f: impl Fn(&[usize]) -> T,
+) -> Tensor<T> {
     let ndim = dims.len();
     let n_elements: usize = dims.iter().product();
     let mut data = vec![T::zero(); n_elements];
-    let strides = col_major_strides(dims);
+    let strides = match order {
+        MemoryOrder::ColumnMajor => col_major_strides(dims),
+        MemoryOrder::RowMajor => row_major_strides(dims),
+    };
     let mut idx = vec![0usize; ndim];
     for _ in 0..n_elements {
         let linear: usize = idx.iter().zip(strides.iter()).map(|(&i, &s)| i * s).sum();
@@ -108,7 +119,7 @@ fn tensor_from_fn<T: Scalar>(dims: &[usize], f: impl Fn(&[usize]) -> T) -> Tenso
             idx[d] = 0;
         }
     }
-    Tensor::from_slice(&data, dims, MemoryOrder::ColumnMajor).unwrap()
+    Tensor::from_slice(&data, dims, order).unwrap()
 }
 
 /// Zero-initialized Tensor (column-major).
@@ -130,6 +141,19 @@ fn col_major_strides(dims: &[usize]) -> Vec<usize> {
     strides[0] = 1;
     for i in 1..ndim {
         strides[i] = strides[i - 1] * dims[i - 1];
+    }
+    strides
+}
+
+fn row_major_strides(dims: &[usize]) -> Vec<usize> {
+    let ndim = dims.len();
+    if ndim == 0 {
+        return vec![];
+    }
+    let mut strides = vec![0usize; ndim];
+    strides[ndim - 1] = 1;
+    for i in (0..ndim - 1).rev() {
+        strides[i] = strides[i + 1] * dims[i + 1];
     }
     strides
 }
@@ -775,6 +799,133 @@ fn contract_generic_fallback_with_b_only_mode() {
             "C[{i}] = {}, expected {expected}",
             tensor_get(&c, &[i])
         );
+    }
+}
+
+#[test]
+fn contract_transposed_scalar_contraction_matches_manual() {
+    let mut ctx = CpuContext::new(1);
+    let a = tensor_from_fn(&[2, 3], |idx| match idx {
+        [0, 0] => 1.0,
+        [1, 0] => -0.5,
+        [0, 1] => 2.0,
+        [1, 1] => 0.3,
+        [0, 2] => 1.2,
+        [1, 2] => -0.8,
+        _ => unreachable!(),
+    });
+    let b = tensor_from_fn(&[3, 2], |idx| match idx {
+        [0, 0] => 0.5,
+        [1, 0] => 1.0,
+        [2, 0] => -1.2,
+        [0, 1] => 0.7,
+        [1, 1] => 0.2,
+        [2, 1] => -0.4,
+        _ => unreachable!(),
+    });
+    let mut c = tensor_zeros::<f64>(&[]);
+
+    let desc = TestPrimitiveDescriptor::SemiringFastPath(SemiringFastPathDescriptor::Contract {
+        modes_a: vec![0, 1],
+        modes_b: vec![1, 0],
+        modes_c: vec![],
+    });
+    let plan = cpu_plan::<f64>(&mut ctx, &desc, &[&[2, 3], &[3, 2], &[]]).unwrap();
+    cpu_execute(&mut ctx, &plan, 1.0, &[&a, &b], 0.0, &mut c).unwrap();
+
+    let mut expected = 0.0;
+    for i in 0..2 {
+        for j in 0..3 {
+            expected += tensor_get(&a, &[i, j]) * tensor_get(&b, &[j, i]);
+        }
+    }
+
+    assert!(
+        (tensor_get(&c, &[]) - expected).abs() < 1e-10,
+        "C = {}, expected {expected}",
+        tensor_get(&c, &[])
+    );
+}
+
+#[test]
+fn contract_transposed_multi_axis_reduction_matches_manual() {
+    let mut ctx = CpuContext::new(1);
+    let a = tensor_from_fn(&[2, 3, 4], |idx| {
+        1.0 + idx[0] as f64 + 0.1 * idx[1] as f64 + 0.01 * idx[2] as f64
+    });
+    let b = tensor_from_fn(&[4, 3, 5], |idx| {
+        -0.5 + 0.2 * idx[0] as f64 - 0.05 * idx[1] as f64 + 0.01 * idx[2] as f64
+    });
+    let mut c = tensor_zeros::<f64>(&[2, 5]);
+
+    let desc = TestPrimitiveDescriptor::SemiringFastPath(SemiringFastPathDescriptor::Contract {
+        modes_a: vec![0, 1, 2],
+        modes_b: vec![2, 1, 3],
+        modes_c: vec![0, 3],
+    });
+    let plan = cpu_plan::<f64>(&mut ctx, &desc, &[&[2, 3, 4], &[4, 3, 5], &[2, 5]]).unwrap();
+    cpu_execute(&mut ctx, &plan, 1.0, &[&a, &b], 0.0, &mut c).unwrap();
+
+    for i in 0..2 {
+        for l in 0..5 {
+            let mut expected = 0.0;
+            for j in 0..3 {
+                for k in 0..4 {
+                    expected += tensor_get(&a, &[i, j, k]) * tensor_get(&b, &[k, j, l]);
+                }
+            }
+            assert!(
+                (tensor_get(&c, &[i, l]) - expected).abs() < 1e-10,
+                "C[{i},{l}] = {}, expected {expected}",
+                tensor_get(&c, &[i, l])
+            );
+        }
+    }
+}
+
+#[test]
+fn batched_gemm_mixed_batch_layouts_match_manual() {
+    let mut ctx = CpuContext::new(1);
+    let a = tensor_from_fn_with_order(&[2, 3, 2, 2], MemoryOrder::RowMajor, |idx| {
+        1.0 + idx[0] as f64 + 0.1 * idx[1] as f64 + 0.01 * idx[2] as f64 + 0.001 * idx[3] as f64
+    });
+    let b = tensor_from_fn_with_order(&[3, 2, 2, 2], MemoryOrder::ColumnMajor, |idx| {
+        -0.5 + 0.2 * idx[0] as f64 - 0.05 * idx[1] as f64 + 0.01 * idx[2] as f64
+            - 0.001 * idx[3] as f64
+    });
+    let mut c = tensor_from_fn_with_order(&[2, 2, 2, 2], MemoryOrder::ColumnMajor, |_| 0.0);
+
+    let desc = TestPrimitiveDescriptor::SemiringCore(SemiringCoreDescriptor::BatchedGemm {
+        batch_dims: vec![2, 2],
+        m: 2,
+        n: 2,
+        k: 3,
+    });
+    let plan = cpu_plan::<f64>(
+        &mut ctx,
+        &desc,
+        &[&[2, 3, 2, 2], &[3, 2, 2, 2], &[2, 2, 2, 2]],
+    )
+    .unwrap();
+    cpu_execute(&mut ctx, &plan, 1.0, &[&a, &b], 0.0, &mut c).unwrap();
+
+    for batch0 in 0..2 {
+        for batch1 in 0..2 {
+            for i in 0..2 {
+                for j in 0..2 {
+                    let mut expected = 0.0;
+                    for k in 0..3 {
+                        expected += tensor_get(&a, &[i, k, batch0, batch1])
+                            * tensor_get(&b, &[k, j, batch0, batch1]);
+                    }
+                    assert!(
+                        (tensor_get(&c, &[i, j, batch0, batch1]) - expected).abs() < 1e-10,
+                        "C[{i},{j},{batch0},{batch1}] = {}, expected {expected}",
+                        tensor_get(&c, &[i, j, batch0, batch1])
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/tenferro/tests/public_surface_tests.rs
+++ b/tenferro/tests/public_surface_tests.rs
@@ -354,6 +354,61 @@ fn tensor_public_einsum_owned_accepts_owned_dynamic_operands() {
 }
 
 #[test]
+fn tensor_public_einsum_transposed_scalar_contraction_matches_manual() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+    let lhs = Tensor::from_tensor(
+        DenseTensor::<Complex64>::from_slice(
+            &[
+                Complex64::new(1.0, 0.2),
+                Complex64::new(-0.5, 0.4),
+                Complex64::new(2.0, -0.1),
+                Complex64::new(0.3, -1.0),
+                Complex64::new(1.2, 0.7),
+                Complex64::new(-0.8, 0.5),
+            ],
+            &[2, 3],
+            MemoryOrder::ColumnMajor,
+        )
+        .unwrap(),
+    );
+    let rhs = Tensor::from_tensor(
+        DenseTensor::<Complex64>::from_slice(
+            &[
+                Complex64::new(0.5, -0.1),
+                Complex64::new(1.0, 0.6),
+                Complex64::new(-1.2, 0.3),
+                Complex64::new(0.7, -0.9),
+                Complex64::new(0.2, 1.1),
+                Complex64::new(-0.4, 0.8),
+            ],
+            &[3, 2],
+            MemoryOrder::ColumnMajor,
+        )
+        .unwrap(),
+    );
+
+    let out = Tensor::einsum("ab,ba->", &[&lhs, &rhs]).unwrap();
+    let actual = match out.try_scalar_value().unwrap() {
+        tenferro::ScalarValue::C64(z) => z,
+        other => panic!("expected C64 scalar, got {other:?}"),
+    };
+
+    let lhs_vals = lhs.as_c64().unwrap().primal().buffer().as_slice().unwrap();
+    let rhs_vals = rhs.as_c64().unwrap().primal().buffer().as_slice().unwrap();
+    let mut expected = Complex64::new(0.0, 0.0);
+    for a in 0..2 {
+        for b in 0..3 {
+            expected += lhs_vals[a + 2 * b] * rhs_vals[b + 3 * a];
+        }
+    }
+
+    assert!(
+        (actual - expected).norm() < 1e-12,
+        "actual={actual:?}, expected={expected:?}"
+    );
+}
+
+#[test]
 fn tensor_public_linalg_single_result_methods_do_not_require_typed_api() {
     let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
     let a = Tensor::from_tensor(


### PR DESCRIPTION
## Summary
- preserve target-axis order when deciding whether einsum reduction groups can be fused
- fix the same orientation-sensitive fusion bug in the CPU contract and batched GEMM layout paths
- add regressions at the prepare, primitive, and public `Tensor::einsum` levels

## Testing
- cargo fmt --all --check
- cargo test --workspace --release
- cargo llvm-cov --workspace --release --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py --doc-root /tmp/tenferro-einsum-transposed-fusion-doc-target/doc --site-index /tmp/tenferro-einsum-transposed-fusion-doc-target/doc/index.html

Fixes #525

Generated with [Claude Code](https://claude.com/claude-code)
