### PR TITLE
refactor: unify scalar type lists via dispatch macros

### DIFF
--- a/tenferro-prims/src/cpu/common.rs
+++ b/tenferro-prims/src/cpu/common.rs
@@ -1,4 +1,3 @@
-use std::any::TypeId;
 use std::ops::{Add, Div, Mul};
 
 use num_complex::{Complex32, Complex64, ComplexFloat};
@@ -8,7 +7,7 @@ use strided_view::{StridedView, StridedViewMut};
 use tenferro_algebra::Scalar;
 use tenferro_device::{Error, Result};
 
-use crate::infra::typed_dispatch::matches_any_type_id;
+use crate::infra::typed_dispatch::{dispatch_real_scalar_type, dispatch_standard_scalar_type};
 use crate::{for_each_index, validate_rank, validate_shape_count, validate_shape_eq};
 
 pub(crate) trait CpuScalarValue:
@@ -186,11 +185,11 @@ pub(super) fn unflatten_index_into(mut flat: usize, dims: &[usize], out: &mut [u
 }
 
 pub(crate) fn is_supported_scalar_type<T: Scalar + 'static>() -> bool {
-    let tid = TypeId::of::<T>();
-    matches_any_type_id!(tid; f32, f64, Complex32, Complex64)
+    dispatch_standard_scalar_type!(T, _Concrete, { return true });
+    false
 }
 
 pub(crate) fn is_supported_ordered_real_type<T: Scalar + 'static>() -> bool {
-    let tid = TypeId::of::<T>();
-    matches_any_type_id!(tid; f32, f64)
+    dispatch_real_scalar_type!(T, _Concrete, { return true });
+    false
 }

--- a/tenferro-prims/src/infra/typed_dispatch.rs
+++ b/tenferro-prims/src/infra/typed_dispatch.rs
@@ -1,11 +1,3 @@
-macro_rules! matches_any_type_id {
-    ($tid:expr; $($ty:ty),+ $(,)?) => {{
-        false $(|| $tid == std::any::TypeId::of::<$ty>())+
-    }};
-}
-
-pub(crate) use matches_any_type_id;
-
 macro_rules! dispatch_type_id {
     ($tid:expr, $concrete:ident, [$($ty:ty),+ $(,)?], $body:block) => {{
         $(


### PR DESCRIPTION
## Summary

- `is_supported_scalar_type` and `is_supported_ordered_real_type` in `cpu/common.rs` previously duplicated the type lists already present in `dispatch_standard_scalar_type!` and `dispatch_real_scalar_type!` in `infra/typed_dispatch.rs`
- Rewrite both functions to reuse the dispatch macros, so the canonical type lists live only in `infra/typed_dispatch.rs`
- Remove the now-unused `matches_any_type_id` macro

Adding a new scalar type now requires updating only one file instead of three.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace --release`
- [x] coverage 180/180 files pass
- [x] `cargo doc --workspace --no-deps`
- [x] `python3 scripts/check-docs-site.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)