### PR TITLE
fix: handle zero-work einsum contractions safely

### DIFF
--- a/tenferro-einsum/tests/empty_tensor_regressions.rs
+++ b/tenferro-einsum/tests/empty_tensor_regressions.rs
@@ -1,0 +1,17 @@
+use tenferro_algebra::Standard;
+use tenferro_einsum::einsum;
+use tenferro_prims::{CpuBackend, CpuContext};
+use tenferro_tensor::{MemoryOrder, Tensor};
+
+#[test]
+fn empty_vector_dot_product_returns_zero_scalar() {
+    let mut ctx = CpuContext::new(1);
+    let a = Tensor::<f64>::from_slice(&[], &[0], MemoryOrder::ColumnMajor).unwrap();
+    let b = Tensor::<f64>::from_slice(&[], &[0], MemoryOrder::ColumnMajor).unwrap();
+
+    let result = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "i,i->", &[&a, &b], None).unwrap();
+
+    assert_eq!(result.dims(), &[] as &[usize]);
+    let scalar = result.buffer().as_slice().unwrap()[result.offset() as usize];
+    assert_eq!(scalar, 0.0);
+}

--- a/tenferro-prims/src/cpu/batched_gemm.rs
+++ b/tenferro-prims/src/cpu/batched_gemm.rs
@@ -9,6 +9,7 @@ use crate::infra::typed_dispatch::{
 use super::context::CpuContext;
 use super::gemm_support::{advance_batch_offset, batch_iteration_count, batch_offset};
 use super::layout_fusion::try_fuse_group_in_order;
+use super::reduction::scale_output;
 
 #[cfg(feature = "gemm-faer")]
 use super::gemm_support::FaerGemm;
@@ -301,6 +302,11 @@ pub(super) fn execute_batched_gemm<T: Scalar + 'static>(
     n: usize,
     k: usize,
 ) -> Result<()> {
+    if inputs.iter().any(|view| view.dims().contains(&0)) || output.dims().contains(&0) {
+        scale_output(output, beta);
+        return Ok(());
+    }
+
     dispatch_standard_scalar_type!(T, Concrete, {
         let a = cast_strided_view!(inputs[0], T, Concrete);
         let b = cast_strided_view!(inputs[1], T, Concrete);

--- a/tenferro-prims/src/cpu/contract.rs
+++ b/tenferro-prims/src/cpu/contract.rs
@@ -9,6 +9,7 @@ use crate::SemiringBinaryOp;
 
 use super::layout_fusion::try_fuse_group_in_order;
 use super::plan::{build_contract_gemm_spec, ContractGemmSpec};
+use super::reduction::scale_output;
 
 #[cfg(feature = "gemm-faer")]
 use super::gemm_support::FaerGemm;
@@ -61,6 +62,11 @@ pub(super) fn execute_contract<T: Scalar>(
     modes_c: &[u32],
     cached_gemm_spec: Option<&ContractGemmSpec>,
 ) -> Result<()> {
+    if inputs.iter().any(|view| view.dims().contains(&0)) || output.dims().contains(&0) {
+        scale_output(output, beta);
+        return Ok(());
+    }
+
     if let Some(done) = try_execute_contract_gemm(
         alpha,
         inputs,

--- a/tenferro-prims/tests/prims_tests.rs
+++ b/tenferro-prims/tests/prims_tests.rs
@@ -2727,6 +2727,45 @@ macro_rules! typed_prims_tests {
             }
 
             #[test]
+            fn batched_gemm_zero_contraction_respects_beta() {
+                let mut ctx = CpuContext::new(1);
+                let a = tensor_zeros::<$T>(&[2, 0]);
+                let b = tensor_zeros::<$T>(&[0, 3]);
+                let mut c = tensor_from_fn(&[2, 3], |_| <$T as TestScalar>::from_f64(5.0));
+
+                let desc =
+                    TestPrimitiveDescriptor::SemiringCore(SemiringCoreDescriptor::BatchedGemm {
+                        batch_dims: vec![],
+                        m: 2,
+                        n: 3,
+                        k: 0,
+                    });
+                let plan = cpu_plan::<$T>(&mut ctx, &desc, &[&[2, 0], &[0, 3], &[2, 3]]).unwrap();
+                cpu_execute(
+                    &mut ctx,
+                    &plan,
+                    <$T as TestScalar>::from_f64(2.0),
+                    &[&a, &b],
+                    <$T as TestScalar>::from_f64(3.0),
+                    &mut c,
+                )
+                .unwrap();
+
+                let expected = <$T as TestScalar>::from_f64(15.0);
+                for i in 0..2 {
+                    for j in 0..3 {
+                        assert!(
+                            <$T as TestScalar>::approx_eq(tensor_get(&c, &[i, j]), expected),
+                            "C[{i},{j}] = {:?}, expected {:?}, diff = {}",
+                            tensor_get(&c, &[i, j]),
+                            expected,
+                            <$T as TestScalar>::diff_norm(tensor_get(&c, &[i, j]), expected)
+                        );
+                    }
+                }
+            }
+
+            #[test]
             fn reduce_sum_axis0() {
                 let mut ctx = CpuContext::new(1);
                 let a = tensor_from_fn(&[3, 4], |idx| {
@@ -3436,6 +3475,45 @@ macro_rules! typed_prims_tests {
                         }
                         let expected = <$T as TestScalar>::from_f64(2.0) * matmul
                             + <$T as TestScalar>::from_f64(3.0) * <$T as TestScalar>::from_f64(5.0);
+                        assert!(
+                            <$T as TestScalar>::approx_eq(tensor_get(&c, &[i, j]), expected),
+                            "C[{i},{j}] = {:?}, expected {:?}, diff = {}",
+                            tensor_get(&c, &[i, j]),
+                            expected,
+                            <$T as TestScalar>::diff_norm(tensor_get(&c, &[i, j]), expected)
+                        );
+                    }
+                }
+            }
+
+            #[test]
+            fn contract_zero_contraction_respects_beta() {
+                let mut ctx = CpuContext::new(1);
+                let a = tensor_zeros::<$T>(&[2, 0]);
+                let b = tensor_zeros::<$T>(&[0, 3]);
+                let mut c = tensor_from_fn(&[2, 3], |_| <$T as TestScalar>::from_f64(4.0));
+
+                let desc = TestPrimitiveDescriptor::SemiringFastPath(
+                    SemiringFastPathDescriptor::Contract {
+                        modes_a: vec![0, 1],
+                        modes_b: vec![1, 2],
+                        modes_c: vec![0, 2],
+                    },
+                );
+                let plan = cpu_plan::<$T>(&mut ctx, &desc, &[&[2, 0], &[0, 3], &[2, 3]]).unwrap();
+                cpu_execute(
+                    &mut ctx,
+                    &plan,
+                    <$T as TestScalar>::from_f64(2.0),
+                    &[&a, &b],
+                    <$T as TestScalar>::from_f64(3.0),
+                    &mut c,
+                )
+                .unwrap();
+
+                let expected = <$T as TestScalar>::from_f64(12.0);
+                for i in 0..2 {
+                    for j in 0..3 {
                         assert!(
                             <$T as TestScalar>::approx_eq(tensor_get(&c, &[i, j]), expected),
                             "C[{i},{j}] = {:?}, expected {:?}, diff = {}",


### PR DESCRIPTION
## Summary

- short-circuit CPU `BatchedGemm` and `Contract` execution when any operand or output extent is zero
- preserve the existing `beta` term for those zero-work cases instead of entering faer GEMM
- add regressions for the empty einsum dot product and the underlying zero-contraction primitive paths

## Root Cause

`einsum("i,i->", [0], [0])` reached the CPU contract fast path. The contraction planners normalize fused zero extents up to `1` for bookkeeping, so the backend ended up calling a strided GEMM kernel on tensors whose real shapes still contained zero extents. The faer path then read invalid memory and segfaulted.

## Verification

- `cargo test -p tenferro-einsum empty_vector_dot_product_returns_zero_scalar -- --exact`
- `cargo test -p tenferro-prims zero_contraction_respects_beta -- --nocapture`
- `cargo test -p tenferro-prims contract_matrix_multiply -- --nocapture`
- `cargo test -p tenferro-prims batched_gemm_2x3_times_3x2 -- --nocapture`

## Documentation

- Reviewed `README.md`, `docs/design/**`, `docs/api_index.md`, and public rustdoc for consistency; no behavior or API documentation changes were required.

Fixes #530

Generated with [Claude Code](https://claude.com/claude-code)
