### PR TITLE
fix: harden remaining issue #537 edge cases

### DIFF
--- a/tenferro-einsum/src/execution/dispatch.rs
+++ b/tenferro-einsum/src/execution/dispatch.rs
@@ -38,6 +38,17 @@ static GEMM_FLOPS: AtomicU64 = AtomicU64::new(0);
 #[cfg(feature = "profile-dispatch")]
 static GEMM_CALLS_TINY: AtomicU64 = AtomicU64::new(0);
 
+#[cfg(feature = "profile-dispatch")]
+fn gemm_flops_u64(plan: &GemmPlan) -> u64 {
+    plan.batch_sizes
+        .iter()
+        .try_fold(2u64, |acc, &dim| acc.checked_mul(u64::try_from(dim).ok()?))
+        .and_then(|acc| acc.checked_mul(u64::try_from(plan.m).ok()?))
+        .and_then(|acc| acc.checked_mul(u64::try_from(plan.n).ok()?))
+        .and_then(|acc| acc.checked_mul(u64::try_from(plan.k).ok()?))
+        .unwrap_or(u64::MAX)
+}
+
 /// Reset and print accumulated dispatch profiling counters.
 #[cfg(feature = "profile-dispatch")]
 pub fn print_and_reset_profile() {
@@ -308,38 +319,28 @@ where
     #[cfg(feature = "profile-dispatch")]
     PREPARE_NS.fetch_add(_prep_t0.elapsed().as_nanos() as u64, Ordering::Relaxed);
 
-    // Try to write GEMM directly into output (skip temp buffer).
-    // Requires: no final permute needed AND output's lo/ro dims are fusable.
     let n_lo = plan.lo_modes.len();
     let n_ro = plan.ro_modes.len();
-    let c_direct = !plan.needs_final_permute && {
+    let c_direct = if plan.needs_final_permute {
+        None
+    } else {
         let c_dims = output.dims();
         let c_strides = output.strides();
-        let g1 = try_fuse_group_in_target_order(&c_dims[..n_lo], &c_strides[..n_lo]);
-        let g2 = try_fuse_group_in_target_order(
-            &c_dims[n_lo..n_lo + n_ro],
-            &c_strides[n_lo..n_lo + n_ro],
-        );
-        g1.is_some() && g2.is_some()
+        match (
+            try_fuse_group_in_target_order(&c_dims[..n_lo], &c_strides[..n_lo]),
+            try_fuse_group_in_target_order(
+                &c_dims[n_lo..n_lo + n_ro],
+                &c_strides[n_lo..n_lo + n_ro],
+            ),
+        ) {
+            (Some((_, m_stride)), Some((_, n_stride))) => Some((m_stride, n_stride)),
+            _ => None,
+        }
     };
 
-    if c_direct {
-        // Direct write: fuse output's lo→M, ro→N dims and write GEMM directly.
-        //
-        // We must take sole ownership of the underlying buffer so that
-        // Arc::get_mut succeeds when the GEMM backend requests mutable
-        // access.  `view_as_strided` clones the Arc, so we swap output
-        // with a placeholder, create the fused view, and drop the
-        // intermediate to bring the refcount back to 1.
+    if let Some((m_stride, n_stride)) = c_direct {
         let c_dims = output.dims().to_vec();
         let c_strides = output.strides().to_vec();
-        let (_, m_stride) =
-            try_fuse_group_in_target_order(&c_dims[..n_lo], &c_strides[..n_lo]).unwrap();
-        let (_, n_stride) = try_fuse_group_in_target_order(
-            &c_dims[n_lo..n_lo + n_ro],
-            &c_strides[n_lo..n_lo + n_ro],
-        )
-        .unwrap();
         let mut fused_dims = Vec::with_capacity(2 + nb);
         let mut fused_strides = Vec::with_capacity(2 + nb);
         fused_dims.push(plan.m);
@@ -349,7 +350,6 @@ where
         fused_dims.extend_from_slice(&c_dims[n_lo + n_ro..]);
         fused_strides.extend_from_slice(&c_strides[n_lo + n_ro..]);
 
-        // Swap output with a tiny placeholder to get sole Arc ownership.
         let placeholder = alloc_tensor_from_pool::<Alg::Scalar>(&[], memory_space, pool);
         let out_tensor = std::mem::replace(output, placeholder);
         let mut c_fused = out_tensor.view_as_strided(fused_dims, fused_strides)?;
@@ -382,20 +382,16 @@ where
         #[cfg(feature = "profile-dispatch")]
         {
             GEMM_NS.fetch_add(_gemm_t0.elapsed().as_nanos() as u64, Ordering::Relaxed);
-            let batch_total: usize = plan.batch_sizes.iter().product();
-            let flops = 2 * batch_total * plan.m * plan.n * plan.k;
-            GEMM_FLOPS.fetch_add(flops as u64, Ordering::Relaxed);
+            GEMM_FLOPS.fetch_add(gemm_flops_u64(plan), Ordering::Relaxed);
             if plan.m * plan.n * plan.k <= 64 {
                 GEMM_CALLS_TINY.fetch_add(1, Ordering::Relaxed);
             }
         }
 
-        // Restore original shape and write back to output.
         let restored = c_fused.view_as_strided(c_dims, c_strides)?;
         drop(c_fused); // Arc refcount → 1
         *output = restored;
     } else {
-        // Fallback: GEMM into temp buffer, then permute/copy to output.
         let mut temp =
             alloc_tensor_from_pool::<Alg::Scalar>(&plan.c_gemm_shape, memory_space, pool);
         let owned_plan;
@@ -425,9 +421,7 @@ where
         #[cfg(feature = "profile-dispatch")]
         {
             GEMM_NS.fetch_add(_gemm_t0.elapsed().as_nanos() as u64, Ordering::Relaxed);
-            let batch_total: usize = plan.batch_sizes.iter().product();
-            let flops = 2 * batch_total * plan.m * plan.n * plan.k;
-            GEMM_FLOPS.fetch_add(flops as u64, Ordering::Relaxed);
+            GEMM_FLOPS.fetch_add(gemm_flops_u64(plan), Ordering::Relaxed);
             if plan.m * plan.n * plan.k <= 64 {
                 GEMM_CALLS_TINY.fetch_add(1, Ordering::Relaxed);
             }

--- a/tenferro-einsum/src/tests/organization.rs
+++ b/tenferro-einsum/src/tests/organization.rs
@@ -96,3 +96,23 @@ fn split_einsum_modules_stay_under_size_guideline() {
         );
     }
 }
+
+#[test]
+fn dispatch_cleanup_guards_against_unwraps_and_usize_flop_math() {
+    let contents = fs::read_to_string(repo_path("src/execution/dispatch.rs")).unwrap();
+
+    assert!(
+        !contents.contains(
+            "try_fuse_group_in_target_order(&c_dims[..n_lo], &c_strides[..n_lo]).unwrap()"
+        ),
+        "dispatch direct-write path should not unwrap fused-layout probes"
+    );
+    assert!(
+        !contents.contains("let flops = 2 * batch_total * plan.m * plan.n * plan.k;"),
+        "dispatch profiling should not compute FLOPS in usize arithmetic"
+    );
+    assert!(
+        contents.contains("checked_mul") || contents.contains("saturating_mul"),
+        "dispatch profiling should use checked or saturating multiply for GEMM FLOPS"
+    );
+}

--- a/tenferro-tensor/src/tensor/views.rs
+++ b/tenferro-tensor/src/tensor/views.rs
@@ -125,7 +125,15 @@ impl<T: Scalar> Tensor<T> {
             used[i] = true;
             used[j] = true;
             diag_dims.push(self.dims[i]);
-            diag_strides.push(self.strides[i] + self.strides[j]);
+            let stride = self.strides[i]
+                .checked_add(self.strides[j])
+                .ok_or_else(|| {
+                    Error::InvalidArgument(format!(
+                        "diagonal stride overflow for axes ({i}, {j}) with strides {} and {}",
+                        self.strides[i], self.strides[j]
+                    ))
+                })?;
+            diag_strides.push(stride);
         }
 
         let mut new_dims = Vec::new();

--- a/tenferro-tensor/src/tests/mod.rs
+++ b/tenferro-tensor/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod completion_event;
 #[cfg(feature = "cuda")]
 mod cuda;
 mod organization;
+mod views;
 
 #[test]
 fn tensor_debug_is_summary_style() {

--- a/tenferro-tensor/src/tests/views.rs
+++ b/tenferro-tensor/src/tests/views.rs
@@ -1,0 +1,20 @@
+use super::*;
+use tenferro_device::{Error, LogicalMemorySpace};
+
+#[test]
+fn diagonal_reports_stride_overflow_for_zero_extent_view() {
+    let base = Tensor::<f64>::zeros(
+        &[0, 0],
+        LogicalMemorySpace::MainMemory,
+        MemoryOrder::ColumnMajor,
+    );
+    let view = base
+        .view_as_strided(vec![0, 0], vec![isize::MAX, 1])
+        .unwrap();
+
+    let err = view.diagonal(&[(0, 1)]).unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(ref message) if message.contains("stride overflow")),
+        "expected diagonal stride overflow error, got {err:?}"
+    );
+}

--- a/tenferro/src/ops/ad/tests/mod.rs
+++ b/tenferro/src/ops/ad/tests/mod.rs
@@ -4,6 +4,7 @@ mod einsum_one_stage_complex;
 mod einsum_one_stage_real;
 mod einsum_two_stage;
 mod linalg_finite_difference;
+mod reduction_edge_cases;
 mod scalar_generic;
 mod structured_pullbacks;
 mod support;

--- a/tenferro/src/ops/ad/tests/reduction_edge_cases.rs
+++ b/tenferro/src/ops/ad/tests/reduction_edge_cases.rs
@@ -1,0 +1,42 @@
+use super::{reverse_leaf_f64, tensor_from_vec_f64 as tensor_from_slice, tensor_to_vec_f64};
+use chainrules::Tape;
+use tenferro_prims::CpuContext;
+
+use crate::ops::std_ad;
+use crate::{set_default_runtime, AdTensor, RuntimeContext};
+
+#[test]
+fn std_ad_reverse_pullback_returns_zero_for_constant_input() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let tape = Tape::<crate::DynTensor>::new();
+    let x = reverse_leaf_f64(tensor_from_slice(&[2.0, 2.0, 2.0, 2.0], &[2, 2]), &tape);
+    let out = std_ad(&x).run().unwrap();
+    let cotangent = AdTensor::new_primal(tensor_from_slice(&[1.0], &[]));
+
+    let grads = crate::ops::ad::pullback_wrt(&out, &cotangent, &[&x]).unwrap();
+    let actual = tensor_to_vec_f64(grads[0].as_ref().unwrap().payload());
+    assert!(
+        actual.iter().all(|value| value.is_finite()),
+        "std_ad gradient should stay finite for constant input, got {actual:?}"
+    );
+    assert_eq!(actual, vec![0.0, 0.0, 0.0, 0.0]);
+}
+
+#[test]
+fn std_ad_forward_tangent_returns_zero_for_constant_input() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let x = tensor_from_slice(&[2.0, 2.0, 2.0, 2.0], &[2, 2]);
+    let dx = tensor_from_slice(&[1.0, -1.0, 0.5, -0.5], &[2, 2]);
+    let out = std_ad(&AdTensor::new_forward(x, dx).unwrap())
+        .run()
+        .unwrap();
+
+    let tangent = tensor_to_vec_f64(out.tangent().unwrap());
+    assert!(
+        tangent.iter().all(|value| value.is_finite()),
+        "std_ad tangent should stay finite for constant input, got {tangent:?}"
+    );
+    assert_eq!(tangent, vec![0.0]);
+}

--- a/tenferro/src/ops/scalar/ad/reduction.rs
+++ b/tenferro/src/ops/scalar/ad/reduction.rs
@@ -38,6 +38,9 @@ define_unary_ad_builder!(StdAdBuilder, std_ad, "std", real, |builder| {
         builder.tensor,
         |input| analytic_full_reduction_primal("std_ad_primal", AnalyticReductionOp::Std, input),
         |input, primal, tangent| {
+            if scalar_from_rank0_tensor(primal, "std_ad")? == T::zero() {
+                return broadcast_scalar_like(T::zero(), primal);
+            }
             let var_tangent = variance_reduction_tangent("std_ad_var_tangent", input, tangent)?;
             let two = two_tensor_like(primal)?;
             let denom = scalar_binary_primal("std_ad_denom", ScalarBinaryOp::Mul, primal, &two)?;
@@ -47,6 +50,9 @@ define_unary_ad_builder!(StdAdBuilder, std_ad, "std", real, |builder| {
             let centered = centered_input_tensor("std_ad_centered", input)?;
             let cotangent_scalar = scalar_from_rank0_tensor(cotangent, "std_ad")?;
             let primal_scalar = scalar_from_rank0_tensor(primal, "std_ad")?;
+            if primal_scalar == T::zero() {
+                return broadcast_scalar_like(T::zero(), input);
+            }
             let coeff = cotangent_scalar / (scalar_from_usize::<T>(input.len())? * primal_scalar);
             let coeff_tensor = broadcast_scalar_like(coeff, input)?;
             scalar_binary_primal(


### PR DESCRIPTION
## Summary

- remove the fragile direct-write `unwrap()` pattern in einsum dispatch by carrying fused output strides through the direct-write decision
- compute `profile-dispatch` GEMM FLOPS with checked `u64` arithmetic instead of unchecked `usize` multiplication
- return a proper error when `Tensor::diagonal()` would overflow the merged stride
- treat zero-variance `std_ad` inputs as a zero-derivative edge case instead of emitting `NaN` tangents or pullbacks
- add focused regression tests for the tensor view overflow, zero-variance std AD behavior, and dispatch cleanup invariants

## Root Cause

- the direct GEMM write path probed fusibility twice and unwrapped the second probe instead of carrying the first successful result forward
- the profiling counter multiplied large `usize` dimensions before casting to `u64`
- diagonal view construction added two strides without overflow checking
- `std_ad` divided by the primal standard deviation even when the reduction result was zero

## Verification

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/tenferro-rs-issue-537-target cargo test -p tenferro-tensor --lib`
- `CARGO_TARGET_DIR=/tmp/tenferro-rs-issue-537-target cargo test -p tenferro-einsum --lib`
- `CARGO_TARGET_DIR=/tmp/tenferro-rs-issue-537-target cargo test -p tenferro std_ad_reverse_pullback_returns_zero_for_constant_input`
- `CARGO_TARGET_DIR=/tmp/tenferro-rs-issue-537-target cargo test -p tenferro std_ad_forward_tangent_returns_zero_for_constant_input`
- `CARGO_TARGET_DIR=/tmp/tenferro-rs-issue-537-target cargo test -p tenferro atan2_and_moment_reductions_reverse_pullback_match_expected_dense_gradients`

## Notes

- the DLPack-related bullets collected under #537 were already resolved or invalidated on current `main`; this PR addresses the remaining live issues in that batch

Fixes #537

Generated with [Codex](https://openai.com)
