### PR TITLE
fix: stage repeated-label diagonals in einsum

### DIFF
--- a/tenferro-einsum/src/execution/dispatch.rs
+++ b/tenferro-einsum/src/execution/dispatch.rs
@@ -13,7 +13,7 @@ use tenferro_tensor::Tensor;
 
 use crate::execution::backend::{BackendContext, BackendPlan, EinsumBackend};
 use crate::execution::pool::BufferPool;
-use crate::execution::util::alloc_tensor_from_pool;
+use crate::execution::util::{alloc_tensor_from_pool, apply_diag_plan};
 use crate::planning::classify::compute_permutation;
 use crate::planning::plan::{GemmPlan, ReducePlan, StepPlan};
 use crate::planning::prepare::{prepare_one_operand, try_fuse_group_in_target_order};
@@ -103,14 +103,14 @@ where
     // 1. Diagonal extraction (zero-copy view)
     let a_diag;
     let a_ref = if let Some(ref dp) = plan.diag_a {
-        a_diag = a.diagonal(&dp.axis_pairs)?;
+        a_diag = apply_diag_plan(a, dp)?;
         &a_diag
     } else {
         a
     };
     let b_diag;
     let b_ref = if let Some(ref dp) = plan.diag_b {
-        b_diag = b.diagonal(&dp.axis_pairs)?;
+        b_diag = apply_diag_plan(b, dp)?;
         &b_diag
     } else {
         b

--- a/tenferro-einsum/src/execution/unary.rs
+++ b/tenferro-einsum/src/execution/unary.rs
@@ -7,8 +7,9 @@ use tenferro_tensor::{MemoryOrder, Tensor};
 
 use crate::execution::backend::BackendContext;
 use crate::execution::pool::BufferPool;
-use crate::execution::util::alloc_tensor_from_pool;
+use crate::execution::util::{alloc_tensor_from_pool, apply_diag_plan};
 use crate::planning::classify::compute_permutation;
+use crate::planning::plan::compute_diag_plan_for_labels;
 
 fn copy_structural_permute<Alg, Backend>(
     ctx: &mut BackendContext<Alg, Backend>,
@@ -151,38 +152,17 @@ where
             <Backend as TensorSemiringCore<Alg>>::execute(ctx, &plan, alpha, &[input], beta, output)
         } else {
             // Diagonal extraction: repeated labels appear in output
-            // Diagonal extraction + copy
-            let mut axis_pairs = Vec::new();
-            for &l in &repeated_in_output {
-                let positions = &label_positions[&l];
-                if positions.len() != 2 {
-                    return Err(tenferro_device::Error::InvalidArgument(format!(
-                        "label {} appears {} times in input; only 2-way diagonal supported",
-                        l,
-                        positions.len()
-                    )));
-                }
-                axis_pairs.push((positions[0], positions[1]));
-            }
+            let labels_to_extract: HashSet<u32> = repeated_in_output.iter().copied().collect();
+            let diag_plan =
+                compute_diag_plan_for_labels(subs_a, &labels_to_extract).ok_or_else(|| {
+                    tenferro_device::Error::InvalidArgument(
+                        "expected repeated labels to produce a diagonal extraction plan".into(),
+                    )
+                })?;
 
-            // Extract diagonal as a new Tensor (shares buffer via Arc)
-            let diag_tensor = input.diagonal(&axis_pairs)?;
-
-            // Build subscripts after diagonal extraction
-            let mut used = vec![false; subs_a.len()];
-            for &(a, b) in &axis_pairs {
-                used[a] = true;
-                used[b] = true;
-            }
-            let mut after_diag_subs: Vec<u32> = Vec::new();
-            for (i, &l) in subs_a.iter().enumerate() {
-                if !used[i] {
-                    after_diag_subs.push(l);
-                }
-            }
-            for &l in &repeated_in_output {
-                after_diag_subs.push(l);
-            }
+            // Extract diagonal as a new Tensor (shares buffer via Arc).
+            let diag_tensor = apply_diag_plan(input, &diag_plan)?;
+            let after_diag_subs = diag_plan.result_subs.clone();
 
             // Check if we need reduction or just permutation
             let after_set: HashSet<u32> = after_diag_subs.iter().copied().collect();
@@ -282,36 +262,15 @@ where
 
         // Stage 1: Diagonal extraction
         if !diag_extract_labels.is_empty() {
-            let mut axis_pairs = Vec::new();
-            for &l in &diag_extract_labels {
-                let positions: Vec<usize> = current_subs
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, &s)| s == l)
-                    .map(|(i, _)| i)
-                    .collect();
-                for pair in positions.windows(2) {
-                    axis_pairs.push((pair[0], pair[1]));
-                }
-            }
-            current = current.diagonal(&axis_pairs)?;
-
-            // Rebuild subscripts: unused positions first, then one copy per diagonal label
-            let mut used = vec![false; current_subs.len()];
-            for &(a, b) in &axis_pairs {
-                used[a] = true;
-                used[b] = true;
-            }
-            let mut new_subs = Vec::new();
-            for (i, &l) in current_subs.iter().enumerate() {
-                if !used[i] {
-                    new_subs.push(l);
-                }
-            }
-            for &l in &diag_extract_labels {
-                new_subs.push(l);
-            }
-            current_subs = new_subs;
+            let labels_to_extract: HashSet<u32> = diag_extract_labels.iter().copied().collect();
+            let diag_plan = compute_diag_plan_for_labels(&current_subs, &labels_to_extract)
+                .ok_or_else(|| {
+                    tenferro_device::Error::InvalidArgument(
+                        "expected repeated labels to produce a diagonal extraction plan".into(),
+                    )
+                })?;
+            current = apply_diag_plan(&current, &diag_plan)?;
+            current_subs = diag_plan.result_subs.clone();
         }
 
         // Stage 2: Trace/Reduce for labels remaining in input but not in output.

--- a/tenferro-einsum/src/execution/util.rs
+++ b/tenferro-einsum/src/execution/util.rs
@@ -5,6 +5,7 @@ use tenferro_device::{Error, LogicalMemorySpace, Result};
 use tenferro_tensor::{MemoryOrder, Tensor};
 
 use crate::execution::pool::BufferPool;
+use crate::planning::plan::DiagPlan;
 use crate::syntax::subscripts::Subscripts;
 
 pub(crate) const MAX_POOLED_BYTES: usize = 64 * 1024 * 1024; // 64 MB
@@ -30,6 +31,15 @@ pub(crate) fn alloc_tensor_from_pool<T: Scalar>(
     }
     Tensor::from_vec(data, dims, &strides, 0)
         .unwrap_or_else(|_| Tensor::zeros(dims, memory_space, MemoryOrder::ColumnMajor))
+}
+
+/// Apply a staged diagonal extraction plan to a tensor.
+pub(crate) fn apply_diag_plan<T: Scalar>(tensor: &Tensor<T>, plan: &DiagPlan) -> Result<Tensor<T>> {
+    let mut current = tensor.clone();
+    for stage in &plan.stages {
+        current = current.diagonal(&stage.axis_pairs)?;
+    }
+    Ok(current)
 }
 
 /// Infer the common memory space from a set of operand tensors.

--- a/tenferro-einsum/src/planning/plan.rs
+++ b/tenferro-einsum/src/planning/plan.rs
@@ -16,12 +16,20 @@ pub(crate) struct ReducePlan {
 /// Pre-computed diagonal extraction plan for one operand.
 ///
 /// When an operand has repeated labels (e.g. `A[i,i,j]`), this plan
-/// describes how to extract the diagonal via `Tensor::diagonal` before
-/// the main contraction.  Only 2-way repetition per label is supported.
-pub(crate) struct DiagPlan {
-    /// Axis pairs to pass to `Tensor::diagonal` (position-based).
+/// describes how to extract the diagonal via one or more
+/// `Tensor::diagonal` stages before the main contraction.
+pub(crate) struct DiagStage {
+    /// Axis pairs to pass to `Tensor::diagonal` for this stage.
     pub(crate) axis_pairs: Vec<(usize, usize)>,
-    /// Subscripts after diagonal extraction: `[non_used..., diag_labels...]`.
+    /// Subscripts after this stage: `[non_used..., diag_labels...]`.
+    pub(crate) result_subs: Vec<u32>,
+}
+
+/// Pre-computed multi-stage diagonal extraction plan for one operand.
+pub(crate) struct DiagPlan {
+    /// Sequential diagonal stages, each using only disjoint axis pairs.
+    pub(crate) stages: Vec<DiagStage>,
+    /// Final subscripts after all diagonal extraction stages.
     pub(crate) result_subs: Vec<u32>,
 }
 
@@ -115,60 +123,103 @@ pub(crate) fn compute_reduce_plan(
 /// Pre-compute a diagonal extraction plan for an operand with repeated labels.
 ///
 /// Returns `None` if all labels are unique (no diagonal extraction needed).
-/// Only 2-way repetition per label is supported; 3+ way repetition returns
-/// an error via the `Err` variant of the returned `Result`.
+pub(crate) fn compute_diag_plan_for_labels(
+    subs: &[u32],
+    labels_to_extract: &HashSet<u32>,
+) -> Option<DiagPlan> {
+    fn label_positions(subs: &[u32]) -> HashMap<u32, Vec<usize>> {
+        let mut positions = HashMap::new();
+        for (i, &label) in subs.iter().enumerate() {
+            positions.entry(label).or_insert_with(Vec::new).push(i);
+        }
+        positions
+    }
+
+    fn build_diag_stage(subs: &[u32], labels_to_extract: &HashSet<u32>) -> Option<DiagStage> {
+        let positions_by_label = label_positions(subs);
+        let mut seen = HashSet::new();
+        let repeated_labels: Vec<u32> = subs
+            .iter()
+            .copied()
+            .filter(|label| {
+                labels_to_extract.contains(label)
+                    && positions_by_label
+                        .get(label)
+                        .is_some_and(|positions| positions.len() > 1)
+                    && seen.insert(*label)
+            })
+            .collect();
+
+        if repeated_labels.is_empty() {
+            return None;
+        }
+
+        let mut axis_pairs = Vec::new();
+        let mut used = vec![false; subs.len()];
+        let mut diag_labels = Vec::new();
+
+        for label in repeated_labels {
+            let positions = &positions_by_label[&label];
+            for chunk in positions.chunks(2) {
+                if let [left, right] = chunk {
+                    axis_pairs.push((*left, *right));
+                    used[*left] = true;
+                    used[*right] = true;
+                    diag_labels.push(label);
+                }
+            }
+        }
+
+        if axis_pairs.is_empty() {
+            return None;
+        }
+
+        let mut result_subs = Vec::with_capacity(subs.len() - axis_pairs.len());
+        for (i, &label) in subs.iter().enumerate() {
+            if !used[i] {
+                result_subs.push(label);
+            }
+        }
+        result_subs.extend(diag_labels);
+
+        Some(DiagStage {
+            axis_pairs,
+            result_subs,
+        })
+    }
+
+    let mut current_subs = subs.to_vec();
+    let mut stages = Vec::new();
+    while let Some(stage) = build_diag_stage(&current_subs, labels_to_extract) {
+        current_subs = stage.result_subs.clone();
+        stages.push(stage);
+    }
+
+    if stages.is_empty() {
+        None
+    } else {
+        Some(DiagPlan {
+            stages,
+            result_subs: current_subs,
+        })
+    }
+}
+
 pub(crate) fn compute_diag_plan(subs: &[u32]) -> Result<Option<DiagPlan>, String> {
-    // Find labels that appear more than once
+    let mut repeated_labels = HashSet::new();
     let mut label_positions: HashMap<u32, Vec<usize>> = HashMap::new();
     for (i, &label) in subs.iter().enumerate() {
         label_positions.entry(label).or_default().push(i);
     }
-
-    let mut axis_pairs = Vec::new();
-    let mut repeated_labels = Vec::new();
-    for (&label, positions) in &label_positions {
-        match positions.len() {
-            1 => {} // unique, nothing to do
-            2 => {
-                axis_pairs.push((positions[0], positions[1]));
-                repeated_labels.push(label);
-            }
-            n => {
-                return Err(format!(
-                    "label {} appears {} times in operand; only 2-way diagonal supported",
-                    label, n
-                ));
-            }
+    for &label in subs {
+        if label_positions
+            .get(&label)
+            .is_some_and(|positions| positions.len() > 1)
+        {
+            repeated_labels.insert(label);
         }
     }
-
-    if axis_pairs.is_empty() {
-        return Ok(None);
-    }
-
-    // Build result_subs matching Tensor::diagonal output layout:
-    // [non_used_axes..., diag_axes...]
-    let mut used = vec![false; subs.len()];
-    for &(a, b) in &axis_pairs {
-        used[a] = true;
-        used[b] = true;
-    }
-
-    let mut result_subs = Vec::new();
-    for (i, &label) in subs.iter().enumerate() {
-        if !used[i] {
-            result_subs.push(label);
-        }
-    }
-    // Diagonal axes are appended in the order of axis_pairs
-    for &label in &repeated_labels {
-        result_subs.push(label);
-    }
-
-    Ok(Some(DiagPlan {
-        axis_pairs,
-        result_subs,
-    }))
+    Ok(compute_diag_plan_for_labels(subs, &repeated_labels))
 }
 
 /// Compile step plans for all steps in a contraction tree.

--- a/tenferro-einsum/tests/einsum_tests.rs
+++ b/tenferro-einsum/tests/einsum_tests.rs
@@ -1431,6 +1431,91 @@ macro_rules! typed_einsum_tests {
             }
 
             #[test]
+            fn einsum_binary_multi_repeat_contract() {
+                let mut ctx = CpuContext::new(1);
+                let a = make_tensor(&[2, 2, 2, 3], |idx| {
+                    <$T as TestScalar>::from_usize(
+                        idx[0] + 10 * idx[1] + 100 * idx[2] + 1000 * idx[3] + 1,
+                    )
+                });
+                let b = make_tensor(&[3, 2], |idx| {
+                    <$T as TestScalar>::from_usize(idx[0] * 2 + idx[1] + 1)
+                });
+
+                let c = einsum::<TS, CpuBackend>(&mut ctx, "iiij,jk->ik", &[&a, &b], None).unwrap();
+                assert_eq!(c.dims(), &[2, 2]);
+
+                for i in 0..2 {
+                    for k in 0..2 {
+                        let mut expected = <$T as TestScalar>::from_f64(0.0);
+                        for j in 0..3 {
+                            expected = expected + get_t(&a, &[i, i, i, j]) * get_t(&b, &[j, k]);
+                        }
+                        assert!(
+                            <$T as TestScalar>::approx_eq(get_t(&c, &[i, k]), expected),
+                            "C[{i},{k}] = {:?}, expected {:?}, diff = {}",
+                            get_t(&c, &[i, k]),
+                            expected,
+                            <$T as TestScalar>::diff_norm(get_t(&c, &[i, k]), expected)
+                        );
+                    }
+                }
+            }
+
+            #[test]
+            fn einsum_multi_repeat_diagonal_extract() {
+                let mut ctx = CpuContext::new(1);
+                let a = make_tensor(&[2, 2, 2, 3], |idx| {
+                    <$T as TestScalar>::from_usize(
+                        idx[0] + 10 * idx[1] + 100 * idx[2] + 1000 * idx[3] + 1,
+                    )
+                });
+
+                let y = einsum::<TS, CpuBackend>(&mut ctx, "iiij->ij", &[&a], None).unwrap();
+                assert_eq!(y.dims(), &[2, 3]);
+
+                for i in 0..2 {
+                    for j in 0..3 {
+                        let expected = get_t(&a, &[i, i, i, j]);
+                        assert!(
+                            <$T as TestScalar>::approx_eq(get_t(&y, &[i, j]), expected),
+                            "Y[{i},{j}] = {:?}, expected {:?}, diff = {}",
+                            get_t(&y, &[i, j]),
+                            expected,
+                            <$T as TestScalar>::diff_norm(get_t(&y, &[i, j]), expected)
+                        );
+                    }
+                }
+            }
+
+            #[test]
+            fn einsum_binary_four_way_repeat_outer_product() {
+                let mut ctx = CpuContext::new(1);
+                let a = make_tensor(&[2, 2, 2, 2], |idx| {
+                    <$T as TestScalar>::from_usize(
+                        idx[0] + 10 * idx[1] + 100 * idx[2] + 1000 * idx[3] + 1,
+                    )
+                });
+                let v = make_tensor(&[3], |idx| <$T as TestScalar>::from_usize(idx[0] + 2));
+
+                let y = einsum::<TS, CpuBackend>(&mut ctx, "iiii,j->ij", &[&a, &v], None).unwrap();
+                assert_eq!(y.dims(), &[2, 3]);
+
+                for i in 0..2 {
+                    for j in 0..3 {
+                        let expected = get_t(&a, &[i, i, i, i]) * get_t(&v, &[j]);
+                        assert!(
+                            <$T as TestScalar>::approx_eq(get_t(&y, &[i, j]), expected),
+                            "Y[{i},{j}] = {:?}, expected {:?}, diff = {}",
+                            get_t(&y, &[i, j]),
+                            expected,
+                            <$T as TestScalar>::diff_norm(get_t(&y, &[i, j]), expected)
+                        );
+                    }
+                }
+            }
+
+            #[test]
             fn einsum_matmul() {
                 let mut ctx = CpuContext::new(1);
                 let a = make_tensor(&[2, 3], |idx| {


### PR DESCRIPTION
## Summary

- replace one-shot diagonal extraction with staged diagonal plans that collapse repeated operand labels until they are unique
- reuse the staged extraction path in pairwise contraction dispatch and unary diagonal-extraction code paths
- add typed regressions for unary and binary `N>=3` repeated-label einsum cases across `f64`, `f32`, and `Complex64`

## Root Cause

The pairwise planner and the unary diagonal-extraction branches assumed repeated labels could always be handled by a single `Tensor::diagonal` call over disjoint axis pairs. That holds for 2-way repeats, but `Tensor::diagonal` rejects overlapping pairs, so 3-way and 4-way repeats still errored even though the underlying semantics are representable.

## Verification

- `CARGO_TARGET_DIR=/tmp/tenferro-rs-issue-264-target cargo test -p tenferro-einsum --test einsum_tests multi_repeat -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/tenferro-rs-issue-264-target cargo test -p tenferro-einsum --test einsum_tests four_way_repeat -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/tenferro-rs-issue-264-target cargo test -p tenferro-einsum --test einsum_tests einsum_binary_diag_iij_jk_to_ik -- --exact`
- `CARGO_TARGET_DIR=/tmp/tenferro-rs-issue-264-target cargo test -p tenferro-einsum`

## Documentation

- reviewed `README.md`, `docs/design/**`, `docs/api_index.md`, and public rustdoc for this behavior change; no documentation updates were required because this fixes unsupported direct-einsum cases without changing the public API shape

Fixes #264

Generated with [OpenAI Codex](https://openai.com)
