### PR TITLE
refactor(tensor): remove Scalar bound from Tensor<T> struct (#554)

### DIFF
--- a/tenferro-tensor/src/tensor/data_ops.rs
+++ b/tenferro-tensor/src/tensor/data_ops.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 
 use num_complex::{Complex32, Complex64};
-use tenferro_algebra::{Conjugate, Scalar};
+use tenferro_algebra::Scalar;
 #[cfg(feature = "cuda")]
 use tenferro_device::LogicalMemorySpace;
 use tenferro_device::{checked_batch_count, unflatten_col_major_index_into};
@@ -13,6 +13,63 @@ use crate::{DataBuffer, MemoryOrder};
 enum TriangularHalf {
     Lower,
     Upper,
+}
+
+impl<T> Tensor<T> {
+    /// Return a lazily-conjugated tensor (shared buffer, flag flip).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use num_complex::Complex64;
+    ///
+    /// let data = vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)];
+    /// let a = Tensor::from_slice(&data, &[2], MemoryOrder::ColumnMajor).unwrap();
+    /// let a_conj = a.conj();
+    /// assert!(a_conj.is_conjugated());
+    /// ```
+    pub fn conj(&self) -> Tensor<T>
+    where
+        T: tenferro_algebra::Conjugate,
+    {
+        Tensor::from_parts(
+            self.buffer.clone(),
+            self.dims.clone(),
+            self.strides.clone(),
+            self.offset,
+            self.logical_memory_space,
+            self.preferred_compute_device,
+            self.event.clone(),
+            !self.conjugated,
+            None,
+        )
+    }
+
+    /// Consume this tensor and return a lazily-conjugated version.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let t = Tensor::<f64>::zeros(&[2, 3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
+    /// let tc = t.into_conj();
+    /// assert!(tc.is_conjugated());
+    /// ```
+    pub fn into_conj(self) -> Tensor<T>
+    where
+        T: tenferro_algebra::Conjugate,
+    {
+        Tensor::from_parts(
+            self.buffer,
+            self.dims,
+            self.strides,
+            self.offset,
+            self.logical_memory_space,
+            self.preferred_compute_device,
+            self.event,
+            !self.conjugated,
+            None,
+        )
+    }
 }
 
 impl<T: Scalar> Tensor<T> {
@@ -95,43 +152,6 @@ impl<T: Scalar> Tensor<T> {
         self.contiguous(order)
     }
 
-    /// Returns `true` if the tensor data is contiguous in memory.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[2, 3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
-    /// assert!(t.is_contiguous());
-    /// ```
-    pub fn is_contiguous(&self) -> bool {
-        is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::ColumnMajor)
-            || is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::RowMajor)
-    }
-
-    /// Check if the tensor has column-major contiguous layout.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[2, 3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
-    /// assert!(t.is_col_major_contiguous());
-    /// ```
-    pub fn is_col_major_contiguous(&self) -> bool {
-        is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::ColumnMajor)
-    }
-
-    /// Check if the tensor has row-major contiguous layout.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[2, 3], LogicalMemorySpace::MainMemory, MemoryOrder::RowMajor);
-    /// assert!(t.is_row_major_contiguous());
-    /// ```
-    pub fn is_row_major_contiguous(&self) -> bool {
-        is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::RowMajor)
-    }
-
     /// Consume this tensor and return a contiguous column-major version.
     ///
     /// This is a convenience wrapper around `into_contiguous(MemoryOrder::ColumnMajor)`
@@ -146,61 +166,6 @@ impl<T: Scalar> Tensor<T> {
     /// ```
     pub fn into_column_major(self) -> Tensor<T> {
         self.into_contiguous(MemoryOrder::ColumnMajor)
-    }
-
-    /// Return a lazily-conjugated tensor (shared buffer, flag flip).
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use num_complex::Complex64;
-    ///
-    /// let data = vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)];
-    /// let a = Tensor::from_slice(&data, &[2], MemoryOrder::ColumnMajor).unwrap();
-    /// let a_conj = a.conj();
-    /// assert!(a_conj.is_conjugated());
-    /// ```
-    pub fn conj(&self) -> Tensor<T>
-    where
-        T: Conjugate,
-    {
-        Tensor::from_parts(
-            self.buffer.clone(),
-            self.dims.clone(),
-            self.strides.clone(),
-            self.offset,
-            self.logical_memory_space,
-            self.preferred_compute_device,
-            self.event.clone(),
-            !self.conjugated,
-            None,
-        )
-    }
-
-    /// Consume this tensor and return a lazily-conjugated version.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let t = Tensor::<f64>::zeros(&[2, 3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
-    /// let tc = t.into_conj();
-    /// assert!(tc.is_conjugated());
-    /// ```
-    pub fn into_conj(self) -> Tensor<T>
-    where
-        T: Conjugate,
-    {
-        Tensor::from_parts(
-            self.buffer,
-            self.dims,
-            self.strides,
-            self.offset,
-            self.logical_memory_space,
-            self.preferred_compute_device,
-            self.event,
-            !self.conjugated,
-            None,
-        )
     }
 
     fn triangular_part(&self, diagonal: isize, half: TriangularHalf) -> Tensor<T> {

--- a/tenferro-tensor/src/tensor/metadata.rs
+++ b/tenferro-tensor/src/tensor/metadata.rs
@@ -1,11 +1,10 @@
-use tenferro_algebra::Scalar;
 use tenferro_device::{
     preferred_compute_devices, ComputeDevice, Error, LogicalMemorySpace, OpKind, Result,
 };
 
 use super::Tensor;
 
-impl<T: Scalar> Tensor<T> {
+impl<T> Tensor<T> {
     /// Returns the shape (size of each dimension).
     ///
     /// # Examples

--- a/tenferro-tensor/src/tensor/mod.rs
+++ b/tenferro-tensor/src/tensor/mod.rs
@@ -10,10 +10,10 @@ mod views;
 
 use std::sync::Arc;
 
-use tenferro_algebra::Scalar;
 use tenferro_device::{ComputeDevice, LogicalMemorySpace};
 
-use crate::{layout::compute_contiguous_strides, CompletionEvent, DataBuffer, MemoryOrder};
+use crate::layout::{compute_contiguous_strides, is_contiguous_in_order};
+use crate::{CompletionEvent, DataBuffer, MemoryOrder};
 
 pub use structural::KeepCountScalar;
 
@@ -53,7 +53,7 @@ pub use structural::KeepCountScalar;
 /// assert_eq!(t.dims(), &[2, 3]);
 /// assert_eq!(t.len(), 6);
 /// ```
-pub struct Tensor<T: Scalar> {
+pub struct Tensor<T> {
     buffer: DataBuffer<T>,
     dims: Arc<[usize]>,
     strides: Arc<[isize]>,
@@ -65,7 +65,7 @@ pub struct Tensor<T: Scalar> {
     fw_grad: Option<Box<Tensor<T>>>,
 }
 
-impl<T: Scalar> Clone for Tensor<T> {
+impl<T> Clone for Tensor<T> {
     /// Shallow clone: shares the underlying data buffer.
     ///
     /// For a deep copy, materialize into a new allocation with
@@ -85,7 +85,7 @@ impl<T: Scalar> Clone for Tensor<T> {
     }
 }
 
-impl<T: Scalar> std::fmt::Debug for Tensor<T> {
+impl<T> std::fmt::Debug for Tensor<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let has_pending_event = self.event.is_some();
         let has_fw_grad = self.fw_grad.is_some();
@@ -105,7 +105,11 @@ impl<T: Scalar> std::fmt::Debug for Tensor<T> {
     }
 }
 
-impl<T: Scalar> Tensor<T> {
+/// Methods that require no element-type bounds at all.
+///
+/// These operate only on tensor metadata (dims, strides, offset, buffer
+/// reference) and never read or write element values.
+impl<T> Tensor<T> {
     pub(crate) fn from_parts(
         buffer: DataBuffer<T>,
         dims: Arc<[usize]>,
@@ -186,5 +190,42 @@ impl<T: Scalar> Tensor<T> {
         self.buffer.as_slice().unwrap_or_else(|| {
             panic!("{operation}: CPU-only operation; GPU tensors are not supported")
         })
+    }
+
+    /// Returns `true` if the tensor data is contiguous in memory.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let t = Tensor::<f64>::zeros(&[2, 3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
+    /// assert!(t.is_contiguous());
+    /// ```
+    pub fn is_contiguous(&self) -> bool {
+        is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::ColumnMajor)
+            || is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::RowMajor)
+    }
+
+    /// Check if the tensor has column-major contiguous layout.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let t = Tensor::<f64>::zeros(&[2, 3], LogicalMemorySpace::MainMemory, MemoryOrder::ColumnMajor);
+    /// assert!(t.is_col_major_contiguous());
+    /// ```
+    pub fn is_col_major_contiguous(&self) -> bool {
+        is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::ColumnMajor)
+    }
+
+    /// Check if the tensor has row-major contiguous layout.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let t = Tensor::<f64>::zeros(&[2, 3], LogicalMemorySpace::MainMemory, MemoryOrder::RowMajor);
+    /// assert!(t.is_row_major_contiguous());
+    /// ```
+    pub fn is_row_major_contiguous(&self) -> bool {
+        is_contiguous_in_order(&self.dims, &self.strides, MemoryOrder::RowMajor)
     }
 }

--- a/tenferro-tensor/src/tensor/transfer.rs
+++ b/tenferro-tensor/src/tensor/transfer.rs
@@ -31,7 +31,9 @@ impl<T: Scalar> Tensor<T> {
             ))
         }
     }
+}
 
+impl<T> Tensor<T> {
     /// Wait for any pending GPU computation to complete.
     ///
     /// # Examples

--- a/tenferro-tensor/src/tensor/views.rs
+++ b/tenferro-tensor/src/tensor/views.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use num_complex::{Complex32, Complex64};
-use tenferro_algebra::Scalar;
 use tenferro_device::{Error, Result};
 
 use super::Tensor;

--- a/tenferro-tensor/src/tensor/views/basic.rs
+++ b/tenferro-tensor/src/tensor/views/basic.rs
@@ -13,7 +13,7 @@ fn matrix_transpose_permutation(ndim: usize) -> Result<Vec<usize>> {
     Ok(perm)
 }
 
-impl<T: Scalar> Tensor<T> {
+impl<T> Tensor<T> {
     /// Permute (reorder) the dimensions of the tensor.
     ///
     /// # Examples
@@ -474,7 +474,7 @@ impl<T: Scalar> Tensor<T> {
 
 impl<T> Tensor<T>
 where
-    T: Scalar + Conjugate,
+    T: Conjugate,
 {
     /// Return a zero-copy conjugate-transpose view over the last two axes.
     ///

--- a/tenferro-tensor/src/tensor/views/complex.rs
+++ b/tenferro-tensor/src/tensor/views/complex.rs
@@ -43,7 +43,7 @@ fn view_as_complex_strides(dims: &[usize], strides: &[isize]) -> Result<Vec<isiz
     Ok(output)
 }
 
-fn select_complex_component<T: Scalar>(view: Tensor<T>, component: usize) -> Result<Tensor<T>> {
+fn select_complex_component<T>(view: Tensor<T>, component: usize) -> Result<Tensor<T>> {
     view.select(view.ndim() - 1, component)
 }
 


### PR DESCRIPTION
## Summary

Remove `T: Scalar` from the `Tensor<T>` struct definition. Bounds are now on individual impl blocks that need them.

This enables `Tensor<bool>`, `Tensor<u8>`, `Tensor<i32>` for pure storage/masking use cases, unblocking mdarray removal in `tensor4all-rs` (#322).

## Bound hierarchy

- `impl<T>` — metadata, view ops (permute, reshape, broadcast, etc.)
- `impl<T: Conjugate>` — mH
- `impl<T: Scalar>` — constructors, contiguous, cat/stack, tril/triu

## Test plan

- [x] `cargo nextest run --release --workspace` — 1920 tests pass
- [x] `cargo clippy --workspace` — no new warnings
- [x] `cargo fmt --all` — clean

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)