### PR TITLE
fix: inject delta tensors for trace einsum VJP/HVP

### DIFF
--- a/tenferro-einsum/src/ad/rules.rs
+++ b/tenferro-einsum/src/ad/rules.rs
@@ -1,9 +1,26 @@
+use std::collections::HashSet;
+
 use tenferro_algebra::{Conjugate, HasAlgebra, Scalar, Semiring};
 use tenferro_device::Result;
 use tenferro_tensor::{MemoryOrder, Tensor};
 use tidu::{AdResult, Differentiable, DualValue};
 
+use tenferro_device::LogicalMemorySpace;
+
 use crate::api::{einsum, einsum_with_subscripts, einsum_with_subscripts_into};
+
+/// Creates an `n x n` identity tensor using only `Scalar` (zero/one) bounds.
+fn make_delta<T: Scalar>(n: usize, _space: LogicalMemorySpace) -> Result<Tensor<T>> {
+    let mut data = vec![T::zero(); n * n];
+    for i in 0..n {
+        data[i * n + i] = T::one();
+    }
+    Ok(Tensor::from_slice(
+        &data,
+        &[n, n],
+        MemoryOrder::ColumnMajor,
+    )?)
+}
 use crate::execution::backend::{BackendContext, EinsumBackend};
 use crate::execution::execute::execute_nested;
 use crate::syntax::nested::NestedEinsum;
@@ -80,6 +97,10 @@ where
     let n = operands.len();
     let mut grads = Vec::with_capacity(n);
 
+    // Build a size dictionary mapping labels to dimensions.
+    let shapes: Vec<&[usize]> = operands.iter().map(|op| op.dims()).collect();
+    let size_dict = crate::execution::util::build_size_dict(&subs, &shapes, None)?;
+
     for k in 0..n {
         let mut rev_inputs_subs = vec![subs.output.clone()];
         // Wirtinger VJP: conjugate non-cotangent operands so that the
@@ -92,17 +113,113 @@ where
                 conj_store.push(op.conj());
             }
         }
-        let mut rev_operands: Vec<&Tensor<Alg::Scalar>> = vec![cotangent];
-        for c in &conj_store {
-            rev_operands.push(c);
-        }
 
-        let rev_subs = Subscripts {
-            inputs: rev_inputs_subs,
-            output: subs.inputs[k].clone(),
+        let rev_output = subs.inputs[k].clone();
+
+        let rev_output = subs.inputs[k].clone();
+
+        // Detect output-only labels: labels that appear in the reverse output
+        // but not in any reverse input. This happens when the forward einsum
+        // contracted labels that we now need to reconstruct (e.g., trace "ii->").
+        let all_input_labels: HashSet<u32> = rev_inputs_subs
+            .iter()
+            .flat_map(|labels| labels.iter().copied())
+            .collect();
+        let has_output_only = rev_output.iter().any(|l| !all_input_labels.contains(l));
+
+        let grad = if has_output_only {
+            // For subscripts with output-only labels (e.g. trace "ii->"),
+            // the reverse einsum "->ii" is invalid. Build the gradient
+            // directly: cotangent broadcast-multiplied with the appropriate
+            // identity structure.
+            //
+            // Step 1: build a delta tensor whose subscripts cover ALL
+            //         output-only labels with fresh paired indices.
+            // Step 2: einsum the cotangent with any remaining operands and
+            //         the delta, producing a tensor with the right unique
+            //         output labels.
+            // Step 3: use "i->ii" (diagonal embedding) via forward einsum
+            //         if the output has repeated labels.
+            //
+            // For the common single-operand trace "ii->":
+            //   unique output labels = {i}, reverse needs shape [n, n]
+            //   grad = cotangent * eye(n)
+            let unique_output: Vec<u32> = {
+                let mut seen = HashSet::new();
+                rev_output
+                    .iter()
+                    .filter(|l| seen.insert(**l))
+                    .copied()
+                    .collect()
+            };
+            // Build a delta tensor for each missing label
+            let mut delta_subs: Vec<u32> = Vec::new();
+            let mut delta_tensors: Vec<Tensor<Alg::Scalar>> = Vec::new();
+            for &label in &unique_output {
+                if !all_input_labels.contains(&label) {
+                    let dim = *size_dict.get(&label).ok_or_else(|| {
+                        tenferro_device::Error::InvalidArgument(format!(
+                            "einsum rrule: missing dimension for label {}",
+                            label
+                        ))
+                    })?;
+                    let space = operands[0].logical_memory_space();
+                    delta_tensors.push(make_delta::<Alg::Scalar>(dim, space)?);
+                    delta_subs.push(label);
+                }
+            }
+            // Build subscripts: cotangent + conj_ops + deltas -> unique_output
+            let mut fwd_inputs = rev_inputs_subs.clone();
+            for &label in &delta_subs {
+                // delta with subscript [label, label_fresh] where label_fresh
+                // is a new label not used anywhere.
+                let max_label = subs
+                    .inputs
+                    .iter()
+                    .flat_map(|v| v.iter())
+                    .chain(subs.output.iter())
+                    .copied()
+                    .max()
+                    .unwrap_or(0);
+                let fresh = max_label + 1 + (fwd_inputs.len() as u32);
+                fwd_inputs.push(vec![label, fresh]);
+            }
+            let fwd_subs = Subscripts {
+                inputs: fwd_inputs,
+                output: unique_output.clone(),
+            };
+            let mut fwd_ops: Vec<&Tensor<Alg::Scalar>> = vec![cotangent];
+            for c in &conj_store {
+                fwd_ops.push(c);
+            }
+            for dt in &delta_tensors {
+                fwd_ops.push(dt);
+            }
+            // This gives a tensor with unique_output labels
+            let base = einsum_with_subscripts::<Alg, Backend>(ctx, &fwd_subs, &fwd_ops, None)?;
+
+            // If unique_output != rev_output, need diagonal embedding
+            if unique_output == rev_output {
+                base
+            } else {
+                // Diagonal embedding: e.g. "i->ii"
+                let embed_subs = Subscripts {
+                    inputs: vec![unique_output],
+                    output: rev_output.clone(),
+                };
+                einsum_with_subscripts::<Alg, Backend>(ctx, &embed_subs, &[&base], None)?
+            }
+        } else {
+            let mut rev_operands: Vec<&Tensor<Alg::Scalar>> = vec![cotangent];
+            for c in &conj_store {
+                rev_operands.push(c);
+            }
+            let rev_subs = Subscripts {
+                inputs: rev_inputs_subs,
+                output: rev_output,
+            };
+            einsum_with_subscripts::<Alg, Backend>(ctx, &rev_subs, &rev_operands, None)?
         };
-
-        let grad = einsum_with_subscripts::<Alg, Backend>(ctx, &rev_subs, &rev_operands, None)?;
         grads.push(grad);
     }
 
@@ -252,6 +369,9 @@ where
     let n = primals.len();
     let mut results = Vec::with_capacity(n);
 
+    let shapes: Vec<&[usize]> = primals.iter().map(|op| op.dims()).collect();
+    let size_dict = crate::execution::util::build_size_dict(&subs, &shapes, None)?;
+
     for k in 0..n {
         let mut rev_inputs_subs = vec![subs.output.clone()];
         // Wirtinger VJP: conjugate non-cotangent operands (same as einsum_rrule).
@@ -262,20 +382,57 @@ where
                 conj_store.push(op.conj());
             }
         }
+
+        let rev_output = subs.inputs[k].clone();
+
+        // Inject delta tensors for output-only labels (same as einsum_rrule).
+        let all_input_labels: HashSet<u32> = rev_inputs_subs
+            .iter()
+            .flat_map(|labels| labels.iter().copied())
+            .collect();
+        let mut unique_missing = Vec::new();
+        {
+            let mut seen = HashSet::new();
+            for &label in &rev_output {
+                if !all_input_labels.contains(&label) && seen.insert(label) {
+                    unique_missing.push(label);
+                }
+            }
+        }
+        let mut delta_tensors: Vec<Tensor<Alg::Scalar>> = Vec::new();
+        for &label in &unique_missing {
+            let dim = *size_dict.get(&label).ok_or_else(|| {
+                tenferro_device::Error::InvalidArgument(format!(
+                    "einsum hvp: missing dimension for label {}",
+                    label
+                ))
+            })?;
+            let space = primals[0].logical_memory_space();
+            let eye = make_delta::<Alg::Scalar>(dim, space)?;
+            rev_inputs_subs.push(vec![label, label]);
+            delta_tensors.push(eye);
+        }
+
         let rev_subs = Subscripts {
             inputs: rev_inputs_subs,
-            output: subs.inputs[k].clone(),
+            output: rev_output,
         };
 
         let mut rev_operands: Vec<&Tensor<Alg::Scalar>> = vec![cotangent];
         for c in &conj_store {
             rev_operands.push(c);
         }
+        for dt in &delta_tensors {
+            rev_operands.push(dt);
+        }
         let grad_k = einsum_with_subscripts::<Alg, Backend>(ctx, &rev_subs, &rev_operands, None)?;
 
         let mut ops: Vec<&Tensor<Alg::Scalar>> = vec![cotangent_tangent];
         for c in &conj_store {
             ops.push(c);
+        }
+        for dt in &delta_tensors {
+            ops.push(dt);
         }
         let mut hvp_k = Some(einsum_with_subscripts::<Alg, Backend>(
             ctx, &rev_subs, &ops, None,
@@ -294,6 +451,9 @@ where
                         ops.push(if i == j { tangent_j } else { &conj_store[ci] });
                         ci += 1;
                     }
+                }
+                for dt in &delta_tensors {
+                    ops.push(dt);
                 }
                 match &mut hvp_k {
                     None => {

--- a/tenferro-einsum/tests/einsum_tests.rs
+++ b/tenferro-einsum/tests/einsum_tests.rs
@@ -3250,3 +3250,52 @@ fn einsum_binary_diag_ii_j_to_j() {
     assert_eq!(data[0], 30.0);
     assert_eq!(data[1], 45.0);
 }
+
+#[test]
+fn einsum_rrule_trace_produces_identity_gradient() {
+    let mut ctx = CpuContext::new(1);
+    // A = [[1, 3], [2, 4]] (col-major), trace = 5
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
+    let cotangent = Tensor::<f64>::from_slice(&[1.0], &[], COL).unwrap();
+    let grads = einsum_rrule::<S, CpuBackend>(&mut ctx, "ii->", &[&a], &cotangent).unwrap();
+    assert_eq!(grads.len(), 1);
+    assert_eq!(grads[0].dims(), &[2, 2]);
+    // grad should be identity * cotangent = [[1,0],[0,1]]
+    let g = &grads[0];
+    let vals = to_col_major_vec(g);
+    // col-major logical order: (0,0), (1,0), (0,1), (1,1)
+    assert!((vals[0] - 1.0).abs() < 1e-12, "grad[0,0]={}", vals[0]);
+    assert!((vals[1] - 0.0).abs() < 1e-12, "grad[1,0]={}", vals[1]);
+    assert!((vals[2] - 0.0).abs() < 1e-12, "grad[0,1]={}", vals[2]);
+    assert!((vals[3] - 1.0).abs() < 1e-12, "grad[1,1]={}", vals[3]);
+}
+
+#[test]
+fn einsum_rrule_trace_with_nonunit_cotangent() {
+    let mut ctx = CpuContext::new(1);
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
+    let cotangent = Tensor::<f64>::from_slice(&[3.0], &[], COL).unwrap();
+    let grads = einsum_rrule::<S, CpuBackend>(&mut ctx, "ii->", &[&a], &cotangent).unwrap();
+    // grad = 3 * I = [[3,0],[0,3]]
+    let vals = to_col_major_vec(&grads[0]);
+    assert!((vals[0] - 3.0).abs() < 1e-12, "grad[0,0]={}", vals[0]);
+    assert!((vals[1] - 0.0).abs() < 1e-12, "grad[1,0]={}", vals[1]);
+    assert!((vals[2] - 0.0).abs() < 1e-12, "grad[0,1]={}", vals[2]);
+    assert!((vals[3] - 3.0).abs() < 1e-12, "grad[1,1]={}", vals[3]);
+}
+
+#[test]
+fn einsum_frule_trace_propagates_tangent() {
+    use tidu::DualValue;
+    let mut ctx = CpuContext::new(1);
+    let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], COL).unwrap();
+    let da = Tensor::<f64>::from_slice(&[0.1, 0.2, 0.3, 0.4], &[2, 2], COL).unwrap();
+    let dual_a = DualValue::with_tangent(a, da).unwrap();
+    let out = dual_einsum::<S, CpuBackend>(&mut ctx, "ii->", &[&dual_a]).unwrap();
+    // primal: trace = 1 + 4 = 5
+    let primal = out.primal().buffer().as_slice().unwrap()[0];
+    assert!((primal - 5.0).abs() < 1e-12);
+    // tangent: d(trace)/dA . dA = trace(dA) = 0.1 + 0.4 = 0.5
+    let tangent = out.tangent().unwrap().buffer().as_slice().unwrap()[0];
+    assert!((tangent - 0.5).abs() < 1e-12);
+}

--- a/tenferro/src/ops/einsum/ad.rs
+++ b/tenferro/src/ops/einsum/ad.rs
@@ -28,13 +28,25 @@ where
     T: EinsumRuntimeValue,
     B: DenseEinsumBackend<T, C>,
 {
+    // Build size dictionary for delta injection.
+    let size_dict: std::collections::HashMap<u32, usize> = {
+        let mut sd = std::collections::HashMap::new();
+        for (i, input_labels) in subscripts.inputs.iter().enumerate() {
+            let dims = primals[i].logical_dims();
+            for (j, &label) in input_labels.iter().enumerate() {
+                sd.entry(label).or_insert(dims[j]);
+            }
+        }
+        sd
+    };
+
     let mut input_grads = Vec::new();
 
     for (k, maybe_node) in reverse_nodes.iter().enumerate() {
         let Some(node) = maybe_node else {
             continue;
         };
-        let rev_subs = reverse_subscripts(subscripts, k);
+        let mut rev_subs = reverse_subscripts(subscripts, k);
         // Wirtinger VJP: conjugate non-cotangent operands.
         let mut conj_store: Vec<StructuredTensor<T>> = Vec::new();
         for (idx, operand) in primals.iter().enumerate() {
@@ -42,10 +54,55 @@ where
                 conj_store.push(operand.conj());
             }
         }
+
+        // Inject delta tensors for output-only labels (e.g., trace "ii->").
+        let all_input_labels: std::collections::HashSet<u32> = rev_subs
+            .inputs
+            .iter()
+            .flat_map(|labels| labels.iter().copied())
+            .collect();
+        let mut unique_missing = Vec::new();
+        {
+            let mut seen = std::collections::HashSet::new();
+            for &label in &rev_subs.output {
+                if !all_input_labels.contains(&label) && seen.insert(label) {
+                    unique_missing.push(label);
+                }
+            }
+        }
+        let mut delta_tensors: Vec<StructuredTensor<T>> = Vec::new();
+        for &label in &unique_missing {
+            let dim = size_dict
+                .get(&label)
+                .copied()
+                .ok_or_else(|| Error::InvalidAdTensor {
+                    message: format!(
+                        "einsum structured pullback: missing dimension for label {}",
+                        label
+                    ),
+                })?;
+            let space = primals[0].payload().logical_memory_space();
+            let mut data = vec![T::zero(); dim * dim];
+            for i in 0..dim {
+                data[i * dim + i] = T::one();
+            }
+            let eye = tenferro_tensor::Tensor::from_slice(
+                &data,
+                &[dim, dim],
+                tenferro_tensor::MemoryOrder::ColumnMajor,
+            )
+            .map_err(Error::from)?;
+            delta_tensors.push(StructuredTensor::from_dense(eye));
+            rev_subs.inputs.push(vec![label, label]);
+        }
+
         let mut rev_operands: Vec<&StructuredTensor<T>> = Vec::with_capacity(primals.len());
         rev_operands.push(cotangent);
         for c in &conj_store {
             rev_operands.push(c);
+        }
+        for dt in &delta_tensors {
+            rev_operands.push(dt);
         }
         let grad = einsum_with_subscripts_in_ctx::<B, _, T>(ctx, &rev_subs, &rev_operands)?;
         input_grads.push((*node, grad));


### PR DESCRIPTION
## Summary

- Trace einsum VJP (`"ii->"`) failed with `"output label 105 is not present in inputs"` because the reverse subscript `"->ii"` has output-only labels
- Fix: detect output-only labels in reverse subscripts and inject identity (delta) tensors as additional inputs
- Applies to rrule, HVP, and structured pullback paths

## Test plan

- [x] `cargo test --workspace --release` — all pass
- [x] External verification: real and complex trace VJP succeeds
- [x] Diagonal extraction `"ii->i"` VJP still works

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)