### PR TITLE
feat: add tenferro-tensor-compute facade crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "tenferro-einsum",
     "tenferro-linalg-prims",
     "tenferro-linalg",
+    "tenferro-tensor-compute",
     "tenferro-capi",
     # extension
     "extension/tenferro-tropical",

--- a/README.md
+++ b/README.md
@@ -71,35 +71,32 @@ primitive execution paths, but broader GPU coverage is still incomplete and
 HIP remains a stub. Outside explicit GPU implementation tasks, do not assume a
 GPU code path works just because the type, trait, or FFI entrypoint exists.
 
-## Two API paths
+## Which crate should I use?
 
-tenferro offers two ways to work with tensors:
+| Crate | Use when |
+|-------|----------|
+| **`tenferro-tensor-compute`** | You want typed `Tensor<T>` with einsum and linalg — **start here** |
+| `tenferro` | You need automatic differentiation (VJP/JVP) |
+| `tenferro-tensor` | You only need the data type, no computation (library authors) |
 
-- **Typed path:** `tenferro_tensor::Tensor<T>` -- fixed scalar type at compile time. Use with `tenferro-prims` + `tenferro-einsum` for computation. Best when you know the scalar type and do not need automatic gradient tracking.
-- **Dynamic AD path:** `tenferro::Tensor` -- dynamic scalar type with automatic differentiation (VJP/JVP). Use the `tenferro` umbrella crate. Best when you need gradients.
+- **Typed path** (`tenferro-tensor-compute`): `Tensor<T>` with a fixed scalar type at compile time. Best when you know the scalar type and do not need automatic gradient tracking.
+- **Dynamic AD path** (`tenferro`): dynamic scalar type with automatic differentiation (VJP/JVP). Best when you need gradients.
 
 The quickstart below uses the typed path; the [Autodiff quickstart](#autodiff-quickstart) shows the dynamic AD path.
 
 ## Quickstart
 
-For a local checkout, a minimal CPU-only downstream crate needs these
-workspace members:
+For a local checkout, a single dependency is enough:
 
 ```toml
 [dependencies]
-tenferro-algebra = { path = "../tenferro-rs/tenferro-algebra" }
-tenferro-device = { path = "../tenferro-rs/tenferro-device" }
-tenferro-tensor = { path = "../tenferro-rs/tenferro-tensor" }
-tenferro-prims = { path = "../tenferro-rs/tenferro-prims" }
-tenferro-einsum = { path = "../tenferro-rs/tenferro-einsum" }
+tenferro-tensor-compute = { path = "../tenferro-rs/tenferro-tensor-compute" }
 ```
 
 ```rust
-use tenferro_algebra::Standard;
-use tenferro_device::LogicalMemorySpace;
-use tenferro_einsum::einsum;
-use tenferro_prims::{CpuBackend, CpuContext};
-use tenferro_tensor::{MemoryOrder, Tensor};
+use tenferro_tensor_compute::{
+    einsum, CpuBackend, CpuContext, LogicalMemorySpace, MemoryOrder, Standard, Tensor,
+};
 
 fn main() {
     let col = MemoryOrder::ColumnMajor;
@@ -174,18 +171,10 @@ For more examples, see the crate docs for `tenferro-einsum` and `tenferro-tensor
 
 ### Linear algebra quickstart
 
-```toml
-[dependencies]
-tenferro-device = { path = "../tenferro-rs/tenferro-device" }
-tenferro-tensor = { path = "../tenferro-rs/tenferro-tensor" }
-tenferro-prims  = { path = "../tenferro-rs/tenferro-prims" }
-tenferro-linalg = { path = "../tenferro-rs/tenferro-linalg" }
-```
+Linalg is included in `tenferro-tensor-compute` by default (the `linalg` feature).
 
 ```rust
-use tenferro_linalg::{svd, solve};
-use tenferro_prims::CpuContext;
-use tenferro_tensor::{MemoryOrder, Tensor};
+use tenferro_tensor_compute::{svd, solve, CpuContext, MemoryOrder, Tensor};
 
 fn main() {
     let col = MemoryOrder::ColumnMajor;

--- a/docs/api_index.md
+++ b/docs/api_index.md
@@ -15,6 +15,8 @@ for architecture, API design, and future phase plans.
 ## Workspace Architecture
 
 ```
+Facade: tenferro-tensor-compute  Typed computation facade — re-exports Tensor<T>,
+                                einsum, and linalg from a single crate
 Layer 5: tenferro-capi       C-API (FFI) for Julia/Python: exposes einsum + SVD
                              with stateless rrule/frule (f64 only),
                              DLPack v1.0 zero-copy tensor exchange
@@ -55,6 +57,14 @@ Small note: this graph omits transitively implied edges by default. If
 information, which keeps the layered structure readable.
 
 ## Crates
+
+<a id="tenferro-tensor-compute"></a>
+### [tenferro-tensor-compute](tenferro_tensor_compute/index.html) <small>(Facade)</small>
+
+Typed tensor computation facade. Re-exports the most commonly used items from
+`tenferro-tensor`, `tenferro-prims`, `tenferro-einsum`, and `tenferro-linalg`
+so downstream users need only a single dependency for `Tensor<T>` computation.
+Start here if you want typed tensors with einsum and linear algebra.
 
 <a id="tenferro-capi"></a>
 ### [tenferro-capi](tenferro_capi/index.html) <small>(Layer 5)</small>

--- a/tenferro-tensor-compute/Cargo.toml
+++ b/tenferro-tensor-compute/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tenferro-tensor-compute"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
+description = "Typed tensor computation facade — re-exports Tensor<T>, einsum, and linalg from one crate"
+
+[dependencies]
+tenferro-device = { path = "../tenferro-device" }
+tenferro-algebra = { path = "../tenferro-algebra" }
+tenferro-tensor = { path = "../tenferro-tensor" }
+tenferro-prims = { path = "../tenferro-prims" }
+tenferro-einsum = { path = "../tenferro-einsum" }
+tenferro-linalg = { path = "../tenferro-linalg", optional = true }
+
+[features]
+default = ["linalg"]
+linalg = ["dep:tenferro-linalg"]

--- a/tenferro-tensor-compute/src/lib.rs
+++ b/tenferro-tensor-compute/src/lib.rs
@@ -1,0 +1,87 @@
+//! Typed tensor computation facade for tenferro-rs.
+//!
+//! This crate re-exports the most commonly used items from the lower-level
+//! tenferro crates so that downstream users need only a single dependency
+//! for typed `Tensor<T>` computation with einsum and linear algebra.
+//!
+//! # When to use this crate
+//!
+//! | Crate | Use when |
+//! |-------|----------|
+//! | **`tenferro-tensor-compute`** | You want typed `Tensor<T>` with einsum and linalg |
+//! | `tenferro` | You need automatic differentiation (VJP/JVP) |
+//! | `tenferro-tensor` | You only need the data type (library/crate authors) |
+//!
+//! # Examples
+//!
+//! Matrix multiplication via einsum, then SVD:
+//!
+//! ```
+//! use tenferro_tensor_compute::{
+//!     einsum, CpuBackend, CpuContext, MemoryOrder, Standard, Tensor,
+//! };
+//!
+//! let col = MemoryOrder::ColumnMajor;
+//! // 4 threads for parallel operations
+//! let mut ctx = CpuContext::new(4);
+//!
+//! // Column-major: data is stored column-first.
+//! // Use Tensor::from_row_major_slice if your data is row-major.
+//! let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
+//! let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
+//!
+//! // Standard<f64> = standard arithmetic (multiply and add) over f64
+//! let c = einsum::<Standard<f64>, CpuBackend>(
+//!     &mut ctx, "ij,jk->ik", &[&a, &b], None,
+//! ).unwrap();
+//!
+//! // Read values back
+//! assert_eq!(c.dims(), &[2, 2]);
+//! assert_eq!(c.get(&[0, 0]), Some(&23.0));
+//! let values = c.to_vec(); // column-major order
+//! assert_eq!(values, vec![23.0, 34.0, 31.0, 46.0]);
+//! ```
+//!
+//! SVD decomposition (requires `linalg` feature, enabled by default):
+//!
+//! ```
+//! # #[cfg(feature = "linalg")]
+//! # {
+//! use tenferro_tensor_compute::{svd, CpuContext, MemoryOrder, Tensor};
+//!
+//! let mut ctx = CpuContext::new(1);
+//! let a = Tensor::<f64>::from_slice(
+//!     &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3], MemoryOrder::ColumnMajor,
+//! ).unwrap();
+//! let result = svd(&mut ctx, &a, None).unwrap();
+//! assert_eq!(result.u.dims(), &[2, 2]);
+//! assert_eq!(result.s.dims(), &[2]);
+//! assert_eq!(result.vt.dims(), &[2, 3]);
+//! # }
+//! ```
+
+// --- Tensor type and layout ---
+pub use tenferro_tensor::{MemoryOrder, Tensor};
+
+// --- Device / memory ---
+pub use tenferro_device::LogicalMemorySpace;
+
+// --- Algebra ---
+pub use tenferro_algebra::Standard;
+
+// --- Backend ---
+pub use tenferro_einsum::BackendContext;
+pub use tenferro_prims::{CpuBackend, CpuContext};
+
+// --- Einsum ---
+pub use tenferro_einsum::{einsum, einsum_into, einsum_with_subscripts, Subscripts};
+
+// --- Linalg (behind feature flag) ---
+#[cfg(feature = "linalg")]
+pub use tenferro_linalg::{
+    cholesky, cross, det, eig, eigen, inv, lstsq, lu, lu_factor, lu_solve, matrix_exp,
+    matrix_power, norm, pinv, qr, slogdet, solve, solve_triangular, svd, svdvals, tensorinv,
+    tensorsolve, vander, CholeskyExResult, EigResult, EigenResult, LstsqResult, LuFactorExResult,
+    LuFactorResult, LuResult, NormKind, QrResult, SlogdetResult, SolveExResult, SvdOptions,
+    SvdResult,
+};


### PR DESCRIPTION
## Summary

- Add `tenferro-tensor-compute` facade crate that re-exports `Tensor<T>`, `einsum`, and `linalg` from a single dependency
- Update README with "Which crate should I use?" guide and simplify quickstart dependency lists

## Motivation

Feature testing (#566) revealed that the typed `Tensor<T>` path requires 5 separate crate dependencies, which is confusing for new users. This facade bundles them into one.

| Crate | Use when |
|-------|----------|
| **`tenferro-tensor-compute`** | Typed `Tensor<T>` with einsum and linalg — start here |
| `tenferro` | Automatic differentiation (VJP/JVP) |
| `tenferro-tensor` | Data type only (library authors) |

## Test plan

- [x] `cargo build -p tenferro-tensor-compute` builds
- [x] `cargo test -p tenferro-tensor-compute --doc` — 2 doc tests pass
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace --release` passes

Generated with [Claude Code](https://claude.com/claude-code)
