### PR TITLE
ci: use cargo-nextest for workspace test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Run tests
-        run: cargo test --workspace --release
+      - uses: taiki-e/install-action@nextest
+      - name: Run unit and integration tests
+        run: cargo nextest run --workspace --release --no-fail-fast
+      - name: Run doc tests
+        run: cargo test --doc --workspace --release
 
   test-inject-prims:
     name: cargo test (prims inject)


### PR DESCRIPTION
## Summary

- Replace `cargo test --workspace --release` with `cargo nextest run` (parallel test execution) + separate `cargo test --doc` step
- The workspace test job was taking ~13min in CI; nextest should reduce this significantly

## Changes

- Install `cargo-nextest` via `taiki-e/install-action@nextest`
- Split into two steps: nextest for unit/integration tests, `cargo test --doc` for doc tests (nextest doesn't support doc tests)

## Test plan

- [x] CI runs on this PR will validate the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)