### PR TITLE
feat(tensor): add set/get_mut/deep_clone for element-level mutation

### DIFF
--- a/tenferro-tensor/src/tensor/data_ops.rs
+++ b/tenferro-tensor/src/tensor/data_ops.rs
@@ -16,51 +16,6 @@ enum TriangularHalf {
 }
 
 impl<T> Tensor<T> {
-    /// Access a single element by multi-dimensional index.
-    ///
-    /// Returns `None` if the index is out of bounds or the underlying buffer
-    /// is not CPU-accessible.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, Tensor};
-    ///
-    /// // Column-major: data is laid out column by column.
-    /// // from_slice with ColumnMajor and data [1,2,3,4] gives:
-    /// //   column 0 = [1, 2], column 1 = [3, 4]
-    /// //   matrix = [[1, 3],
-    /// //             [2, 4]]
-    /// let t = Tensor::<f64>::from_slice(
-    ///     &[1.0, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::ColumnMajor,
-    /// ).unwrap();
-    /// assert_eq!(t.get(&[0, 0]), Some(&1.0));
-    /// assert_eq!(t.get(&[1, 0]), Some(&2.0));
-    /// assert_eq!(t.get(&[0, 1]), Some(&3.0));
-    /// assert_eq!(t.get(&[1, 1]), Some(&4.0));
-    /// assert_eq!(t.get(&[2, 0]), None); // out of bounds
-    /// ```
-    pub fn get(&self, index: &[usize]) -> Option<&T> {
-        if index.len() != self.dims.len() {
-            return None;
-        }
-        for (i, &idx) in index.iter().enumerate() {
-            if idx >= self.dims[i] {
-                return None;
-            }
-        }
-        let pos: isize = index.iter().zip(self.strides.iter()).try_fold(
-            self.offset,
-            |acc, (&idx, &stride)| {
-                (idx as isize)
-                    .checked_mul(stride)
-                    .and_then(|v| acc.checked_add(v))
-            },
-        )?;
-        let pos = usize::try_from(pos).ok()?;
-        self.buffer.as_slice().and_then(|s| s.get(pos))
-    }
-
     /// Return a lazily-conjugated tensor (shared buffer, flag flip).
     ///
     /// # Examples
@@ -118,6 +73,47 @@ impl<T> Tensor<T> {
 }
 
 impl<T: Scalar> Tensor<T> {
+    /// Create a deep copy with an exclusively-owned contiguous buffer.
+    ///
+    /// Unlike [`clone`](Clone::clone) (which is a shallow `Arc` refcount
+    /// bump), this always allocates a fresh buffer and copies element data.
+    /// The returned tensor is contiguous in column-major order and has
+    /// `buffer.is_unique() == true`, so [`set`](Tensor::set) and
+    /// [`get_mut`](Tensor::get_mut) are guaranteed to succeed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let a = Tensor::<f64>::from_slice(
+    ///     &[1.0, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::ColumnMajor,
+    /// ).unwrap();
+    /// let b = a.clone(); // shallow — shares buffer
+    ///
+    /// let mut c = a.deep_clone(); // deep — independent buffer
+    /// c.set(&[0, 0], 99.0).unwrap();
+    /// assert_eq!(c.get(&[0, 0]), Some(&99.0));
+    /// assert_eq!(a.get(&[0, 0]), Some(&1.0)); // original unchanged
+    /// ```
+    pub fn deep_clone(&self) -> Tensor<T> {
+        self.wait();
+        let order = MemoryOrder::ColumnMajor;
+        let mut data = vec![T::zero(); self.len()];
+        if !data.is_empty() {
+            let dst_strides = compute_contiguous_strides(&self.dims, order);
+            copy_strided(
+                self.cpu_backed_slice_or_panic("deep_clone"),
+                &self.dims,
+                &self.strides,
+                self.offset,
+                &mut data,
+                &dst_strides,
+            );
+        }
+        self.materialized_from_vec(data, order)
+    }
+
     /// Return a contiguous copy of this tensor in the given memory order.
     ///
     /// `order` controls the materialized output buffer only. It does not change

--- a/tenferro-tensor/src/tensor/element_access.rs
+++ b/tenferro-tensor/src/tensor/element_access.rs
@@ -1,0 +1,191 @@
+use super::Tensor;
+
+impl<T> Tensor<T> {
+    /// Access a single element by multi-dimensional index.
+    ///
+    /// Returns `None` if the index is out of bounds or the underlying buffer
+    /// is not CPU-accessible.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// // Column-major: data is laid out column by column.
+    /// // from_slice with ColumnMajor and data [1,2,3,4] gives:
+    /// //   column 0 = [1, 2], column 1 = [3, 4]
+    /// //   matrix = [[1, 3],
+    /// //             [2, 4]]
+    /// let t = Tensor::<f64>::from_slice(
+    ///     &[1.0, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::ColumnMajor,
+    /// ).unwrap();
+    /// assert_eq!(t.get(&[0, 0]), Some(&1.0));
+    /// assert_eq!(t.get(&[1, 0]), Some(&2.0));
+    /// assert_eq!(t.get(&[0, 1]), Some(&3.0));
+    /// assert_eq!(t.get(&[1, 1]), Some(&4.0));
+    /// assert_eq!(t.get(&[2, 0]), None); // out of bounds
+    /// ```
+    pub fn get(&self, index: &[usize]) -> Option<&T> {
+        let pos = self.linear_offset(index)?;
+        self.buffer.as_slice().and_then(|s| s.get(pos))
+    }
+
+    /// Access a single element mutably by multi-dimensional index.
+    ///
+    /// Returns `None` if the index is out of bounds, the buffer is not
+    /// CPU-accessible, or the buffer is shared (Arc refcount > 1).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let mut t = Tensor::<f64>::from_slice(
+    ///     &[1.0, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::ColumnMajor,
+    /// ).unwrap();
+    /// *t.get_mut(&[0, 1]).unwrap() = 99.0;
+    /// assert_eq!(t.get(&[0, 1]), Some(&99.0));
+    /// // Out of bounds returns None:
+    /// assert!(t.get_mut(&[2, 0]).is_none());
+    /// ```
+    pub fn get_mut(&mut self, index: &[usize]) -> Option<&mut T> {
+        let pos = self.linear_offset(index)?;
+        self.buffer.as_mut_slice().and_then(|s| s.get_mut(pos))
+    }
+
+    /// Write a value at the given multi-dimensional index.
+    ///
+    /// Returns `Ok(())` on success, or an error if the index is out of bounds,
+    /// the buffer is not CPU-accessible, or the buffer is shared
+    /// (Arc refcount > 1). Call [`deep_clone`](Tensor::deep_clone) first to
+    /// obtain an exclusively-owned copy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let mut t = Tensor::<f64>::from_slice(
+    ///     &[1.0, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::ColumnMajor,
+    /// ).unwrap();
+    /// t.set(&[1, 0], 10.0).unwrap();
+    /// assert_eq!(t.get(&[1, 0]), Some(&10.0));
+    ///
+    /// // Shared buffers cannot be written:
+    /// let shared = t.clone(); // refcount == 2
+    /// // t.set(&[0, 0], 5.0) would fail here because buffer is shared
+    /// ```
+    pub fn set(&mut self, index: &[usize], value: T) -> tenferro_device::Result<()> {
+        // Collect error context before taking &mut self.
+        let dims_debug = format!("{:?}", &*self.dims);
+        let unique = self.buffer.is_unique();
+        let elem = self.get_mut(index).ok_or_else(|| {
+            tenferro_device::Error::InvalidArgument(format!(
+                "set: cannot write at index {index:?} (dims {dims_debug}, buffer {})",
+                if unique { "accessible" } else { "shared" },
+            ))
+        })?;
+        *elem = value;
+        Ok(())
+    }
+
+    /// Compute the linear buffer offset for a multi-dimensional index.
+    ///
+    /// Returns `None` if the index is out of bounds.
+    fn linear_offset(&self, index: &[usize]) -> Option<usize> {
+        if index.len() != self.dims.len() {
+            return None;
+        }
+        for (i, &idx) in index.iter().enumerate() {
+            if idx >= self.dims[i] {
+                return None;
+            }
+        }
+        let pos: isize = index.iter().zip(self.strides.iter()).try_fold(
+            self.offset,
+            |acc, (&idx, &stride)| {
+                (idx as isize)
+                    .checked_mul(stride)
+                    .and_then(|v| acc.checked_add(v))
+            },
+        )?;
+        usize::try_from(pos).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{MemoryOrder, Tensor};
+
+    #[test]
+    fn get_mut_and_set() {
+        let mut t =
+            Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::ColumnMajor)
+                .unwrap();
+        *t.get_mut(&[0, 1]).unwrap() = 99.0;
+        assert_eq!(t.get(&[0, 1]), Some(&99.0));
+
+        t.set(&[1, 0], 42.0).unwrap();
+        assert_eq!(t.get(&[1, 0]), Some(&42.0));
+    }
+
+    #[test]
+    fn get_mut_out_of_bounds() {
+        let mut t = Tensor::<f64>::from_slice(&[1.0, 2.0], &[2], MemoryOrder::ColumnMajor).unwrap();
+        assert!(t.get_mut(&[2]).is_none());
+    }
+
+    #[test]
+    fn get_mut_wrong_rank() {
+        let mut t = Tensor::<f64>::from_slice(&[1.0, 2.0], &[2], MemoryOrder::ColumnMajor).unwrap();
+        assert!(t.get_mut(&[0, 0]).is_none());
+    }
+
+    #[test]
+    fn set_shared_buffer_fails() {
+        let mut t = Tensor::<f64>::from_slice(&[1.0, 2.0], &[2], MemoryOrder::ColumnMajor).unwrap();
+        let _shared = t.clone(); // refcount == 2
+        assert!(t.set(&[0], 99.0).is_err());
+    }
+
+    #[test]
+    fn set_out_of_bounds_fails() {
+        let mut t = Tensor::<f64>::from_slice(&[1.0, 2.0], &[2], MemoryOrder::ColumnMajor).unwrap();
+        assert!(t.set(&[5], 99.0).is_err());
+    }
+
+    #[test]
+    fn get_and_set_on_view() {
+        let t = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[4], MemoryOrder::ColumnMajor)
+            .unwrap();
+        // narrow creates a view sharing the buffer
+        let view = t.narrow(0, 1, 2).unwrap();
+        assert_eq!(view.get(&[0]), Some(&2.0));
+        assert_eq!(view.get(&[1]), Some(&3.0));
+
+        // view is shared, so deep_clone to get exclusive ownership
+        let mut owned = view.deep_clone();
+        owned.set(&[0], 99.0).unwrap();
+        assert_eq!(owned.get(&[0]), Some(&99.0));
+        // original unchanged
+        assert_eq!(t.get(&[1]), Some(&2.0));
+    }
+
+    #[test]
+    fn deep_clone_is_independent() {
+        let a =
+            Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0], &[3], MemoryOrder::ColumnMajor).unwrap();
+        let mut b = a.deep_clone();
+        b.set(&[0], 99.0).unwrap();
+        assert_eq!(b.get(&[0]), Some(&99.0));
+        assert_eq!(a.get(&[0]), Some(&1.0));
+    }
+
+    #[test]
+    fn deep_clone_empty_tensor() {
+        let a = Tensor::<f64>::from_slice(&[], &[0], MemoryOrder::ColumnMajor).unwrap();
+        let b = a.deep_clone();
+        assert_eq!(b.dims(), &[0]);
+        assert_eq!(b.to_vec(), Vec::<f64>::new());
+    }
+}

--- a/tenferro-tensor/src/tensor/mod.rs
+++ b/tenferro-tensor/src/tensor/mod.rs
@@ -3,6 +3,7 @@ mod combine;
 mod constructors;
 mod constructors_special;
 mod data_ops;
+mod element_access;
 mod metadata;
 mod structural;
 mod transfer;

--- a/tenferro-tensor/src/tests/organization.rs
+++ b/tenferro-tensor/src/tests/organization.rs
@@ -41,6 +41,7 @@ fn tensor_modules_stay_under_size_guideline() {
         "src/tensor/metadata.rs",
         "src/tensor/views.rs",
         "src/tensor/data_ops.rs",
+        "src/tensor/element_access.rs",
         "src/tensor/transfer.rs",
         "src/tensor/autodiff.rs",
     ] {


### PR DESCRIPTION
## Summary

Add element-level write APIs and deep copy to `tenferro_tensor::Tensor<T>`:

- `get_mut(&mut self, &[usize]) -> Option<&mut T>` — mutable element access
- `set(&mut self, &[usize], T) -> Result<()>` — write by index with error reporting
- `deep_clone(&self) -> Tensor<T>` — always-allocating deep copy (vs `clone()` which is shallow Arc bump)

All write operations require exclusive ownership (Arc refcount == 1). Use `deep_clone()` to obtain an independent copy first.

Extracted element access into `tensor/element_access.rs` to stay within the 500-line file size guideline.

## Test plan

- [x] `cargo test -p tenferro-tensor --release` — all tests pass (including file size guard)
- [x] `cargo test --workspace --release` — all tests pass
- [x] Doc examples on all 3 new methods are runnable

Generated with [Claude Code](https://claude.com/claude-code)
