### PR TITLE
Re-export MemoryOrder from tenferro

### DIFF
--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -53,3 +53,4 @@ pub use error::{Error, Result};
 pub use runtime::{set_default_runtime, with_default_runtime, DefaultRuntimeGuard, RuntimeContext};
 pub use scalar_value::ScalarValue;
 pub use tenferro_device::{ComputeDevice, LogicalMemorySpace};
+pub use tenferro_tensor::MemoryOrder;

--- a/tenferro/tests/public_surface_tests.rs
+++ b/tenferro/tests/public_surface_tests.rs
@@ -1,9 +1,10 @@
 use num_complex::{Complex32, Complex64};
 use tenferro::{
-    backward, forward_ad, set_default_runtime, BackwardOptions, RuntimeContext, ScalarType, Tensor,
+    backward, forward_ad, set_default_runtime, BackwardOptions, MemoryOrder, RuntimeContext,
+    ScalarType, Tensor,
 };
 use tenferro_prims::CpuContext;
-use tenferro_tensor::{MemoryOrder, Tensor as DenseTensor};
+use tenferro_tensor::Tensor as DenseTensor;
 
 fn scalar_f64(value: f64) -> DenseTensor<f64> {
     DenseTensor::from_slice(&[value], &[], MemoryOrder::ColumnMajor).unwrap()
@@ -109,6 +110,12 @@ fn tensor_public_primal_constructor_handles_dense_and_diag() {
     let diag = Tensor::diag(&Tensor::from_tensor(vector_f64(&[3.0, 4.0]))).unwrap();
     assert!(diag.is_diag());
     assert_eq!(diag.dims(), &[2, 2]);
+}
+
+#[test]
+fn tensor_public_surface_reexports_memory_order() {
+    let dense = DenseTensor::from_slice(&[1.0_f64, 2.0], &[2], MemoryOrder::ColumnMajor).unwrap();
+    assert_eq!(dense.dims(), &[2]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- re-export `MemoryOrder` from the `tenferro` facade
- switch the public surface test to import `MemoryOrder` from `tenferro`
- add explicit coverage for the facade re-export

Closes #578

## Verification
- cargo fmt --all --check
- cargo test --workspace --release
- cargo llvm-cov --workspace --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py