### PR TITLE
docs: align linalg support docs with current behavior

### DIFF
--- a/docs/AD/eig.md
+++ b/docs/AD/eig.md
@@ -103,15 +103,19 @@ See `eigen.md` for the symmetric case.
 one runtime-typed tensor payload, and scalar AD values are rank-0 tensors
 rather than a separate scalar graph type.
 
-That means `eig_ad(...).run()` is split as follows:
+That means the public `tenferro::Tensor::eig()` wrapper is currently split as
+follows:
 
-- primal / forward mode: supported
-- reverse mode with complex inputs and complex outputs: same-domain reverse path
-- reverse mode with real inputs and complex outputs: currently unsupported
+- real inputs in primal mode: supported
+- real inputs in forward mode: supported
+- reverse mode: currently unsupported in the `tenferro` frontend
+- complex inputs: currently rejected at the public frontend
 
-The old mixed-type reverse bridge (`Complex -> Real`) was removed to keep the
-the `tenferro` frontend tape homogeneous. Dense `eig_rrule` still exists in
-`tenferro-linalg`; the restriction is in the frontend wrapper layer.
+The frontend keeps reverse-mode tapes homogeneous, but `eig()` turns real
+inputs into complex outputs. The old mixed-type reverse bridge was removed, so
+the public wrapper cannot currently register a reverse pullback. Dense
+`eig_rrule` / `eig_frule` still exist in `tenferro-linalg` for real typed
+inputs; the restriction is in the frontend wrapper layer.
 
 ## References
 

--- a/docs/AD/index.md
+++ b/docs/AD/index.md
@@ -75,7 +75,7 @@ one layer up in `tenferro` by composing runtime-generic tensor prims.
   - scalar/analytic: `add`, `atan2`, `pow`, `hypot`, `sqrt`, `exp`, `expm1`, `log`, `log1p`, `sin`, `cos`, `tanh`, `asin`, `acos`, `atan`, `sinh`, `cosh`, `asinh`, `acosh`, `atanh`
   - linalg: `svd`, `qr`, `lu`, `eigen`, `eig`, `lstsq`, `cholesky`, `solve`, `inv`, `det`, `slogdet`, `pinv`, `matrix_exp`, `solve_triangular`, `norm`
 - Internal builder plumbing still lives in `*_ad(...).run()` builders, but the preferred public surface is now the `Tensor` method API
-  - `eig` reverse mode is same-domain only; real-input reverse mode is currently unsupported in the `tenferro` frontend
+  - `eig` is real-input-only at the public frontend; forward mode is supported, but reverse mode is currently unsupported because the output becomes complex while the `tenferro` tape stays homogeneous
 
 For a broader crate-by-crate support view, including primal coverage and
 runtime status, see [Supported Operations by Crate](../design/supported-ops.md).

--- a/docs/design/supported-ops.md
+++ b/docs/design/supported-ops.md
@@ -13,7 +13,7 @@ here.
 
 ### Structural tensor operations
 
-- Shape/view: `reshape`, `reshape_owned`, `permute`, `broadcast_to`
+- Shape/view: `reshape`, `reshape_owned`, `permute`, `broadcast`
 - Matrix helpers: `transpose_last2`, `diagonal`
 - Indexing/view selection: `slice_axis`, `select_axis`
 - Materialization helpers: `to_tensor`, `to_owned`, contiguous conversion APIs
@@ -182,7 +182,22 @@ Internal builder APIs are implemented for:
   `sinh_ad`, `cosh_ad`, `asinh_ad`, `acosh_ad`, `atanh_ad`,
   `sum_ad`, `mean_ad`, `var_ad`, `std_ad`
 - Linalg: `svd_ad`, `qr_ad`, `lu_ad`, `eigen_ad`, `lstsq_ad`, `cholesky_ad`, `solve_ad`, `inv_ad`, `det_ad`, `slogdet_ad`, `eig_ad`, `pinv_ad`, `matrix_exp_ad`, `solve_triangular_ad`, `norm_ad`
-  - `eig_ad` reverse mode is same-domain only in `tenferro`; real-input reverse mode is intentionally rejected to keep the tape homogeneous
+  - `eig_ad` is real-input-only at the public frontend; forward mode is supported, but reverse mode is intentionally rejected because the output becomes complex while the frontend tape stays homogeneous
+
+### Complex linalg AD coverage
+
+For current public `tenferro::Tensor` behavior, complex linalg support splits
+into three buckets: full AD for a small subset, primal-only complex execution
+for several ops whose stateless rules are still real-only, and some entrypoints
+that remain real-input-only today.
+
+| Operation | `tenferro::Tensor` with complex input | `tenferro-linalg` stateless AD | Notes |
+| --- | --- | --- | --- |
+| `svd` | primal + forward + reverse | complex-capable `_frule` / `_rrule` | singular values remain real |
+| `solve`, `solve_triangular` | primal + forward + reverse | complex-capable `_frule` / `_rrule` | operands must share dtype |
+| `qr`, `lu`, `eigen`, `cholesky`, `inv`, `matrix_exp` | primal only | current `_frule` / `_rrule` are real-only | the dynamic wrapper rejects non-primal complex tensors |
+| `det`, `slogdet`, `pinv`, `norm`, `lstsq` | complex input unsupported | current `_frule` / `_rrule` are real-only | use real tensors only today |
+| `eig` | complex input unsupported; real-input eager reverse is also unsupported | `eig_frule` / `eig_rrule` exist for real inputs | the frontend still lacks a mixed real-to-complex reverse bridge |
 
 ### Runtime status
 


### PR DESCRIPTION
## Summary
- replace the stale `broadcast_to` docs reference with `broadcast`
- document the current complex linalg AD coverage split in `supported-ops`
- update `eig` AD docs to match the current public `tenferro` frontend behavior

## Testing
- cargo fmt --all --check
- cargo test --workspace --release
- cargo llvm-cov --workspace --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py

Closes #579
Closes #580

Attribution: generated with Codex.