### PR TITLE
Support complex QR/LU autodiff

### DIFF
--- a/docs/design/supported-ops.md
+++ b/docs/design/supported-ops.md
@@ -195,7 +195,8 @@ that remain real-input-only today.
 | --- | --- | --- | --- |
 | `svd` | primal + forward + reverse | complex-capable `_frule` / `_rrule` | singular values remain real |
 | `solve`, `solve_triangular` | primal + forward + reverse | complex-capable `_frule` / `_rrule` | operands must share dtype |
-| `qr`, `lu`, `eigen`, `cholesky`, `inv`, `matrix_exp` | primal only | current `_frule` / `_rrule` are real-only | the dynamic wrapper rejects non-primal complex tensors |
+| `qr`, `lu` | primal + forward + reverse | complex-capable `_frule` / `_rrule` | follows the real-loss/Wirtinger reverse convention used elsewhere |
+| `eigen`, `cholesky`, `inv`, `matrix_exp` | primal only | current `_frule` / `_rrule` are real-only | the dynamic wrapper rejects non-primal complex tensors |
 | `det`, `slogdet`, `pinv`, `norm`, `lstsq` | complex input unsupported | current `_frule` / `_rrule` are real-only | use real tensors only today |
 | `eig` | complex input unsupported; real-input eager reverse is also unsupported | `eig_frule` / `eig_rrule` exist for real inputs | the frontend still lacks a mixed real-to-complex reverse bridge |
 

--- a/internal/tenferro-internal-ad-linalg/src/ops/linalg/ad/eager.rs
+++ b/internal/tenferro-internal-ad-linalg/src/ops/linalg/ad/eager.rs
@@ -55,7 +55,7 @@ eager_unary!(
     /// ```
     fn qr -> TypedQrResult<T> => qr_ad;
     where {
-        T: RealLinalgRuntimeValue,
+        T: LinalgRuntimeValue,
     }
 );
 
@@ -71,7 +71,7 @@ eager_unary!(
     /// ```
     fn lu -> TypedLuResult<T> => lu_ad;
     where {
-        T: crate::runtime::dispatch::RealLuLinalgDispatchValue,
+        T: crate::runtime::dispatch::LuLinalgDispatchValue,
     }
 );
 

--- a/internal/tenferro-internal-ad-linalg/src/ops/linalg/ad/lu_lstsq.rs
+++ b/internal/tenferro-internal-ad-linalg/src/ops/linalg/ad/lu_lstsq.rs
@@ -14,7 +14,7 @@ pub struct LuAdBuilder<'a, T: Scalar> {
 
 impl<'a, T> LuAdBuilder<'a, T>
 where
-    T: crate::runtime::dispatch::RealLuLinalgDispatchValue,
+    T: crate::runtime::dispatch::LuLinalgDispatchValue,
 {
     /// Sets LU pivot policy.
     /// # Examples

--- a/internal/tenferro-internal-ad-linalg/src/ops/linalg/ad/svd_qr.rs
+++ b/internal/tenferro-internal-ad-linalg/src/ops/linalg/ad/svd_qr.rs
@@ -290,7 +290,7 @@ pub struct QrAdBuilder<'a, T: Scalar> {
 
 impl<'a, T> QrAdBuilder<'a, T>
 where
-    T: RealLinalgRuntimeValue,
+    T: LinalgRuntimeValue,
 {
     /// Executes AD QR.
     /// # Examples

--- a/internal/tenferro-internal-ad-surface/src/core/dynamic/dyn_ad_tensor/eager_linalg/mod.rs
+++ b/internal/tenferro-internal-ad-surface/src/core/dynamic/dyn_ad_tensor/eager_linalg/mod.rs
@@ -149,19 +149,17 @@ impl Tensor {
                 })
             }
             Self::C32(value) => {
-                let dense = Self::dense_primal_complex_only(value, "qr")?;
-                let out = crate::ops::qr(&dense).run()?;
+                let out = ad::qr(value)?;
                 Ok(QrResult {
-                    q: Tensor::from_tensor(out.q),
-                    r: Tensor::from_tensor(out.r),
+                    q: out.q.into(),
+                    r: out.r.into(),
                 })
             }
             Self::C64(value) => {
-                let dense = Self::dense_primal_complex_only(value, "qr")?;
-                let out = crate::ops::qr(&dense).run()?;
+                let out = ad::qr(value)?;
                 Ok(QrResult {
-                    q: Tensor::from_tensor(out.q),
-                    r: Tensor::from_tensor(out.r),
+                    q: out.q.into(),
+                    r: out.r.into(),
                 })
             }
         }
@@ -194,21 +192,19 @@ impl Tensor {
                 })
             }
             Self::C32(value) => {
-                let dense = Self::dense_primal_complex_only(value, "lu")?;
-                let out = crate::ops::lu(&dense).run()?;
+                let out = ad::lu(value)?;
                 Ok(LuResult {
                     p: out.p.into(),
-                    l: Tensor::from_tensor(out.l),
-                    u: Tensor::from_tensor(out.u),
+                    l: out.l.into(),
+                    u: out.u.into(),
                 })
             }
             Self::C64(value) => {
-                let dense = Self::dense_primal_complex_only(value, "lu")?;
-                let out = crate::ops::lu(&dense).run()?;
+                let out = ad::lu(value)?;
                 Ok(LuResult {
                     p: out.p.into(),
-                    l: Tensor::from_tensor(out.l),
-                    u: Tensor::from_tensor(out.u),
+                    l: out.l.into(),
+                    u: out.u.into(),
                 })
             }
         }

--- a/internal/tenferro-internal-ad-surface/src/ops/linalg/primal/mod.rs
+++ b/internal/tenferro-internal-ad-surface/src/ops/linalg/primal/mod.rs
@@ -13,3 +13,6 @@ pub use factorizations::*;
 pub use solve::*;
 pub use spectral::*;
 pub use tensorized::*;
+
+#[cfg(test)]
+mod tests;

--- a/internal/tenferro-internal-ad-surface/src/ops/linalg/primal/tests/mod.rs
+++ b/internal/tenferro-internal-ad-surface/src/ops/linalg/primal/tests/mod.rs
@@ -1,0 +1,52 @@
+use super::*;
+use tenferro_prims::CpuContext;
+use tenferro_tensor::{MemoryOrder, Tensor};
+
+use crate::{set_default_runtime, RuntimeContext};
+
+fn matrix_f64(values: &[f64], dims: &[usize]) -> Tensor<f64> {
+    Tensor::from_slice(values, dims, MemoryOrder::ColumnMajor).unwrap()
+}
+
+#[test]
+fn factorization_builders_cover_qr_and_lu_variants() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let a = matrix_f64(&[4.0, 1.0, 1.0, 3.0], &[2, 2]);
+
+    let qr_out = qr(&a).run().unwrap();
+    assert_eq!(qr_out.q.dims(), &[2, 2]);
+    assert_eq!(qr_out.r.dims(), &[2, 2]);
+
+    let lu_out = lu(&a).pivot(LuPivot::NoPivot).run().unwrap();
+    assert_eq!(lu_out.p.dims(), &[0]);
+    assert_eq!(lu_out.l.dims(), &[2, 2]);
+    assert_eq!(lu_out.u.dims(), &[2, 2]);
+
+    let lu_factor_out = lu_factor(&a).run().unwrap();
+    assert_eq!(lu_factor_out.factors.dims(), &[2, 2]);
+    assert_eq!(lu_factor_out.pivots.dims(), &[2]);
+
+    let lu_factor_ex_out = lu_factor_ex(&a).run().unwrap();
+    assert_eq!(lu_factor_ex_out.factors.dims(), &[2, 2]);
+    assert_eq!(lu_factor_ex_out.pivots.dims(), &[2]);
+    assert_eq!(lu_factor_ex_out.info.buffer().as_slice().unwrap(), &[0]);
+}
+
+#[test]
+fn factorization_builders_cover_eigen_and_cholesky_variants() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let spd = matrix_f64(&[5.0, 1.0, 1.0, 4.0], &[2, 2]);
+
+    let eigen_out = eigen(&spd).run().unwrap();
+    assert_eq!(eigen_out.values.dims(), &[2]);
+    assert_eq!(eigen_out.vectors.dims(), &[2, 2]);
+
+    let cholesky_out = cholesky(&spd).run().unwrap();
+    assert_eq!(cholesky_out.dims(), &[2, 2]);
+
+    let cholesky_ex_out = cholesky_ex(&spd).run().unwrap();
+    assert_eq!(cholesky_ex_out.l.dims(), &[2, 2]);
+    assert_eq!(cholesky_ex_out.info.buffer().as_slice().unwrap(), &[0]);
+}

--- a/tenferro-linalg/src/ad_helpers/matrix_ops.rs
+++ b/tenferro-linalg/src/ad_helpers/matrix_ops.rs
@@ -79,6 +79,47 @@ pub(crate) fn tril_strict<T: LinalgScalar>(data: &[T], n: usize) -> Vec<T> {
     result
 }
 
+/// Extract the lower-triangular part used by complex QR JVPs.
+///
+/// For real inputs this matches `tril_strict`. For complex inputs the diagonal
+/// keeps only the imaginary-axis component.
+pub(crate) fn tril_im<T: LinalgScalar>(data: &[T], n: usize) -> AdResult<Vec<T>> {
+    let mut result = vec![T::zero(); n * n];
+    for j in 0..n {
+        for i in (j + 1)..n {
+            result[i + j * n] = data[i + j * n];
+        }
+        result[j + j * n] = imag_axis_component(data[j + j * n])?;
+    }
+    Ok(result)
+}
+
+/// Invert `tril_im` onto the skew-Hermitian gauge space used by complex QR JVPs.
+pub(crate) fn tril_im_inv<T: LinalgScalar>(data: &[T], n: usize) -> AdResult<Vec<T>> {
+    let mut result = vec![T::zero(); n * n];
+    for j in 0..n {
+        for i in (j + 1)..n {
+            let value = data[i + j * n];
+            result[i + j * n] = value;
+            result[j + i * n] = -value.conj();
+        }
+        result[j + j * n] = imag_axis_component(data[j + j * n])?;
+    }
+    Ok(result)
+}
+
+/// Adjoint helper for the wide complex QR VJP.
+pub(crate) fn tril_im_inv_adj_skew<T: LinalgScalar>(data: &[T], n: usize) -> AdResult<Vec<T>> {
+    let mut result = vec![T::zero(); n * n];
+    for j in 0..n {
+        for i in (j + 1)..n {
+            result[i + j * n] = data[i + j * n] - data[j + i * n].conj();
+        }
+        result[j + j * n] = imag_axis_component(data[j + j * n])?;
+    }
+    Ok(result)
+}
+
 /// Hermitianize from the lower triangle.
 pub(crate) fn copyltu<T: LinalgScalar>(data: &[T], n: usize) -> Vec<T> {
     let mut result = vec![T::zero(); n * n];
@@ -86,9 +127,9 @@ pub(crate) fn copyltu<T: LinalgScalar>(data: &[T], n: usize) -> Vec<T> {
         for i in 0..n {
             if i > j {
                 result[i + j * n] = data[i + j * n];
-                result[j + i * n] = data[i + j * n];
+                result[j + i * n] = data[i + j * n].conj();
             } else if i == j {
-                result[i + j * n] = data[i + j * n];
+                result[i + j * n] = T::from_real(data[i + j * n].real_part());
             }
         }
     }

--- a/tenferro-linalg/src/frules/lu_eigen.rs
+++ b/tenferro-linalg/src/frules/lu_eigen.rs
@@ -20,7 +20,7 @@ use super::*;
 /// let da = Tensor::<f64>::ones(&[3, 3], mem, col).unwrap();
 /// let (result, dresult) = lu_frule(&mut ctx, &a, &da, LuPivot::Partial).unwrap();
 /// ```
-pub fn lu_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn lu_frule<T, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
@@ -30,10 +30,11 @@ where
     T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>
         + tenferro_prims::TensorMetadataContextFor
-        + tenferro_prims::TensorScalarContextFor<tenferro_algebra::Standard<T>>,
+        + tenferro_prims::TensorScalarContextFor<tenferro_algebra::Standard<T::Real>>,
     C::MetadataBackend: tenferro_prims::TensorMetadataPrims<Context = C>,
-    <C as tenferro_prims::TensorScalarContextFor<tenferro_algebra::Standard<T>>>::ScalarBackend:
-        tenferro_prims::TensorMetadataCastPrims<T, Context = C>,
+    <C as tenferro_prims::TensorScalarContextFor<
+        tenferro_algebra::Standard<T::Real>,
+    >>::ScalarBackend: tenferro_prims::TensorMetadataCastPrims<T::Real, Context = C>,
     T: crate::primal::LiftPermutationMatrixTensor<C>,
     C::Backend: 'static,
 {
@@ -67,65 +68,125 @@ where
             }
         }
 
-        // F = L^{-1} P dA U^{-1} (k×k for square part)
-        // First: L^{-1} PdA → solve L x = PdA
-        let l_sq: Vec<T> = {
-            let mut s = vec![T::zero(); k * k];
+        if m == n {
+            let l_sq = l_b.to_vec();
+            let u_sq = u_b.to_vec();
+            let linv_pda = backend_solve_tri(ctx, &l_sq, &pda, k, k, false)?;
+            let f_h = backend_solve_tri(
+                ctx,
+                &adjoint_transpose(&u_sq, k, k),
+                &adjoint_transpose(&linv_pda, k, k),
+                k,
+                k,
+                false,
+            )?;
+            let f = adjoint_transpose(&f_h, k, k);
+            let lower_f = tril_strict(&f, k);
+            let upper_f = triu(&f, k);
+
+            let dl_b_vec = backend_mat_mul(ctx, &l_sq, k, k, &lower_f, k)?;
+            let du_b_vec = backend_mat_mul(ctx, &upper_f, k, k, &u_sq, k)?;
+            dl_data[b * m * k..(b + 1) * m * k].copy_from_slice(&dl_b_vec);
+            du_data[b * k * n..(b + 1) * k * n].copy_from_slice(&du_b_vec);
+        } else if m < n {
+            let l_sq = l_b.to_vec();
+            let u1 = u_b[..k * k].to_vec();
+            let u2 = u_b[k * k..].to_vec();
+            let pda1 = pda[..k * k].to_vec();
+            let pda2 = pda[k * k..].to_vec();
+
+            let linv_pda1 = backend_solve_tri(ctx, &l_sq, &pda1, k, k, false)?;
+            let f_h = backend_solve_tri(
+                ctx,
+                &adjoint_transpose(&u1, k, k),
+                &adjoint_transpose(&linv_pda1, k, k),
+                k,
+                k,
+                false,
+            )?;
+            let f = adjoint_transpose(&f_h, k, k);
+            let lower_f = tril_strict(&f, k);
+            let upper_f = triu(&f, k);
+
+            let dl_b_vec = backend_mat_mul(ctx, &l_sq, k, k, &lower_f, k)?;
+            let du1 = backend_mat_mul(ctx, &upper_f, k, k, &u1, k)?;
+            let du2 = if n > k {
+                let linv_pda2 = backend_solve_tri(ctx, &l_sq, &pda2, k, n - k, false)?;
+                let correction = backend_mat_mul(ctx, &lower_f, k, k, &u2, n - k)?;
+                sub_vec(&linv_pda2, &correction)
+            } else {
+                Vec::new()
+            };
+
+            dl_data[b * m * k..(b + 1) * m * k].copy_from_slice(&dl_b_vec);
+            du_data[b * k * n..b * k * n + k * k].copy_from_slice(&du1);
+            if n > k {
+                du_data[b * k * n + k * k..(b + 1) * k * n].copy_from_slice(&du2);
+            }
+        } else {
+            let mut l1 = vec![T::zero(); k * k];
+            let mut l2 = vec![T::zero(); (m - k) * k];
             for j in 0..k {
                 for i in 0..k {
-                    s[i + j * k] = l_b[i + j * m];
+                    l1[i + j * k] = l_b[i + j * m];
+                }
+                for i in k..m {
+                    l2[(i - k) + j * (m - k)] = l_b[i + j * m];
                 }
             }
-            s
-        };
-        let pda_sq: Vec<T> = {
-            let mut s = vec![T::zero(); k * n];
-            for j in 0..n {
-                for i in 0..k {
-                    s[i + j * k] = pda[i + j * m];
-                }
-            }
-            s
-        };
-        let linv_pda = backend_solve_tri(ctx, &l_sq, &pda_sq, k, n, false)?;
+            let u_sq = u_b.to_vec();
 
-        // Then: (L^{-1} PdA) U^{-1} → solve (result) U = linv_pda
-        let u_sq: Vec<T> = {
-            let mut s = vec![T::zero(); k * k];
+            let mut pda1 = vec![T::zero(); k * k];
+            let mut pda2 = vec![T::zero(); (m - k) * k];
             for j in 0..k {
                 for i in 0..k {
-                    s[i + j * k] = u_b[i + j * k];
+                    pda1[i + j * k] = pda[i + j * m];
+                }
+                for i in k..m {
+                    pda2[(i - k) + j * (m - k)] = pda[i + j * m];
                 }
             }
-            s
-        };
-        // Solve x U = linv_pda → U^T x^T = linv_pda^T
-        let f_t = backend_solve_tri(
-            ctx,
-            &transpose(&u_sq, k, k),
-            &transpose(&linv_pda, k, n),
-            k,
-            k,
-            false,
-        )?;
-        let f = transpose(&f_t, k, k);
 
-        // dL = L tril_strict(F) (m×k)
-        let tril_f = tril_strict(&f, k);
-        let dl_b_vec = backend_mat_mul(ctx, &l_sq, k, k, &tril_f, k)?;
-        for j in 0..k {
-            for i in 0..k {
-                dl_data[b * m * k + i + j * m] = dl_b_vec[i + j * k];
-            }
-        }
+            let linv_pda1 = backend_solve_tri(ctx, &l1, &pda1, k, k, false)?;
+            let f_h = backend_solve_tri(
+                ctx,
+                &adjoint_transpose(&u_sq, k, k),
+                &adjoint_transpose(&linv_pda1, k, k),
+                k,
+                k,
+                false,
+            )?;
+            let f = adjoint_transpose(&f_h, k, k);
+            let lower_f = tril_strict(&f, k);
+            let upper_f = triu(&f, k);
 
-        // dU = triu(F) U (k×n)
-        let triu_f = triu(&f, k);
-        let du_b_vec = backend_mat_mul(ctx, &triu_f, k, k, &u_sq, k)?;
-        for j in 0..k {
-            for i in 0..k {
-                du_data[b * k * n + i + j * k] = du_b_vec[i + j * k];
+            let dl1 = backend_mat_mul(ctx, &l1, k, k, &lower_f, k)?;
+            let du_b_vec = backend_mat_mul(ctx, &upper_f, k, k, &u_sq, k)?;
+            let dl2 = if m > k {
+                let pda2_uinv_h = backend_solve_tri(
+                    ctx,
+                    &adjoint_transpose(&u_sq, k, k),
+                    &adjoint_transpose(&pda2, m - k, k),
+                    k,
+                    m - k,
+                    false,
+                )?;
+                let pda2_uinv = adjoint_transpose(&pda2_uinv_h, k, m - k);
+                let correction = backend_mat_mul(ctx, &l2, m - k, k, &upper_f, k)?;
+                sub_vec(&pda2_uinv, &correction)
+            } else {
+                Vec::new()
+            };
+
+            for j in 0..k {
+                for i in 0..k {
+                    dl_data[b * m * k + i + j * m] = dl1[i + j * k];
+                }
+                for i in k..m {
+                    dl_data[b * m * k + i + j * m] = dl2[(i - k) + j * (m - k)];
+                }
             }
+            du_data[b * k * n..(b + 1) * k * n].copy_from_slice(&du_b_vec);
         }
     }
 

--- a/tenferro-linalg/src/frules/svd_qr.rs
+++ b/tenferro-linalg/src/frules/svd_qr.rs
@@ -177,7 +177,7 @@ where
 /// let da = Tensor::<f64>::ones(&[4, 3], mem, col).unwrap();
 /// let (result, dresult) = qr_frule(&mut ctx, &a, &da).unwrap();
 /// ```
-pub fn qr_frule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn qr_frule<T, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     tangent: &Tensor<T>,
@@ -193,7 +193,7 @@ where
         .map_err(|e| chainrules_core::AutodiffError::InvalidArgument(e.to_string()))?;
     let k = m.min(n);
     let bc = batch_count(batch_dims);
-    let half: T = scalar_from(0.5).map_err(to_ad_err)?;
+    let half: T::Real = scalar_from(0.5).map_err(to_ad_err)?;
 
     let (q_data, _) = extract_data(&result.q)?;
     let (r_data, _) = extract_data(&result.r)?;
@@ -209,24 +209,24 @@ where
 
         let (dq_b_vec, dr_b_vec) = if m >= n {
             let r_sq = r_b[..n * n].to_vec();
-            let darinv_t = backend_solve_tri(
+            let darinv_h = backend_solve_tri(
                 ctx,
-                &transpose(&r_sq, n, n),
-                &transpose(da_b, m, n),
+                &adjoint_transpose(&r_sq, n, n),
+                &adjoint_transpose(da_b, m, n),
                 n,
                 m,
                 false,
             )?;
-            let darinv = transpose(&darinv_t, n, m);
-            let qhdarinv = backend_mat_mul(ctx, &transpose(q_b, m, n), n, m, &darinv, n)?;
-            let sym = add_vec(&qhdarinv, &transpose(&qhdarinv, n, n));
+            let darinv = adjoint_transpose(&darinv_h, n, m);
+            let qhdarinv = backend_mat_mul(ctx, &adjoint_transpose(q_b, m, n), n, m, &darinv, n)?;
+            let sym = add_vec(&qhdarinv, &adjoint_transpose(&qhdarinv, n, n));
 
             let mut dr_hat = vec![T::zero(); n * n];
             for j in 0..n {
                 for i in 0..=j {
                     let mut val = sym[i + j * n];
                     if i == j {
-                        val = val * half;
+                        val = T::from_real(val.real_part() * half);
                     }
                     dr_hat[i + j * n] = val;
                 }
@@ -236,27 +236,20 @@ where
             let dr = backend_mat_mul(ctx, &dr_hat, n, n, &r_sq, n)?;
             (dq, dr)
         } else {
-            let qhda = backend_mat_mul(ctx, &transpose(q_b, m, k), k, m, da_b, n)?;
-            // k = min(m,n) so k*n == k*k when n == k (the only case reaching here)
-            let r1 = r_b[..k * n].to_vec();
-
-            let mut qhda1 = vec![T::zero(); k * k];
-            for j in 0..k {
-                for i in 0..k {
-                    qhda1[i + j * k] = qhda[i + j * k];
-                }
-            }
-            let qhda1_rinv_t = backend_solve_tri(
+            let qhda = backend_mat_mul(ctx, &adjoint_transpose(q_b, m, k), k, m, da_b, n)?;
+            let r1 = r_b[..k * k].to_vec();
+            let qhda1 = qhda[..k * k].to_vec();
+            let qhda1_rinv_h = backend_solve_tri(
                 ctx,
-                &transpose(&r1, k, k),
-                &transpose(&qhda1, k, k),
+                &adjoint_transpose(&r1, k, k),
+                &adjoint_transpose(&qhda1, k, k),
                 k,
                 k,
                 false,
             )?;
-            let qhda1_rinv = transpose(&qhda1_rinv_t, k, k);
-            let lower = tril_strict(&qhda1_rinv, k);
-            let dq_hat = sub_vec(&lower, &transpose(&lower, k, k));
+            let qhda1_rinv = adjoint_transpose(&qhda1_rinv_h, k, k);
+            let lower = tril_im(&qhda1_rinv, k)?;
+            let dq_hat = tril_im_inv(&lower, k)?;
 
             let dr = sub_vec(&qhda, &backend_mat_mul(ctx, &dq_hat, k, k, r_b, n)?);
             let dq = backend_mat_mul(ctx, q_b, m, k, &dq_hat, k)?;

--- a/tenferro-linalg/src/primal/decompositions.rs
+++ b/tenferro-linalg/src/primal/decompositions.rs
@@ -152,9 +152,40 @@ where
     C::Backend: 'static,
 {
     let result = <C::Backend as backend::TensorLinalgBackend<T>>::qr(ctx, tensor)?;
+    let (m, n, batch_dims) = validate_2d(tensor)?;
+    let k = m.min(n);
+    let bc = batch_count(batch_dims);
+    let (mut q_data, _) =
+        extract_data(&result.q).map_err(|e| Error::InvalidArgument(e.to_string()))?;
+    let (mut r_data, _) =
+        extract_data(&result.r).map_err(|e| Error::InvalidArgument(e.to_string()))?;
+
+    for batch in 0..bc {
+        let q_base = batch * m * k;
+        let r_base = batch * k * n;
+        for i in 0..k {
+            let diag = r_data[r_base + i + i * k];
+            if diag.imag_part() == T::Real::zero() {
+                continue;
+            }
+            let mag = diag.abs_real();
+            if mag == T::Real::zero() {
+                continue;
+            }
+            let phase = diag / T::from_real(mag);
+            for row in 0..m {
+                q_data[q_base + row + i * m] = q_data[q_base + row + i * m] * phase;
+            }
+            let phase_inv = phase.conj();
+            for col in 0..n {
+                r_data[r_base + i + col * k] = r_data[r_base + i + col * k] * phase_inv;
+            }
+        }
+    }
+
     Ok(QrResult {
-        q: result.q,
-        r: result.r,
+        q: tensor_from_data(q_data, result.q.dims())?,
+        r: tensor_from_data(r_data, result.r.dims())?,
     })
 }
 

--- a/tenferro-linalg/src/rrules/lu_eigen.rs
+++ b/tenferro-linalg/src/rrules/lu_eigen.rs
@@ -23,7 +23,7 @@ use super::*;
 /// };
 /// let grad_a = lu_rrule(&mut ctx, &a, &cotangent, LuPivot::Partial).unwrap();
 /// ```
-pub fn lu_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn lu_rrule<T, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &LuCotangent<T>,
@@ -33,10 +33,11 @@ where
     T: KernelLinalgScalar,
     C: backend::TensorLinalgContextFor<T>
         + tenferro_prims::TensorMetadataContextFor
-        + tenferro_prims::TensorScalarContextFor<tenferro_algebra::Standard<T>>,
+        + tenferro_prims::TensorScalarContextFor<tenferro_algebra::Standard<T::Real>>,
     C::MetadataBackend: tenferro_prims::TensorMetadataPrims<Context = C>,
-    <C as tenferro_prims::TensorScalarContextFor<tenferro_algebra::Standard<T>>>::ScalarBackend:
-        tenferro_prims::TensorMetadataCastPrims<T, Context = C>,
+    <C as tenferro_prims::TensorScalarContextFor<
+        tenferro_algebra::Standard<T::Real>,
+    >>::ScalarBackend: tenferro_prims::TensorMetadataCastPrims<T::Real, Context = C>,
     T: crate::primal::LiftPermutationMatrixTensor<C>,
     C::Backend: 'static,
 {
@@ -94,105 +95,100 @@ where
             .map(|data| &data[b * k * n..(b + 1) * k * n]);
 
         let batch_grad = if m == n {
-            let l_t = transpose(l_b, k, k);
+            let l_h = adjoint_transpose(l_b, k, k);
             let mut inner = vec![T::zero(); k * k];
 
             if let Some(dl_b) = dl_b {
-                let lt_dl = backend_mat_mul(ctx, &l_t, k, k, dl_b, k)?;
+                let lt_dl = backend_mat_mul(ctx, &l_h, k, k, dl_b, k)?;
                 inner = add_vec(&inner, &tril_strict(&lt_dl, k));
             }
             if let Some(du_b) = du_b {
-                let du_ut = backend_mat_mul(ctx, du_b, k, k, &transpose(u_b, k, k), k)?;
+                let du_ut = backend_mat_mul(ctx, du_b, k, k, &adjoint_transpose(u_b, k, k), k)?;
                 inner = add_vec(&inner, &triu(&du_ut, k));
             }
 
-            let right_t = backend_solve_tri(ctx, u_b, &transpose(&inner, k, k), k, k, true)?;
-            let right = transpose(&right_t, k, k);
-            backend_solve_tri(ctx, &l_t, &right, k, k, true)?
+            let left = backend_solve_tri(ctx, &l_h, &inner, k, k, true)?;
+            let grad_h = backend_solve_tri(ctx, u_b, &adjoint_transpose(&left, k, k), k, k, true)?;
+            adjoint_transpose(&grad_h, k, k)
         } else if m < n {
-            let l_t = transpose(l_b, k, k);
-            let u1: Vec<T> = {
-                let mut out = vec![T::zero(); k * k];
-                for j in 0..k {
-                    for i in 0..k {
-                        out[i + j * k] = u_b[i + j * k];
-                    }
-                }
-                out
-            };
-
-            let mut core = vec![T::zero(); k * k];
+            let l_h = adjoint_transpose(l_b, k, k);
+            let u1 = u_b[..k * k].to_vec();
+            let u2 = u_b[k * k..].to_vec();
+            let mut lower_source = vec![T::zero(); k * k];
             if let Some(dl_b) = dl_b {
-                let lt_dl = backend_mat_mul(ctx, &l_t, k, k, dl_b, k)?;
-                core = add_vec(&core, &lt_dl);
+                let lt_dl = backend_mat_mul(ctx, &l_h, k, k, dl_b, k)?;
+                lower_source = add_vec(&lower_source, &lt_dl);
             }
-            if let Some(du_b) = du_b {
-                let mut du_triu = vec![T::zero(); k * n];
-                for j in 0..n {
-                    for i in 0..k {
-                        if i <= j {
-                            du_triu[i + j * k] = du_b[i + j * k];
-                        }
-                    }
-                }
-                let du_term = backend_mat_mul(ctx, &du_triu, k, n, &transpose(u_b, k, n), k)?;
-                core = sub_vec(&core, &du_term);
+            if let Some(du_b) = du_b.filter(|_| n > k) {
+                let du2 = &du_b[k * k..];
+                let du2_u2h =
+                    backend_mat_mul(ctx, du2, k, n - k, &adjoint_transpose(&u2, k, n - k), k)?;
+                lower_source = sub_vec(&lower_source, &du2_u2h);
             }
 
-            let lower = tril_strict(&core, k);
-            let lower_t = backend_solve_tri(ctx, &u1, &transpose(&lower, k, k), k, k, true)?;
-            let leading = transpose(&lower_t, k, k);
+            let mut inner = tril_strict(&lower_source, k);
+            if let Some(du_b) = du_b {
+                let du1 = &du_b[..k * k];
+                let du1_u1h = backend_mat_mul(ctx, du1, k, k, &adjoint_transpose(&u1, k, k), k)?;
+                inner = add_vec(&inner, &triu(&du1_u1h, k));
+            }
+
+            let leading_h = backend_solve_tri(
+                ctx,
+                u1.as_slice(),
+                &adjoint_transpose(&inner, k, k),
+                k,
+                k,
+                true,
+            )?;
+            let leading = adjoint_transpose(&leading_h, k, k);
 
             let mut pre_left = vec![T::zero(); k * n];
+            pre_left[..k * k].copy_from_slice(&leading);
+            if let Some(du_b) = du_b.filter(|_| n > k) {
+                pre_left[k * k..].copy_from_slice(&du_b[k * k..]);
+            }
+
+            backend_solve_tri(ctx, &l_h, &pre_left, k, n, true)?
+        } else {
+            let mut l1 = vec![T::zero(); k * k];
+            let mut l2 = vec![T::zero(); (m - k) * k];
             for j in 0..k {
                 for i in 0..k {
-                    pre_left[i + j * k] = leading[i + j * k];
+                    l1[i + j * k] = l_b[i + j * m];
+                }
+                for i in k..m {
+                    l2[(i - k) + j * (m - k)] = l_b[i + j * m];
                 }
             }
-            if let Some(du_b) = du_b {
-                for j in 0..k {
-                    for i in 0..=j {
-                        pre_left[i + j * k] = pre_left[i + j * k] + du_b[i + j * k];
-                    }
-                }
-                for j in k..n {
-                    for i in 0..k {
-                        pre_left[i + j * k] = du_b[i + j * k];
-                    }
-                }
-            }
+            let l1_h = adjoint_transpose(&l1, k, k);
 
-            backend_solve_tri(ctx, &l_t, &pre_left, k, n, true)?
-        } else {
-            let l1: Vec<T> = {
-                let mut out = vec![T::zero(); k * k];
-                for j in 0..k {
-                    for i in 0..k {
-                        out[i + j * k] = l_b[i + j * m];
-                    }
-                }
-                out
-            };
-            let l1_t = transpose(&l1, k, k);
-
-            let mut core = vec![T::zero(); k * k];
-            if let Some(du_b) = du_b {
-                let du_term = backend_mat_mul(ctx, du_b, k, k, &transpose(u_b, k, k), k)?;
-                core = add_vec(&core, &du_term);
-            }
+            let mut inner = vec![T::zero(); k * k];
             if let Some(dl_b) = dl_b {
-                let mut dl_tril = vec![T::zero(); m * k];
+                let mut dl1 = vec![T::zero(); k * k];
+                let mut dl2 = vec![T::zero(); (m - k) * k];
                 for j in 0..k {
-                    for i in (j + 1)..m {
-                        dl_tril[i + j * m] = dl_b[i + j * m];
+                    for i in 0..k {
+                        dl1[i + j * k] = dl_b[i + j * m];
+                    }
+                    for i in k..m {
+                        dl2[(i - k) + j * (m - k)] = dl_b[i + j * m];
                     }
                 }
-                let lt_dl = backend_mat_mul(ctx, &transpose(l_b, m, k), k, m, &dl_tril, k)?;
-                core = sub_vec(&core, &lt_dl);
+                let l1h_dl1 = backend_mat_mul(ctx, &l1_h, k, k, &dl1, k)?;
+                inner = add_vec(&inner, &tril_strict(&l1h_dl1, k));
+                if m > k {
+                    let l2h_dl2 =
+                        backend_mat_mul(ctx, &adjoint_transpose(&l2, m - k, k), k, m - k, &dl2, k)?;
+                    inner = sub_vec(&inner, &triu(&l2h_dl2, k));
+                }
+            }
+            if let Some(du_b) = du_b {
+                let du_term = backend_mat_mul(ctx, du_b, k, k, &adjoint_transpose(u_b, k, k), k)?;
+                inner = add_vec(&inner, &triu(&du_term, k));
             }
 
-            let upper = triu(&core, k);
-            let leading = backend_solve_tri(ctx, &l1_t, &upper, k, k, true)?;
+            let leading = backend_solve_tri(ctx, &l1_h, &inner, k, k, true)?;
 
             let mut pre_right = vec![T::zero(); m * k];
             for j in 0..k {
@@ -202,18 +198,15 @@ where
             }
             if let Some(dl_b) = dl_b {
                 for j in 0..k {
-                    for i in (j + 1)..k {
-                        pre_right[i + j * m] = pre_right[i + j * m] + dl_b[i + j * m];
-                    }
                     for i in k..m {
                         pre_right[i + j * m] = dl_b[i + j * m];
                     }
                 }
             }
 
-            let batch_grad_t =
-                backend_solve_tri(ctx, u_b, &transpose(&pre_right, m, k), k, m, true)?;
-            transpose(&batch_grad_t, k, m)
+            let batch_grad_h =
+                backend_solve_tri(ctx, u_b, &adjoint_transpose(&pre_right, m, k), k, m, true)?;
+            adjoint_transpose(&batch_grad_h, k, m)
         };
 
         let out = &mut grad_a[b * m * n..(b + 1) * m * n];

--- a/tenferro-linalg/src/rrules/svd_qr.rs
+++ b/tenferro-linalg/src/rrules/svd_qr.rs
@@ -205,7 +205,7 @@ where
 /// };
 /// let grad_a = qr_rrule(&mut ctx, &a, &cotangent).unwrap();
 /// ```
-pub fn qr_rrule<T: KernelLinalgScalar<Real = T> + num_traits::Float, C>(
+pub fn qr_rrule<T, C>(
     ctx: &mut C,
     tensor: &Tensor<T>,
     cotangent: &QrCotangent<T>,
@@ -246,20 +246,18 @@ where
         };
 
         if m >= n {
-            // For thin QR (m >= n): A = QR where Q is m×k, R is k×n.
-            // Match PyTorch's reduced-QR backward for the real case.
-            let r_drt = backend_mat_mul(ctx, r_b, k, n, &transpose(&dr_b, k, n), k)?;
-            let dqt_q = backend_mat_mul(ctx, &transpose(&dq_b, m, k), k, m, q_b, k)?;
-            let w = sub_vec(&r_drt, &dqt_q);
+            let r_drh = backend_mat_mul(ctx, r_b, k, n, &adjoint_transpose(&dr_b, k, n), k)?;
+            let dqh_q = backend_mat_mul(ctx, &adjoint_transpose(&dq_b, m, k), k, m, q_b, k)?;
+            let w = sub_vec(&r_drh, &dqh_q);
 
             let h = copyltu(&w, k);
             let qh = backend_mat_mul(ctx, q_b, m, k, &h, k)?;
             let rhs = add_vec(&dq_b, &qh);
 
             let r_square = r_b[..k * n].to_vec();
-            let rhs_t = transpose(&rhs, m, k);
-            let da_t = backend_solve_tri(ctx, &r_square, &rhs_t, k, m, true)?;
-            let da_first_k = transpose(&da_t, k, m);
+            let rhs_h = adjoint_transpose(&rhs, m, k);
+            let da_h = backend_solve_tri(ctx, &r_square, &rhs_h, k, m, true)?;
+            let da_first_k = adjoint_transpose(&da_h, k, m);
 
             for j in 0..k.min(n) {
                 for i in 0..m {
@@ -267,29 +265,21 @@ where
                 }
             }
         } else {
-            // Wide reduced QR follows the PyTorch backward:
-            // gA = pi*(Q trilImInvAdjSkew(Q^T gQ - gR R^T) R1^{-T}) + Q gR
-            let qtgq = backend_mat_mul(ctx, &transpose(q_b, m, k), k, m, &dq_b, k)?;
-            let gr_rt = backend_mat_mul(ctx, &dr_b, k, n, &transpose(r_b, k, n), k)?;
-            let wide_inner = sub_vec(&qtgq, &gr_rt);
-
-            let mut lower_skew = vec![T::zero(); k * k];
-            for j in 0..k {
-                for i in j..k {
-                    lower_skew[i + j * k] = wide_inner[i + j * k] - wide_inner[j + i * k];
-                }
-            }
+            let qhgq = backend_mat_mul(ctx, &adjoint_transpose(q_b, m, k), k, m, &dq_b, k)?;
+            let gr_rh = backend_mat_mul(ctx, &dr_b, k, n, &adjoint_transpose(r_b, k, n), k)?;
+            let wide_inner = sub_vec(&qhgq, &gr_rh);
+            let lower_skew = tril_im_inv_adj_skew(&wide_inner, k)?;
 
             let q_lower = backend_mat_mul(ctx, q_b, m, k, &lower_skew, k)?;
-            let q_lower_t = transpose(&q_lower, m, k);
             let mut r1 = vec![T::zero(); k * k];
             for j in 0..k {
                 for i in 0..k {
                     r1[i + j * k] = r_b[i + j * k];
                 }
             }
-            let leading_t = backend_solve_tri(ctx, &r1, &q_lower_t, k, m, true)?;
-            let leading = transpose(&leading_t, k, m);
+            let q_lower_h = adjoint_transpose(&q_lower, m, k);
+            let leading_h = backend_solve_tri(ctx, &r1, &q_lower_h, k, m, true)?;
+            let leading = adjoint_transpose(&leading_h, k, m);
 
             for j in 0..k {
                 for i in 0..m {

--- a/tenferro-linalg/tests/qr_lu_complex_ad_tests.rs
+++ b/tenferro-linalg/tests/qr_lu_complex_ad_tests.rs
@@ -1,0 +1,647 @@
+use num_complex::Complex64;
+use tenferro_linalg::{
+    lu, lu_frule, lu_rrule, qr, qr_frule, qr_rrule, LuCotangent, LuPivot, QrCotangent,
+};
+use tenferro_linalg_prims::{KernelLinalgScalar, LinalgScalar};
+use tenferro_prims::CpuContext;
+use tenferro_tensor::{MemoryOrder, Tensor};
+
+trait FdScalar: KernelLinalgScalar + Copy {
+    fn from_f64_parts(real: f64, imag: f64) -> Self;
+    fn max_abs_diff(lhs: &[Self], rhs: &[Self]) -> f64;
+    fn real_pairing(lhs: &[Self], rhs: &[Self]) -> f64;
+}
+
+impl FdScalar for f64 {
+    fn from_f64_parts(real: f64, _imag: f64) -> Self {
+        real
+    }
+
+    fn max_abs_diff(lhs: &[Self], rhs: &[Self]) -> f64 {
+        lhs.iter()
+            .zip(rhs.iter())
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0_f64, f64::max)
+    }
+
+    fn real_pairing(lhs: &[Self], rhs: &[Self]) -> f64 {
+        lhs.iter().zip(rhs.iter()).map(|(x, y)| x * y).sum()
+    }
+}
+
+impl FdScalar for Complex64 {
+    fn from_f64_parts(real: f64, imag: f64) -> Self {
+        Self::new(real, imag)
+    }
+
+    fn max_abs_diff(lhs: &[Self], rhs: &[Self]) -> f64 {
+        lhs.iter()
+            .zip(rhs.iter())
+            .map(|(x, y)| (*x - *y).norm())
+            .fold(0.0_f64, f64::max)
+    }
+
+    fn real_pairing(lhs: &[Self], rhs: &[Self]) -> f64 {
+        lhs.iter()
+            .zip(rhs.iter())
+            .map(|(x, y)| (x.conj() * *y).re)
+            .sum()
+    }
+}
+
+fn tensor_from_pairs<T: FdScalar>(pairs: &[(f64, f64)], dims: &[usize]) -> Tensor<T> {
+    let data = pairs
+        .iter()
+        .map(|(real, imag)| T::from_f64_parts(*real, *imag))
+        .collect();
+    tensor_from_vec(data, dims)
+}
+
+fn tensor_from_vec<T: LinalgScalar>(data: Vec<T>, dims: &[usize]) -> Tensor<T> {
+    let mut strides = vec![0isize; dims.len()];
+    if !dims.is_empty() {
+        strides[0] = 1;
+        for axis in 1..dims.len() {
+            strides[axis] = strides[axis - 1] * dims[axis - 1] as isize;
+        }
+    }
+    Tensor::from_vec(data, dims, &strides, 0).unwrap()
+}
+
+fn tensor_data<T: LinalgScalar>(tensor: &Tensor<T>) -> Vec<T> {
+    let contiguous = tensor.contiguous(MemoryOrder::ColumnMajor);
+    let offset = contiguous.offset() as usize;
+    let len: usize = contiguous.dims().iter().product();
+    contiguous.buffer().as_slice().unwrap()[offset..offset + len].to_vec()
+}
+
+fn add_scaled<T: FdScalar>(base: &[T], direction: &[T], scale: f64) -> Vec<T> {
+    let alpha = T::from_f64_parts(scale, 0.0);
+    base.iter()
+        .zip(direction.iter())
+        .map(|(x, dx)| *x + *dx * alpha)
+        .collect()
+}
+
+fn check_forward_fd<T, Forward, Frule>(
+    a: &Tensor<T>,
+    da: &Tensor<T>,
+    eps: f64,
+    tol: f64,
+    forward: Forward,
+    frule: Frule,
+    label: &str,
+) where
+    T: FdScalar,
+    Forward: Fn(&mut CpuContext, &Tensor<T>) -> Tensor<T>,
+    Frule: Fn(&mut CpuContext, &Tensor<T>, &Tensor<T>) -> Tensor<T>,
+{
+    let mut ctx = CpuContext::new(1);
+    let analytic = tensor_data(&frule(&mut ctx, a, da));
+
+    let base = tensor_data(a);
+    let direction = tensor_data(da);
+    let plus = tensor_from_vec(add_scaled(&base, &direction, eps), a.dims());
+    let minus = tensor_from_vec(add_scaled(&base, &direction, -eps), a.dims());
+
+    let mut plus_ctx = CpuContext::new(1);
+    let mut minus_ctx = CpuContext::new(1);
+    let plus_data = tensor_data(&forward(&mut plus_ctx, &plus));
+    let minus_data = tensor_data(&forward(&mut minus_ctx, &minus));
+    let fd: Vec<T> = plus_data
+        .iter()
+        .zip(minus_data.iter())
+        .map(|(p, m)| (*p - *m) * T::from_f64_parts(0.5 / eps, 0.0))
+        .collect();
+
+    let err = T::max_abs_diff(&analytic, &fd);
+    assert!(err < tol, "{label} forward fd mismatch: {err}");
+}
+
+fn check_backward_directional_fd<T, Forward, Rrule>(
+    a: &Tensor<T>,
+    da: &Tensor<T>,
+    cotangent: &Tensor<T>,
+    eps: f64,
+    tol: f64,
+    forward: Forward,
+    rrule: Rrule,
+    label: &str,
+) where
+    T: FdScalar,
+    Forward: Fn(&mut CpuContext, &Tensor<T>) -> Tensor<T>,
+    Rrule: Fn(&mut CpuContext, &Tensor<T>, &Tensor<T>) -> Tensor<T>,
+{
+    let mut ctx = CpuContext::new(1);
+    let grad = rrule(&mut ctx, a, cotangent);
+    let predicted = T::real_pairing(&tensor_data(&grad), &tensor_data(da));
+
+    let objective = |a_now: &Tensor<T>| -> f64 {
+        let mut ctx = CpuContext::new(1);
+        let out = forward(&mut ctx, a_now);
+        T::real_pairing(&tensor_data(cotangent), &tensor_data(&out))
+    };
+
+    let base = tensor_data(a);
+    let direction = tensor_data(da);
+    let plus = tensor_from_vec(add_scaled(&base, &direction, eps), a.dims());
+    let minus = tensor_from_vec(add_scaled(&base, &direction, -eps), a.dims());
+    let fd = (objective(&plus) - objective(&minus)) / (2.0 * eps);
+    let err = (predicted - fd).abs();
+    assert!(err < tol, "{label} backward directional fd mismatch: {err}");
+}
+
+fn qr_square_fixture<T: FdScalar>() -> (Tensor<T>, Tensor<T>, Tensor<T>) {
+    let a = tensor_from_pairs(
+        &[
+            (1.2, 0.2),
+            (-0.4, 0.5),
+            (0.3, -0.2),
+            (0.7, -0.1),
+            (1.5, 0.3),
+            (-0.6, 0.4),
+            (-0.2, 0.6),
+            (0.8, -0.3),
+            (1.1, 0.1),
+        ],
+        &[3, 3],
+    );
+    let da = tensor_from_pairs(
+        &[
+            (0.04, -0.01),
+            (-0.03, 0.05),
+            (0.02, 0.01),
+            (-0.01, 0.03),
+            (0.05, -0.02),
+            (0.01, 0.04),
+            (-0.02, 0.02),
+            (0.03, -0.05),
+            (0.02, 0.03),
+        ],
+        &[3, 3],
+    );
+    let cq = tensor_from_pairs(
+        &[
+            (0.2, -0.1),
+            (-0.1, 0.05),
+            (0.04, 0.03),
+            (0.03, 0.02),
+            (-0.15, 0.04),
+            (0.06, -0.02),
+            (-0.05, 0.01),
+            (0.08, -0.06),
+            (0.07, 0.02),
+        ],
+        &[3, 3],
+    );
+    (a, da, cq)
+}
+
+fn qr_wide_fixture() -> (Tensor<Complex64>, Tensor<Complex64>, Tensor<Complex64>) {
+    let a = tensor_from_pairs(
+        &[
+            (1.0, 0.2),
+            (0.4, 0.6),
+            (0.3, -0.5),
+            (1.3, -0.2),
+            (-0.7, 0.1),
+            (0.5, 0.4),
+        ],
+        &[2, 3],
+    );
+    let da = tensor_from_pairs(
+        &[
+            (0.05, -0.03),
+            (-0.02, 0.04),
+            (0.03, 0.01),
+            (-0.04, 0.02),
+            (0.01, -0.05),
+            (0.02, 0.03),
+        ],
+        &[2, 3],
+    );
+    let cr = tensor_from_pairs(
+        &[
+            (0.2, -0.1),
+            (-0.05, 0.02),
+            (0.04, 0.03),
+            (0.03, 0.01),
+            (-0.08, 0.05),
+            (0.06, -0.04),
+        ],
+        &[2, 3],
+    );
+    (a, da, cr)
+}
+
+fn lu_square_fixture<T: FdScalar>() -> (Tensor<T>, Tensor<T>, Tensor<T>) {
+    let a = tensor_from_pairs(
+        &[
+            (2.2, 0.3),
+            (0.5, -0.2),
+            (-0.1, 0.4),
+            (0.8, -0.1),
+            (1.9, 0.2),
+            (0.6, 0.1),
+            (-0.3, 0.2),
+            (0.4, -0.5),
+            (1.6, 0.3),
+        ],
+        &[3, 3],
+    );
+    let da = tensor_from_pairs(
+        &[
+            (0.03, -0.01),
+            (-0.02, 0.04),
+            (0.01, 0.02),
+            (0.04, 0.01),
+            (-0.03, 0.02),
+            (0.02, -0.04),
+            (0.01, 0.03),
+            (0.05, -0.02),
+            (-0.04, 0.01),
+        ],
+        &[3, 3],
+    );
+    let cu = tensor_from_pairs(
+        &[
+            (0.2, 0.0),
+            (-0.1, 0.03),
+            (0.04, -0.02),
+            (0.05, 0.01),
+            (0.07, -0.04),
+            (-0.03, 0.02),
+            (0.01, 0.03),
+            (0.06, -0.01),
+            (0.08, 0.02),
+        ],
+        &[3, 3],
+    );
+    (a, da, cu)
+}
+
+fn lu_wide_fixture() -> (Tensor<Complex64>, Tensor<Complex64>, Tensor<Complex64>) {
+    let a = tensor_from_pairs(
+        &[
+            (1.8, 0.2),
+            (0.6, -0.1),
+            (0.4, 0.5),
+            (2.1, -0.3),
+            (-0.2, 0.4),
+            (0.7, 0.1),
+        ],
+        &[2, 3],
+    );
+    let da = tensor_from_pairs(
+        &[
+            (0.03, -0.02),
+            (-0.01, 0.03),
+            (0.02, 0.01),
+            (-0.04, 0.02),
+            (0.01, -0.03),
+            (0.05, 0.01),
+        ],
+        &[2, 3],
+    );
+    let cu = tensor_from_pairs(
+        &[
+            (0.15, -0.02),
+            (0.03, 0.04),
+            (-0.06, 0.01),
+            (0.07, -0.03),
+            (0.04, 0.02),
+            (-0.02, 0.05),
+        ],
+        &[2, 3],
+    );
+    (a, da, cu)
+}
+
+fn lu_tall_fixture() -> (Tensor<Complex64>, Tensor<Complex64>, Tensor<Complex64>) {
+    let a = tensor_from_pairs(
+        &[
+            (2.0, 0.1),
+            (0.5, -0.2),
+            (-0.4, 0.3),
+            (0.6, 0.2),
+            (1.7, -0.1),
+            (0.8, 0.4),
+        ],
+        &[3, 2],
+    );
+    let da = tensor_from_pairs(
+        &[
+            (0.04, -0.01),
+            (-0.03, 0.02),
+            (0.02, 0.03),
+            (0.01, -0.04),
+            (-0.02, 0.01),
+            (0.03, 0.02),
+        ],
+        &[3, 2],
+    );
+    let cl = tensor_from_pairs(
+        &[
+            (0.0, 0.0),
+            (0.08, -0.02),
+            (-0.05, 0.03),
+            (0.0, 0.0),
+            (0.0, 0.0),
+            (0.07, -0.01),
+        ],
+        &[3, 2],
+    );
+    (a, da, cl)
+}
+
+#[test]
+fn qr_square_q_forward_matches_fd_f64() {
+    let (a, da, _) = qr_square_fixture::<f64>();
+    check_forward_fd(
+        &a,
+        &da,
+        1e-6,
+        2e-5,
+        |ctx, a_now| qr(ctx, a_now).unwrap().q,
+        |ctx, a_now, da_now| qr_frule(ctx, a_now, da_now).unwrap().1.q,
+        "qr_square_q_forward_matches_fd_f64",
+    );
+}
+
+#[test]
+fn qr_square_q_backward_matches_fd_f64() {
+    let (a, da, cq) = qr_square_fixture::<f64>();
+    check_backward_directional_fd(
+        &a,
+        &da,
+        &cq,
+        1e-6,
+        2e-5,
+        |ctx, a_now| qr(ctx, a_now).unwrap().q,
+        |ctx, a_now, cotangent| {
+            qr_rrule(
+                ctx,
+                a_now,
+                &QrCotangent {
+                    q: Some(cotangent.clone()),
+                    r: None,
+                },
+            )
+            .unwrap()
+        },
+        "qr_square_q_backward_matches_fd_f64",
+    );
+}
+
+#[test]
+fn lu_square_u_forward_matches_fd_f64() {
+    let (a, da, _) = lu_square_fixture::<f64>();
+    check_forward_fd(
+        &a,
+        &da,
+        1e-6,
+        2e-5,
+        |ctx, a_now| lu(ctx, a_now, LuPivot::Partial).unwrap().u,
+        |ctx, a_now, da_now| lu_frule(ctx, a_now, da_now, LuPivot::Partial).unwrap().1.u,
+        "lu_square_u_forward_matches_fd_f64",
+    );
+}
+
+#[test]
+fn lu_square_u_backward_matches_fd_f64() {
+    let (a, da, cu) = lu_square_fixture::<f64>();
+    check_backward_directional_fd(
+        &a,
+        &da,
+        &cu,
+        1e-6,
+        2e-5,
+        |ctx, a_now| lu(ctx, a_now, LuPivot::Partial).unwrap().u,
+        |ctx, a_now, cotangent| {
+            lu_rrule(
+                ctx,
+                a_now,
+                &LuCotangent {
+                    l: None,
+                    u: Some(cotangent.clone()),
+                },
+                LuPivot::Partial,
+            )
+            .unwrap()
+        },
+        "lu_square_u_backward_matches_fd_f64",
+    );
+}
+
+#[test]
+fn qr_square_q_forward_matches_fd_c64() {
+    let (a, da, _) = qr_square_fixture::<Complex64>();
+    check_forward_fd(
+        &a,
+        &da,
+        1e-6,
+        5e-5,
+        |ctx, a_now| qr(ctx, a_now).unwrap().q,
+        |ctx, a_now, da_now| qr_frule(ctx, a_now, da_now).unwrap().1.q,
+        "qr_square_q_forward_matches_fd_c64",
+    );
+}
+
+#[test]
+fn qr_square_q_backward_matches_fd_c64() {
+    let (a, da, cq) = qr_square_fixture::<Complex64>();
+    check_backward_directional_fd(
+        &a,
+        &da,
+        &cq,
+        1e-6,
+        5e-5,
+        |ctx, a_now| qr(ctx, a_now).unwrap().q,
+        |ctx, a_now, cotangent| {
+            qr_rrule(
+                ctx,
+                a_now,
+                &QrCotangent {
+                    q: Some(cotangent.clone()),
+                    r: None,
+                },
+            )
+            .unwrap()
+        },
+        "qr_square_q_backward_matches_fd_c64",
+    );
+}
+
+#[test]
+fn lu_square_u_forward_matches_fd_c64() {
+    let (a, da, _) = lu_square_fixture::<Complex64>();
+    check_forward_fd(
+        &a,
+        &da,
+        1e-6,
+        5e-5,
+        |ctx, a_now| lu(ctx, a_now, LuPivot::Partial).unwrap().u,
+        |ctx, a_now, da_now| lu_frule(ctx, a_now, da_now, LuPivot::Partial).unwrap().1.u,
+        "lu_square_u_forward_matches_fd_c64",
+    );
+}
+
+#[test]
+fn lu_square_u_backward_matches_fd_c64() {
+    let (a, da, cu) = lu_square_fixture::<Complex64>();
+    check_backward_directional_fd(
+        &a,
+        &da,
+        &cu,
+        1e-6,
+        5e-5,
+        |ctx, a_now| lu(ctx, a_now, LuPivot::Partial).unwrap().u,
+        |ctx, a_now, cotangent| {
+            lu_rrule(
+                ctx,
+                a_now,
+                &LuCotangent {
+                    l: None,
+                    u: Some(cotangent.clone()),
+                },
+                LuPivot::Partial,
+            )
+            .unwrap()
+        },
+        "lu_square_u_backward_matches_fd_c64",
+    );
+}
+
+#[test]
+fn qr_wide_r_forward_matches_fd_c64() {
+    let (a, da, _) = qr_wide_fixture();
+    check_forward_fd(
+        &a,
+        &da,
+        1e-6,
+        8e-5,
+        |ctx, a_now| qr(ctx, a_now).unwrap().r,
+        |ctx, a_now, da_now| qr_frule(ctx, a_now, da_now).unwrap().1.r,
+        "qr_wide_r_forward_matches_fd_c64",
+    );
+}
+
+#[test]
+fn qr_wide_r_backward_matches_fd_c64() {
+    let (a, da, cr) = qr_wide_fixture();
+    check_backward_directional_fd(
+        &a,
+        &da,
+        &cr,
+        1e-6,
+        8e-5,
+        |ctx, a_now| qr(ctx, a_now).unwrap().r,
+        |ctx, a_now, cotangent| {
+            qr_rrule(
+                ctx,
+                a_now,
+                &QrCotangent {
+                    q: None,
+                    r: Some(cotangent.clone()),
+                },
+            )
+            .unwrap()
+        },
+        "qr_wide_r_backward_matches_fd_c64",
+    );
+}
+
+#[test]
+fn lu_wide_u_forward_matches_fd_c64() {
+    let (a, da, _) = lu_wide_fixture();
+    check_forward_fd(
+        &a,
+        &da,
+        1e-6,
+        8e-5,
+        |ctx, a_now| lu(ctx, a_now, LuPivot::Partial).unwrap().u,
+        |ctx, a_now, da_now| lu_frule(ctx, a_now, da_now, LuPivot::Partial).unwrap().1.u,
+        "lu_wide_u_forward_matches_fd_c64",
+    );
+}
+
+#[test]
+fn lu_wide_u_backward_matches_fd_c64() {
+    let (a, da, cu) = lu_wide_fixture();
+    check_backward_directional_fd(
+        &a,
+        &da,
+        &cu,
+        1e-6,
+        8e-5,
+        |ctx, a_now| lu(ctx, a_now, LuPivot::Partial).unwrap().u,
+        |ctx, a_now, cotangent| {
+            lu_rrule(
+                ctx,
+                a_now,
+                &LuCotangent {
+                    l: None,
+                    u: Some(cotangent.clone()),
+                },
+                LuPivot::Partial,
+            )
+            .unwrap()
+        },
+        "lu_wide_u_backward_matches_fd_c64",
+    );
+}
+
+#[test]
+fn lu_tall_l_forward_matches_fd_c64() {
+    let (a, da, _) = lu_tall_fixture();
+    check_forward_fd(
+        &a,
+        &da,
+        1e-6,
+        8e-5,
+        |ctx, a_now| lu(ctx, a_now, LuPivot::Partial).unwrap().l,
+        |ctx, a_now, da_now| lu_frule(ctx, a_now, da_now, LuPivot::Partial).unwrap().1.l,
+        "lu_tall_l_forward_matches_fd_c64",
+    );
+}
+
+#[test]
+fn lu_tall_l_backward_matches_fd_c64() {
+    let (a, da, cl) = lu_tall_fixture();
+    check_backward_directional_fd(
+        &a,
+        &da,
+        &cl,
+        1e-6,
+        8e-5,
+        |ctx, a_now| lu(ctx, a_now, LuPivot::Partial).unwrap().l,
+        |ctx, a_now, cotangent| {
+            lu_rrule(
+                ctx,
+                a_now,
+                &LuCotangent {
+                    l: Some(cotangent.clone()),
+                    u: None,
+                },
+                LuPivot::Partial,
+            )
+            .unwrap()
+        },
+        "lu_tall_l_backward_matches_fd_c64",
+    );
+}
+
+#[test]
+fn qr_complex64_r_diagonal_is_real() {
+    let (a, _, _) = qr_square_fixture::<Complex64>();
+    let mut ctx = CpuContext::new(1);
+    let result = qr(&mut ctx, &a).unwrap();
+    let r = tensor_data(&result.r);
+    for i in 0..3 {
+        assert!(
+            r[i + i * 3].im.abs() < 1e-10,
+            "expected real diagonal, got {:?} at {i}",
+            r[i + i * 3]
+        );
+    }
+}

--- a/tenferro/tests/integration/dynamic_wrapper_coverage_tests.rs
+++ b/tenferro/tests/integration/dynamic_wrapper_coverage_tests.rs
@@ -521,7 +521,7 @@ fn tensor_dynamic_linalg_wrappers_cover_success_and_error_paths() {
     assert_eq!(reverse_svd_grad.scalar_type(), ScalarType::C64);
     assert_eq!(reverse_svd_grad.dims(), &[2, 2]);
 
-    let complex32_err = match reverse!(matrix_c32(
+    let mut reverse_complex32_qr = reverse!(matrix_c32(
         &[
             Complex32::new(4.0, 0.5),
             Complex32::new(1.0, -0.25),
@@ -529,15 +529,59 @@ fn tensor_dynamic_linalg_wrappers_cover_success_and_error_paths() {
             Complex32::new(3.0, 1.0),
         ],
         &[2, 2],
-    ))
-    .qr()
-    {
-        Ok(_) => panic!("complex reverse-mode qr should stay rejected by the dynamic wrapper"),
-        Err(err) => err,
-    };
-    assert!(
-        matches!(complex32_err, tenferro::Error::InvalidAdTensor { message } if message.contains("supports complex tensors only in primal mode"))
-    );
+    ));
+    reverse_complex32_qr.set_requires_grad(true).unwrap();
+    let reverse_complex32_qr_out = reverse_complex32_qr.qr().unwrap();
+    let reverse_complex32_qr_cotangent = primal!(matrix_c32(
+        &[
+            Complex32::new(1.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(1.0, 0.0),
+        ],
+        &[2, 2],
+    ));
+    let reverse_complex32_qr_grads = grad(
+        &[&reverse_complex32_qr_out.q],
+        &[&reverse_complex32_qr],
+        Some(&[reverse_complex32_qr_cotangent]),
+        GradOptions::default(),
+    )
+    .unwrap();
+    let reverse_complex32_qr_grad = reverse_complex32_qr_grads[0].as_ref().unwrap();
+    assert_eq!(reverse_complex32_qr_grad.scalar_type(), ScalarType::C32);
+    assert_eq!(reverse_complex32_qr_grad.dims(), &[2, 2]);
+
+    let mut reverse_complex32_lu = reverse!(matrix_c32(
+        &[
+            Complex32::new(4.0, 0.5),
+            Complex32::new(1.0, -0.25),
+            Complex32::new(1.0, 0.25),
+            Complex32::new(3.0, 1.0),
+        ],
+        &[2, 2],
+    ));
+    reverse_complex32_lu.set_requires_grad(true).unwrap();
+    let reverse_complex32_lu_out = reverse_complex32_lu.lu().unwrap();
+    let reverse_complex32_lu_cotangent = primal!(matrix_c32(
+        &[
+            Complex32::new(1.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(1.0, 0.0),
+        ],
+        &[2, 2],
+    ));
+    let reverse_complex32_lu_grads = grad(
+        &[&reverse_complex32_lu_out.u],
+        &[&reverse_complex32_lu],
+        Some(&[reverse_complex32_lu_cotangent]),
+        GradOptions::default(),
+    )
+    .unwrap();
+    let reverse_complex32_lu_grad = reverse_complex32_lu_grads[0].as_ref().unwrap();
+    assert_eq!(reverse_complex32_lu_grad.scalar_type(), ScalarType::C32);
+    assert_eq!(reverse_complex32_lu_grad.dims(), &[2, 2]);
 
     let mismatch_err = matrix32.solve(&rhs64).unwrap_err();
     assert!(

--- a/tenferro/tests/integration/linalg_frontend_gap_tests.rs
+++ b/tenferro/tests/integration/linalg_frontend_gap_tests.rs
@@ -1,5 +1,7 @@
 use num_complex::{Complex32, Complex64};
-use tenferro::{forward_ad, set_default_runtime, RuntimeContext, ScalarType, Tensor};
+use tenferro::{
+    forward_ad, grad, set_default_runtime, GradOptions, RuntimeContext, ScalarType, Tensor,
+};
 use tenferro_prims::CpuContext;
 use tenferro_tensor::{MemoryOrder, Tensor as DenseTensor};
 
@@ -107,6 +109,102 @@ fn complex_forward_wrappers_cover_supported_svd_and_solve_paths() {
     .unwrap();
     assert_eq!(solve_primal.scalar_type(), ScalarType::C64);
     assert_eq!(solve_tangent.unwrap().scalar_type(), ScalarType::C64);
+}
+
+#[test]
+fn complex_forward_wrappers_cover_qr_and_lu_paths() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let a = matrix_c64(
+        &[
+            Complex64::new(4.0, 0.5),
+            Complex64::new(1.0, -0.25),
+            Complex64::new(1.0, 0.25),
+            Complex64::new(3.0, 1.0),
+        ],
+        &[2, 2],
+    );
+    let da = matrix_c64(
+        &[
+            Complex64::new(0.1, 0.0),
+            Complex64::new(-0.2, 0.05),
+            Complex64::new(0.3, -0.1),
+            Complex64::new(-0.4, 0.2),
+        ],
+        &[2, 2],
+    );
+
+    let (qr_primal, qr_tangent) = forward_ad::dual_level(|fw| {
+        let dual_a = fw.make_dual(&a, &da)?;
+        let qr = dual_a.qr()?;
+        fw.unpack_dual(&qr.q)
+    })
+    .unwrap();
+    assert_eq!(qr_primal.scalar_type(), ScalarType::C64);
+    assert_eq!(qr_tangent.unwrap().scalar_type(), ScalarType::C64);
+
+    let (lu_primal, lu_tangent) = forward_ad::dual_level(|fw| {
+        let dual_a = fw.make_dual(&a, &da)?;
+        let lu = dual_a.lu()?;
+        fw.unpack_dual(&lu.l)
+    })
+    .unwrap();
+    assert_eq!(lu_primal.scalar_type(), ScalarType::C64);
+    assert_eq!(lu_tangent.unwrap().scalar_type(), ScalarType::C64);
+}
+
+#[test]
+fn complex_reverse_wrappers_cover_qr_and_lu_paths() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let mut a = matrix_c64(
+        &[
+            Complex64::new(4.0, 0.5),
+            Complex64::new(1.0, -0.25),
+            Complex64::new(1.0, 0.25),
+            Complex64::new(3.0, 1.0),
+        ],
+        &[2, 2],
+    );
+    a.set_requires_grad(true).unwrap();
+
+    let qr = a.qr().unwrap();
+    let qr_cotangent = matrix_c64(
+        &[
+            Complex64::new(1.0, -0.5),
+            Complex64::new(-0.25, 0.75),
+            Complex64::new(0.5, 0.25),
+            Complex64::new(-1.0, 0.125),
+        ],
+        &[2, 2],
+    );
+    let qr_grads = grad(
+        &[&qr.q],
+        &[&a],
+        Some(&[qr_cotangent]),
+        GradOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(qr_grads[0].as_ref().unwrap().scalar_type(), ScalarType::C64);
+
+    let lu = a.lu().unwrap();
+    let lu_cotangent = matrix_c64(
+        &[
+            Complex64::new(0.25, -0.125),
+            Complex64::new(0.5, 0.0),
+            Complex64::new(-0.75, 0.5),
+            Complex64::new(1.0, -0.25),
+        ],
+        &[2, 2],
+    );
+    let lu_grads = grad(
+        &[&lu.u],
+        &[&a],
+        Some(&[lu_cotangent]),
+        GradOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(lu_grads[0].as_ref().unwrap().scalar_type(), ScalarType::C64);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add complex forward- and reverse-mode support for QR and LU in `tenferro-linalg`
- route complex QR/LU eager wrappers through the AD builders instead of the old primal-only fallback
- add focused finite-difference coverage plus frontend/internal regression tests

## Root Cause
Complex `qr` and `lu` primal kernels already existed, and `solve`/`solve_triangular` already handled complex AD, but the QR/LU AD rules and dynamic wrapper bounds were still real-only. On top of that, complex QR needed phase canonicalization so the returned `R` diagonal is real, matching the math note / oracle convention used by the AD formulas.

## Notes
- reverse mode follows the repo's real-loss / Wirtinger convention for complex cotangents
- complex QR now canonicalizes phases in the high-level primal so the AD formulas see the expected gauge
- the new tests are written to share real/complex finite-difference helpers where practical

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Closes #603.
