### PR TITLE
[codex] Add reverse tape sharing helper for pending leaves

### DIFF
--- a/internal/tenferro-internal-ad-surface/src/core/dynamic/dyn_ad_tensor/basics.rs
+++ b/internal/tenferro-internal-ad-surface/src/core/dynamic/dyn_ad_tensor/basics.rs
@@ -270,6 +270,34 @@ impl Tensor {
         }
     }
 
+    /// Ensures that reverse-mode operands share one tape.
+    ///
+    /// Pending reverse leaves created by [`Tensor::set_requires_grad`] do not
+    /// attach to a concrete reverse tape until needed. Calling this helper on
+    /// a collection of tensors attaches all pending reverse leaves in the
+    /// collection to one common tape, while rejecting already-attached tensors
+    /// that belong to different tapes.
+    ///
+    /// This is useful before branch-local unary or linalg transforms on a
+    /// tensor network whose leaves should remain in one reverse graph.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro::{set_default_runtime, RuntimeContext, Tensor};
+    /// use tenferro_prims::CpuContext;
+    ///
+    /// let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+    /// let mut x = Tensor::from_slice(&[1.0_f64, 2.0], &[2]).unwrap();
+    /// let mut y = Tensor::from_slice(&[3.0_f64, 4.0], &[2]).unwrap();
+    /// x.set_requires_grad(true).unwrap();
+    /// y.set_requires_grad(true).unwrap();
+    /// Tensor::ensure_common_reverse_tape(&[&x, &y]).unwrap();
+    /// ```
+    pub fn ensure_common_reverse_tape(operands: &[&Self]) -> Result<()> {
+        ensure_common_reverse_tape(operands).map(|_| ())
+    }
+
     /// Returns the accumulated gradient for a reverse leaf, if available.
     ///
     /// # Examples

--- a/tenferro/tests/integration/homogeneous_tape_tests.rs
+++ b/tenferro/tests/integration/homogeneous_tape_tests.rs
@@ -19,6 +19,12 @@ fn diag(values: &[f64]) -> Tensor {
     Tensor::diag(&Tensor::from_tensor(vector(values))).unwrap()
 }
 
+fn dense(values: &[f64], dims: &[usize]) -> Tensor {
+    Tensor::from_tensor(
+        DenseTensor::<f64>::from_slice(values, dims, MemoryOrder::ColumnMajor).unwrap(),
+    )
+}
+
 #[test]
 fn reverse_scale_accepts_rank0_tensor_scalar_on_same_tape() {
     let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
@@ -69,4 +75,62 @@ fn real_part_reverse_rejects_mixed_dtype_graphs() {
         Err(err) => err,
     };
     assert!(matches!(err, Error::UnsupportedAdOp { op } if op == "real_part_reverse"));
+}
+
+#[test]
+fn ensure_common_reverse_tape_allows_sequential_qr_branch_absorption() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let mut left = dense(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+    let mut center = dense(&[1.0, 0.0, 0.5, 2.0, 3.0, 1.0, 0.0, 4.0], &[2, 2, 2]);
+    let mut right = dense(&[2.0, 0.5, 1.0, 3.0], &[2, 2]);
+    left.set_requires_grad(true).unwrap();
+    center.set_requires_grad(true).unwrap();
+    right.set_requires_grad(true).unwrap();
+
+    Tensor::ensure_common_reverse_tape(&[&left, &center, &right]).unwrap();
+
+    let left_qr = left.qr().unwrap();
+    let center_after_left = Tensor::einsum("abc,da->dbc", &[&center, &left_qr.r]).unwrap();
+
+    let right_qr = right.qr().unwrap();
+    let dense = Tensor::einsum("abc,dc->abd", &[&center_after_left, &right_qr.r]).unwrap();
+    let loss = dense.sum().unwrap();
+    loss.backward(None, &[&left, &center, &right], Default::default())
+        .unwrap();
+
+    assert!(left.grad().is_some());
+    assert!(center.grad().is_some());
+    assert!(right.grad().is_some());
+}
+
+#[test]
+fn ensure_common_reverse_tape_allows_sequential_svd_branch_absorption() {
+    let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(1)));
+
+    let mut left = dense(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+    let mut center = dense(&[1.0, 0.0, 0.5, 2.0, 3.0, 1.0, 0.0, 4.0], &[2, 2, 2]);
+    let mut right = dense(&[2.0, 0.5, 1.0, 3.0], &[2, 2]);
+    left.set_requires_grad(true).unwrap();
+    center.set_requires_grad(true).unwrap();
+    right.set_requires_grad(true).unwrap();
+
+    Tensor::ensure_common_reverse_tape(&[&left, &center, &right]).unwrap();
+
+    let left_svd = left.svd().unwrap();
+    let left_sigma = Tensor::diag(&left_svd.s).unwrap();
+    let left_rhs = Tensor::einsum("ab,bc->ac", &[&left_sigma, &left_svd.vt]).unwrap();
+    let center_after_left = Tensor::einsum("abc,da->dbc", &[&center, &left_rhs]).unwrap();
+
+    let right_svd = right.svd().unwrap();
+    let right_sigma = Tensor::diag(&right_svd.s).unwrap();
+    let right_rhs = Tensor::einsum("ab,bc->ac", &[&right_sigma, &right_svd.vt]).unwrap();
+    let dense = Tensor::einsum("abc,dc->abd", &[&center_after_left, &right_rhs]).unwrap();
+    let loss = dense.sum().unwrap();
+    loss.backward(None, &[&left, &center, &right], Default::default())
+        .unwrap();
+
+    assert!(left.grad().is_some());
+    assert!(center.grad().is_some());
+    assert!(right.grad().is_some());
 }


### PR DESCRIPTION
## Summary
- add `Tensor::ensure_common_reverse_tape(&[&Tensor])` so multiple pending reverse leaves can be attached to one shared tape before branch-local reverse ops run
- cover the sequential QR and SVD absorption paths with integration tests that reproduce the mixed-tape failure mode and verify the shared-tape fix

## Why
Tree-style downstream code can factorize one branch at a time and then absorb the result into neighboring reverse leaves. Before this change, each pending reverse leaf that first touched a branch-local reverse op could get attached to its own fresh tape, so a later contraction across branches failed with a mixed-tape error.

## Root Cause
`ensure_reverse_leaf_attached()` only knew how to attach one pending reverse leaf at a time, and it allocated a fresh tape whenever that leaf had not been attached yet. QR/SVD-style branch-local flows therefore split sibling leaves across different tapes before the downstream absorption step combined them.

## Validation
- `cargo fmt --all --check`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Closes #605.

Tool used: OpenAI Codex.
