### PR TITLE
feat: wire BufferPool + last_use into eval_exec_ir (#622)

### DIFF
--- a/tenferro/src/engine.rs
+++ b/tenferro/src/engine.rs
@@ -51,7 +51,7 @@ fn compute_cache_key(exec: &ExecProgram) -> CacheKey {
 pub struct Engine<B: TensorBackend> {
     pub(crate) backend: B,
     pub(crate) compile_cache: HashMap<CacheKey, ExecProgram>,
-    pub(crate) _buffer_pool: BufferPool,
+    pub(crate) buffer_pool: BufferPool,
 }
 
 impl<B: TensorBackend> Engine<B> {
@@ -69,8 +69,22 @@ impl<B: TensorBackend> Engine<B> {
         Self {
             backend,
             compile_cache: HashMap::new(),
-            _buffer_pool: BufferPool::new(),
+            buffer_pool: BufferPool::new(),
         }
+    }
+
+    /// Number of reusable host buffers currently retained by the engine.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let engine = Engine::new(CpuBackend::new());
+    /// assert_eq!(engine.buffer_pool_len(), 0);
+    /// ```
+    pub fn buffer_pool_len(&self) -> usize {
+        self.buffer_pool.len()
     }
 
     /// Look up a cached ExecProgram, or cache and return the given one.

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -1,10 +1,11 @@
+use super::buffer_pool::BufferPool;
 use tenferro_algebra::Semiring;
 use tenferro_tensor::cpu::structural::{
     typed_broadcast_in_dim, typed_embed_diagonal, typed_extract_diagonal, typed_reshape,
     typed_transpose,
 };
 use tenferro_tensor::{
-    CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SemiringBackend,
+    Buffer, CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SemiringBackend,
     SliceConfig, Tensor, TensorBackend, TypedTensor,
 };
 
@@ -122,6 +123,7 @@ pub fn eval_exec_ir<B: TensorBackend>(
     backend: &mut B,
     program: &ExecProgram,
     inputs: Vec<Tensor>,
+    pool: &mut BufferPool,
 ) -> Vec<Tensor> {
     let mut slots: Vec<Option<Tensor>> = vec![None; program.n_slots];
     for (i, tensor) in inputs.into_iter().enumerate() {
@@ -268,10 +270,12 @@ pub fn eval_exec_ir<B: TensorBackend>(
                 for (i, tensor) in results.into_iter().enumerate() {
                     slots[inst.output_slots[i]] = Some(tensor);
                 }
+                reclaim_last_use_inputs(&mut slots, inst, pool);
                 continue;
             }
         };
         slots[inst.output_slots[0]] = Some(result);
+        reclaim_last_use_inputs(&mut slots, inst, pool);
     }
 
     program
@@ -279,6 +283,46 @@ pub fn eval_exec_ir<B: TensorBackend>(
         .iter()
         .map(|&slot| slots[slot].take().expect("missing output slot"))
         .collect()
+}
+
+fn reclaim_last_use_inputs(
+    slots: &mut [Option<Tensor>],
+    inst: &ExecInstruction,
+    pool: &mut BufferPool,
+) {
+    for (i, &is_last) in inst.last_use.iter().enumerate() {
+        if is_last {
+            if let Some(tensor) = slots[inst.input_slots[i]].take() {
+                reclaim_tensor_buffer(tensor, pool);
+            }
+        }
+    }
+}
+
+fn reclaim_tensor_buffer(tensor: Tensor, pool: &mut BufferPool) {
+    let bytes = match tensor {
+        Tensor::F64(t) => extract_host_bytes(t),
+        Tensor::F32(t) => extract_host_bytes(t),
+        Tensor::C64(t) => extract_host_bytes(t),
+        Tensor::C32(t) => extract_host_bytes(t),
+    };
+
+    if let Some(buf) = bytes {
+        pool.return_buffer(buf);
+    }
+}
+
+fn extract_host_bytes<T>(typed: TypedTensor<T>) -> Option<Vec<u8>> {
+    match typed.buffer {
+        Buffer::Host(data) => {
+            let mut data = std::mem::ManuallyDrop::new(data);
+            let ptr = data.as_mut_ptr() as *mut u8;
+            let len = data.len() * std::mem::size_of::<T>();
+            let cap = data.capacity() * std::mem::size_of::<T>();
+            Some(unsafe { Vec::from_raw_parts(ptr, len, cap) })
+        }
+        Buffer::Backend(_) => None,
+    }
 }
 
 pub fn eval_semiring_ir<B, Alg>(

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -131,7 +131,12 @@ impl TracedTensor {
 
         // Use compile cache: store or retrieve the ExecProgram.
         let cached_exec = engine.get_or_compile(exec);
-        let mut results = eval_exec_ir(&mut engine.backend, &cached_exec, input_tensors);
+        let mut results = eval_exec_ir(
+            &mut engine.backend,
+            &cached_exec,
+            input_tensors,
+            &mut engine.buffer_pool,
+        );
         if results.len() != 1 {
             return Err(Error::Internal(format!(
                 "expected 1 output, got {}",
@@ -658,7 +663,12 @@ pub fn eval_all<B: TensorBackend>(
     }
 
     let cached_exec = engine.get_or_compile(exec);
-    let results = eval_exec_ir(&mut engine.backend, &cached_exec, input_tensors);
+    let results = eval_exec_ir(
+        &mut engine.backend,
+        &cached_exec,
+        input_tensors,
+        &mut engine.buffer_pool,
+    );
 
     for (tt, result) in outputs.iter_mut().zip(results.iter()) {
         tt.data = Some(result.clone());

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use tenferro::buffer_pool::BufferPool;
 
 use computegraph::compile::compile;
 use computegraph::fragment::{Fragment, FragmentBuilder};
@@ -185,7 +186,8 @@ fn eval_fragment_outputs(
         })
         .collect();
     let mut backend = CpuBackend::new();
-    eval_exec_ir(&mut backend, &exec, inputs)
+    let mut pool = BufferPool::new();
+    eval_exec_ir(&mut backend, &exec, inputs, &mut pool)
 }
 
 fn scalar_f64_tensor(value: f64) -> Tensor {

--- a/tenferro/tests/cpu_backend.rs
+++ b/tenferro/tests/cpu_backend.rs
@@ -318,3 +318,21 @@ fn test_buffer_pool_best_fit() {
     assert_eq!(reused.len(), 150); // resized to requested size
     assert_eq!(pool.len(), 2); // two buffers left
 }
+
+#[test]
+fn buffer_pool_reclaims_intermediate_buffers() {
+    let a = f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let b = f64_tensor(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    let c = f64_tensor(vec![2, 2], vec![9.0, 10.0, 11.0, 12.0]);
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let ta = TracedTensor::from_tensor(a);
+    let tb = TracedTensor::from_tensor(b);
+    let tc = TracedTensor::from_tensor(c);
+    let mut out = einsum(&mut engine, &[&ta, &tb, &tc], "ij,jk,kl->il").unwrap();
+
+    let result = out.eval(&mut engine).unwrap();
+
+    assert_eq!(get_f64_data(result), &[517.0, 766.0, 625.0, 926.0]);
+    assert!(engine.buffer_pool_len() > 0);
+}

--- a/tenferro/tests/exec_dispatch.rs
+++ b/tenferro/tests/exec_dispatch.rs
@@ -1,3 +1,4 @@
+use tenferro::buffer_pool::BufferPool;
 use tenferro::exec::{eval_exec_ir, eval_semiring_ir, ExecInstruction, ExecOp, ExecProgram};
 use tenferro_algebra::Standard;
 use tenferro_tensor::cpu::CpuBackend;
@@ -374,8 +375,9 @@ fn eval_exec_ir_dispatches_tensor_ops_to_backend_methods() {
         let inputs = (0..n_inputs)
             .map(|idx| scalar_tensor(idx as f64 + 1.0))
             .collect();
+        let mut pool = BufferPool::new();
 
-        let outputs = eval_exec_ir(&mut backend, &program, inputs);
+        let outputs = eval_exec_ir(&mut backend, &program, inputs, &mut pool);
 
         assert_eq!(backend.calls, vec![expected_call]);
         assert_eq!(outputs.len(), 1);
@@ -402,6 +404,7 @@ fn multi_output_program(op: ExecOp, n_inputs: usize, n_outputs: usize) -> ExecPr
 #[test]
 fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
     let mut backend = FakeTensorBackend::default();
+    let mut pool = BufferPool::new();
 
     // SVD: 1 input, 2 outputs (fake returns 2)
     let program = multi_output_program(
@@ -411,13 +414,14 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
         1,
         2,
     );
-    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)]);
+    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool);
     assert_eq!(backend.calls, vec!["svd"]);
     assert_eq!(outputs.len(), 2);
     assert_eq!(scalar_value(&outputs[0]), 41.0);
     assert_eq!(scalar_value(&outputs[1]), 41.5);
 
     backend.calls.clear();
+    pool = BufferPool::new();
 
     // QR: 1 input, 2 outputs
     let program = multi_output_program(
@@ -427,13 +431,14 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
         1,
         2,
     );
-    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)]);
+    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool);
     assert_eq!(backend.calls, vec!["qr"]);
     assert_eq!(outputs.len(), 2);
     assert_eq!(scalar_value(&outputs[0]), 42.0);
     assert_eq!(scalar_value(&outputs[1]), 42.5);
 
     backend.calls.clear();
+    pool = BufferPool::new();
 
     // Eigh: 1 input, 2 outputs
     let program = multi_output_program(
@@ -443,11 +448,50 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
         1,
         2,
     );
-    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)]);
+    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool);
     assert_eq!(backend.calls, vec!["eigh"]);
     assert_eq!(outputs.len(), 2);
     assert_eq!(scalar_value(&outputs[0]), 43.0);
     assert_eq!(scalar_value(&outputs[1]), 43.5);
+}
+
+#[test]
+fn eval_exec_ir_reclaims_last_use_host_buffers() {
+    let program = ExecProgram {
+        instructions: vec![
+            ExecInstruction {
+                op: ExecOp::Add,
+                input_slots: vec![0, 1],
+                output_slots: vec![2],
+                dtype: DType::F64,
+                last_use: vec![true, true],
+            },
+            ExecInstruction {
+                op: ExecOp::Negate,
+                input_slots: vec![2],
+                output_slots: vec![3],
+                dtype: DType::F64,
+                last_use: vec![true],
+            },
+        ],
+        input_slots: vec![0, 1],
+        output_slots: vec![3],
+        n_slots: 4,
+    };
+
+    let mut backend = FakeTensorBackend::default();
+    let mut pool = BufferPool::new();
+    let outputs = eval_exec_ir(
+        &mut backend,
+        &program,
+        vec![scalar_tensor(1.0), scalar_tensor(2.0)],
+        &mut pool,
+    );
+
+    assert_eq!(backend.calls, vec!["add", "neg"]);
+    assert_eq!(outputs.len(), 1);
+    assert_eq!(scalar_value(&outputs[0]), 3.0);
+    assert_eq!(pool.len(), 3);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `eval_exec_ir` now accepts `&mut BufferPool`
- After each instruction, `last_use=true` inputs have their host buffers reclaimed to the pool
- `Engine` passes its pool through `TracedTensor::eval` and `eval_all`
- `eval_semiring_ir` unchanged (future work)

Closes #622

## Test plan
- [x] Existing tests pass with pool parameter
- [x] Buffer pool reclaims intermediate buffers during einsum execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)