### PR TITLE
feat: SVD AD rectangular correction + configurable eps (#627, #628)

### DIFF
--- a/tenferro-ops/src/ad/linalg.rs
+++ b/tenferro-ops/src/ad/linalg.rs
@@ -4,8 +4,6 @@ use tenferro_tensor::DotGeneralConfig;
 
 use crate::std_tensor_op::StdTensorOp;
 
-const F_MATRIX_EPS: f64 = 1.0e-12;
-
 pub fn linearize_solve(
     builder: &mut FragmentBuilder<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
@@ -63,17 +61,21 @@ pub fn linearize_svd(
     builder: &mut FragmentBuilder<StdTensorOp>,
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
+    eps: f64,
+    m: usize,
+    n: usize,
 ) -> Vec<Option<LocalValId>> {
     let Some(da) = tangent_in[0] else {
         return vec![None, None, None];
     };
 
+    let k = m.min(n);
     let u = ValRef::External(primal_out[0].clone());
     let s = ValRef::External(primal_out[1].clone());
     let vt = ValRef::External(primal_out[2].clone());
 
     let uh = adjoint_2d_fixed(builder, u.clone());
-    let v = adjoint_2d_fixed(builder, vt);
+    let v = adjoint_2d_fixed(builder, vt.clone());
     let tmp = matmul_linear(
         builder,
         ValRef::Local(uh),
@@ -90,23 +92,19 @@ pub fn linearize_svd(
 
     let diag_s = embed_diag_fixed(builder, s.clone());
     let ones_mat = one_like_fixed(builder, ValRef::Local(diag_s));
-    let s_col = matmul_fixed(builder, ValRef::Local(diag_s), ValRef::Local(ones_mat));
-    let s_row = matmul_fixed(builder, ValRef::Local(ones_mat), ValRef::Local(diag_s));
-    let s_sum = fixed_add(builder, ValRef::Local(s_col), ValRef::Local(s_row));
-    let s_diff = fixed_sub(builder, ValRef::Local(s_col), ValRef::Local(s_row));
+    let s_dim = matmul_fixed(builder, ValRef::Local(ones_mat), ValRef::Local(diag_s));
+    let s_dim_t = matmul_fixed(builder, ValRef::Local(diag_s), ValRef::Local(ones_mat));
+    let s_sum = fixed_add(builder, ValRef::Local(s_dim), ValRef::Local(s_dim_t));
+    let s_diff = fixed_sub(builder, ValRef::Local(s_dim), ValRef::Local(s_dim_t));
     let s_gap = fixed_mul(builder, ValRef::Local(s_sum), ValRef::Local(s_diff));
     let s_gap_sq = fixed_mul(builder, ValRef::Local(s_gap), ValRef::Local(s_gap));
-    let eps_sq = fixed_scale(
-        builder,
-        ValRef::Local(ones_mat),
-        F_MATRIX_EPS * F_MATRIX_EPS,
-    );
+    let eps_sq = fixed_scale(builder, ValRef::Local(ones_mat), eps * eps);
     let safe_gap = fixed_add(builder, ValRef::Local(s_gap_sq), ValRef::Local(eps_sq));
     let f = fixed_div(builder, ValRef::Local(s_gap), ValRef::Local(safe_gap));
 
     let s_ones = one_like_fixed(builder, s.clone());
     let s_sq = fixed_mul(builder, s.clone(), s.clone());
-    let s_eps_sq = fixed_scale(builder, ValRef::Local(s_ones), F_MATRIX_EPS * F_MATRIX_EPS);
+    let s_eps_sq = fixed_scale(builder, ValRef::Local(s_ones), eps * eps);
     let safe_s_sq = fixed_add(builder, ValRef::Local(s_sq), ValRef::Local(s_eps_sq));
     let s_inv = fixed_div(builder, s.clone(), ValRef::Local(safe_s_sq));
     let s_inv_mat = embed_diag_fixed(builder, ValRef::Local(s_inv));
@@ -117,29 +115,71 @@ pub fn linearize_svd(
     let d_udv_diag = hadamard_fixed_linear(builder, ValRef::Local(s_inv_mat), anti_hermitian);
     let d_udv_diag = linear_unary(builder, StdTensorOp::Scale { factor: 0.5 }, d_udv_diag);
 
-    let dss = hadamard_fixed_linear(builder, ValRef::Local(s_col), ds_mat);
+    let dss = hadamard_fixed_linear(builder, ValRef::Local(s_dim), ds_mat);
     let dss_h = adjoint_2d_linear(builder, dss);
     let du_inner_sum = linear_add(builder, dss, dss_h);
     let du_inner = hadamard_fixed_linear(builder, ValRef::Local(f), du_inner_sum);
     let du_inner = linear_add(builder, du_inner, d_udv_diag);
-    let du = matmul_linear(builder, u, ValRef::Local(du_inner), vec![false, true]);
+    let mut du = matmul_linear(
+        builder,
+        u.clone(),
+        ValRef::Local(du_inner),
+        vec![false, true],
+    );
 
-    let sds = hadamard_fixed_linear(builder, ValRef::Local(s_row), ds_mat);
+    let sds = hadamard_fixed_linear(builder, ValRef::Local(s_dim_t), ds_mat);
     let sds_h = adjoint_2d_linear(builder, sds);
     let dv_inner_sum = linear_add(builder, sds, sds_h);
     let dv_inner = hadamard_fixed_linear(builder, ValRef::Local(f), dv_inner_sum);
-    let dv = matmul_linear(
+    let mut dv = matmul_linear(
         builder,
         ValRef::Local(v),
         ValRef::Local(dv_inner),
         vec![false, true],
     );
-    let dvt = adjoint_2d_linear(builder, dv);
 
-    // TODO: add JAX's rectangular projection corrections once runtime matrix
-    // dimensions are available in this graph-level rule:
-    // dU += (dA V - U (U^H dA V)) / s
-    // dV += (dA^H U - V (V^H dA^H U)) / s
+    if m > n {
+        let d_av = matmul_linear(
+            builder,
+            ValRef::Local(da),
+            ValRef::Local(v),
+            vec![true, false],
+        );
+        let ut_d_av = matmul_linear(
+            builder,
+            ValRef::Local(uh),
+            ValRef::Local(d_av),
+            vec![false, true],
+        );
+        let u_ut_d_av = matmul_linear(
+            builder,
+            u.clone(),
+            ValRef::Local(ut_d_av),
+            vec![false, true],
+        );
+        let proj = linear_sub(builder, d_av, u_ut_d_av);
+        let s_broadcast = broadcast_in_dim_fixed(builder, s.clone(), vec![m, k], vec![1]);
+        let correction = linear_div_fixed(builder, proj, ValRef::Local(s_broadcast));
+        du = linear_add(builder, du, correction);
+    }
+
+    if n > m {
+        let da_h = adjoint_2d_linear(builder, da);
+        let d_ahu = matmul_linear(builder, ValRef::Local(da_h), u.clone(), vec![true, false]);
+        let vt_d_ahu = matmul_linear(builder, vt.clone(), ValRef::Local(d_ahu), vec![false, true]);
+        let v_vt_d_ahu = matmul_linear(
+            builder,
+            ValRef::Local(v),
+            ValRef::Local(vt_d_ahu),
+            vec![false, true],
+        );
+        let proj = linear_sub(builder, d_ahu, v_vt_d_ahu);
+        let s_broadcast = broadcast_in_dim_fixed(builder, s.clone(), vec![n, k], vec![1]);
+        let correction = linear_div_fixed(builder, proj, ValRef::Local(s_broadcast));
+        dv = linear_add(builder, dv, correction);
+    }
+
+    let dvt = adjoint_2d_linear(builder, dv);
 
     vec![Some(du), Some(ds), Some(dvt)]
 }
@@ -148,6 +188,7 @@ pub fn linearize_eigh(
     builder: &mut FragmentBuilder<StdTensorOp>,
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
+    eps: f64,
 ) -> Vec<Option<LocalValId>> {
     let Some(da) = tangent_in[0] else {
         return vec![None, None];
@@ -173,11 +214,7 @@ pub fn linearize_eigh(
     let w_row = matmul_fixed(builder, ValRef::Local(ones_mat), ValRef::Local(diag_w));
     let diff = fixed_sub(builder, ValRef::Local(w_row), ValRef::Local(w_col));
     let diff_sq = fixed_mul(builder, ValRef::Local(diff), ValRef::Local(diff));
-    let eps_sq = fixed_scale(
-        builder,
-        ValRef::Local(ones_mat),
-        F_MATRIX_EPS * F_MATRIX_EPS,
-    );
+    let eps_sq = fixed_scale(builder, ValRef::Local(ones_mat), eps * eps);
     let safe_diff = fixed_add(builder, ValRef::Local(diff_sq), ValRef::Local(eps_sq));
     let f = fixed_div(builder, ValRef::Local(diff), ValRef::Local(safe_diff));
     let fm = hadamard_fixed_linear(builder, ValRef::Local(f), projected);
@@ -470,6 +507,15 @@ fn fixed_scale(
     fixed_unary(builder, StdTensorOp::Scale { factor }, input)
 }
 
+fn broadcast_in_dim_fixed(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    input: ValRef<StdTensorOp>,
+    shape: Vec<usize>,
+    dims: Vec<usize>,
+) -> LocalValId {
+    fixed_unary(builder, StdTensorOp::BroadcastInDim { shape, dims }, input)
+}
+
 fn fixed_sub(
     builder: &mut FragmentBuilder<StdTensorOp>,
     lhs: ValRef<StdTensorOp>,
@@ -498,6 +544,20 @@ fn linear_sub(
 ) -> LocalValId {
     let neg_rhs = linear_neg(builder, rhs);
     linear_add(builder, lhs, neg_rhs)
+}
+
+fn linear_div_fixed(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    lhs: LocalValId,
+    rhs: ValRef<StdTensorOp>,
+) -> LocalValId {
+    builder.add_op(
+        StdTensorOp::Div,
+        vec![ValRef::Local(lhs), rhs],
+        OpMode::Linear {
+            active_mask: vec![true, false],
+        },
+    )[0]
 }
 
 fn hadamard_fixed_linear(

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -74,9 +74,11 @@ fn linearize_non_semiring(
             *unit_diagonal,
         ),
         StdTensorOp::Cholesky => linalg::linearize_cholesky(builder, primal_out, tangent_in),
-        StdTensorOp::Svd => linalg::linearize_svd(builder, primal_out, tangent_in),
+        StdTensorOp::Svd { eps, m, n } => {
+            linalg::linearize_svd(builder, primal_out, tangent_in, *eps, *m, *n)
+        }
         StdTensorOp::Qr => linalg::linearize_qr(builder, primal_out, tangent_in),
-        StdTensorOp::Eigh => linalg::linearize_eigh(builder, primal_out, tangent_in),
+        StdTensorOp::Eigh { eps } => linalg::linearize_eigh(builder, primal_out, tangent_in, *eps),
         _ => return None,
     })
 }

--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -104,9 +104,15 @@ pub enum StdTensorOp {
 
     // Linalg
     Cholesky,
-    Svd,
+    Svd {
+        eps: f64,
+        m: usize,
+        n: usize,
+    },
     Qr,
-    Eigh,
+    Eigh {
+        eps: f64,
+    },
     Solve,
     TriangularSolve {
         left_side: bool,
@@ -143,11 +149,17 @@ impl Hash for StdTensorOp {
             | Self::Pow
             | Self::Expm1
             | Self::Log1p
-            | Self::Cholesky
-            | Self::Svd
             | Self::Qr
-            | Self::Eigh
+            | Self::Cholesky
             | Self::Solve => {}
+            Self::Svd { eps, m, n } => {
+                hash_f64(*eps, state);
+                m.hash(state);
+                n.hash(state);
+            }
+            Self::Eigh { eps } => {
+                hash_f64(*eps, state);
+            }
             Self::DotGeneral(config) => config.hash(state),
             Self::Transpose { perm } => perm.hash(state),
             Self::Reshape {
@@ -245,7 +257,7 @@ impl GraphOp for StdTensorOp {
             | Self::Log1p => 1,
             Self::Select | Self::Clamp => 3,
             Self::Compare(_) => 2,
-            Self::Cholesky | Self::Svd | Self::Qr | Self::Eigh => 1,
+            Self::Cholesky | Self::Svd { .. } | Self::Qr | Self::Eigh { .. } => 1,
             Self::Solve | Self::TriangularSolve { .. } => 2,
             _ => todo!("n_inputs not yet implemented for {:?}", self),
         }
@@ -292,9 +304,9 @@ impl GraphOp for StdTensorOp {
             | Self::Pad(_)
             | Self::Reverse { .. } => 1,
             Self::Cholesky | Self::Solve | Self::TriangularSolve { .. } => 1,
-            Self::Svd => 3,  // U, S, Vt
-            Self::Qr => 2,   // Q, R
-            Self::Eigh => 2, // eigenvalues, eigenvectors
+            Self::Svd { .. } => 3,  // U, S, Vt
+            Self::Qr => 2,          // Q, R
+            Self::Eigh { .. } => 2, // eigenvalues, eigenvectors
             Self::Concatenate { .. } => todo!(
                 "n_outputs not yet implemented for variable-arity op {:?}",
                 self

--- a/tenferro-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-ops/src/tests/std_tensor_op_tests.rs
@@ -233,12 +233,28 @@ fn test_std_tensor_op_input_output_counts() {
 fn test_std_tensor_op_linalg_input_output_counts() {
     assert_eq!(StdTensorOp::Cholesky.n_inputs(), 1);
     assert_eq!(StdTensorOp::Cholesky.n_outputs(), 1);
-    assert_eq!(StdTensorOp::Svd.n_inputs(), 1);
-    assert_eq!(StdTensorOp::Svd.n_outputs(), 3);
+    assert_eq!(
+        StdTensorOp::Svd {
+            eps: 1.0e-12,
+            m: 2,
+            n: 2,
+        }
+        .n_inputs(),
+        1
+    );
+    assert_eq!(
+        StdTensorOp::Svd {
+            eps: 1.0e-12,
+            m: 2,
+            n: 2,
+        }
+        .n_outputs(),
+        3
+    );
     assert_eq!(StdTensorOp::Qr.n_inputs(), 1);
     assert_eq!(StdTensorOp::Qr.n_outputs(), 2);
-    assert_eq!(StdTensorOp::Eigh.n_inputs(), 1);
-    assert_eq!(StdTensorOp::Eigh.n_outputs(), 2);
+    assert_eq!(StdTensorOp::Eigh { eps: 1.0e-12 }.n_inputs(), 1);
+    assert_eq!(StdTensorOp::Eigh { eps: 1.0e-12 }.n_outputs(), 2);
     assert_eq!(StdTensorOp::Solve.n_inputs(), 2);
     assert_eq!(StdTensorOp::Solve.n_outputs(), 1);
     assert_eq!(

--- a/tenferro/src/compiler.rs
+++ b/tenferro/src/compiler.rs
@@ -89,13 +89,13 @@ pub fn lower_to_stablehlo(prog: &CompiledProgram<StdTensorOp>) -> StableHloProgr
                     transpose_a: *transpose_a,
                     unit_diagonal: *unit_diagonal,
                 },
-                StdTensorOp::Svd => StableHloOp::CustomCall {
+                StdTensorOp::Svd { .. } => StableHloOp::CustomCall {
                     target: "svd".to_string(),
                 },
                 StdTensorOp::Qr => StableHloOp::CustomCall {
                     target: "qr".to_string(),
                 },
-                StdTensorOp::Eigh => StableHloOp::CustomCall {
+                StdTensorOp::Eigh { .. } => StableHloOp::CustomCall {
                     target: "eigh".to_string(),
                 },
                 StdTensorOp::Solve => StableHloOp::CustomCall {

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -234,7 +234,15 @@ fn build_svd_values_sum_fragment() -> (
     let input_key = tensor_input_key(10_000);
     let mut builder = FragmentBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key.clone());
-    let svd = builder.add_op(StdTensorOp::Svd, vec![ValRef::Local(a)], OpMode::Primal);
+    let svd = builder.add_op(
+        StdTensorOp::Svd {
+            eps: 1.0e-12,
+            m: 2,
+            n: 2,
+        },
+        vec![ValRef::Local(a)],
+        OpMode::Primal,
+    );
     let loss = builder.add_op(
         StdTensorOp::ReduceSum {
             axes: vec![0],
@@ -250,15 +258,24 @@ fn build_svd_values_sum_fragment() -> (
 
 fn build_svd_values_real_sum_fragment(
     input_key: TensorInputKey,
-    singular_shape: Vec<usize>,
+    input_shape: Vec<usize>,
 ) -> (
     Arc<Fragment<StdTensorOp>>,
     TensorInputKey,
     GlobalValKey<StdTensorOp>,
 ) {
+    let singular_shape = vec![input_shape[0].min(input_shape[1])];
     let mut builder = FragmentBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key.clone());
-    let svd = builder.add_op(StdTensorOp::Svd, vec![ValRef::Local(a)], OpMode::Primal);
+    let svd = builder.add_op(
+        StdTensorOp::Svd {
+            eps: 1.0e-12,
+            m: input_shape[0],
+            n: input_shape[1],
+        },
+        vec![ValRef::Local(a)],
+        OpMode::Primal,
+    );
     let loss = add_real_reduce_sum_loss(&mut builder, svd[1], singular_shape);
     let loss_key = builder.global_key(loss).clone();
     builder.set_outputs(vec![loss]);
@@ -270,7 +287,7 @@ fn build_svd_values_real_sum_complex_fragment() -> (
     TensorInputKey,
     GlobalValKey<StdTensorOp>,
 ) {
-    build_svd_values_real_sum_fragment(tensor_input_key(12_000), vec![2])
+    build_svd_values_real_sum_fragment(tensor_input_key(12_000), vec![2, 2])
 }
 
 fn build_svd_values_real_sum_complex_3x3_fragment() -> (
@@ -278,7 +295,7 @@ fn build_svd_values_real_sum_complex_3x3_fragment() -> (
     TensorInputKey,
     GlobalValKey<StdTensorOp>,
 ) {
-    build_svd_values_real_sum_fragment(tensor_input_key(12_100), vec![3])
+    build_svd_values_real_sum_fragment(tensor_input_key(12_100), vec![3, 3])
 }
 
 fn build_svd_uv_product_fragment(
@@ -292,7 +309,15 @@ fn build_svd_uv_product_fragment(
 ) {
     let mut builder = FragmentBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key.clone());
-    let svd = builder.add_op(StdTensorOp::Svd, vec![ValRef::Local(a)], OpMode::Primal);
+    let svd = builder.add_op(
+        StdTensorOp::Svd {
+            eps: 1.0e-12,
+            m: product_shape[0],
+            n: product_shape[1],
+        },
+        vec![ValRef::Local(a)],
+        OpMode::Primal,
+    );
     let uv_product = builder.add_op(
         StdTensorOp::DotGeneral(matmul_config()),
         vec![ValRef::Local(svd[0]), ValRef::Local(svd[2])],
@@ -331,6 +356,55 @@ fn build_svd_uv_product_real_sum_complex_fragment() -> (
     build_svd_uv_product_fragment(tensor_input_key(15_100), vec![3, 3], true)
 }
 
+fn build_svd_reconstruction_sum_fragment(
+    input_key: TensorInputKey,
+    shape: Vec<usize>,
+    eps: f64,
+) -> (
+    Arc<Fragment<StdTensorOp>>,
+    TensorInputKey,
+    GlobalValKey<StdTensorOp>,
+) {
+    let m = shape[0];
+    let n = shape[1];
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let a = builder.add_input(input_key.clone());
+    let svd = builder.add_op(
+        StdTensorOp::Svd { eps, m, n },
+        vec![ValRef::Local(a)],
+        OpMode::Primal,
+    );
+    let diag_s = builder.add_op(
+        StdTensorOp::EmbedDiag {
+            axis_a: 0,
+            axis_b: 1,
+        },
+        vec![ValRef::Local(svd[1])],
+        OpMode::Primal,
+    );
+    let us = builder.add_op(
+        StdTensorOp::DotGeneral(matmul_config()),
+        vec![ValRef::Local(svd[0]), ValRef::Local(diag_s[0])],
+        OpMode::Primal,
+    );
+    let reconstructed = builder.add_op(
+        StdTensorOp::DotGeneral(matmul_config()),
+        vec![ValRef::Local(us[0]), ValRef::Local(svd[2])],
+        OpMode::Primal,
+    );
+    let loss = builder.add_op(
+        StdTensorOp::ReduceSum {
+            axes: vec![0, 1],
+            input_shape: vec![m, n],
+        },
+        vec![ValRef::Local(reconstructed[0])],
+        OpMode::Primal,
+    );
+    let loss_key = builder.global_key(loss[0]).clone();
+    builder.set_outputs(vec![loss[0]]);
+    (Arc::new(builder.build()), input_key, loss_key)
+}
+
 fn build_eigh_values_sum_fragment() -> (
     Arc<Fragment<StdTensorOp>>,
     TensorInputKey,
@@ -339,7 +413,11 @@ fn build_eigh_values_sum_fragment() -> (
     let input_key = tensor_input_key(20_000);
     let mut builder = FragmentBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key.clone());
-    let eigh = builder.add_op(StdTensorOp::Eigh, vec![ValRef::Local(a)], OpMode::Primal);
+    let eigh = builder.add_op(
+        StdTensorOp::Eigh { eps: 1.0e-12 },
+        vec![ValRef::Local(a)],
+        OpMode::Primal,
+    );
     let loss = builder.add_op(
         StdTensorOp::ReduceSum {
             axes: vec![0],
@@ -361,7 +439,11 @@ fn build_eigh_values_real_sum_complex_fragment() -> (
     let input_key = tensor_input_key(22_000);
     let mut builder = FragmentBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key.clone());
-    let eigh = builder.add_op(StdTensorOp::Eigh, vec![ValRef::Local(a)], OpMode::Primal);
+    let eigh = builder.add_op(
+        StdTensorOp::Eigh { eps: 1.0e-12 },
+        vec![ValRef::Local(a)],
+        OpMode::Primal,
+    );
     let loss = add_real_reduce_sum_loss(&mut builder, eigh[0], vec![2]);
     let loss_key = builder.global_key(loss).clone();
     builder.set_outputs(vec![loss]);
@@ -385,7 +467,11 @@ fn build_eigh_projector_fragment(
     let a = builder.add_input(input_key.clone());
     let weights = builder.add_input(weights_key.clone());
     let probe = builder.add_input(probe_key.clone());
-    let eigh = builder.add_op(StdTensorOp::Eigh, vec![ValRef::Local(a)], OpMode::Primal);
+    let eigh = builder.add_op(
+        StdTensorOp::Eigh { eps: 1.0e-12 },
+        vec![ValRef::Local(a)],
+        OpMode::Primal,
+    );
     let diag = builder.add_op(
         StdTensorOp::EmbedDiag {
             axis_a: 0,
@@ -761,6 +847,17 @@ fn sum_svd_uv_product(data: &[f64]) -> f64 {
     let product =
         TensorBackend::dot_general(&mut backend, &outputs[0], &outputs[2], &matmul_config());
     get_f64_data(&product).iter().sum()
+}
+
+fn sum_svd_reconstruction(data: &[f64], shape: [usize; 2]) -> f64 {
+    let mut backend = CpuBackend::new();
+    let input = f64_tensor(shape.to_vec(), data.to_vec());
+    let outputs = TensorBackend::svd(&mut backend, &input);
+    let diag_s = TensorBackend::embed_diagonal(&mut backend, &outputs[1], 0, 1);
+    let us = TensorBackend::dot_general(&mut backend, &outputs[0], &diag_s, &matmul_config());
+    let reconstructed =
+        TensorBackend::dot_general(&mut backend, &us, &outputs[2], &matmul_config());
+    get_f64_data(&reconstructed).iter().sum()
 }
 
 fn sum_eigh_values(data: &[f64]) -> f64 {
@@ -1720,6 +1817,81 @@ fn grad_svd_uv_product_matches_finite_diff() {
         let expected = finite_diff_scalar(sum_svd_uv_product, &a_data, index, 1e-6);
         assert!(
             (grad_data[index] - expected).abs() <= 1e-4,
+            "index {index}: expected {expected}, got {}",
+            grad_data[index]
+        );
+    }
+}
+
+#[test]
+fn grad_svd_rectangular_tall_matches_finite_diff() {
+    let shape = [4, 2];
+    let a_data = vec![3.0, -0.5, 1.2, 0.8, 0.7, 2.1, -1.4, 0.3];
+    let (fragment, input_key, loss_key) =
+        build_svd_reconstruction_sum_fragment(tensor_input_key(16_000), shape.to_vec(), 1.0e-12);
+    let grad = grad_from_fragment(
+        fragment,
+        loss_key,
+        input_key,
+        f64_tensor(shape.to_vec(), a_data.clone()),
+    );
+    let grad_data = get_f64_data(&grad);
+
+    for index in 0..a_data.len() {
+        let expected =
+            finite_diff_scalar(|xs| sum_svd_reconstruction(xs, shape), &a_data, index, 1e-6);
+        assert!(
+            (grad_data[index] - expected).abs() <= 1e-4,
+            "index {index}: expected {expected}, got {}",
+            grad_data[index]
+        );
+    }
+}
+
+#[test]
+fn grad_svd_rectangular_wide_matches_finite_diff() {
+    let shape = [2, 4];
+    let a_data = vec![2.4, -0.6, 1.1, 0.5, -1.3, 0.9, 0.7, 1.8];
+    let (fragment, input_key, loss_key) =
+        build_svd_reconstruction_sum_fragment(tensor_input_key(16_100), shape.to_vec(), 1.0e-12);
+    let grad = grad_from_fragment(
+        fragment,
+        loss_key,
+        input_key,
+        f64_tensor(shape.to_vec(), a_data.clone()),
+    );
+    let grad_data = get_f64_data(&grad);
+
+    for index in 0..a_data.len() {
+        let expected =
+            finite_diff_scalar(|xs| sum_svd_reconstruction(xs, shape), &a_data, index, 1e-6);
+        assert!(
+            (grad_data[index] - expected).abs() <= 1e-4,
+            "index {index}: expected {expected}, got {}",
+            grad_data[index]
+        );
+    }
+}
+
+#[test]
+fn grad_svd_custom_eps() {
+    let shape = [2, 2];
+    let a_data = vec![2.2, -0.4, 1.1, 0.8];
+    let (fragment, input_key, loss_key) =
+        build_svd_reconstruction_sum_fragment(tensor_input_key(16_200), shape.to_vec(), 1.0e-8);
+    let grad = grad_from_fragment(
+        fragment,
+        loss_key,
+        input_key,
+        f64_tensor(shape.to_vec(), a_data.clone()),
+    );
+    let grad_data = get_f64_data(&grad);
+
+    for index in 0..a_data.len() {
+        let expected =
+            finite_diff_scalar(|xs| sum_svd_reconstruction(xs, shape), &a_data, index, 1e-6);
+        assert!(
+            (grad_data[index] - expected).abs() <= 1e-5,
             "index {index}: expected {expected}, got {}",
             grad_data[index]
         );


### PR DESCRIPTION
## Summary
- **#627**: SVD eigenvector tangents now handle rectangular matrices (m≠n) with JAX's projection correction
- **#628**: `Svd { eps, m, n }` and `Eigh { eps }` carry configurable Lorentzian broadening parameter. Default `1e-12`.

Closes #627, closes #628

## Test plan
- [x] Tall rectangular SVD (4x2) grad matches finite diff
- [x] Wide rectangular SVD (2x4) grad matches finite diff
- [x] Custom eps works
- [x] Existing square + degenerate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)