### PR TITLE
refactor: remove Scale/ScaleComplex ops, use Constant + Mul (#635)

### DIFF
--- a/tenferro-ops/src/ad/elementwise_tier2.rs
+++ b/tenferro-ops/src/ad/elementwise_tier2.rs
@@ -166,47 +166,6 @@ pub fn linearize_sign(
     }
 }
 
-pub fn linearize_scale(
-    builder: &mut FragmentBuilder<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
-    factor: f64,
-) -> Vec<Option<LocalValId>> {
-    match tangent_in[0] {
-        Some(dx) => {
-            let out = builder.add_op(
-                StdTensorOp::Scale { factor },
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
-                    active_mask: vec![true],
-                },
-            );
-            vec![Some(out[0])]
-        }
-        None => vec![None],
-    }
-}
-
-pub fn linearize_scale_complex(
-    builder: &mut FragmentBuilder<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
-    re: f64,
-    im: f64,
-) -> Vec<Option<LocalValId>> {
-    match tangent_in[0] {
-        Some(dx) => {
-            let out = builder.add_op(
-                StdTensorOp::ScaleComplex { re, im },
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
-                    active_mask: vec![true],
-                },
-            );
-            vec![Some(out[0])]
-        }
-        None => vec![None],
-    }
-}
-
 pub fn transpose_div(
     builder: &mut FragmentBuilder<StdTensorOp>,
     cotangent_out: &[Option<LocalValId>],
@@ -278,55 +237,6 @@ pub fn transpose_sign(
     }
     match cotangent_out[0] {
         Some(ct) => vec![Some(emit_zero_from_active(builder, ct))],
-        None => vec![None],
-    }
-}
-
-pub fn transpose_scale(
-    builder: &mut FragmentBuilder<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    mode: &OpMode,
-    factor: f64,
-) -> Vec<Option<LocalValId>> {
-    if !unary_is_active(mode) {
-        return vec![None];
-    }
-    match cotangent_out[0] {
-        Some(ct) => {
-            let out = builder.add_op(
-                StdTensorOp::Scale { factor },
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
-                    active_mask: vec![true],
-                },
-            );
-            vec![Some(out[0])]
-        }
-        None => vec![None],
-    }
-}
-
-pub fn transpose_scale_complex(
-    builder: &mut FragmentBuilder<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    mode: &OpMode,
-    re: f64,
-    im: f64,
-) -> Vec<Option<LocalValId>> {
-    if !unary_is_active(mode) {
-        return vec![None];
-    }
-    match cotangent_out[0] {
-        Some(ct) => {
-            let out = builder.add_op(
-                StdTensorOp::ScaleComplex { re, im: -im },
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
-                    active_mask: vec![true],
-                },
-            );
-            vec![Some(out[0])]
-        }
         None => vec![None],
     }
 }

--- a/tenferro-ops/src/ad/linalg.rs
+++ b/tenferro-ops/src/ad/linalg.rs
@@ -113,7 +113,7 @@ pub fn linearize_svd(
     let anti_hermitian = linear_sub(builder, ds_mat, ds_h);
     // Matches JAX's complex gauge correction: 0.5 * (dS - dS^H) * diag(1 / s).
     let d_udv_diag = hadamard_fixed_linear(builder, ValRef::Local(s_inv_mat), anti_hermitian);
-    let d_udv_diag = linear_unary(builder, StdTensorOp::Scale { factor: 0.5 }, d_udv_diag);
+    let d_udv_diag = linear_scale(builder, d_udv_diag, 0.5);
 
     let dss = hadamard_fixed_linear(builder, ValRef::Local(s_dim), ds_mat);
     let dss_h = adjoint_2d_linear(builder, dss);
@@ -269,13 +269,7 @@ pub fn linearize_cholesky(
         },
     )[0];
     let diag_s = extract_diag_linear(builder, s);
-    let half_diag = builder.add_op(
-        StdTensorOp::Scale { factor: 0.5 },
-        vec![ValRef::Local(diag_s)],
-        OpMode::Linear {
-            active_mask: vec![true],
-        },
-    )[0];
+    let half_diag = linear_scale(builder, diag_s, 0.5);
     let half_diag_mat = embed_diag_linear(builder, half_diag);
     let phi_s = linear_add(builder, strict_lower, half_diag_mat);
     let dl = matmul_linear(builder, l, ValRef::Local(phi_s), vec![false, true]);
@@ -327,7 +321,7 @@ pub fn linearize_qr(
         },
     )[0];
     let sym_diag = extract_diag_linear(builder, sym);
-    let half_sym_diag = linear_unary(builder, StdTensorOp::Scale { factor: 0.5 }, sym_diag);
+    let half_sym_diag = linear_scale(builder, sym_diag, 0.5);
     let half_sym_diag_mat = embed_diag_linear(builder, half_sym_diag);
     let dr_hat = linear_add(builder, upper, half_sym_diag_mat);
 
@@ -504,7 +498,12 @@ fn fixed_scale(
     input: ValRef<StdTensorOp>,
     factor: f64,
 ) -> LocalValId {
-    fixed_unary(builder, StdTensorOp::Scale { factor }, input)
+    let constant = builder.add_op(StdTensorOp::constant_f64(factor), vec![], OpMode::Primal);
+    builder.add_op(
+        StdTensorOp::Mul,
+        vec![ValRef::Local(constant[0]), input],
+        OpMode::Primal,
+    )[0]
 }
 
 fn broadcast_in_dim_fixed(
@@ -535,6 +534,21 @@ fn linear_add(
 
 fn linear_neg(builder: &mut FragmentBuilder<StdTensorOp>, input: LocalValId) -> LocalValId {
     linear_unary(builder, StdTensorOp::Neg, input)
+}
+
+fn linear_scale(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    input: LocalValId,
+    factor: f64,
+) -> LocalValId {
+    let constant = builder.add_op(StdTensorOp::constant_f64(factor), vec![], OpMode::Primal);
+    builder.add_op(
+        StdTensorOp::Mul,
+        vec![ValRef::Local(constant[0]), ValRef::Local(input)],
+        OpMode::Linear {
+            active_mask: vec![false, true],
+        },
+    )[0]
 }
 
 fn linear_sub(
@@ -668,13 +682,7 @@ fn self_adjoint_from_lower_linear(
     let diag = extract_diag_linear(builder, input);
     let diag_h = linear_unary(builder, StdTensorOp::Conj, diag);
     let diag_sum = linear_add(builder, diag, diag_h);
-    let real_diag = builder.add_op(
-        StdTensorOp::Scale { factor: 0.5 },
-        vec![ValRef::Local(diag_sum)],
-        OpMode::Linear {
-            active_mask: vec![true],
-        },
-    )[0];
+    let real_diag = linear_scale(builder, diag_sum, 0.5);
     let diag_mat = embed_diag_linear(builder, real_diag);
     linear_add(builder, offdiag, diag_mat)
 }

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -24,12 +24,6 @@ fn linearize_non_semiring(
         }
         StdTensorOp::Abs => elementwise_tier2::linearize_abs(builder, primal_in, tangent_in),
         StdTensorOp::Sign => elementwise_tier2::linearize_sign(builder, tangent_in),
-        StdTensorOp::Scale { factor } => {
-            elementwise_tier2::linearize_scale(builder, tangent_in, *factor)
-        }
-        StdTensorOp::ScaleComplex { re, im } => {
-            elementwise_tier2::linearize_scale_complex(builder, tangent_in, *re, *im)
-        }
         StdTensorOp::Constant { .. } => vec![None],
         StdTensorOp::Exp => analytic::linearize_exp(builder, primal_out, tangent_in),
         StdTensorOp::Log => analytic::linearize_log(builder, primal_in, tangent_in),
@@ -113,12 +107,6 @@ fn transpose_non_semiring(
         StdTensorOp::Div => elementwise_tier2::transpose_div(builder, cotangent_out, inputs, mode),
         StdTensorOp::Abs => elementwise_tier2::transpose_abs(builder, cotangent_out, inputs, mode),
         StdTensorOp::Sign => elementwise_tier2::transpose_sign(builder, cotangent_out, mode),
-        StdTensorOp::Scale { factor } => {
-            elementwise_tier2::transpose_scale(builder, cotangent_out, mode, *factor)
-        }
-        StdTensorOp::ScaleComplex { re, im } => {
-            elementwise_tier2::transpose_scale_complex(builder, cotangent_out, mode, *re, *im)
-        }
         StdTensorOp::Constant { .. } => vec![],
         StdTensorOp::Exp => analytic::transpose_exp(builder, cotangent_out, inputs, mode),
         StdTensorOp::Log => analytic::transpose_log(builder, cotangent_out, inputs, mode),

--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -49,13 +49,6 @@ pub enum StdTensorOp {
     Compare(CompareDir),
     Select,
     Clamp,
-    Scale {
-        factor: f64,
-    },
-    ScaleComplex {
-        re: f64,
-        im: f64,
-    },
 
     // Tier 2: analytic
     Exp,
@@ -265,11 +258,6 @@ impl Hash for StdTensorOp {
                 input_shape.hash(state);
             }
             Self::Compare(dir) => dir.hash(state),
-            Self::Scale { factor } => hash_f64(*factor, state),
-            Self::ScaleComplex { re, im } => {
-                hash_f64(*re, state);
-                hash_f64(*im, state);
-            }
             Self::ExtractDiag { axis_a, axis_b } | Self::EmbedDiag { axis_a, axis_b } => {
                 axis_a.hash(state);
                 axis_b.hash(state);
@@ -337,8 +325,6 @@ impl GraphOp for StdTensorOp {
             }
             Self::Abs
             | Self::Sign
-            | Self::Scale { .. }
-            | Self::ScaleComplex { .. }
             | Self::Exp
             | Self::Log
             | Self::Sin
@@ -370,8 +356,6 @@ impl GraphOp for StdTensorOp {
             | Self::Div
             | Self::Abs
             | Self::Sign
-            | Self::Scale { .. }
-            | Self::ScaleComplex { .. }
             | Self::Maximum
             | Self::Minimum
             | Self::Compare(_)

--- a/tenferro-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-ops/src/tests/std_tensor_op_tests.rs
@@ -179,11 +179,6 @@ fn test_std_tensor_op_input_output_counts() {
     assert_eq!(StdTensorOp::Div.n_inputs(), 2);
     assert_eq!(StdTensorOp::Pow.n_inputs(), 2);
     assert_eq!(StdTensorOp::Abs.n_inputs(), 1);
-    assert_eq!(StdTensorOp::Scale { factor: 0.5 }.n_inputs(), 1);
-    assert_eq!(
-        StdTensorOp::ScaleComplex { re: 0.5, im: -1.0 }.n_inputs(),
-        1
-    );
     assert_eq!(StdTensorOp::Exp.n_inputs(), 1);
     assert_eq!(StdTensorOp::Log1p.n_inputs(), 1);
     assert_eq!(StdTensorOp::constant_f64(1.0).n_outputs(), 1);
@@ -554,7 +549,7 @@ fn test_std_tensor_op_transpose_rule_add_fans_out_cotangent() {
 }
 
 #[test]
-fn test_std_tensor_op_hash_covers_remaining_variants_and_normalizes_zero_scale() {
+fn test_std_tensor_op_hash_covers_remaining_variants() {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
@@ -600,12 +595,6 @@ fn test_std_tensor_op_hash_covers_remaining_variants_and_normalizes_zero_scale()
         op.hash(&mut hasher);
         assert_ne!(hasher.finish(), 0, "unexpected zero hash for {op:?}");
     }
-
-    let mut neg_zero = DefaultHasher::new();
-    StdTensorOp::Scale { factor: -0.0 }.hash(&mut neg_zero);
-    let mut pos_zero = DefaultHasher::new();
-    StdTensorOp::Scale { factor: 0.0 }.hash(&mut pos_zero);
-    assert_eq!(neg_zero.finish(), pos_zero.finish());
 
     let mut lhs = DefaultHasher::new();
     StdTensorOp::constant_f64(1.25).hash(&mut lhs);
@@ -753,31 +742,6 @@ fn test_std_tensor_op_elementwise_tier2_special_cases_are_covered() {
     assert_eq!(sign_fragment.ops()[0].op, StdTensorOp::Neg);
     assert_eq!(sign_fragment.ops()[1].op, StdTensorOp::Add);
 
-    let (scale_none_result, scale_none_fragment) =
-        run_linearize_case(StdTensorOp::Scale { factor: -2.0 }, 0, 0, &[false]);
-    assert_eq!(scale_none_result, vec![None]);
-    assert!(scale_none_fragment.ops().is_empty());
-
-    let (scale_result, scale_fragment) =
-        run_linearize_case(StdTensorOp::Scale { factor: 0.25 }, 0, 0, &[true]);
-    assert!(scale_result[0].is_some());
-    assert_eq!(
-        scale_fragment.ops()[0].op,
-        StdTensorOp::Scale { factor: 0.25 }
-    );
-
-    let (scale_complex_result, scale_complex_fragment) = run_linearize_case(
-        StdTensorOp::ScaleComplex { re: 0.25, im: -0.5 },
-        0,
-        0,
-        &[true],
-    );
-    assert!(scale_complex_result[0].is_some());
-    assert_eq!(
-        scale_complex_fragment.ops()[0].op,
-        StdTensorOp::ScaleComplex { re: 0.25, im: -0.5 }
-    );
-
     let (transpose_div_result, _, transpose_div_fragment) =
         run_transpose_case(StdTensorOp::Div, 2, &[false, true], true);
     assert_eq!(transpose_div_result[0], None);
@@ -815,48 +779,6 @@ fn test_std_tensor_op_elementwise_tier2_special_cases_are_covered() {
     assert!(transpose_abs_result[0].is_some());
     assert_eq!(transpose_abs_fragment.ops()[0].op, StdTensorOp::Sign);
     assert_eq!(transpose_abs_fragment.ops()[1].op, StdTensorOp::Mul);
-
-    let (transpose_scale_result, _, transpose_scale_fragment) =
-        run_transpose_case(StdTensorOp::Scale { factor: -3.0 }, 1, &[true], true);
-    assert!(transpose_scale_result[0].is_some());
-    assert_eq!(
-        transpose_scale_fragment.ops()[0].op,
-        StdTensorOp::Scale { factor: -3.0 }
-    );
-
-    let (transpose_scale_complex_result, _, transpose_scale_complex_fragment) = run_transpose_case(
-        StdTensorOp::ScaleComplex { re: 1.5, im: -2.0 },
-        1,
-        &[true],
-        true,
-    );
-    assert!(transpose_scale_complex_result[0].is_some());
-    assert_eq!(
-        transpose_scale_complex_fragment.ops()[0].op,
-        StdTensorOp::ScaleComplex { re: 1.5, im: 2.0 }
-    );
-
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
-    let cotangent = builder.add_input(tensor_input_key(922));
-    let scale_primal_mode = StdTensorOp::Scale { factor: 1.5 }.transpose_rule(
-        &mut builder,
-        &[Some(cotangent)],
-        &external_inputs(923, 1),
-        &OpMode::Primal,
-    );
-    assert_eq!(scale_primal_mode, vec![None]);
-    assert!(builder.build().ops().is_empty());
-
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
-    let cotangent = builder.add_input(tensor_input_key(924));
-    let scale_complex_primal_mode = StdTensorOp::ScaleComplex { re: 1.5, im: 0.25 }.transpose_rule(
-        &mut builder,
-        &[Some(cotangent)],
-        &external_inputs(925, 1),
-        &OpMode::Primal,
-    );
-    assert_eq!(scale_complex_primal_mode, vec![None]);
-    assert!(builder.build().ops().is_empty());
 }
 
 #[test]

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -49,8 +49,6 @@ pub trait TensorBackend {
     fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> Tensor;
     fn select(&mut self, pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> Tensor;
     fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> Tensor;
-    fn scale(&mut self, input: &Tensor, factor: f64) -> Tensor;
-    fn scale_complex(&mut self, input: &Tensor, re: f64, im: f64) -> Tensor;
 
     fn exp(&mut self, input: &Tensor) -> Tensor;
     fn log(&mut self, input: &Tensor) -> Tensor;

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -166,14 +166,6 @@ impl TensorBackend for CpuBackend {
         self.install(|| elementwise::clamp(input, lower, upper))
     }
 
-    fn scale(&mut self, input: &Tensor, factor: f64) -> Tensor {
-        self.install(|| elementwise::scale(input, factor))
-    }
-
-    fn scale_complex(&mut self, input: &Tensor, re: f64, im: f64) -> Tensor {
-        self.install(|| elementwise::scale_complex(input, re, im))
-    }
-
     fn exp(&mut self, input: &Tensor) -> Tensor {
         self.install(|| analytic::exp(input))
     }

--- a/tenferro-tensor/src/cpu/elementwise.rs
+++ b/tenferro-tensor/src/cpu/elementwise.rs
@@ -32,14 +32,6 @@ pub(crate) trait Tier2Elem: Copy + Clone + One + Zero {
     fn is_nonzero(self) -> bool;
 }
 
-pub(crate) trait ScaleElem: Copy + Clone + Zero + Mul<Output = Self> {
-    fn from_factor(factor: f64) -> Self;
-}
-
-pub(crate) trait ScaleComplexElem: Copy + Clone + Zero + Mul<Output = Self> {
-    fn from_complex_factor(re: f64, im: f64) -> Self;
-}
-
 macro_rules! impl_tier2_elem_real {
     ($ty:ty) => {
         impl Tier2Elem for $ty {
@@ -151,48 +143,63 @@ impl_tier2_elem_real!(f64);
 impl_tier2_elem_complex!(f32);
 impl_tier2_elem_complex!(f64);
 
-impl ScaleElem for f32 {
-    fn from_factor(factor: f64) -> Self {
-        factor as f32
-    }
-}
-
-impl ScaleElem for f64 {
-    fn from_factor(factor: f64) -> Self {
-        factor
-    }
-}
-
-impl ScaleElem for Complex<f32> {
-    fn from_factor(factor: f64) -> Self {
-        Self::new(factor as f32, 0.0)
-    }
-}
-
-impl ScaleElem for Complex<f64> {
-    fn from_factor(factor: f64) -> Self {
-        Self::new(factor, 0.0)
-    }
-}
-
-impl ScaleComplexElem for Complex<f32> {
-    fn from_complex_factor(re: f64, im: f64) -> Self {
-        Self::new(re as f32, im as f32)
-    }
-}
-
-impl ScaleComplexElem for Complex<f64> {
-    fn from_complex_factor(re: f64, im: f64) -> Self {
-        Self::new(re, im)
-    }
+fn complex_scalar_tensor<T>(scalar: T) -> TypedTensor<Complex<T>>
+where
+    T: Copy + Clone + Zero,
+{
+    TypedTensor::from_vec(vec![], vec![Complex::new(scalar, T::zero())])
 }
 
 pub fn add(lhs: &Tensor, rhs: &Tensor) -> Tensor {
-    dispatch_binary!(lhs, rhs, |a, b| typed_add(a, b))
+    match (lhs, rhs) {
+        (Tensor::F32(a), Tensor::F32(b)) => Tensor::F32(typed_add(a, b)),
+        (Tensor::F64(a), Tensor::F64(b)) => Tensor::F64(typed_add(a, b)),
+        (Tensor::C32(a), Tensor::C32(b)) => Tensor::C32(typed_add(a, b)),
+        (Tensor::C64(a), Tensor::C64(b)) => Tensor::C64(typed_add(a, b)),
+        (Tensor::F32(a), Tensor::C32(b)) if a.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            Tensor::C32(typed_add(&scalar, b))
+        }
+        (Tensor::C32(a), Tensor::F32(b)) if b.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            Tensor::C32(typed_add(a, &scalar))
+        }
+        (Tensor::F64(a), Tensor::C64(b)) if a.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            Tensor::C64(typed_add(&scalar, b))
+        }
+        (Tensor::C64(a), Tensor::F64(b)) if b.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            Tensor::C64(typed_add(a, &scalar))
+        }
+        _ => panic!("dtype mismatch in binary op"),
+    }
 }
 
 pub fn mul(lhs: &Tensor, rhs: &Tensor) -> Tensor {
-    dispatch_binary!(lhs, rhs, |a, b| typed_mul(a, b))
+    match (lhs, rhs) {
+        (Tensor::F32(a), Tensor::F32(b)) => Tensor::F32(typed_mul(a, b)),
+        (Tensor::F64(a), Tensor::F64(b)) => Tensor::F64(typed_mul(a, b)),
+        (Tensor::C32(a), Tensor::C32(b)) => Tensor::C32(typed_mul(a, b)),
+        (Tensor::C64(a), Tensor::C64(b)) => Tensor::C64(typed_mul(a, b)),
+        (Tensor::F32(a), Tensor::C32(b)) if a.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            Tensor::C32(typed_mul(&scalar, b))
+        }
+        (Tensor::C32(a), Tensor::F32(b)) if b.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            Tensor::C32(typed_mul(a, &scalar))
+        }
+        (Tensor::F64(a), Tensor::C64(b)) if a.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            Tensor::C64(typed_mul(&scalar, b))
+        }
+        (Tensor::C64(a), Tensor::F64(b)) if b.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            Tensor::C64(typed_mul(a, &scalar))
+        }
+        _ => panic!("dtype mismatch in binary op"),
+    }
 }
 
 pub fn div(lhs: &Tensor, rhs: &Tensor) -> Tensor {
@@ -235,48 +242,62 @@ pub fn clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> Tensor {
     dispatch_ternary!(input, lower, upper, |x, lo, hi| typed_clamp(x, lo, hi))
 }
 
-pub fn scale(input: &Tensor, factor: f64) -> Tensor {
-    dispatch_tensor!(input, t => typed_scale(t, factor))
-}
-
-pub fn scale_complex(input: &Tensor, re: f64, im: f64) -> Tensor {
-    match input {
-        Tensor::C32(t) => Tensor::C32(typed_scale_complex(t, re, im)),
-        Tensor::C64(t) => Tensor::C64(typed_scale_complex(t, re, im)),
-        _ => panic!("scale_complex: input must have complex dtype"),
-    }
-}
-
 pub fn typed_add<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> TypedTensor<T>
 where
     T: Copy + Clone + Zero + Add<Output = T>,
 {
-    assert_eq!(lhs.shape, rhs.shape, "add: shape mismatch");
-    let mut out = typed_array(&lhs.shape, T::zero());
-    zip_map2_into(
-        &mut out.view_mut(),
-        &typed_view(lhs),
-        &typed_view(rhs),
-        |x, y| x + y,
-    )
-    .expect("typed_add");
-    tensor_from_array(out)
+    if lhs.shape == rhs.shape {
+        let mut out = typed_array(&lhs.shape, T::zero());
+        zip_map2_into(
+            &mut out.view_mut(),
+            &typed_view(lhs),
+            &typed_view(rhs),
+            |x, y| x + y,
+        )
+        .expect("typed_add");
+        tensor_from_array(out)
+    } else if lhs.shape.is_empty() {
+        let scalar = lhs.host_data()[0];
+        let mut out = typed_array(&rhs.shape, T::zero());
+        map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar + x).expect("scalar_add");
+        tensor_from_array(out)
+    } else if rhs.shape.is_empty() {
+        let scalar = rhs.host_data()[0];
+        let mut out = typed_array(&lhs.shape, T::zero());
+        map_into(&mut out.view_mut(), &typed_view(lhs), |x| x + scalar).expect("scalar_add");
+        tensor_from_array(out)
+    } else {
+        panic!("add: shape mismatch {:?} vs {:?}", lhs.shape, rhs.shape);
+    }
 }
 
 pub fn typed_mul<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> TypedTensor<T>
 where
     T: Copy + Clone + Zero + Mul<Output = T>,
 {
-    assert_eq!(lhs.shape, rhs.shape, "mul: shape mismatch");
-    let mut out = typed_array(&lhs.shape, T::zero());
-    zip_map2_into(
-        &mut out.view_mut(),
-        &typed_view(lhs),
-        &typed_view(rhs),
-        |x, y| x * y,
-    )
-    .expect("typed_mul");
-    tensor_from_array(out)
+    if lhs.shape == rhs.shape {
+        let mut out = typed_array(&lhs.shape, T::zero());
+        zip_map2_into(
+            &mut out.view_mut(),
+            &typed_view(lhs),
+            &typed_view(rhs),
+            |x, y| x * y,
+        )
+        .expect("typed_mul");
+        tensor_from_array(out)
+    } else if lhs.shape.is_empty() {
+        let scalar = lhs.host_data()[0];
+        let mut out = typed_array(&rhs.shape, T::zero());
+        map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar * x).expect("scalar_mul");
+        tensor_from_array(out)
+    } else if rhs.shape.is_empty() {
+        let scalar = rhs.host_data()[0];
+        let mut out = typed_array(&lhs.shape, T::zero());
+        map_into(&mut out.view_mut(), &typed_view(lhs), |x| x * scalar).expect("scalar_mul");
+        tensor_from_array(out)
+    } else {
+        panic!("mul: shape mismatch {:?} vs {:?}", lhs.shape, rhs.shape);
+    }
 }
 
 pub fn typed_div<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> TypedTensor<T>
@@ -301,26 +322,6 @@ where
 {
     let mut out = typed_array(&input.shape, T::zero());
     map_into(&mut out.view_mut(), &typed_view(input), |x| -x).expect("typed_neg");
-    tensor_from_array(out)
-}
-
-pub(crate) fn typed_scale<T>(input: &TypedTensor<T>, factor: f64) -> TypedTensor<T>
-where
-    T: ScaleElem,
-{
-    let factor = T::from_factor(factor);
-    let mut out = typed_array(&input.shape, T::zero());
-    map_into(&mut out.view_mut(), &typed_view(input), |x| x * factor).expect("typed_scale");
-    tensor_from_array(out)
-}
-
-pub(crate) fn typed_scale_complex<T>(input: &TypedTensor<T>, re: f64, im: f64) -> TypedTensor<T>
-where
-    T: ScaleComplexElem,
-{
-    let factor = T::from_complex_factor(re, im);
-    let mut out = typed_array(&input.shape, T::zero());
-    map_into(&mut out.view_mut(), &typed_view(input), |x| x * factor).expect("typed_scale_complex");
     tensor_from_array(out)
 }
 

--- a/tenferro-tensor/src/cpu/mod.rs
+++ b/tenferro-tensor/src/cpu/mod.rs
@@ -13,8 +13,7 @@ use crate::{Buffer, TypedTensor};
 
 pub use backend::CpuBackend;
 pub use elementwise::{
-    abs, add, clamp, compare, conj, div, maximum, minimum, mul, neg, scale, scale_complex, select,
-    sign,
+    abs, add, clamp, compare, conj, div, maximum, minimum, mul, neg, select, sign,
 };
 pub use indexing::{dynamic_slice, gather, pad, scatter};
 pub use reduction::{reduce_max, reduce_min, reduce_prod, reduce_sum};

--- a/tenferro-tensor/src/cuda/mod.rs
+++ b/tenferro-tensor/src/cuda/mod.rs
@@ -54,12 +54,6 @@ macro_rules! impl_stub_backend {
             fn clamp(&mut self, _input: &Tensor, _lower: &Tensor, _upper: &Tensor) -> Tensor {
                 todo!(concat!($label, " clamp"))
             }
-            fn scale(&mut self, _input: &Tensor, _factor: f64) -> Tensor {
-                todo!(concat!($label, " scale"))
-            }
-            fn scale_complex(&mut self, _input: &Tensor, _re: f64, _im: f64) -> Tensor {
-                todo!(concat!($label, " scale_complex"))
-            }
             fn exp(&mut self, _input: &Tensor) -> Tensor {
                 todo!(concat!($label, " exp"))
             }

--- a/tenferro-tensor/src/rocm/mod.rs
+++ b/tenferro-tensor/src/rocm/mod.rs
@@ -54,12 +54,6 @@ macro_rules! impl_stub_backend {
             fn clamp(&mut self, _input: &Tensor, _lower: &Tensor, _upper: &Tensor) -> Tensor {
                 todo!(concat!($label, " clamp"))
             }
-            fn scale(&mut self, _input: &Tensor, _factor: f64) -> Tensor {
-                todo!(concat!($label, " scale"))
-            }
-            fn scale_complex(&mut self, _input: &Tensor, _re: f64, _im: f64) -> Tensor {
-                todo!(concat!($label, " scale_complex"))
-            }
             fn exp(&mut self, _input: &Tensor) -> Tensor {
                 todo!(concat!($label, " exp"))
             }

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -9,8 +9,8 @@ use crate::config::{
 };
 use crate::cpu::{
     add, broadcast_in_dim, conj, dynamic_slice, embed_diagonal, extract_diagonal, gather, mul, neg,
-    pad, reduce_max, reduce_min, reduce_prod, reduce_sum, reshape, scale_complex, scatter,
-    transpose, tril, triu, CpuBackend,
+    pad, reduce_max, reduce_min, reduce_prod, reduce_sum, reshape, scatter, transpose, tril, triu,
+    CpuBackend,
 };
 use crate::types::{DType, Tensor, TypedTensor};
 
@@ -324,22 +324,64 @@ fn test_add_mul() {
 }
 
 #[test]
-fn test_scale_complex() {
-    let input = Tensor::C64(TypedTensor::from_vec(
-        vec![2],
-        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
-    ));
-    let output = scale_complex(&input, 2.0, -1.0);
+fn test_add_mul_rank0_broadcast() {
+    let scalar = Tensor::F64(TypedTensor::from_vec(vec![], vec![2.0]));
+    let tensor = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
 
-    assert_c64_close(get_c64(&output, &[0]), Complex64::new(4.0, 3.0));
-    assert_c64_close(get_c64(&output, &[1]), Complex64::new(-5.5, 4.0));
+    let scalar_plus_tensor = add(&scalar, &tensor);
+    let tensor_plus_scalar = add(&tensor, &scalar);
+    let scalar_times_tensor = mul(&scalar, &tensor);
+    let tensor_times_scalar = mul(&tensor, &scalar);
+
+    for actual in [&scalar_plus_tensor, &tensor_plus_scalar] {
+        assert_eq!(actual.shape(), &[2, 2]);
+        assert_eq!(get_f64(actual, &[0, 0]), 3.0);
+        assert_eq!(get_f64(actual, &[1, 0]), 4.0);
+        assert_eq!(get_f64(actual, &[0, 1]), 5.0);
+        assert_eq!(get_f64(actual, &[1, 1]), 6.0);
+    }
+
+    for actual in [&scalar_times_tensor, &tensor_times_scalar] {
+        assert_eq!(actual.shape(), &[2, 2]);
+        assert_eq!(get_f64(actual, &[0, 0]), 2.0);
+        assert_eq!(get_f64(actual, &[1, 0]), 4.0);
+        assert_eq!(get_f64(actual, &[0, 1]), 6.0);
+        assert_eq!(get_f64(actual, &[1, 1]), 8.0);
+    }
 }
 
 #[test]
-fn test_scale_complex_rejects_real_inputs() {
-    let input = Tensor::F64(TypedTensor::from_vec(vec![1], vec![2.0]));
-    let result = catch_unwind(AssertUnwindSafe(|| scale_complex(&input, 1.0, 1.0)));
-    assert!(result.is_err());
+fn test_mul_rank0_real_scalar_broadcasts_over_complex_tensor() {
+    let scalar = Tensor::F64(TypedTensor::from_vec(vec![], vec![2.0]));
+    let tensor = Tensor::C64(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
+    ));
+
+    let scalar_times_tensor = mul(&scalar, &tensor);
+    let tensor_times_scalar = mul(&tensor, &scalar);
+
+    for actual in [&scalar_times_tensor, &tensor_times_scalar] {
+        assert_eq!(actual.shape(), &[2]);
+        assert_c64_close(get_c64(actual, &[0]), Complex64::new(2.0, 4.0));
+        assert_c64_close(get_c64(actual, &[1]), Complex64::new(-6.0, 1.0));
+    }
+}
+
+#[test]
+fn test_mul_rank0_complex_scalar_broadcasts_over_complex_tensor() {
+    let scalar = Tensor::C64(TypedTensor::from_vec(
+        vec![],
+        vec![Complex64::new(2.0, -1.0)],
+    ));
+    let tensor = Tensor::C64(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
+    ));
+    let output = mul(&scalar, &tensor);
+
+    assert_c64_close(get_c64(&output, &[0]), Complex64::new(4.0, 3.0));
+    assert_c64_close(get_c64(&output, &[1]), Complex64::new(-5.5, 4.0));
 }
 
 #[test]

--- a/tenferro/src/compiler.rs
+++ b/tenferro/src/compiler.rs
@@ -61,10 +61,6 @@ pub fn lower_to_stablehlo(prog: &CompiledProgram<StdTensorOp>) -> StableHloProgr
                 StdTensorOp::Compare(dir) => StableHloOp::Compare(dir.clone()),
                 StdTensorOp::Select => StableHloOp::Select,
                 StdTensorOp::Clamp => StableHloOp::Clamp,
-                StdTensorOp::Scale { factor } => StableHloOp::Scale { factor: *factor },
-                StdTensorOp::ScaleComplex { re, im } => {
-                    StableHloOp::ScaleComplex { re: *re, im: *im }
-                }
                 StdTensorOp::Exp => StableHloOp::Exp,
                 StdTensorOp::Log => StableHloOp::Log,
                 StdTensorOp::Sin => StableHloOp::Sin,
@@ -225,8 +221,6 @@ pub fn compile_to_exec(stablehlo: &StableHloProgram) -> ExecProgram {
                 StableHloOp::Compare(dir) => ExecOp::Compare(dir.clone()),
                 StableHloOp::Select => ExecOp::Select,
                 StableHloOp::Clamp => ExecOp::Clamp,
-                StableHloOp::Scale { factor } => ExecOp::Scale { factor: *factor },
-                StableHloOp::ScaleComplex { re, im } => ExecOp::ScaleComplex { re: *re, im: *im },
                 StableHloOp::Constant { dtype, bytes } => ExecOp::Constant {
                     dtype: *dtype,
                     bytes: bytes.clone(),

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -56,13 +56,6 @@ pub enum ExecOp {
     Compare(CompareDir),
     Select,
     Clamp,
-    Scale {
-        factor: f64,
-    },
-    ScaleComplex {
-        re: f64,
-        im: f64,
-    },
     Exp,
     Log,
     Sin,
@@ -202,10 +195,6 @@ pub fn eval_exec_ir<B: TensorBackend>(
                 get(&slots, &inst.input_slots, 1),
                 get(&slots, &inst.input_slots, 2),
             ),
-            ExecOp::Scale { factor } => backend.scale(get(&slots, &inst.input_slots, 0), *factor),
-            ExecOp::ScaleComplex { re, im } => {
-                backend.scale_complex(get(&slots, &inst.input_slots, 0), *re, *im)
-            }
             ExecOp::Exp => backend.exp(get(&slots, &inst.input_slots, 0)),
             ExecOp::Log => backend.log(get(&slots, &inst.input_slots, 0)),
             ExecOp::Sin => backend.sin(get(&slots, &inst.input_slots, 0)),

--- a/tenferro/src/stablehlo.rs
+++ b/tenferro/src/stablehlo.rs
@@ -50,13 +50,6 @@ pub enum StableHloOp {
     Compare(CompareDir),
     Select,
     Clamp,
-    Scale {
-        factor: f64,
-    },
-    ScaleComplex {
-        re: f64,
-        im: f64,
-    },
     // Tier 2 analytic
     Exp,
     Log,

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -213,9 +213,10 @@ fn add_real_reduce_sum_loss(
         vec![ValRef::Local(input), ValRef::Local(conjugated[0])],
         OpMode::Primal,
     );
+    let half = builder.add_op(StdTensorOp::constant_f64(0.5), vec![], OpMode::Primal);
     let scaled = builder.add_op(
-        StdTensorOp::Scale { factor: 0.5 },
-        vec![ValRef::Local(summed[0])],
+        StdTensorOp::Mul,
+        vec![ValRef::Local(half[0]), ValRef::Local(summed[0])],
         OpMode::Primal,
     );
     builder.add_op(

--- a/tenferro/tests/compiler_wiring.rs
+++ b/tenferro/tests/compiler_wiring.rs
@@ -1,4 +1,5 @@
 use computegraph::compile::{CompiledProgram, Instruction};
+use num_complex::Complex64;
 use tenferro::compiler::{compile_to_exec, lower_to_stablehlo};
 use tenferro::exec::ExecOp;
 use tenferro::stablehlo::StableHloOp;
@@ -45,7 +46,7 @@ fn lower_to_stablehlo_and_compile_to_exec_wire_remaining_simple_ops() {
         make_instr(StdTensorOp::Reverse { axes: vec![0] }, vec![1], vec![7]),
         make_instr(StdTensorOp::Concatenate { axis: 0 }, vec![0, 1], vec![8]),
         make_instr(StdTensorOp::Tril { k: -1 }, vec![2], vec![9]),
-        make_instr(StdTensorOp::Scale { factor: 0.5 }, vec![0], vec![10]),
+        make_instr(StdTensorOp::Mul, vec![0, 1], vec![10]),
         make_instr(
             StdTensorOp::TriangularSolve {
                 left_side: true,
@@ -90,7 +91,7 @@ fn lower_to_stablehlo_and_compile_to_exec_wire_remaining_simple_ops() {
     ));
     assert!(matches!(
         stablehlo.instructions[7].op,
-        StableHloOp::Scale { factor } if factor == 0.5
+        StableHloOp::Multiply
     ));
     assert!(matches!(
         stablehlo.instructions[8].op,
@@ -132,10 +133,7 @@ fn lower_to_stablehlo_and_compile_to_exec_wire_remaining_simple_ops() {
         ExecOp::Concatenate { axis: 0 }
     ));
     assert!(matches!(exec.instructions[6].op, ExecOp::Tril { k: -1 }));
-    assert!(matches!(
-        exec.instructions[7].op,
-        ExecOp::Scale { factor } if factor == 0.5
-    ));
+    assert!(matches!(exec.instructions[7].op, ExecOp::Multiply));
     assert!(matches!(
         exec.instructions[8].op,
         ExecOp::TriangularSolve {
@@ -224,17 +222,18 @@ fn lower_to_stablehlo_and_compile_to_exec_wire_indexing_ops() {
 }
 
 #[test]
-fn lower_to_stablehlo_and_compile_to_exec_wire_constant_and_scale_complex_ops() {
+fn lower_to_stablehlo_and_compile_to_exec_wire_constant_ops() {
+    let complex = Complex64::new(1.0, -2.0);
+    let mut complex_bytes = Vec::new();
+    complex_bytes.extend_from_slice(&complex.re.to_le_bytes());
+    complex_bytes.extend_from_slice(&complex.im.to_le_bytes());
+
     let program = CompiledProgram {
         instructions: vec![
             make_instr(StdTensorOp::constant_f64(2.5), vec![], vec![1]),
-            make_instr(
-                StdTensorOp::ScaleComplex { re: 1.0, im: -2.0 },
-                vec![0],
-                vec![2],
-            ),
+            make_instr(StdTensorOp::constant_c64(complex), vec![], vec![2]),
         ],
-        input_slots: vec![0],
+        input_slots: vec![],
         output_slots: vec![1, 2],
         n_slots: 3,
     };
@@ -248,7 +247,7 @@ fn lower_to_stablehlo_and_compile_to_exec_wire_constant_and_scale_complex_ops() 
     assert!(stablehlo.instructions[0].input_slots.is_empty());
     assert!(matches!(
         stablehlo.instructions[1].op,
-        StableHloOp::ScaleComplex { re, im } if re == 1.0 && im == -2.0
+        StableHloOp::Constant { dtype: DType::C64, ref bytes } if bytes == &complex_bytes
     ));
 
     let exec = compile_to_exec(&stablehlo);
@@ -260,6 +259,6 @@ fn lower_to_stablehlo_and_compile_to_exec_wire_constant_and_scale_complex_ops() 
     assert!(exec.instructions[0].input_slots.is_empty());
     assert!(matches!(
         exec.instructions[1].op,
-        ExecOp::ScaleComplex { re, im } if re == 1.0 && im == -2.0
+        ExecOp::Constant { dtype: DType::C64, ref bytes } if bytes == &complex_bytes
     ));
 }

--- a/tenferro/tests/exec_dispatch.rs
+++ b/tenferro/tests/exec_dispatch.rs
@@ -121,12 +121,6 @@ impl TensorBackend for FakeTensorBackend {
     fn clamp(&mut self, _input: &Tensor, _lower: &Tensor, _upper: &Tensor) -> Tensor {
         self.result("clamp", 12.0)
     }
-    fn scale(&mut self, _input: &Tensor, _factor: f64) -> Tensor {
-        self.result("scale", 12.5)
-    }
-    fn scale_complex(&mut self, _input: &Tensor, _re: f64, _im: f64) -> Tensor {
-        self.result("scale_complex", 12.75)
-    }
     fn exp(&mut self, _input: &Tensor) -> Tensor {
         self.result("exp", 13.0)
     }
@@ -321,13 +315,6 @@ fn eval_exec_ir_dispatches_tensor_ops_to_backend_methods() {
         (ExecOp::Compare(CompareDir::Eq), 2, "compare", 10.0),
         (ExecOp::Select, 3, "select", 11.0),
         (ExecOp::Clamp, 3, "clamp", 12.0),
-        (ExecOp::Scale { factor: 0.5 }, 1, "scale", 12.5),
-        (
-            ExecOp::ScaleComplex { re: 0.5, im: -1.0 },
-            1,
-            "scale_complex",
-            12.75,
-        ),
         (ExecOp::Exp, 1, "exp", 13.0),
         (ExecOp::Log, 1, "log", 14.0),
         (ExecOp::Sin, 1, "sin", 15.0),


### PR DESCRIPTION
## Summary
- Remove `Scale { factor }` and `ScaleComplex { re, im }` from all IR layers
- AD rules now emit `Constant(f64) + Mul` instead of Scale
- CPU Mul/Add kernels handle rank-0 broadcasting (scalar * tensor)
- CPU Mul also handles real rank-0 * complex tensor (for AD rule compatibility)
- Net -205 lines (simpler, fewer ops)

Closes #635

## Test plan
- [x] All existing AD tests pass (Scale → Constant + Mul transparent)
- [x] Rank-0 broadcast in Mul/Add kernels
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)