### PR TITLE
feat: add EinsumCache for contraction path reuse (#625)

### DIFF
--- a/tenferro/src/einsum.rs
+++ b/tenferro/src/einsum.rs
@@ -242,14 +242,38 @@ pub fn einsum_with<B: TensorBackend>(
     subscripts: &str,
     optimize: EinsumOptimize,
 ) -> Result<TracedTensor> {
-    let _ = engine;
     let subs =
         Subscripts::parse(subscripts).map_err(|e| Error::InvalidSubscripts(format!("{e}")))?;
     let shapes: Vec<Vec<usize>> = inputs.iter().map(|t| t.shape.clone()).collect();
     let shape_refs: Vec<&[usize]> = shapes.iter().map(|s| s.as_slice()).collect();
 
-    let tree = resolve_strategy(optimize, &subs, &shape_refs)?;
-    Ok(build_traced_from_tree(inputs, &subs, &tree, &shapes))
+    match optimize {
+        // Reuse TreeSA results for repeated calls with the same equation and input shapes.
+        EinsumOptimize::Auto(opts) => {
+            let cache_key = (subscripts.to_string(), shapes.clone());
+            let tree = if let Some(cached) = engine.einsum_cache.get(&cache_key) {
+                cached.clone()
+            } else {
+                let tree = Arc::new(resolve_strategy(
+                    EinsumOptimize::Auto(opts),
+                    &subs,
+                    &shape_refs,
+                )?);
+                engine.einsum_cache.insert(cache_key, tree.clone());
+                tree
+            };
+            Ok(build_traced_from_tree(
+                inputs,
+                &subs,
+                tree.as_ref(),
+                &shapes,
+            ))
+        }
+        optimize => {
+            let tree = resolve_strategy(optimize, &subs, &shape_refs)?;
+            Ok(build_traced_from_tree(inputs, &subs, &tree, &shapes))
+        }
+    }
 }
 
 /// Resolve an [`EinsumOptimize`] strategy to a [`ContractionTree`].

--- a/tenferro/src/engine.rs
+++ b/tenferro/src/engine.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use super::buffer_pool::BufferPool;
 use super::exec::ExecProgram;
+use tenferro_einsum::ContractionTree;
 use tenferro_tensor::TensorBackend;
 
 /// Cache key derived from the compiled graph topology.
@@ -52,6 +54,7 @@ pub struct Engine<B: TensorBackend> {
     pub(crate) backend: B,
     pub(crate) compile_cache: HashMap<CacheKey, ExecProgram>,
     pub(crate) buffer_pool: BufferPool,
+    pub(crate) einsum_cache: HashMap<(String, Vec<Vec<usize>>), Arc<ContractionTree>>,
 }
 
 impl<B: TensorBackend> Engine<B> {
@@ -70,6 +73,7 @@ impl<B: TensorBackend> Engine<B> {
             backend,
             compile_cache: HashMap::new(),
             buffer_pool: BufferPool::new(),
+            einsum_cache: HashMap::new(),
         }
     }
 
@@ -85,6 +89,20 @@ impl<B: TensorBackend> Engine<B> {
     /// ```
     pub fn buffer_pool_len(&self) -> usize {
         self.buffer_pool.len()
+    }
+
+    /// Number of cached einsum contraction trees currently retained by the engine.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let engine = Engine::new(CpuBackend::new());
+    /// assert_eq!(engine.einsum_cache_len(), 0);
+    /// ```
+    pub fn einsum_cache_len(&self) -> usize {
+        self.einsum_cache.len()
     }
 
     /// Look up a cached ExecProgram, or cache and return the given one.

--- a/tenferro/tests/einsum.rs
+++ b/tenferro/tests/einsum.rs
@@ -249,6 +249,47 @@ fn einsum_matmul() {
 }
 
 #[test]
+fn einsum_cache_reuses_contraction_path() {
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let a = TracedTensor::from_tensor(f64_tensor(vec![3, 4], (1..=12).map(|x| x as f64).collect()));
+    let b = TracedTensor::from_tensor(f64_tensor(
+        vec![4, 5],
+        (1..=20).map(|x| (x * 2) as f64).collect(),
+    ));
+
+    let c1 = einsum(&mut engine, &[&a, &b], "ij,jk->ik").unwrap();
+    assert_eq!(c1.shape, vec![3, 5]);
+    assert_eq!(engine.einsum_cache_len(), 1);
+
+    let a2 = TracedTensor::from_tensor(f64_tensor(
+        vec![3, 4],
+        (21..=32).map(|x| x as f64).collect(),
+    ));
+    let b2 = TracedTensor::from_tensor(f64_tensor(
+        vec![4, 5],
+        (41..=60).map(|x| x as f64).collect(),
+    ));
+
+    let c2 = einsum(&mut engine, &[&a2, &b2], "ij,jk->ik").unwrap();
+    assert_eq!(c2.shape, vec![3, 5]);
+    assert_eq!(engine.einsum_cache_len(), 1);
+
+    let a3 = TracedTensor::from_tensor(f64_tensor(
+        vec![5, 6],
+        (1..=30).map(|x| (x as f64) / 10.0).collect(),
+    ));
+    let b3 = TracedTensor::from_tensor(f64_tensor(
+        vec![6, 7],
+        (1..=42).map(|x| (x as f64) / 5.0).collect(),
+    ));
+
+    let c3 = einsum(&mut engine, &[&a3, &b3], "ij,jk->ik").unwrap();
+    assert_eq!(c3.shape, vec![5, 7]);
+    assert_eq!(engine.einsum_cache_len(), 2);
+}
+
+#[test]
 fn einsum_outer_product() {
     // "i,j->ij"
     let u = f64_tensor(vec![2], vec![1.0, 2.0]);


### PR DESCRIPTION
## Summary
- Engine now caches contraction trees keyed by (subscripts, shapes)
- Repeated einsum calls with same subscripts/shapes skip TreeSA optimizer
- Uses `Arc<ContractionTree>` (ContractionTree is not Clone)

Closes #625

## Test plan
- [x] Cache reuses path for same subscripts+shapes
- [x] Different shapes create new cache entry
- [x] All existing einsum tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)