### PR TITLE
ci: split full PR tests to self-hosted workflow

### DIFF
--- a/.github/workflows/CI_rs_selfhost.yml
+++ b/.github/workflows/CI_rs_selfhost.yml
@@ -1,0 +1,46 @@
+name: CI_rs_selfhost
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # fork からの PR: GitHub-hosted runner で通常 CI
+  ci-fork:
+    name: CI (fork PR / github-hosted)
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Run unit and integration tests
+        run: cargo nextest run --workspace --release --no-fail-fast
+      - name: Run doc tests
+        run: cargo test --doc --workspace --release
+
+  # PRs from the same repository: run heavy CI on self-hosted runner
+  ci-maintainer:
+    name: CI (same-repo PR / self-hosted heavy)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux, x64]
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/../target
+      CARGO_PROFILE_RELEASE_DEBUG: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
+      - name: Run unit and integration tests
+        run: cargo nextest run --workspace --release --no-fail-fast
+      - name: Run doc tests
+        run: cargo test --doc --workspace --release

--- a/.github/workflows/CI_rs_selfhost.yml
+++ b/.github/workflows/CI_rs_selfhost.yml
@@ -44,3 +44,23 @@ jobs:
         run: cargo nextest run --workspace --release --no-fail-fast
       - name: Run doc tests
         run: cargo test --doc --workspace --release
+
+  # Single check for branch protection: passes when the one runnable path
+  # (fork = ci-fork, same-repo = ci-maintainer) succeeds; the other is skipped.
+  ci-gate:
+    name: CI gate (PR workspace tests)
+    needs: [ci-fork, ci-maintainer]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require fork or same-repo workspace CI
+        env:
+          FORK_RESULT: ${{ needs.ci-fork.result }}
+          MAINTAINER_RESULT: ${{ needs.ci-maintainer.result }}
+        run: |
+          set -euo pipefail
+          if [ "$FORK_RESULT" = "success" ] || [ "$MAINTAINER_RESULT" = "success" ]; then
+            exit 0
+          fi
+          echo "Expected ci-fork or ci-maintainer to succeed; got ci-fork=$FORK_RESULT ci-maintainer=$MAINTAINER_RESULT"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,18 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all --check
 
-  test-workspace:
-    name: cargo test (workspace)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@nextest
-      - name: Run unit and integration tests
-        run: cargo nextest run --workspace --release --no-fail-fast
-      - name: Run doc tests
-        run: cargo test --doc --workspace --release
+  # test-workspace:
+  #   name: cargo test (workspace)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - uses: Swatinem/rust-cache@v2
+  #     - uses: taiki-e/install-action@nextest
+  #     - name: Run unit and integration tests
+  #       run: cargo nextest run --workspace --release --no-fail-fast
+  #     - name: Run doc tests
+  #       run: cargo test --doc --workspace --release
 
   test-inject-blas:
     name: cargo test (blas inject)


### PR DESCRIPTION
## Summary

- **`ci.yml`**: Disable the default GitHub-hosted `test-workspace` job (commented out). The main workflow still runs rustfmt, BLAS inject tests, coverage, and the docs site build on `ubuntu-latest`.
- **`CI_rs_selfhost.yml`** (new): On pull requests to `main`, run full `cargo nextest` plus `cargo test --doc` on GitHub-hosted runners for fork PRs, and on self-hosted runners for same-repo PRs (shared `CARGO_TARGET_DIR`, `checkout@v6`).

## Rationale

Heavy workspace tests move off the default CI path for PRs while keeping inject/coverage/docs checks in the standard workflow; maintainers get faster repeat builds via the self-hosted cache layout.

Made with [Cursor](https://cursor.com)