### PR TITLE
[codex] Propagate runtime errors through backend execution

### DIFF
--- a/tenferro-tensor/Cargo.toml
+++ b/tenferro-tensor/Cargo.toml
@@ -25,6 +25,7 @@ num-complex.workspace = true
 rayon = "1"
 tenferro-algebra = { path = "../tenferro-algebra" }
 strided-kernel.workspace = true
+thiserror.workspace = true
 faer = { workspace = true, optional = true }
 cblas-sys = { workspace = true, optional = true }
 cblas-inject = { workspace = true, optional = true }

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -37,62 +37,96 @@ pub(crate) fn tensor_from_array<T: Clone>(array: StridedArray<T>) -> TypedTensor
 /// let mut backend = CpuBackend::new();
 /// ```
 pub trait TensorBackend {
-    fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor;
-    fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor;
-    fn neg(&mut self, input: &Tensor) -> Tensor;
-    fn conj(&mut self, input: &Tensor) -> Tensor;
-    fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor;
-    fn abs(&mut self, input: &Tensor) -> Tensor;
-    fn sign(&mut self, input: &Tensor) -> Tensor;
-    fn maximum(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor;
-    fn minimum(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor;
-    fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> Tensor;
-    fn select(&mut self, pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> Tensor;
-    fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> Tensor;
+    fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    fn neg(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    fn abs(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn sign(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn maximum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    fn minimum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor>;
+    fn select(
+        &mut self,
+        pred: &Tensor,
+        on_true: &Tensor,
+        on_false: &Tensor,
+    ) -> crate::Result<Tensor>;
+    fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor>;
 
-    fn exp(&mut self, input: &Tensor) -> Tensor;
-    fn log(&mut self, input: &Tensor) -> Tensor;
-    fn sin(&mut self, input: &Tensor) -> Tensor;
-    fn cos(&mut self, input: &Tensor) -> Tensor;
-    fn tanh(&mut self, input: &Tensor) -> Tensor;
-    fn sqrt(&mut self, input: &Tensor) -> Tensor;
-    fn rsqrt(&mut self, input: &Tensor) -> Tensor;
-    fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor;
-    fn expm1(&mut self, input: &Tensor) -> Tensor;
-    fn log1p(&mut self, input: &Tensor) -> Tensor;
+    fn exp(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn log(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn sin(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn cos(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn tanh(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn sqrt(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn rsqrt(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    fn expm1(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    fn log1p(&mut self, input: &Tensor) -> crate::Result<Tensor>;
 
-    fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> Tensor;
-    fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> Tensor;
-    fn broadcast_in_dim(&mut self, input: &Tensor, shape: &[usize], dims: &[usize]) -> Tensor;
-    fn convert(&mut self, input: &Tensor, to: crate::DType) -> Tensor;
-    fn extract_diagonal(&mut self, input: &Tensor, axis_a: usize, axis_b: usize) -> Tensor;
-    fn embed_diagonal(&mut self, input: &Tensor, axis_a: usize, axis_b: usize) -> Tensor;
-    fn tril(&mut self, input: &Tensor, k: i64) -> Tensor;
-    fn triu(&mut self, input: &Tensor, k: i64) -> Tensor;
+    fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor>;
+    fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor>;
+    fn broadcast_in_dim(
+        &mut self,
+        input: &Tensor,
+        shape: &[usize],
+        dims: &[usize],
+    ) -> crate::Result<Tensor>;
+    fn convert(&mut self, input: &Tensor, to: crate::DType) -> crate::Result<Tensor>;
+    fn extract_diagonal(
+        &mut self,
+        input: &Tensor,
+        axis_a: usize,
+        axis_b: usize,
+    ) -> crate::Result<Tensor>;
+    fn embed_diagonal(
+        &mut self,
+        input: &Tensor,
+        axis_a: usize,
+        axis_b: usize,
+    ) -> crate::Result<Tensor>;
+    fn tril(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor>;
+    fn triu(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor>;
 
-    fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> Tensor;
-    fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> Tensor;
-    fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> Tensor;
-    fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> Tensor;
+    fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+    fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+    fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+    fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
 
-    fn dot_general(&mut self, lhs: &Tensor, rhs: &Tensor, config: &DotGeneralConfig) -> Tensor;
+    fn dot_general(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor>;
 
-    fn gather(&mut self, operand: &Tensor, start_indices: &Tensor, config: &GatherConfig)
-        -> Tensor;
+    fn gather(
+        &mut self,
+        operand: &Tensor,
+        start_indices: &Tensor,
+        config: &GatherConfig,
+    ) -> crate::Result<Tensor>;
     fn scatter(
         &mut self,
         operand: &Tensor,
         scatter_indices: &Tensor,
         updates: &Tensor,
         config: &ScatterConfig,
-    ) -> Tensor;
-    fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> Tensor;
-    fn dynamic_slice(&mut self, input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> Tensor;
-    fn pad(&mut self, input: &Tensor, config: &PadConfig) -> Tensor;
-    fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> Tensor;
-    fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> Tensor;
+    ) -> crate::Result<Tensor>;
+    fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor>;
+    fn dynamic_slice(
+        &mut self,
+        input: &Tensor,
+        starts: &Tensor,
+        slice_sizes: &[usize],
+    ) -> crate::Result<Tensor>;
+    fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
+    fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;
+    fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
 
-    fn cholesky(&mut self, input: &Tensor) -> Tensor;
+    fn cholesky(&mut self, input: &Tensor) -> crate::Result<Tensor>;
     fn triangular_solve(
         &mut self,
         a: &Tensor,
@@ -101,13 +135,13 @@ pub trait TensorBackend {
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-    ) -> Tensor;
-    fn lu(&mut self, input: &Tensor) -> Vec<Tensor>;
-    fn svd(&mut self, input: &Tensor) -> Vec<Tensor>;
-    fn qr(&mut self, input: &Tensor) -> Vec<Tensor>;
-    fn eigh(&mut self, input: &Tensor) -> Vec<Tensor>;
-    fn eig(&mut self, input: &Tensor) -> Vec<Tensor>;
-    fn solve(&mut self, a: &Tensor, b: &Tensor) -> Tensor;
+    ) -> crate::Result<Tensor>;
+    fn lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
+    fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
+    fn qr(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
+    fn eigh(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
+    fn eig(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
+    fn solve(&mut self, a: &Tensor, b: &Tensor) -> crate::Result<Tensor>;
 }
 
 /// Algebra-generic backend over typed tensors.
@@ -128,13 +162,13 @@ pub trait SemiringBackend<Alg: Semiring> {
         lhs: &TypedTensor<Alg::Scalar>,
         rhs: &TypedTensor<Alg::Scalar>,
         config: &DotGeneralConfig,
-    ) -> TypedTensor<Alg::Scalar>;
+    ) -> crate::Result<TypedTensor<Alg::Scalar>>;
 
     fn add(
         &mut self,
         lhs: &TypedTensor<Alg::Scalar>,
         rhs: &TypedTensor<Alg::Scalar>,
-    ) -> TypedTensor<Alg::Scalar> {
+    ) -> crate::Result<TypedTensor<Alg::Scalar>> {
         assert_eq!(lhs.shape, rhs.shape, "add: shape mismatch");
         let mut out = typed_array(&lhs.shape, Alg::zero());
         zip_map2_into(
@@ -144,14 +178,14 @@ pub trait SemiringBackend<Alg: Semiring> {
             |x, y| Alg::add(x, y),
         )
         .expect("semiring add");
-        tensor_from_array(out)
+        Ok(tensor_from_array(out))
     }
 
     fn mul(
         &mut self,
         lhs: &TypedTensor<Alg::Scalar>,
         rhs: &TypedTensor<Alg::Scalar>,
-    ) -> TypedTensor<Alg::Scalar> {
+    ) -> crate::Result<TypedTensor<Alg::Scalar>> {
         assert_eq!(lhs.shape, rhs.shape, "mul: shape mismatch");
         let mut out = typed_array(&lhs.shape, Alg::zero());
         zip_map2_into(
@@ -161,16 +195,16 @@ pub trait SemiringBackend<Alg: Semiring> {
             |x, y| Alg::mul(x, y),
         )
         .expect("semiring mul");
-        tensor_from_array(out)
+        Ok(tensor_from_array(out))
     }
 
     fn reduce_sum(
         &mut self,
         input: &TypedTensor<Alg::Scalar>,
         axes: &[usize],
-    ) -> TypedTensor<Alg::Scalar> {
+    ) -> crate::Result<TypedTensor<Alg::Scalar>> {
         if axes.is_empty() {
-            return input.clone();
+            return Ok(input.clone());
         }
 
         let output_shape: Vec<usize> = input
@@ -198,6 +232,6 @@ pub trait SemiringBackend<Alg: Semiring> {
             )
             .expect("semiring reduce_sum");
         }
-        TypedTensor::from_vec(output_shape, current.into_data())
+        Ok(TypedTensor::from_vec(output_shape, current.into_data()))
     }
 }

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -27,6 +27,43 @@ pub(crate) fn tensor_from_array<T: Clone>(array: StridedArray<T>) -> TypedTensor
     TypedTensor::from_vec(array.dims().to_vec(), array.into_data())
 }
 
+fn backend_failure(op: &'static str, err: impl ToString) -> crate::Error {
+    crate::Error::BackendFailure {
+        op,
+        message: err.to_string(),
+    }
+}
+
+fn validate_axis_list(
+    op: &'static str,
+    role: &'static str,
+    axes: &[usize],
+    rank: usize,
+) -> crate::Result<()> {
+    let mut seen = vec![false; rank];
+    for &axis in axes {
+        if axis >= rank {
+            return Err(crate::Error::AxisOutOfBounds { op, axis, rank });
+        }
+        if seen[axis] {
+            return Err(crate::Error::DuplicateAxis { op, axis, role });
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn validate_binary_shapes(op: &'static str, lhs: &[usize], rhs: &[usize]) -> crate::Result<()> {
+    if lhs != rhs {
+        return Err(crate::Error::ShapeMismatch {
+            op,
+            lhs: lhs.to_vec(),
+            rhs: rhs.to_vec(),
+        });
+    }
+    Ok(())
+}
+
 /// Standard runtime backend over dynamic [`Tensor`] values.
 ///
 /// # Examples
@@ -169,7 +206,7 @@ pub trait SemiringBackend<Alg: Semiring> {
         lhs: &TypedTensor<Alg::Scalar>,
         rhs: &TypedTensor<Alg::Scalar>,
     ) -> crate::Result<TypedTensor<Alg::Scalar>> {
-        assert_eq!(lhs.shape, rhs.shape, "add: shape mismatch");
+        validate_binary_shapes("add", &lhs.shape, &rhs.shape)?;
         let mut out = typed_array(&lhs.shape, Alg::zero());
         zip_map2_into(
             &mut out.view_mut(),
@@ -177,7 +214,7 @@ pub trait SemiringBackend<Alg: Semiring> {
             &typed_view(rhs),
             |x, y| Alg::add(x, y),
         )
-        .expect("semiring add");
+        .map_err(|err| backend_failure("add", err))?;
         Ok(tensor_from_array(out))
     }
 
@@ -186,7 +223,7 @@ pub trait SemiringBackend<Alg: Semiring> {
         lhs: &TypedTensor<Alg::Scalar>,
         rhs: &TypedTensor<Alg::Scalar>,
     ) -> crate::Result<TypedTensor<Alg::Scalar>> {
-        assert_eq!(lhs.shape, rhs.shape, "mul: shape mismatch");
+        validate_binary_shapes("mul", &lhs.shape, &rhs.shape)?;
         let mut out = typed_array(&lhs.shape, Alg::zero());
         zip_map2_into(
             &mut out.view_mut(),
@@ -194,7 +231,7 @@ pub trait SemiringBackend<Alg: Semiring> {
             &typed_view(rhs),
             |x, y| Alg::mul(x, y),
         )
-        .expect("semiring mul");
+        .map_err(|err| backend_failure("mul", err))?;
         Ok(tensor_from_array(out))
     }
 
@@ -203,6 +240,7 @@ pub trait SemiringBackend<Alg: Semiring> {
         input: &TypedTensor<Alg::Scalar>,
         axes: &[usize],
     ) -> crate::Result<TypedTensor<Alg::Scalar>> {
+        validate_axis_list("reduce_sum", "axes", axes, input.shape.len())?;
         if axes.is_empty() {
             return Ok(input.clone());
         }
@@ -218,7 +256,7 @@ pub trait SemiringBackend<Alg: Semiring> {
         let strides = col_major_strides(&input.shape);
         let mut current =
             StridedArray::from_parts(input.host_data().to_vec(), &input.shape, &strides, 0)
-                .expect("semiring reduce input");
+                .map_err(|err| backend_failure("reduce_sum", err))?;
 
         let mut sorted_axes = axes.to_vec();
         sorted_axes.sort_unstable_by(|a, b| b.cmp(a));
@@ -230,7 +268,7 @@ pub trait SemiringBackend<Alg: Semiring> {
                 |a, b| Alg::add(a, b),
                 Alg::zero(),
             )
-            .expect("semiring reduce_sum");
+            .map_err(|err| backend_failure("reduce_sum", err))?;
         }
         Ok(TypedTensor::from_vec(output_shape, current.into_data()))
     }

--- a/tenferro-tensor/src/cpu/analytic.rs
+++ b/tenferro-tensor/src/cpu/analytic.rs
@@ -3,7 +3,7 @@ use num_traits::{One, Zero};
 use strided_kernel::{map_into, zip_map2_into};
 
 use crate::backend::{tensor_from_array, typed_array, typed_view};
-use crate::types::{dispatch_binary, dispatch_tensor, Tensor, TypedTensor};
+use crate::types::{Tensor, TypedTensor};
 
 trait UnaryAnalyticElem: Copy + Clone + One + Zero {
     fn exp_elem(self) -> Self;
@@ -122,20 +122,32 @@ impl_real_analytic_elem!(f64);
 impl_complex_analytic_elem!(Complex32);
 impl_complex_analytic_elem!(Complex64);
 
+fn backend_failure(op: &'static str, err: impl ToString) -> crate::Error {
+    crate::Error::BackendFailure {
+        op,
+        message: err.to_string(),
+    }
+}
+
 macro_rules! define_unary_analytic_op {
     ($dispatch_fn:ident, $typed_fn:ident, $elem_fn:ident) => {
-        pub fn $dispatch_fn(input: &Tensor) -> Tensor {
-            dispatch_tensor!(input, t => $typed_fn(t))
+        pub fn $dispatch_fn(input: &Tensor) -> crate::Result<Tensor> {
+            match input {
+                Tensor::F32(t) => Ok(Tensor::F32($typed_fn(t)?)),
+                Tensor::F64(t) => Ok(Tensor::F64($typed_fn(t)?)),
+                Tensor::C32(t) => Ok(Tensor::C32($typed_fn(t)?)),
+                Tensor::C64(t) => Ok(Tensor::C64($typed_fn(t)?)),
+            }
         }
 
-        fn $typed_fn<T>(input: &TypedTensor<T>) -> TypedTensor<T>
+        fn $typed_fn<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
         where
             T: UnaryAnalyticElem,
         {
             let mut out = typed_array(&input.shape, T::zero());
             map_into(&mut out.view_mut(), &typed_view(input), |x| x.$elem_fn())
-                .expect(stringify!($typed_fn));
-            tensor_from_array(out)
+                .map_err(|err| backend_failure(stringify!($typed_fn), err))?;
+            Ok(tensor_from_array(out))
         }
     };
 }
@@ -150,15 +162,31 @@ define_unary_analytic_op!(rsqrt, typed_rsqrt, rsqrt_elem);
 define_unary_analytic_op!(expm1, typed_expm1, expm1_elem);
 define_unary_analytic_op!(log1p, typed_log1p, log1p_elem);
 
-pub fn pow(lhs: &Tensor, rhs: &Tensor) -> Tensor {
-    dispatch_binary!(lhs, rhs, |a, b| typed_pow(a, b))
+pub fn pow(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    match (lhs, rhs) {
+        (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_pow(a, b)?)),
+        (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_pow(a, b)?)),
+        (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_pow(a, b)?)),
+        (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_pow(a, b)?)),
+        _ => Err(crate::Error::DTypeMismatch {
+            op: "pow",
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        }),
+    }
 }
 
-fn typed_pow<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> TypedTensor<T>
+fn typed_pow<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
     T: PowElem,
 {
-    assert_eq!(lhs.shape, rhs.shape, "pow: shape mismatch");
+    if lhs.shape != rhs.shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "pow",
+            lhs: lhs.shape.clone(),
+            rhs: rhs.shape.clone(),
+        });
+    }
     let mut out = typed_array(&lhs.shape, T::zero());
     zip_map2_into(
         &mut out.view_mut(),
@@ -166,6 +194,6 @@ where
         &typed_view(rhs),
         |x, y| x.pow_elem(y),
     )
-    .expect("typed_pow");
-    tensor_from_array(out)
+    .map_err(|err| backend_failure("pow", err))?;
+    Ok(tensor_from_array(out))
 }

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -118,144 +118,169 @@ impl CpuBackend {
 }
 
 impl TensorBackend for CpuBackend {
-    fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
-        self.install(|| elementwise::add(lhs, rhs))
+    fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::add(lhs, rhs)))
     }
 
-    fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
-        self.install(|| elementwise::mul(lhs, rhs))
+    fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::mul(lhs, rhs)))
     }
 
-    fn neg(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| elementwise::neg(input))
+    fn neg(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::neg(input)))
     }
 
-    fn conj(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| elementwise::conj(input))
+    fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::conj(input)))
     }
 
-    fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
-        self.install(|| elementwise::div(lhs, rhs))
+    fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::div(lhs, rhs)))
     }
 
-    fn abs(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| elementwise::abs(input))
+    fn abs(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::abs(input)))
     }
 
-    fn sign(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| elementwise::sign(input))
+    fn sign(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::sign(input)))
     }
 
-    fn maximum(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
-        self.install(|| elementwise::maximum(lhs, rhs))
+    fn maximum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::maximum(lhs, rhs)))
     }
 
-    fn minimum(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
-        self.install(|| elementwise::minimum(lhs, rhs))
+    fn minimum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::minimum(lhs, rhs)))
     }
 
-    fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> Tensor {
-        self.install(|| elementwise::compare(lhs, rhs, dir))
+    fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::compare(lhs, rhs, dir)))
     }
 
-    fn select(&mut self, pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> Tensor {
-        self.install(|| elementwise::select(pred, on_true, on_false))
+    fn select(
+        &mut self,
+        pred: &Tensor,
+        on_true: &Tensor,
+        on_false: &Tensor,
+    ) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::select(pred, on_true, on_false)))
     }
 
-    fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> Tensor {
-        self.install(|| elementwise::clamp(input, lower, upper))
+    fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| elementwise::clamp(input, lower, upper)))
     }
 
-    fn exp(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| analytic::exp(input))
+    fn exp(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| analytic::exp(input)))
     }
 
-    fn log(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| analytic::log(input))
+    fn log(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| analytic::log(input)))
     }
 
-    fn sin(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| analytic::sin(input))
+    fn sin(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| analytic::sin(input)))
     }
 
-    fn cos(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| analytic::cos(input))
+    fn cos(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| analytic::cos(input)))
     }
 
-    fn tanh(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| analytic::tanh(input))
+    fn tanh(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| analytic::tanh(input)))
     }
 
-    fn sqrt(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| analytic::sqrt(input))
+    fn sqrt(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| analytic::sqrt(input)))
     }
 
-    fn rsqrt(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| analytic::rsqrt(input))
+    fn rsqrt(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| analytic::rsqrt(input)))
     }
 
-    fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
-        self.install(|| analytic::pow(lhs, rhs))
+    fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| analytic::pow(lhs, rhs)))
     }
 
-    fn expm1(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| analytic::expm1(input))
+    fn expm1(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| analytic::expm1(input)))
     }
 
-    fn log1p(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| analytic::log1p(input))
+    fn log1p(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| analytic::log1p(input)))
     }
 
-    fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> Tensor {
-        self.install(|| structural::transpose(input, perm))
+    fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
+        Ok(self.install(|| structural::transpose(input, perm)))
     }
 
-    fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> Tensor {
-        self.install(|| structural::reshape(input, shape))
+    fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
+        Ok(self.install(|| structural::reshape(input, shape)))
     }
 
-    fn broadcast_in_dim(&mut self, input: &Tensor, shape: &[usize], dims: &[usize]) -> Tensor {
-        self.install(|| structural::broadcast_in_dim(input, shape, dims))
+    fn broadcast_in_dim(
+        &mut self,
+        input: &Tensor,
+        shape: &[usize],
+        dims: &[usize],
+    ) -> crate::Result<Tensor> {
+        Ok(self.install(|| structural::broadcast_in_dim(input, shape, dims)))
     }
 
-    fn convert(&mut self, input: &Tensor, to: crate::DType) -> Tensor {
-        self.install(|| structural::convert(input, to))
+    fn convert(&mut self, input: &Tensor, to: crate::DType) -> crate::Result<Tensor> {
+        Ok(self.install(|| structural::convert(input, to)))
     }
 
-    fn extract_diagonal(&mut self, input: &Tensor, axis_a: usize, axis_b: usize) -> Tensor {
-        self.install(|| structural::extract_diagonal(input, axis_a, axis_b))
+    fn extract_diagonal(
+        &mut self,
+        input: &Tensor,
+        axis_a: usize,
+        axis_b: usize,
+    ) -> crate::Result<Tensor> {
+        Ok(self.install(|| structural::extract_diagonal(input, axis_a, axis_b)))
     }
 
-    fn embed_diagonal(&mut self, input: &Tensor, axis_a: usize, axis_b: usize) -> Tensor {
-        self.install(|| structural::embed_diagonal(input, axis_a, axis_b))
+    fn embed_diagonal(
+        &mut self,
+        input: &Tensor,
+        axis_a: usize,
+        axis_b: usize,
+    ) -> crate::Result<Tensor> {
+        Ok(self.install(|| structural::embed_diagonal(input, axis_a, axis_b)))
     }
 
-    fn tril(&mut self, input: &Tensor, k: i64) -> Tensor {
-        self.install(|| structural::tril(input, k))
+    fn tril(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor> {
+        Ok(self.install(|| structural::tril(input, k)))
     }
 
-    fn triu(&mut self, input: &Tensor, k: i64) -> Tensor {
-        self.install(|| structural::triu(input, k))
+    fn triu(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor> {
+        Ok(self.install(|| structural::triu(input, k)))
     }
 
-    fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> Tensor {
-        self.install(|| reduction::reduce_sum(input, axes))
+    fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+        Ok(self.install(|| reduction::reduce_sum(input, axes)))
     }
 
-    fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> Tensor {
-        self.install(|| reduction::reduce_prod(input, axes))
+    fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+        Ok(self.install(|| reduction::reduce_prod(input, axes)))
     }
 
-    fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> Tensor {
-        self.install(|| reduction::reduce_max(input, axes))
+    fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+        Ok(self.install(|| reduction::reduce_max(input, axes)))
     }
 
-    fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> Tensor {
-        self.install(|| reduction::reduce_min(input, axes))
+    fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+        Ok(self.install(|| reduction::reduce_min(input, axes)))
     }
 
-    fn dot_general(&mut self, lhs: &Tensor, rhs: &Tensor, config: &DotGeneralConfig) -> Tensor {
-        self.install(|| dispatch_binary!(lhs, rhs, |a, b| gemm::dot_general(a, b, config)))
+    fn dot_general(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        Ok(self.install(|| dispatch_binary!(lhs, rhs, |a, b| gemm::dot_general(a, b, config))))
     }
 
     fn gather(
@@ -263,8 +288,8 @@ impl TensorBackend for CpuBackend {
         operand: &Tensor,
         start_indices: &Tensor,
         config: &GatherConfig,
-    ) -> Tensor {
-        self.install(|| indexing::gather(operand, start_indices, config))
+    ) -> crate::Result<Tensor> {
+        Ok(self.install(|| indexing::gather(operand, start_indices, config)))
     }
 
     fn scatter(
@@ -273,37 +298,42 @@ impl TensorBackend for CpuBackend {
         scatter_indices: &Tensor,
         updates: &Tensor,
         config: &ScatterConfig,
-    ) -> Tensor {
-        self.install(|| indexing::scatter(operand, scatter_indices, updates, config))
+    ) -> crate::Result<Tensor> {
+        Ok(self.install(|| indexing::scatter(operand, scatter_indices, updates, config)))
     }
 
-    fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> Tensor {
-        self.install(|| indexing::slice(input, config))
+    fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> {
+        Ok(self.install(|| indexing::slice(input, config)))
     }
 
-    fn dynamic_slice(&mut self, input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> Tensor {
-        self.install(|| indexing::dynamic_slice(input, starts, slice_sizes))
+    fn dynamic_slice(
+        &mut self,
+        input: &Tensor,
+        starts: &Tensor,
+        slice_sizes: &[usize],
+    ) -> crate::Result<Tensor> {
+        Ok(self.install(|| indexing::dynamic_slice(input, starts, slice_sizes)))
     }
 
-    fn pad(&mut self, input: &Tensor, config: &PadConfig) -> Tensor {
-        self.install(|| indexing::pad(input, config))
+    fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
+        Ok(self.install(|| indexing::pad(input, config)))
     }
 
-    fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> Tensor {
-        self.install(|| indexing::concatenate(inputs, axis))
+    fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
+        Ok(self.install(|| indexing::concatenate(inputs, axis)))
     }
 
-    fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> Tensor {
-        self.install(|| indexing::reverse(input, axes))
+    fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+        Ok(self.install(|| indexing::reverse(input, axes)))
     }
 
-    fn cholesky(&mut self, input: &Tensor) -> Tensor {
-        self.install(|| match input {
+    fn cholesky(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        Ok(self.install(|| match input {
             Tensor::F64(t) => Tensor::F64(linalg::cholesky(t)),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => Tensor::C64(linalg::cholesky(t)),
             _ => todo!("cholesky: unsupported dtype"),
-        })
+        }))
     }
 
     fn triangular_solve(
@@ -314,8 +344,8 @@ impl TensorBackend for CpuBackend {
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-    ) -> Tensor {
-        self.install(|| match (a, b) {
+    ) -> crate::Result<Tensor> {
+        Ok(self.install(|| match (a, b) {
             (Tensor::F64(a), Tensor::F64(b)) => Tensor::F64(linalg::triangular_solve(
                 a,
                 b,
@@ -334,73 +364,76 @@ impl TensorBackend for CpuBackend {
                 unit_diagonal,
             )),
             _ => todo!("triangular_solve: unsupported dtype"),
-        })
+        }))
     }
 
-    fn lu(&mut self, input: &Tensor) -> Vec<Tensor> {
-        self.install(|| match input {
+    fn lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        Ok(self.install(|| match input {
             Tensor::F64(t) => linalg::lu(t).into_iter().map(Tensor::F64).collect(),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => linalg::lu(t).into_iter().map(Tensor::C64).collect(),
             _ => todo!("lu: unsupported dtype"),
-        })
+        }))
     }
 
-    fn svd(&mut self, input: &Tensor) -> Vec<Tensor> {
-        self.install(|| match input {
+    fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        Ok(self.install(|| match input {
             Tensor::F64(t) => linalg::svd(t).into_iter().map(Tensor::F64).collect(),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => linalg::svd(t).into_iter().map(Tensor::C64).collect(),
             _ => todo!("svd: unsupported dtype"),
-        })
+        }))
     }
 
-    fn qr(&mut self, input: &Tensor) -> Vec<Tensor> {
-        self.install(|| match input {
+    fn qr(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        Ok(self.install(|| match input {
             Tensor::F64(t) => linalg::qr(t).into_iter().map(Tensor::F64).collect(),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => linalg::qr(t).into_iter().map(Tensor::C64).collect(),
             _ => todo!("qr: unsupported dtype"),
-        })
+        }))
     }
 
-    fn eigh(&mut self, input: &Tensor) -> Vec<Tensor> {
-        self.install(|| match input {
+    fn eigh(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        Ok(self.install(|| match input {
             Tensor::F64(t) => linalg::eigh(t).into_iter().map(Tensor::F64).collect(),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => linalg::eigh(t).into_iter().map(Tensor::C64).collect(),
             _ => todo!("eigh: unsupported dtype"),
-        })
+        }))
     }
 
-    fn eig(&mut self, input: &Tensor) -> Vec<Tensor> {
-        self.install(|| linalg::eig(input))
+    fn eig(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        Ok(self.install(|| linalg::eig(input)))
     }
 
-    fn solve(&mut self, a: &Tensor, b: &Tensor) -> Tensor {
+    fn solve(&mut self, a: &Tensor, b: &Tensor) -> crate::Result<Tensor> {
         if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
-            return zeros_like_tensor(b);
+            return Ok(zeros_like_tensor(b));
         }
 
         let (rhs, restore_shape) = if let Some(matrix_rhs_shape) = batched_vector_rhs_shape(a, b) {
-            (self.reshape(b, &matrix_rhs_shape), Some(b.shape().to_vec()))
+            (
+                self.reshape(b, &matrix_rhs_shape)?,
+                Some(b.shape().to_vec()),
+            )
         } else {
             (b.clone(), None)
         };
 
-        let outputs = self.lu(a);
+        let outputs = self.lu(a)?;
         let p = &outputs[0];
         let l = &outputs[1];
         let u = &outputs[2];
         assert_nonsingular_u(u);
 
-        let pb = matmul_preserve_trailing_batch(self, p, &rhs);
-        let z = self.triangular_solve(l, &pb, true, true, false, true);
-        let x = self.triangular_solve(u, &z, true, false, false, false);
+        let pb = matmul_preserve_trailing_batch(self, p, &rhs)?;
+        let z = self.triangular_solve(l, &pb, true, true, false, true)?;
+        let x = self.triangular_solve(u, &z, true, false, false, false)?;
         if let Some(shape) = restore_shape {
             self.reshape(&x, &shape)
         } else {
-            x
+            Ok(x)
         }
     }
 }
@@ -427,7 +460,11 @@ fn batched_vector_rhs_shape(a: &Tensor, b: &Tensor) -> Option<Vec<usize>> {
     Some(rhs_shape)
 }
 
-fn matmul_preserve_trailing_batch(backend: &mut CpuBackend, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+fn matmul_preserve_trailing_batch(
+    backend: &mut CpuBackend,
+    lhs: &Tensor,
+    rhs: &Tensor,
+) -> crate::Result<Tensor> {
     let rank = lhs.shape().len();
     let batch_dims: Vec<usize> = (2..rank).collect();
     backend.dot_general(
@@ -494,8 +531,8 @@ impl<Alg: Semiring> SemiringBackend<Alg> for CpuBackend {
         lhs: &TypedTensor<Alg::Scalar>,
         rhs: &TypedTensor<Alg::Scalar>,
         config: &DotGeneralConfig,
-    ) -> TypedTensor<Alg::Scalar> {
-        self.install(|| {
+    ) -> crate::Result<TypedTensor<Alg::Scalar>> {
+        Ok(self.install(|| {
             assert_eq!(
                 config.lhs_contracting_dims.len(),
                 config.rhs_contracting_dims.len()
@@ -581,7 +618,7 @@ impl<Alg: Semiring> SemiringBackend<Alg> for CpuBackend {
             }
 
             result
-        })
+        }))
     }
 }
 

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -1,4 +1,6 @@
+use std::any::Any;
 use std::collections::HashMap;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use tenferro_algebra::Semiring;
@@ -7,7 +9,7 @@ use crate::backend::{SemiringBackend, TensorBackend};
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use crate::types::{dispatch_binary, flat_to_multi};
+use crate::types::flat_to_multi;
 use crate::{Tensor, TypedTensor};
 
 use super::{analytic, elementwise, gemm, indexing, linalg, reduction, structural};
@@ -119,43 +121,43 @@ impl CpuBackend {
 
 impl TensorBackend for CpuBackend {
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::add(lhs, rhs)))
+        self.install(|| elementwise::add(lhs, rhs))
     }
 
     fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::mul(lhs, rhs)))
+        self.install(|| elementwise::mul(lhs, rhs))
     }
 
     fn neg(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::neg(input)))
+        self.install(|| elementwise::neg(input))
     }
 
     fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::conj(input)))
+        self.install(|| elementwise::conj(input))
     }
 
     fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::div(lhs, rhs)))
+        self.install(|| elementwise::div(lhs, rhs))
     }
 
     fn abs(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::abs(input)))
+        self.install(|| elementwise::abs(input))
     }
 
     fn sign(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::sign(input)))
+        self.install(|| elementwise::sign(input))
     }
 
     fn maximum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::maximum(lhs, rhs)))
+        self.install(|| elementwise::maximum(lhs, rhs))
     }
 
     fn minimum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::minimum(lhs, rhs)))
+        self.install(|| elementwise::minimum(lhs, rhs))
     }
 
     fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::compare(lhs, rhs, dir)))
+        self.install(|| elementwise::compare(lhs, rhs, dir))
     }
 
     fn select(
@@ -164,59 +166,59 @@ impl TensorBackend for CpuBackend {
         on_true: &Tensor,
         on_false: &Tensor,
     ) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::select(pred, on_true, on_false)))
+        self.install(|| elementwise::select(pred, on_true, on_false))
     }
 
     fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| elementwise::clamp(input, lower, upper)))
+        self.install(|| elementwise::clamp(input, lower, upper))
     }
 
     fn exp(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| analytic::exp(input)))
+        self.install(|| analytic::exp(input))
     }
 
     fn log(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| analytic::log(input)))
+        self.install(|| analytic::log(input))
     }
 
     fn sin(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| analytic::sin(input)))
+        self.install(|| analytic::sin(input))
     }
 
     fn cos(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| analytic::cos(input)))
+        self.install(|| analytic::cos(input))
     }
 
     fn tanh(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| analytic::tanh(input)))
+        self.install(|| analytic::tanh(input))
     }
 
     fn sqrt(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| analytic::sqrt(input)))
+        self.install(|| analytic::sqrt(input))
     }
 
     fn rsqrt(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| analytic::rsqrt(input)))
+        self.install(|| analytic::rsqrt(input))
     }
 
     fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| analytic::pow(lhs, rhs)))
+        self.install(|| analytic::pow(lhs, rhs))
     }
 
     fn expm1(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| analytic::expm1(input)))
+        self.install(|| analytic::expm1(input))
     }
 
     fn log1p(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| analytic::log1p(input)))
+        self.install(|| analytic::log1p(input))
     }
 
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
-        Ok(self.install(|| structural::transpose(input, perm)))
+        self.install(|| structural::transpose(input, perm))
     }
 
     fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
-        Ok(self.install(|| structural::reshape(input, shape)))
+        self.install(|| structural::reshape(input, shape))
     }
 
     fn broadcast_in_dim(
@@ -225,7 +227,7 @@ impl TensorBackend for CpuBackend {
         shape: &[usize],
         dims: &[usize],
     ) -> crate::Result<Tensor> {
-        Ok(self.install(|| structural::broadcast_in_dim(input, shape, dims)))
+        self.install(|| structural::broadcast_in_dim(input, shape, dims))
     }
 
     fn convert(&mut self, input: &Tensor, to: crate::DType) -> crate::Result<Tensor> {
@@ -238,7 +240,7 @@ impl TensorBackend for CpuBackend {
         axis_a: usize,
         axis_b: usize,
     ) -> crate::Result<Tensor> {
-        Ok(self.install(|| structural::extract_diagonal(input, axis_a, axis_b)))
+        self.install(|| structural::extract_diagonal(input, axis_a, axis_b))
     }
 
     fn embed_diagonal(
@@ -247,31 +249,31 @@ impl TensorBackend for CpuBackend {
         axis_a: usize,
         axis_b: usize,
     ) -> crate::Result<Tensor> {
-        Ok(self.install(|| structural::embed_diagonal(input, axis_a, axis_b)))
+        self.install(|| structural::embed_diagonal(input, axis_a, axis_b))
     }
 
     fn tril(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor> {
-        Ok(self.install(|| structural::tril(input, k)))
+        self.install(|| structural::tril(input, k))
     }
 
     fn triu(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor> {
-        Ok(self.install(|| structural::triu(input, k)))
+        self.install(|| structural::triu(input, k))
     }
 
     fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        Ok(self.install(|| reduction::reduce_sum(input, axes)))
+        self.install(|| reduction::reduce_sum(input, axes))
     }
 
     fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        Ok(self.install(|| reduction::reduce_prod(input, axes)))
+        self.install(|| reduction::reduce_prod(input, axes))
     }
 
     fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        Ok(self.install(|| reduction::reduce_max(input, axes)))
+        self.install(|| reduction::reduce_max(input, axes))
     }
 
     fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        Ok(self.install(|| reduction::reduce_min(input, axes)))
+        self.install(|| reduction::reduce_min(input, axes))
     }
 
     fn dot_general(
@@ -280,7 +282,17 @@ impl TensorBackend for CpuBackend {
         rhs: &Tensor,
         config: &DotGeneralConfig,
     ) -> crate::Result<Tensor> {
-        Ok(self.install(|| dispatch_binary!(lhs, rhs, |a, b| gemm::dot_general(a, b, config))))
+        self.install(|| match (lhs, rhs) {
+            (Tensor::F32(a), Tensor::F32(b)) => gemm::dot_general(a, b, config).map(Tensor::F32),
+            (Tensor::F64(a), Tensor::F64(b)) => gemm::dot_general(a, b, config).map(Tensor::F64),
+            (Tensor::C32(a), Tensor::C32(b)) => gemm::dot_general(a, b, config).map(Tensor::C32),
+            (Tensor::C64(a), Tensor::C64(b)) => gemm::dot_general(a, b, config).map(Tensor::C64),
+            _ => Err(crate::Error::DTypeMismatch {
+                op: "dot_general",
+                lhs: lhs.dtype(),
+                rhs: rhs.dtype(),
+            }),
+        })
     }
 
     fn gather(
@@ -289,7 +301,11 @@ impl TensorBackend for CpuBackend {
         start_indices: &Tensor,
         config: &GatherConfig,
     ) -> crate::Result<Tensor> {
-        Ok(self.install(|| indexing::gather(operand, start_indices, config)))
+        self.install(|| {
+            catch_backend_panic("gather", || {
+                indexing::gather(operand, start_indices, config)
+            })
+        })
     }
 
     fn scatter(
@@ -299,11 +315,15 @@ impl TensorBackend for CpuBackend {
         updates: &Tensor,
         config: &ScatterConfig,
     ) -> crate::Result<Tensor> {
-        Ok(self.install(|| indexing::scatter(operand, scatter_indices, updates, config)))
+        self.install(|| {
+            catch_backend_panic("scatter", || {
+                indexing::scatter(operand, scatter_indices, updates, config)
+            })
+        })
     }
 
     fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> {
-        Ok(self.install(|| indexing::slice(input, config)))
+        self.install(|| indexing::try_slice(input, config))
     }
 
     fn dynamic_slice(
@@ -312,28 +332,36 @@ impl TensorBackend for CpuBackend {
         starts: &Tensor,
         slice_sizes: &[usize],
     ) -> crate::Result<Tensor> {
-        Ok(self.install(|| indexing::dynamic_slice(input, starts, slice_sizes)))
+        self.install(|| {
+            catch_backend_panic("dynamic_slice", || {
+                indexing::dynamic_slice(input, starts, slice_sizes)
+            })
+        })
     }
 
     fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
-        Ok(self.install(|| indexing::pad(input, config)))
+        self.install(|| indexing::try_pad(input, config))
     }
 
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
-        Ok(self.install(|| indexing::concatenate(inputs, axis)))
+        self.install(|| catch_backend_panic("concatenate", || indexing::concatenate(inputs, axis)))
     }
 
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        Ok(self.install(|| indexing::reverse(input, axes)))
+        self.install(|| catch_backend_panic("reverse", || indexing::reverse(input, axes)))
     }
 
     fn cholesky(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        Ok(self.install(|| match input {
-            Tensor::F64(t) => Tensor::F64(linalg::cholesky(t)),
+        self.install(|| match input {
+            Tensor::F64(t) => {
+                catch_backend_panic("cholesky", || linalg::cholesky(t))?.map(Tensor::F64)
+            }
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => Tensor::C64(linalg::cholesky(t)),
-            _ => todo!("cholesky: unsupported dtype"),
-        }))
+            Tensor::C64(t) => {
+                catch_backend_panic("cholesky", || linalg::cholesky(t))?.map(Tensor::C64)
+            }
+            _ => Err(unsupported_dtype("cholesky", input.dtype())),
+        })
     }
 
     fn triangular_solve(
@@ -345,66 +373,96 @@ impl TensorBackend for CpuBackend {
         transpose_a: bool,
         unit_diagonal: bool,
     ) -> crate::Result<Tensor> {
-        Ok(self.install(|| match (a, b) {
-            (Tensor::F64(a), Tensor::F64(b)) => Tensor::F64(linalg::triangular_solve(
-                a,
-                b,
-                left_side,
-                lower,
-                transpose_a,
-                unit_diagonal,
-            )),
+        self.install(|| match (a, b) {
+            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
+                Tensor::F64(linalg::triangular_solve(
+                    a,
+                    b,
+                    left_side,
+                    lower,
+                    transpose_a,
+                    unit_diagonal,
+                ))
+            }),
             #[cfg(feature = "cpu-faer")]
-            (Tensor::C64(a), Tensor::C64(b)) => Tensor::C64(linalg::triangular_solve(
-                a,
-                b,
-                left_side,
-                lower,
-                transpose_a,
-                unit_diagonal,
-            )),
-            _ => todo!("triangular_solve: unsupported dtype"),
-        }))
+            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
+                Tensor::C64(linalg::triangular_solve(
+                    a,
+                    b,
+                    left_side,
+                    lower,
+                    transpose_a,
+                    unit_diagonal,
+                ))
+            }),
+            _ => {
+                if a.dtype() != b.dtype() {
+                    Err(crate::Error::DTypeMismatch {
+                        op: "triangular_solve",
+                        lhs: a.dtype(),
+                        rhs: b.dtype(),
+                    })
+                } else {
+                    Err(unsupported_dtype("triangular_solve", a.dtype()))
+                }
+            }
+        })
     }
 
     fn lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        Ok(self.install(|| match input {
-            Tensor::F64(t) => linalg::lu(t).into_iter().map(Tensor::F64).collect(),
+        self.install(|| match input {
+            Tensor::F64(t) => catch_backend_panic("lu", || {
+                linalg::lu(t).into_iter().map(Tensor::F64).collect()
+            }),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => linalg::lu(t).into_iter().map(Tensor::C64).collect(),
-            _ => todo!("lu: unsupported dtype"),
-        }))
+            Tensor::C64(t) => catch_backend_panic("lu", || {
+                linalg::lu(t).into_iter().map(Tensor::C64).collect()
+            }),
+            _ => Err(unsupported_dtype("lu", input.dtype())),
+        })
     }
 
     fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        Ok(self.install(|| match input {
-            Tensor::F64(t) => linalg::svd(t).into_iter().map(Tensor::F64).collect(),
+        self.install(|| match input {
+            Tensor::F64(t) => catch_backend_panic("svd", || {
+                linalg::svd(t).into_iter().map(Tensor::F64).collect()
+            }),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => linalg::svd(t).into_iter().map(Tensor::C64).collect(),
-            _ => todo!("svd: unsupported dtype"),
-        }))
+            Tensor::C64(t) => catch_backend_panic("svd", || {
+                linalg::svd(t).into_iter().map(Tensor::C64).collect()
+            }),
+            _ => Err(unsupported_dtype("svd", input.dtype())),
+        })
     }
 
     fn qr(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        Ok(self.install(|| match input {
-            Tensor::F64(t) => linalg::qr(t).into_iter().map(Tensor::F64).collect(),
+        self.install(|| match input {
+            Tensor::F64(t) => catch_backend_panic("qr", || {
+                linalg::qr(t).into_iter().map(Tensor::F64).collect()
+            }),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => linalg::qr(t).into_iter().map(Tensor::C64).collect(),
-            _ => todo!("qr: unsupported dtype"),
-        }))
+            Tensor::C64(t) => catch_backend_panic("qr", || {
+                linalg::qr(t).into_iter().map(Tensor::C64).collect()
+            }),
+            _ => Err(unsupported_dtype("qr", input.dtype())),
+        })
     }
 
     fn eigh(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        Ok(self.install(|| match input {
-            Tensor::F64(t) => linalg::eigh(t).into_iter().map(Tensor::F64).collect(),
+        self.install(|| match input {
+            Tensor::F64(t) => catch_backend_panic("eigh", || {
+                linalg::eigh(t).into_iter().map(Tensor::F64).collect()
+            }),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => linalg::eigh(t).into_iter().map(Tensor::C64).collect(),
-            _ => todo!("eigh: unsupported dtype"),
-        }))
+            Tensor::C64(t) => catch_backend_panic("eigh", || {
+                linalg::eigh(t).into_iter().map(Tensor::C64).collect()
+            }),
+            _ => Err(unsupported_dtype("eigh", input.dtype())),
+        })
     }
 
     fn eig(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        Ok(self.install(|| linalg::eig(input)))
+        self.install(|| catch_backend_panic("eig", || linalg::eig(input)))
     }
 
     fn solve(&mut self, a: &Tensor, b: &Tensor) -> crate::Result<Tensor> {
@@ -425,7 +483,7 @@ impl TensorBackend for CpuBackend {
         let p = &outputs[0];
         let l = &outputs[1];
         let u = &outputs[2];
-        assert_nonsingular_u(u);
+        validate_nonsingular_u(u)?;
 
         let pb = matmul_preserve_trailing_batch(self, p, &rhs)?;
         let z = self.triangular_solve(l, &pb, true, true, false, true)?;
@@ -490,7 +548,31 @@ fn zeros_like_tensor(input: &Tensor) -> Tensor {
     }
 }
 
-fn assert_nonsingular_u(u: &Tensor) {
+fn panic_payload_message(payload: Box<dyn Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "backend panic".into()
+    }
+}
+
+fn catch_backend_panic<R>(op: &'static str, f: impl FnOnce() -> R) -> crate::Result<R> {
+    catch_unwind(AssertUnwindSafe(f)).map_err(|payload| crate::Error::BackendFailure {
+        op,
+        message: panic_payload_message(payload),
+    })
+}
+
+fn unsupported_dtype(op: &'static str, dtype: crate::DType) -> crate::Error {
+    crate::Error::BackendFailure {
+        op,
+        message: format!("unsupported dtype {dtype:?}"),
+    }
+}
+
+fn validate_nonsingular_u(u: &Tensor) -> crate::Result<()> {
     match u {
         Tensor::F64(t) => {
             let n = t.shape[0].min(t.shape[1]);
@@ -501,9 +583,15 @@ fn assert_nonsingular_u(u: &Tensor) {
                 let batch = &t.host_data()[batch_idx * slice_size..(batch_idx + 1) * slice_size];
                 for i in 0..n {
                     let diag = batch[i + i * t.shape[0]];
-                    assert!(diag.is_finite() && diag != 0.0, "solve: singular matrix");
+                    if !diag.is_finite() || diag == 0.0 {
+                        return Err(crate::Error::BackendFailure {
+                            op: "solve",
+                            message: "singular matrix".into(),
+                        });
+                    }
                 }
             }
+            Ok(())
         }
         Tensor::C64(t) => {
             let n = t.shape[0].min(t.shape[1]);
@@ -514,15 +602,138 @@ fn assert_nonsingular_u(u: &Tensor) {
                 let batch = &t.host_data()[batch_idx * slice_size..(batch_idx + 1) * slice_size];
                 for i in 0..n {
                     let diag = batch[i + i * t.shape[0]];
-                    assert!(
-                        diag.re.is_finite() && diag.im.is_finite() && diag.norm_sqr() != 0.0,
-                        "solve: singular matrix"
-                    );
+                    if !diag.re.is_finite() || !diag.im.is_finite() || diag.norm_sqr() == 0.0 {
+                        return Err(crate::Error::BackendFailure {
+                            op: "solve",
+                            message: "singular matrix".into(),
+                        });
+                    }
                 }
             }
+            Ok(())
         }
-        _ => todo!("solve: unsupported dtype"),
+        _ => Err(crate::Error::BackendFailure {
+            op: "solve",
+            message: format!("unsupported dtype {:?}", u.dtype()),
+        }),
     }
+}
+
+fn validate_axis_role_conflicts(
+    op: &'static str,
+    first_role: &'static str,
+    first_axes: &[usize],
+    second_role: &'static str,
+    second_axes: &[usize],
+) -> crate::Result<()> {
+    for &axis in first_axes {
+        if second_axes.contains(&axis) {
+            return Err(crate::Error::AxisRoleConflict {
+                op,
+                axis,
+                first_role,
+                second_role,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_axis_list(
+    op: &'static str,
+    role: &'static str,
+    axes: &[usize],
+    rank: usize,
+) -> crate::Result<()> {
+    let mut seen = vec![false; rank];
+    for &axis in axes {
+        if axis >= rank {
+            return Err(crate::Error::AxisOutOfBounds { op, axis, rank });
+        }
+        if seen[axis] {
+            return Err(crate::Error::DuplicateAxis { op, axis, role });
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn validate_semiring_batched_gemm_config<T>(
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+    config: &DotGeneralConfig,
+) -> crate::Result<()> {
+    const OP: &str = "batched_gemm";
+
+    if config.lhs_contracting_dims.len() != config.rhs_contracting_dims.len() {
+        return Err(crate::Error::InvalidConfig {
+            op: OP,
+            message: "contracting dim count mismatch".into(),
+        });
+    }
+    if config.lhs_batch_dims.len() != config.rhs_batch_dims.len() {
+        return Err(crate::Error::InvalidConfig {
+            op: OP,
+            message: "batch dim count mismatch".into(),
+        });
+    }
+
+    let lhs_rank = lhs.shape.len();
+    let rhs_rank = rhs.shape.len();
+    validate_axis_list(
+        OP,
+        "lhs_contracting_dims",
+        &config.lhs_contracting_dims,
+        lhs_rank,
+    )?;
+    validate_axis_list(
+        OP,
+        "rhs_contracting_dims",
+        &config.rhs_contracting_dims,
+        rhs_rank,
+    )?;
+    validate_axis_list(OP, "lhs_batch_dims", &config.lhs_batch_dims, lhs_rank)?;
+    validate_axis_list(OP, "rhs_batch_dims", &config.rhs_batch_dims, rhs_rank)?;
+    validate_axis_role_conflicts(
+        OP,
+        "lhs_contracting_dims",
+        &config.lhs_contracting_dims,
+        "lhs_batch_dims",
+        &config.lhs_batch_dims,
+    )?;
+    validate_axis_role_conflicts(
+        OP,
+        "rhs_contracting_dims",
+        &config.rhs_contracting_dims,
+        "rhs_batch_dims",
+        &config.rhs_batch_dims,
+    )?;
+
+    for (&lhs_axis, &rhs_axis) in config
+        .lhs_contracting_dims
+        .iter()
+        .zip(&config.rhs_contracting_dims)
+    {
+        if lhs.shape[lhs_axis] != rhs.shape[rhs_axis] {
+            return Err(crate::Error::ShapeMismatch {
+                op: OP,
+                lhs: vec![lhs.shape[lhs_axis]],
+                rhs: vec![rhs.shape[rhs_axis]],
+            });
+        }
+    }
+
+    for (&lhs_axis, &rhs_axis) in config.lhs_batch_dims.iter().zip(&config.rhs_batch_dims) {
+        if lhs.shape[lhs_axis] != rhs.shape[rhs_axis] {
+            return Err(crate::Error::ShapeMismatch {
+                op: OP,
+                lhs: vec![lhs.shape[lhs_axis]],
+                rhs: vec![rhs.shape[rhs_axis]],
+            });
+        }
+    }
+
+    Ok(())
 }
 
 impl<Alg: Semiring> SemiringBackend<Alg> for CpuBackend {
@@ -532,13 +743,8 @@ impl<Alg: Semiring> SemiringBackend<Alg> for CpuBackend {
         rhs: &TypedTensor<Alg::Scalar>,
         config: &DotGeneralConfig,
     ) -> crate::Result<TypedTensor<Alg::Scalar>> {
+        validate_semiring_batched_gemm_config(lhs, rhs, config)?;
         Ok(self.install(|| {
-            assert_eq!(
-                config.lhs_contracting_dims.len(),
-                config.rhs_contracting_dims.len()
-            );
-            assert_eq!(config.lhs_batch_dims.len(), config.rhs_batch_dims.len());
-
             let lhs_rank = lhs.shape.len();
             let rhs_rank = rhs.shape.len();
             let lhs_free: Vec<usize> = (0..lhs_rank)

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -353,13 +353,18 @@ impl TensorBackend for CpuBackend {
 
     fn cholesky(&mut self, input: &Tensor) -> crate::Result<Tensor> {
         self.install(|| match input {
+            #[cfg(feature = "cpu-faer")]
+            Tensor::F64(t) => catch_backend_panic("cholesky", || linalg::cholesky(t))
+                .and_then(|result| result)
+                .map(Tensor::F64),
+            #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => {
-                catch_backend_panic("cholesky", || linalg::cholesky(t))?.map(Tensor::F64)
+                catch_backend_panic("cholesky", || linalg::cholesky(t)).map(Tensor::F64)
             }
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => {
-                catch_backend_panic("cholesky", || linalg::cholesky(t))?.map(Tensor::C64)
-            }
+            Tensor::C64(t) => catch_backend_panic("cholesky", || linalg::cholesky(t))
+                .and_then(|result| result)
+                .map(Tensor::C64),
             _ => Err(unsupported_dtype("cholesky", input.dtype())),
         })
     }

--- a/tenferro-tensor/src/cpu/elementwise.rs
+++ b/tenferro-tensor/src/cpu/elementwise.rs
@@ -6,19 +6,22 @@ use strided_kernel::{map_into, zip_map2_into, zip_map3_into};
 
 use crate::{
     config::CompareDir,
-    types::{dispatch_binary, dispatch_tensor, ConjElem, Tensor, TypedTensor},
+    types::{ConjElem, Tensor, TypedTensor},
 };
 
 use super::{tensor_from_array, typed_array, typed_view};
 
-macro_rules! dispatch_ternary {
-    ($a:expr, $b:expr, $c:expr, |$x:ident, $y:ident, $z:ident| $body:expr) => {
+macro_rules! dispatch_ternary_result {
+    ($op:literal, $a:expr, $b:expr, $c:expr, |$x:ident, $y:ident, $z:ident| $body:expr) => {
         match ($a, $b, $c) {
-            (Tensor::F32($x), Tensor::F32($y), Tensor::F32($z)) => Tensor::F32($body),
-            (Tensor::F64($x), Tensor::F64($y), Tensor::F64($z)) => Tensor::F64($body),
-            (Tensor::C32($x), Tensor::C32($y), Tensor::C32($z)) => Tensor::C32($body),
-            (Tensor::C64($x), Tensor::C64($y), Tensor::C64($z)) => Tensor::C64($body),
-            _ => panic!("dtype mismatch in ternary op"),
+            (Tensor::F32($x), Tensor::F32($y), Tensor::F32($z)) => Ok(Tensor::F32($body?)),
+            (Tensor::F64($x), Tensor::F64($y), Tensor::F64($z)) => Ok(Tensor::F64($body?)),
+            (Tensor::C32($x), Tensor::C32($y), Tensor::C32($z)) => Ok(Tensor::C32($body?)),
+            (Tensor::C64($x), Tensor::C64($y), Tensor::C64($z)) => Ok(Tensor::C64($body?)),
+            _ => Err(crate::Error::BackendFailure {
+                op: $op,
+                message: "dtype mismatch".into(),
+            }),
         }
     };
 }
@@ -150,99 +153,178 @@ where
     TypedTensor::from_vec(vec![], vec![Complex::new(scalar, T::zero())])
 }
 
-pub fn add(lhs: &Tensor, rhs: &Tensor) -> Tensor {
-    match (lhs, rhs) {
-        (Tensor::F32(a), Tensor::F32(b)) => Tensor::F32(typed_add(a, b)),
-        (Tensor::F64(a), Tensor::F64(b)) => Tensor::F64(typed_add(a, b)),
-        (Tensor::C32(a), Tensor::C32(b)) => Tensor::C32(typed_add(a, b)),
-        (Tensor::C64(a), Tensor::C64(b)) => Tensor::C64(typed_add(a, b)),
-        (Tensor::F32(a), Tensor::C32(b)) if a.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(a.host_data()[0]);
-            Tensor::C32(typed_add(&scalar, b))
-        }
-        (Tensor::C32(a), Tensor::F32(b)) if b.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(b.host_data()[0]);
-            Tensor::C32(typed_add(a, &scalar))
-        }
-        (Tensor::F64(a), Tensor::C64(b)) if a.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(a.host_data()[0]);
-            Tensor::C64(typed_add(&scalar, b))
-        }
-        (Tensor::C64(a), Tensor::F64(b)) if b.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(b.host_data()[0]);
-            Tensor::C64(typed_add(a, &scalar))
-        }
-        _ => panic!("dtype mismatch in binary op"),
+fn backend_failure(op: &'static str, err: impl ToString) -> crate::Error {
+    crate::Error::BackendFailure {
+        op,
+        message: err.to_string(),
     }
 }
 
-pub fn mul(lhs: &Tensor, rhs: &Tensor) -> Tensor {
+pub fn add(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
     match (lhs, rhs) {
-        (Tensor::F32(a), Tensor::F32(b)) => Tensor::F32(typed_mul(a, b)),
-        (Tensor::F64(a), Tensor::F64(b)) => Tensor::F64(typed_mul(a, b)),
-        (Tensor::C32(a), Tensor::C32(b)) => Tensor::C32(typed_mul(a, b)),
-        (Tensor::C64(a), Tensor::C64(b)) => Tensor::C64(typed_mul(a, b)),
+        (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_add(a, b)?)),
+        (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_add(a, b)?)),
+        (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_add(a, b)?)),
+        (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_add(a, b)?)),
         (Tensor::F32(a), Tensor::C32(b)) if a.shape.is_empty() => {
             let scalar = complex_scalar_tensor(a.host_data()[0]);
-            Tensor::C32(typed_mul(&scalar, b))
+            Ok(Tensor::C32(typed_add(&scalar, b)?))
         }
         (Tensor::C32(a), Tensor::F32(b)) if b.shape.is_empty() => {
             let scalar = complex_scalar_tensor(b.host_data()[0]);
-            Tensor::C32(typed_mul(a, &scalar))
+            Ok(Tensor::C32(typed_add(a, &scalar)?))
         }
         (Tensor::F64(a), Tensor::C64(b)) if a.shape.is_empty() => {
             let scalar = complex_scalar_tensor(a.host_data()[0]);
-            Tensor::C64(typed_mul(&scalar, b))
+            Ok(Tensor::C64(typed_add(&scalar, b)?))
         }
         (Tensor::C64(a), Tensor::F64(b)) if b.shape.is_empty() => {
             let scalar = complex_scalar_tensor(b.host_data()[0]);
-            Tensor::C64(typed_mul(a, &scalar))
+            Ok(Tensor::C64(typed_add(a, &scalar)?))
         }
-        _ => panic!("dtype mismatch in binary op"),
+        _ => Err(crate::Error::DTypeMismatch {
+            op: "add",
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        }),
     }
 }
 
-pub fn div(lhs: &Tensor, rhs: &Tensor) -> Tensor {
-    dispatch_binary!(lhs, rhs, |a, b| typed_div(a, b))
+pub fn mul(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    match (lhs, rhs) {
+        (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_mul(a, b)?)),
+        (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_mul(a, b)?)),
+        (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_mul(a, b)?)),
+        (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_mul(a, b)?)),
+        (Tensor::F32(a), Tensor::C32(b)) if a.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            Ok(Tensor::C32(typed_mul(&scalar, b)?))
+        }
+        (Tensor::C32(a), Tensor::F32(b)) if b.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            Ok(Tensor::C32(typed_mul(a, &scalar)?))
+        }
+        (Tensor::F64(a), Tensor::C64(b)) if a.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            Ok(Tensor::C64(typed_mul(&scalar, b)?))
+        }
+        (Tensor::C64(a), Tensor::F64(b)) if b.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            Ok(Tensor::C64(typed_mul(a, &scalar)?))
+        }
+        _ => Err(crate::Error::DTypeMismatch {
+            op: "mul",
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        }),
+    }
 }
 
-pub fn neg(input: &Tensor) -> Tensor {
-    dispatch_tensor!(input, t => typed_neg(t))
+pub fn div(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    match (lhs, rhs) {
+        (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_div(a, b)?)),
+        (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_div(a, b)?)),
+        (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_div(a, b)?)),
+        (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_div(a, b)?)),
+        _ => Err(crate::Error::DTypeMismatch {
+            op: "div",
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        }),
+    }
 }
 
-pub fn conj(input: &Tensor) -> Tensor {
-    dispatch_tensor!(input, t => typed_conj(t))
+pub fn neg(input: &Tensor) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_neg(t)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_neg(t)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_neg(t)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_neg(t)?)),
+    }
 }
 
-pub fn abs(input: &Tensor) -> Tensor {
-    dispatch_tensor!(input, t => typed_abs(t))
+pub fn conj(input: &Tensor) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_conj(t)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_conj(t)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_conj(t)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_conj(t)?)),
+    }
 }
 
-pub fn sign(input: &Tensor) -> Tensor {
-    dispatch_tensor!(input, t => typed_sign(t))
+pub fn abs(input: &Tensor) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_abs(t)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_abs(t)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_abs(t)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_abs(t)?)),
+    }
 }
 
-pub fn maximum(lhs: &Tensor, rhs: &Tensor) -> Tensor {
-    dispatch_binary!(lhs, rhs, |a, b| typed_maximum(a, b))
+pub fn sign(input: &Tensor) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_sign(t)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_sign(t)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_sign(t)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_sign(t)?)),
+    }
 }
 
-pub fn minimum(lhs: &Tensor, rhs: &Tensor) -> Tensor {
-    dispatch_binary!(lhs, rhs, |a, b| typed_minimum(a, b))
+pub fn maximum(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    match (lhs, rhs) {
+        (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_maximum(a, b)?)),
+        (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_maximum(a, b)?)),
+        (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_maximum(a, b)?)),
+        (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_maximum(a, b)?)),
+        _ => Err(crate::Error::DTypeMismatch {
+            op: "maximum",
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        }),
+    }
 }
 
-pub fn compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> Tensor {
-    dispatch_binary!(lhs, rhs, |a, b| typed_compare(a, b, dir))
+pub fn minimum(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    match (lhs, rhs) {
+        (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_minimum(a, b)?)),
+        (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_minimum(a, b)?)),
+        (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_minimum(a, b)?)),
+        (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_minimum(a, b)?)),
+        _ => Err(crate::Error::DTypeMismatch {
+            op: "minimum",
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        }),
+    }
 }
 
-pub fn select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> Tensor {
-    dispatch_ternary!(pred, on_true, on_false, |p, t, f| typed_select(p, t, f))
+pub fn compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor> {
+    match (lhs, rhs) {
+        (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_compare(a, b, dir)?)),
+        (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_compare(a, b, dir)?)),
+        (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_compare(a, b, dir)?)),
+        (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_compare(a, b, dir)?)),
+        _ => Err(crate::Error::DTypeMismatch {
+            op: "compare",
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        }),
+    }
 }
 
-pub fn clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> Tensor {
-    dispatch_ternary!(input, lower, upper, |x, lo, hi| typed_clamp(x, lo, hi))
+pub fn select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> crate::Result<Tensor> {
+    dispatch_ternary_result!("select", pred, on_true, on_false, |p, t, f| typed_select(
+        p, t, f
+    ))
 }
 
-pub fn typed_add<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> TypedTensor<T>
+pub fn clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor> {
+    dispatch_ternary_result!("clamp", input, lower, upper, |x, lo, hi| typed_clamp(
+        x, lo, hi
+    ))
+}
+
+pub fn typed_add<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Zero + Add<Output = T>,
 {
@@ -254,24 +336,41 @@ where
             &typed_view(rhs),
             |x, y| x + y,
         )
-        .expect("typed_add");
-        tensor_from_array(out)
+        .map_err(|err| crate::Error::BackendFailure {
+            op: "add",
+            message: err.to_string(),
+        })?;
+        Ok(tensor_from_array(out))
     } else if lhs.shape.is_empty() {
         let scalar = lhs.host_data()[0];
         let mut out = typed_array(&rhs.shape, T::zero());
-        map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar + x).expect("scalar_add");
-        tensor_from_array(out)
+        map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar + x).map_err(|err| {
+            crate::Error::BackendFailure {
+                op: "add",
+                message: err.to_string(),
+            }
+        })?;
+        Ok(tensor_from_array(out))
     } else if rhs.shape.is_empty() {
         let scalar = rhs.host_data()[0];
         let mut out = typed_array(&lhs.shape, T::zero());
-        map_into(&mut out.view_mut(), &typed_view(lhs), |x| x + scalar).expect("scalar_add");
-        tensor_from_array(out)
+        map_into(&mut out.view_mut(), &typed_view(lhs), |x| x + scalar).map_err(|err| {
+            crate::Error::BackendFailure {
+                op: "add",
+                message: err.to_string(),
+            }
+        })?;
+        Ok(tensor_from_array(out))
     } else {
-        panic!("add: shape mismatch {:?} vs {:?}", lhs.shape, rhs.shape);
+        Err(crate::Error::ShapeMismatch {
+            op: "add",
+            lhs: lhs.shape.clone(),
+            rhs: rhs.shape.clone(),
+        })
     }
 }
 
-pub fn typed_mul<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> TypedTensor<T>
+pub fn typed_mul<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Zero + Mul<Output = T>,
 {
@@ -283,28 +382,40 @@ where
             &typed_view(rhs),
             |x, y| x * y,
         )
-        .expect("typed_mul");
-        tensor_from_array(out)
+        .map_err(|err| backend_failure("mul", err))?;
+        Ok(tensor_from_array(out))
     } else if lhs.shape.is_empty() {
         let scalar = lhs.host_data()[0];
         let mut out = typed_array(&rhs.shape, T::zero());
-        map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar * x).expect("scalar_mul");
-        tensor_from_array(out)
+        map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar * x)
+            .map_err(|err| backend_failure("mul", err))?;
+        Ok(tensor_from_array(out))
     } else if rhs.shape.is_empty() {
         let scalar = rhs.host_data()[0];
         let mut out = typed_array(&lhs.shape, T::zero());
-        map_into(&mut out.view_mut(), &typed_view(lhs), |x| x * scalar).expect("scalar_mul");
-        tensor_from_array(out)
+        map_into(&mut out.view_mut(), &typed_view(lhs), |x| x * scalar)
+            .map_err(|err| backend_failure("mul", err))?;
+        Ok(tensor_from_array(out))
     } else {
-        panic!("mul: shape mismatch {:?} vs {:?}", lhs.shape, rhs.shape);
+        Err(crate::Error::ShapeMismatch {
+            op: "mul",
+            lhs: lhs.shape.clone(),
+            rhs: rhs.shape.clone(),
+        })
     }
 }
 
-pub fn typed_div<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> TypedTensor<T>
+pub fn typed_div<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Zero + Div<Output = T>,
 {
-    assert_eq!(lhs.shape, rhs.shape, "div: shape mismatch");
+    if lhs.shape != rhs.shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "div",
+            lhs: lhs.shape.clone(),
+            rhs: rhs.shape.clone(),
+        });
+    }
     let mut out = typed_array(&lhs.shape, T::zero());
     zip_map2_into(
         &mut out.view_mut(),
@@ -312,51 +423,64 @@ where
         &typed_view(rhs),
         |x, y| x / y,
     )
-    .expect("typed_div");
-    tensor_from_array(out)
+    .map_err(|err| backend_failure("div", err))?;
+    Ok(tensor_from_array(out))
 }
 
-pub fn typed_neg<T>(input: &TypedTensor<T>) -> TypedTensor<T>
+pub fn typed_neg<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Zero + Neg<Output = T>,
 {
     let mut out = typed_array(&input.shape, T::zero());
-    map_into(&mut out.view_mut(), &typed_view(input), |x| -x).expect("typed_neg");
-    tensor_from_array(out)
+    map_into(&mut out.view_mut(), &typed_view(input), |x| -x)
+        .map_err(|err| backend_failure("neg", err))?;
+    Ok(tensor_from_array(out))
 }
 
-pub fn typed_conj<T>(input: &TypedTensor<T>) -> TypedTensor<T>
+pub fn typed_conj<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Zero + ConjElem,
 {
     let mut out = typed_array(&input.shape, T::zero());
-    map_into(&mut out.view_mut(), &typed_view(input), |x| x.conj_elem()).expect("typed_conj");
-    tensor_from_array(out)
+    map_into(&mut out.view_mut(), &typed_view(input), |x| x.conj_elem())
+        .map_err(|err| backend_failure("conj", err))?;
+    Ok(tensor_from_array(out))
 }
 
-pub(crate) fn typed_abs<T>(input: &TypedTensor<T>) -> TypedTensor<T>
+pub(crate) fn typed_abs<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
     T: Tier2Elem,
 {
     let mut out = typed_array(&input.shape, T::zero());
-    map_into(&mut out.view_mut(), &typed_view(input), |x| x.abs_elem()).expect("typed_abs");
-    tensor_from_array(out)
+    map_into(&mut out.view_mut(), &typed_view(input), |x| x.abs_elem())
+        .map_err(|err| backend_failure("abs", err))?;
+    Ok(tensor_from_array(out))
 }
 
-pub(crate) fn typed_sign<T>(input: &TypedTensor<T>) -> TypedTensor<T>
+pub(crate) fn typed_sign<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
     T: Tier2Elem,
 {
     let mut out = typed_array(&input.shape, T::zero());
-    map_into(&mut out.view_mut(), &typed_view(input), |x| x.sign_elem()).expect("typed_sign");
-    tensor_from_array(out)
+    map_into(&mut out.view_mut(), &typed_view(input), |x| x.sign_elem())
+        .map_err(|err| backend_failure("sign", err))?;
+    Ok(tensor_from_array(out))
 }
 
-pub(crate) fn typed_maximum<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> TypedTensor<T>
+pub(crate) fn typed_maximum<T>(
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+) -> crate::Result<TypedTensor<T>>
 where
     T: Tier2Elem,
 {
-    assert_eq!(lhs.shape, rhs.shape, "maximum: shape mismatch");
+    if lhs.shape != rhs.shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "maximum",
+            lhs: lhs.shape.clone(),
+            rhs: rhs.shape.clone(),
+        });
+    }
     let mut out = typed_array(&lhs.shape, T::zero());
     zip_map2_into(
         &mut out.view_mut(),
@@ -364,15 +488,24 @@ where
         &typed_view(rhs),
         |x, y| x.max_elem(y),
     )
-    .expect("typed_maximum");
-    tensor_from_array(out)
+    .map_err(|err| backend_failure("maximum", err))?;
+    Ok(tensor_from_array(out))
 }
 
-pub(crate) fn typed_minimum<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> TypedTensor<T>
+pub(crate) fn typed_minimum<T>(
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+) -> crate::Result<TypedTensor<T>>
 where
     T: Tier2Elem,
 {
-    assert_eq!(lhs.shape, rhs.shape, "minimum: shape mismatch");
+    if lhs.shape != rhs.shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "minimum",
+            lhs: lhs.shape.clone(),
+            rhs: rhs.shape.clone(),
+        });
+    }
     let mut out = typed_array(&lhs.shape, T::zero());
     zip_map2_into(
         &mut out.view_mut(),
@@ -380,19 +513,25 @@ where
         &typed_view(rhs),
         |x, y| x.min_elem(y),
     )
-    .expect("typed_minimum");
-    tensor_from_array(out)
+    .map_err(|err| backend_failure("minimum", err))?;
+    Ok(tensor_from_array(out))
 }
 
 pub(crate) fn typed_compare<T>(
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     dir: &CompareDir,
-) -> TypedTensor<T>
+) -> crate::Result<TypedTensor<T>>
 where
     T: Tier2Elem,
 {
-    assert_eq!(lhs.shape, rhs.shape, "compare: shape mismatch");
+    if lhs.shape != rhs.shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "compare",
+            lhs: lhs.shape.clone(),
+            rhs: rhs.shape.clone(),
+        });
+    }
     let mut out = typed_array(&lhs.shape, T::zero());
     zip_map2_into(
         &mut out.view_mut(),
@@ -400,20 +539,32 @@ where
         &typed_view(rhs),
         |x, y| x.compare_elem(y, dir),
     )
-    .expect("typed_compare");
-    tensor_from_array(out)
+    .map_err(|err| backend_failure("compare", err))?;
+    Ok(tensor_from_array(out))
 }
 
 pub(crate) fn typed_select<T>(
     pred: &TypedTensor<T>,
     on_true: &TypedTensor<T>,
     on_false: &TypedTensor<T>,
-) -> TypedTensor<T>
+) -> crate::Result<TypedTensor<T>>
 where
     T: Tier2Elem,
 {
-    assert_eq!(pred.shape, on_true.shape, "select: shape mismatch");
-    assert_eq!(pred.shape, on_false.shape, "select: shape mismatch");
+    if pred.shape != on_true.shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "select",
+            lhs: pred.shape.clone(),
+            rhs: on_true.shape.clone(),
+        });
+    }
+    if pred.shape != on_false.shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "select",
+            lhs: pred.shape.clone(),
+            rhs: on_false.shape.clone(),
+        });
+    }
     let mut out = typed_array(&pred.shape, T::zero());
     zip_map3_into(
         &mut out.view_mut(),
@@ -422,20 +573,32 @@ where
         &typed_view(on_false),
         |p, t, f| if p.is_nonzero() { t } else { f },
     )
-    .expect("typed_select");
-    tensor_from_array(out)
+    .map_err(|err| backend_failure("select", err))?;
+    Ok(tensor_from_array(out))
 }
 
 pub(crate) fn typed_clamp<T>(
     input: &TypedTensor<T>,
     lower: &TypedTensor<T>,
     upper: &TypedTensor<T>,
-) -> TypedTensor<T>
+) -> crate::Result<TypedTensor<T>>
 where
     T: Tier2Elem,
 {
-    assert_eq!(input.shape, lower.shape, "clamp: shape mismatch");
-    assert_eq!(input.shape, upper.shape, "clamp: shape mismatch");
+    if input.shape != lower.shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "clamp",
+            lhs: input.shape.clone(),
+            rhs: lower.shape.clone(),
+        });
+    }
+    if input.shape != upper.shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "clamp",
+            lhs: input.shape.clone(),
+            rhs: upper.shape.clone(),
+        });
+    }
     let mut out = typed_array(&input.shape, T::zero());
     zip_map3_into(
         &mut out.view_mut(),
@@ -444,6 +607,6 @@ where
         &typed_view(upper),
         |x, lo, hi| lo.max_elem(hi.min_elem(x)),
     )
-    .expect("typed_clamp");
-    tensor_from_array(out)
+    .map_err(|err| backend_failure("clamp", err))?;
+    Ok(tensor_from_array(out))
 }

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -3,6 +3,7 @@ use num_traits::{One, Zero};
 use crate::config::DotGeneralConfig;
 use crate::cpu::structural::typed_transpose;
 use crate::types::{col_major_strides, Buffer, TypedTensor};
+use crate::Error;
 
 #[cfg(feature = "cpu-blas")]
 mod blas_gemm;
@@ -32,6 +33,140 @@ struct GemmDims {
     c_cs: isize,
     c_bs: isize,
     out_shape: Vec<usize>,
+}
+
+fn validate_axis_list(
+    op: &'static str,
+    role: &'static str,
+    axes: &[usize],
+    rank: usize,
+) -> crate::Result<()> {
+    let mut seen = vec![false; rank];
+    for &axis in axes {
+        if axis >= rank {
+            return Err(Error::AxisOutOfBounds { op, axis, rank });
+        }
+        if seen[axis] {
+            return Err(Error::DuplicateAxis { op, axis, role });
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn validate_role_disjoint(
+    op: &'static str,
+    first_role: &'static str,
+    first_axes: &[usize],
+    second_role: &'static str,
+    second_axes: &[usize],
+) -> crate::Result<()> {
+    for &axis in first_axes {
+        if second_axes.contains(&axis) {
+            return Err(Error::AxisRoleConflict {
+                op,
+                axis,
+                first_role,
+                second_role,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_dot_general<T>(
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+    config: &DotGeneralConfig,
+) -> crate::Result<()> {
+    const OP: &str = "dot_general";
+
+    if config.lhs_contracting_dims.len() != config.rhs_contracting_dims.len() {
+        return Err(Error::InvalidConfig {
+            op: OP,
+            message: "lhs/rhs contracting dim counts differ".into(),
+        });
+    }
+    if config.lhs_batch_dims.len() != config.rhs_batch_dims.len() {
+        return Err(Error::InvalidConfig {
+            op: OP,
+            message: "lhs/rhs batch dim counts differ".into(),
+        });
+    }
+
+    let lhs_rank = lhs.shape.len();
+    let rhs_rank = rhs.shape.len();
+    if config.lhs_rank != lhs_rank {
+        return Err(Error::RankMismatch {
+            op: OP,
+            expected: config.lhs_rank,
+            actual: lhs_rank,
+        });
+    }
+    if config.rhs_rank != rhs_rank {
+        return Err(Error::RankMismatch {
+            op: OP,
+            expected: config.rhs_rank,
+            actual: rhs_rank,
+        });
+    }
+    validate_axis_list(
+        OP,
+        "lhs_contracting",
+        &config.lhs_contracting_dims,
+        lhs_rank,
+    )?;
+    validate_axis_list(
+        OP,
+        "rhs_contracting",
+        &config.rhs_contracting_dims,
+        rhs_rank,
+    )?;
+    validate_axis_list(OP, "lhs_batch", &config.lhs_batch_dims, lhs_rank)?;
+    validate_axis_list(OP, "rhs_batch", &config.rhs_batch_dims, rhs_rank)?;
+    validate_role_disjoint(
+        OP,
+        "lhs_contracting",
+        &config.lhs_contracting_dims,
+        "lhs_batch",
+        &config.lhs_batch_dims,
+    )?;
+    validate_role_disjoint(
+        OP,
+        "rhs_contracting",
+        &config.rhs_contracting_dims,
+        "rhs_batch",
+        &config.rhs_batch_dims,
+    )?;
+
+    for (&lhs_axis, &rhs_axis) in config
+        .lhs_contracting_dims
+        .iter()
+        .zip(&config.rhs_contracting_dims)
+    {
+        if lhs.shape[lhs_axis] != rhs.shape[rhs_axis] {
+            return Err(Error::InvalidConfig {
+                op: OP,
+                message: format!(
+                    "contracting dim size mismatch: lhs axis {lhs_axis}={} rhs axis {rhs_axis}={}",
+                    lhs.shape[lhs_axis], rhs.shape[rhs_axis]
+                ),
+            });
+        }
+    }
+    for (&lhs_axis, &rhs_axis) in config.lhs_batch_dims.iter().zip(&config.rhs_batch_dims) {
+        if lhs.shape[lhs_axis] != rhs.shape[rhs_axis] {
+            return Err(Error::InvalidConfig {
+                op: OP,
+                message: format!(
+                    "batch dim size mismatch: lhs axis {lhs_axis}={} rhs axis {rhs_axis}={}",
+                    lhs.shape[lhs_axis], rhs.shape[rhs_axis]
+                ),
+            });
+        }
+    }
+
+    Ok(())
 }
 
 fn try_fuse_dims(shapes: &[usize], strides: &[isize]) -> Option<(usize, isize)> {
@@ -219,29 +354,30 @@ pub(crate) fn dot_general<T>(
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     config: &DotGeneralConfig,
-) -> TypedTensor<T>
+) -> crate::Result<TypedTensor<T>>
 where
     T: FaerGemm + Copy + Clone + Zero + One + PartialEq,
 {
+    validate_dot_general(lhs, rhs, config)?;
     if let Some(result) = typed_faer_gemm(lhs, rhs, config) {
-        return result;
+        return Ok(result);
     }
     let (lhs_perm, rhs_perm, new_config) =
         canonical_gemm_layout(config, lhs.shape.len(), rhs.shape.len());
     let lhs_canon = if is_identity_perm(&lhs_perm) {
         std::borrow::Cow::Borrowed(lhs)
     } else {
-        std::borrow::Cow::Owned(typed_transpose(lhs, &lhs_perm))
+        std::borrow::Cow::Owned(typed_transpose(lhs, &lhs_perm)?)
     };
     let rhs_canon = if is_identity_perm(&rhs_perm) {
         std::borrow::Cow::Borrowed(rhs)
     } else {
-        std::borrow::Cow::Owned(typed_transpose(rhs, &rhs_perm))
+        std::borrow::Cow::Owned(typed_transpose(rhs, &rhs_perm)?)
     };
-    // Canonical layout guarantees contiguous dim groups in col-major,
-    // so analyse_gemm / try_fuse_dims will always succeed here.
-    typed_faer_gemm(&lhs_canon, &rhs_canon, &new_config)
-        .unwrap_or_else(|| unreachable!("canonical layout is always fusable"))
+    typed_faer_gemm(&lhs_canon, &rhs_canon, &new_config).ok_or_else(|| Error::BackendFailure {
+        op: "dot_general",
+        message: "CPU GEMM requires host-backed canonical inputs".into(),
+    })
 }
 
 #[cfg(feature = "cpu-faer")]
@@ -311,12 +447,13 @@ pub(crate) fn dot_general<T>(
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     config: &DotGeneralConfig,
-) -> TypedTensor<T>
+) -> crate::Result<TypedTensor<T>>
 where
     T: BlasGemm + Copy + Clone + Zero + One,
 {
+    validate_dot_general(lhs, rhs, config)?;
     if let Some(result) = typed_blas_gemm(lhs, rhs, config) {
-        return result;
+        return Ok(result);
     }
     let (lhs_perm, rhs_perm, new_config) =
         canonical_gemm_layout(config, lhs.shape.len(), rhs.shape.len());
@@ -330,10 +467,10 @@ where
     } else {
         std::borrow::Cow::Owned(typed_transpose(rhs, &rhs_perm))
     };
-    // Canonical layout guarantees contiguous dim groups in col-major,
-    // so analyse_gemm / try_fuse_dims will always succeed here.
-    typed_blas_gemm(&lhs_canon, &rhs_canon, &new_config)
-        .unwrap_or_else(|| unreachable!("canonical layout is always fusable"))
+    typed_blas_gemm(&lhs_canon, &rhs_canon, &new_config).ok_or_else(|| Error::BackendFailure {
+        op: "dot_general",
+        message: "CPU GEMM requires host-backed canonical inputs".into(),
+    })
 }
 
 #[cfg(feature = "cpu-blas")]

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -460,12 +460,12 @@ where
     let lhs_canon = if is_identity_perm(&lhs_perm) {
         std::borrow::Cow::Borrowed(lhs)
     } else {
-        std::borrow::Cow::Owned(typed_transpose(lhs, &lhs_perm))
+        std::borrow::Cow::Owned(typed_transpose(lhs, &lhs_perm)?)
     };
     let rhs_canon = if is_identity_perm(&rhs_perm) {
         std::borrow::Cow::Borrowed(rhs)
     } else {
-        std::borrow::Cow::Owned(typed_transpose(rhs, &rhs_perm))
+        std::borrow::Cow::Owned(typed_transpose(rhs, &rhs_perm)?)
     };
     typed_blas_gemm(&lhs_canon, &rhs_canon, &new_config).ok_or_else(|| Error::BackendFailure {
         op: "dot_general",

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -66,7 +66,16 @@ pub fn scatter(
 }
 
 pub fn slice(input: &Tensor, config: &SliceConfig) -> Tensor {
-    dispatch_tensor!(input, tensor => typed_slice(tensor, config))
+    try_slice(input, config).expect("slice")
+}
+
+pub fn try_slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(tensor) => Ok(Tensor::F32(typed_slice(tensor, config)?)),
+        Tensor::F64(tensor) => Ok(Tensor::F64(typed_slice(tensor, config)?)),
+        Tensor::C32(tensor) => Ok(Tensor::C32(typed_slice(tensor, config)?)),
+        Tensor::C64(tensor) => Ok(Tensor::C64(typed_slice(tensor, config)?)),
+    }
 }
 
 pub fn dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> Tensor {
@@ -75,7 +84,16 @@ pub fn dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> 
 }
 
 pub fn pad(input: &Tensor, config: &PadConfig) -> Tensor {
-    dispatch_tensor!(input, t => typed_pad(t, config))
+    try_pad(input, config).expect("pad")
+}
+
+pub fn try_pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(tensor) => Ok(Tensor::F32(typed_pad(tensor, config)?)),
+        Tensor::F64(tensor) => Ok(Tensor::F64(typed_pad(tensor, config)?)),
+        Tensor::C32(tensor) => Ok(Tensor::C32(typed_pad(tensor, config)?)),
+        Tensor::C64(tensor) => Ok(Tensor::C64(typed_pad(tensor, config)?)),
+    }
 }
 
 pub fn concatenate(inputs: &[&Tensor], axis: usize) -> Tensor {
@@ -90,11 +108,32 @@ pub fn reverse(input: &Tensor, axes: &[usize]) -> Tensor {
     dispatch_tensor!(input, tensor => typed_reverse(tensor, axes))
 }
 
-fn typed_slice<T: Copy + Clone>(input: &TypedTensor<T>, config: &SliceConfig) -> TypedTensor<T> {
+fn typed_slice<T: Copy + Clone>(
+    input: &TypedTensor<T>,
+    config: &SliceConfig,
+) -> crate::Result<TypedTensor<T>> {
     let rank = input.shape.len();
-    assert_eq!(config.starts.len(), rank, "slice: starts rank mismatch");
-    assert_eq!(config.limits.len(), rank, "slice: limits rank mismatch");
-    assert_eq!(config.strides.len(), rank, "slice: strides rank mismatch");
+    if config.starts.len() != rank {
+        return Err(crate::Error::RankMismatch {
+            op: "slice",
+            expected: rank,
+            actual: config.starts.len(),
+        });
+    }
+    if config.limits.len() != rank {
+        return Err(crate::Error::RankMismatch {
+            op: "slice",
+            expected: rank,
+            actual: config.limits.len(),
+        });
+    }
+    if config.strides.len() != rank {
+        return Err(crate::Error::RankMismatch {
+            op: "slice",
+            expected: rank,
+            actual: config.strides.len(),
+        });
+    }
 
     let out_shape: Vec<usize> = input
         .shape
@@ -104,13 +143,29 @@ fn typed_slice<T: Copy + Clone>(input: &TypedTensor<T>, config: &SliceConfig) ->
             let start = config.starts[axis];
             let limit = config.limits[axis];
             let stride = config.strides[axis];
-            assert!(start <= limit, "slice: start exceeds limit on axis {axis}");
-            assert!(limit <= dim, "slice: limit out of bounds on axis {axis}");
-            assert!(stride > 0, "slice: stride must be positive on axis {axis}");
+            if start > limit {
+                return Err(crate::Error::InvalidConfig {
+                    op: "slice",
+                    message: format!("start exceeds limit on axis {axis}"),
+                });
+            }
+            if limit > dim {
+                return Err(crate::Error::AxisOutOfBounds {
+                    op: "slice",
+                    axis,
+                    rank,
+                });
+            }
+            if stride == 0 {
+                return Err(crate::Error::InvalidConfig {
+                    op: "slice",
+                    message: format!("stride must be positive on axis {axis}"),
+                });
+            }
             let span = limit - start;
-            (span + stride - 1) / stride
+            Ok((span + stride - 1) / stride)
         })
-        .collect();
+        .collect::<crate::Result<Vec<_>>>()?;
 
     let out_len: usize = out_shape.iter().product();
     let mut out_data = Vec::with_capacity(out_len);
@@ -125,7 +180,7 @@ fn typed_slice<T: Copy + Clone>(input: &TypedTensor<T>, config: &SliceConfig) ->
         out_data.push(*input.get(&in_idx));
     }
 
-    TypedTensor::from_vec(out_shape, out_data)
+    Ok(TypedTensor::from_vec(out_shape, out_data))
 }
 
 fn typed_concatenate_from_dyn_inputs<T>(
@@ -581,36 +636,53 @@ fn typed_dynamic_slice<T: Copy + Clone + Zero>(
     out
 }
 
-fn typed_pad<T: Copy + Clone + Zero>(input: &TypedTensor<T>, config: &PadConfig) -> TypedTensor<T> {
-    assert_eq!(
-        config.edge_padding_low.len(),
-        input.shape.len(),
-        "pad: edge_padding_low rank mismatch"
-    );
-    assert_eq!(
-        config.edge_padding_high.len(),
-        input.shape.len(),
-        "pad: edge_padding_high rank mismatch"
-    );
-    assert_eq!(
-        config.interior_padding.len(),
-        input.shape.len(),
-        "pad: interior_padding rank mismatch"
-    );
+fn typed_pad<T: Copy + Clone + Zero>(
+    input: &TypedTensor<T>,
+    config: &PadConfig,
+) -> crate::Result<TypedTensor<T>> {
+    let rank = input.shape.len();
+    if config.edge_padding_low.len() != rank {
+        return Err(crate::Error::RankMismatch {
+            op: "pad",
+            expected: rank,
+            actual: config.edge_padding_low.len(),
+        });
+    }
+    if config.edge_padding_high.len() != rank {
+        return Err(crate::Error::RankMismatch {
+            op: "pad",
+            expected: rank,
+            actual: config.edge_padding_high.len(),
+        });
+    }
+    if config.interior_padding.len() != rank {
+        return Err(crate::Error::RankMismatch {
+            op: "pad",
+            expected: rank,
+            actual: config.interior_padding.len(),
+        });
+    }
 
     let mut out_shape = Vec::with_capacity(input.shape.len());
     for axis in 0..input.shape.len() {
-        assert!(
-            config.interior_padding[axis] >= 0,
-            "pad: interior padding must be non-negative"
-        );
+        if config.interior_padding[axis] < 0 {
+            return Err(crate::Error::InvalidConfig {
+                op: "pad",
+                message: format!("interior padding must be non-negative on axis {axis}"),
+            });
+        }
         let base = if input.shape[axis] == 0 {
             0
         } else {
             (input.shape[axis] as i64 - 1) * (config.interior_padding[axis] + 1) + 1
         };
         let dim = config.edge_padding_low[axis] + config.edge_padding_high[axis] + base;
-        out_shape.push(usize::try_from(dim).expect("pad: negative output dimension"));
+        out_shape.push(
+            usize::try_from(dim).map_err(|_| crate::Error::InvalidConfig {
+                op: "pad",
+                message: format!("negative output dimension on axis {axis}"),
+            })?,
+        );
     }
 
     let mut out = TypedTensor::zeros(out_shape.clone());
@@ -634,5 +706,5 @@ fn typed_pad<T: Copy + Clone + Zero>(input: &TypedTensor<T>, config: &PadConfig)
         }
     }
 
-    out
+    Ok(out)
 }

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -5,7 +5,7 @@ use crate::{Buffer, Tensor, TypedTensor};
 
 pub(crate) trait FaerLinalg: Copy + Clone {
     fn parity_one() -> Self;
-    fn cholesky_2d(input: &TypedTensor<Self>) -> TypedTensor<Self>;
+    fn cholesky_2d(input: &TypedTensor<Self>) -> crate::Result<TypedTensor<Self>>;
     fn lu_2d(input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>>;
     fn triangular_solve_2d(
         a: &TypedTensor<Self>,
@@ -149,10 +149,14 @@ fn transpose_col_major_data<T: Copy>(data: &[T], rows: usize, cols: usize) -> Ve
     transposed
 }
 
-fn batched_single<T, F>(input: &TypedTensor<T>, core_rank: usize, op: F) -> TypedTensor<T>
+fn batched_single<T, F>(
+    input: &TypedTensor<T>,
+    core_rank: usize,
+    op: F,
+) -> crate::Result<TypedTensor<T>>
 where
     T: Clone,
-    F: Fn(&TypedTensor<T>) -> TypedTensor<T>,
+    F: Fn(&TypedTensor<T>) -> crate::Result<TypedTensor<T>>,
 {
     let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, "batched_single");
     if batch_shape.is_empty() {
@@ -177,7 +181,7 @@ where
             input.host_data()[start..end].to_vec(),
             input,
         );
-        let batch_output = op(&batch_input);
+        let batch_output = op(&batch_input)?;
 
         if let Some(expected_shape) = &out_core_shape {
             assert_eq!(
@@ -195,7 +199,7 @@ where
 
     let mut out_shape = out_core_shape.expect("batched_single: missing output shape");
     out_shape.extend_from_slice(batch_shape);
-    tensor_from_vec_with_template(out_shape, out_data, input)
+    Ok(tensor_from_vec_with_template(out_shape, out_data, input))
 }
 
 fn batched_multi<T, F>(input: &TypedTensor<T>, core_rank: usize, op: F) -> Vec<TypedTensor<T>>
@@ -412,14 +416,19 @@ impl FaerLinalg for f64 {
         1.0
     }
 
-    fn cholesky_2d(input: &TypedTensor<Self>) -> TypedTensor<Self> {
+    fn cholesky_2d(input: &TypedTensor<Self>) -> crate::Result<TypedTensor<Self>> {
         let n = square_matrix_dim(input, "cholesky");
         let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
         let chol = match mat.llt(Side::Lower) {
             Ok(chol) => chol,
-            Err(_) => panic!("cholesky: matrix is not positive definite"),
+            Err(_) => {
+                return Err(crate::Error::BackendFailure {
+                    op: "cholesky",
+                    message: "matrix is not positive definite".into(),
+                });
+            }
         };
-        tensor_from_mat(chol.L(), vec![n, n], input)
+        Ok(tensor_from_mat(chol.L(), vec![n, n], input))
     }
 
     fn lu_2d(input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
@@ -660,14 +669,19 @@ impl FaerLinalg for Complex64 {
         Complex64::new(1.0, 0.0)
     }
 
-    fn cholesky_2d(input: &TypedTensor<Self>) -> TypedTensor<Self> {
+    fn cholesky_2d(input: &TypedTensor<Self>) -> crate::Result<TypedTensor<Self>> {
         let n = square_matrix_dim(input, "cholesky");
         let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), n, n);
         let chol = match mat.llt(Side::Lower) {
             Ok(chol) => chol,
-            Err(_) => panic!("cholesky: matrix is not positive definite"),
+            Err(_) => {
+                return Err(crate::Error::BackendFailure {
+                    op: "cholesky",
+                    message: "matrix is not positive definite".into(),
+                });
+            }
         };
-        tensor_from_mat(chol.L(), vec![n, n], input)
+        Ok(tensor_from_mat(chol.L(), vec![n, n], input))
     }
 
     fn lu_2d(input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
@@ -912,9 +926,13 @@ impl FaerLinalg for Complex64 {
     }
 }
 
-pub(crate) fn cholesky<T: FaerLinalg>(input: &TypedTensor<T>) -> TypedTensor<T> {
+pub(crate) fn cholesky<T: FaerLinalg>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&input.shape) {
-        return tensor_from_vec_with_template(input.shape.clone(), Vec::new(), input);
+        return Ok(tensor_from_vec_with_template(
+            input.shape.clone(),
+            Vec::new(),
+            input,
+        ));
     }
     batched_single(input, 2, T::cholesky_2d)
 }

--- a/tenferro-tensor/src/cpu/reduction.rs
+++ b/tenferro-tensor/src/cpu/reduction.rs
@@ -3,41 +3,78 @@ use std::ops::{Add, Mul};
 use num_traits::{Float, One, Zero};
 use strided_kernel::{col_major_strides, reduce_axis, StridedArray};
 
-use crate::types::{dispatch_tensor, Tensor, TypedTensor};
+use crate::types::{Tensor, TypedTensor};
 
-pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> Tensor {
-    dispatch_tensor!(input, t => typed_reduce_sum(t, axes))
+fn backend_failure(op: &'static str, err: impl ToString) -> crate::Error {
+    crate::Error::BackendFailure {
+        op,
+        message: err.to_string(),
+    }
 }
 
-pub fn reduce_prod(input: &Tensor, axes: &[usize]) -> Tensor {
-    dispatch_tensor!(input, t => typed_reduce_prod(t, axes))
+fn validate_axes(op: &'static str, axes: &[usize], rank: usize) -> crate::Result<()> {
+    let mut seen = vec![false; rank];
+    for &axis in axes {
+        if axis >= rank {
+            return Err(crate::Error::AxisOutOfBounds { op, axis, rank });
+        }
+        if seen[axis] {
+            return Err(crate::Error::DuplicateAxis {
+                op,
+                axis,
+                role: "axes",
+            });
+        }
+        seen[axis] = true;
+    }
+    Ok(())
 }
 
-pub fn reduce_max(input: &Tensor, axes: &[usize]) -> Tensor {
+pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_sum(t, axes)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_sum(t, axes)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_sum(t, axes)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_sum(t, axes)?)),
+    }
+}
+
+pub fn reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_prod(t, axes)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_prod(t, axes)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_prod(t, axes)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_prod(t, axes)?)),
+    }
+}
+
+pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     if axes.is_empty() {
-        return input.clone();
+        return Ok(input.clone());
     }
 
     match input {
-        Tensor::F32(tensor) => Tensor::F32(typed_reduce_max(tensor, axes)),
-        Tensor::F64(tensor) => Tensor::F64(typed_reduce_max(tensor, axes)),
-        Tensor::C32(_) | Tensor::C64(_) => {
-            panic!("reduce_max is only implemented for real tensors")
-        }
+        Tensor::F32(tensor) => Ok(Tensor::F32(typed_reduce_max(tensor, axes)?)),
+        Tensor::F64(tensor) => Ok(Tensor::F64(typed_reduce_max(tensor, axes)?)),
+        Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            op: "reduce_max",
+            message: format!("unsupported dtype {:?}", input.dtype()),
+        }),
     }
 }
 
-pub fn reduce_min(input: &Tensor, axes: &[usize]) -> Tensor {
+pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     if axes.is_empty() {
-        return input.clone();
+        return Ok(input.clone());
     }
 
     match input {
-        Tensor::F32(tensor) => Tensor::F32(typed_reduce_min(tensor, axes)),
-        Tensor::F64(tensor) => Tensor::F64(typed_reduce_min(tensor, axes)),
-        Tensor::C32(_) | Tensor::C64(_) => {
-            panic!("reduce_min is only implemented for real tensors")
-        }
+        Tensor::F32(tensor) => Ok(Tensor::F32(typed_reduce_min(tensor, axes)?)),
+        Tensor::F64(tensor) => Ok(Tensor::F64(typed_reduce_min(tensor, axes)?)),
+        Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            op: "reduce_min",
+            message: format!("unsupported dtype {:?}", input.dtype()),
+        }),
     }
 }
 
@@ -47,15 +84,16 @@ fn typed_reduce<T, M, R>(
     map_fn: M,
     reduce_fn: R,
     init: T,
-    label: &str,
-) -> TypedTensor<T>
+    label: &'static str,
+) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone,
     M: Fn(T) -> T + Copy,
     R: Fn(T, T) -> T + Copy,
 {
+    validate_axes(label, axes, input.shape.len())?;
     if axes.is_empty() {
-        return input.clone();
+        return Ok(input.clone());
     }
 
     let output_shape: Vec<usize> = input
@@ -69,33 +107,33 @@ where
     let strides = col_major_strides(&input.shape);
     let mut current =
         StridedArray::from_parts(input.host_data().to_vec(), &input.shape, &strides, 0)
-            .unwrap_or_else(|err| panic!("{label} input: {err}"));
+            .map_err(|err| backend_failure(label, err))?;
 
     let mut sorted_axes = axes.to_vec();
     sorted_axes.sort_unstable_by(|a, b| b.cmp(a));
     for axis in sorted_axes {
         current = reduce_axis(&current.view(), axis, map_fn, reduce_fn, init)
-            .unwrap_or_else(|err| panic!("{label}: {err}"));
+            .map_err(|err| backend_failure(label, err))?;
     }
 
-    TypedTensor::from_vec(output_shape, current.into_data())
+    Ok(TypedTensor::from_vec(output_shape, current.into_data()))
 }
 
-pub fn typed_reduce_sum<T>(input: &TypedTensor<T>, axes: &[usize]) -> TypedTensor<T>
+pub fn typed_reduce_sum<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Zero + Add<Output = T>,
 {
     typed_reduce(input, axes, |x| x, |a, b| a + b, T::zero(), "reduce_sum")
 }
 
-pub fn typed_reduce_prod<T>(input: &TypedTensor<T>, axes: &[usize]) -> TypedTensor<T>
+pub fn typed_reduce_prod<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + One + Mul<Output = T>,
 {
     typed_reduce(input, axes, |x| x, |a, b| a * b, T::one(), "reduce_prod")
 }
 
-pub fn typed_reduce_max<T>(input: &TypedTensor<T>, axes: &[usize]) -> TypedTensor<T>
+pub fn typed_reduce_max<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
 where
     T: Float,
 {
@@ -109,7 +147,7 @@ where
     )
 }
 
-pub fn typed_reduce_min<T>(input: &TypedTensor<T>, axes: &[usize]) -> TypedTensor<T>
+pub fn typed_reduce_min<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
 where
     T: Float,
 {

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -1,25 +1,115 @@
 use num_complex::{Complex32, Complex64};
-use strided_kernel::{copy_into, map_into, StridedView};
-
 use num_traits::Zero;
+use strided_kernel::{copy_into, map_into, Identity, StridedView};
 
 use crate::{
-    types::{dispatch_tensor, flat_to_multi, Tensor, TypedTensor},
+    types::{flat_to_multi, Tensor, TypedTensor},
     DType,
 };
 
 use super::{tensor_from_array, typed_array, typed_view};
 
-pub fn transpose(input: &Tensor, perm: &[usize]) -> Tensor {
-    dispatch_tensor!(input, t => typed_transpose(t, perm))
+fn backend_failure(op: &'static str, err: impl ToString) -> crate::Error {
+    crate::Error::BackendFailure {
+        op,
+        message: err.to_string(),
+    }
 }
 
-pub fn reshape(input: &Tensor, shape: &[usize]) -> Tensor {
-    dispatch_tensor!(input, t => typed_reshape(t, shape))
+fn validate_rank(op: &'static str, expected: usize, actual: usize) -> crate::Result<()> {
+    if expected != actual {
+        return Err(crate::Error::RankMismatch {
+            op,
+            expected,
+            actual,
+        });
+    }
+    Ok(())
 }
 
-pub fn broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> Tensor {
-    dispatch_tensor!(input, t => typed_broadcast_in_dim(t, shape, dims))
+fn validate_axis(op: &'static str, axis: usize, rank: usize) -> crate::Result<()> {
+    if axis >= rank {
+        return Err(crate::Error::AxisOutOfBounds { op, axis, rank });
+    }
+    Ok(())
+}
+
+fn validate_axes_distinct(op: &'static str, axis_a: usize, axis_b: usize) -> crate::Result<()> {
+    if axis_a == axis_b {
+        return Err(crate::Error::DuplicateAxis {
+            op,
+            axis: axis_a,
+            role: "axes",
+        });
+    }
+    Ok(())
+}
+
+fn validate_permutation(op: &'static str, perm: &[usize], rank: usize) -> crate::Result<()> {
+    validate_rank(op, rank, perm.len())?;
+    let mut seen = vec![false; rank];
+    for &axis in perm {
+        validate_axis(op, axis, rank)?;
+        if seen[axis] {
+            return Err(crate::Error::DuplicateAxis {
+                op,
+                axis,
+                role: "perm",
+            });
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn host_view<T: Copy>(tensor: &TypedTensor<T>) -> crate::Result<StridedView<'_, T, Identity>> {
+    match &tensor.buffer {
+        crate::Buffer::Host(data) => {
+            let strides = crate::col_major_strides(&tensor.shape);
+            StridedView::new(data, &tensor.shape, &strides, 0)
+                .map_err(|err| backend_failure("structural", err))
+        }
+        crate::Buffer::Backend(_) => Err(crate::Error::BackendFailure {
+            op: "structural",
+            message: "backend buffers are not supported for structural CPU helpers".into(),
+        }),
+    }
+}
+
+fn copy_view_to_array<T: Copy + Clone>(
+    op: &'static str,
+    mut out: strided_kernel::StridedArray<T>,
+    src: &StridedView<'_, T>,
+) -> crate::Result<TypedTensor<T>> {
+    copy_into(&mut out.view_mut(), src).map_err(|err| backend_failure(op, err))?;
+    Ok(tensor_from_array(out))
+}
+
+pub fn transpose(input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_transpose(t, perm)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_transpose(t, perm)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_transpose(t, perm)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_transpose(t, perm)?)),
+    }
+}
+
+pub fn reshape(input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_reshape(t, shape)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_reshape(t, shape)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_reshape(t, shape)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_reshape(t, shape)?)),
+    }
+}
+
+pub fn broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_broadcast_in_dim(t, shape, dims)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_broadcast_in_dim(t, shape, dims)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_broadcast_in_dim(t, shape, dims)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_broadcast_in_dim(t, shape, dims)?)),
+    }
 }
 
 pub fn convert(input: &Tensor, to: DType) -> Tensor {
@@ -51,71 +141,124 @@ pub fn convert(input: &Tensor, to: DType) -> Tensor {
     }
 }
 
-pub fn extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> Tensor {
-    dispatch_tensor!(input, t => typed_extract_diagonal(t, axis_a, axis_b))
+pub fn extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_extract_diagonal(t, axis_a, axis_b)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_extract_diagonal(t, axis_a, axis_b)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_extract_diagonal(t, axis_a, axis_b)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_extract_diagonal(t, axis_a, axis_b)?)),
+    }
 }
 
-pub fn embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> Tensor {
-    dispatch_tensor!(input, t => typed_embed_diagonal(t, axis_a, axis_b))
+pub fn embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_embed_diagonal(t, axis_a, axis_b)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_embed_diagonal(t, axis_a, axis_b)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_embed_diagonal(t, axis_a, axis_b)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_embed_diagonal(t, axis_a, axis_b)?)),
+    }
 }
 
-pub fn tril(input: &Tensor, k: i64) -> Tensor {
-    dispatch_tensor!(input, t => typed_tril(t, k))
+pub fn tril(input: &Tensor, k: i64) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_tril(t, k)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_tril(t, k)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_tril(t, k)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_tril(t, k)?)),
+    }
 }
 
-pub fn triu(input: &Tensor, k: i64) -> Tensor {
-    dispatch_tensor!(input, t => typed_triu(t, k))
+pub fn triu(input: &Tensor, k: i64) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_triu(t, k)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_triu(t, k)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_triu(t, k)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_triu(t, k)?)),
+    }
 }
 
 pub fn typed_transpose<T: Copy + Zero + Clone>(
     tensor: &TypedTensor<T>,
     perm: &[usize],
-) -> TypedTensor<T> {
-    let src = typed_view(tensor);
-    let permuted = src.permute(perm).expect("transpose perm");
-    let mut out = typed_array(permuted.dims(), T::zero());
-    copy_into(&mut out.view_mut(), &permuted).expect("transpose copy");
-    tensor_from_array(out)
+) -> crate::Result<TypedTensor<T>> {
+    validate_permutation("transpose", perm, tensor.shape.len())?;
+    let src = host_view(tensor)?;
+    let permuted = src
+        .permute(perm)
+        .map_err(|err| backend_failure("transpose", err))?;
+    let out = typed_array(permuted.dims(), T::zero());
+    copy_view_to_array("transpose", out, &permuted)
 }
 
-pub fn typed_reshape<T: Clone>(tensor: &TypedTensor<T>, shape: &[usize]) -> TypedTensor<T> {
+pub fn typed_reshape<T: Clone>(
+    tensor: &TypedTensor<T>,
+    shape: &[usize],
+) -> crate::Result<TypedTensor<T>> {
     let old_n: usize = tensor.shape.iter().product();
     let new_n: usize = shape.iter().product();
-    assert_eq!(old_n, new_n, "reshape: element count mismatch");
-    TypedTensor {
+    if old_n != new_n {
+        return Err(crate::Error::ShapeMismatch {
+            op: "reshape",
+            lhs: tensor.shape.clone(),
+            rhs: shape.to_vec(),
+        });
+    }
+    Ok(TypedTensor {
         buffer: tensor.buffer.clone(),
         shape: shape.to_vec(),
         placement: tensor.placement.clone(),
-    }
+    })
 }
 
 pub fn typed_broadcast_in_dim<T: Copy + Zero + Clone>(
     tensor: &TypedTensor<T>,
     shape: &[usize],
     dims: &[usize],
-) -> TypedTensor<T> {
-    assert_eq!(
-        dims.len(),
-        tensor.shape.len(),
-        "broadcast_in_dim rank mismatch"
-    );
+) -> crate::Result<TypedTensor<T>> {
+    validate_rank("broadcast_in_dim", tensor.shape.len(), dims.len())?;
+    let mut seen = vec![false; shape.len()];
     let mut base_dims = vec![1usize; shape.len()];
     let mut base_strides = vec![0isize; shape.len()];
     let source_strides = crate::col_major_strides(&tensor.shape);
     for (src_axis, &dst_axis) in dims.iter().enumerate() {
-        base_dims[dst_axis] = tensor.shape[src_axis];
+        validate_axis("broadcast_in_dim", dst_axis, shape.len())?;
+        if seen[dst_axis] {
+            return Err(crate::Error::DuplicateAxis {
+                op: "broadcast_in_dim",
+                axis: dst_axis,
+                role: "dims",
+            });
+        }
+        seen[dst_axis] = true;
+        let source_dim = tensor.shape[src_axis];
+        let target_dim = shape[dst_axis];
+        if source_dim != target_dim && source_dim != 1 {
+            return Err(crate::Error::ShapeMismatch {
+                op: "broadcast_in_dim",
+                lhs: tensor.shape.clone(),
+                rhs: shape.to_vec(),
+            });
+        }
+        base_dims[dst_axis] = source_dim;
         base_strides[dst_axis] = source_strides[src_axis];
     }
-    let base: StridedView<'_, T> = match &tensor.buffer {
-        crate::Buffer::Host(data) => {
-            StridedView::new(data, &base_dims, &base_strides, 0).expect("broadcast base view")
+    let base: StridedView<'_, T, Identity> = match &tensor.buffer {
+        crate::Buffer::Host(data) => StridedView::new(data, &base_dims, &base_strides, 0)
+            .map_err(|err| backend_failure("broadcast_in_dim", err))?,
+        crate::Buffer::Backend(_) => {
+            return Err(crate::Error::BackendFailure {
+                op: "broadcast_in_dim",
+                message: "backend buffers are not supported for structural CPU helpers".into(),
+            })
         }
-        crate::Buffer::Backend(_) => todo!("broadcast_in_dim for backend buffers"),
     };
-    let broadcast = base.broadcast(shape).expect("broadcast shape");
+    let broadcast: StridedView<'_, T, Identity> = base
+        .broadcast(shape)
+        .map_err(|err| backend_failure("broadcast_in_dim", err))?;
     let mut out = typed_array(shape, T::zero());
-    copy_into(&mut out.view_mut(), &broadcast).expect("broadcast copy");
-    tensor_from_array(out)
+    copy_into(&mut out.view_mut(), &broadcast)
+        .map_err(|err| backend_failure("broadcast_in_dim", err))?;
+    Ok(tensor_from_array(out))
 }
 
 fn typed_convert<S, T>(tensor: &TypedTensor<S>, f: impl Fn(S) -> T) -> TypedTensor<T>
@@ -132,28 +275,33 @@ pub fn typed_extract_diagonal<T: Copy + Zero + Clone>(
     tensor: &TypedTensor<T>,
     axis_a: usize,
     axis_b: usize,
-) -> TypedTensor<T> {
-    let diag = typed_view(tensor)
+) -> crate::Result<TypedTensor<T>> {
+    validate_axis("extract_diagonal", axis_a, tensor.shape.len())?;
+    validate_axis("extract_diagonal", axis_b, tensor.shape.len())?;
+    validate_axes_distinct("extract_diagonal", axis_a, axis_b)?;
+
+    let diag = host_view(tensor)?
         .diagonal_view(&[(axis_a, axis_b)])
-        .expect("diagonal_view");
+        .map_err(|err| backend_failure("extract_diagonal", err))?;
     let mut out = typed_array(diag.dims(), T::zero());
-    copy_into(&mut out.view_mut(), &diag).expect("extract_diagonal copy");
-    tensor_from_array(out)
+    copy_into(&mut out.view_mut(), &diag)
+        .map_err(|err| backend_failure("extract_diagonal", err))?;
+    Ok(tensor_from_array(out))
 }
 
 pub fn typed_embed_diagonal<T: Copy + Zero + Clone>(
     tensor: &TypedTensor<T>,
     axis_a: usize,
     axis_b: usize,
-) -> TypedTensor<T> {
-    assert!(
-        axis_a < tensor.shape.len(),
-        "embed_diagonal: axis_a out of range"
-    );
-    assert!(
-        axis_b <= tensor.shape.len(),
-        "embed_diagonal: axis_b must be <= rank"
-    );
+) -> crate::Result<TypedTensor<T>> {
+    validate_axis("embed_diagonal", axis_a, tensor.shape.len())?;
+    if axis_b > tensor.shape.len() {
+        return Err(crate::Error::AxisOutOfBounds {
+            op: "embed_diagonal",
+            axis: axis_b,
+            rank: tensor.shape.len(),
+        });
+    }
 
     let n = tensor.shape[axis_a];
     let mut out_shape = tensor.shape.clone();
@@ -164,6 +312,16 @@ pub fn typed_embed_diagonal<T: Copy + Zero + Clone>(
     let out_rank = out.shape.len();
     let mut in_idx = vec![0usize; in_rank];
     let mut out_idx = vec![0usize; out_rank];
+
+    let input_data = match &tensor.buffer {
+        crate::Buffer::Host(data) => data,
+        crate::Buffer::Backend(_) => {
+            return Err(crate::Error::BackendFailure {
+                op: "embed_diagonal",
+                message: "backend buffers are not supported for structural CPU helpers".into(),
+            })
+        }
+    };
 
     for flat in 0..tensor.n_elements() {
         flat_to_multi(flat, &tensor.shape, &mut in_idx);
@@ -177,16 +335,22 @@ pub fn typed_embed_diagonal<T: Copy + Zero + Clone>(
                 src_axis += 1;
             }
         }
-        *out.get_mut(&out_idx) = *tensor.get(&in_idx);
+        *out.get_mut(&out_idx) = input_data[flat];
     }
-    out
+    Ok(out)
 }
 
-pub fn typed_tril<T: Copy + Zero + Clone>(tensor: &TypedTensor<T>, k: i64) -> TypedTensor<T> {
+pub fn typed_tril<T: Copy + Zero + Clone>(
+    tensor: &TypedTensor<T>,
+    k: i64,
+) -> crate::Result<TypedTensor<T>> {
     typed_triangular_mask(tensor, k, false)
 }
 
-pub fn typed_triu<T: Copy + Zero + Clone>(tensor: &TypedTensor<T>, k: i64) -> TypedTensor<T> {
+pub fn typed_triu<T: Copy + Zero + Clone>(
+    tensor: &TypedTensor<T>,
+    k: i64,
+) -> crate::Result<TypedTensor<T>> {
     typed_triangular_mask(tensor, k, true)
 }
 
@@ -194,23 +358,33 @@ fn typed_triangular_mask<T: Copy + Zero + Clone>(
     tensor: &TypedTensor<T>,
     k: i64,
     upper: bool,
-) -> TypedTensor<T> {
-    assert!(
-        tensor.shape.len() >= 2,
-        "triangular mask: expected rank >= 2, got {}",
-        tensor.shape.len()
-    );
+) -> crate::Result<TypedTensor<T>> {
+    if tensor.shape.len() < 2 {
+        return Err(crate::Error::RankMismatch {
+            op: if upper { "triu" } else { "tril" },
+            expected: 2,
+            actual: tensor.shape.len(),
+        });
+    }
 
     let rows = tensor.shape[0];
     let cols = tensor.shape[1];
     if tensor.shape.contains(&0) {
-        return tensor.clone();
+        return Ok(tensor.clone());
     }
 
     let batch_count: usize = tensor.shape[2..].iter().product();
     let block_size = rows * cols;
     let mut out = tensor.clone();
-    let data = out.host_data_mut();
+    let data = match &mut out.buffer {
+        crate::Buffer::Host(data) => data,
+        crate::Buffer::Backend(_) => {
+            return Err(crate::Error::BackendFailure {
+                op: if upper { "triu" } else { "tril" },
+                message: "backend buffers are not supported for structural CPU helpers".into(),
+            })
+        }
+    };
 
     for batch_idx in 0..batch_count {
         let base = batch_idx * block_size;
@@ -229,5 +403,5 @@ fn typed_triangular_mask<T: Copy + Zero + Clone>(
         }
     }
 
-    out
+    Ok(out)
 }

--- a/tenferro-tensor/src/cuda/mod.rs
+++ b/tenferro-tensor/src/cuda/mod.rs
@@ -18,76 +18,91 @@ impl CudaBackend {
 macro_rules! impl_stub_backend {
     ($ty:ty, $label:literal) => {
         impl TensorBackend for $ty {
-            fn add(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn add(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " add"))
             }
-            fn mul(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn mul(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " mul"))
             }
-            fn neg(&mut self, _input: &Tensor) -> Tensor {
+            fn neg(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " neg"))
             }
-            fn conj(&mut self, _input: &Tensor) -> Tensor {
+            fn conj(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " conj"))
             }
-            fn div(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn div(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " div"))
             }
-            fn abs(&mut self, _input: &Tensor) -> Tensor {
+            fn abs(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " abs"))
             }
-            fn sign(&mut self, _input: &Tensor) -> Tensor {
+            fn sign(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " sign"))
             }
-            fn maximum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn maximum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " maximum"))
             }
-            fn minimum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn minimum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " minimum"))
             }
-            fn compare(&mut self, _lhs: &Tensor, _rhs: &Tensor, _dir: &CompareDir) -> Tensor {
+            fn compare(
+                &mut self,
+                _lhs: &Tensor,
+                _rhs: &Tensor,
+                _dir: &CompareDir,
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " compare"))
             }
-            fn select(&mut self, _pred: &Tensor, _on_true: &Tensor, _on_false: &Tensor) -> Tensor {
+            fn select(
+                &mut self,
+                _pred: &Tensor,
+                _on_true: &Tensor,
+                _on_false: &Tensor,
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " select"))
             }
-            fn clamp(&mut self, _input: &Tensor, _lower: &Tensor, _upper: &Tensor) -> Tensor {
+            fn clamp(
+                &mut self,
+                _input: &Tensor,
+                _lower: &Tensor,
+                _upper: &Tensor,
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " clamp"))
             }
-            fn exp(&mut self, _input: &Tensor) -> Tensor {
+            fn exp(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " exp"))
             }
-            fn log(&mut self, _input: &Tensor) -> Tensor {
+            fn log(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " log"))
             }
-            fn sin(&mut self, _input: &Tensor) -> Tensor {
+            fn sin(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " sin"))
             }
-            fn cos(&mut self, _input: &Tensor) -> Tensor {
+            fn cos(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " cos"))
             }
-            fn tanh(&mut self, _input: &Tensor) -> Tensor {
+            fn tanh(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " tanh"))
             }
-            fn sqrt(&mut self, _input: &Tensor) -> Tensor {
+            fn sqrt(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " sqrt"))
             }
-            fn rsqrt(&mut self, _input: &Tensor) -> Tensor {
+            fn rsqrt(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " rsqrt"))
             }
-            fn pow(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn pow(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " pow"))
             }
-            fn expm1(&mut self, _input: &Tensor) -> Tensor {
+            fn expm1(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " expm1"))
             }
-            fn log1p(&mut self, _input: &Tensor) -> Tensor {
+            fn log1p(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " log1p"))
             }
-            fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> Tensor {
+            fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " transpose"))
             }
-            fn reshape(&mut self, _input: &Tensor, _shape: &[usize]) -> Tensor {
+            fn reshape(&mut self, _input: &Tensor, _shape: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reshape"))
             }
             fn broadcast_in_dim(
@@ -95,10 +110,10 @@ macro_rules! impl_stub_backend {
                 _input: &Tensor,
                 _shape: &[usize],
                 _dims: &[usize],
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " broadcast_in_dim"))
             }
-            fn convert(&mut self, _input: &Tensor, _to: crate::DType) -> Tensor {
+            fn convert(&mut self, _input: &Tensor, _to: crate::DType) -> crate::Result<Tensor> {
                 todo!(concat!($label, " convert"))
             }
             fn extract_diagonal(
@@ -106,7 +121,7 @@ macro_rules! impl_stub_backend {
                 _input: &Tensor,
                 _axis_a: usize,
                 _axis_b: usize,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " extract_diagonal"))
             }
             fn embed_diagonal(
@@ -114,25 +129,25 @@ macro_rules! impl_stub_backend {
                 _input: &Tensor,
                 _axis_a: usize,
                 _axis_b: usize,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " embed_diagonal"))
             }
-            fn tril(&mut self, _input: &Tensor, _k: i64) -> Tensor {
+            fn tril(&mut self, _input: &Tensor, _k: i64) -> crate::Result<Tensor> {
                 todo!(concat!($label, " tril"))
             }
-            fn triu(&mut self, _input: &Tensor, _k: i64) -> Tensor {
+            fn triu(&mut self, _input: &Tensor, _k: i64) -> crate::Result<Tensor> {
                 todo!(concat!($label, " triu"))
             }
-            fn reduce_sum(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+            fn reduce_sum(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reduce_sum"))
             }
-            fn reduce_prod(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+            fn reduce_prod(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reduce_prod"))
             }
-            fn reduce_max(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+            fn reduce_max(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reduce_max"))
             }
-            fn reduce_min(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+            fn reduce_min(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reduce_min"))
             }
             fn dot_general(
@@ -140,7 +155,7 @@ macro_rules! impl_stub_backend {
                 _lhs: &Tensor,
                 _rhs: &Tensor,
                 _config: &DotGeneralConfig,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " dot_general"))
             }
             fn gather(
@@ -148,7 +163,7 @@ macro_rules! impl_stub_backend {
                 _operand: &Tensor,
                 _start_indices: &Tensor,
                 _config: &GatherConfig,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " gather"))
             }
             fn scatter(
@@ -157,10 +172,10 @@ macro_rules! impl_stub_backend {
                 _scatter_indices: &Tensor,
                 _updates: &Tensor,
                 _config: &ScatterConfig,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " scatter"))
             }
-            fn slice(&mut self, _input: &Tensor, _config: &SliceConfig) -> Tensor {
+            fn slice(&mut self, _input: &Tensor, _config: &SliceConfig) -> crate::Result<Tensor> {
                 todo!(concat!($label, " slice"))
             }
             fn dynamic_slice(
@@ -168,19 +183,19 @@ macro_rules! impl_stub_backend {
                 _input: &Tensor,
                 _starts: &Tensor,
                 _slice_sizes: &[usize],
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " dynamic_slice"))
             }
-            fn pad(&mut self, _input: &Tensor, _config: &PadConfig) -> Tensor {
+            fn pad(&mut self, _input: &Tensor, _config: &PadConfig) -> crate::Result<Tensor> {
                 todo!(concat!($label, " pad"))
             }
-            fn concatenate(&mut self, _inputs: &[&Tensor], _axis: usize) -> Tensor {
+            fn concatenate(&mut self, _inputs: &[&Tensor], _axis: usize) -> crate::Result<Tensor> {
                 todo!(concat!($label, " concatenate"))
             }
-            fn reverse(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+            fn reverse(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reverse"))
             }
-            fn cholesky(&mut self, _input: &Tensor) -> Tensor {
+            fn cholesky(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " cholesky"))
             }
             fn triangular_solve(
@@ -191,25 +206,25 @@ macro_rules! impl_stub_backend {
                 _lower: bool,
                 _transpose_a: bool,
                 _unit_diagonal: bool,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " triangular_solve"))
             }
-            fn lu(&mut self, _input: &Tensor) -> Vec<Tensor> {
+            fn lu(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " lu"))
             }
-            fn svd(&mut self, _input: &Tensor) -> Vec<Tensor> {
+            fn svd(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " svd"))
             }
-            fn qr(&mut self, _input: &Tensor) -> Vec<Tensor> {
+            fn qr(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " qr"))
             }
-            fn eigh(&mut self, _input: &Tensor) -> Vec<Tensor> {
+            fn eigh(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " eigh"))
             }
-            fn eig(&mut self, _input: &Tensor) -> Vec<Tensor> {
+            fn eig(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " eig"))
             }
-            fn solve(&mut self, _a: &Tensor, _b: &Tensor) -> Tensor {
+            fn solve(&mut self, _a: &Tensor, _b: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " solve"))
             }
         }
@@ -220,7 +235,7 @@ macro_rules! impl_stub_backend {
                 _lhs: &TypedTensor<Alg::Scalar>,
                 _rhs: &TypedTensor<Alg::Scalar>,
                 _config: &DotGeneralConfig,
-            ) -> TypedTensor<Alg::Scalar> {
+            ) -> crate::Result<TypedTensor<Alg::Scalar>> {
                 todo!(concat!($label, " batched_gemm"))
             }
         }

--- a/tenferro-tensor/src/error.rs
+++ b/tenferro-tensor/src/error.rs
@@ -1,0 +1,81 @@
+//! Runtime error types for tensor execution.
+//!
+//! # Examples
+//!
+//! ```ignore
+//! use tenferro_tensor::Error;
+//!
+//! let err = Error::AxisOutOfBounds {
+//!     op: "dot_general",
+//!     axis: 2,
+//!     rank: 1,
+//! };
+//! assert!(err.to_string().contains("dot_general"));
+//! ```
+
+/// Runtime failures produced by tensor execution backends and helpers.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tensor::Error;
+///
+/// let err = Error::MissingValue { slot: 3 };
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum Error {
+    #[error("{op}: axis {axis} out of bounds for rank {rank}")]
+    AxisOutOfBounds {
+        op: &'static str,
+        axis: usize,
+        rank: usize,
+    },
+    #[error("{op}: duplicate {role} axis {axis}")]
+    DuplicateAxis {
+        op: &'static str,
+        axis: usize,
+        role: &'static str,
+    },
+    #[error("{op}: axis {axis} appears in both {first_role} and {second_role}")]
+    AxisRoleConflict {
+        op: &'static str,
+        axis: usize,
+        first_role: &'static str,
+        second_role: &'static str,
+    },
+    #[error("{op}: shape mismatch lhs={lhs:?} rhs={rhs:?}")]
+    ShapeMismatch {
+        op: &'static str,
+        lhs: Vec<usize>,
+        rhs: Vec<usize>,
+    },
+    #[error("{op}: rank mismatch expected {expected}, actual {actual}")]
+    RankMismatch {
+        op: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("{op}: dtype mismatch lhs={lhs:?} rhs={rhs:?}")]
+    DTypeMismatch {
+        op: &'static str,
+        lhs: crate::DType,
+        rhs: crate::DType,
+    },
+    #[error("{op}: invalid config: {message}")]
+    InvalidConfig { op: &'static str, message: String },
+    #[error("{op}: backend failure: {message}")]
+    BackendFailure { op: &'static str, message: String },
+    #[error("missing runtime value for slot {slot}")]
+    MissingValue { slot: usize },
+}
+
+/// Result type alias for runtime tensor operations.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tensor::{Error, Result};
+///
+/// let output: Result<()> = Err(Error::MissingValue { slot: 0 });
+/// ```
+pub type Result<T> = std::result::Result<T, Error>;

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod backend;
 pub mod config;
 pub mod cpu;
+pub mod error;
 #[cfg(feature = "provider-inject")]
 pub mod inject;
 pub mod types;
@@ -27,6 +28,7 @@ pub mod rocm;
 
 pub use backend::*;
 pub use config::*;
+pub use error::*;
 pub use types::*;
 
 #[cfg(not(any(feature = "cpu-faer", feature = "cpu-blas")))]

--- a/tenferro-tensor/src/rocm/mod.rs
+++ b/tenferro-tensor/src/rocm/mod.rs
@@ -18,76 +18,91 @@ impl RocmBackend {
 macro_rules! impl_stub_backend {
     ($ty:ty, $label:literal) => {
         impl TensorBackend for $ty {
-            fn add(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn add(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " add"))
             }
-            fn mul(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn mul(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " mul"))
             }
-            fn neg(&mut self, _input: &Tensor) -> Tensor {
+            fn neg(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " neg"))
             }
-            fn conj(&mut self, _input: &Tensor) -> Tensor {
+            fn conj(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " conj"))
             }
-            fn div(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn div(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " div"))
             }
-            fn abs(&mut self, _input: &Tensor) -> Tensor {
+            fn abs(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " abs"))
             }
-            fn sign(&mut self, _input: &Tensor) -> Tensor {
+            fn sign(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " sign"))
             }
-            fn maximum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn maximum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " maximum"))
             }
-            fn minimum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn minimum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " minimum"))
             }
-            fn compare(&mut self, _lhs: &Tensor, _rhs: &Tensor, _dir: &CompareDir) -> Tensor {
+            fn compare(
+                &mut self,
+                _lhs: &Tensor,
+                _rhs: &Tensor,
+                _dir: &CompareDir,
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " compare"))
             }
-            fn select(&mut self, _pred: &Tensor, _on_true: &Tensor, _on_false: &Tensor) -> Tensor {
+            fn select(
+                &mut self,
+                _pred: &Tensor,
+                _on_true: &Tensor,
+                _on_false: &Tensor,
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " select"))
             }
-            fn clamp(&mut self, _input: &Tensor, _lower: &Tensor, _upper: &Tensor) -> Tensor {
+            fn clamp(
+                &mut self,
+                _input: &Tensor,
+                _lower: &Tensor,
+                _upper: &Tensor,
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " clamp"))
             }
-            fn exp(&mut self, _input: &Tensor) -> Tensor {
+            fn exp(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " exp"))
             }
-            fn log(&mut self, _input: &Tensor) -> Tensor {
+            fn log(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " log"))
             }
-            fn sin(&mut self, _input: &Tensor) -> Tensor {
+            fn sin(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " sin"))
             }
-            fn cos(&mut self, _input: &Tensor) -> Tensor {
+            fn cos(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " cos"))
             }
-            fn tanh(&mut self, _input: &Tensor) -> Tensor {
+            fn tanh(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " tanh"))
             }
-            fn sqrt(&mut self, _input: &Tensor) -> Tensor {
+            fn sqrt(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " sqrt"))
             }
-            fn rsqrt(&mut self, _input: &Tensor) -> Tensor {
+            fn rsqrt(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " rsqrt"))
             }
-            fn pow(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+            fn pow(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " pow"))
             }
-            fn expm1(&mut self, _input: &Tensor) -> Tensor {
+            fn expm1(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " expm1"))
             }
-            fn log1p(&mut self, _input: &Tensor) -> Tensor {
+            fn log1p(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " log1p"))
             }
-            fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> Tensor {
+            fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " transpose"))
             }
-            fn reshape(&mut self, _input: &Tensor, _shape: &[usize]) -> Tensor {
+            fn reshape(&mut self, _input: &Tensor, _shape: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reshape"))
             }
             fn broadcast_in_dim(
@@ -95,10 +110,10 @@ macro_rules! impl_stub_backend {
                 _input: &Tensor,
                 _shape: &[usize],
                 _dims: &[usize],
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " broadcast_in_dim"))
             }
-            fn convert(&mut self, _input: &Tensor, _to: crate::DType) -> Tensor {
+            fn convert(&mut self, _input: &Tensor, _to: crate::DType) -> crate::Result<Tensor> {
                 todo!(concat!($label, " convert"))
             }
             fn extract_diagonal(
@@ -106,7 +121,7 @@ macro_rules! impl_stub_backend {
                 _input: &Tensor,
                 _axis_a: usize,
                 _axis_b: usize,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " extract_diagonal"))
             }
             fn embed_diagonal(
@@ -114,25 +129,25 @@ macro_rules! impl_stub_backend {
                 _input: &Tensor,
                 _axis_a: usize,
                 _axis_b: usize,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " embed_diagonal"))
             }
-            fn tril(&mut self, _input: &Tensor, _k: i64) -> Tensor {
+            fn tril(&mut self, _input: &Tensor, _k: i64) -> crate::Result<Tensor> {
                 todo!(concat!($label, " tril"))
             }
-            fn triu(&mut self, _input: &Tensor, _k: i64) -> Tensor {
+            fn triu(&mut self, _input: &Tensor, _k: i64) -> crate::Result<Tensor> {
                 todo!(concat!($label, " triu"))
             }
-            fn reduce_sum(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+            fn reduce_sum(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reduce_sum"))
             }
-            fn reduce_prod(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+            fn reduce_prod(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reduce_prod"))
             }
-            fn reduce_max(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+            fn reduce_max(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reduce_max"))
             }
-            fn reduce_min(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+            fn reduce_min(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reduce_min"))
             }
             fn dot_general(
@@ -140,7 +155,7 @@ macro_rules! impl_stub_backend {
                 _lhs: &Tensor,
                 _rhs: &Tensor,
                 _config: &DotGeneralConfig,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " dot_general"))
             }
             fn gather(
@@ -148,7 +163,7 @@ macro_rules! impl_stub_backend {
                 _operand: &Tensor,
                 _start_indices: &Tensor,
                 _config: &GatherConfig,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " gather"))
             }
             fn scatter(
@@ -157,10 +172,10 @@ macro_rules! impl_stub_backend {
                 _scatter_indices: &Tensor,
                 _updates: &Tensor,
                 _config: &ScatterConfig,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " scatter"))
             }
-            fn slice(&mut self, _input: &Tensor, _config: &SliceConfig) -> Tensor {
+            fn slice(&mut self, _input: &Tensor, _config: &SliceConfig) -> crate::Result<Tensor> {
                 todo!(concat!($label, " slice"))
             }
             fn dynamic_slice(
@@ -168,19 +183,19 @@ macro_rules! impl_stub_backend {
                 _input: &Tensor,
                 _starts: &Tensor,
                 _slice_sizes: &[usize],
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " dynamic_slice"))
             }
-            fn pad(&mut self, _input: &Tensor, _config: &PadConfig) -> Tensor {
+            fn pad(&mut self, _input: &Tensor, _config: &PadConfig) -> crate::Result<Tensor> {
                 todo!(concat!($label, " pad"))
             }
-            fn concatenate(&mut self, _inputs: &[&Tensor], _axis: usize) -> Tensor {
+            fn concatenate(&mut self, _inputs: &[&Tensor], _axis: usize) -> crate::Result<Tensor> {
                 todo!(concat!($label, " concatenate"))
             }
-            fn reverse(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+            fn reverse(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
                 todo!(concat!($label, " reverse"))
             }
-            fn cholesky(&mut self, _input: &Tensor) -> Tensor {
+            fn cholesky(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " cholesky"))
             }
             fn triangular_solve(
@@ -191,25 +206,25 @@ macro_rules! impl_stub_backend {
                 _lower: bool,
                 _transpose_a: bool,
                 _unit_diagonal: bool,
-            ) -> Tensor {
+            ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " triangular_solve"))
             }
-            fn lu(&mut self, _input: &Tensor) -> Vec<Tensor> {
+            fn lu(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " lu"))
             }
-            fn svd(&mut self, _input: &Tensor) -> Vec<Tensor> {
+            fn svd(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " svd"))
             }
-            fn qr(&mut self, _input: &Tensor) -> Vec<Tensor> {
+            fn qr(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " qr"))
             }
-            fn eigh(&mut self, _input: &Tensor) -> Vec<Tensor> {
+            fn eigh(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " eigh"))
             }
-            fn eig(&mut self, _input: &Tensor) -> Vec<Tensor> {
+            fn eig(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " eig"))
             }
-            fn solve(&mut self, _a: &Tensor, _b: &Tensor) -> Tensor {
+            fn solve(&mut self, _a: &Tensor, _b: &Tensor) -> crate::Result<Tensor> {
                 todo!(concat!($label, " solve"))
             }
         }
@@ -220,7 +235,7 @@ macro_rules! impl_stub_backend {
                 _lhs: &TypedTensor<Alg::Scalar>,
                 _rhs: &TypedTensor<Alg::Scalar>,
                 _config: &DotGeneralConfig,
-            ) -> TypedTensor<Alg::Scalar> {
+            ) -> crate::Result<TypedTensor<Alg::Scalar>> {
                 todo!(concat!($label, " batched_gemm"))
             }
         }

--- a/tenferro-tensor/src/tests/cpu_semiring_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_semiring_tests.rs
@@ -14,14 +14,19 @@ fn semiring_backend_default_add_mul_and_reduce_sum_work_for_standard_f64() {
     let lhs = f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
     let rhs = f64_tensor(vec![2, 2], vec![10.0, 20.0, 30.0, 40.0]);
 
-    let sum = <CpuBackend as SemiringBackend<Standard<f64>>>::add(&mut backend, &lhs, &rhs);
-    let prod = <CpuBackend as SemiringBackend<Standard<f64>>>::mul(&mut backend, &lhs, &rhs);
+    let sum =
+        <CpuBackend as SemiringBackend<Standard<f64>>>::add(&mut backend, &lhs, &rhs).unwrap();
+    let prod =
+        <CpuBackend as SemiringBackend<Standard<f64>>>::mul(&mut backend, &lhs, &rhs).unwrap();
     let reduced =
-        <CpuBackend as SemiringBackend<Standard<f64>>>::reduce_sum(&mut backend, &lhs, &[1]);
+        <CpuBackend as SemiringBackend<Standard<f64>>>::reduce_sum(&mut backend, &lhs, &[1])
+            .unwrap();
     let scalar =
-        <CpuBackend as SemiringBackend<Standard<f64>>>::reduce_sum(&mut backend, &lhs, &[0, 1]);
+        <CpuBackend as SemiringBackend<Standard<f64>>>::reduce_sum(&mut backend, &lhs, &[0, 1])
+            .unwrap();
     let unchanged =
-        <CpuBackend as SemiringBackend<Standard<f64>>>::reduce_sum(&mut backend, &lhs, &[]);
+        <CpuBackend as SemiringBackend<Standard<f64>>>::reduce_sum(&mut backend, &lhs, &[])
+            .unwrap();
 
     assert_eq!(sum.host_data(), &[11.0, 22.0, 33.0, 44.0]);
     assert_eq!(prod.host_data(), &[10.0, 40.0, 90.0, 160.0]);
@@ -56,7 +61,8 @@ fn semiring_backend_batched_gemm_handles_batch_and_contract_dimensions() {
             lhs_rank: 3,
             rhs_rank: 3,
         },
-    );
+    )
+    .unwrap();
 
     assert_eq!(out.shape, vec![2, 2, 2]);
     assert_eq!(
@@ -83,7 +89,8 @@ fn semiring_backend_batched_gemm_inner_product_returns_rank0_scalar() {
             lhs_rank: 1,
             rhs_rank: 1,
         },
-    );
+    )
+    .unwrap();
 
     assert_eq!(out.shape, vec![]);
     assert_eq!(out.host_data(), &[32.0]);

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -7,9 +7,9 @@ use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
 use crate::cpu::{
-    add, broadcast_in_dim, conj, dynamic_slice, embed_diagonal, extract_diagonal, gather, mul, neg,
-    pad, reduce_max, reduce_min, reduce_prod, reduce_sum, reshape, scatter, transpose, tril, triu,
-    CpuBackend,
+    abs, add, broadcast_in_dim, clamp, compare, conj, div, dynamic_slice, embed_diagonal,
+    extract_diagonal, gather, maximum, minimum, mul, neg, pad, reduce_max, reduce_min, reduce_prod,
+    reduce_sum, reshape, scatter, select, sign, transpose, tril, triu, CpuBackend,
 };
 use crate::types::{DType, Tensor, TypedTensor};
 
@@ -24,6 +24,20 @@ fn get_c64(t: &Tensor, idx: &[usize]) -> Complex64 {
     match t {
         Tensor::C64(inner) => *inner.get(idx),
         _ => panic!("expected C64 tensor"),
+    }
+}
+
+fn get_f32(t: &Tensor, idx: &[usize]) -> f32 {
+    match t {
+        Tensor::F32(inner) => *inner.get(idx),
+        _ => panic!("expected F32 tensor"),
+    }
+}
+
+fn get_c32(t: &Tensor, idx: &[usize]) -> Complex32 {
+    match t {
+        Tensor::C32(inner) => *inner.get(idx),
+        _ => panic!("expected C32 tensor"),
     }
 }
 
@@ -1152,6 +1166,443 @@ fn test_tier2_elementwise_ops_complex() {
     let minimum = backend.minimum(&lhs, &rhs).unwrap();
     assert_c64_close(get_c64(&minimum, &[0]), Complex64::new(1.0, 0.0));
     assert_c64_close(get_c64(&minimum, &[1]), Complex64::new(1.0, 0.0));
+}
+
+#[test]
+fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
+    let lhs_f32 = Tensor::F32(TypedTensor::from_vec(vec![2], vec![8.0f32, -2.0]));
+    let rhs_f32 = Tensor::F32(TypedTensor::from_vec(vec![2], vec![2.0f32, 5.0]));
+    let pred_f32 = Tensor::F32(TypedTensor::from_vec(vec![2], vec![0.0f32, 1.0]));
+    let lower_f32 = Tensor::F32(TypedTensor::from_vec(vec![2], vec![-1.0f32, -1.0]));
+    let upper_f32 = Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.0f32, 4.0]));
+
+    let div_out = div(&lhs_f32, &rhs_f32).unwrap();
+    assert_eq!(get_f32(&div_out, &[0]), 4.0);
+    assert_eq!(get_f32(&div_out, &[1]), -0.4);
+
+    let abs_out = abs(&lhs_f32).unwrap();
+    assert_eq!(get_f32(&abs_out, &[0]), 8.0);
+    assert_eq!(get_f32(&abs_out, &[1]), 2.0);
+
+    let sign_out = sign(&lhs_f32).unwrap();
+    assert_eq!(get_f32(&sign_out, &[0]), 1.0);
+    assert_eq!(get_f32(&sign_out, &[1]), -1.0);
+
+    let max_out = maximum(&lhs_f32, &rhs_f32).unwrap();
+    assert_eq!(get_f32(&max_out, &[0]), 8.0);
+    assert_eq!(get_f32(&max_out, &[1]), 5.0);
+
+    let min_out = minimum(&lhs_f32, &rhs_f32).unwrap();
+    assert_eq!(get_f32(&min_out, &[0]), 2.0);
+    assert_eq!(get_f32(&min_out, &[1]), -2.0);
+
+    let cmp_out = compare(&lhs_f32, &rhs_f32, &CompareDir::Gt).unwrap();
+    assert_eq!(get_f32(&cmp_out, &[0]), 1.0);
+    assert_eq!(get_f32(&cmp_out, &[1]), 0.0);
+
+    let select_out = select(&pred_f32, &lhs_f32, &rhs_f32).unwrap();
+    assert_eq!(get_f32(&select_out, &[0]), 2.0);
+    assert_eq!(get_f32(&select_out, &[1]), -2.0);
+
+    let clamp_out = clamp(&lhs_f32, &lower_f32, &upper_f32).unwrap();
+    assert_eq!(get_f32(&clamp_out, &[0]), 1.0);
+    assert_eq!(get_f32(&clamp_out, &[1]), -1.0);
+
+    let input_c32 = Tensor::C32(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex32::new(3.0, 4.0), Complex32::new(0.0, 0.0)],
+    ));
+    let lhs_c32 = Tensor::C32(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex32::new(3.0, 4.0), Complex32::new(1.0, 0.0)],
+    ));
+    let rhs_c32 = Tensor::C32(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex32::new(1.0, 0.0), Complex32::new(0.0, 2.0)],
+    ));
+    let pred_c32 = Tensor::C32(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex32::new(0.0, 0.0), Complex32::new(1.0, 0.0)],
+    ));
+    let lower_c32 = Tensor::C32(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex32::new(0.5, 0.0), Complex32::new(0.5, 0.0)],
+    ));
+    let upper_c32 = Tensor::C32(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex32::new(4.0, 0.0), Complex32::new(2.0, 2.0)],
+    ));
+
+    let abs_c32 = abs(&input_c32).unwrap();
+    assert_eq!(get_c32(&abs_c32, &[0]), Complex32::new(5.0, 0.0));
+    assert_eq!(get_c32(&abs_c32, &[1]), Complex32::new(0.0, 0.0));
+
+    let sign_c32 = sign(&input_c32).unwrap();
+    assert_eq!(get_c32(&sign_c32, &[1]), Complex32::new(0.0, 0.0));
+
+    let max_c32 = maximum(&lhs_c32, &rhs_c32).unwrap();
+    assert_eq!(get_c32(&max_c32, &[0]), Complex32::new(3.0, 4.0));
+
+    let min_c32 = minimum(&lhs_c32, &rhs_c32).unwrap();
+    assert_eq!(get_c32(&min_c32, &[1]), Complex32::new(1.0, 0.0));
+
+    let cmp_c32 = compare(&lhs_c32, &rhs_c32, &CompareDir::Eq).unwrap();
+    assert_eq!(get_c32(&cmp_c32, &[0]), Complex32::new(0.0, 0.0));
+
+    let select_c32 = select(&pred_c32, &lhs_c32, &rhs_c32).unwrap();
+    assert_eq!(get_c32(&select_c32, &[0]), Complex32::new(1.0, 0.0));
+    assert_eq!(get_c32(&select_c32, &[1]), Complex32::new(1.0, 0.0));
+
+    let clamp_c32 = clamp(&lhs_c32, &lower_c32, &upper_c32).unwrap();
+    assert_eq!(get_c32(&clamp_c32, &[0]), Complex32::new(4.0, 0.0));
+
+    let scalar_f32 = Tensor::F32(TypedTensor::from_vec(vec![], vec![2.0f32]));
+    let add_c32 = add(&scalar_f32, &rhs_c32).unwrap();
+    assert_eq!(get_c32(&add_c32, &[0]), Complex32::new(3.0, 0.0));
+
+    let mul_c32 = mul(&scalar_f32, &rhs_c32).unwrap();
+    assert_eq!(get_c32(&mul_c32, &[1]), Complex32::new(0.0, 4.0));
+
+    assert!(matches!(
+        div(
+            &lhs_f32,
+            &Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.0, 2.0]))
+        ),
+        Err(crate::Error::DTypeMismatch { op: "div", .. })
+    ));
+    assert!(matches!(
+        clamp(
+            &lhs_f32,
+            &Tensor::F32(TypedTensor::from_vec(vec![1], vec![0.0f32])),
+            &upper_f32
+        ),
+        Err(crate::Error::ShapeMismatch { op: "clamp", .. })
+    ));
+}
+
+#[test]
+fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
+    let lhs_f64 = Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.5f64, -3.0]));
+    let rhs_f64 = Tensor::F64(TypedTensor::from_vec(vec![2], vec![2.0f64, 4.0]));
+    let scalar_f64 = Tensor::F64(TypedTensor::from_vec(vec![], vec![2.0f64]));
+    let pred_f64 = Tensor::F64(TypedTensor::from_vec(vec![2], vec![0.0f64, 1.0]));
+    let lower_f64 = Tensor::F64(TypedTensor::from_vec(vec![2], vec![0.0f64, -2.0]));
+    let upper_f64 = Tensor::F64(TypedTensor::from_vec(vec![2], vec![2.0f64, 3.0]));
+    let short_f64 = Tensor::F64(TypedTensor::from_vec(vec![1], vec![1.0f64]));
+
+    let add_out = add(&lhs_f64, &rhs_f64).unwrap();
+    assert_eq!(get_f64(&add_out, &[0]), 3.5);
+    assert_eq!(get_f64(&add_out, &[1]), 1.0);
+
+    let mul_out = mul(&lhs_f64, &rhs_f64).unwrap();
+    assert_eq!(get_f64(&mul_out, &[0]), 3.0);
+    assert_eq!(get_f64(&mul_out, &[1]), -12.0);
+
+    let div_out = div(
+        &rhs_f64,
+        &Tensor::F64(TypedTensor::from_vec(vec![2], vec![2.0, 2.0])),
+    )
+    .unwrap();
+    assert_eq!(get_f64(&div_out, &[0]), 1.0);
+    assert_eq!(get_f64(&div_out, &[1]), 2.0);
+
+    let neg_out = neg(&lhs_f64).unwrap();
+    assert_eq!(get_f64(&neg_out, &[0]), -1.5);
+    assert_eq!(get_f64(&neg_out, &[1]), 3.0);
+
+    let conj_out = conj(&lhs_f64).unwrap();
+    assert_eq!(get_f64(&conj_out, &[0]), 1.5);
+    assert_eq!(get_f64(&conj_out, &[1]), -3.0);
+
+    let compare_out = compare(&lhs_f64, &rhs_f64, &CompareDir::Lt).unwrap();
+    assert_eq!(get_f64(&compare_out, &[0]), 1.0);
+    assert_eq!(get_f64(&compare_out, &[1]), 1.0);
+
+    let select_out = select(&pred_f64, &lhs_f64, &rhs_f64).unwrap();
+    assert_eq!(get_f64(&select_out, &[0]), 2.0);
+    assert_eq!(get_f64(&select_out, &[1]), -3.0);
+
+    let clamp_out = clamp(&lhs_f64, &lower_f64, &upper_f64).unwrap();
+    assert_eq!(get_f64(&clamp_out, &[0]), 1.5);
+    assert_eq!(get_f64(&clamp_out, &[1]), -2.0);
+
+    let lhs_c64 = Tensor::C64(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex64::new(3.0, 4.0), Complex64::new(1.0, 0.0)],
+    ));
+    let rhs_c64 = Tensor::C64(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 2.0)],
+    ));
+    let pred_c64 = Tensor::C64(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+    ));
+    let lower_c64 = Tensor::C64(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex64::new(0.5, 0.0), Complex64::new(0.5, 0.0)],
+    ));
+    let upper_c64 = Tensor::C64(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex64::new(4.0, 0.0), Complex64::new(2.0, 2.0)],
+    ));
+
+    let add_left_scalar = add(&scalar_f64, &rhs_c64).unwrap();
+    assert_c64_close(get_c64(&add_left_scalar, &[0]), Complex64::new(3.0, 0.0));
+    let add_right_scalar = add(&lhs_c64, &scalar_f64).unwrap();
+    assert_c64_close(get_c64(&add_right_scalar, &[1]), Complex64::new(3.0, 0.0));
+
+    let mul_left_scalar = mul(&scalar_f64, &rhs_c64).unwrap();
+    assert_c64_close(get_c64(&mul_left_scalar, &[1]), Complex64::new(0.0, 4.0));
+    let mul_right_scalar = mul(&lhs_c64, &scalar_f64).unwrap();
+    assert_c64_close(get_c64(&mul_right_scalar, &[0]), Complex64::new(6.0, 8.0));
+
+    let div_c64 = div(
+        &lhs_c64,
+        &Tensor::C64(TypedTensor::from_vec(
+            vec![2],
+            vec![Complex64::new(1.0, 1.0), Complex64::new(1.0, 0.0)],
+        )),
+    )
+    .unwrap();
+    assert_c64_close(get_c64(&div_c64, &[0]), Complex64::new(3.5, 0.5));
+    assert_c64_close(get_c64(&div_c64, &[1]), Complex64::new(1.0, 0.0));
+
+    let neg_c64 = neg(&lhs_c64).unwrap();
+    assert_c64_close(get_c64(&neg_c64, &[0]), Complex64::new(-3.0, -4.0));
+    let conj_c64 = conj(&lhs_c64).unwrap();
+    assert_c64_close(get_c64(&conj_c64, &[0]), Complex64::new(3.0, -4.0));
+
+    let compare_lt = compare(&lhs_c64, &rhs_c64, &CompareDir::Lt).unwrap();
+    let compare_le = compare(&lhs_c64, &rhs_c64, &CompareDir::Le).unwrap();
+    let compare_gt = compare(&lhs_c64, &rhs_c64, &CompareDir::Gt).unwrap();
+    let compare_ge = compare(&lhs_c64, &rhs_c64, &CompareDir::Ge).unwrap();
+    assert_c64_close(get_c64(&compare_lt, &[0]), Complex64::new(0.0, 0.0));
+    assert_c64_close(get_c64(&compare_le, &[0]), Complex64::new(0.0, 0.0));
+    assert_c64_close(get_c64(&compare_gt, &[0]), Complex64::new(1.0, 0.0));
+    assert_c64_close(get_c64(&compare_ge, &[0]), Complex64::new(1.0, 0.0));
+
+    let select_c64 = select(&pred_c64, &lhs_c64, &rhs_c64).unwrap();
+    assert_c64_close(get_c64(&select_c64, &[0]), Complex64::new(1.0, 0.0));
+    assert_c64_close(get_c64(&select_c64, &[1]), Complex64::new(1.0, 0.0));
+
+    let clamp_c64 = clamp(&lhs_c64, &lower_c64, &upper_c64).unwrap();
+    assert_c64_close(get_c64(&clamp_c64, &[0]), Complex64::new(4.0, 0.0));
+    assert_c64_close(get_c64(&clamp_c64, &[1]), Complex64::new(1.0, 0.0));
+
+    let lhs_f32 = Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.0f32, 2.0]));
+
+    assert!(matches!(
+        add(&lhs_f32, &rhs_f64),
+        Err(crate::Error::DTypeMismatch { op: "add", .. })
+    ));
+    assert!(matches!(
+        mul(&lhs_f32, &rhs_f64),
+        Err(crate::Error::DTypeMismatch { op: "mul", .. })
+    ));
+    assert!(matches!(
+        maximum(&lhs_f32, &rhs_f64),
+        Err(crate::Error::DTypeMismatch { op: "maximum", .. })
+    ));
+    assert!(matches!(
+        minimum(&lhs_f32, &rhs_f64),
+        Err(crate::Error::DTypeMismatch { op: "minimum", .. })
+    ));
+    assert!(matches!(
+        compare(&lhs_f32, &rhs_f64, &CompareDir::Eq),
+        Err(crate::Error::DTypeMismatch { op: "compare", .. })
+    ));
+    assert!(matches!(
+        select(&lhs_f32, &lhs_f32, &rhs_f64),
+        Err(crate::Error::BackendFailure {
+            op: "select",
+            message,
+        }) if message == "dtype mismatch"
+    ));
+    assert!(matches!(
+        clamp(&lhs_f32, &lhs_f32, &rhs_f64),
+        Err(crate::Error::BackendFailure {
+            op: "clamp",
+            message,
+        }) if message == "dtype mismatch"
+    ));
+
+    assert!(matches!(
+        add(&lhs_f64, &short_f64),
+        Err(crate::Error::ShapeMismatch { op: "add", .. })
+    ));
+    assert!(matches!(
+        mul(&lhs_f64, &short_f64),
+        Err(crate::Error::ShapeMismatch { op: "mul", .. })
+    ));
+    assert!(matches!(
+        div(&lhs_f64, &short_f64),
+        Err(crate::Error::ShapeMismatch { op: "div", .. })
+    ));
+    assert!(matches!(
+        maximum(&lhs_f64, &short_f64),
+        Err(crate::Error::ShapeMismatch { op: "maximum", .. })
+    ));
+    assert!(matches!(
+        minimum(&lhs_f64, &short_f64),
+        Err(crate::Error::ShapeMismatch { op: "minimum", .. })
+    ));
+    assert!(matches!(
+        compare(&lhs_f64, &short_f64, &CompareDir::Eq),
+        Err(crate::Error::ShapeMismatch { op: "compare", .. })
+    ));
+    assert!(matches!(
+        select(&pred_f64, &short_f64, &rhs_f64),
+        Err(crate::Error::ShapeMismatch { op: "select", .. })
+    ));
+    assert!(matches!(
+        select(&pred_f64, &rhs_f64, &short_f64),
+        Err(crate::Error::ShapeMismatch { op: "select", .. })
+    ));
+    assert!(matches!(
+        clamp(&lhs_f64, &lower_f64, &short_f64),
+        Err(crate::Error::ShapeMismatch { op: "clamp", .. })
+    ));
+}
+
+#[test]
+fn test_reduction_helpers_cover_complex_and_error_paths() {
+    let complex = Tensor::C32(TypedTensor::from_vec(
+        vec![2, 2],
+        vec![
+            Complex32::new(1.0, 1.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(3.0, -1.0),
+            Complex32::new(4.0, 2.0),
+        ],
+    ));
+    let sum = reduce_sum(&complex, &[0]).unwrap();
+    assert_eq!(get_c32(&sum, &[0]), Complex32::new(3.0, 1.0));
+    assert_eq!(get_c32(&sum, &[1]), Complex32::new(7.0, 1.0));
+
+    let prod = reduce_prod(&complex, &[]).unwrap();
+    assert_eq!(prod.shape(), &[2, 2]);
+
+    assert!(matches!(
+        reduce_sum(
+            &Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.0f32, 2.0])),
+            &[2]
+        ),
+        Err(crate::Error::AxisOutOfBounds {
+            op: "reduce_sum",
+            ..
+        })
+    ));
+    assert!(matches!(
+        reduce_prod(
+            &Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.0f32, 2.0])),
+            &[0, 0]
+        ),
+        Err(crate::Error::DuplicateAxis {
+            op: "reduce_prod",
+            ..
+        })
+    ));
+    assert!(matches!(
+        reduce_max(&complex, &[0]),
+        Err(crate::Error::BackendFailure {
+            op: "reduce_max",
+            ..
+        })
+    ));
+    assert!(matches!(
+        reduce_min(&complex, &[0]),
+        Err(crate::Error::BackendFailure {
+            op: "reduce_min",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn test_structural_helpers_cover_f32_success_and_error_paths() {
+    let matrix = Tensor::F32(TypedTensor::from_vec(
+        vec![2, 2],
+        vec![1.0f32, 2.0, 3.0, 4.0],
+    ));
+    let transposed = transpose(&matrix, &[1, 0]).unwrap();
+    assert_eq!(transposed.shape(), &[2, 2]);
+    assert_eq!(get_f32(&transposed, &[1, 0]), 3.0);
+
+    let scalar = Tensor::F32(TypedTensor::from_vec(vec![], vec![5.0f32]));
+    let broadcast = broadcast_in_dim(&scalar, &[2], &[]).unwrap();
+    assert_eq!(get_f32(&broadcast, &[1]), 5.0);
+
+    let diag = extract_diagonal(&matrix, 0, 1).unwrap();
+    assert_eq!(get_f32(&diag, &[0]), 1.0);
+    assert_eq!(get_f32(&diag, &[1]), 4.0);
+
+    let embedded = embed_diagonal(
+        &Tensor::F32(TypedTensor::from_vec(vec![2], vec![7.0f32, 8.0])),
+        0,
+        1,
+    )
+    .unwrap();
+    assert_eq!(embedded.shape(), &[2, 2]);
+    assert_eq!(get_f32(&embedded, &[1, 1]), 8.0);
+
+    let lower = tril(&matrix, 0).unwrap();
+    assert_eq!(get_f32(&lower, &[0, 1]), 0.0);
+    let upper = triu(&matrix, 0).unwrap();
+    assert_eq!(get_f32(&upper, &[1, 0]), 0.0);
+
+    assert!(matches!(
+        transpose(&matrix, &[0]),
+        Err(crate::Error::RankMismatch {
+            op: "transpose",
+            ..
+        })
+    ));
+    assert!(matches!(
+        transpose(&matrix, &[0, 0]),
+        Err(crate::Error::DuplicateAxis {
+            op: "transpose",
+            ..
+        })
+    ));
+    assert!(matches!(
+        broadcast_in_dim(
+            &Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.0f32, 2.0])),
+            &[3, 2],
+            &[0]
+        ),
+        Err(crate::Error::ShapeMismatch {
+            op: "broadcast_in_dim",
+            ..
+        })
+    ));
+    assert!(matches!(
+        extract_diagonal(&matrix, 1, 1),
+        Err(crate::Error::DuplicateAxis {
+            op: "extract_diagonal",
+            ..
+        })
+    ));
+    assert!(matches!(
+        embed_diagonal(
+            &Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.0f32, 2.0])),
+            0,
+            2
+        ),
+        Err(crate::Error::AxisOutOfBounds {
+            op: "embed_diagonal",
+            ..
+        })
+    ));
+    let vector = Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.0f32, 2.0]));
+    assert!(matches!(
+        tril(&vector, 0),
+        Err(crate::Error::RankMismatch { op: "tril", .. })
+    ));
+    assert!(matches!(
+        triu(&vector, 0),
+        Err(crate::Error::RankMismatch { op: "triu", .. })
+    ));
 }
 
 #[test]

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -1,4 +1,3 @@
-use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use num_complex::{Complex32, Complex64};
@@ -292,7 +291,7 @@ fn test_reshape() {
         vec![2, 3],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     ));
-    let r = reshape(&t, &[3, 2]);
+    let r = reshape(&t, &[3, 2]).unwrap();
     assert_eq!(r.shape(), &[3, 2]);
     assert_eq!(get_f64(&r, &[0, 0]), 1.0);
     assert_eq!(get_f64(&r, &[1, 0]), 2.0);
@@ -309,8 +308,8 @@ fn test_add_mul() {
         vec![2, 2],
         vec![10.0, 20.0, 30.0, 40.0],
     ));
-    let sum = add(&a, &b);
-    let prod = mul(&a, &b);
+    let sum = add(&a, &b).unwrap();
+    let prod = mul(&a, &b).unwrap();
 
     assert_eq!(get_f64(&sum, &[0, 0]), 11.0);
     assert_eq!(get_f64(&sum, &[1, 0]), 22.0);
@@ -328,10 +327,10 @@ fn test_add_mul_rank0_broadcast() {
     let scalar = Tensor::F64(TypedTensor::from_vec(vec![], vec![2.0]));
     let tensor = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
 
-    let scalar_plus_tensor = add(&scalar, &tensor);
-    let tensor_plus_scalar = add(&tensor, &scalar);
-    let scalar_times_tensor = mul(&scalar, &tensor);
-    let tensor_times_scalar = mul(&tensor, &scalar);
+    let scalar_plus_tensor = add(&scalar, &tensor).unwrap();
+    let tensor_plus_scalar = add(&tensor, &scalar).unwrap();
+    let scalar_times_tensor = mul(&scalar, &tensor).unwrap();
+    let tensor_times_scalar = mul(&tensor, &scalar).unwrap();
 
     for actual in [&scalar_plus_tensor, &tensor_plus_scalar] {
         assert_eq!(actual.shape(), &[2, 2]);
@@ -358,8 +357,8 @@ fn test_mul_rank0_real_scalar_broadcasts_over_complex_tensor() {
         vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
     ));
 
-    let scalar_times_tensor = mul(&scalar, &tensor);
-    let tensor_times_scalar = mul(&tensor, &scalar);
+    let scalar_times_tensor = mul(&scalar, &tensor).unwrap();
+    let tensor_times_scalar = mul(&tensor, &scalar).unwrap();
 
     for actual in [&scalar_times_tensor, &tensor_times_scalar] {
         assert_eq!(actual.shape(), &[2]);
@@ -378,7 +377,7 @@ fn test_mul_rank0_complex_scalar_broadcasts_over_complex_tensor() {
         vec![2],
         vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
     ));
-    let output = mul(&scalar, &tensor);
+    let output = mul(&scalar, &tensor).unwrap();
 
     assert_c64_close(get_c64(&output, &[0]), Complex64::new(4.0, 3.0));
     assert_c64_close(get_c64(&output, &[1]), Complex64::new(-5.5, 4.0));
@@ -413,13 +412,13 @@ fn test_reduce_sum() {
         vec![2, 3],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     ));
-    let r = reduce_sum(&t, &[0]);
+    let r = reduce_sum(&t, &[0]).unwrap();
     assert_eq!(r.shape(), &[3]);
     assert_eq!(get_f64(&r, &[0]), 3.0);
     assert_eq!(get_f64(&r, &[1]), 7.0);
     assert_eq!(get_f64(&r, &[2]), 11.0);
 
-    let all = reduce_sum(&t, &[0, 1]);
+    let all = reduce_sum(&t, &[0, 1]).unwrap();
     assert!(all.shape().is_empty());
     assert_eq!(get_f64(&all, &[]), 21.0);
 }
@@ -431,13 +430,13 @@ fn test_reduce_prod() {
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     ));
 
-    let r = reduce_prod(&t, &[0]);
+    let r = reduce_prod(&t, &[0]).unwrap();
     assert_eq!(r.shape(), &[3]);
     assert_eq!(get_f64(&r, &[0]), 2.0);
     assert_eq!(get_f64(&r, &[1]), 12.0);
     assert_eq!(get_f64(&r, &[2]), 30.0);
 
-    let all = reduce_prod(&t, &[0, 1]);
+    let all = reduce_prod(&t, &[0, 1]).unwrap();
     assert!(all.shape().is_empty());
     assert_eq!(get_f64(&all, &[]), 720.0);
 }
@@ -449,22 +448,22 @@ fn test_reduce_max_and_min() {
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     ));
 
-    let max_cols = reduce_max(&t, &[0]);
+    let max_cols = reduce_max(&t, &[0]).unwrap();
     assert_eq!(max_cols.shape(), &[3]);
     assert_eq!(get_f64(&max_cols, &[0]), 2.0);
     assert_eq!(get_f64(&max_cols, &[1]), 4.0);
     assert_eq!(get_f64(&max_cols, &[2]), 6.0);
 
-    let max_all = reduce_max(&t, &[0, 1]);
+    let max_all = reduce_max(&t, &[0, 1]).unwrap();
     assert!(max_all.shape().is_empty());
     assert_eq!(get_f64(&max_all, &[]), 6.0);
 
-    let min_rows = reduce_min(&t, &[1]);
+    let min_rows = reduce_min(&t, &[1]).unwrap();
     assert_eq!(min_rows.shape(), &[2]);
     assert_eq!(get_f64(&min_rows, &[0]), 1.0);
     assert_eq!(get_f64(&min_rows, &[1]), 2.0);
 
-    let min_all = reduce_min(&t, &[0, 1]);
+    let min_all = reduce_min(&t, &[0, 1]).unwrap();
     assert!(min_all.shape().is_empty());
     assert_eq!(get_f64(&min_all, &[]), 1.0);
 }
@@ -477,18 +476,18 @@ fn test_backend_reduce_prod_max_and_min_delegate_to_cpu_reduction_impls() {
     ));
     let mut backend = CpuBackend::new();
 
-    let prod = backend.reduce_prod(&t, &[0]);
+    let prod = backend.reduce_prod(&t, &[0]).unwrap();
     assert_eq!(prod.shape(), &[3]);
     assert_eq!(get_f64(&prod, &[0]), 2.0);
     assert_eq!(get_f64(&prod, &[1]), 12.0);
     assert_eq!(get_f64(&prod, &[2]), 30.0);
 
-    let max = backend.reduce_max(&t, &[1]);
+    let max = backend.reduce_max(&t, &[1]).unwrap();
     assert_eq!(max.shape(), &[2]);
     assert_eq!(get_f64(&max, &[0]), 5.0);
     assert_eq!(get_f64(&max, &[1]), 6.0);
 
-    let min = backend.reduce_min(&t, &[0, 1]);
+    let min = backend.reduce_min(&t, &[0, 1]).unwrap();
     assert!(min.shape().is_empty());
     assert_eq!(get_f64(&min, &[]), 1.0);
 }
@@ -500,14 +499,16 @@ fn test_slice() {
         (1..=16).map(|value| value as f64).collect(),
     ));
     let mut backend = CpuBackend::new();
-    let out = backend.slice(
-        &input,
-        &SliceConfig {
-            starts: vec![1, 1],
-            limits: vec![3, 3],
-            strides: vec![1, 1],
-        },
-    );
+    let out = backend
+        .slice(
+            &input,
+            &SliceConfig {
+                starts: vec![1, 1],
+                limits: vec![3, 3],
+                strides: vec![1, 1],
+            },
+        )
+        .unwrap();
 
     assert_eq!(out.shape(), &[2, 2]);
     assert_eq!(get_f64(&out, &[0, 0]), 6.0);
@@ -523,7 +524,7 @@ fn test_reverse_axis_zero() {
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     ));
     let mut backend = CpuBackend::new();
-    let out = backend.reverse(&input, &[0]);
+    let out = backend.reverse(&input, &[0]).unwrap();
 
     assert_eq!(out.shape(), &[2, 3]);
     assert_eq!(get_f64(&out, &[0, 0]), 2.0);
@@ -545,7 +546,7 @@ fn test_concatenate_axis_zero() {
         vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
     ));
     let mut backend = CpuBackend::new();
-    let out = backend.concatenate(&[&lhs, &rhs], 0);
+    let out = backend.concatenate(&[&lhs, &rhs], 0).unwrap();
 
     assert_eq!(out.shape(), &[4, 3]);
     assert_eq!(get_f64(&out, &[0, 0]), 1.0);
@@ -575,18 +576,20 @@ fn test_dot_general_matmul() {
         ],
     ));
     let mut backend = CpuBackend::new();
-    let c = backend.dot_general(
-        &a,
-        &b,
-        &DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![],
-            rhs_batch_dims: vec![],
-            lhs_rank: 2,
-            rhs_rank: 2,
-        },
-    );
+    let c = backend
+        .dot_general(
+            &a,
+            &b,
+            &DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+                lhs_rank: 2,
+                rhs_rank: 2,
+            },
+        )
+        .unwrap();
     assert_eq!(c.shape(), &[2, 4]);
     assert_eq!(get_f64(&c, &[0, 0]), 38.0);
     assert_eq!(get_f64(&c, &[1, 0]), 83.0);
@@ -601,18 +604,20 @@ fn test_dot_general_inner_product_returns_rank0_scalar() {
     let a = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
     let b = Tensor::F64(TypedTensor::from_vec(vec![3], vec![4.0, 5.0, 6.0]));
     let mut backend = CpuBackend::new();
-    let c = backend.dot_general(
-        &a,
-        &b,
-        &DotGeneralConfig {
-            lhs_contracting_dims: vec![0],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![],
-            rhs_batch_dims: vec![],
-            lhs_rank: 1,
-            rhs_rank: 1,
-        },
-    );
+    let c = backend
+        .dot_general(
+            &a,
+            &b,
+            &DotGeneralConfig {
+                lhs_contracting_dims: vec![0],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+                lhs_rank: 1,
+                rhs_rank: 1,
+            },
+        )
+        .unwrap();
     assert!(c.shape().is_empty());
     assert_eq!(get_f64(&c, &[]), 32.0);
 }
@@ -622,18 +627,20 @@ fn test_dot_general_zero_sized_matmul_returns_empty_matrix() {
     let a = Tensor::F64(TypedTensor::from_vec(vec![0, 0], Vec::new()));
     let b = Tensor::F64(TypedTensor::from_vec(vec![0, 0], Vec::new()));
     let mut backend = CpuBackend::new();
-    let c = backend.dot_general(
-        &a,
-        &b,
-        &DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![],
-            rhs_batch_dims: vec![],
-            lhs_rank: 2,
-            rhs_rank: 2,
-        },
-    );
+    let c = backend
+        .dot_general(
+            &a,
+            &b,
+            &DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+                lhs_rank: 2,
+                rhs_rank: 2,
+            },
+        )
+        .unwrap();
 
     assert_eq!(c.shape(), &[0, 0]);
     match c {
@@ -647,18 +654,20 @@ fn test_dot_general_zero_contracting_dim_returns_zero_filled_output() {
     let a = Tensor::F64(TypedTensor::from_vec(vec![2, 0], Vec::new()));
     let b = Tensor::F64(TypedTensor::from_vec(vec![0, 3], Vec::new()));
     let mut backend = CpuBackend::new();
-    let c = backend.dot_general(
-        &a,
-        &b,
-        &DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![],
-            rhs_batch_dims: vec![],
-            lhs_rank: 2,
-            rhs_rank: 2,
-        },
-    );
+    let c = backend
+        .dot_general(
+            &a,
+            &b,
+            &DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+                lhs_rank: 2,
+                rhs_rank: 2,
+            },
+        )
+        .unwrap();
 
     assert_eq!(c.shape(), &[2, 3]);
     match c {
@@ -682,18 +691,20 @@ fn test_dot_general_falls_back_for_unfusable_lhs_batch_layout() {
         ],
     ));
     let mut backend = CpuBackend::new();
-    let c = backend.dot_general(
-        &a,
-        &b,
-        &DotGeneralConfig {
-            lhs_contracting_dims: vec![3],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![0, 2],
-            rhs_batch_dims: vec![2, 3],
-            lhs_rank: 4,
-            rhs_rank: 4,
-        },
-    );
+    let c = backend
+        .dot_general(
+            &a,
+            &b,
+            &DotGeneralConfig {
+                lhs_contracting_dims: vec![3],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![0, 2],
+                rhs_batch_dims: vec![2, 3],
+                lhs_rank: 4,
+                rhs_rank: 4,
+            },
+        )
+        .unwrap();
 
     assert_eq!(c.shape(), &[2, 2, 2, 2]);
     assert_eq!(get_f64(&c, &[0, 0, 0, 0]), 1.0);
@@ -715,7 +726,7 @@ fn test_dot_general_falls_back_for_unfusable_lhs_batch_layout() {
 }
 
 #[test]
-fn test_dot_general_fallback_uses_actual_runtime_rank_for_canonical_layout() {
+fn test_dot_general_rejects_stale_rank_metadata() {
     let a = Tensor::F64(TypedTensor::from_vec(
         vec![2, 2, 2],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
@@ -725,24 +736,29 @@ fn test_dot_general_fallback_uses_actual_runtime_rank_for_canonical_layout() {
         vec![1.0, 10.0, 2.0, 20.0, 3.0, 30.0, 4.0, 40.0],
     ));
     let mut backend = CpuBackend::new();
-    let c = backend.dot_general(
-        &a,
-        &b,
-        &DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![0, 2],
-            rhs_batch_dims: vec![1, 2],
-            lhs_rank: 4,
-            rhs_rank: 4,
-        },
-    );
+    let err = backend
+        .dot_general(
+            &a,
+            &b,
+            &DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![0, 2],
+                rhs_batch_dims: vec![1, 2],
+                lhs_rank: 4,
+                rhs_rank: 4,
+            },
+        )
+        .unwrap_err();
 
-    assert_eq!(c.shape(), &[2, 2]);
-    assert_eq!(get_f64(&c, &[0, 0]), 31.0);
-    assert_eq!(get_f64(&c, &[1, 0]), 84.0);
-    assert_eq!(get_f64(&c, &[0, 1]), 225.0);
-    assert_eq!(get_f64(&c, &[1, 1]), 344.0);
+    assert!(matches!(
+        err,
+        crate::Error::RankMismatch {
+            op: "dot_general",
+            expected: 4,
+            actual: 3,
+        }
+    ));
 }
 
 #[test]
@@ -751,7 +767,7 @@ fn test_transpose() {
         vec![2, 3],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     ));
-    let tr = transpose(&t, &[1, 0]);
+    let tr = transpose(&t, &[1, 0]).unwrap();
     assert_eq!(tr.shape(), &[3, 2]);
     assert_eq!(get_f64(&tr, &[0, 0]), 1.0);
     assert_eq!(get_f64(&tr, &[0, 1]), 2.0);
@@ -764,14 +780,14 @@ fn test_transpose() {
 #[test]
 fn test_broadcast_in_dim() {
     let scalar = Tensor::F64(TypedTensor::from_vec(vec![], vec![5.0]));
-    let broadcast = broadcast_in_dim(&scalar, &[3], &[]);
+    let broadcast = broadcast_in_dim(&scalar, &[3], &[]).unwrap();
     assert_eq!(broadcast.shape(), &[3]);
     assert_eq!(get_f64(&broadcast, &[0]), 5.0);
     assert_eq!(get_f64(&broadcast, &[1]), 5.0);
     assert_eq!(get_f64(&broadcast, &[2]), 5.0);
 
     let v = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
-    let m = broadcast_in_dim(&v, &[3, 2], &[0]);
+    let m = broadcast_in_dim(&v, &[3, 2], &[0]).unwrap();
     assert_eq!(m.shape(), &[3, 2]);
     for j in 0..2 {
         assert_eq!(get_f64(&m, &[0, j]), 1.0);
@@ -786,7 +802,7 @@ fn test_tril_3x3() {
         vec![3, 3],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
     ));
-    let lower = tril(&t, 0);
+    let lower = tril(&t, 0).unwrap();
     assert_eq!(lower.shape(), &[3, 3]);
     assert_eq!(
         match &lower {
@@ -803,7 +819,7 @@ fn test_triu_3x3() {
         vec![3, 3],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
     ));
-    let upper = triu(&t, 0);
+    let upper = triu(&t, 0).unwrap();
     assert_eq!(upper.shape(), &[3, 3]);
     assert_eq!(
         match &upper {
@@ -818,14 +834,14 @@ fn test_triu_3x3() {
 fn test_tril_triu_zero_sized_batch_return_empty_tensor() {
     let t = Tensor::F64(TypedTensor::from_vec(vec![2, 2, 0], Vec::new()));
 
-    let lower = tril(&t, 0);
+    let lower = tril(&t, 0).unwrap();
     assert_eq!(lower.shape(), &[2, 2, 0]);
     match lower {
         Tensor::F64(inner) => assert!(inner.host_data().is_empty()),
         _ => panic!("expected f64 tensor"),
     }
 
-    let upper = triu(&t, 0);
+    let upper = triu(&t, 0).unwrap();
     assert_eq!(upper.shape(), &[2, 2, 0]);
     match upper {
         Tensor::F64(inner) => assert!(inner.host_data().is_empty()),
@@ -836,11 +852,11 @@ fn test_tril_triu_zero_sized_batch_return_empty_tensor() {
 #[test]
 fn test_neg_and_conj() {
     let t = Tensor::F64(TypedTensor::from_vec(vec![2], vec![3.0, -7.0]));
-    let n = neg(&t);
+    let n = neg(&t).unwrap();
     assert_eq!(get_f64(&n, &[0]), -3.0);
     assert_eq!(get_f64(&n, &[1]), 7.0);
 
-    let c = conj(&t);
+    let c = conj(&t).unwrap();
     assert_eq!(get_f64(&c, &[0]), 3.0);
     assert_eq!(get_f64(&c, &[1]), -7.0);
 }
@@ -850,12 +866,12 @@ fn test_cpu_backend_analytic_ops_real() {
     let mut backend = CpuBackend::new();
 
     let exp_input = Tensor::F64(TypedTensor::from_vec(vec![2], vec![0.0, 1.0]));
-    let exp_out = backend.exp(&exp_input);
+    let exp_out = backend.exp(&exp_input).unwrap();
     assert_f64_close(get_f64(&exp_out, &[0]), 1.0);
     assert_f64_close(get_f64(&exp_out, &[1]), std::f64::consts::E);
 
     let log_input = Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.0, 4.0]));
-    let log_out = backend.log(&log_input);
+    let log_out = backend.log(&log_input).unwrap();
     assert_f64_close(get_f64(&log_out, &[0]), 0.0);
     assert_f64_close(get_f64(&log_out, &[1]), 4.0_f64.ln());
 
@@ -863,28 +879,28 @@ fn test_cpu_backend_analytic_ops_real() {
         vec![2],
         vec![0.0, std::f64::consts::FRAC_PI_2],
     ));
-    let sin_out = backend.sin(&trig_input);
-    let cos_out = backend.cos(&trig_input);
+    let sin_out = backend.sin(&trig_input).unwrap();
+    let cos_out = backend.cos(&trig_input).unwrap();
     assert_f64_close(get_f64(&sin_out, &[0]), 0.0);
     assert_f64_close(get_f64(&sin_out, &[1]), 1.0);
     assert_f64_close(get_f64(&cos_out, &[0]), 1.0);
     assert_f64_close(get_f64(&cos_out, &[1]), 0.0);
 
     let tanh_input = Tensor::F64(TypedTensor::from_vec(vec![2], vec![0.0, 1.0]));
-    let tanh_out = backend.tanh(&tanh_input);
+    let tanh_out = backend.tanh(&tanh_input).unwrap();
     assert_f64_close(get_f64(&tanh_out, &[0]), 0.0);
     assert_f64_close(get_f64(&tanh_out, &[1]), 1.0_f64.tanh());
 
     let sqrt_input = Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.0, 4.0]));
-    let sqrt_out = backend.sqrt(&sqrt_input);
-    let rsqrt_out = backend.rsqrt(&sqrt_input);
+    let sqrt_out = backend.sqrt(&sqrt_input).unwrap();
+    let rsqrt_out = backend.rsqrt(&sqrt_input).unwrap();
     assert_f64_close(get_f64(&sqrt_out, &[0]), 1.0);
     assert_f64_close(get_f64(&sqrt_out, &[1]), 2.0);
     assert_f64_close(get_f64(&rsqrt_out, &[0]), 1.0);
     assert_f64_close(get_f64(&rsqrt_out, &[1]), 0.5);
 
-    let expm1_out = backend.expm1(&exp_input);
-    let log1p_out = backend.log1p(&log_input);
+    let expm1_out = backend.expm1(&exp_input).unwrap();
+    let log1p_out = backend.log1p(&log_input).unwrap();
     assert_f64_close(get_f64(&expm1_out, &[0]), 0.0);
     assert_f64_close(get_f64(&expm1_out, &[1]), 1.0_f64.exp_m1());
     assert_f64_close(get_f64(&log1p_out, &[0]), 2.0_f64.ln());
@@ -892,7 +908,7 @@ fn test_cpu_backend_analytic_ops_real() {
 
     let pow_base = Tensor::F64(TypedTensor::from_vec(vec![2], vec![2.0, 9.0]));
     let pow_exp = Tensor::F64(TypedTensor::from_vec(vec![2], vec![3.0, 0.5]));
-    let pow_out = backend.pow(&pow_base, &pow_exp);
+    let pow_out = backend.pow(&pow_base, &pow_exp).unwrap();
     assert_f64_close(get_f64(&pow_out, &[0]), 8.0);
     assert_f64_close(get_f64(&pow_out, &[1]), 3.0);
 }
@@ -905,7 +921,7 @@ fn test_cpu_backend_analytic_ops_complex() {
         vec![2],
         vec![Complex64::new(0.0, 0.0), Complex64::new(1.0, 1.0)],
     ));
-    let exp_out = backend.exp(&exp_input);
+    let exp_out = backend.exp(&exp_input).unwrap();
     assert_c64_close(get_c64(&exp_out, &[0]), Complex64::new(1.0, 0.0));
     assert_c64_close(get_c64(&exp_out, &[1]), Complex64::new(1.0, 1.0).exp());
 
@@ -913,7 +929,7 @@ fn test_cpu_backend_analytic_ops_complex() {
         vec![2],
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, -0.5)],
     ));
-    let log_out = backend.log(&log_input);
+    let log_out = backend.log(&log_input).unwrap();
     assert_c64_close(get_c64(&log_out, &[0]), Complex64::new(1.0, 0.0).ln());
     assert_c64_close(get_c64(&log_out, &[1]), Complex64::new(2.0, -0.5).ln());
 
@@ -921,9 +937,9 @@ fn test_cpu_backend_analytic_ops_complex() {
         vec![2],
         vec![Complex64::new(0.0, 0.0), Complex64::new(0.5, -0.25)],
     ));
-    let sin_out = backend.sin(&trig_input);
-    let cos_out = backend.cos(&trig_input);
-    let tanh_out = backend.tanh(&trig_input);
+    let sin_out = backend.sin(&trig_input).unwrap();
+    let cos_out = backend.cos(&trig_input).unwrap();
+    let tanh_out = backend.tanh(&trig_input).unwrap();
     assert_c64_close(get_c64(&sin_out, &[0]), Complex64::new(0.0, 0.0).sin());
     assert_c64_close(get_c64(&sin_out, &[1]), Complex64::new(0.5, -0.25).sin());
     assert_c64_close(get_c64(&cos_out, &[0]), Complex64::new(0.0, 0.0).cos());
@@ -935,8 +951,8 @@ fn test_cpu_backend_analytic_ops_complex() {
         vec![2],
         vec![Complex64::new(1.0, 0.0), Complex64::new(4.0, 3.0)],
     ));
-    let sqrt_out = backend.sqrt(&sqrt_input);
-    let rsqrt_out = backend.rsqrt(&sqrt_input);
+    let sqrt_out = backend.sqrt(&sqrt_input).unwrap();
+    let rsqrt_out = backend.rsqrt(&sqrt_input).unwrap();
     assert_c64_close(get_c64(&sqrt_out, &[0]), Complex64::new(1.0, 0.0).sqrt());
     assert_c64_close(get_c64(&sqrt_out, &[1]), Complex64::new(4.0, 3.0).sqrt());
     assert_c64_close_tol(
@@ -950,8 +966,8 @@ fn test_cpu_backend_analytic_ops_complex() {
         1.0e-12,
     );
 
-    let expm1_out = backend.expm1(&exp_input);
-    let log1p_out = backend.log1p(&log_input);
+    let expm1_out = backend.expm1(&exp_input).unwrap();
+    let log1p_out = backend.log1p(&log_input).unwrap();
     assert_c64_close(
         get_c64(&expm1_out, &[0]),
         Complex64::new(0.0, 0.0).exp() - Complex64::new(1.0, 0.0),
@@ -977,7 +993,7 @@ fn test_cpu_backend_analytic_ops_complex() {
         vec![2],
         vec![Complex64::new(2.0, 0.0), Complex64::new(0.5, 0.25)],
     ));
-    let pow_out = backend.pow(&pow_base, &pow_exp);
+    let pow_out = backend.pow(&pow_base, &pow_exp).unwrap();
     assert_c64_close(
         get_c64(&pow_out, &[0]),
         Complex64::new(1.0, 1.0).powc(Complex64::new(2.0, 0.0)),
@@ -994,7 +1010,7 @@ fn test_extract_diagonal() {
         vec![3, 3],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
     ));
-    let d = extract_diagonal(&square, 0, 1);
+    let d = extract_diagonal(&square, 0, 1).unwrap();
     assert_eq!(d.shape(), &[3]);
     assert_eq!(get_f64(&d, &[0]), 1.0);
     assert_eq!(get_f64(&d, &[1]), 5.0);
@@ -1004,7 +1020,7 @@ fn test_extract_diagonal() {
         vec![2, 3, 3],
         (1..=18).map(|x| x as f64).collect(),
     ));
-    let diag = extract_diagonal(&cube, 1, 2);
+    let diag = extract_diagonal(&cube, 1, 2).unwrap();
     assert_eq!(diag.shape(), &[2, 3]);
     assert_eq!(get_f64(&diag, &[0, 0]), 1.0);
     assert_eq!(get_f64(&diag, &[1, 1]), 10.0);
@@ -1014,7 +1030,7 @@ fn test_extract_diagonal() {
 #[test]
 fn test_embed_diagonal() {
     let v = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
-    let m = embed_diagonal(&v, 0, 1);
+    let m = embed_diagonal(&v, 0, 1).unwrap();
     assert_eq!(m.shape(), &[3, 3]);
     assert_eq!(get_f64(&m, &[0, 0]), 1.0);
     assert_eq!(get_f64(&m, &[1, 1]), 2.0);
@@ -1028,7 +1044,7 @@ fn test_cpu_backend_dispatches_tensor_backend_ops() {
     let a = Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.0, 2.0]));
     let b = Tensor::F64(TypedTensor::from_vec(vec![2], vec![3.0, 4.0]));
     let mut backend = CpuBackend::new();
-    let out = TensorBackend::add(&mut backend, &a, &b);
+    let out = TensorBackend::add(&mut backend, &a, &b).unwrap();
     assert_eq!(get_f64(&out, &[0]), 4.0);
     assert_eq!(get_f64(&out, &[1]), 6.0);
 }
@@ -1044,62 +1060,62 @@ fn test_tier2_elementwise_ops_real() {
     let upper = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 0.25, 4.0]));
     let mut backend = CpuBackend::new();
 
-    let div = backend.div(&lhs, &rhs);
+    let div = backend.div(&lhs, &rhs).unwrap();
     assert_eq!(get_f64(&div, &[0]), 4.0);
     assert_eq!(get_f64(&div, &[1]), -0.4);
     assert_eq!(get_f64(&div, &[2]), 3.0);
 
-    let abs = backend.abs(&lhs);
+    let abs = backend.abs(&lhs).unwrap();
     assert_eq!(get_f64(&abs, &[0]), 8.0);
     assert_eq!(get_f64(&abs, &[1]), 2.0);
     assert_eq!(get_f64(&abs, &[2]), 9.0);
 
-    let sign = backend.sign(&lhs);
+    let sign = backend.sign(&lhs).unwrap();
     assert_eq!(get_f64(&sign, &[0]), 1.0);
     assert_eq!(get_f64(&sign, &[1]), -1.0);
     assert_eq!(get_f64(&sign, &[2]), 1.0);
 
-    let maximum = backend.maximum(&lhs, &rhs);
+    let maximum = backend.maximum(&lhs, &rhs).unwrap();
     assert_eq!(get_f64(&maximum, &[0]), 8.0);
     assert_eq!(get_f64(&maximum, &[1]), 5.0);
     assert_eq!(get_f64(&maximum, &[2]), 9.0);
 
-    let minimum = backend.minimum(&lhs, &rhs);
+    let minimum = backend.minimum(&lhs, &rhs).unwrap();
     assert_eq!(get_f64(&minimum, &[0]), 2.0);
     assert_eq!(get_f64(&minimum, &[1]), -2.0);
     assert_eq!(get_f64(&minimum, &[2]), 3.0);
 
-    let eq = backend.compare(&lhs, &rhs, &CompareDir::Eq);
+    let eq = backend.compare(&lhs, &rhs, &CompareDir::Eq).unwrap();
     assert_eq!(get_f64(&eq, &[0]), 0.0);
     assert_eq!(get_f64(&eq, &[1]), 0.0);
     assert_eq!(get_f64(&eq, &[2]), 0.0);
 
-    let lt = backend.compare(&lhs, &rhs, &CompareDir::Lt);
+    let lt = backend.compare(&lhs, &rhs, &CompareDir::Lt).unwrap();
     assert_eq!(get_f64(&lt, &[0]), 0.0);
     assert_eq!(get_f64(&lt, &[1]), 1.0);
     assert_eq!(get_f64(&lt, &[2]), 0.0);
 
-    let le = backend.compare(&lhs, &rhs, &CompareDir::Le);
+    let le = backend.compare(&lhs, &rhs, &CompareDir::Le).unwrap();
     assert_eq!(get_f64(&le, &[0]), 0.0);
     assert_eq!(get_f64(&le, &[1]), 1.0);
     assert_eq!(get_f64(&le, &[2]), 0.0);
 
-    let gt = backend.compare(&lhs, &rhs, &CompareDir::Gt);
+    let gt = backend.compare(&lhs, &rhs, &CompareDir::Gt).unwrap();
     assert_eq!(get_f64(&gt, &[0]), 1.0);
     assert_eq!(get_f64(&gt, &[1]), 0.0);
     assert_eq!(get_f64(&gt, &[2]), 1.0);
 
-    let ge = backend.compare(&lhs, &rhs, &CompareDir::Ge);
+    let ge = backend.compare(&lhs, &rhs, &CompareDir::Ge).unwrap();
     assert_eq!(get_f64(&ge, &[0]), 1.0);
     assert_eq!(get_f64(&ge, &[1]), 0.0);
     assert_eq!(get_f64(&ge, &[2]), 1.0);
 
-    let select = backend.select(&pred, &on_true, &on_false);
+    let select = backend.select(&pred, &on_true, &on_false).unwrap();
     assert_eq!(get_f64(&select, &[0]), 1.0);
     assert_eq!(get_f64(&select, &[1]), 20.0);
     assert_eq!(get_f64(&select, &[2]), 30.0);
 
-    let clamp = backend.clamp(&lhs, &lower, &upper);
+    let clamp = backend.clamp(&lhs, &lower, &upper).unwrap();
     assert_eq!(get_f64(&clamp, &[0]), 1.0);
     assert_eq!(get_f64(&clamp, &[1]), -1.0);
     assert_eq!(get_f64(&clamp, &[2]), 4.0);
@@ -1121,19 +1137,19 @@ fn test_tier2_elementwise_ops_complex() {
     ));
     let mut backend = CpuBackend::new();
 
-    let abs = backend.abs(&input);
+    let abs = backend.abs(&input).unwrap();
     assert_c64_close(get_c64(&abs, &[0]), Complex64::new(5.0, 0.0));
     assert_c64_close(get_c64(&abs, &[1]), Complex64::new(0.0, 0.0));
 
-    let sign = backend.sign(&input);
+    let sign = backend.sign(&input).unwrap();
     assert_c64_close(get_c64(&sign, &[0]), Complex64::new(0.6, 0.8));
     assert_c64_close(get_c64(&sign, &[1]), Complex64::new(0.0, 0.0));
 
-    let maximum = backend.maximum(&lhs, &rhs);
+    let maximum = backend.maximum(&lhs, &rhs).unwrap();
     assert_c64_close(get_c64(&maximum, &[0]), Complex64::new(3.0, 4.0));
     assert_c64_close(get_c64(&maximum, &[1]), Complex64::new(0.0, 2.0));
 
-    let minimum = backend.minimum(&lhs, &rhs);
+    let minimum = backend.minimum(&lhs, &rhs).unwrap();
     assert_c64_close(get_c64(&minimum, &[0]), Complex64::new(1.0, 0.0));
     assert_c64_close(get_c64(&minimum, &[1]), Complex64::new(1.0, 0.0));
 }
@@ -1150,7 +1166,7 @@ fn test_batched_cholesky() {
         a0.iter().chain(a1.iter()).copied().collect(),
     ));
     let mut backend = CpuBackend::new();
-    let out = backend.cholesky(&input);
+    let out = backend.cholesky(&input).unwrap();
 
     assert_eq!(out.shape(), &[3, 3, 2]);
     for batch_idx in 0..2 {
@@ -1174,7 +1190,7 @@ fn test_batched_svd() {
         a0.iter().chain(a1.iter()).copied().collect(),
     ));
     let mut backend = CpuBackend::new();
-    let out = backend.svd(&input);
+    let out = backend.svd(&input).unwrap();
 
     assert_eq!(out.len(), 3);
     assert_eq!(out[0].shape(), &[4, 3, 2]);
@@ -1202,7 +1218,7 @@ fn test_batched_qr() {
         a0.iter().chain(a1.iter()).copied().collect(),
     ));
     let mut backend = CpuBackend::new();
-    let out = backend.qr(&input);
+    let out = backend.qr(&input).unwrap();
 
     assert_eq!(out.len(), 2);
     assert_eq!(out[0].shape(), &[3, 2, 2]);
@@ -1235,7 +1251,7 @@ fn test_batched_solve() {
     ));
 
     let mut backend = CpuBackend::new();
-    let x = backend.solve(&a, &b);
+    let x = backend.solve(&a, &b).unwrap();
 
     assert_eq!(x.shape(), &[3, 1, 2]);
     for batch_idx in 0..2 {
@@ -1257,7 +1273,9 @@ fn test_triangular_solve_lower() {
     let b = Tensor::F64(TypedTensor::from_vec(vec![3, 1], b_data.clone()));
 
     let mut backend = CpuBackend::new();
-    let x = backend.triangular_solve(&l, &b, true, true, false, false);
+    let x = backend
+        .triangular_solve(&l, &b, true, true, false, false)
+        .unwrap();
 
     assert_eq!(x.shape(), &[3, 1]);
     let x_data = match &x {
@@ -1278,7 +1296,9 @@ fn test_triangular_solve_right_side_unit_transpose() {
     let b = Tensor::F64(TypedTensor::from_vec(vec![1, 2], b_data.clone()));
 
     let mut backend = CpuBackend::new();
-    let x = backend.triangular_solve(&a, &b, false, true, true, true);
+    let x = backend
+        .triangular_solve(&a, &b, false, true, true, true)
+        .unwrap();
 
     assert_eq!(x.shape(), &[1, 2]);
     let x_data = match &x {
@@ -1323,14 +1343,9 @@ fn test_triangular_solve_covers_all_real_branch_combinations() {
                     let a = Tensor::F64(TypedTensor::from_vec(vec![2, 2], a_data));
                     let b = Tensor::F64(TypedTensor::from_vec(vec![2, 2], b_data));
                     let mut backend = CpuBackend::new();
-                    let x = backend.triangular_solve(
-                        &a,
-                        &b,
-                        left_side,
-                        lower,
-                        transpose_a,
-                        unit_diagonal,
-                    );
+                    let x = backend
+                        .triangular_solve(&a, &b, left_side, lower, transpose_a, unit_diagonal)
+                        .unwrap();
 
                     let x_data = match &x {
                         Tensor::F64(inner) => inner.host_data(),
@@ -1376,7 +1391,7 @@ fn test_batched_complex_solve() {
     ));
 
     let mut backend = CpuBackend::new();
-    let x = backend.solve(&a, &b);
+    let x = backend.solve(&a, &b).unwrap();
 
     assert_eq!(x.shape(), &[2, 1, 2]);
     for batch_idx in 0..2 {
@@ -1398,7 +1413,7 @@ fn test_real_solve_non_batched() {
     let b = Tensor::F64(TypedTensor::from_vec(vec![2, 2], b_data.clone()));
 
     let mut backend = CpuBackend::new();
-    let x = backend.solve(&a, &b);
+    let x = backend.solve(&a, &b).unwrap();
 
     let x_data = match &x {
         Tensor::F64(inner) => inner.host_data(),
@@ -1414,7 +1429,7 @@ fn test_real_solve_non_batched() {
 fn test_real_lu_returns_permutation_factors_and_parity() {
     let input = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]));
     let mut backend = CpuBackend::new();
-    let outputs = backend.lu(&input);
+    let outputs = backend.lu(&input).unwrap();
 
     assert_eq!(outputs.len(), 4);
     let p = matrix_f64_from_tensor(&outputs[0], 2, 2);
@@ -1434,7 +1449,7 @@ fn test_real_lu_returns_permutation_factors_and_parity() {
 fn test_real_eig_returns_complex_outputs() {
     let input = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0]));
     let mut backend = CpuBackend::new();
-    let outputs = backend.eig(&input);
+    let outputs = backend.eig(&input).unwrap();
 
     assert_eq!(outputs.len(), 2);
     assert_eq!(outputs[0].shape(), &[2]);
@@ -1472,7 +1487,7 @@ fn test_batched_complex_eigh() {
     ));
 
     let mut backend = CpuBackend::new();
-    let out = backend.eigh(&input);
+    let out = backend.eigh(&input).unwrap();
 
     assert_eq!(out.len(), 2);
     assert_eq!(out[0].shape(), &[2, 2]);
@@ -1504,7 +1519,7 @@ fn test_real_eigh() {
     let input = Tensor::F64(TypedTensor::from_vec(vec![2, 2], a_data.clone()));
 
     let mut backend = CpuBackend::new();
-    let out = backend.eigh(&input);
+    let out = backend.eigh(&input).unwrap();
 
     assert_eq!(out.len(), 2);
     assert_eq!(out[0].shape(), &[2]);
@@ -1528,20 +1543,26 @@ fn test_real_eigh() {
 }
 
 #[test]
-#[should_panic(expected = "cholesky: matrix is not positive definite")]
-fn test_real_cholesky_panics_for_non_positive_definite_input() {
+fn test_real_cholesky_returns_error_for_non_positive_definite_input() {
     let input = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 2.0, 1.0]));
     let mut backend = CpuBackend::new();
-    let _ = backend.cholesky(&input);
+    let err = backend.cholesky(&input).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::BackendFailure { op: "cholesky", .. }
+    ));
 }
 
 #[test]
-#[should_panic(expected = "solve: singular matrix")]
-fn test_real_solve_panics_for_singular_matrix() {
+fn test_real_solve_returns_error_for_singular_matrix() {
     let a = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 2.0, 4.0]));
     let b = Tensor::F64(TypedTensor::from_vec(vec![2, 1], vec![1.0, 1.0]));
     let mut backend = CpuBackend::new();
-    let _ = backend.solve(&a, &b);
+    let err = backend.solve(&a, &b).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::BackendFailure { op: "solve", .. }
+    ));
 }
 
 #[test]
@@ -1556,7 +1577,7 @@ fn test_complex_cholesky() {
     let input = Tensor::C64(TypedTensor::from_vec(vec![2, 2], a.clone()));
 
     let mut backend = CpuBackend::new();
-    let out = backend.cholesky(&input);
+    let out = backend.cholesky(&input).unwrap();
 
     assert_eq!(out.shape(), &[2, 2]);
     let l_out = matrix_c64_from_tensor(&out, 2, 2);
@@ -1567,8 +1588,7 @@ fn test_complex_cholesky() {
 }
 
 #[test]
-#[should_panic(expected = "cholesky: matrix is not positive definite")]
-fn test_complex_cholesky_panics_for_non_positive_definite_input() {
+fn test_complex_cholesky_returns_error_for_non_positive_definite_input() {
     let input = Tensor::C64(TypedTensor::from_vec(
         vec![2, 2],
         vec![
@@ -1579,7 +1599,11 @@ fn test_complex_cholesky_panics_for_non_positive_definite_input() {
         ],
     ));
     let mut backend = CpuBackend::new();
-    let _ = backend.cholesky(&input);
+    let err = backend.cholesky(&input).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::BackendFailure { op: "cholesky", .. }
+    ));
 }
 
 #[test]
@@ -1595,7 +1619,7 @@ fn test_complex_qr() {
     let input = Tensor::C64(TypedTensor::from_vec(vec![3, 2], input_data.clone()));
 
     let mut backend = CpuBackend::new();
-    let out = backend.qr(&input);
+    let out = backend.qr(&input).unwrap();
 
     assert_eq!(out.len(), 2);
     assert_eq!(out[0].shape(), &[3, 2]);
@@ -1621,7 +1645,7 @@ fn test_complex_svd() {
     ];
     let input = Tensor::C64(TypedTensor::from_vec(vec![3, 2], input_data.clone()));
     let mut backend = CpuBackend::new();
-    let out = backend.svd(&input);
+    let out = backend.svd(&input).unwrap();
 
     assert_eq!(out.len(), 3);
     assert_eq!(out[0].shape(), &[3, 2]);
@@ -1650,7 +1674,9 @@ fn test_complex_triangular_solve_right_side_unit_transpose() {
     let b = Tensor::C64(TypedTensor::from_vec(vec![1, 2], b_data.clone()));
 
     let mut backend = CpuBackend::new();
-    let x = backend.triangular_solve(&a, &b, false, true, true, true);
+    let x = backend
+        .triangular_solve(&a, &b, false, true, true, true)
+        .unwrap();
 
     assert_eq!(x.shape(), &[1, 2]);
     let x_data = match &x {
@@ -1710,14 +1736,9 @@ fn test_triangular_solve_covers_all_complex_branch_combinations() {
                     let a = Tensor::C64(TypedTensor::from_vec(vec![2, 2], a_data));
                     let b = Tensor::C64(TypedTensor::from_vec(vec![2, 2], b_data));
                     let mut backend = CpuBackend::new();
-                    let x = backend.triangular_solve(
-                        &a,
-                        &b,
-                        left_side,
-                        lower,
-                        transpose_a,
-                        unit_diagonal,
-                    );
+                    let x = backend
+                        .triangular_solve(&a, &b, left_side, lower, transpose_a, unit_diagonal)
+                        .unwrap();
 
                     let x_data = match &x {
                         Tensor::C64(inner) => inner.host_data(),
@@ -1733,8 +1754,7 @@ fn test_triangular_solve_covers_all_complex_branch_combinations() {
 }
 
 #[test]
-#[should_panic(expected = "solve: singular matrix")]
-fn test_complex_solve_panics_for_singular_matrix() {
+fn test_complex_solve_returns_error_for_singular_matrix() {
     let a = Tensor::C64(TypedTensor::from_vec(
         vec![2, 2],
         vec![
@@ -1749,7 +1769,11 @@ fn test_complex_solve_panics_for_singular_matrix() {
         vec![Complex64::new(1.0, 0.0), Complex64::new(1.0, 0.0)],
     ));
     let mut backend = CpuBackend::new();
-    let _ = backend.solve(&a, &b);
+    let err = backend.solve(&a, &b).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::BackendFailure { op: "solve", .. }
+    ));
 }
 
 #[test]
@@ -1908,7 +1932,7 @@ fn test_slice_concatenate_and_reverse_edge_cases() {
         strides: vec![2, 2],
     };
     let mut backend = CpuBackend::new();
-    let sliced = backend.slice(&input, &config);
+    let sliced = backend.slice(&input, &config).unwrap();
     assert_eq!(sliced.shape(), &[2, 2]);
     assert_eq!(get_f64(&sliced, &[0, 0]), 1.0);
     assert_eq!(get_f64(&sliced, &[1, 0]), 3.0);
@@ -1918,13 +1942,13 @@ fn test_slice_concatenate_and_reverse_edge_cases() {
     let a = Tensor::F64(TypedTensor::from_vec(vec![2, 1], vec![1.0, 2.0]));
     let b = Tensor::F64(TypedTensor::from_vec(vec![2, 1], vec![3.0, 4.0]));
     let c = Tensor::F64(TypedTensor::from_vec(vec![2, 1], vec![5.0, 6.0]));
-    let concatenated = backend.concatenate(&[&a, &b, &c], 1);
+    let concatenated = backend.concatenate(&[&a, &b, &c], 1).unwrap();
     assert_eq!(concatenated.shape(), &[2, 3]);
     assert_eq!(get_f64(&concatenated, &[0, 0]), 1.0);
     assert_eq!(get_f64(&concatenated, &[1, 1]), 4.0);
     assert_eq!(get_f64(&concatenated, &[0, 2]), 5.0);
 
-    let reversed = backend.reverse(&input, &[0, 1]);
+    let reversed = backend.reverse(&input, &[0, 1]).unwrap();
     assert_eq!(reversed.shape(), &[4, 3]);
     assert_eq!(get_f64(&reversed, &[0, 0]), 12.0);
     assert_eq!(get_f64(&reversed, &[3, 2]), 1.0);
@@ -1964,7 +1988,7 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
     ];
 
     for (input, to) in cases {
-        let output = backend.convert(input, to);
+        let output = backend.convert(input, to).unwrap();
         assert_eq!(output.shape(), &[2]);
         assert_eq!(output.dtype(), to);
 
@@ -2014,7 +2038,7 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
 }
 
 #[test]
-fn test_backend_linalg_panics_for_unsupported_dtypes() {
+fn test_backend_linalg_returns_errors_for_unsupported_dtypes() {
     let mut backend = CpuBackend::new();
     let f32_matrix = Tensor::F32(TypedTensor::from_vec(
         vec![2, 2],
@@ -2031,14 +2055,13 @@ fn test_backend_linalg_panics_for_unsupported_dtypes() {
         ],
     ));
 
-    assert!(catch_unwind(AssertUnwindSafe(|| backend.cholesky(&f32_matrix))).is_err());
-    assert!(catch_unwind(AssertUnwindSafe(|| backend.svd(&f32_matrix))).is_err());
-    assert!(catch_unwind(AssertUnwindSafe(|| backend.qr(&f32_matrix))).is_err());
-    assert!(catch_unwind(AssertUnwindSafe(|| backend.eigh(&f32_matrix))).is_err());
-    assert!(catch_unwind(AssertUnwindSafe(|| backend.solve(&f32_matrix, &f32_rhs))).is_err());
-    assert!(catch_unwind(AssertUnwindSafe(|| {
-        backend.triangular_solve(&f32_matrix, &f32_rhs, true, true, false, false)
-    }))
-    .is_err());
-    assert!(catch_unwind(AssertUnwindSafe(|| backend.cholesky(&c32_matrix))).is_err());
+    assert!(backend.cholesky(&f32_matrix).is_err());
+    assert!(backend.svd(&f32_matrix).is_err());
+    assert!(backend.qr(&f32_matrix).is_err());
+    assert!(backend.eigh(&f32_matrix).is_err());
+    assert!(backend.solve(&f32_matrix, &f32_rhs).is_err());
+    assert!(backend
+        .triangular_solve(&f32_matrix, &f32_rhs, true, true, false, false)
+        .is_err());
+    assert!(backend.cholesky(&c32_matrix).is_err());
 }

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -6,6 +6,7 @@ use crate::types::{
     col_major_strides, flat_to_multi, Buffer, BufferHandle, ComputeDevice, ConjElem, DType,
     MemoryKind, Placement, Tensor, TypedTensor,
 };
+use crate::Error;
 
 #[test]
 fn col_major_helpers_cover_scalar_and_higher_rank_shapes() {
@@ -129,4 +130,15 @@ fn memory_kind_variants_are_constructible() {
     assert!(matches!(kinds[1], MemoryKind::PinnedHost));
     assert!(matches!(kinds[2], MemoryKind::UnpinnedHost));
     assert!(matches!(kinds[3], MemoryKind::Other(_)));
+}
+
+#[test]
+fn runtime_error_formats_include_op_name() {
+    let err = Error::AxisOutOfBounds {
+        op: "dot_general",
+        axis: 2,
+        rank: 1,
+    };
+
+    assert!(err.to_string().contains("dot_general"));
 }

--- a/tenferro-tensor/tests/inject_tests.rs
+++ b/tenferro-tensor/tests/inject_tests.rs
@@ -85,7 +85,7 @@ fn provider_inject_dot_general_uses_registered_blas() {
 
     assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
     match c {
-        Tensor::F64(inner) => assert_eq!(inner.host_data(), &[19.0, 43.0, 22.0, 50.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[19.0, 43.0, 22.0, 50.0]),
         _ => panic!("expected f64 tensor"),
     }
 }

--- a/tenferro-tensor/tests/runtime_error_tests.rs
+++ b/tenferro-tensor/tests/runtime_error_tests.rs
@@ -1,0 +1,257 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use tenferro_algebra::Standard;
+use tenferro_tensor::{
+    cpu::CpuBackend, DotGeneralConfig, Error, PadConfig, SemiringBackend, SliceConfig, Tensor,
+    TensorBackend, TypedTensor,
+};
+
+fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(shape, data))
+}
+
+#[test]
+fn dot_general_rejects_out_of_bounds_contracting_dim() {
+    let lhs = f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let rhs = f64_tensor(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .dot_general(
+            &lhs,
+            &rhs,
+            &DotGeneralConfig {
+                lhs_contracting_dims: vec![2],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+                lhs_rank: 2,
+                rhs_rank: 2,
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::AxisOutOfBounds {
+            op: "dot_general",
+            axis: 2,
+            rank: 2,
+        }
+    ));
+}
+
+#[test]
+fn semiring_add_rejects_shape_mismatch() {
+    let lhs = TypedTensor::from_vec(vec![2], vec![1.0, 2.0]);
+    let rhs = TypedTensor::from_vec(vec![3], vec![3.0, 4.0, 5.0]);
+    let mut backend = CpuBackend::new();
+
+    let err =
+        <CpuBackend as SemiringBackend<Standard<f64>>>::add(&mut backend, &lhs, &rhs).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::ShapeMismatch {
+            op: "add",
+            lhs,
+            rhs,
+        } if lhs == vec![2] && rhs == vec![3]
+    ));
+}
+
+#[test]
+fn add_rejects_shape_mismatch() {
+    let lhs = f64_tensor(vec![2], vec![1.0, 2.0]);
+    let rhs = f64_tensor(vec![3], vec![3.0, 4.0, 5.0]);
+    let mut backend = CpuBackend::new();
+
+    let err = <CpuBackend as TensorBackend>::add(&mut backend, &lhs, &rhs).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::ShapeMismatch {
+            op: "add",
+            lhs,
+            rhs,
+        } if lhs == vec![2] && rhs == vec![3]
+    ));
+}
+
+#[test]
+fn solve_rejects_singular_matrix() {
+    let a = f64_tensor(vec![2, 2], vec![1.0, 2.0, 2.0, 4.0]);
+    let b = f64_tensor(vec![2, 1], vec![1.0, 2.0]);
+    let mut backend = CpuBackend::new();
+
+    let err = backend.solve(&a, &b).unwrap_err();
+
+    assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+}
+
+#[test]
+fn semiring_reduce_sum_rejects_out_of_bounds_axis() {
+    let input = TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let mut backend = CpuBackend::new();
+
+    let err =
+        <CpuBackend as SemiringBackend<Standard<f64>>>::reduce_sum(&mut backend, &input, &[2])
+            .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::AxisOutOfBounds {
+            op: "reduce_sum",
+            axis: 2,
+            rank: 2,
+        }
+    ));
+}
+
+#[test]
+fn semiring_batched_gemm_returns_error_instead_of_panicking() {
+    let lhs = TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let rhs = TypedTensor::from_vec(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    let mut backend = CpuBackend::new();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![0],
+        rhs_contracting_dims: vec![0, 1],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+        lhs_rank: 2,
+        rhs_rank: 2,
+    };
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        <CpuBackend as SemiringBackend<Standard<f64>>>::batched_gemm(
+            &mut backend,
+            &lhs,
+            &rhs,
+            &config,
+        )
+    }));
+
+    assert!(
+        result.is_ok(),
+        "semiring batched_gemm should return Err, not panic"
+    );
+    let err = result.unwrap().unwrap_err();
+    assert!(matches!(
+        err,
+        Error::InvalidConfig {
+            op: "batched_gemm",
+            ..
+        } | Error::BackendFailure {
+            op: "batched_gemm",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn transpose_returns_error_instead_of_panicking() {
+    let input = f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let mut backend = CpuBackend::new();
+
+    let result = catch_unwind(AssertUnwindSafe(|| backend.transpose(&input, &[0])));
+
+    assert!(result.is_ok(), "transpose should return Err, not panic");
+    let err = result.unwrap().unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "transpose",
+            ..
+        } | Error::InvalidConfig {
+            op: "transpose",
+            ..
+        } | Error::RankMismatch {
+            op: "transpose",
+            ..
+        } | Error::AxisOutOfBounds {
+            op: "transpose",
+            ..
+        } | Error::DuplicateAxis {
+            op: "transpose",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn reshape_returns_error_instead_of_panicking() {
+    let input = f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let mut backend = CpuBackend::new();
+
+    let result = catch_unwind(AssertUnwindSafe(|| backend.reshape(&input, &[3])));
+
+    assert!(result.is_ok(), "reshape should return Err, not panic");
+    let err = result.unwrap().unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure { op: "reshape", .. }
+            | Error::InvalidConfig { op: "reshape", .. }
+            | Error::ShapeMismatch { op: "reshape", .. }
+    ));
+}
+
+#[test]
+fn pow_returns_error_on_shape_mismatch_instead_of_panicking() {
+    let lhs = f64_tensor(vec![2], vec![1.0, 2.0]);
+    let rhs = f64_tensor(vec![1], vec![3.0]);
+    let mut backend = CpuBackend::new();
+
+    let result = catch_unwind(AssertUnwindSafe(|| backend.pow(&lhs, &rhs)));
+
+    assert!(result.is_ok(), "pow should return Err, not panic");
+    let err = result.unwrap().unwrap_err();
+    assert!(matches!(
+        err,
+        Error::ShapeMismatch { op: "pow", .. } | Error::BackendFailure { op: "pow", .. }
+    ));
+}
+
+#[test]
+fn slice_returns_error_instead_of_panicking() {
+    let input = f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let mut backend = CpuBackend::new();
+    let config = SliceConfig {
+        starts: vec![0],
+        limits: vec![2],
+        strides: vec![1],
+    };
+
+    let result = catch_unwind(AssertUnwindSafe(|| backend.slice(&input, &config)));
+
+    assert!(result.is_ok(), "slice should return Err, not panic");
+    let err = result.unwrap().unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure { op: "slice", .. }
+            | Error::InvalidConfig { op: "slice", .. }
+            | Error::RankMismatch { op: "slice", .. }
+            | Error::AxisOutOfBounds { op: "slice", .. }
+    ));
+}
+
+#[test]
+fn pad_returns_error_instead_of_panicking() {
+    let input = f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let mut backend = CpuBackend::new();
+    let config = PadConfig {
+        edge_padding_low: vec![0, 0],
+        edge_padding_high: vec![0],
+        interior_padding: vec![0, 0],
+    };
+
+    let result = catch_unwind(AssertUnwindSafe(|| backend.pad(&input, &config)));
+
+    assert!(result.is_ok(), "pad should return Err, not panic");
+    let err = result.unwrap().unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure { op: "pad", .. }
+            | Error::InvalidConfig { op: "pad", .. }
+            | Error::RankMismatch { op: "pad", .. }
+    ));
+}

--- a/tenferro/src/error.rs
+++ b/tenferro/src/error.rs
@@ -36,6 +36,10 @@ pub enum Error {
     #[error("grad requires a scalar output, got shape {shape:?}")]
     NonScalarGrad { shape: Vec<usize> },
 
+    /// Runtime tensor execution failed in the backend layer.
+    #[error(transparent)]
+    TensorRuntime(#[from] tenferro_tensor::Error),
+
     /// An unexpected internal error.
     #[error("internal error: {0}")]
     Internal(String),

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -461,9 +461,9 @@ where
                 get(&slots, &inst.input_slots, 0)?,
                 get(&slots, &inst.input_slots, 1)?,
                 config,
-            )?,
+            ),
             ExecOp::ReduceSum { axes } => {
-                backend.reduce_sum(get(&slots, &inst.input_slots, 0)?, axes)?
+                backend.reduce_sum(get(&slots, &inst.input_slots, 0)?, axes)
             }
             ExecOp::ExtractDiag { axis_a, axis_b } => {
                 typed_extract_diagonal(get(&slots, &inst.input_slots, 0)?, *axis_a, *axis_b)
@@ -474,14 +474,14 @@ where
             ExecOp::Add => backend.add(
                 get(&slots, &inst.input_slots, 0)?,
                 get(&slots, &inst.input_slots, 1)?,
-            )?,
+            ),
             ExecOp::Multiply => backend.mul(
                 get(&slots, &inst.input_slots, 0)?,
                 get(&slots, &inst.input_slots, 1)?,
-            )?,
+            ),
             _ => panic!("non-semiring op in semiring program: {:?}", inst.op),
         };
-        slots[inst.output_slots[0]] = Some(result);
+        slots[inst.output_slots[0]] = Some(result?);
     }
 
     program

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -1,4 +1,5 @@
 use super::buffer_pool::BufferPool;
+use crate::error::Result;
 use num_complex::{Complex32, Complex64};
 use tenferro_algebra::Semiring;
 use tenferro_ops::dim_expr::DimExpr;
@@ -6,6 +7,7 @@ use tenferro_tensor::cpu::structural::{
     typed_broadcast_in_dim, typed_embed_diagonal, typed_extract_diagonal, typed_reshape,
     typed_transpose,
 };
+use tenferro_tensor::Error as TensorError;
 use tenferro_tensor::{
     Buffer, CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
     SemiringBackend, SliceConfig, Tensor, TensorBackend, TypedTensor,
@@ -121,43 +123,46 @@ pub struct ExecProgram {
     pub n_slots: usize,
 }
 
-fn get<'a, T>(slots: &'a [Option<T>], input_slots: &[usize], idx: usize) -> &'a T {
-    slots[input_slots[idx]].as_ref().expect("missing slot")
+fn get<'a, T>(slots: &'a [Option<T>], input_slots: &[usize], idx: usize) -> Result<&'a T> {
+    let slot = input_slots[idx];
+    slots[slot]
+        .as_ref()
+        .ok_or(TensorError::MissingValue { slot }.into())
 }
 
 fn resolve_tensor_shape_exprs(
     slots: &[Option<Tensor>],
     input_slots: &[usize],
     exprs: &[DimExpr],
-) -> Vec<usize> {
-    let input_shapes: Vec<&[usize]> = input_slots
-        .iter()
-        .map(|&slot| {
+) -> Result<Vec<usize>> {
+    let mut input_shapes = Vec::with_capacity(input_slots.len());
+    for &slot in input_slots {
+        input_shapes.push(
             slots[slot]
                 .as_ref()
-                .expect("missing input slot for shape evaluation")
-                .shape()
-        })
-        .collect();
-    DimExpr::eval_all(exprs, &input_shapes)
+                .ok_or(TensorError::MissingValue { slot })?
+                .shape(),
+        );
+    }
+    Ok(DimExpr::eval_all(exprs, &input_shapes))
 }
 
 fn resolve_semiring_shape_exprs<Alg: Semiring>(
     slots: &[Option<TypedTensor<Alg::Scalar>>],
     input_slots: &[usize],
     exprs: &[DimExpr],
-) -> Vec<usize> {
-    let input_shapes: Vec<&[usize]> = input_slots
-        .iter()
-        .map(|&slot| {
+) -> Result<Vec<usize>> {
+    let mut input_shapes = Vec::with_capacity(input_slots.len());
+    for &slot in input_slots {
+        input_shapes.push(
             slots[slot]
                 .as_ref()
-                .expect("missing semiring input slot for shape evaluation")
+                .ok_or(TensorError::MissingValue { slot })?
                 .shape
-                .as_slice()
-        })
-        .collect();
-    DimExpr::eval_all(exprs, &input_shapes)
+                .as_slice(),
+        );
+    }
+    Ok(DimExpr::eval_all(exprs, &input_shapes))
 }
 
 pub fn eval_exec_ir<B: TensorBackend>(
@@ -165,7 +170,7 @@ pub fn eval_exec_ir<B: TensorBackend>(
     program: &ExecProgram,
     inputs: Vec<Tensor>,
     pool: &mut BufferPool,
-) -> Vec<Tensor> {
+) -> Result<Vec<Tensor>> {
     let mut slots: Vec<Option<Tensor>> = vec![None; program.n_slots];
     for (i, tensor) in inputs.into_iter().enumerate() {
         slots[program.input_slots[i]] = Some(tensor);
@@ -173,144 +178,151 @@ pub fn eval_exec_ir<B: TensorBackend>(
 
     for inst in &program.instructions {
         let result = match &inst.op {
-            ExecOp::Permute { perm } => backend.transpose(get(&slots, &inst.input_slots, 0), perm),
+            ExecOp::Permute { perm } => {
+                backend.transpose(get(&slots, &inst.input_slots, 0)?, perm)?
+            }
             ExecOp::Reshape { shape } => {
-                let shape = resolve_tensor_shape_exprs(&slots, &inst.input_slots, shape);
-                backend.reshape(get(&slots, &inst.input_slots, 0), &shape)
+                let shape = resolve_tensor_shape_exprs(&slots, &inst.input_slots, shape)?;
+                backend.reshape(get(&slots, &inst.input_slots, 0)?, &shape)?
             }
             ExecOp::BroadcastInDim { shape, dims } => {
-                let shape = resolve_tensor_shape_exprs(&slots, &inst.input_slots, shape);
-                backend.broadcast_in_dim(get(&slots, &inst.input_slots, 0), &shape, dims)
+                let shape = resolve_tensor_shape_exprs(&slots, &inst.input_slots, shape)?;
+                backend.broadcast_in_dim(get(&slots, &inst.input_slots, 0)?, &shape, dims)?
             }
-            ExecOp::Convert { to } => backend.convert(get(&slots, &inst.input_slots, 0), *to),
+            ExecOp::Convert { to } => backend.convert(get(&slots, &inst.input_slots, 0)?, *to)?,
             ExecOp::Constant { dtype, bytes } => constant_tensor(*dtype, bytes),
             ExecOp::BatchedGemm(config) => backend.dot_general(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
                 config,
-            ),
+            )?,
             ExecOp::ReduceSum { axes } => {
-                backend.reduce_sum(get(&slots, &inst.input_slots, 0), axes)
+                backend.reduce_sum(get(&slots, &inst.input_slots, 0)?, axes)?
             }
             ExecOp::ExtractDiag { axis_a, axis_b } => {
-                backend.extract_diagonal(get(&slots, &inst.input_slots, 0), *axis_a, *axis_b)
+                backend.extract_diagonal(get(&slots, &inst.input_slots, 0)?, *axis_a, *axis_b)?
             }
             ExecOp::EmbedDiag { axis_a, axis_b } => {
-                backend.embed_diagonal(get(&slots, &inst.input_slots, 0), *axis_a, *axis_b)
+                backend.embed_diagonal(get(&slots, &inst.input_slots, 0)?, *axis_a, *axis_b)?
             }
-            ExecOp::Tril { k } => backend.tril(get(&slots, &inst.input_slots, 0), *k),
-            ExecOp::Triu { k } => backend.triu(get(&slots, &inst.input_slots, 0), *k),
+            ExecOp::Tril { k } => backend.tril(get(&slots, &inst.input_slots, 0)?, *k)?,
+            ExecOp::Triu { k } => backend.triu(get(&slots, &inst.input_slots, 0)?, *k)?,
             ExecOp::Add => backend.add(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-            ),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+            )?,
             ExecOp::Multiply => backend.mul(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-            ),
-            ExecOp::Negate => backend.neg(get(&slots, &inst.input_slots, 0)),
-            ExecOp::Conj => backend.conj(get(&slots, &inst.input_slots, 0)),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+            )?,
+            ExecOp::Negate => backend.neg(get(&slots, &inst.input_slots, 0)?)?,
+            ExecOp::Conj => backend.conj(get(&slots, &inst.input_slots, 0)?)?,
             ExecOp::Divide => backend.div(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-            ),
-            ExecOp::Abs => backend.abs(get(&slots, &inst.input_slots, 0)),
-            ExecOp::Sign => backend.sign(get(&slots, &inst.input_slots, 0)),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+            )?,
+            ExecOp::Abs => backend.abs(get(&slots, &inst.input_slots, 0)?)?,
+            ExecOp::Sign => backend.sign(get(&slots, &inst.input_slots, 0)?)?,
             ExecOp::Maximum => backend.maximum(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-            ),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+            )?,
             ExecOp::Minimum => backend.minimum(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-            ),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+            )?,
             ExecOp::Compare(dir) => backend.compare(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
                 dir,
-            ),
+            )?,
             ExecOp::Select => backend.select(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-                get(&slots, &inst.input_slots, 2),
-            ),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+                get(&slots, &inst.input_slots, 2)?,
+            )?,
             ExecOp::Clamp => backend.clamp(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-                get(&slots, &inst.input_slots, 2),
-            ),
-            ExecOp::Exp => backend.exp(get(&slots, &inst.input_slots, 0)),
-            ExecOp::Log => backend.log(get(&slots, &inst.input_slots, 0)),
-            ExecOp::Sin => backend.sin(get(&slots, &inst.input_slots, 0)),
-            ExecOp::Cos => backend.cos(get(&slots, &inst.input_slots, 0)),
-            ExecOp::Tanh => backend.tanh(get(&slots, &inst.input_slots, 0)),
-            ExecOp::Sqrt => backend.sqrt(get(&slots, &inst.input_slots, 0)),
-            ExecOp::Rsqrt => backend.rsqrt(get(&slots, &inst.input_slots, 0)),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+                get(&slots, &inst.input_slots, 2)?,
+            )?,
+            ExecOp::Exp => backend.exp(get(&slots, &inst.input_slots, 0)?)?,
+            ExecOp::Log => backend.log(get(&slots, &inst.input_slots, 0)?)?,
+            ExecOp::Sin => backend.sin(get(&slots, &inst.input_slots, 0)?)?,
+            ExecOp::Cos => backend.cos(get(&slots, &inst.input_slots, 0)?)?,
+            ExecOp::Tanh => backend.tanh(get(&slots, &inst.input_slots, 0)?)?,
+            ExecOp::Sqrt => backend.sqrt(get(&slots, &inst.input_slots, 0)?)?,
+            ExecOp::Rsqrt => backend.rsqrt(get(&slots, &inst.input_slots, 0)?)?,
             ExecOp::Pow => backend.pow(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-            ),
-            ExecOp::Expm1 => backend.expm1(get(&slots, &inst.input_slots, 0)),
-            ExecOp::Log1p => backend.log1p(get(&slots, &inst.input_slots, 0)),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+            )?,
+            ExecOp::Expm1 => backend.expm1(get(&slots, &inst.input_slots, 0)?)?,
+            ExecOp::Log1p => backend.log1p(get(&slots, &inst.input_slots, 0)?)?,
             ExecOp::Gather(config) => backend.gather(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
                 config,
-            ),
+            )?,
             ExecOp::Scatter(config) => backend.scatter(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-                get(&slots, &inst.input_slots, 2),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+                get(&slots, &inst.input_slots, 2)?,
                 config,
-            ),
-            ExecOp::Slice(config) => backend.slice(get(&slots, &inst.input_slots, 0), config),
+            )?,
+            ExecOp::Slice(config) => backend.slice(get(&slots, &inst.input_slots, 0)?, config)?,
             ExecOp::DynamicSlice { slice_sizes } => backend.dynamic_slice(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
                 slice_sizes,
-            ),
-            ExecOp::Pad(config) => backend.pad(get(&slots, &inst.input_slots, 0), config),
+            )?,
+            ExecOp::Pad(config) => backend.pad(get(&slots, &inst.input_slots, 0)?, config)?,
             ExecOp::Concatenate { axis } => {
-                let inputs: Vec<&Tensor> = inst
-                    .input_slots
-                    .iter()
-                    .map(|&slot| slots[slot].as_ref().expect("missing concat slot"))
-                    .collect();
-                backend.concatenate(&inputs, *axis)
+                let mut inputs = Vec::with_capacity(inst.input_slots.len());
+                for &slot in &inst.input_slots {
+                    inputs.push(
+                        slots[slot]
+                            .as_ref()
+                            .ok_or(TensorError::MissingValue { slot })?,
+                    );
+                }
+                backend.concatenate(&inputs, *axis)?
             }
-            ExecOp::Reverse { axes } => backend.reverse(get(&slots, &inst.input_slots, 0), axes),
+            ExecOp::Reverse { axes } => {
+                backend.reverse(get(&slots, &inst.input_slots, 0)?, axes)?
+            }
             ExecOp::ReduceProd { axes } => {
-                backend.reduce_prod(get(&slots, &inst.input_slots, 0), axes)
+                backend.reduce_prod(get(&slots, &inst.input_slots, 0)?, axes)?
             }
             ExecOp::ReduceMax { axes } => {
-                backend.reduce_max(get(&slots, &inst.input_slots, 0), axes)
+                backend.reduce_max(get(&slots, &inst.input_slots, 0)?, axes)?
             }
             ExecOp::ReduceMin { axes } => {
-                backend.reduce_min(get(&slots, &inst.input_slots, 0), axes)
+                backend.reduce_min(get(&slots, &inst.input_slots, 0)?, axes)?
             }
-            ExecOp::Cholesky => backend.cholesky(get(&slots, &inst.input_slots, 0)),
+            ExecOp::Cholesky => backend.cholesky(get(&slots, &inst.input_slots, 0)?)?,
             ExecOp::TriangularSolve {
                 left_side,
                 lower,
                 transpose_a,
                 unit_diagonal,
             } => backend.triangular_solve(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
                 *left_side,
                 *lower,
                 *transpose_a,
                 *unit_diagonal,
-            ),
+            )?,
             ExecOp::CustomCall { target } => {
                 let results: Vec<Tensor> = match target.as_str() {
-                    "lu" => backend.lu(get(&slots, &inst.input_slots, 0)),
-                    "svd" => backend.svd(get(&slots, &inst.input_slots, 0)),
-                    "qr" => backend.qr(get(&slots, &inst.input_slots, 0)),
-                    "eigh" => backend.eigh(get(&slots, &inst.input_slots, 0)),
-                    "eig" => backend.eig(get(&slots, &inst.input_slots, 0)),
+                    "lu" => backend.lu(get(&slots, &inst.input_slots, 0)?),
+                    "svd" => backend.svd(get(&slots, &inst.input_slots, 0)?),
+                    "qr" => backend.qr(get(&slots, &inst.input_slots, 0)?),
+                    "eigh" => backend.eigh(get(&slots, &inst.input_slots, 0)?),
+                    "eig" => backend.eig(get(&slots, &inst.input_slots, 0)?),
                     _ => todo!("custom call target {target}"),
-                };
+                }?;
                 for (i, tensor) in results.into_iter().enumerate() {
                     slots[inst.output_slots[i]] = Some(tensor);
                 }
@@ -325,7 +337,11 @@ pub fn eval_exec_ir<B: TensorBackend>(
     program
         .output_slots
         .iter()
-        .map(|&slot| slots[slot].take().expect("missing output slot"))
+        .map(|&slot| {
+            slots[slot]
+                .take()
+                .ok_or(TensorError::MissingValue { slot }.into())
+        })
         .collect()
 }
 
@@ -420,7 +436,7 @@ pub fn eval_semiring_ir<B, Alg>(
     backend: &mut B,
     program: &ExecProgram,
     inputs: Vec<TypedTensor<Alg::Scalar>>,
-) -> Vec<TypedTensor<Alg::Scalar>>
+) -> Result<Vec<TypedTensor<Alg::Scalar>>>
 where
     Alg: Semiring,
     B: SemiringBackend<Alg>,
@@ -432,37 +448,37 @@ where
 
     for inst in &program.instructions {
         let result = match &inst.op {
-            ExecOp::Permute { perm } => typed_transpose(get(&slots, &inst.input_slots, 0), perm),
+            ExecOp::Permute { perm } => typed_transpose(get(&slots, &inst.input_slots, 0)?, perm),
             ExecOp::Reshape { shape } => {
-                let shape = resolve_semiring_shape_exprs::<Alg>(&slots, &inst.input_slots, shape);
-                typed_reshape(get(&slots, &inst.input_slots, 0), &shape)
+                let shape = resolve_semiring_shape_exprs::<Alg>(&slots, &inst.input_slots, shape)?;
+                typed_reshape(get(&slots, &inst.input_slots, 0)?, &shape)
             }
             ExecOp::BroadcastInDim { shape, dims } => {
-                let shape = resolve_semiring_shape_exprs::<Alg>(&slots, &inst.input_slots, shape);
-                typed_broadcast_in_dim(get(&slots, &inst.input_slots, 0), &shape, dims)
+                let shape = resolve_semiring_shape_exprs::<Alg>(&slots, &inst.input_slots, shape)?;
+                typed_broadcast_in_dim(get(&slots, &inst.input_slots, 0)?, &shape, dims)
             }
             ExecOp::BatchedGemm(config) => backend.batched_gemm(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
                 config,
-            ),
+            )?,
             ExecOp::ReduceSum { axes } => {
-                backend.reduce_sum(get(&slots, &inst.input_slots, 0), axes)
+                backend.reduce_sum(get(&slots, &inst.input_slots, 0)?, axes)?
             }
             ExecOp::ExtractDiag { axis_a, axis_b } => {
-                typed_extract_diagonal(get(&slots, &inst.input_slots, 0), *axis_a, *axis_b)
+                typed_extract_diagonal(get(&slots, &inst.input_slots, 0)?, *axis_a, *axis_b)
             }
             ExecOp::EmbedDiag { axis_a, axis_b } => {
-                typed_embed_diagonal(get(&slots, &inst.input_slots, 0), *axis_a, *axis_b)
+                typed_embed_diagonal(get(&slots, &inst.input_slots, 0)?, *axis_a, *axis_b)
             }
             ExecOp::Add => backend.add(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-            ),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+            )?,
             ExecOp::Multiply => backend.mul(
-                get(&slots, &inst.input_slots, 0),
-                get(&slots, &inst.input_slots, 1),
-            ),
+                get(&slots, &inst.input_slots, 0)?,
+                get(&slots, &inst.input_slots, 1)?,
+            )?,
             _ => panic!("non-semiring op in semiring program: {:?}", inst.op),
         };
         slots[inst.output_slots[0]] = Some(result);
@@ -471,6 +487,10 @@ where
     program
         .output_slots
         .iter()
-        .map(|&slot| slots[slot].take().expect("missing semiring output"))
+        .map(|&slot| {
+            slots[slot]
+                .take()
+                .ok_or(TensorError::MissingValue { slot }.into())
+        })
         .collect()
 }

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -285,7 +285,7 @@ impl TracedTensor {
             &cached_exec,
             input_tensors,
             &mut engine.buffer_pool,
-        );
+        )?;
         if results.len() != 1 {
             return Err(Error::Internal(format!(
                 "expected 1 output, got {}",
@@ -1200,12 +1200,12 @@ pub fn eval_all<B: TensorBackend>(
     }
 
     let cached_exec = engine.get_or_compile(exec);
-    let results = eval_exec_ir(
+    let results: Vec<Tensor> = eval_exec_ir(
         &mut engine.backend,
         &cached_exec,
         input_tensors,
         &mut engine.buffer_pool,
-    );
+    )?;
 
     for (tt, result) in outputs.iter_mut().zip(results.iter()) {
         tt.data = Some(result.clone());

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -328,7 +328,7 @@ fn eval_fragment_outputs(
         .collect();
     let mut backend = CpuBackend::new();
     let mut pool = BufferPool::new();
-    eval_exec_ir(&mut backend, &exec, inputs, &mut pool)
+    eval_exec_ir(&mut backend, &exec, inputs, &mut pool).unwrap()
 }
 
 fn scalar_f64_tensor(value: f64) -> Tensor {
@@ -999,15 +999,15 @@ fn eval_f64_reduction_op(op: &StdTensorOp, data: &[f64]) -> Vec<f64> {
     let output = match op {
         StdTensorOp::ReduceProd { axes, input_shape } => {
             let input = f64_tensor(concrete_dim_shape(input_shape), data.to_vec());
-            backend.reduce_prod(&input, axes)
+            backend.reduce_prod(&input, axes).unwrap()
         }
         StdTensorOp::ReduceMax { axes, input_shape } => {
             let input = f64_tensor(concrete_dim_shape(input_shape), data.to_vec());
-            backend.reduce_max(&input, axes)
+            backend.reduce_max(&input, axes).unwrap()
         }
         StdTensorOp::ReduceMin { axes, input_shape } => {
             let input = f64_tensor(concrete_dim_shape(input_shape), data.to_vec());
-            backend.reduce_min(&input, axes)
+            backend.reduce_min(&input, axes).unwrap()
         }
         _ => panic!("expected reduction op"),
     };
@@ -1060,53 +1060,57 @@ fn transpose_primal_unary_op_with_inputs(
 fn sum_svd_values(data: &[f64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = f64_tensor(vec![2, 2], data.to_vec());
-    let outputs = TensorBackend::svd(&mut backend, &input);
+    let outputs = TensorBackend::svd(&mut backend, &input).unwrap();
     get_f64_data(&outputs[1]).iter().sum()
 }
 
 fn sum_svd_uv_product(data: &[f64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = f64_tensor(vec![2, 2], data.to_vec());
-    let outputs = TensorBackend::svd(&mut backend, &input);
+    let outputs = TensorBackend::svd(&mut backend, &input).unwrap();
     let product =
-        TensorBackend::dot_general(&mut backend, &outputs[0], &outputs[2], &matmul_config());
+        TensorBackend::dot_general(&mut backend, &outputs[0], &outputs[2], &matmul_config())
+            .unwrap();
     get_f64_data(&product).iter().sum()
 }
 
 fn sum_svd_reconstruction(data: &[f64], shape: [usize; 2]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = f64_tensor(shape.to_vec(), data.to_vec());
-    let outputs = TensorBackend::svd(&mut backend, &input);
-    let diag_s = TensorBackend::embed_diagonal(&mut backend, &outputs[1], 0, 1);
-    let us = TensorBackend::dot_general(&mut backend, &outputs[0], &diag_s, &matmul_config());
+    let outputs = TensorBackend::svd(&mut backend, &input).unwrap();
+    let diag_s = TensorBackend::embed_diagonal(&mut backend, &outputs[1], 0, 1).unwrap();
+    let us =
+        TensorBackend::dot_general(&mut backend, &outputs[0], &diag_s, &matmul_config()).unwrap();
     let reconstructed =
-        TensorBackend::dot_general(&mut backend, &us, &outputs[2], &matmul_config());
+        TensorBackend::dot_general(&mut backend, &us, &outputs[2], &matmul_config()).unwrap();
     get_f64_data(&reconstructed).iter().sum()
 }
 
 fn sum_eigh_values(data: &[f64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = f64_tensor(vec![2, 2], data.to_vec());
-    let outputs = TensorBackend::eigh(&mut backend, &input);
+    let outputs = TensorBackend::eigh(&mut backend, &input).unwrap();
     get_f64_data(&outputs[0]).iter().sum()
 }
 
 fn sum_eigh_projector(data: &[f64], weights: &[f64], probe: &[f64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = f64_tensor(vec![2, 2], data.to_vec());
-    let outputs = TensorBackend::eigh(&mut backend, &input);
+    let outputs = TensorBackend::eigh(&mut backend, &input).unwrap();
     let diag =
-        TensorBackend::embed_diagonal(&mut backend, &f64_tensor(vec![2], weights.to_vec()), 0, 1);
+        TensorBackend::embed_diagonal(&mut backend, &f64_tensor(vec![2], weights.to_vec()), 0, 1)
+            .unwrap();
     let weighted_vectors =
-        TensorBackend::dot_general(&mut backend, &outputs[1], &diag, &matmul_config());
-    let vt = TensorBackend::transpose(&mut backend, &outputs[1], &[1, 0]);
+        TensorBackend::dot_general(&mut backend, &outputs[1], &diag, &matmul_config()).unwrap();
+    let vt = TensorBackend::transpose(&mut backend, &outputs[1], &[1, 0]).unwrap();
     let projector =
-        TensorBackend::dot_general(&mut backend, &weighted_vectors, &vt, &matmul_config());
+        TensorBackend::dot_general(&mut backend, &weighted_vectors, &vt, &matmul_config()).unwrap();
     let weighted = TensorBackend::mul(
         &mut backend,
         &projector,
         &f64_tensor(vec![2, 2], probe.to_vec()),
-    );
+    )
+    .unwrap();
     get_f64_data(&weighted).iter().sum()
 }
 
@@ -1114,7 +1118,7 @@ fn sum_solve(a: &[f64], b: &[f64]) -> f64 {
     let mut backend = CpuBackend::new();
     let a_tensor = f64_tensor(vec![2, 2], a.to_vec());
     let b_tensor = f64_tensor(vec![2, 1], b.to_vec());
-    let out = TensorBackend::solve(&mut backend, &a_tensor, &b_tensor);
+    let out = TensorBackend::solve(&mut backend, &a_tensor, &b_tensor).unwrap();
     get_f64_data(&out).iter().sum()
 }
 
@@ -1130,28 +1134,29 @@ fn sum_triangular_solve(a: &[f64], b: &[f64]) -> f64 {
         true,
         false,
         false,
-    );
+    )
+    .unwrap();
     get_f64_data(&out).iter().sum()
 }
 
 fn sum_cholesky(data: &[f64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = f64_tensor(vec![3, 3], data.to_vec());
-    let output = TensorBackend::cholesky(&mut backend, &input);
+    let output = TensorBackend::cholesky(&mut backend, &input).unwrap();
     get_f64_data(&output).iter().sum()
 }
 
 fn sum_qr_r(data: &[f64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = f64_tensor(vec![3, 2], data.to_vec());
-    let outputs = TensorBackend::qr(&mut backend, &input);
+    let outputs = TensorBackend::qr(&mut backend, &input).unwrap();
     get_f64_data(&outputs[1]).iter().sum()
 }
 
 fn sum_qr_r_real_parts_complex(data: &[Complex64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = c64_tensor(vec![3, 2], data.to_vec());
-    let outputs = TensorBackend::qr(&mut backend, &input);
+    let outputs = TensorBackend::qr(&mut backend, &input).unwrap();
     sum_real_parts(get_c64_data(&outputs[1]))
 }
 
@@ -1162,30 +1167,31 @@ fn sum_real_parts(values: &[Complex64]) -> f64 {
 fn sum_svd_values_complex(data: &[Complex64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = c64_tensor(vec![2, 2], data.to_vec());
-    let outputs = TensorBackend::svd(&mut backend, &input);
+    let outputs = TensorBackend::svd(&mut backend, &input).unwrap();
     sum_real_parts(get_c64_data(&outputs[1]))
 }
 
 fn sum_svd_values_complex_3x3(data: &[Complex64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = c64_tensor(vec![3, 3], data.to_vec());
-    let outputs = TensorBackend::svd(&mut backend, &input);
+    let outputs = TensorBackend::svd(&mut backend, &input).unwrap();
     sum_real_parts(get_c64_data(&outputs[1]))
 }
 
 fn sum_svd_uv_product_real_parts_complex(data: &[Complex64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = c64_tensor(vec![3, 3], data.to_vec());
-    let outputs = TensorBackend::svd(&mut backend, &input);
+    let outputs = TensorBackend::svd(&mut backend, &input).unwrap();
     let product =
-        TensorBackend::dot_general(&mut backend, &outputs[0], &outputs[2], &matmul_config());
+        TensorBackend::dot_general(&mut backend, &outputs[0], &outputs[2], &matmul_config())
+            .unwrap();
     sum_real_parts(get_c64_data(&product))
 }
 
 fn sum_eigh_values_complex(data: &[Complex64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = c64_tensor(vec![2, 2], data.to_vec());
-    let outputs = TensorBackend::eigh(&mut backend, &input);
+    let outputs = TensorBackend::eigh(&mut backend, &input).unwrap();
     sum_real_parts(get_c64_data(&outputs[0]))
 }
 
@@ -1196,27 +1202,29 @@ fn sum_eigh_projector_real_parts_complex(
 ) -> f64 {
     let mut backend = CpuBackend::new();
     let input = c64_tensor(vec![2, 2], data.to_vec());
-    let outputs = TensorBackend::eigh(&mut backend, &input);
+    let outputs = TensorBackend::eigh(&mut backend, &input).unwrap();
     let diag =
-        TensorBackend::embed_diagonal(&mut backend, &c64_tensor(vec![2], weights.to_vec()), 0, 1);
+        TensorBackend::embed_diagonal(&mut backend, &c64_tensor(vec![2], weights.to_vec()), 0, 1)
+            .unwrap();
     let weighted_vectors =
-        TensorBackend::dot_general(&mut backend, &outputs[1], &diag, &matmul_config());
-    let vectors_conj = TensorBackend::conj(&mut backend, &outputs[1]);
-    let vh = TensorBackend::transpose(&mut backend, &vectors_conj, &[1, 0]);
+        TensorBackend::dot_general(&mut backend, &outputs[1], &diag, &matmul_config()).unwrap();
+    let vectors_conj = TensorBackend::conj(&mut backend, &outputs[1]).unwrap();
+    let vh = TensorBackend::transpose(&mut backend, &vectors_conj, &[1, 0]).unwrap();
     let projector =
-        TensorBackend::dot_general(&mut backend, &weighted_vectors, &vh, &matmul_config());
+        TensorBackend::dot_general(&mut backend, &weighted_vectors, &vh, &matmul_config()).unwrap();
     let weighted = TensorBackend::mul(
         &mut backend,
         &projector,
         &c64_tensor(vec![2, 2], probe.to_vec()),
-    );
+    )
+    .unwrap();
     sum_real_parts(get_c64_data(&weighted))
 }
 
 fn sum_cholesky_real_parts_complex(data: &[Complex64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = c64_tensor(vec![2, 2], data.to_vec());
-    let output = TensorBackend::cholesky(&mut backend, &input);
+    let output = TensorBackend::cholesky(&mut backend, &input).unwrap();
     sum_real_parts(get_c64_data(&output))
 }
 
@@ -1224,7 +1232,7 @@ fn sum_solve_real_parts_complex(a: &[Complex64], b: &[Complex64]) -> f64 {
     let mut backend = CpuBackend::new();
     let a_tensor = c64_tensor(vec![2, 2], a.to_vec());
     let b_tensor = c64_tensor(vec![2, 1], b.to_vec());
-    let output = TensorBackend::solve(&mut backend, &a_tensor, &b_tensor);
+    let output = TensorBackend::solve(&mut backend, &a_tensor, &b_tensor).unwrap();
     sum_real_parts(get_c64_data(&output))
 }
 
@@ -1240,7 +1248,8 @@ fn sum_triangular_solve_real_parts_complex(a: &[Complex64], b: &[Complex64]) -> 
         true,
         false,
         false,
-    );
+    )
+    .unwrap();
     sum_real_parts(get_c64_data(&output))
 }
 

--- a/tenferro/tests/batched_linalg.rs
+++ b/tenferro/tests/batched_linalg.rs
@@ -67,7 +67,7 @@ fn finite_diff_scalar(f: impl Fn(&[f64]) -> f64, x: &[f64], index: usize, h: f64
 fn wide_qr_r_sum(data: &[f64]) -> f64 {
     let mut backend = CpuBackend::new();
     let input = f64_tensor(vec![2, 5], data.to_vec());
-    let outputs = TensorBackend::qr(&mut backend, &input);
+    let outputs = TensorBackend::qr(&mut backend, &input).unwrap();
     get_f64_data(&outputs[1]).iter().sum()
 }
 

--- a/tenferro/tests/exec_dispatch.rs
+++ b/tenferro/tests/exec_dispatch.rs
@@ -1,5 +1,6 @@
 use num_complex::Complex64;
 use tenferro::buffer_pool::BufferPool;
+use tenferro::error::Error;
 use tenferro::exec::{eval_exec_ir, eval_semiring_ir, ExecInstruction, ExecOp, ExecProgram};
 use tenferro_algebra::Standard;
 use tenferro_ops::dim_expr::DimExpr;
@@ -80,119 +81,161 @@ fn single_instruction_program(op: ExecOp, n_inputs: usize) -> ExecProgram {
 #[derive(Default)]
 struct FakeTensorBackend {
     calls: Vec<&'static str>,
+    error_on: Option<&'static str>,
 }
 
 impl FakeTensorBackend {
-    fn result(&mut self, name: &'static str, value: f64) -> Tensor {
+    fn result(&mut self, name: &'static str, value: f64) -> tenferro_tensor::Result<Tensor> {
         self.calls.push(name);
-        scalar_tensor(value)
+        if self.error_on == Some(name) {
+            return Err(tenferro_tensor::Error::BackendFailure {
+                op: name,
+                message: "injected failure".into(),
+            });
+        }
+        Ok(scalar_tensor(value))
     }
 }
 
 impl TensorBackend for FakeTensorBackend {
-    fn add(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+    fn add(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("add", 1.0)
     }
-    fn mul(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+    fn mul(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("mul", 2.0)
     }
-    fn neg(&mut self, _input: &Tensor) -> Tensor {
+    fn neg(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("neg", 3.0)
     }
-    fn conj(&mut self, _input: &Tensor) -> Tensor {
+    fn conj(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("conj", 4.0)
     }
-    fn div(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+    fn div(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("div", 5.0)
     }
-    fn abs(&mut self, _input: &Tensor) -> Tensor {
+    fn abs(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("abs", 6.0)
     }
-    fn sign(&mut self, _input: &Tensor) -> Tensor {
+    fn sign(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("sign", 7.0)
     }
-    fn maximum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+    fn maximum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("maximum", 8.0)
     }
-    fn minimum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+    fn minimum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("minimum", 9.0)
     }
-    fn compare(&mut self, _lhs: &Tensor, _rhs: &Tensor, _dir: &CompareDir) -> Tensor {
+    fn compare(
+        &mut self,
+        _lhs: &Tensor,
+        _rhs: &Tensor,
+        _dir: &CompareDir,
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("compare", 10.0)
     }
-    fn select(&mut self, _pred: &Tensor, _on_true: &Tensor, _on_false: &Tensor) -> Tensor {
+    fn select(
+        &mut self,
+        _pred: &Tensor,
+        _on_true: &Tensor,
+        _on_false: &Tensor,
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("select", 11.0)
     }
-    fn clamp(&mut self, _input: &Tensor, _lower: &Tensor, _upper: &Tensor) -> Tensor {
+    fn clamp(
+        &mut self,
+        _input: &Tensor,
+        _lower: &Tensor,
+        _upper: &Tensor,
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("clamp", 12.0)
     }
-    fn exp(&mut self, _input: &Tensor) -> Tensor {
+    fn exp(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("exp", 13.0)
     }
-    fn log(&mut self, _input: &Tensor) -> Tensor {
+    fn log(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("log", 14.0)
     }
-    fn sin(&mut self, _input: &Tensor) -> Tensor {
+    fn sin(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("sin", 15.0)
     }
-    fn cos(&mut self, _input: &Tensor) -> Tensor {
+    fn cos(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("cos", 16.0)
     }
-    fn tanh(&mut self, _input: &Tensor) -> Tensor {
+    fn tanh(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("tanh", 17.0)
     }
-    fn sqrt(&mut self, _input: &Tensor) -> Tensor {
+    fn sqrt(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("sqrt", 18.0)
     }
-    fn rsqrt(&mut self, _input: &Tensor) -> Tensor {
+    fn rsqrt(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("rsqrt", 19.0)
     }
-    fn pow(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> Tensor {
+    fn pow(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("pow", 20.0)
     }
-    fn expm1(&mut self, _input: &Tensor) -> Tensor {
+    fn expm1(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("expm1", 21.0)
     }
-    fn log1p(&mut self, _input: &Tensor) -> Tensor {
+    fn log1p(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("log1p", 22.0)
     }
-    fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> Tensor {
+    fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("transpose", 23.0)
     }
-    fn reshape(&mut self, _input: &Tensor, _shape: &[usize]) -> Tensor {
+    fn reshape(&mut self, _input: &Tensor, _shape: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("reshape", 24.0)
     }
-    fn broadcast_in_dim(&mut self, _input: &Tensor, _shape: &[usize], _dims: &[usize]) -> Tensor {
+    fn broadcast_in_dim(
+        &mut self,
+        _input: &Tensor,
+        _shape: &[usize],
+        _dims: &[usize],
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("broadcast_in_dim", 25.0)
     }
-    fn convert(&mut self, _input: &Tensor, _to: DType) -> Tensor {
+    fn convert(&mut self, _input: &Tensor, _to: DType) -> tenferro_tensor::Result<Tensor> {
         self.result("convert", 25.5)
     }
-    fn extract_diagonal(&mut self, _input: &Tensor, _axis_a: usize, _axis_b: usize) -> Tensor {
+    fn extract_diagonal(
+        &mut self,
+        _input: &Tensor,
+        _axis_a: usize,
+        _axis_b: usize,
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("extract_diagonal", 26.0)
     }
-    fn embed_diagonal(&mut self, _input: &Tensor, _axis_a: usize, _axis_b: usize) -> Tensor {
+    fn embed_diagonal(
+        &mut self,
+        _input: &Tensor,
+        _axis_a: usize,
+        _axis_b: usize,
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("embed_diagonal", 27.0)
     }
-    fn tril(&mut self, _input: &Tensor, _k: i64) -> Tensor {
+    fn tril(&mut self, _input: &Tensor, _k: i64) -> tenferro_tensor::Result<Tensor> {
         self.result("tril", 27.5)
     }
-    fn triu(&mut self, _input: &Tensor, _k: i64) -> Tensor {
+    fn triu(&mut self, _input: &Tensor, _k: i64) -> tenferro_tensor::Result<Tensor> {
         self.result("triu", 27.75)
     }
-    fn reduce_sum(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+    fn reduce_sum(&mut self, _input: &Tensor, _axes: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("reduce_sum", 28.0)
     }
-    fn reduce_prod(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+    fn reduce_prod(&mut self, _input: &Tensor, _axes: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("reduce_prod", 29.0)
     }
-    fn reduce_max(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+    fn reduce_max(&mut self, _input: &Tensor, _axes: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("reduce_max", 30.0)
     }
-    fn reduce_min(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+    fn reduce_min(&mut self, _input: &Tensor, _axes: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("reduce_min", 31.0)
     }
-    fn dot_general(&mut self, _lhs: &Tensor, _rhs: &Tensor, _config: &DotGeneralConfig) -> Tensor {
+    fn dot_general(
+        &mut self,
+        _lhs: &Tensor,
+        _rhs: &Tensor,
+        _config: &DotGeneralConfig,
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("dot_general", 32.0)
     }
     fn gather(
@@ -200,7 +243,7 @@ impl TensorBackend for FakeTensorBackend {
         _operand: &Tensor,
         _start_indices: &Tensor,
         _config: &GatherConfig,
-    ) -> Tensor {
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("gather", 33.0)
     }
     fn scatter(
@@ -209,10 +252,10 @@ impl TensorBackend for FakeTensorBackend {
         _scatter_indices: &Tensor,
         _updates: &Tensor,
         _config: &ScatterConfig,
-    ) -> Tensor {
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("scatter", 34.0)
     }
-    fn slice(&mut self, _input: &Tensor, _config: &SliceConfig) -> Tensor {
+    fn slice(&mut self, _input: &Tensor, _config: &SliceConfig) -> tenferro_tensor::Result<Tensor> {
         self.result("slice", 35.0)
     }
     fn dynamic_slice(
@@ -220,19 +263,23 @@ impl TensorBackend for FakeTensorBackend {
         _input: &Tensor,
         _starts: &Tensor,
         _slice_sizes: &[usize],
-    ) -> Tensor {
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("dynamic_slice", 36.0)
     }
-    fn pad(&mut self, _input: &Tensor, _config: &PadConfig) -> Tensor {
+    fn pad(&mut self, _input: &Tensor, _config: &PadConfig) -> tenferro_tensor::Result<Tensor> {
         self.result("pad", 37.0)
     }
-    fn concatenate(&mut self, _inputs: &[&Tensor], _axis: usize) -> Tensor {
+    fn concatenate(
+        &mut self,
+        _inputs: &[&Tensor],
+        _axis: usize,
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("concatenate", 38.0)
     }
-    fn reverse(&mut self, _input: &Tensor, _axes: &[usize]) -> Tensor {
+    fn reverse(&mut self, _input: &Tensor, _axes: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("reverse", 39.0)
     }
-    fn cholesky(&mut self, _input: &Tensor) -> Tensor {
+    fn cholesky(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("cholesky", 40.0)
     }
     fn triangular_solve(
@@ -243,33 +290,33 @@ impl TensorBackend for FakeTensorBackend {
         _lower: bool,
         _transpose_a: bool,
         _unit_diagonal: bool,
-    ) -> Tensor {
+    ) -> tenferro_tensor::Result<Tensor> {
         self.result("triangular_solve", 40.5)
     }
-    fn lu(&mut self, _input: &Tensor) -> Vec<Tensor> {
+    fn lu(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         self.calls.push("lu");
-        vec![
+        Ok(vec![
             scalar_tensor(40.75),
             scalar_tensor(41.0),
             scalar_tensor(41.25),
             scalar_tensor(41.5),
-        ]
+        ])
     }
-    fn svd(&mut self, _input: &Tensor) -> Vec<Tensor> {
+    fn svd(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         self.calls.push("svd");
-        vec![scalar_tensor(42.0), scalar_tensor(42.5)]
+        Ok(vec![scalar_tensor(42.0), scalar_tensor(42.5)])
     }
-    fn qr(&mut self, _input: &Tensor) -> Vec<Tensor> {
+    fn qr(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         self.calls.push("qr");
-        vec![scalar_tensor(43.0), scalar_tensor(43.5)]
+        Ok(vec![scalar_tensor(43.0), scalar_tensor(43.5)])
     }
-    fn eigh(&mut self, _input: &Tensor) -> Vec<Tensor> {
+    fn eigh(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         self.calls.push("eigh");
-        vec![scalar_tensor(44.0), scalar_tensor(44.5)]
+        Ok(vec![scalar_tensor(44.0), scalar_tensor(44.5)])
     }
-    fn eig(&mut self, _input: &Tensor) -> Vec<Tensor> {
+    fn eig(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         self.calls.push("eig");
-        vec![
+        Ok(vec![
             Tensor::C64(TypedTensor::from_vec(
                 vec![],
                 vec![Complex64::new(45.0, 0.5)],
@@ -278,9 +325,9 @@ impl TensorBackend for FakeTensorBackend {
                 vec![],
                 vec![Complex64::new(45.5, -0.5)],
             )),
-        ]
+        ])
     }
-    fn solve(&mut self, _a: &Tensor, _b: &Tensor) -> Tensor {
+    fn solve(&mut self, _a: &Tensor, _b: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("solve", 44.0)
     }
 }
@@ -411,7 +458,7 @@ fn eval_exec_ir_dispatches_tensor_ops_to_backend_methods() {
             .collect();
         let mut pool = BufferPool::new();
 
-        let outputs = eval_exec_ir(&mut backend, &program, inputs, &mut pool);
+        let outputs = eval_exec_ir(&mut backend, &program, inputs, &mut pool).unwrap();
 
         assert_eq!(backend.calls, vec![expected_call]);
         assert_eq!(outputs.len(), 1);
@@ -439,7 +486,7 @@ fn eval_exec_ir_materializes_constant_scalars_without_backend_dispatch() {
         n_slots: 1,
     };
 
-    let outputs = eval_exec_ir(&mut backend, &program, vec![], &mut pool);
+    let outputs = eval_exec_ir(&mut backend, &program, vec![], &mut pool).unwrap();
 
     assert!(backend.calls.is_empty());
     assert_eq!(outputs.len(), 1);
@@ -470,11 +517,60 @@ fn eval_exec_ir_materializes_complex_constants() {
         n_slots: 1,
     };
 
-    let outputs = eval_exec_ir(&mut backend, &program, vec![], &mut pool);
+    let outputs = eval_exec_ir(&mut backend, &program, vec![], &mut pool).unwrap();
 
     assert!(backend.calls.is_empty());
     assert_eq!(outputs.len(), 1);
     assert_eq!(scalar_c64_value(&outputs[0]), value);
+}
+
+#[test]
+fn eval_exec_ir_propagates_backend_errors() {
+    let mut backend = FakeTensorBackend {
+        calls: Vec::new(),
+        error_on: Some("add"),
+    };
+    let mut pool = BufferPool::new();
+    let err = eval_exec_ir(
+        &mut backend,
+        &single_instruction_program(ExecOp::Add, 2),
+        vec![scalar_tensor(1.0), scalar_tensor(2.0)],
+        &mut pool,
+    )
+    .unwrap_err();
+
+    assert_eq!(backend.calls, vec!["add"]);
+    assert!(matches!(
+        err,
+        Error::TensorRuntime(tenferro_tensor::Error::BackendFailure { op: "add", .. })
+    ));
+}
+
+#[test]
+fn eval_exec_ir_reports_missing_slots_as_runtime_errors() {
+    let mut backend = FakeTensorBackend::default();
+    let mut pool = BufferPool::new();
+    let program = ExecProgram {
+        instructions: vec![ExecInstruction {
+            op: ExecOp::Add,
+            input_slots: vec![0, 1],
+            output_slots: vec![2],
+            dtype: DType::F64,
+            last_use: vec![false, false],
+        }],
+        input_slots: vec![0],
+        output_slots: vec![2],
+        n_slots: 3,
+    };
+
+    let err =
+        eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool).unwrap_err();
+
+    assert!(backend.calls.is_empty());
+    assert!(matches!(
+        err,
+        Error::TensorRuntime(tenferro_tensor::Error::MissingValue { slot: 1 })
+    ));
 }
 
 fn multi_output_program(op: ExecOp, n_inputs: usize, n_outputs: usize) -> ExecProgram {
@@ -506,7 +602,8 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
         1,
         4,
     );
-    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool);
+    let outputs =
+        eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool).unwrap();
     assert_eq!(backend.calls, vec!["lu"]);
     assert_eq!(outputs.len(), 4);
     assert_eq!(scalar_value(&outputs[0]), 40.75);
@@ -525,7 +622,8 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
         1,
         2,
     );
-    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool);
+    let outputs =
+        eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool).unwrap();
     assert_eq!(backend.calls, vec!["svd"]);
     assert_eq!(outputs.len(), 2);
     assert_eq!(scalar_value(&outputs[0]), 42.0);
@@ -542,7 +640,8 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
         1,
         2,
     );
-    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool);
+    let outputs =
+        eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool).unwrap();
     assert_eq!(backend.calls, vec!["qr"]);
     assert_eq!(outputs.len(), 2);
     assert_eq!(scalar_value(&outputs[0]), 43.0);
@@ -559,7 +658,8 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
         1,
         2,
     );
-    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool);
+    let outputs =
+        eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool).unwrap();
     assert_eq!(backend.calls, vec!["eigh"]);
     assert_eq!(outputs.len(), 2);
     assert_eq!(scalar_value(&outputs[0]), 44.0);
@@ -576,7 +676,8 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
         1,
         2,
     );
-    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool);
+    let outputs =
+        eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)], &mut pool).unwrap();
     assert_eq!(backend.calls, vec!["eig"]);
     assert_eq!(outputs.len(), 2);
     assert_eq!(scalar_c64_value(&outputs[0]), Complex64::new(45.0, 0.5));
@@ -614,7 +715,8 @@ fn eval_exec_ir_reclaims_last_use_host_buffers() {
         &program,
         vec![scalar_tensor(1.0), scalar_tensor(2.0)],
         &mut pool,
-    );
+    )
+    .unwrap();
 
     assert_eq!(backend.calls, vec!["add", "neg"]);
     assert_eq!(outputs.len(), 1);
@@ -630,21 +732,24 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
         &mut backend,
         &single_instruction_program(ExecOp::Add, 2),
         vec![typed_scalar(2.0), typed_scalar(3.0)],
-    );
+    )
+    .unwrap();
     assert_eq!(add_out[0].host_data(), &[5.0]);
 
     let mul_out = eval_semiring_ir::<_, Standard<f64>>(
         &mut backend,
         &single_instruction_program(ExecOp::Multiply, 2),
         vec![typed_scalar(2.0), typed_scalar(3.0)],
-    );
+    )
+    .unwrap();
     assert_eq!(mul_out[0].host_data(), &[6.0]);
 
     let reduce_out = eval_semiring_ir::<_, Standard<f64>>(
         &mut backend,
         &single_instruction_program(ExecOp::ReduceSum { axes: vec![0] }, 1),
         vec![TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0])],
-    );
+    )
+    .unwrap();
     assert_eq!(reduce_out[0].shape, vec![2]);
     assert_eq!(reduce_out[0].host_data(), &[3.0, 7.0]);
 
@@ -655,7 +760,8 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
             vec![2, 3],
             vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
         )],
-    );
+    )
+    .unwrap();
     assert_eq!(permute_out[0].shape, vec![3, 2]);
     assert_eq!(permute_out[0].host_data(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
 
@@ -671,7 +777,8 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
             vec![2, 3],
             vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
         )],
-    );
+    )
+    .unwrap();
     assert_eq!(reshape_out[0].shape, vec![3, 2]);
     assert_eq!(reshape_out[0].host_data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
@@ -685,7 +792,8 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
             1,
         ),
         vec![TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0])],
-    );
+    )
+    .unwrap();
     assert_eq!(broadcast_out[0].shape, vec![3, 2]);
     assert_eq!(
         broadcast_out[0].host_data(),
@@ -705,7 +813,8 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
             vec![3, 3],
             vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
         )],
-    );
+    )
+    .unwrap();
     assert_eq!(extract_out[0].shape, vec![3]);
     assert_eq!(extract_out[0].host_data(), &[1.0, 5.0, 9.0]);
 
@@ -719,7 +828,8 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
             1,
         ),
         vec![TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0])],
-    );
+    )
+    .unwrap();
     assert_eq!(embed_out[0].shape, vec![3, 3]);
     assert_eq!(
         embed_out[0].host_data(),
@@ -743,7 +853,8 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
             TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]),
             TypedTensor::from_vec(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]),
         ],
-    );
+    )
+    .unwrap();
     assert_eq!(gemm_out[0].shape, vec![2, 2]);
     assert_eq!(gemm_out[0].host_data(), &[23.0, 34.0, 31.0, 46.0]);
 }

--- a/tenferro/tests/tropical.rs
+++ b/tenferro/tests/tropical.rs
@@ -61,6 +61,7 @@ fn eval_fragment(
         })
         .collect();
     eval_semiring_ir::<_, TropicalAlgebra>(backend, &exec, inputs)
+        .unwrap()
         .into_iter()
         .next()
         .expect("semiring output")
@@ -114,9 +115,9 @@ fn tropical_default_semiring_ops_work_on_cpu_backend() {
     let b = TypedTensor::from_vec(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]);
     let mut backend = CpuBackend::new();
 
-    let sum = SemiringBackend::<TropicalAlgebra>::add(&mut backend, &a, &b);
-    let prod = SemiringBackend::<TropicalAlgebra>::mul(&mut backend, &a, &b);
-    let reduced = SemiringBackend::<TropicalAlgebra>::reduce_sum(&mut backend, &a, &[0]);
+    let sum = SemiringBackend::<TropicalAlgebra>::add(&mut backend, &a, &b).unwrap();
+    let prod = SemiringBackend::<TropicalAlgebra>::mul(&mut backend, &a, &b).unwrap();
+    let reduced = SemiringBackend::<TropicalAlgebra>::reduce_sum(&mut backend, &a, &[0]).unwrap();
 
     assert_eq!(sum.host_data(), &[5.0, 6.0, 7.0, 8.0]);
     assert_eq!(prod.host_data(), &[6.0, 8.0, 10.0, 12.0]);


### PR DESCRIPTION
## Summary
- add a typed `tenferro-tensor::Error` surface and make tensor / semiring backend execution return `Result`
- validate CPU runtime paths such as `dot_general`, structural helpers, indexing, semiring ops, and linalg dispatch so malformed configs fail with structured runtime errors instead of panicking or crashing
- add runtime regression tests plus direct helper coverage tests for elementwise mismatch and scalar-complex dispatch paths

## Why
- issue #664 exposed malformed runtime configs reaching native kernels, which could escalate into panics or `SIGSEGV` instead of a user-facing error
- runtime evaluation should fail at the backend boundary with a descriptive typed error

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Generated with Codex.
