### PR TITLE
[codex] Reduce intermediate einsum transposes

### DIFF
--- a/tenferro-einsum/src/builder.rs
+++ b/tenferro-einsum/src/builder.rs
@@ -1,21 +1,10 @@
-// TODO: Unimplemented einsum optimizations
+// TODO: Remaining einsum optimizations
 //
-// The current v2 einsum builder produces correct but unoptimized IR.
-// The following optimizations from v1 / the spec are not yet implemented:
+// The v2 einsum builder is correct, and some permutation-reduction work now
+// happens in the builder/compiler path, but several v1-era optimizations are
+// still missing or only partially covered.
 //
-// Compiler passes (spec: optimizer-passes.md):
-//   - TransposeFolding: absorb Transpose into DotGeneral dimension_numbers.
-//     v1 equivalent: lazy permutation (dispatch.rs:446-454).
-//     Impact: eliminates physical copies for permuted GEMM inputs.
-//   - DotDimensionSorter: sort contracting dims to avoid transposes.
-//     v1 equivalent: implicit (modes already ordered).
-//   - DotDecomposer: canonicalize DotGeneral to [batch, M, K] × [batch, K, N].
-//     v1 equivalent: fusability check + partial materialization.
-//     Impact: maps arbitrary DotGeneral to BatchedGemm without extra copies.
-//   - ReductionSimplification: hoist independent ReduceSum before DotGeneral.
-//     v1 equivalent: pre-reduction (dispatch.rs:121-139).
-//
-// Einsum-level optimizations:
+// Remaining gaps:
 //   - Diagonal embedding ("i->ii"): requires Scatter op (not yet implemented).
 //   - Hyper-edge einsum ("ik,k,kj->ij"): 3+ tensors sharing an index.
 //     Currently decomposed into binary steps; v1 handled this with a
@@ -23,8 +12,6 @@
 //   - Binary diagonal ("ii,jk->ijk"): v1 diagonal plan in dispatch.rs.
 //     Currently works via ExtractDiag + standard contraction, but v1 had
 //     fused paths for better performance.
-//
-// Execution-level optimizations:
 //   - Stride-aware engine: v1 inspects strides at dispatch time and uses
 //     BLAS trans flags for transposed inputs. v2 engine does physical copies.
 //   - Buffer pooling: v1 reuses buffers via Arc refcount + pool.

--- a/tenferro-einsum/src/builder.rs
+++ b/tenferro-einsum/src/builder.rs
@@ -1,12 +1,16 @@
-// TODO: Unimplemented einsum optimizations
+// TODO: Remaining einsum optimizations
 //
-// The current v2 einsum builder produces correct but unoptimized IR.
-// The following optimizations from v1 / the spec are not yet implemented:
+// The current v2 einsum lowering is correct and already removes some
+// intermediate permutations by keeping N-ary intermediates in canonical dot
+// order. The following optimizations from v1 / the spec are still partial or
+// not yet implemented:
 //
 // Compiler passes (spec: optimizer-passes.md):
-//   - TransposeFolding: absorb Transpose into DotGeneral dimension_numbers.
+//   - TransposeFolding: partially absorb Transpose into DotGeneral
+//     dimension_numbers when the free/contract/batch axis order remains
+//     compatible with the lowering.
 //     v1 equivalent: lazy permutation (dispatch.rs:446-454).
-//     Impact: eliminates physical copies for permuted GEMM inputs.
+//     Impact: eliminates physical copies for supported permuted GEMM inputs.
 //   - DotDimensionSorter: sort contracting dims to avoid transposes.
 //     v1 equivalent: implicit (modes already ordered).
 //   - DotDecomposer: canonicalize DotGeneral to [batch, M, K] × [batch, K, N].

--- a/tenferro-einsum/src/builder.rs
+++ b/tenferro-einsum/src/builder.rs
@@ -1,10 +1,21 @@
-// TODO: Remaining einsum optimizations
+// TODO: Unimplemented einsum optimizations
 //
-// The v2 einsum builder is correct, and some permutation-reduction work now
-// happens in the builder/compiler path, but several v1-era optimizations are
-// still missing or only partially covered.
+// The current v2 einsum builder produces correct but unoptimized IR.
+// The following optimizations from v1 / the spec are not yet implemented:
 //
-// Remaining gaps:
+// Compiler passes (spec: optimizer-passes.md):
+//   - TransposeFolding: absorb Transpose into DotGeneral dimension_numbers.
+//     v1 equivalent: lazy permutation (dispatch.rs:446-454).
+//     Impact: eliminates physical copies for permuted GEMM inputs.
+//   - DotDimensionSorter: sort contracting dims to avoid transposes.
+//     v1 equivalent: implicit (modes already ordered).
+//   - DotDecomposer: canonicalize DotGeneral to [batch, M, K] × [batch, K, N].
+//     v1 equivalent: fusability check + partial materialization.
+//     Impact: maps arbitrary DotGeneral to BatchedGemm without extra copies.
+//   - ReductionSimplification: hoist independent ReduceSum before DotGeneral.
+//     v1 equivalent: pre-reduction (dispatch.rs:121-139).
+//
+// Einsum-level optimizations:
 //   - Diagonal embedding ("i->ii"): requires Scatter op (not yet implemented).
 //   - Hyper-edge einsum ("ik,k,kj->ij"): 3+ tensors sharing an index.
 //     Currently decomposed into binary steps; v1 handled this with a
@@ -12,6 +23,8 @@
 //   - Binary diagonal ("ii,jk->ijk"): v1 diagonal plan in dispatch.rs.
 //     Currently works via ExtractDiag + standard contraction, but v1 had
 //     fused paths for better performance.
+//
+// Execution-level optimizations:
 //   - Stride-aware engine: v1 inspects strides at dispatch time and uses
 //     BLAS trans flags for transposed inputs. v2 engine does physical copies.
 //   - Buffer pooling: v1 reuses buffers via Arc refcount + pool.

--- a/tenferro-einsum/src/builder.rs
+++ b/tenferro-einsum/src/builder.rs
@@ -179,9 +179,10 @@ fn binary_contract<Op: GraphOp + SemiringOps>(
     builder: &mut FragmentBuilder<Op>,
     lhs: &LabeledVal<Op>,
     rhs: &LabeledVal<Op>,
-    output_labels: &[u32],
+    survive_labels: &[u32],
+    reorder_result: bool,
 ) -> LabeledVal<Op> {
-    let output_set: HashSet<u32> = output_labels.iter().copied().collect();
+    let survive_set: HashSet<u32> = survive_labels.iter().copied().collect();
     let rhs_label_set: HashSet<u32> = rhs.labels.iter().copied().collect();
     let lhs_label_set: HashSet<u32> = lhs.labels.iter().copied().collect();
 
@@ -189,13 +190,13 @@ fn binary_contract<Op: GraphOp + SemiringOps>(
     let lhs_reduce: HashSet<u32> = lhs
         .labels
         .iter()
-        .filter(|l| !rhs_label_set.contains(l) && !output_set.contains(l))
+        .filter(|l| !rhs_label_set.contains(l) && !survive_set.contains(l))
         .copied()
         .collect();
     let rhs_reduce: HashSet<u32> = rhs
         .labels
         .iter()
-        .filter(|l| !lhs_label_set.contains(l) && !output_set.contains(l))
+        .filter(|l| !lhs_label_set.contains(l) && !survive_set.contains(l))
         .copied()
         .collect();
 
@@ -214,7 +215,7 @@ fn binary_contract<Op: GraphOp + SemiringOps>(
     // Preserve order from lhs for batch and contracting
     for &l in &lhs.labels {
         if rhs_label_set.contains(&l) {
-            if output_set.contains(&l) {
+            if survive_set.contains(&l) {
                 if !batch_labels.contains(&l) {
                     batch_labels.push(l);
                 }
@@ -311,15 +312,19 @@ fn binary_contract<Op: GraphOp + SemiringOps>(
         )
     };
 
-    // Reorder to match output_labels if needed
+    if !reorder_result {
+        return result;
+    }
+
+    // Reorder to match the caller-visible order if needed.
     let current_labels = &result.labels;
     if current_labels.is_empty() {
         return result;
     }
 
-    // Filter output_labels to those present in result (to handle final reduction later)
+    // Filter survivor labels to those present in result (to handle final reduction later)
     let result_label_set: HashSet<u32> = current_labels.iter().copied().collect();
-    let target_labels: Vec<u32> = output_labels
+    let target_labels: Vec<u32> = survive_labels
         .iter()
         .filter(|l| result_label_set.contains(l))
         .copied()
@@ -499,7 +504,14 @@ pub fn build_einsum_fragment<Op: GraphOp + SemiringOps>(
         // Use the step's intermediate output subscripts so that labels needed
         // by later contractions are preserved (not pre-reduced away).
         let (_, _, step_out_labels) = tree.step_subscripts(step_idx).unwrap();
-        let result = binary_contract(builder, &labeled[left], &labeled[right], step_out_labels);
+        let is_last = step_idx + 1 == tree.step_count();
+        let result = binary_contract(
+            builder,
+            &labeled[left],
+            &labeled[right],
+            step_out_labels,
+            is_last,
+        );
         // Push intermediate as new entry in labeled
         labeled.push(result);
     }

--- a/tenferro-einsum/src/tests/builder_tests.rs
+++ b/tenferro-einsum/src/tests/builder_tests.rs
@@ -123,6 +123,38 @@ fn fragment_hadamard_ij_ij_ij() {
 }
 
 #[test]
+fn fragment_batched_chain_avoids_intermediate_transpose() {
+    let subs = Subscripts::parse("bik,bkj,bjl->bil").expect("bad notation");
+    let shapes = [&[2, 3, 4][..], &[2, 4, 5][..], &[2, 5, 6][..]];
+    let tree = ContractionTree::from_pairs(&subs, &shapes, &[(0, 1), (3, 2)]).unwrap();
+
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let a = builder.add_input(input_key(0));
+    let b = builder.add_input(input_key(1));
+    let c = builder.add_input(input_key(2));
+
+    let result = build_einsum_fragment(
+        &mut builder,
+        &tree,
+        &[ValRef::Local(a), ValRef::Local(b), ValRef::Local(c)],
+        &[vec![2, 3, 4], vec![2, 4, 5], vec![2, 5, 6]],
+    );
+
+    builder.set_outputs(vec![match &result {
+        ValRef::Local(id) => *id,
+        _ => panic!("expected local"),
+    }]);
+    let fragment = builder.build();
+    let transpose_count = fragment
+        .ops()
+        .iter()
+        .filter(|node| matches!(node.op, StdTensorOp::Transpose { .. }))
+        .count();
+
+    assert_eq!(transpose_count, 1, "expected only the final transpose");
+}
+
+#[test]
 fn tree_binary() {
     let tree = make_tree("ij,jk->ik", &[&[2, 3], &[3, 4]]);
     assert_eq!(tree.step_count(), 1);

--- a/tenferro-einsum/src/tests/builder_tests.rs
+++ b/tenferro-einsum/src/tests/builder_tests.rs
@@ -152,6 +152,10 @@ fn fragment_batched_chain_avoids_intermediate_transpose() {
         .count();
 
     assert_eq!(transpose_count, 1, "expected only the final transpose");
+    match &fragment.ops().last().expect("fragment should have ops").op {
+        StdTensorOp::Transpose { perm } => assert_eq!(perm, &vec![2, 0, 1]),
+        other => panic!("expected final transpose, got {other:?}"),
+    }
 }
 
 #[test]

--- a/tenferro/src/compiler.rs
+++ b/tenferro/src/compiler.rs
@@ -760,77 +760,29 @@ fn find_producer(program: &StableHloProgram, slot: usize) -> Option<usize> {
 /// Check if a Transpose can be folded into DotGeneral for the given operand.
 ///
 /// Foldability conditions:
-/// - The transpose must be a valid permutation of the operand rank.
-/// - The DotGeneral dim numbers must be a valid partition of the operand
-///   dimensions (no duplicates, no out-of-range dims).
+/// - Batch dims must be unchanged by the permutation (perm[d] == d for each
+///   batch dim).
+/// - Exactly 1 contracting dimension.
 fn is_transpose_foldable(config: &DotGeneralConfig, operand_idx: usize, perm: &[usize]) -> bool {
-    let (rank, batch_dims, contracting_dims) = if operand_idx == 0 {
-        (
-            config.lhs_rank,
-            &config.lhs_batch_dims,
-            &config.lhs_contracting_dims,
-        )
+    let (batch_dims, contracting_dims) = if operand_idx == 0 {
+        (&config.lhs_batch_dims, &config.lhs_contracting_dims)
     } else {
-        (
-            config.rhs_rank,
-            &config.rhs_batch_dims,
-            &config.rhs_contracting_dims,
-        )
+        (&config.rhs_batch_dims, &config.rhs_contracting_dims)
     };
 
-    if perm.len() != rank || !is_valid_permutation(perm, rank) {
-        return false;
-    }
-
-    if !are_valid_dim_numbers(contracting_dims, batch_dims, rank) {
-        return false;
-    }
-
-    let free_dims = free_dims_in_operand_order(contracting_dims, batch_dims, rank);
-    let mapped_free_dims: Vec<usize> = free_dims.iter().map(|&dim| perm[dim]).collect();
-    if !is_strictly_increasing(&mapped_free_dims) {
-        return false;
-    }
-
-    true
-}
-
-fn is_valid_permutation(perm: &[usize], rank: usize) -> bool {
-    let mut seen = vec![false; rank];
-    for &dim in perm {
-        if dim >= rank || seen[dim] {
+    // Batch dims must be fixed points of the permutation.
+    for &d in batch_dims {
+        if d >= perm.len() || perm[d] != d {
             return false;
         }
-        seen[dim] = true;
     }
+
+    // Must have exactly 1 contracting dimension.
+    if contracting_dims.len() != 1 {
+        return false;
+    }
+
     true
-}
-
-fn are_valid_dim_numbers(contracting_dims: &[usize], batch_dims: &[usize], rank: usize) -> bool {
-    let mut seen = vec![false; rank];
-    for &dim in contracting_dims.iter().chain(batch_dims.iter()) {
-        if dim >= rank || seen[dim] {
-            return false;
-        }
-        seen[dim] = true;
-    }
-    true
-}
-
-fn free_dims_in_operand_order(
-    contracting_dims: &[usize],
-    batch_dims: &[usize],
-    rank: usize,
-) -> Vec<usize> {
-    let mut taken = vec![false; rank];
-    for &dim in contracting_dims.iter().chain(batch_dims.iter()) {
-        taken[dim] = true;
-    }
-    (0..rank).filter(|&dim| !taken[dim]).collect()
-}
-
-fn is_strictly_increasing(dims: &[usize]) -> bool {
-    dims.windows(2).all(|pair| pair[0] < pair[1])
 }
 
 /// Apply the transpose permutation to DotGeneral dimension numbers.

--- a/tenferro/src/compiler.rs
+++ b/tenferro/src/compiler.rs
@@ -760,11 +760,12 @@ fn find_producer(program: &StableHloProgram, slot: usize) -> Option<usize> {
 /// Check if a Transpose can be folded into DotGeneral for the given operand.
 ///
 /// Foldability conditions:
-/// - The operand's contracting and batch axes must still form a valid
+/// - The operand's free, contracting, and batch axes must still form a valid
 ///   partition after mapping the transposed axes back through `perm`.
-/// - The implied free-axis order must stay stable. In practice this rejects
-///   permutations that reorder free dims, while still allowing moved batch
-///   axes when the role partition is preserved.
+/// - The relative order within each role group must stay stable. In practice
+///   this rejects permutations that reorder free dims, contracting dims, or
+///   batch dims, while still allowing moved batch axes when the role
+///   partition is preserved.
 fn is_transpose_foldable(config: &DotGeneralConfig, operand_idx: usize, perm: &[usize]) -> bool {
     let (rank, contracting_dims, batch_dims) = if operand_idx == 0 {
         (
@@ -780,18 +781,17 @@ fn is_transpose_foldable(config: &DotGeneralConfig, operand_idx: usize, perm: &[
         )
     };
 
-    let Some(free_dims) = free_axes(rank, contracting_dims, batch_dims) else {
-        return false;
-    };
-    let Some(mapped_free_dims) = map_axes(&free_dims, perm) else {
-        return false;
-    };
-
-    if !is_strictly_increasing(&mapped_free_dims) {
+    if perm.len() != rank || !is_valid_permutation(perm, rank) {
         return false;
     }
 
-    true
+    let Some(free_dims) = free_axes(rank, contracting_dims, batch_dims) else {
+        return false;
+    };
+
+    is_role_group_order_preserved(&free_dims, perm)
+        && is_role_group_order_preserved(contracting_dims, perm)
+        && is_role_group_order_preserved(batch_dims, perm)
 }
 
 fn free_axes(rank: usize, contracting_dims: &[usize], batch_dims: &[usize]) -> Option<Vec<usize>> {
@@ -806,8 +806,26 @@ fn free_axes(rank: usize, contracting_dims: &[usize], batch_dims: &[usize]) -> O
     Some((0..rank).filter(|&axis| !used[axis]).collect())
 }
 
+fn is_valid_permutation(perm: &[usize], rank: usize) -> bool {
+    let mut seen = vec![false; rank];
+    for &axis in perm {
+        if axis >= rank || seen[axis] {
+            return false;
+        }
+        seen[axis] = true;
+    }
+    true
+}
+
 fn map_axes(axes: &[usize], perm: &[usize]) -> Option<Vec<usize>> {
     axes.iter().map(|&axis| perm.get(axis).copied()).collect()
+}
+
+fn is_role_group_order_preserved(axes: &[usize], perm: &[usize]) -> bool {
+    let Some(mapped_axes) = map_axes(axes, perm) else {
+        return false;
+    };
+    is_strictly_increasing(&mapped_axes)
 }
 
 fn is_strictly_increasing(values: &[usize]) -> bool {

--- a/tenferro/src/compiler.rs
+++ b/tenferro/src/compiler.rs
@@ -760,29 +760,58 @@ fn find_producer(program: &StableHloProgram, slot: usize) -> Option<usize> {
 /// Check if a Transpose can be folded into DotGeneral for the given operand.
 ///
 /// Foldability conditions:
-/// - Batch dims must be unchanged by the permutation (perm[d] == d for each
-///   batch dim).
-/// - Exactly 1 contracting dimension.
+/// - The operand's contracting and batch axes must still form a valid
+///   partition after mapping the transposed axes back through `perm`.
+/// - The implied free-axis order must stay stable. In practice this rejects
+///   permutations that reorder free dims, while still allowing moved batch
+///   axes when the role partition is preserved.
 fn is_transpose_foldable(config: &DotGeneralConfig, operand_idx: usize, perm: &[usize]) -> bool {
-    let (batch_dims, contracting_dims) = if operand_idx == 0 {
-        (&config.lhs_batch_dims, &config.lhs_contracting_dims)
+    let (rank, contracting_dims, batch_dims) = if operand_idx == 0 {
+        (
+            config.lhs_rank,
+            config.lhs_contracting_dims.as_slice(),
+            config.lhs_batch_dims.as_slice(),
+        )
     } else {
-        (&config.rhs_batch_dims, &config.rhs_contracting_dims)
+        (
+            config.rhs_rank,
+            config.rhs_contracting_dims.as_slice(),
+            config.rhs_batch_dims.as_slice(),
+        )
     };
 
-    // Batch dims must be fixed points of the permutation.
-    for &d in batch_dims {
-        if d >= perm.len() || perm[d] != d {
-            return false;
-        }
-    }
+    let Some(free_dims) = free_axes(rank, contracting_dims, batch_dims) else {
+        return false;
+    };
+    let Some(mapped_free_dims) = map_axes(&free_dims, perm) else {
+        return false;
+    };
 
-    // Must have exactly 1 contracting dimension.
-    if contracting_dims.len() != 1 {
+    if !is_strictly_increasing(&mapped_free_dims) {
         return false;
     }
 
     true
+}
+
+fn free_axes(rank: usize, contracting_dims: &[usize], batch_dims: &[usize]) -> Option<Vec<usize>> {
+    let mut used = vec![false; rank];
+    for &axis in contracting_dims.iter().chain(batch_dims.iter()) {
+        if axis >= rank || used[axis] {
+            return None;
+        }
+        used[axis] = true;
+    }
+
+    Some((0..rank).filter(|&axis| !used[axis]).collect())
+}
+
+fn map_axes(axes: &[usize], perm: &[usize]) -> Option<Vec<usize>> {
+    axes.iter().map(|&axis| perm.get(axis).copied()).collect()
+}
+
+fn is_strictly_increasing(values: &[usize]) -> bool {
+    values.windows(2).all(|pair| pair[0] < pair[1])
 }
 
 /// Apply the transpose permutation to DotGeneral dimension numbers.

--- a/tenferro/src/compiler.rs
+++ b/tenferro/src/compiler.rs
@@ -760,29 +760,77 @@ fn find_producer(program: &StableHloProgram, slot: usize) -> Option<usize> {
 /// Check if a Transpose can be folded into DotGeneral for the given operand.
 ///
 /// Foldability conditions:
-/// - Batch dims must be unchanged by the permutation (perm[d] == d for each
-///   batch dim).
-/// - Exactly 1 contracting dimension.
+/// - The transpose must be a valid permutation of the operand rank.
+/// - The DotGeneral dim numbers must be a valid partition of the operand
+///   dimensions (no duplicates, no out-of-range dims).
 fn is_transpose_foldable(config: &DotGeneralConfig, operand_idx: usize, perm: &[usize]) -> bool {
-    let (batch_dims, contracting_dims) = if operand_idx == 0 {
-        (&config.lhs_batch_dims, &config.lhs_contracting_dims)
+    let (rank, batch_dims, contracting_dims) = if operand_idx == 0 {
+        (
+            config.lhs_rank,
+            &config.lhs_batch_dims,
+            &config.lhs_contracting_dims,
+        )
     } else {
-        (&config.rhs_batch_dims, &config.rhs_contracting_dims)
+        (
+            config.rhs_rank,
+            &config.rhs_batch_dims,
+            &config.rhs_contracting_dims,
+        )
     };
 
-    // Batch dims must be fixed points of the permutation.
-    for &d in batch_dims {
-        if d >= perm.len() || perm[d] != d {
-            return false;
-        }
+    if perm.len() != rank || !is_valid_permutation(perm, rank) {
+        return false;
     }
 
-    // Must have exactly 1 contracting dimension.
-    if contracting_dims.len() != 1 {
+    if !are_valid_dim_numbers(contracting_dims, batch_dims, rank) {
+        return false;
+    }
+
+    let free_dims = free_dims_in_operand_order(contracting_dims, batch_dims, rank);
+    let mapped_free_dims: Vec<usize> = free_dims.iter().map(|&dim| perm[dim]).collect();
+    if !is_strictly_increasing(&mapped_free_dims) {
         return false;
     }
 
     true
+}
+
+fn is_valid_permutation(perm: &[usize], rank: usize) -> bool {
+    let mut seen = vec![false; rank];
+    for &dim in perm {
+        if dim >= rank || seen[dim] {
+            return false;
+        }
+        seen[dim] = true;
+    }
+    true
+}
+
+fn are_valid_dim_numbers(contracting_dims: &[usize], batch_dims: &[usize], rank: usize) -> bool {
+    let mut seen = vec![false; rank];
+    for &dim in contracting_dims.iter().chain(batch_dims.iter()) {
+        if dim >= rank || seen[dim] {
+            return false;
+        }
+        seen[dim] = true;
+    }
+    true
+}
+
+fn free_dims_in_operand_order(
+    contracting_dims: &[usize],
+    batch_dims: &[usize],
+    rank: usize,
+) -> Vec<usize> {
+    let mut taken = vec![false; rank];
+    for &dim in contracting_dims.iter().chain(batch_dims.iter()) {
+        taken[dim] = true;
+    }
+    (0..rank).filter(|&dim| !taken[dim]).collect()
+}
+
+fn is_strictly_increasing(dims: &[usize]) -> bool {
+    dims.windows(2).all(|pair| pair[0] < pair[1])
 }
 
 /// Apply the transpose permutation to DotGeneral dimension numbers.

--- a/tenferro/tests/compiler_passes.rs
+++ b/tenferro/tests/compiler_passes.rs
@@ -329,6 +329,82 @@ fn test_transpose_folding_rejects_free_dim_reorder() {
 }
 
 #[test]
+fn test_transpose_folding_rejects_contracting_dim_reorder() {
+    // slot 0: input A (shape [2,3,4,5])
+    // slot 2 = Transpose(slot 0, perm=[0,3,2,1])  => reorders contracting dims
+    // slot 3 = DotGeneral(slot 2, slot 1, lhs_contract={1,3}, lhs_batch={0})
+    //
+    // Folding should be rejected because the contracting axis order reverses.
+    let transpose = make_instr(
+        StableHloOp::Transpose {
+            perm: vec![0, 3, 2, 1],
+        },
+        vec![0],
+        vec![2],
+    );
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1, 3],
+        rhs_contracting_dims: vec![0, 2],
+        lhs_batch_dims: vec![0],
+        rhs_batch_dims: vec![1],
+        lhs_rank: 4,
+        rhs_rank: 3,
+    };
+    let dot = make_instr(StableHloOp::DotGeneral(config.clone()), vec![2, 1], vec![3]);
+    let mut program = make_program(vec![transpose, dot], vec![0, 1], vec![3], 4);
+
+    transpose_folding(&mut program);
+
+    let dot_instr = &program.instructions[1];
+    assert_eq!(dot_instr.input_slots[0], 2);
+    assert_eq!(dot_instr.input_slots[1], 1);
+    match &dot_instr.op {
+        StableHloOp::DotGeneral(c) => {
+            assert_eq!(c, &config);
+        }
+        _ => panic!("expected DotGeneral"),
+    }
+}
+
+#[test]
+fn test_transpose_folding_rejects_batch_dim_reorder() {
+    // slot 0: input A (shape [2,3,4,5])
+    // slot 2 = Transpose(slot 0, perm=[2,1,0,3])  => reorders batch dims
+    // slot 3 = DotGeneral(slot 2, slot 1, lhs_contract={1}, lhs_batch={0,2})
+    //
+    // Folding should be rejected because the batch axis order reverses.
+    let transpose = make_instr(
+        StableHloOp::Transpose {
+            perm: vec![2, 1, 0, 3],
+        },
+        vec![0],
+        vec![2],
+    );
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![0, 2],
+        rhs_batch_dims: vec![1, 2],
+        lhs_rank: 4,
+        rhs_rank: 3,
+    };
+    let dot = make_instr(StableHloOp::DotGeneral(config.clone()), vec![2, 1], vec![3]);
+    let mut program = make_program(vec![transpose, dot], vec![0, 1], vec![3], 4);
+
+    transpose_folding(&mut program);
+
+    let dot_instr = &program.instructions[1];
+    assert_eq!(dot_instr.input_slots[0], 2);
+    assert_eq!(dot_instr.input_slots[1], 1);
+    match &dot_instr.op {
+        StableHloOp::DotGeneral(c) => {
+            assert_eq!(c, &config);
+        }
+        _ => panic!("expected DotGeneral"),
+    }
+}
+
+#[test]
 fn test_transpose_folding_allows_batch_dim_move_when_free_order_is_stable() {
     // Transpose that moves a batch axis but keeps the free-axis order stable.
     // slot 0: input A (batch dim 0, but perm moves it to slot 1)

--- a/tenferro/tests/compiler_passes.rs
+++ b/tenferro/tests/compiler_passes.rs
@@ -247,67 +247,23 @@ fn test_transpose_folding_absorbs_transpose_on_rhs() {
 }
 
 #[test]
-fn test_transpose_folding_batch_and_contracting_dims_can_move() {
-    // A transpose can be folded even when it moves batch dims, as long as the
-    // DotGeneral dim numbers are otherwise valid.
-    //
-    // slot 0: input A (rank 4)
-    // slot 1: input B
-    // slot 2 = Transpose(slot 0, perm=[2,0,3,1])  => batch dim 0 moves to 2
-    // slot 3 = DotGeneral(slot 2, slot 1, lhs_contract={1,3}, rhs_contract={0,2},
-    //                    lhs_batch={0}, rhs_batch={1})
-    //
-    // After folding, the DotGeneral reads slot 0 directly and its lhs dims
-    // are remapped through the transpose permutation.
+fn test_transpose_folding_unfoldable_batch_changed() {
+    // Transpose that changes batch dims => not foldable.
+    // slot 0: input A (batch dim 0, but perm shuffles it)
+    // slot 2 = Transpose(slot 0, perm=[1,0,2])  => changes dim 0
+    // slot 3 = DotGeneral with batch_dims=[0]
     let transpose = make_instr(
         StableHloOp::Transpose {
-            perm: vec![2, 0, 3, 1],
+            perm: vec![1, 0, 2],
         },
         vec![0],
         vec![2],
     );
     let config = DotGeneralConfig {
-        lhs_contracting_dims: vec![1, 3],
-        rhs_contracting_dims: vec![0, 2],
-        lhs_batch_dims: vec![0],
-        rhs_batch_dims: vec![1],
-        lhs_rank: 4,
-        rhs_rank: 4,
-    };
-    let dot = make_instr(StableHloOp::DotGeneral(config), vec![2, 1], vec![3]);
-    let mut program = make_program(vec![transpose, dot], vec![0, 1], vec![3], 4);
-
-    transpose_folding(&mut program);
-
-    let dot_instr = &program.instructions[1];
-    assert_eq!(dot_instr.input_slots[0], 0);
-    assert_eq!(dot_instr.input_slots[1], 1);
-    match &dot_instr.op {
-        StableHloOp::DotGeneral(c) => {
-            assert_eq!(c.lhs_contracting_dims, vec![0, 1]);
-            assert_eq!(c.lhs_batch_dims, vec![2]);
-            assert_eq!(c.rhs_contracting_dims, vec![0, 2]);
-            assert_eq!(c.rhs_batch_dims, vec![1]);
-        }
-        _ => panic!("expected DotGeneral"),
-    }
-}
-
-#[test]
-fn test_transpose_folding_rejects_free_dim_reordering() {
-    // Folding must reject transposes that reorder the implicit free dimensions.
-    let transpose = make_instr(
-        StableHloOp::Transpose {
-            perm: vec![2, 1, 0],
-        },
-        vec![0],
-        vec![2],
-    );
-    let config = DotGeneralConfig {
-        lhs_contracting_dims: vec![1],
+        lhs_contracting_dims: vec![2],
         rhs_contracting_dims: vec![0],
-        lhs_batch_dims: vec![],
-        rhs_batch_dims: vec![],
+        lhs_batch_dims: vec![0],
+        rhs_batch_dims: vec![0],
         lhs_rank: 3,
         rhs_rank: 2,
     };
@@ -316,15 +272,9 @@ fn test_transpose_folding_rejects_free_dim_reordering() {
 
     transpose_folding(&mut program);
 
+    // Not foldable: DotGeneral still reads slot 2 (transpose output).
     let dot_instr = &program.instructions[1];
-    assert_eq!(dot_instr.input_slots[0], 2);
-    match &dot_instr.op {
-        StableHloOp::DotGeneral(c) => {
-            assert_eq!(c.lhs_contracting_dims, vec![1]);
-            assert!(c.lhs_batch_dims.is_empty());
-        }
-        _ => panic!("expected DotGeneral"),
-    }
+    assert_eq!(dot_instr.input_slots[0], 2); // unchanged
 }
 
 #[test]

--- a/tenferro/tests/compiler_passes.rs
+++ b/tenferro/tests/compiler_passes.rs
@@ -247,23 +247,67 @@ fn test_transpose_folding_absorbs_transpose_on_rhs() {
 }
 
 #[test]
-fn test_transpose_folding_unfoldable_batch_changed() {
-    // Transpose that changes batch dims => not foldable.
-    // slot 0: input A (batch dim 0, but perm shuffles it)
-    // slot 2 = Transpose(slot 0, perm=[1,0,2])  => changes dim 0
-    // slot 3 = DotGeneral with batch_dims=[0]
+fn test_transpose_folding_batch_and_contracting_dims_can_move() {
+    // A transpose can be folded even when it moves batch dims, as long as the
+    // DotGeneral dim numbers are otherwise valid.
+    //
+    // slot 0: input A (rank 4)
+    // slot 1: input B
+    // slot 2 = Transpose(slot 0, perm=[2,0,3,1])  => batch dim 0 moves to 2
+    // slot 3 = DotGeneral(slot 2, slot 1, lhs_contract={1,3}, rhs_contract={0,2},
+    //                    lhs_batch={0}, rhs_batch={1})
+    //
+    // After folding, the DotGeneral reads slot 0 directly and its lhs dims
+    // are remapped through the transpose permutation.
     let transpose = make_instr(
         StableHloOp::Transpose {
-            perm: vec![1, 0, 2],
+            perm: vec![2, 0, 3, 1],
         },
         vec![0],
         vec![2],
     );
     let config = DotGeneralConfig {
-        lhs_contracting_dims: vec![2],
-        rhs_contracting_dims: vec![0],
+        lhs_contracting_dims: vec![1, 3],
+        rhs_contracting_dims: vec![0, 2],
         lhs_batch_dims: vec![0],
-        rhs_batch_dims: vec![0],
+        rhs_batch_dims: vec![1],
+        lhs_rank: 4,
+        rhs_rank: 4,
+    };
+    let dot = make_instr(StableHloOp::DotGeneral(config), vec![2, 1], vec![3]);
+    let mut program = make_program(vec![transpose, dot], vec![0, 1], vec![3], 4);
+
+    transpose_folding(&mut program);
+
+    let dot_instr = &program.instructions[1];
+    assert_eq!(dot_instr.input_slots[0], 0);
+    assert_eq!(dot_instr.input_slots[1], 1);
+    match &dot_instr.op {
+        StableHloOp::DotGeneral(c) => {
+            assert_eq!(c.lhs_contracting_dims, vec![0, 1]);
+            assert_eq!(c.lhs_batch_dims, vec![2]);
+            assert_eq!(c.rhs_contracting_dims, vec![0, 2]);
+            assert_eq!(c.rhs_batch_dims, vec![1]);
+        }
+        _ => panic!("expected DotGeneral"),
+    }
+}
+
+#[test]
+fn test_transpose_folding_rejects_free_dim_reordering() {
+    // Folding must reject transposes that reorder the implicit free dimensions.
+    let transpose = make_instr(
+        StableHloOp::Transpose {
+            perm: vec![2, 1, 0],
+        },
+        vec![0],
+        vec![2],
+    );
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
         lhs_rank: 3,
         rhs_rank: 2,
     };
@@ -272,9 +316,15 @@ fn test_transpose_folding_unfoldable_batch_changed() {
 
     transpose_folding(&mut program);
 
-    // Not foldable: DotGeneral still reads slot 2 (transpose output).
     let dot_instr = &program.instructions[1];
-    assert_eq!(dot_instr.input_slots[0], 2); // unchanged
+    assert_eq!(dot_instr.input_slots[0], 2);
+    match &dot_instr.op {
+        StableHloOp::DotGeneral(c) => {
+            assert_eq!(c.lhs_contracting_dims, vec![1]);
+            assert!(c.lhs_batch_dims.is_empty());
+        }
+        _ => panic!("expected DotGeneral"),
+    }
 }
 
 #[test]

--- a/tenferro/tests/compiler_passes.rs
+++ b/tenferro/tests/compiler_passes.rs
@@ -247,10 +247,92 @@ fn test_transpose_folding_absorbs_transpose_on_rhs() {
 }
 
 #[test]
-fn test_transpose_folding_unfoldable_batch_changed() {
-    // Transpose that changes batch dims => not foldable.
-    // slot 0: input A (batch dim 0, but perm shuffles it)
-    // slot 2 = Transpose(slot 0, perm=[1,0,2])  => changes dim 0
+fn test_transpose_folding_absorbs_transpose_when_batch_moves_to_trailing_slot() {
+    // slot 0: input A (shape [2,3,4])
+    // slot 2 = Transpose(slot 0, perm=[1,2,0])  => A' shape [3,4,2]
+    // slot 3 = DotGeneral(slot 2, slot 1, lhs_contract={0}, lhs_batch={1},
+    //                     rhs_contract={0}, rhs_batch={1})
+    //
+    // Folding should be legal because the batch axis moves to the trailing slot
+    // while the free/contract/batch partition is preserved.
+    let transpose = make_instr(
+        StableHloOp::Transpose {
+            perm: vec![1, 2, 0],
+        },
+        vec![0],
+        vec![2],
+    );
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![0],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![1],
+        rhs_batch_dims: vec![1],
+        lhs_rank: 3,
+        rhs_rank: 2,
+    };
+    let dot = make_instr(StableHloOp::DotGeneral(config), vec![2, 1], vec![3]);
+    let mut program = make_program(vec![transpose, dot], vec![0, 1], vec![3], 4);
+
+    transpose_folding(&mut program);
+
+    let dot_instr = &program.instructions[1];
+    assert_eq!(dot_instr.input_slots[0], 0);
+    assert_eq!(dot_instr.input_slots[1], 1);
+    match &dot_instr.op {
+        StableHloOp::DotGeneral(c) => {
+            assert_eq!(c.lhs_contracting_dims, vec![1]);
+            assert_eq!(c.lhs_batch_dims, vec![2]);
+            assert_eq!(c.rhs_contracting_dims, vec![0]);
+            assert_eq!(c.rhs_batch_dims, vec![1]);
+        }
+        _ => panic!("expected DotGeneral"),
+    }
+}
+
+#[test]
+fn test_transpose_folding_rejects_free_dim_reorder() {
+    // slot 0: input A (shape [2,3,4,5])
+    // slot 2 = Transpose(slot 0, perm=[1,0,2,3])  => reorders free dims
+    // slot 3 = DotGeneral(slot 2, slot 1, lhs_contract={2}, lhs_batch={3})
+    //
+    // The current narrow rule would fold this because the batch axis is fixed.
+    // The broadened rule should reject it because free dims reorder.
+    let transpose = make_instr(
+        StableHloOp::Transpose {
+            perm: vec![1, 0, 2, 3],
+        },
+        vec![0],
+        vec![2],
+    );
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![2],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![3],
+        rhs_batch_dims: vec![1],
+        lhs_rank: 4,
+        rhs_rank: 2,
+    };
+    let dot = make_instr(StableHloOp::DotGeneral(config.clone()), vec![2, 1], vec![3]);
+    let mut program = make_program(vec![transpose, dot], vec![0, 1], vec![3], 4);
+
+    transpose_folding(&mut program);
+
+    let dot_instr = &program.instructions[1];
+    assert_eq!(dot_instr.input_slots[0], 2);
+    assert_eq!(dot_instr.input_slots[1], 1);
+    match &dot_instr.op {
+        StableHloOp::DotGeneral(c) => {
+            assert_eq!(c, &config);
+        }
+        _ => panic!("expected DotGeneral"),
+    }
+}
+
+#[test]
+fn test_transpose_folding_allows_batch_dim_move_when_free_order_is_stable() {
+    // Transpose that moves a batch axis but keeps the free-axis order stable.
+    // slot 0: input A (batch dim 0, but perm moves it to slot 1)
+    // slot 2 = Transpose(slot 0, perm=[1,0,2])
     // slot 3 = DotGeneral with batch_dims=[0]
     let transpose = make_instr(
         StableHloOp::Transpose {
@@ -272,9 +354,18 @@ fn test_transpose_folding_unfoldable_batch_changed() {
 
     transpose_folding(&mut program);
 
-    // Not foldable: DotGeneral still reads slot 2 (transpose output).
     let dot_instr = &program.instructions[1];
-    assert_eq!(dot_instr.input_slots[0], 2); // unchanged
+    assert_eq!(dot_instr.input_slots[0], 0);
+    assert_eq!(dot_instr.input_slots[1], 1);
+    match &dot_instr.op {
+        StableHloOp::DotGeneral(c) => {
+            assert_eq!(c.lhs_contracting_dims, vec![2]);
+            assert_eq!(c.lhs_batch_dims, vec![1]);
+            assert_eq!(c.rhs_contracting_dims, vec![0]);
+            assert_eq!(c.rhs_batch_dims, vec![0]);
+        }
+        _ => panic!("expected DotGeneral"),
+    }
 }
 
 #[test]

--- a/tenferro/tests/einsum.rs
+++ b/tenferro/tests/einsum.rs
@@ -423,6 +423,46 @@ fn einsum_three_matrices() {
     }
 }
 
+#[test]
+fn einsum_batched_three_matrix_chain_matches_pairwise_reference() {
+    // "bik,bkj,bjl->bil" — batched three-matrix chain with deterministic data.
+    let a = f64_tensor(vec![2, 2, 3], (1..=12).map(|x| x as f64).collect());
+    let b = f64_tensor(vec![2, 3, 4], (13..=36).map(|x| x as f64).collect());
+    let c = f64_tensor(vec![2, 4, 2], (37..=52).map(|x| x as f64).collect());
+
+    let mut direct_engine = Engine::new(CpuBackend::new());
+    let ta = TracedTensor::from_tensor(a.clone());
+    let tb = TracedTensor::from_tensor(b.clone());
+    let tc = TracedTensor::from_tensor(c.clone());
+    let mut direct = einsum(&mut direct_engine, &[&ta, &tb, &tc], "bik,bkj,bjl->bil").unwrap();
+    let direct_result = direct.eval(&mut direct_engine).unwrap();
+
+    let mut pairwise_engine = Engine::new(CpuBackend::new());
+    let pa = TracedTensor::from_tensor(a);
+    let pb = TracedTensor::from_tensor(b);
+    let pc = TracedTensor::from_tensor(c);
+    let mut first = einsum(&mut pairwise_engine, &[&pa, &pb], "bik,bkj->bij").unwrap();
+    let first_result = first.eval(&mut pairwise_engine).unwrap().clone();
+    let first_tensor = TracedTensor::from_tensor(first_result);
+    let mut reference =
+        einsum(&mut pairwise_engine, &[&first_tensor, &pc], "bij,bjl->bil").unwrap();
+    let reference_result = reference.eval(&mut pairwise_engine).unwrap();
+
+    assert_eq!(direct_result.shape(), reference_result.shape());
+    assert_eq!(direct_result.shape(), &[2, 2, 2]);
+    for b in 0..2 {
+        for i in 0..2 {
+            for l in 0..2 {
+                assert_close(
+                    get_v2(direct_result, &[b, i, l]),
+                    get_v2(reference_result, &[b, i, l]),
+                    &format!("batched_chain[{b},{i},{l}]"),
+                );
+            }
+        }
+    }
+}
+
 // ============================================================================
 // Group 4: Contraction tree / path tests
 // ============================================================================

--- a/tenferro/tests/einsum.rs
+++ b/tenferro/tests/einsum.rs
@@ -423,36 +423,6 @@ fn einsum_three_matrices() {
     }
 }
 
-#[test]
-fn einsum_batched_three_matrix_chain_matches_pairwise_reference() {
-    let mut engine = Engine::new(CpuBackend::new());
-
-    let ta = TracedTensor::from_tensor(f64_tensor(
-        vec![2, 3, 4],
-        (1..=24).map(|x| x as f64).collect(),
-    ));
-    let tb = TracedTensor::from_tensor(f64_tensor(
-        vec![2, 4, 5],
-        (1..=40).map(|x| x as f64).collect(),
-    ));
-    let tc = TracedTensor::from_tensor(f64_tensor(
-        vec![2, 5, 6],
-        (1..=60).map(|x| x as f64).collect(),
-    ));
-
-    let mut direct = einsum(&mut engine, &[&ta, &tb, &tc], "bik,bkj,bjl->bil").unwrap();
-    let direct_value = direct.eval(&mut engine).unwrap();
-
-    let mut left = einsum(&mut engine, &[&ta, &tb], "bik,bkj->bij").unwrap();
-    let left_value = left.eval(&mut engine).unwrap();
-    let left_traced = TracedTensor::from_tensor(left_value.clone());
-    let mut reference = einsum(&mut engine, &[&left_traced, &tc], "bij,bjl->bil").unwrap();
-    let reference_value = reference.eval(&mut engine).unwrap();
-
-    assert_eq!(direct_value.shape(), reference_value.shape());
-    assert_eq!(get_f64_data(&direct_value), get_f64_data(&reference_value));
-}
-
 // ============================================================================
 // Group 4: Contraction tree / path tests
 // ============================================================================

--- a/tenferro/tests/einsum.rs
+++ b/tenferro/tests/einsum.rs
@@ -423,6 +423,36 @@ fn einsum_three_matrices() {
     }
 }
 
+#[test]
+fn einsum_batched_three_matrix_chain_matches_pairwise_reference() {
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let ta = TracedTensor::from_tensor(f64_tensor(
+        vec![2, 3, 4],
+        (1..=24).map(|x| x as f64).collect(),
+    ));
+    let tb = TracedTensor::from_tensor(f64_tensor(
+        vec![2, 4, 5],
+        (1..=40).map(|x| x as f64).collect(),
+    ));
+    let tc = TracedTensor::from_tensor(f64_tensor(
+        vec![2, 5, 6],
+        (1..=60).map(|x| x as f64).collect(),
+    ));
+
+    let mut direct = einsum(&mut engine, &[&ta, &tb, &tc], "bik,bkj,bjl->bil").unwrap();
+    let direct_value = direct.eval(&mut engine).unwrap();
+
+    let mut left = einsum(&mut engine, &[&ta, &tb], "bik,bkj->bij").unwrap();
+    let left_value = left.eval(&mut engine).unwrap();
+    let left_traced = TracedTensor::from_tensor(left_value.clone());
+    let mut reference = einsum(&mut engine, &[&left_traced, &tc], "bij,bjl->bil").unwrap();
+    let reference_value = reference.eval(&mut engine).unwrap();
+
+    assert_eq!(direct_value.shape(), reference_value.shape());
+    assert_eq!(get_f64_data(&direct_value), get_f64_data(&reference_value));
+}
+
 // ============================================================================
 // Group 4: Contraction tree / path tests
 // ============================================================================

--- a/tenferro/tests/einsum.rs
+++ b/tenferro/tests/einsum.rs
@@ -450,6 +450,16 @@ fn einsum_batched_three_matrix_chain_matches_pairwise_reference() {
 
     assert_eq!(direct_result.shape(), reference_result.shape());
     assert_eq!(direct_result.shape(), &[2, 2, 2]);
+    assert_close(
+        get_v2(direct_result, &[0, 0, 0]),
+        61060.0,
+        "batched_chain_manual[0,0,0]",
+    );
+    assert_close(
+        get_v2(direct_result, &[1, 1, 1]),
+        122176.0,
+        "batched_chain_manual[1,1,1]",
+    );
     for b in 0..2 {
         for i in 0..2 {
             for l in 0..2 {


### PR DESCRIPTION
## Summary
- keep N-ary einsum intermediate results in canonical `DotGeneral` order so the builder avoids inserting unnecessary intermediate transposes
- broaden compiler transpose folding so legal `Transpose -> DotGeneral` pairs are absorbed even when batch axes move to trailing slots
- add builder, compiler-pass, and end-to-end einsum regressions for the batched chain case `bik,bkj,bjl->bil`

## Root Cause
The current lowering reordered every N-ary intermediate back into `step_out_labels` order, which inserted an avoidable transpose between contraction steps. In parallel, compiler transpose folding only handled a narrow fixed-point batch case, so more legal transpose/dot pairs survived into execution than necessary.

## Impact
CPU einsum lowering now emits fewer intermediate transposes for common N-ary contraction chains while preserving the StableHLO-compatible interface. The new tests lock down both the canonical-intermediate lowering behavior and the broader transpose-folding legality checks.

## Validation
- `cargo fmt --all --check`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Attribution: created with Codex.
