### PR TITLE
[codex] parallelize oracle replay tests

### DIFF
--- a/docs/superpowers/plans/2026-04-10-oracle-replay-adaptive-sharding.md
+++ b/docs/superpowers/plans/2026-04-10-oracle-replay-adaptive-sharding.md
@@ -1,0 +1,109 @@
+# Oracle Replay Adaptive Sharding Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make oracle replay shard count adapt to the local environment, while keeping shard runtimes balanced enough that workspace `nextest` wall time improves beyond the current fixed 4-shard implementation.
+
+**Architecture:** Replace the fixed shard count constant with a runtime-selected active shard count and a fixed compile-time ceiling of registered shard tests. Build a filtered replay manifest first, compute the active shard count, then let each registered shard test execute the manifest entries selected by deterministic round-robin assignment or return immediately when it is outside the active set.
+
+**Tech Stack:** Rust integration tests, `cargo test`, `cargo nextest`, existing tenferro CPU backend
+
+---
+
+### Task 1: Add pure tests for adaptive shard helpers
+
+**Files:**
+- Modify: `tenferro/tests/oracle_replay/main.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add focused tests for pure helpers:
+- override parsing and validation for shard count
+- automatic shard count clamping from `(available, total_cases, max_supported, min_cases_per_shard)`
+- shard assignment coverage: every manifest entry belongs to exactly one active shard
+- shard assignment balance on a deterministic fixture
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p tenferro --test oracle_replay --release adaptive_`
+Expected: FAIL because the helper APIs do not exist yet
+
+- [ ] **Step 3: Write minimal helper implementations**
+
+Add pure functions for:
+- shard count resolution inputs
+- active shard count calculation
+- deterministic active-shard entry assignment helpers
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p tenferro --test oracle_replay --release adaptive_`
+Expected: PASS
+
+### Task 2: Refactor replay execution around a manifest
+
+**Files:**
+- Modify: `tenferro/tests/oracle_replay/main.rs`
+
+- [ ] **Step 1: Add manifest structs**
+
+Introduce small test-local structs for loaded files and manifest entries.
+
+- [ ] **Step 2: Build the filtered manifest first**
+
+Discover files, load case vectors, apply `ORACLE_REPLAY_OP`, then apply `ORACLE_REPLAY_CASE_LIMIT` while building a deterministic manifest.
+
+- [ ] **Step 3: Resolve active shard count**
+
+Read `ORACLE_REPLAY_SHARD_COUNT` when present; otherwise compute a default from available parallelism and total filtered cases.
+
+- [ ] **Step 4: Assign manifest entries to active shards**
+
+Use round-robin assignment across manifest entry indices for the active shard count and skip execution entirely for registered shards outside the active set.
+
+- [ ] **Step 5: Keep thread budgeting aligned**
+
+Derive backend thread count from the active shard count and continue using `CpuBackend::with_threads(...)`.
+
+### Task 3: Replace fixed shard entrypoints with a fixed ceiling
+
+**Files:**
+- Modify: `tenferro/tests/oracle_replay/main.rs`
+
+- [ ] **Step 1: Replace fixed 4-shard setup**
+
+Introduce a compile-time `MAX_ORACLE_REPLAY_SHARDS` and register shard tests up to that ceiling, preferably with a macro to keep the file readable.
+
+- [ ] **Step 2: Preserve the ignored sequential test**
+
+Keep `oracle_replay_all` available for baseline comparison and debugging.
+
+- [ ] **Step 3: Update summary output**
+
+Print active shard count and the executed shard selector so `--nocapture` output remains useful.
+
+### Task 4: Verify behavior and timing
+
+**Files:**
+- Modify: `tenferro/tests/oracle_replay/main.rs` if follow-up fixes are needed
+
+- [ ] **Step 1: Run focused helper tests**
+
+Run: `cargo test -p tenferro --test oracle_replay --release adaptive_`
+Expected: PASS
+
+- [ ] **Step 2: Run focused replay tests**
+
+Run: `cargo test -p tenferro --test oracle_replay --release shard_`
+Expected: PASS
+
+- [ ] **Step 3: Run workspace nextest**
+
+Run: `cargo nextest run --workspace --release --no-fail-fast`
+Expected: PASS, with no single oracle replay shard regressing toward the old single-test baseline
+
+- [ ] **Step 4: Record outcome**
+
+Capture the new slowest shard timing and compare it against both earlier baselines:
+- `oracle_replay_all` about 80 seconds
+- fixed 4-shard workspace about 30.5 seconds

--- a/docs/superpowers/plans/2026-04-10-oracle-replay-sharding.md
+++ b/docs/superpowers/plans/2026-04-10-oracle-replay-sharding.md
@@ -1,0 +1,76 @@
+# Oracle Replay Sharding Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `oracle_replay_all` into a small fixed number of deterministic shards so `nextest` can run oracle replay work in parallel and reduce end-to-end wall time.
+
+**Architecture:** Extract the existing sequential runner in `tenferro/tests/oracle_replay/main.rs` into a shard-aware helper that filters cases by deterministic global case index. Keep the existing summary and replay logic, add focused shard-assignment tests first, then expose multiple `#[test]` entrypoints that `nextest` can schedule concurrently while constraining per-shard backend threads.
+
+**Tech Stack:** Rust integration tests, `cargo test`, `cargo nextest`, existing tenferro CPU backend
+
+---
+
+### Task 1: Add shard-selection tests
+
+**Files:**
+- Modify: `tenferro/tests/oracle_replay/main.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add tests for a pure shard-selection helper:
+- one test that verifies every global case index in a sample range is assigned to exactly one shard
+- one test that verifies shard assignment is deterministic and balanced within 1 case
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p tenferro --test oracle_replay --release shard_`
+Expected: FAIL because the helper does not exist yet
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add a small pure helper such as `case_in_shard(global_index, shard_index, shard_count) -> bool`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p tenferro --test oracle_replay --release shard_`
+Expected: PASS
+
+### Task 2: Refactor the replay runner for shard-aware execution
+
+**Files:**
+- Modify: `tenferro/tests/oracle_replay/main.rs`
+
+- [ ] **Step 1: Extract the existing loop into a runner**
+
+Move the body of `oracle_replay_all` into a helper that accepts shard parameters and accumulates `ReplayStats`.
+
+- [ ] **Step 2: Keep existing env-filter behavior**
+
+Preserve `ORACLE_REPLAY_OP` and `ORACLE_REPLAY_CASE_LIMIT`, applying the limit after shard filtering so each shard remains locally debuggable.
+
+- [ ] **Step 3: Bound per-shard backend threads**
+
+Create `Engine` with `CpuBackend::with_threads(...)` when running sharded tests so each shard does not grab the full machine by default.
+
+- [ ] **Step 4: Add shard entrypoint tests**
+
+Replace the single monolithic replay entrypoint with a small fixed set of tests such as `oracle_replay_shard_0` to `oracle_replay_shard_3`, each calling the shared runner.
+
+### Task 3: Verify correctness and wall-clock behavior
+
+**Files:**
+- Modify: `tenferro/tests/oracle_replay/main.rs` if follow-up adjustments are needed
+
+- [ ] **Step 1: Run focused oracle replay tests**
+
+Run: `cargo test -p tenferro --test oracle_replay --release -- --nocapture shard_`
+Expected: all shard tests pass
+
+- [ ] **Step 2: Run workspace nextest**
+
+Run: `cargo nextest run --workspace --release --no-fail-fast`
+Expected: all tests pass, and oracle replay work is no longer represented by one long tail test
+
+- [ ] **Step 3: Record outcome**
+
+Capture the new shard timings and compare them against the baseline `oracle_replay_all` runtime of about 80 seconds.

--- a/docs/superpowers/specs/2026-04-10-oracle-replay-adaptive-sharding-design.md
+++ b/docs/superpowers/specs/2026-04-10-oracle-replay-adaptive-sharding-design.md
@@ -1,0 +1,117 @@
+# Oracle Replay Adaptive Sharding Design
+
+## Goal
+
+Reduce `cargo nextest run --workspace --release --no-fail-fast` wall time further by replacing the current fixed 4-way oracle replay split with an adaptive scheme that chooses shard count from the execution environment and keeps shard runtimes more even.
+
+## Current State
+
+`tenferro/tests/oracle_replay/main.rs` currently exposes four replay shard tests plus an ignored legacy `oracle_replay_all`. The fixed split reduced workspace wall time from about 80.8 seconds to about 30.5 seconds, but the slowest shard still ran for about 30.2 seconds while the others finished earlier. The remaining tail comes from uneven case cost and from treating shard count as a compile-time constant.
+
+## Requirements
+
+1. Shard count must be environment-sensitive by default.
+2. A caller must be able to override shard count explicitly for CI or local debugging.
+3. The number of registered test entrypoints must remain fixed at compile time because Rust integration tests cannot be generated dynamically.
+4. The active shard set must remain deterministic for a given environment and override configuration.
+5. Per-shard backend thread count must continue to scale down with the active shard count to avoid oversubscription.
+6. Existing `ORACLE_REPLAY_OP` and `ORACLE_REPLAY_CASE_LIMIT` behavior must remain available.
+
+## Approaches Considered
+
+### 1. Environment override only
+
+Use `ORACLE_REPLAY_SHARD_COUNT` and otherwise keep the current fixed default.
+
+Pros: smallest code change.
+Cons: no automatic improvement on larger or smaller machines; every environment needs manual tuning.
+
+### 2. Fully automatic shard count
+
+Derive shard count only from `available_parallelism()`.
+
+Pros: zero configuration.
+Cons: harder to stabilize across CI and local runs; risks picking too many tiny shards on large machines.
+
+### 3. Automatic default with explicit override
+
+Compute a default active shard count from `available_parallelism()` and bounded local heuristics, but allow `ORACLE_REPLAY_SHARD_COUNT` to override it.
+
+Pros: good default behavior, still reproducible when needed, clean CI escape hatch.
+Cons: slightly more logic.
+
+## Chosen Design
+
+Use approach 3.
+
+### Test shape
+
+Keep a fixed compile-time ceiling such as `MAX_ORACLE_REPLAY_SHARDS = 16`. Expose `oracle_replay_shard_0` through `oracle_replay_shard_15` as normal `#[test]` entrypoints. Each entrypoint queries the active shard count at runtime. If its index is outside the active shard count, it returns immediately.
+
+This preserves compatibility with Rust's static test registration while allowing the active shard count to vary by machine or by environment variable.
+
+### Active shard count
+
+Add `oracle_replay_active_shard_count(total_cases: usize) -> usize`.
+
+Resolution order:
+
+1. If `ORACLE_REPLAY_SHARD_COUNT` is set, parse and use it after validation.
+2. Otherwise compute a default from `available_parallelism()`.
+
+Default policy:
+
+- start from `available_parallelism()`
+- cap at `MAX_ORACLE_REPLAY_SHARDS`
+- cap at `total_cases` so we never create empty active shards
+- cap again by a minimum target cases-per-shard heuristic so we do not fragment small filtered runs
+
+The default should favor predictable coarse shards over maximal fan-out.
+
+### Shard balancing
+
+Build a lightweight replay manifest from the filtered case set, then assign entries to active shards with deterministic round-robin selection:
+
+- shard `i` executes entries where `entry_index % active_shard_count == i`
+
+This keeps large case files and expensive ops interleaved across shards. A contiguous weighted-range prototype was measured and rejected because the manifest order clusters expensive operations near the tail of the replay corpus; that produced badly imbalanced shards even when case counts looked balanced.
+
+### Thread budgeting
+
+Continue deriving backend thread count from active shard count:
+
+- `threads = max(1, available_parallelism / active_shard_count)`
+
+This keeps the outer test parallelism and inner CPU backend parallelism in balance.
+
+## Data Flow
+
+1. Discover case files.
+2. Apply `ORACLE_REPLAY_OP`.
+3. Load or count cases needed to build the filtered manifest.
+4. Apply `ORACLE_REPLAY_CASE_LIMIT`.
+5. Compute active shard count.
+6. Assign manifest entries to shards with round-robin selection.
+7. Each registered shard test either exits early or runs its assigned entry subset with the derived backend thread budget.
+
+## Error Handling
+
+- Invalid `ORACLE_REPLAY_SHARD_COUNT` should panic with a precise message, matching the existing style used for `ORACLE_REPLAY_CASE_LIMIT`.
+- Values less than 1 or greater than `MAX_ORACLE_REPLAY_SHARDS` should be rejected explicitly.
+- If filtering leaves zero runnable cases, shard tests should return successfully without work.
+
+## Testing
+
+Add focused tests for:
+
+1. environment override parsing and validation
+2. automatic shard count clamping
+3. shard assignment coverage: every manifest entry belongs to exactly one active shard
+4. shard assignment balance: entry counts across shards stay within a small bound on deterministic fixtures
+5. inactive shard entrypoints exiting without replay work
+
+Retain any helper-level partition tests only as analysis support; the execution path should be validated against the round-robin selector that the test runner actually uses.
+
+## Expected Outcome
+
+The workspace `nextest` run should still pass cleanly. Exact timing remains machine-dependent, but the design should remove the need to hard-code shard count for each environment while staying close to or better than the fixed-4 baseline on typical developer machines.

--- a/tenferro/tests/oracle_replay/main.rs
+++ b/tenferro/tests/oracle_replay/main.rs
@@ -5,6 +5,7 @@ mod dispatch;
 mod observable;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::ops::Range;
 use std::{env, num::ParseIntError};
 
 use num_complex::{Complex32, Complex64};
@@ -17,6 +18,9 @@ use crate::db::{oracle_cases_dir, try_discover_case_files, try_load_cases};
 use crate::decode::{try_decode_tensor, CaseRecord, Probe, TensorData, Tolerance};
 use crate::dispatch::{dispatch_case, DispatchResult, NamedTensor};
 use crate::observable::apply_observable;
+
+const MAX_ORACLE_REPLAY_SHARDS: usize = 16;
+const MIN_CASES_PER_ORACLE_REPLAY_SHARD: usize = 2_048;
 
 #[derive(Default)]
 struct ReplayStats {
@@ -44,8 +48,63 @@ enum DerivativeKind {
     Hvp,
 }
 
+struct LoadedCaseFile {
+    cases: Vec<CaseRecord>,
+}
+
+struct ManifestEntry {
+    file_index: usize,
+    case_index: usize,
+}
+
+struct ReplayManifest {
+    loaded_files: Vec<LoadedCaseFile>,
+    entries: Vec<ManifestEntry>,
+    load_failures: Vec<String>,
+}
+
 #[test]
+#[ignore = "replaced by sharded tests for nextest parallelism"]
 fn oracle_replay_all() {
+    run_oracle_replay(0, Some(1));
+}
+
+macro_rules! oracle_replay_shard_tests {
+    ($(($name:ident, $index:expr)),* $(,)?) => {
+        $(
+            #[test]
+            fn $name() {
+                run_oracle_replay($index, None);
+            }
+        )*
+    };
+}
+
+oracle_replay_shard_tests!(
+    (oracle_replay_shard_0, 0),
+    (oracle_replay_shard_1, 1),
+    (oracle_replay_shard_2, 2),
+    (oracle_replay_shard_3, 3),
+    (oracle_replay_shard_4, 4),
+    (oracle_replay_shard_5, 5),
+    (oracle_replay_shard_6, 6),
+    (oracle_replay_shard_7, 7),
+    (oracle_replay_shard_8, 8),
+    (oracle_replay_shard_9, 9),
+    (oracle_replay_shard_10, 10),
+    (oracle_replay_shard_11, 11),
+    (oracle_replay_shard_12, 12),
+    (oracle_replay_shard_13, 13),
+    (oracle_replay_shard_14, 14),
+    (oracle_replay_shard_15, 15),
+);
+
+fn run_oracle_replay(registered_shard_index: usize, forced_shard_count: Option<usize>) {
+    assert!(
+        registered_shard_index < MAX_ORACLE_REPLAY_SHARDS,
+        "invalid registered shard index {registered_shard_index}"
+    );
+
     let root = oracle_cases_dir();
     let case_files = match try_discover_case_files(&root) {
         Ok(files) => files,
@@ -62,44 +121,48 @@ fn oracle_replay_all() {
         Err(err) => panic!("{err}"),
     };
 
-    for (op_name, path) in &case_files {
-        if op_filter.as_deref().is_some_and(|filter| op_name != filter) {
+    let manifest = build_replay_manifest(&case_files, op_filter.as_deref(), case_limit);
+    stats.failed.extend(manifest.load_failures);
+
+    let active_shard_count = match forced_shard_count {
+        Some(count) => count.min(manifest.entries.len().max(1)),
+        None => match resolve_active_shard_count(manifest.entries.len()) {
+            Ok(count) => count,
+            Err(err) => panic!("{err}"),
+        },
+    };
+    if registered_shard_index >= active_shard_count {
+        return;
+    }
+
+    let backend_threads = oracle_replay_backend_threads(active_shard_count);
+
+    for (entry_index, manifest_entry) in manifest.entries.iter().enumerate() {
+        if !entry_in_active_shard(entry_index, registered_shard_index, active_shard_count) {
             continue;
         }
-        let cases = match try_load_cases(path) {
-            Ok(cases) => cases,
-            Err(err) => {
-                stats.failed.push(err);
-                continue;
+        let case =
+            &manifest.loaded_files[manifest_entry.file_index].cases[manifest_entry.case_index];
+        stats.cases += 1;
+        let mut engine = Engine::new(CpuBackend::with_threads(backend_threads));
+        match replay_case(case, &mut engine) {
+            Ok(CaseOutcome::Passed) => stats.passed += 1,
+            Ok(CaseOutcome::SkippedDType) => stats.skipped_dtype += 1,
+            Ok(CaseOutcome::ExpectedError) => stats.expected_error += 1,
+            Ok(CaseOutcome::SkippedUnimplemented(op)) => {
+                stats.skipped_unimplemented_cases += 1;
+                stats.skipped_unimplemented_ops.insert(op);
             }
-        };
-
-        for case in &cases {
-            if op_filter.as_deref().is_some_and(|filter| case.op != filter) {
-                continue;
-            }
-            if stats.cases >= case_limit {
-                break;
-            }
-            stats.cases += 1;
-            let mut engine = Engine::new(CpuBackend::new());
-            match replay_case(case, &mut engine) {
-                Ok(CaseOutcome::Passed) => stats.passed += 1,
-                Ok(CaseOutcome::SkippedDType) => stats.skipped_dtype += 1,
-                Ok(CaseOutcome::ExpectedError) => stats.expected_error += 1,
-                Ok(CaseOutcome::SkippedUnimplemented(op)) => {
-                    stats.skipped_unimplemented_cases += 1;
-                    stats.skipped_unimplemented_ops.insert(op);
-                }
-                Err(err) => stats.failed.push(format!("{}: {err}", case.case_id)),
-            }
-        }
-        if stats.cases >= case_limit {
-            break;
+            Err(err) => stats.failed.push(format!("{}: {err}", case.case_id)),
         }
     }
 
-    print_summary(&stats);
+    print_summary(
+        &stats,
+        registered_shard_index,
+        active_shard_count,
+        backend_threads,
+    );
     assert!(
         stats.failed.is_empty(),
         "oracle replay had {} failures",
@@ -318,6 +381,266 @@ fn parse_case_limit(value: Option<String>) -> Result<usize, String> {
         }),
         None => Ok(usize::MAX),
     }
+}
+
+#[test]
+fn adaptive_shard_count_override_validates_bounds() {
+    assert_eq!(
+        parse_shard_count_override(Some("4".to_string()), 16).expect("valid override"),
+        Some(4)
+    );
+    assert!(parse_shard_count_override(Some("0".to_string()), 16)
+        .expect_err("zero override must fail")
+        .contains("must be between 1 and 16"));
+    assert!(parse_shard_count_override(Some("17".to_string()), 16)
+        .expect_err("too-large override must fail")
+        .contains("must be between 1 and 16"));
+}
+
+#[test]
+fn adaptive_auto_shard_count_clamps_to_limits() {
+    assert_eq!(compute_auto_shard_count(8, 9_572, 16, 2_048), 4);
+    assert_eq!(compute_auto_shard_count(64, 9_572, 16, 2_048), 4);
+    assert_eq!(compute_auto_shard_count(8, 600, 16, 2_048), 1);
+    assert_eq!(compute_auto_shard_count(8, 0, 16, 2_048), 1);
+}
+
+#[test]
+fn adaptive_partition_covers_each_entry_once() {
+    let weights = vec![3usize, 3, 3, 3, 3, 3, 3];
+    let ranges = partition_weighted_indices(&weights, 3);
+    let mut owners = vec![0usize; weights.len()];
+
+    for (shard_index, range) in ranges.iter().enumerate() {
+        for entry_index in range.clone() {
+            owners[entry_index] += 1;
+            assert!(entry_index < weights.len(), "entry index out of bounds");
+        }
+        assert!(
+            range.start <= range.end,
+            "invalid range for shard {shard_index}"
+        );
+    }
+
+    assert!(owners.into_iter().all(|count| count == 1));
+}
+
+#[test]
+fn adaptive_partition_balances_weighted_fixture() {
+    let weights = vec![8usize, 1, 8, 1, 8, 1];
+    let ranges = partition_weighted_indices(&weights, 3);
+    let shard_weights: Vec<usize> = ranges
+        .iter()
+        .map(|range| weights[range.clone()].iter().sum())
+        .collect();
+    assert_eq!(shard_weights, vec![9, 9, 9]);
+}
+
+#[test]
+fn adaptive_entry_assignment_covers_each_index_once() {
+    let shard_count = 5usize;
+    for entry_index in 0..97usize {
+        let owners: Vec<usize> = (0..shard_count)
+            .filter(|&shard_index| entry_in_active_shard(entry_index, shard_index, shard_count))
+            .collect();
+        assert_eq!(
+            owners,
+            vec![entry_index % shard_count],
+            "entry {entry_index}"
+        );
+    }
+}
+
+#[test]
+fn adaptive_entry_assignment_balances_prefix_within_one() {
+    let shard_count = 5usize;
+    let total_entries = 97usize;
+    let counts: Vec<usize> = (0..shard_count)
+        .map(|shard_index| {
+            (0..total_entries)
+                .filter(|&entry_index| entry_in_active_shard(entry_index, shard_index, shard_count))
+                .count()
+        })
+        .collect();
+    let min = *counts.iter().min().expect("non-empty shard counts");
+    let max = *counts.iter().max().expect("non-empty shard counts");
+    assert!(max - min <= 1, "counts: {counts:?}");
+}
+
+fn entry_in_active_shard(entry_index: usize, shard_index: usize, shard_count: usize) -> bool {
+    assert!(shard_count > 0, "shard_count must be > 0");
+    assert!(
+        shard_index < shard_count,
+        "invalid shard {shard_index}/{shard_count}"
+    );
+    entry_index % shard_count == shard_index
+}
+
+fn parse_shard_count_override(
+    value: Option<String>,
+    max_supported: usize,
+) -> Result<Option<usize>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let parsed = value.parse::<usize>().map_err(|err: ParseIntError| {
+        format!("invalid ORACLE_REPLAY_SHARD_COUNT {value}: {err}")
+    })?;
+    if !(1..=max_supported).contains(&parsed) {
+        return Err(format!(
+            "ORACLE_REPLAY_SHARD_COUNT must be between 1 and {max_supported}, got {parsed}"
+        ));
+    }
+    Ok(Some(parsed))
+}
+
+fn compute_auto_shard_count(
+    available_parallelism: usize,
+    total_cases: usize,
+    max_supported: usize,
+    min_cases_per_shard: usize,
+) -> usize {
+    let available_parallelism = available_parallelism.max(1);
+    let total_cases_cap = total_cases.max(1);
+    let max_supported = max_supported.max(1);
+    let min_cases_per_shard = min_cases_per_shard.max(1);
+    let by_case_budget = std::cmp::max(1, total_cases / min_cases_per_shard);
+
+    available_parallelism
+        .min(total_cases_cap)
+        .min(max_supported)
+        .min(by_case_budget)
+}
+
+fn resolve_active_shard_count(total_cases: usize) -> Result<usize, String> {
+    let override_count = parse_shard_count_override(
+        env::var("ORACLE_REPLAY_SHARD_COUNT").ok(),
+        MAX_ORACLE_REPLAY_SHARDS,
+    )?;
+    if let Some(count) = override_count {
+        return Ok(count.min(total_cases.max(1)));
+    }
+
+    let available_parallelism = std::thread::available_parallelism()
+        .map(|threads| threads.get())
+        .unwrap_or(1);
+    Ok(compute_auto_shard_count(
+        available_parallelism,
+        total_cases,
+        MAX_ORACLE_REPLAY_SHARDS,
+        MIN_CASES_PER_ORACLE_REPLAY_SHARD,
+    ))
+}
+
+fn partition_weighted_indices(weights: &[usize], shard_count: usize) -> Vec<Range<usize>> {
+    assert!(shard_count > 0, "shard_count must be > 0");
+    if weights.is_empty() {
+        return (0..shard_count).map(|_| 0..0).collect();
+    }
+
+    let total_weight: usize = weights.iter().sum();
+    let mut ranges = Vec::with_capacity(shard_count);
+    let mut start = 0usize;
+    let mut cumulative_weight = 0usize;
+
+    for shard_index in 0..shard_count {
+        if shard_index == shard_count - 1 {
+            ranges.push(start..weights.len());
+            break;
+        }
+        if start >= weights.len() {
+            ranges.push(weights.len()..weights.len());
+            continue;
+        }
+
+        let remaining_shards = shard_count - shard_index;
+        let remaining_entries = weights.len() - start;
+        if remaining_entries <= remaining_shards {
+            cumulative_weight += weights[start];
+            ranges.push(start..start + 1);
+            start += 1;
+            continue;
+        }
+
+        let target_weight = (total_weight * (shard_index + 1)).div_ceil(shard_count);
+        let max_end = weights.len() - (remaining_shards - 1);
+        let mut end = start;
+        while end < max_end && cumulative_weight < target_weight {
+            cumulative_weight += weights[end];
+            end += 1;
+        }
+        if end == start {
+            cumulative_weight += weights[end];
+            end += 1;
+        }
+        ranges.push(start..end);
+        start = end;
+    }
+
+    while ranges.len() < shard_count {
+        ranges.push(weights.len()..weights.len());
+    }
+    ranges
+}
+
+fn build_replay_manifest(
+    case_files: &[(String, std::path::PathBuf)],
+    op_filter: Option<&str>,
+    case_limit: usize,
+) -> ReplayManifest {
+    let mut loaded_files = Vec::new();
+    let mut entries = Vec::new();
+    let mut load_failures = Vec::new();
+
+    for (op_name, path) in case_files {
+        if op_filter.is_some_and(|filter| op_name != filter) {
+            continue;
+        }
+        let cases = match try_load_cases(path) {
+            Ok(cases) => cases,
+            Err(err) => {
+                load_failures.push(err);
+                continue;
+            }
+        };
+
+        let file_index = loaded_files.len();
+        let case_count = cases.len();
+        loaded_files.push(LoadedCaseFile { cases });
+
+        for case_index in 0..case_count {
+            if entries.len() >= case_limit {
+                break;
+            }
+            let case = &loaded_files[file_index].cases[case_index];
+            if op_filter.is_some_and(|filter| case.op != filter) {
+                continue;
+            }
+            entries.push(ManifestEntry {
+                file_index,
+                case_index,
+            });
+        }
+        if entries.len() >= case_limit {
+            break;
+        }
+    }
+
+    ReplayManifest {
+        loaded_files,
+        entries,
+        load_failures,
+    }
+}
+
+fn oracle_replay_backend_threads(shard_count: usize) -> usize {
+    let available = std::thread::available_parallelism()
+        .map(|threads| threads.get())
+        .unwrap_or(1);
+    if shard_count <= 1 {
+        return available;
+    }
+    std::cmp::max(1, available / shard_count)
 }
 
 fn replay_case(case: &CaseRecord, engine: &mut Engine<CpuBackend>) -> Result<CaseOutcome, String> {
@@ -653,8 +976,16 @@ fn supports_output(case: &CaseRecord, derivative: DerivativeKind, name: &str) ->
     )
 }
 
-fn print_summary(stats: &ReplayStats) {
+fn print_summary(
+    stats: &ReplayStats,
+    shard_index: usize,
+    shard_count: usize,
+    backend_threads: usize,
+) {
     eprintln!("oracle replay summary:");
+    eprintln!("  shard: {}/{}", shard_index + 1, shard_count);
+    eprintln!("  backend threads: {}", backend_threads);
+    eprintln!("  selector: entry % {} == {}", shard_count, shard_index);
     eprintln!("  files: {}", stats.files);
     eprintln!("  cases: {}", stats.cases);
     eprintln!("  passed: {}", stats.passed);


### PR DESCRIPTION
## Summary
- replace the monolithic oracle replay test with sharded nextest entrypoints
- make the active shard count configurable and environment-sensitive
- record the sharding design notes used for the implementation

## Why
- `oracle_replay_all` dominated workspace nextest time at about 80.5 seconds
- letting nextest schedule oracle replay shards reduces the long tail to about 31.1 seconds for the full workspace run on this machine
- the automatic shard count stays conservative so the CPU backend still gets multiple worker threads per active shard

## Validation
- `cargo fmt --all`
- `cargo test -p tenferro --test oracle_replay --release adaptive_`
- `cargo test -p tenferro --test oracle_replay --release shard_`
- `cargo nextest run --workspace --release --no-fail-fast`
