### PR TITLE
[codex] Make public tensors stride-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ path.
 - CPU execution is implemented and tested.
 - GPU support is partial and experimental. CUDA symbols exist, but coverage is
   incomplete and ROCm remains mostly stubbed.
-- Tensor storage is dense, contiguous, and column-major.
+- Tensor values are dense and stride-aware. New host allocations default to
+  column-major layout, and explicit materialization chooses row-major or
+  column-major output when needed.
 
 Legacy facade, internal, FFI, and extension crates were removed from the main
 tree on April 6, 2026 to keep the repository aligned with the current 6-crate
@@ -178,8 +180,8 @@ fn main() {
 
 - [Getting Started](docs/getting-started/) — tutorials and worked examples
 - [Architecture](docs/architecture/) — design rationale for each subsystem
-- [Specification](docs/spec/) — normative specs for ops, backends, and AD
-- [Implementation Design](docs/design/) — implementation-focused design notes
+- [Implementation Design](docs/design/) — current implementation-focused design notes
+- [Specification](docs/spec/) — legacy low-level notes that are being retired from source-of-truth status
 
 ## Design Notes
 
@@ -206,11 +208,10 @@ architecture and ChainRules.jl's derivative contract. The key original contribut
 
 Key types:
 
-- `Tensor` — concrete dense runtime value (col-major storage).
+- `Tensor` — concrete dense runtime value with stride-aware host layout metadata.
 - `TracedTensor` — lazy graph-aware wrapper for computation and AD.
 - `Engine` — holds backend + compile cache; triggers evaluation.
 - Public einsum: `tenferro::einsum::einsum(...)`.
 - Multi-output linalg: free functions `tenferro::svd(...)`, `tenferro::qr(...)`, etc.
-See [`docs/architecture/`](docs/architecture/) for design rationale,
-[`docs/spec/`](docs/spec/) for normative specifications, and
-[`docs/design/`](docs/design/) for implementation-focused design notes.
+See [`docs/architecture/`](docs/architecture/) for design rationale and
+[`docs/design/`](docs/design/) for current implementation-focused design notes.

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -4,6 +4,14 @@
 
 - `README`, rustdoc, and examples must not claim capabilities beyond the current public surface.
 - When the public API changes, check for stale names, stale capability claims, and deleted paths in `README`, rustdoc, and examples before considering the work complete.
+- `docs/design/**` must stay in sync with the current implementation for any subsystem whose behavior or public contract changed in the branch.
+
+## Tensor Layout Guardrails
+
+- Public tensors are stride-aware. Dense column-major storage is the default allocation layout, not a global invariant.
+- Runtime and kernel code must use tensor stride/offset metadata directly instead of reconstructing layout from shape alone.
+- Explicit materialization boundaries must stay explicit. If an operation requires dense column-major input, materialize at that boundary instead of earlier in the pipeline.
+- FFI and C-API boundaries must export column-major contiguous tensors unless the external contract explicitly says otherwise.
 
 ## Oracle Gate
 

--- a/docs/design/capi.md
+++ b/docs/design/capi.md
@@ -1,7 +1,19 @@
 # C-API (FFI)
 
-C-API for Julia, Python (JAX, PyTorch), and other languages. Exposes
-tensor lifecycle, einsum, SVD (with AD rules), and DLPack interop.
+The main workspace does not currently ship an active `tenferro-capi` crate.
+This document is a design note for when the FFI layer is reintroduced.
+
+The important current contract is simpler than the historical design below:
+
+- internal tensors are stride-aware
+- FFI is an explicit materialization boundary
+- exported dense tensors must be column-major contiguous unless the external
+  ABI explicitly states another layout
+- imported tensors must validate or normalize layout explicitly instead of
+  assuming arbitrary incoming pointers already match the runtime contract
+
+The older design notes below are retained as background for lifecycle, error,
+and DLPack considerations.
 
 ---
 

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,8 +1,8 @@
 # Implementation Design Notes
 
-Implementation-focused design notes for specific subsystems. For high-level
-architecture see [Architecture](../architecture/). For normative specs see
-[Specification](../spec/).
+Implementation-focused design notes for specific subsystems. These notes are
+kept current with the code for low-level behavior and runtime contracts. For
+high-level structure see [Architecture](../architecture/).
 
 ## Core Design
 

--- a/docs/design/tensor.md
+++ b/docs/design/tensor.md
@@ -1,367 +1,90 @@
 # Tensor
 
-`Tensor<T>` is the core data type. It wraps a `DataBuffer<T>` with
-shape/stride metadata and provides zero-copy view operations.
+`tenferro-tensor` now treats layout as first-class runtime metadata. The
+public dense tensor types are:
 
----
+- `TypedTensor<T>` for a concrete scalar type
+- `Tensor` as the dynamic dtype enum wrapper
 
-## Core Types
+The current host representation is:
 
 ```rust
-/// Memory ordering for new allocations only.
-/// Not stored on the tensor — strides fully describe the layout.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MemoryOrder {
-    ColumnMajor,  // First dimension has stride 1 (Fortran/Julia)
-    RowMajor,     // Last dimension has stride 1 (C/NumPy)
+pub enum Buffer<T> {
+    Host(Arc<Vec<T>>),
+    Backend(BufferHandle<T>),
 }
 
-/// Owned data buffer, device-aware.
-/// Internally wraps Arc<BufferInner<T>> for shared ownership.
-pub struct DataBuffer<T> {
-    inner: Arc<BufferInner<T>>,
-}
-
-enum BufferInner<T> {
-    Owned(Vec<T>),
-    External { ptr: *const T, len: usize, release: Option<Box<dyn FnOnce() + Send>> },
-    Gpu { device_ptr: *mut T, len: usize, space: LogicalMemorySpace, release: ... },
-}
-
-/// Multi-dimensional dense tensor.
-pub struct Tensor<T> {
-    buffer: DataBuffer<T>,
-    dims: Arc<[usize]>,
-    strides: Arc<[isize]>,
-    offset: isize,
-    logical_memory_space: LogicalMemorySpace,
-    preferred_compute_device: Option<ComputeDevice>,
-    event: Option<CompletionEvent>,
-    conjugated: bool,     // lazy conjugation flag
-    fw_grad: Option<Box<Tensor<T>>>,  // forward-mode AD tangent
+pub struct TypedTensor<T> {
+    pub buffer: Buffer<T>,
+    pub shape: Vec<usize>,
+    pub strides: Vec<isize>,
+    pub offset: isize,
+    pub placement: Placement,
 }
 ```
 
-Key design points:
-- `DataBuffer<T>` uses `Arc<BufferInner<T>>` for shared ownership (PyTorch pattern)
-- `clone()` is shallow (Arc refcount++, O(1))
-- `conj()` is lazy (Arc clone + conjugated flag flip, O(1))
-- Deep copy uses explicit materialization (`MakeContiguous`)
-- Fields: `dims` (`Arc<[usize]>`), `strides` (`Arc<[isize]>`), `offset` (`isize`) — no `SmallVec`
-- `fw_grad: Option<Box<Tensor<T>>>` carries the forward-mode AD tangent
-- `MemoryOrder` is only used at allocation time, **not stored** on the tensor
-- No direct dependency on strided-rs — prims backends build `StridedView` from
-  `buffer.as_slice()` + `dims()` + `strides()` + `offset()`
-
----
-
-## Constructors
-
-```rust
-impl<T: Scalar> Tensor<T> {
-    pub fn zeros(dims: &[usize], memory_space: LogicalMemorySpace, order: MemoryOrder) -> Result<Self>;
-    pub fn ones(dims: &[usize], memory_space: LogicalMemorySpace, order: MemoryOrder) -> Result<Self>;
-    pub fn from_slice(data: &[T], dims: &[usize], order: MemoryOrder) -> Result<Self>;
-    pub fn from_vec(data: Vec<T>, dims: &[usize], strides: &[isize], offset: isize) -> Result<Self>;
-    pub fn eye(n: usize, memory_space: LogicalMemorySpace, order: MemoryOrder) -> Result<Self>;
-}
-```
-
-## Metadata
-
-```rust
-impl<T> Tensor<T> {
-    pub fn dims(&self) -> &[usize];
-    pub fn strides(&self) -> &[isize];
-    pub fn ndim(&self) -> usize;
-    pub fn len(&self) -> usize;
-    pub fn is_empty(&self) -> bool;
-    pub fn offset(&self) -> isize;
-    pub fn buffer(&self) -> &DataBuffer<T>;
-    pub fn logical_memory_space(&self) -> LogicalMemorySpace;
-    pub fn preferred_compute_device(&self) -> Option<ComputeDevice>;
-    pub fn set_preferred_compute_device(&mut self, d: Option<ComputeDevice>);
-    pub fn effective_compute_devices(&self, op: OpKind) -> Result<Vec<ComputeDevice>>;
-    pub fn is_conjugated(&self) -> bool;
-}
-```
-
-## View Operations (zero-copy)
-
-All view operations return `Tensor<T>` (not `TensorView`). They are
-zero-copy because `DataBuffer` uses `Arc` — the returned tensor shares
-the same underlying buffer with only metadata (dims, strides, offset)
-changed.
-
-```rust
-impl<T> Tensor<T> {
-    pub fn permute(&self, perm: &[usize]) -> Result<Tensor<T>>;
-    pub fn broadcast(&self, target_dims: &[usize]) -> Result<Tensor<T>>;
-    pub fn diagonal(&self, axes: &[(usize, usize)]) -> Result<Tensor<T>>;
-    pub fn reshape(&self, new_dims: &[usize]) -> Result<Tensor<T>>;
-    pub fn select(&self, dim: usize, index: usize) -> Result<Tensor<T>>;
-    pub fn narrow(&self, dim: usize, start: usize, length: usize) -> Result<Tensor<T>>;
-}
-```
-
-## Data Operations
-
-```rust
-impl<T: Scalar> Tensor<T> {
-    pub fn contiguous(&self, order: MemoryOrder) -> Tensor<T>;
-    pub fn into_contiguous(self, order: MemoryOrder) -> Tensor<T>;
-    pub fn tril(&self, diagonal: isize) -> Tensor<T>;
-    pub fn triu(&self, diagonal: isize) -> Tensor<T>;
-    pub fn get(&self, index: &[usize]) -> Option<&T>;
-    pub fn to_vec(&self) -> Vec<T>;
-}
-
-impl<T: Conjugate> Tensor<T> {
-    pub fn conj(&self) -> Tensor<T>;       // lazy: Arc clone + flag flip
-    pub fn into_conj(self) -> Tensor<T>;   // lazy: flag flip only (no refcount)
-}
-
-impl<T> Tensor<T> {
-    pub fn is_contiguous(&self) -> bool;
-    pub fn wait(&self);
-    pub fn is_ready(&self) -> bool;
-}
-```
-
-## Explicit Memory Movement
-
-```rust
-impl<T> Tensor<T> {
-    /// Asynchronous explicit move between logical memory spaces.
-    /// Same source/destination space: zero-copy no-op.
-    /// Different spaces: explicit transfer (never implicit in ops).
-    pub fn to_memory_space_async(&self, dst: LogicalMemorySpace) -> Result<Tensor<T>>;
-}
-```
-
----
-
-## DataBuffer Shared Ownership (Arc)
-
-### Motivation
-
-`Tensor<T>` needs cheap zero-copy operations (permute, broadcast, etc.)
-AND must satisfy `Differentiable::Tangent: Clone` from chainrules-core.
-Arc-based shared ownership achieves both:
-
-| Operation | Cost | Mechanism |
-|-----------|------|-----------|
-| `clone()` | O(1) | Arc refcount++ |
-| `conj()` | O(1) | Arc clone + flag flip |
-| `permute()` | O(1) | Arc clone + metadata change |
-| Deep copy | O(n) | `MakeContiguous` / explicit materialize |
-| `as_mut_slice()` | — | `Arc::get_mut()` — `Some` only if refcount == 1 |
-
-### DataBuffer API
-
-```rust
-impl<T> DataBuffer<T> {
-    pub fn from_vec(v: Vec<T>) -> Self;
-    pub unsafe fn from_external(ptr, len, release) -> Self;
-    pub fn as_slice(&self) -> Option<&[T]>;        // None for GPU
-    pub fn as_mut_slice(&mut self) -> Option<&mut [T]>; // None if shared or GPU
-    pub fn as_ptr(&self) -> Option<*const T>;       // None for GPU
-    pub fn as_device_ptr(&self) -> Option<*const T>; // None for CPU
-    pub fn len(&self) -> usize;
-    pub fn is_empty(&self) -> bool;
-    pub fn is_owned(&self) -> bool;
-    pub fn is_gpu(&self) -> bool;
-    pub fn is_unique(&self) -> bool;  // Arc::strong_count == 1
-    pub fn gpu_memory_space(&self) -> Option<LogicalMemorySpace>;
-}
-```
-
-### Mutable Access Pattern
-
-`as_mut_slice()` uses `Arc::get_mut()` — returns `Some` only when
-the Arc reference count is 1 (exclusive ownership). If shared:
-
-```rust
-// Shared: as_mut_slice() returns None
-let a = tensor.clone(); // Arc refcount = 2
-assert!(tensor.buffer_mut().as_mut_slice().is_none());
-
-// Deep copy first to get exclusive ownership
-let mut deep = /* prims MakeContiguous */ ;
-assert!(deep.buffer_mut().as_mut_slice().is_some());
-```
-
-Prims backends bypass this via raw pointers (unsafe), guaranteeing
-non-overlapping input/output buffers.
-
----
-
-## View Operations: No Separate TensorView Type
-
-All view operations return `Tensor<T>`, not a separate `TensorView` type.
-Because `DataBuffer<T>` uses `Arc`, view operations are zero-copy: they
-share the underlying buffer and only change metadata (dims, strides, offset).
-
-```rust
-impl<T> Tensor<T> {
-    // Zero-copy metadata operations → return Tensor (Arc shared)
-    fn permute(&self, perm: &[usize]) -> Result<Tensor<T>>;
-    fn broadcast(&self, dims: &[usize]) -> Result<Tensor<T>>;
-    fn diagonal(&self, axes: &[(usize, usize)]) -> Result<Tensor<T>>;
-    fn reshape(&self, new_dims: &[usize]) -> Result<Tensor<T>>;
-    fn select(&self, dim: usize, index: usize) -> Result<Tensor<T>>;
-    fn narrow(&self, dim: usize, start: usize, length: usize) -> Result<Tensor<T>>;
-    fn unsqueeze(&self, dim: isize) -> Result<Tensor<T>>;
-    fn squeeze(&self) -> Result<Tensor<T>>;
-    fn mT(&self) -> Result<Tensor<T>>;  // matrix transpose (last two axes)
-}
-
-impl<T: Scalar> Tensor<T> {
-    // Consume self → Tensor (may reuse buffer if unique)
-    fn into_contiguous(self, order: MemoryOrder) -> Tensor<T>;
-    // Borrow → new Tensor (Arc shared or new allocation)
-    fn contiguous(&self, order: MemoryOrder) -> Tensor<T>;
-}
-
-impl<T: Conjugate> Tensor<T> {
-    fn into_conj(self) -> Tensor<T>;
-    fn conj(&self) -> Tensor<T>;  // lazy: Arc clone + flag flip
-    fn mH(&self) -> Result<Tensor<T>>;  // conjugate transpose
-}
-```
-
-**einsum takes &Tensor references:**
-
-```rust
-pub fn einsum<Alg, Backend>(
-    ctx: &mut BackendContext<Alg, Backend>,
-    subscripts: &str,
-    operands: &[&Tensor<Alg::Scalar>],
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<Alg::Scalar>>
-where
-    Alg: Semiring,
-    Alg::Scalar: Scalar + Conjugate + HasAlgebra<Algebra = Alg>,
-    Backend: EinsumBackend<Alg>;
-```
-
-### Ownership Safety Examples
-
-```rust
-let a = Tensor::<f64>::zeros(&[3, 4], LogicalMemorySpace::MainMemory, ColumnMajor).unwrap();
-
-// permute returns Tensor (Arc shared, zero-copy)
-let at = a.permute(&[1, 0]).unwrap();
-assert_eq!(at.dims(), &[4, 3]);
-// a and at share the same buffer — both usable simultaneously
-
-// clone is cheap (Arc refcount++)
-let a2 = a.clone();
-```
-
-### Design Choice: Arc-Only (No TensorView)
-
-Arc was chosen over a separate `TensorView<'a, T>` because:
-1. `Differentiable::Tangent: Clone` in chainrules-core requires Clone on Tensor
-2. GPU buffer clone needs device operations — Arc avoids this for shallow clone
-3. `conj()` needs buffer sharing for lazy semantics (both CPU and GPU)
-4. View operations return owned `Tensor<T>` — simpler API, no lifetime propagation
-
-A borrowed `TensorView<'a, T>` could be added in the future for
-specialized use cases (e.g., GPU event wait semantics, avoiding Arc
-refcount overhead on read-only access), but the current implementation
-uses `Tensor<T>` uniformly
-
----
-
-## Asynchronous Execution (CompletionEvent)
-
-### Chosen Approach: Tensor Embeds Async State
-
-Rather than separate `einsum` / `einsum_async` functions, `Tensor<T>`
-carries an optional `CompletionEvent` that tracks pending accelerator
-computation (PyTorch model):
-
-```rust
-// Accelerator operations return immediately with event attached
-let c = einsum("ij,jk->ik", &[&a_gpu, &b_gpu])?;
-//  → GPU submit, c.event = Some(event_1), returns immediately
-
-let d = einsum("ij,jk->ik", &[&c, &e_gpu])?;
-//  → detects c.event → sets up stream dependency → no CPU wait
-
-// CPU data access triggers implicit synchronization
-let slice = d.buffer().as_slice();  // as_slice() calls wait() internally
-```
-
-For CPU tensors, `event` is always `None` with zero overhead.
-
-### CompletionEvent Variants
-
-```rust
-pub struct CompletionEvent {
-    inner: CompletionEventInner,
-}
-
-enum CompletionEventInner {
-    Noop,
-    Cuda { _event: *mut c_void },   // cudaEvent_t
-    Rocm { _event: *mut c_void },   // hipEvent_t
-}
-```
-
-### Two-Tier API Contract
-
-| Tier | Methods | Event handling | User visibility |
-|------|---------|---------------|-----------------|
-| **Public (CPU-read)** | `buffer().as_slice()`, `permute()`, `broadcast()`, `diagonal()`, etc. | **Wait** if pending, return ready data | Yes |
-| **Internal (pipeline)** | `pub(crate) as_operand_view()` | **Propagate** event | No (crate-internal) |
-| **Accelerator ops** | `einsum` (takes `&[&Tensor]`) | Calls `as_operand_view()` internally, **detects** events → stream dependency | Yes (transparent) |
-
-### Applicability Beyond GPU
-
-`CompletionEvent` applies equally to multi-threaded CPU execution:
-
-- **Contraction tree parallelism**: Independent subtrees dispatched to
-  different threads, each result carries a `CompletionEvent`.
-- **User-level parallelism**: Independent `einsum` calls on separate threads
-  with automatic event-based chaining.
-
-**Implementation note**: `wait(&self)` requires interior mutability
-(e.g., `Cell<Option<CompletionEvent>>`) to clear the event field through
-a shared reference.
-
-**Current status**: POC `event` field is `Option<CompletionEvent>` (placeholder).
-Actual async execution will be implemented with accelerator backends.
-
----
-
-## Lazy Conjugation
-
-`Tensor::conj()` is always lazy (both CPU and GPU), matching PyTorch's
-`torch.conj()` semantics:
-
-| Operation | Cost | Mechanism |
-|-----------|------|-----------|
-| `tensor.conj()` | O(1) | Arc clone + `conjugated` flag flip |
-| `tensor.into_conj()` | O(1) | Flag flip only (no Arc clone) |
-| `view.conj()` | O(1) | Flag flip (zero-cost, no refcount) |
-| Materialize | O(n) | `Backend::resolve_conj()` via `ElementwiseUnary(Conj)` |
-
-Backends read `is_conjugated()` when building operation descriptors:
-- **GPU**: `CUTENSOR_OP_CONJ` / `HIPTENSOR_OP_CONJ` in tensor descriptors
-- **CPU**: conjugation applied during computation kernels
-
----
-
-## Custom Element-Wise Operations
-
-For arbitrary user functions not covered by the primitive family traits, use
-strided-kernel
-directly via `buffer().as_slice()`:
-
-```rust
-let a_slice = tensor_a.buffer().as_slice().unwrap();
-let b_slice = tensor_b.buffer().as_slice().unwrap();
-// Build StridedView from dims/strides/offset and use strided_kernel
-```
+## Core Rules
+
+- Dense tensors are stride-aware. Column-major layout is the default for new
+  host allocations, not a global invariant.
+- Host-backed tensor clones are shallow. `Buffer::Host` uses `Arc<Vec<T>>`, so
+  metadata-only views share storage.
+- Mutable host access is copy-on-write through `Arc::make_mut`.
+- Logical indexing always uses `shape + strides + offset`.
+- Kernels must not reconstruct layout from shape when stride metadata exists.
+
+## Layout Semantics
+
+`shape`, `strides`, and `offset` define the logical tensor view over the
+underlying storage.
+
+- `col_major_strides(shape)` gives the default column-major layout.
+- `row_major_strides(shape)` gives the dense row-major layout.
+- `is_contiguous_col_major()` and `is_contiguous_row_major()` are predicates
+  over the current metadata.
+- `to_contiguous(LayoutOrder)` materializes a dense host tensor in the
+  requested order.
+
+`host_data()` exposes the raw host storage buffer. It does not promise logical
+iteration order for non-contiguous tensors. Use `get()` for indexed access or
+`to_contiguous(...)` before handing storage to code that expects dense layout.
+
+## Metadata-Only Operations
+
+The following operations are intended to stay metadata-only whenever possible:
+
+- `transpose` / `permute`
+- `broadcast_in_dim`
+- `reshape` when the source layout is already exactly dense row-major or dense
+  column-major for the requested shape
+
+For broadcasted views, broadcast axes carry stride `0`.
+
+## Materialization Boundaries
+
+Materialization is explicit and delayed to the last responsible boundary.
+
+Current materialization boundaries include:
+
+- faer-backed linalg entry points that require dense column-major slices
+- CPU GEMM fallback canonicalization when direct strided GEMM lowering is not
+  possible
+- FFI / C-API export boundaries
+
+The contract is:
+
+- keep values as views while graph/runtime metadata is sufficient
+- materialize only at a kernel or external boundary that genuinely requires a
+  specific dense layout
+
+## Copy-On-Write Host Storage
+
+Copy-on-write is part of the current public behavior.
+
+- `clone()` on a host tensor keeps sharing the same `Arc<Vec<T>>`
+- `host_data_mut()` and `get_mut()` detach only when the storage is shared
+- metadata-only structural ops can stay cheap without exposing interior
+  mutability to users
+
+This gives eager mode the same basic freedom as the compiled path: views can
+survive until a mutation or dense-kernel boundary forces a copy.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Documentation for the tenferro-rs tensor computation library.
 
 - **[Getting Started](getting-started/)** — Installation, tutorials, and examples
 - **[Architecture](architecture/)** — Design rationale for each subsystem
-- **[Specification](spec/)** — Normative specs: op catalog, backend contract, AD contract
-- **[Implementation Design](design/)** — Implementation-focused design notes
+- **[Implementation Design](design/)** — Current implementation-focused design notes
+- **[Specification](spec/)** — Legacy low-level notes retained while design docs and rustdoc absorb the current source of truth
 - **[Oracle Replay](oracle/)** — AD correctness validation via oracle database
 - **[Reference](reference/)** — External system surveys and comparisons

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use strided_kernel::{col_major_strides, reduce_axis, zip_map2_into, StridedArray, StridedView};
 use tenferro_algebra::Semiring;
 
@@ -8,10 +10,8 @@ use crate::{Buffer, Tensor, TypedTensor};
 
 pub(crate) fn typed_view<T: Copy>(tensor: &TypedTensor<T>) -> StridedView<'_, T> {
     match &tensor.buffer {
-        Buffer::Host(data) => {
-            let strides = col_major_strides(&tensor.shape);
-            StridedView::new(data, &tensor.shape, &strides, 0).expect("contiguous host tensor")
-        }
+        Buffer::Host(data) => StridedView::new(data, &tensor.shape, &tensor.strides, tensor.offset)
+            .expect("valid host tensor view"),
         Buffer::Backend(_) => todo!("typed_view for backend buffers"),
     }
 }
@@ -24,7 +24,13 @@ pub(crate) fn typed_array<T: Clone>(shape: &[usize], fill: T) -> StridedArray<T>
 }
 
 pub(crate) fn tensor_from_array<T: Clone>(array: StridedArray<T>) -> TypedTensor<T> {
-    TypedTensor::from_vec(array.dims().to_vec(), array.into_data())
+    TypedTensor {
+        buffer: Buffer::Host(Arc::new(array.data().to_vec())),
+        shape: array.dims().to_vec(),
+        strides: array.strides().to_vec(),
+        offset: array.view().offset(),
+        placement: crate::types::default_placement(),
+    }
 }
 
 fn backend_failure(op: &'static str, err: impl ToString) -> crate::Error {
@@ -253,10 +259,13 @@ pub trait SemiringBackend<Alg: Semiring> {
             .map(|(_, &dim)| dim)
             .collect();
 
-        let strides = col_major_strides(&input.shape);
-        let mut current =
-            StridedArray::from_parts(input.host_data().to_vec(), &input.shape, &strides, 0)
-                .map_err(|err| backend_failure("reduce_sum", err))?;
+        let mut current = StridedArray::from_parts(
+            input.host_data().to_vec(),
+            &input.shape,
+            &input.strides,
+            input.offset,
+        )
+        .map_err(|err| backend_failure("reduce_sum", err))?;
 
         let mut sorted_axes = axes.to_vec();
         sorted_axes.sort_unstable_by(|a, b| b.cmp(a));

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -10,7 +10,7 @@ use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
 use crate::types::flat_to_multi;
-use crate::{Tensor, TypedTensor};
+use crate::{LayoutOrder, Tensor, TypedTensor};
 
 use super::{analytic, elementwise, gemm, indexing, linalg, reduction, structural};
 
@@ -116,6 +116,19 @@ impl CpuBackend {
         R: Send,
     {
         self.pool.install(op)
+    }
+}
+
+fn materialize_col_major_if_needed(tensor: &Tensor) -> crate::Result<Tensor> {
+    match tensor {
+        Tensor::F32(inner) if inner.is_contiguous_col_major() => Ok(Tensor::F32(inner.clone())),
+        Tensor::F32(inner) => Ok(Tensor::F32(inner.to_contiguous(LayoutOrder::ColumnMajor)?)),
+        Tensor::F64(inner) if inner.is_contiguous_col_major() => Ok(Tensor::F64(inner.clone())),
+        Tensor::F64(inner) => Ok(Tensor::F64(inner.to_contiguous(LayoutOrder::ColumnMajor)?)),
+        Tensor::C32(inner) if inner.is_contiguous_col_major() => Ok(Tensor::C32(inner.clone())),
+        Tensor::C32(inner) => Ok(Tensor::C32(inner.to_contiguous(LayoutOrder::ColumnMajor)?)),
+        Tensor::C64(inner) if inner.is_contiguous_col_major() => Ok(Tensor::C64(inner.clone())),
+        Tensor::C64(inner) => Ok(Tensor::C64(inner.to_contiguous(LayoutOrder::ColumnMajor)?)),
     }
 }
 
@@ -476,8 +489,9 @@ impl TensorBackend for CpuBackend {
         }
 
         let (rhs, restore_shape) = if let Some(matrix_rhs_shape) = batched_vector_rhs_shape(a, b) {
+            let rhs_matrix = materialize_col_major_if_needed(b)?;
             (
-                self.reshape(b, &matrix_rhs_shape)?,
+                self.reshape(&rhs_matrix, &matrix_rhs_shape)?,
                 Some(b.shape().to_vec()),
             )
         } else {
@@ -494,7 +508,8 @@ impl TensorBackend for CpuBackend {
         let z = self.triangular_solve(l, &pb, true, true, false, true)?;
         let x = self.triangular_solve(u, &z, true, false, false, false)?;
         if let Some(shape) = restore_shape {
-            self.reshape(&x, &shape)
+            let x_matrix = materialize_col_major_if_needed(&x)?;
+            self.reshape(&x_matrix, &shape)
         } else {
             Ok(x)
         }
@@ -581,13 +596,19 @@ fn validate_nonsingular_u(u: &Tensor) -> crate::Result<()> {
     match u {
         Tensor::F64(t) => {
             let n = t.shape[0].min(t.shape[1]);
-            let batch_total: usize = t.shape[2..].iter().product();
-            let batch_total = batch_total.max(1);
-            let slice_size = t.shape[0] * t.shape[1];
-            for batch_idx in 0..batch_total {
-                let batch = &t.host_data()[batch_idx * slice_size..(batch_idx + 1) * slice_size];
+            let batch_shape = &t.shape[2..];
+            let batch_total: usize = batch_shape.iter().product::<usize>().max(1);
+            let mut batch_coord = vec![0usize; batch_shape.len()];
+            let mut diag_idx = vec![0usize; t.shape.len()];
+            for batch_flat in 0..batch_total {
+                if !batch_shape.is_empty() {
+                    flat_to_multi(batch_flat, batch_shape, &mut batch_coord);
+                    diag_idx[2..].copy_from_slice(&batch_coord);
+                }
                 for i in 0..n {
-                    let diag = batch[i + i * t.shape[0]];
+                    diag_idx[0] = i;
+                    diag_idx[1] = i;
+                    let diag = *t.get(&diag_idx);
                     if !diag.is_finite() || diag == 0.0 {
                         return Err(crate::Error::BackendFailure {
                             op: "solve",
@@ -600,13 +621,19 @@ fn validate_nonsingular_u(u: &Tensor) -> crate::Result<()> {
         }
         Tensor::C64(t) => {
             let n = t.shape[0].min(t.shape[1]);
-            let batch_total: usize = t.shape[2..].iter().product();
-            let batch_total = batch_total.max(1);
-            let slice_size = t.shape[0] * t.shape[1];
-            for batch_idx in 0..batch_total {
-                let batch = &t.host_data()[batch_idx * slice_size..(batch_idx + 1) * slice_size];
+            let batch_shape = &t.shape[2..];
+            let batch_total: usize = batch_shape.iter().product::<usize>().max(1);
+            let mut batch_coord = vec![0usize; batch_shape.len()];
+            let mut diag_idx = vec![0usize; t.shape.len()];
+            for batch_flat in 0..batch_total {
+                if !batch_shape.is_empty() {
+                    flat_to_multi(batch_flat, batch_shape, &mut batch_coord);
+                    diag_idx[2..].copy_from_slice(&batch_coord);
+                }
                 for i in 0..n {
-                    let diag = batch[i + i * t.shape[0]];
+                    diag_idx[0] = i;
+                    diag_idx[1] = i;
+                    let diag = t.get(&diag_idx);
                     if !diag.re.is_finite() || !diag.im.is_finite() || diag.norm_sqr() == 0.0 {
                         return Err(crate::Error::BackendFailure {
                             op: "solve",

--- a/tenferro-tensor/src/cpu/elementwise.rs
+++ b/tenferro-tensor/src/cpu/elementwise.rs
@@ -167,19 +167,19 @@ pub fn add(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_add(a, b)?)),
         (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_add(a, b)?)),
         (Tensor::F32(a), Tensor::C32(b)) if a.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            let scalar = complex_scalar_tensor(*a.get(&[]));
             Ok(Tensor::C32(typed_add(&scalar, b)?))
         }
         (Tensor::C32(a), Tensor::F32(b)) if b.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            let scalar = complex_scalar_tensor(*b.get(&[]));
             Ok(Tensor::C32(typed_add(a, &scalar)?))
         }
         (Tensor::F64(a), Tensor::C64(b)) if a.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            let scalar = complex_scalar_tensor(*a.get(&[]));
             Ok(Tensor::C64(typed_add(&scalar, b)?))
         }
         (Tensor::C64(a), Tensor::F64(b)) if b.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            let scalar = complex_scalar_tensor(*b.get(&[]));
             Ok(Tensor::C64(typed_add(a, &scalar)?))
         }
         _ => Err(crate::Error::DTypeMismatch {
@@ -197,19 +197,19 @@ pub fn mul(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_mul(a, b)?)),
         (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_mul(a, b)?)),
         (Tensor::F32(a), Tensor::C32(b)) if a.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            let scalar = complex_scalar_tensor(*a.get(&[]));
             Ok(Tensor::C32(typed_mul(&scalar, b)?))
         }
         (Tensor::C32(a), Tensor::F32(b)) if b.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            let scalar = complex_scalar_tensor(*b.get(&[]));
             Ok(Tensor::C32(typed_mul(a, &scalar)?))
         }
         (Tensor::F64(a), Tensor::C64(b)) if a.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            let scalar = complex_scalar_tensor(*a.get(&[]));
             Ok(Tensor::C64(typed_mul(&scalar, b)?))
         }
         (Tensor::C64(a), Tensor::F64(b)) if b.shape.is_empty() => {
-            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            let scalar = complex_scalar_tensor(*b.get(&[]));
             Ok(Tensor::C64(typed_mul(a, &scalar)?))
         }
         _ => Err(crate::Error::DTypeMismatch {
@@ -342,7 +342,7 @@ where
         })?;
         Ok(tensor_from_array(out))
     } else if lhs.shape.is_empty() {
-        let scalar = lhs.host_data()[0];
+        let scalar = *lhs.get(&[]);
         let mut out = typed_array(&rhs.shape, T::zero());
         map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar + x).map_err(|err| {
             crate::Error::BackendFailure {
@@ -352,7 +352,7 @@ where
         })?;
         Ok(tensor_from_array(out))
     } else if rhs.shape.is_empty() {
-        let scalar = rhs.host_data()[0];
+        let scalar = *rhs.get(&[]);
         let mut out = typed_array(&lhs.shape, T::zero());
         map_into(&mut out.view_mut(), &typed_view(lhs), |x| x + scalar).map_err(|err| {
             crate::Error::BackendFailure {
@@ -385,13 +385,13 @@ where
         .map_err(|err| backend_failure("mul", err))?;
         Ok(tensor_from_array(out))
     } else if lhs.shape.is_empty() {
-        let scalar = lhs.host_data()[0];
+        let scalar = *lhs.get(&[]);
         let mut out = typed_array(&rhs.shape, T::zero());
         map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar * x)
             .map_err(|err| backend_failure("mul", err))?;
         Ok(tensor_from_array(out))
     } else if rhs.shape.is_empty() {
-        let scalar = rhs.host_data()[0];
+        let scalar = *rhs.get(&[]);
         let mut out = typed_array(&lhs.shape, T::zero());
         map_into(&mut out.view_mut(), &typed_view(lhs), |x| x * scalar)
             .map_err(|err| backend_failure("mul", err))?;

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -1,8 +1,9 @@
 use num_traits::{One, Zero};
+use std::sync::Arc;
 
 use crate::config::DotGeneralConfig;
 use crate::cpu::structural::typed_transpose;
-use crate::types::{col_major_strides, Buffer, TypedTensor};
+use crate::types::{col_major_strides, Buffer, LayoutOrder, TypedTensor};
 use crate::Error;
 
 #[cfg(feature = "cpu-blas")]
@@ -235,6 +236,17 @@ fn is_identity_perm(perm: &[usize]) -> bool {
     perm.iter().enumerate().all(|(i, &p)| i == p)
 }
 
+fn materialize_canonical_input<T>(tensor: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
+where
+    T: Copy + Clone + Default,
+{
+    if tensor.is_contiguous_col_major() {
+        Ok(tensor.clone())
+    } else {
+        tensor.to_contiguous(LayoutOrder::ColumnMajor)
+    }
+}
+
 fn analyse_gemm<T>(
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
@@ -250,8 +262,8 @@ fn analyse_gemm<T>(
         .filter(|d| !config.rhs_contracting_dims.contains(d) && !config.rhs_batch_dims.contains(d))
         .collect();
 
-    let lhs_strides = col_major_strides(&lhs.shape);
-    let rhs_strides = col_major_strides(&rhs.shape);
+    let lhs_strides = lhs.strides.clone();
+    let rhs_strides = rhs.strides.clone();
 
     let batch_shapes: Vec<usize> = config
         .lhs_batch_dims
@@ -356,7 +368,7 @@ pub(crate) fn dot_general<T>(
     config: &DotGeneralConfig,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: FaerGemm + Copy + Clone + Zero + One + PartialEq,
+    T: FaerGemm + Copy + Clone + Default + Zero + One + PartialEq,
 {
     validate_dot_general(lhs, rhs, config)?;
     if let Some(result) = typed_faer_gemm(lhs, rhs, config) {
@@ -365,14 +377,14 @@ where
     let (lhs_perm, rhs_perm, new_config) =
         canonical_gemm_layout(config, lhs.shape.len(), rhs.shape.len());
     let lhs_canon = if is_identity_perm(&lhs_perm) {
-        std::borrow::Cow::Borrowed(lhs)
+        materialize_canonical_input(lhs)?
     } else {
-        std::borrow::Cow::Owned(typed_transpose(lhs, &lhs_perm)?)
+        materialize_canonical_input(&typed_transpose(lhs, &lhs_perm)?)?
     };
     let rhs_canon = if is_identity_perm(&rhs_perm) {
-        std::borrow::Cow::Borrowed(rhs)
+        materialize_canonical_input(rhs)?
     } else {
-        std::borrow::Cow::Owned(typed_transpose(rhs, &rhs_perm)?)
+        materialize_canonical_input(&typed_transpose(rhs, &rhs_perm)?)?
     };
     typed_faer_gemm(&lhs_canon, &rhs_canon, &new_config).ok_or_else(|| Error::BackendFailure {
         op: "dot_general",
@@ -387,14 +399,17 @@ fn typed_faer_gemm<T>(
     config: &DotGeneralConfig,
 ) -> Option<TypedTensor<T>>
 where
-    T: FaerGemm + Copy + Clone + Zero + One + PartialEq,
+    T: FaerGemm + Copy + Clone + Default + Zero + One + PartialEq,
 {
     let dims = analyse_gemm(lhs, rhs, config)?;
     let out_n: usize = dims.out_shape.iter().product();
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
+        let out_shape = dims.out_shape;
         return Some(TypedTensor {
-            buffer: Buffer::Host(vec![T::zero(); out_n]),
-            shape: dims.out_shape,
+            buffer: Buffer::Host(Arc::new(vec![T::zero(); out_n])),
+            strides: col_major_strides(&out_shape),
+            shape: out_shape,
+            offset: 0,
             placement: lhs.placement.clone(),
         });
     }
@@ -412,8 +427,8 @@ where
     let c_ptr = out_data.as_mut_ptr();
 
     for batch in 0..dims.batch_total {
-        let a_off = batch as isize * dims.a_bs;
-        let b_off = batch as isize * dims.b_bs;
+        let a_off = lhs.offset + batch as isize * dims.a_bs;
+        let b_off = rhs.offset + batch as isize * dims.b_bs;
         let c_off = batch as isize * dims.c_bs;
         unsafe {
             T::strided_gemm(
@@ -435,9 +450,12 @@ where
         }
     }
 
+    let out_shape = dims.out_shape;
     Some(TypedTensor {
-        buffer: Buffer::Host(out_data),
-        shape: dims.out_shape,
+        buffer: Buffer::Host(Arc::new(out_data)),
+        strides: col_major_strides(&out_shape),
+        shape: out_shape,
+        offset: 0,
         placement: lhs.placement.clone(),
     })
 }
@@ -449,7 +467,7 @@ pub(crate) fn dot_general<T>(
     config: &DotGeneralConfig,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: BlasGemm + Copy + Clone + Zero + One,
+    T: BlasGemm + Copy + Clone + Default + Zero + One,
 {
     validate_dot_general(lhs, rhs, config)?;
     if let Some(result) = typed_blas_gemm(lhs, rhs, config) {
@@ -458,14 +476,14 @@ where
     let (lhs_perm, rhs_perm, new_config) =
         canonical_gemm_layout(config, lhs.shape.len(), rhs.shape.len());
     let lhs_canon = if is_identity_perm(&lhs_perm) {
-        std::borrow::Cow::Borrowed(lhs)
+        materialize_canonical_input(lhs)?
     } else {
-        std::borrow::Cow::Owned(typed_transpose(lhs, &lhs_perm)?)
+        materialize_canonical_input(&typed_transpose(lhs, &lhs_perm)?)?
     };
     let rhs_canon = if is_identity_perm(&rhs_perm) {
-        std::borrow::Cow::Borrowed(rhs)
+        materialize_canonical_input(rhs)?
     } else {
-        std::borrow::Cow::Owned(typed_transpose(rhs, &rhs_perm)?)
+        materialize_canonical_input(&typed_transpose(rhs, &rhs_perm)?)?
     };
     typed_blas_gemm(&lhs_canon, &rhs_canon, &new_config).ok_or_else(|| Error::BackendFailure {
         op: "dot_general",
@@ -480,14 +498,17 @@ fn typed_blas_gemm<T>(
     config: &DotGeneralConfig,
 ) -> Option<TypedTensor<T>>
 where
-    T: BlasGemm + Copy + Clone + Zero + One,
+    T: BlasGemm + Copy + Clone + Default + Zero + One,
 {
     let dims = analyse_gemm(lhs, rhs, config)?;
     let out_n: usize = dims.out_shape.iter().product();
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
+        let out_shape = dims.out_shape;
         return Some(TypedTensor {
-            buffer: Buffer::Host(vec![T::zero(); out_n]),
-            shape: dims.out_shape,
+            buffer: Buffer::Host(Arc::new(vec![T::zero(); out_n])),
+            strides: col_major_strides(&out_shape),
+            shape: out_shape,
+            offset: 0,
             placement: lhs.placement.clone(),
         });
     }
@@ -511,8 +532,8 @@ where
     let c_block = dims.m * dims.n;
 
     for batch in 0..dims.batch_total {
-        let a_start = (batch as isize * dims.a_bs) as usize;
-        let b_start = (batch as isize * dims.b_bs) as usize;
+        let a_start = usize::try_from(lhs.offset + batch as isize * dims.a_bs).ok()?;
+        let b_start = usize::try_from(rhs.offset + batch as isize * dims.b_bs).ok()?;
         let c_start = (batch as isize * dims.c_bs) as usize;
         T::contiguous_gemm(
             T::one(),
@@ -526,9 +547,12 @@ where
         );
     }
 
+    let out_shape = dims.out_shape;
     Some(TypedTensor {
-        buffer: Buffer::Host(out),
-        shape: dims.out_shape,
+        buffer: Buffer::Host(Arc::new(out)),
+        strides: col_major_strides(&out_shape),
+        shape: out_shape,
+        offset: 0,
         placement: lhs.placement.clone(),
     })
 }

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -299,14 +299,30 @@ struct IndexTensor {
 }
 
 fn index_tensor(tensor: &Tensor) -> IndexTensor {
+    fn collect_values<T: Copy>(t: &TypedTensor<T>) -> Vec<T> {
+        let mut values = Vec::with_capacity(t.n_elements());
+        let mut idx = vec![0usize; t.shape.len()];
+        for flat in 0..t.n_elements() {
+            flat_to_multi(flat, &t.shape, &mut idx);
+            values.push(*t.get(&idx));
+        }
+        values
+    }
+
     match tensor {
         Tensor::F32(t) => IndexTensor {
             shape: t.shape.clone(),
-            values: t.host_data().iter().map(|&value| value as i64).collect(),
+            values: collect_values(t)
+                .into_iter()
+                .map(|value| value as i64)
+                .collect(),
         },
         Tensor::F64(t) => IndexTensor {
             shape: t.shape.clone(),
-            values: t.host_data().iter().map(|&value| value as i64).collect(),
+            values: collect_values(t)
+                .into_iter()
+                .map(|value| value as i64)
+                .collect(),
         },
         Tensor::C32(_) | Tensor::C64(_) => panic!("complex index tensors are not supported"),
     }

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -1,7 +1,7 @@
 use faer::{diag::DiagRef, MatMut, MatRef, Par, Side};
 use num_complex::Complex64;
 
-use crate::{Buffer, Tensor, TypedTensor};
+use crate::{Buffer, LayoutOrder, Tensor, TypedTensor};
 
 pub(crate) trait FaerLinalg: Copy + Clone {
     fn parity_one() -> Self;
@@ -37,9 +37,25 @@ fn tensor_from_vec_with_template<T: Clone, U>(
     template: &TypedTensor<U>,
 ) -> TypedTensor<T> {
     TypedTensor {
-        buffer: Buffer::Host(data),
+        buffer: Buffer::Host(data.into()),
+        strides: crate::col_major_strides(&shape),
+        offset: 0,
         shape,
         placement: template.placement.clone(),
+    }
+}
+
+fn with_col_major_input<T, R>(input: &TypedTensor<T>, f: impl FnOnce(&TypedTensor<T>) -> R) -> R
+where
+    T: Copy + Default,
+{
+    if input.is_contiguous_col_major() {
+        f(input)
+    } else {
+        let materialized = input
+            .to_contiguous(LayoutOrder::ColumnMajor)
+            .expect("linalg input materialization must succeed");
+        f(&materialized)
     }
 }
 
@@ -926,51 +942,57 @@ impl FaerLinalg for Complex64 {
     }
 }
 
-pub(crate) fn cholesky<T: FaerLinalg>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>> {
-    if has_zero_dim(&input.shape) {
-        return Ok(tensor_from_vec_with_template(
-            input.shape.clone(),
-            Vec::new(),
-            input,
-        ));
-    }
-    batched_single(input, 2, T::cholesky_2d)
+pub(crate) fn cholesky<T: FaerLinalg + Default>(
+    input: &TypedTensor<T>,
+) -> crate::Result<TypedTensor<T>> {
+    with_col_major_input(input, |input| {
+        if has_zero_dim(&input.shape) {
+            return Ok(tensor_from_vec_with_template(
+                input.shape.clone(),
+                Vec::new(),
+                input,
+            ));
+        }
+        batched_single(input, 2, T::cholesky_2d)
+    })
 }
 
-pub(crate) fn lu<T: FaerLinalg>(input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
-    if has_zero_dim(&input.shape) {
-        let m = input.shape[0];
-        let n = input.shape[1];
-        let k = m.min(n);
-        let batch_shape = &input.shape[2..];
-        let parity_elements: usize = batch_shape.iter().product::<usize>().max(1);
-        return vec![
-            tensor_from_vec_with_template(
-                matrix_with_batch_shape(m, m, batch_shape),
-                Vec::new(),
-                input,
-            ),
-            tensor_from_vec_with_template(
-                matrix_with_batch_shape(m, k, batch_shape),
-                Vec::new(),
-                input,
-            ),
-            tensor_from_vec_with_template(
-                matrix_with_batch_shape(k, n, batch_shape),
-                Vec::new(),
-                input,
-            ),
-            tensor_from_vec_with_template(
-                batch_shape.to_vec(),
-                vec![T::parity_one(); parity_elements],
-                input,
-            ),
-        ];
-    }
-    batched_multi(input, 2, T::lu_2d)
+pub(crate) fn lu<T: FaerLinalg + Default>(input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+    with_col_major_input(input, |input| {
+        if has_zero_dim(&input.shape) {
+            let m = input.shape[0];
+            let n = input.shape[1];
+            let k = m.min(n);
+            let batch_shape = &input.shape[2..];
+            let parity_elements: usize = batch_shape.iter().product::<usize>().max(1);
+            return vec![
+                tensor_from_vec_with_template(
+                    matrix_with_batch_shape(m, m, batch_shape),
+                    Vec::new(),
+                    input,
+                ),
+                tensor_from_vec_with_template(
+                    matrix_with_batch_shape(m, k, batch_shape),
+                    Vec::new(),
+                    input,
+                ),
+                tensor_from_vec_with_template(
+                    matrix_with_batch_shape(k, n, batch_shape),
+                    Vec::new(),
+                    input,
+                ),
+                tensor_from_vec_with_template(
+                    batch_shape.to_vec(),
+                    vec![T::parity_one(); parity_elements],
+                    input,
+                ),
+            ];
+        }
+        batched_multi(input, 2, T::lu_2d)
+    })
 }
 
-pub(crate) fn triangular_solve<T: FaerLinalg>(
+pub(crate) fn triangular_solve<T: FaerLinalg + Default>(
     a: &TypedTensor<T>,
     b: &TypedTensor<T>,
     left_side: bool,
@@ -978,81 +1000,91 @@ pub(crate) fn triangular_solve<T: FaerLinalg>(
     transpose_a: bool,
     unit_diagonal: bool,
 ) -> TypedTensor<T> {
-    if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
-        return tensor_from_vec_with_template(b.shape.clone(), Vec::new(), b);
-    }
-    batched_binary(a, b, 2, 2, |a, b| {
-        T::triangular_solve_2d(a, b, left_side, lower, transpose_a, unit_diagonal)
+    with_col_major_input(a, |a| {
+        with_col_major_input(b, |b| {
+            if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
+                return tensor_from_vec_with_template(b.shape.clone(), Vec::new(), b);
+            }
+            batched_binary(a, b, 2, 2, |a, b| {
+                T::triangular_solve_2d(a, b, left_side, lower, transpose_a, unit_diagonal)
+            })
+        })
     })
 }
 
-pub(crate) fn svd<T: FaerLinalg>(input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
-    if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "svd");
-        let m = matrix_shape[0];
-        let n = matrix_shape[1];
-        let k = m.min(n);
-        return vec![
-            tensor_from_vec_with_template(
-                matrix_with_batch_shape(m, k, batch_shape),
-                Vec::new(),
-                input,
-            ),
-            tensor_from_vec_with_template(
-                vector_with_batch_shape(k, batch_shape),
-                Vec::new(),
-                input,
-            ),
-            tensor_from_vec_with_template(
-                matrix_with_batch_shape(k, n, batch_shape),
-                Vec::new(),
-                input,
-            ),
-        ];
-    }
-    batched_multi(input, 2, T::svd_2d)
+pub(crate) fn svd<T: FaerLinalg + Default>(input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+    with_col_major_input(input, |input| {
+        if has_zero_dim(&input.shape) {
+            let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "svd");
+            let m = matrix_shape[0];
+            let n = matrix_shape[1];
+            let k = m.min(n);
+            return vec![
+                tensor_from_vec_with_template(
+                    matrix_with_batch_shape(m, k, batch_shape),
+                    Vec::new(),
+                    input,
+                ),
+                tensor_from_vec_with_template(
+                    vector_with_batch_shape(k, batch_shape),
+                    Vec::new(),
+                    input,
+                ),
+                tensor_from_vec_with_template(
+                    matrix_with_batch_shape(k, n, batch_shape),
+                    Vec::new(),
+                    input,
+                ),
+            ];
+        }
+        batched_multi(input, 2, T::svd_2d)
+    })
 }
 
-pub(crate) fn qr<T: FaerLinalg>(input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
-    if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "qr");
-        let m = matrix_shape[0];
-        let n = matrix_shape[1];
-        let k = m.min(n);
-        return vec![
-            tensor_from_vec_with_template(
-                matrix_with_batch_shape(m, k, batch_shape),
-                Vec::new(),
-                input,
-            ),
-            tensor_from_vec_with_template(
-                matrix_with_batch_shape(k, n, batch_shape),
-                Vec::new(),
-                input,
-            ),
-        ];
-    }
-    batched_multi(input, 2, T::qr_2d)
+pub(crate) fn qr<T: FaerLinalg + Default>(input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+    with_col_major_input(input, |input| {
+        if has_zero_dim(&input.shape) {
+            let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "qr");
+            let m = matrix_shape[0];
+            let n = matrix_shape[1];
+            let k = m.min(n);
+            return vec![
+                tensor_from_vec_with_template(
+                    matrix_with_batch_shape(m, k, batch_shape),
+                    Vec::new(),
+                    input,
+                ),
+                tensor_from_vec_with_template(
+                    matrix_with_batch_shape(k, n, batch_shape),
+                    Vec::new(),
+                    input,
+                ),
+            ];
+        }
+        batched_multi(input, 2, T::qr_2d)
+    })
 }
 
-pub(crate) fn eigh<T: FaerLinalg>(input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
-    if has_zero_dim(&input.shape) {
-        let n = input.shape[0];
-        let batch_shape = &input.shape[2..];
-        return vec![
-            tensor_from_vec_with_template(
-                vector_with_batch_shape(n, batch_shape),
-                Vec::new(),
-                input,
-            ),
-            tensor_from_vec_with_template(
-                matrix_with_batch_shape(n, n, batch_shape),
-                Vec::new(),
-                input,
-            ),
-        ];
-    }
-    batched_multi(input, 2, T::eigh_2d)
+pub(crate) fn eigh<T: FaerLinalg + Default>(input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+    with_col_major_input(input, |input| {
+        if has_zero_dim(&input.shape) {
+            let n = input.shape[0];
+            let batch_shape = &input.shape[2..];
+            return vec![
+                tensor_from_vec_with_template(
+                    vector_with_batch_shape(n, batch_shape),
+                    Vec::new(),
+                    input,
+                ),
+                tensor_from_vec_with_template(
+                    matrix_with_batch_shape(n, n, batch_shape),
+                    Vec::new(),
+                    input,
+                ),
+            ];
+        }
+        batched_multi(input, 2, T::eigh_2d)
+    })
 }
 
 fn eig_real_2d(input: &TypedTensor<f64>) -> Vec<TypedTensor<Complex64>> {
@@ -1084,30 +1116,47 @@ fn eig_complex_2d(input: &TypedTensor<Complex64>) -> Vec<TypedTensor<Complex64>>
 }
 
 pub(crate) fn eig(input: &Tensor) -> Vec<Tensor> {
-    if has_zero_dim(input.shape()) {
-        let n = input.shape()[0];
-        let batch_shape = &input.shape()[2..];
-        return vec![
-            Tensor::C64(TypedTensor::from_vec(
-                vector_with_batch_shape(n, batch_shape),
-                Vec::new(),
-            )),
-            Tensor::C64(TypedTensor::from_vec(
-                matrix_with_batch_shape(n, n, batch_shape),
-                Vec::new(),
-            )),
-        ];
-    }
-
     match input {
-        Tensor::F64(t) => batched_multi_convert(t, 2, eig_real_2d)
-            .into_iter()
-            .map(Tensor::C64)
-            .collect(),
-        Tensor::C64(t) => batched_multi_convert(t, 2, eig_complex_2d)
-            .into_iter()
-            .map(Tensor::C64)
-            .collect(),
+        Tensor::F64(t) => with_col_major_input(t, |t| {
+            if has_zero_dim(&t.shape) {
+                let n = t.shape[0];
+                let batch_shape = &t.shape[2..];
+                return vec![
+                    Tensor::C64(TypedTensor::from_vec(
+                        vector_with_batch_shape(n, batch_shape),
+                        Vec::new(),
+                    )),
+                    Tensor::C64(TypedTensor::from_vec(
+                        matrix_with_batch_shape(n, n, batch_shape),
+                        Vec::new(),
+                    )),
+                ];
+            }
+            batched_multi_convert(t, 2, eig_real_2d)
+                .into_iter()
+                .map(Tensor::C64)
+                .collect()
+        }),
+        Tensor::C64(t) => with_col_major_input(t, |t| {
+            if has_zero_dim(&t.shape) {
+                let n = t.shape[0];
+                let batch_shape = &t.shape[2..];
+                return vec![
+                    Tensor::C64(TypedTensor::from_vec(
+                        vector_with_batch_shape(n, batch_shape),
+                        Vec::new(),
+                    )),
+                    Tensor::C64(TypedTensor::from_vec(
+                        matrix_with_batch_shape(n, n, batch_shape),
+                        Vec::new(),
+                    )),
+                ];
+            }
+            batched_multi_convert(t, 2, eig_complex_2d)
+                .into_iter()
+                .map(Tensor::C64)
+                .collect()
+        }),
         _ => todo!("eig: unsupported dtype"),
     }
 }

--- a/tenferro-tensor/src/cpu/mod.rs
+++ b/tenferro-tensor/src/cpu/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 pub mod analytic;
 pub mod backend;
 pub mod elementwise;
@@ -23,10 +25,8 @@ pub use structural::{
 
 pub(crate) fn typed_view<T: Copy>(tensor: &TypedTensor<T>) -> StridedView<'_, T> {
     match &tensor.buffer {
-        Buffer::Host(data) => {
-            let strides = col_major_strides(&tensor.shape);
-            StridedView::new(data, &tensor.shape, &strides, 0).expect("contiguous host tensor")
-        }
+        Buffer::Host(data) => StridedView::new(data, &tensor.shape, &tensor.strides, tensor.offset)
+            .expect("valid host tensor view"),
         Buffer::Backend(_) => todo!("typed_view for backend buffers"),
     }
 }
@@ -39,5 +39,11 @@ pub(crate) fn typed_array<T: Clone>(shape: &[usize], fill: T) -> StridedArray<T>
 }
 
 pub(crate) fn tensor_from_array<T: Clone>(array: StridedArray<T>) -> TypedTensor<T> {
-    TypedTensor::from_vec(array.dims().to_vec(), array.into_data())
+    TypedTensor {
+        buffer: Buffer::Host(Arc::new(array.data().to_vec())),
+        shape: array.dims().to_vec(),
+        strides: array.strides().to_vec(),
+        offset: array.view().offset(),
+        placement: crate::types::default_placement(),
+    }
 }

--- a/tenferro-tensor/src/cpu/reduction.rs
+++ b/tenferro-tensor/src/cpu/reduction.rs
@@ -1,7 +1,7 @@
 use std::ops::{Add, Mul};
 
 use num_traits::{Float, One, Zero};
-use strided_kernel::{col_major_strides, reduce_axis, StridedArray};
+use strided_kernel::{reduce_axis, StridedArray};
 
 use crate::types::{Tensor, TypedTensor};
 
@@ -104,10 +104,13 @@ where
         .map(|(_, &dim)| dim)
         .collect();
 
-    let strides = col_major_strides(&input.shape);
-    let mut current =
-        StridedArray::from_parts(input.host_data().to_vec(), &input.shape, &strides, 0)
-            .map_err(|err| backend_failure(label, err))?;
+    let mut current = StridedArray::from_parts(
+        input.host_data().to_vec(),
+        &input.shape,
+        &input.strides,
+        input.offset,
+    )
+    .map_err(|err| backend_failure(label, err))?;
 
     let mut sorted_axes = axes.to_vec();
     sorted_axes.sort_unstable_by(|a, b| b.cmp(a));

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -3,7 +3,9 @@ use num_traits::Zero;
 use strided_kernel::{copy_into, map_into, Identity, StridedView};
 
 use crate::{
-    types::{flat_to_multi, Tensor, TypedTensor},
+    types::{
+        col_major_strides, flat_to_multi, row_major_strides, LayoutOrder, Tensor, TypedTensor,
+    },
     DType,
 };
 
@@ -65,8 +67,7 @@ fn validate_permutation(op: &'static str, perm: &[usize], rank: usize) -> crate:
 fn host_view<T: Copy>(tensor: &TypedTensor<T>) -> crate::Result<StridedView<'_, T, Identity>> {
     match &tensor.buffer {
         crate::Buffer::Host(data) => {
-            let strides = crate::col_major_strides(&tensor.shape);
-            StridedView::new(data, &tensor.shape, &strides, 0)
+            StridedView::new(data, &tensor.shape, &tensor.strides, tensor.offset)
                 .map_err(|err| backend_failure("structural", err))
         }
         crate::Buffer::Backend(_) => Err(crate::Error::BackendFailure {
@@ -74,15 +75,6 @@ fn host_view<T: Copy>(tensor: &TypedTensor<T>) -> crate::Result<StridedView<'_, 
             message: "backend buffers are not supported for structural CPU helpers".into(),
         }),
     }
-}
-
-fn copy_view_to_array<T: Copy + Clone>(
-    op: &'static str,
-    mut out: strided_kernel::StridedArray<T>,
-    src: &StridedView<'_, T>,
-) -> crate::Result<TypedTensor<T>> {
-    copy_into(&mut out.view_mut(), src).map_err(|err| backend_failure(op, err))?;
-    Ok(tensor_from_array(out))
 }
 
 pub fn transpose(input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
@@ -177,17 +169,77 @@ pub fn triu(input: &Tensor, k: i64) -> crate::Result<Tensor> {
     }
 }
 
-pub fn typed_transpose<T: Copy + Zero + Clone>(
+fn permute_axes<T: Clone>(tensor: &TypedTensor<T>, perm: &[usize]) -> TypedTensor<T> {
+    let shape = perm.iter().map(|&axis| tensor.shape[axis]).collect();
+    let strides = perm.iter().map(|&axis| tensor.strides[axis]).collect();
+    TypedTensor {
+        buffer: tensor.buffer.clone(),
+        shape,
+        strides,
+        offset: tensor.offset,
+        placement: tensor.placement.clone(),
+    }
+}
+
+fn reshape_strides(tensor: &TypedTensor<impl Clone>, shape: &[usize]) -> crate::Result<Vec<isize>> {
+    if tensor.strides.iter().all(|&stride| stride == 0) {
+        return Ok(vec![0; shape.len()]);
+    }
+    if tensor.strides == col_major_strides(&tensor.shape) {
+        return Ok(col_major_strides(shape));
+    }
+    if tensor.strides == row_major_strides(&tensor.shape) {
+        return Ok(row_major_strides(shape));
+    }
+    if let Some(strides) = reshape_singleton_only_strides(tensor, shape) {
+        return Ok(strides);
+    }
+    Err(crate::Error::BackendFailure {
+        op: "reshape",
+        message: "reshape requires contiguous tensor".into(),
+    })
+}
+
+fn reshape_singleton_only_strides(
+    tensor: &TypedTensor<impl Clone>,
+    new_shape: &[usize],
+) -> Option<Vec<isize>> {
+    let old_non_singleton = tensor
+        .shape
+        .iter()
+        .copied()
+        .zip(tensor.strides.iter().copied())
+        .filter(|(dim, _)| *dim != 1)
+        .collect::<Vec<_>>();
+    let new_non_singleton = new_shape
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, &dim)| (dim != 1).then_some((idx, dim)))
+        .collect::<Vec<_>>();
+    if old_non_singleton.len() != new_non_singleton.len() {
+        return None;
+    }
+    if old_non_singleton
+        .iter()
+        .map(|(dim, _)| *dim)
+        .ne(new_non_singleton.iter().map(|(_, dim)| *dim))
+    {
+        return None;
+    }
+
+    let mut new_strides = vec![0; new_shape.len()];
+    for ((_, stride), (new_idx, _)) in old_non_singleton.iter().zip(new_non_singleton.iter()) {
+        new_strides[*new_idx] = *stride;
+    }
+    Some(new_strides)
+}
+
+pub fn typed_transpose<T: Clone>(
     tensor: &TypedTensor<T>,
     perm: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
     validate_permutation("transpose", perm, tensor.shape.len())?;
-    let src = host_view(tensor)?;
-    let permuted = src
-        .permute(perm)
-        .map_err(|err| backend_failure("transpose", err))?;
-    let out = typed_array(permuted.dims(), T::zero());
-    copy_view_to_array("transpose", out, &permuted)
+    Ok(permute_axes(tensor, perm))
 }
 
 pub fn typed_reshape<T: Clone>(
@@ -203,23 +255,36 @@ pub fn typed_reshape<T: Clone>(
             rhs: shape.to_vec(),
         });
     }
-    Ok(TypedTensor {
-        buffer: tensor.buffer.clone(),
-        shape: shape.to_vec(),
-        placement: tensor.placement.clone(),
-    })
+    if let Ok(strides) = reshape_strides(tensor, shape) {
+        return Ok(TypedTensor {
+            buffer: tensor.buffer.clone(),
+            shape: shape.to_vec(),
+            strides,
+            offset: tensor.offset,
+            placement: tensor.placement.clone(),
+        });
+    }
+
+    let mut data = Vec::with_capacity(old_n);
+    let mut idx = vec![0usize; tensor.shape.len()];
+    for flat in 0..old_n {
+        flat_to_multi(flat, &tensor.shape, &mut idx);
+        data.push(tensor.get(&idx).clone());
+    }
+
+    let mut dense = TypedTensor::from_vec(shape.to_vec(), data);
+    dense.placement = tensor.placement.clone();
+    Ok(dense)
 }
 
-pub fn typed_broadcast_in_dim<T: Copy + Zero + Clone>(
+pub fn typed_broadcast_in_dim<T: Clone>(
     tensor: &TypedTensor<T>,
     shape: &[usize],
     dims: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
     validate_rank("broadcast_in_dim", tensor.shape.len(), dims.len())?;
     let mut seen = vec![false; shape.len()];
-    let mut base_dims = vec![1usize; shape.len()];
-    let mut base_strides = vec![0isize; shape.len()];
-    let source_strides = crate::col_major_strides(&tensor.shape);
+    let mut out_strides = vec![0isize; shape.len()];
     for (src_axis, &dst_axis) in dims.iter().enumerate() {
         validate_axis("broadcast_in_dim", dst_axis, shape.len())?;
         if seen[dst_axis] {
@@ -239,26 +304,19 @@ pub fn typed_broadcast_in_dim<T: Copy + Zero + Clone>(
                 rhs: shape.to_vec(),
             });
         }
-        base_dims[dst_axis] = source_dim;
-        base_strides[dst_axis] = source_strides[src_axis];
+        out_strides[dst_axis] = if source_dim == 1 && target_dim > 1 {
+            0
+        } else {
+            tensor.strides[src_axis]
+        };
     }
-    let base: StridedView<'_, T, Identity> = match &tensor.buffer {
-        crate::Buffer::Host(data) => StridedView::new(data, &base_dims, &base_strides, 0)
-            .map_err(|err| backend_failure("broadcast_in_dim", err))?,
-        crate::Buffer::Backend(_) => {
-            return Err(crate::Error::BackendFailure {
-                op: "broadcast_in_dim",
-                message: "backend buffers are not supported for structural CPU helpers".into(),
-            })
-        }
-    };
-    let broadcast: StridedView<'_, T, Identity> = base
-        .broadcast(shape)
-        .map_err(|err| backend_failure("broadcast_in_dim", err))?;
-    let mut out = typed_array(shape, T::zero());
-    copy_into(&mut out.view_mut(), &broadcast)
-        .map_err(|err| backend_failure("broadcast_in_dim", err))?;
-    Ok(tensor_from_array(out))
+    Ok(TypedTensor {
+        buffer: tensor.buffer.clone(),
+        shape: shape.to_vec(),
+        strides: out_strides,
+        offset: tensor.offset,
+        placement: tensor.placement.clone(),
+    })
 }
 
 fn typed_convert<S, T>(tensor: &TypedTensor<S>, f: impl Fn(S) -> T) -> TypedTensor<T>
@@ -313,16 +371,6 @@ pub fn typed_embed_diagonal<T: Copy + Zero + Clone>(
     let mut in_idx = vec![0usize; in_rank];
     let mut out_idx = vec![0usize; out_rank];
 
-    let input_data = match &tensor.buffer {
-        crate::Buffer::Host(data) => data,
-        crate::Buffer::Backend(_) => {
-            return Err(crate::Error::BackendFailure {
-                op: "embed_diagonal",
-                message: "backend buffers are not supported for structural CPU helpers".into(),
-            })
-        }
-    };
-
     for flat in 0..tensor.n_elements() {
         flat_to_multi(flat, &tensor.shape, &mut in_idx);
         let diag_val = in_idx[axis_a];
@@ -335,26 +383,26 @@ pub fn typed_embed_diagonal<T: Copy + Zero + Clone>(
                 src_axis += 1;
             }
         }
-        *out.get_mut(&out_idx) = input_data[flat];
+        *out.get_mut(&out_idx) = *tensor.get(&in_idx);
     }
     Ok(out)
 }
 
-pub fn typed_tril<T: Copy + Zero + Clone>(
+pub fn typed_tril<T: Copy + Zero + Clone + Default>(
     tensor: &TypedTensor<T>,
     k: i64,
 ) -> crate::Result<TypedTensor<T>> {
     typed_triangular_mask(tensor, k, false)
 }
 
-pub fn typed_triu<T: Copy + Zero + Clone>(
+pub fn typed_triu<T: Copy + Zero + Clone + Default>(
     tensor: &TypedTensor<T>,
     k: i64,
 ) -> crate::Result<TypedTensor<T>> {
     typed_triangular_mask(tensor, k, true)
 }
 
-fn typed_triangular_mask<T: Copy + Zero + Clone>(
+fn typed_triangular_mask<T: Copy + Zero + Clone + Default>(
     tensor: &TypedTensor<T>,
     k: i64,
     upper: bool,
@@ -375,16 +423,8 @@ fn typed_triangular_mask<T: Copy + Zero + Clone>(
 
     let batch_count: usize = tensor.shape[2..].iter().product();
     let block_size = rows * cols;
-    let mut out = tensor.clone();
-    let data = match &mut out.buffer {
-        crate::Buffer::Host(data) => data,
-        crate::Buffer::Backend(_) => {
-            return Err(crate::Error::BackendFailure {
-                op: if upper { "triu" } else { "tril" },
-                message: "backend buffers are not supported for structural CPU helpers".into(),
-            })
-        }
-    };
+    let mut out = tensor.to_contiguous(LayoutOrder::ColumnMajor)?;
+    let data = out.host_data_mut();
 
     for batch_idx in 0..batch_count {
         let base = batch_idx * block_size;

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -11,7 +11,7 @@ use crate::cpu::{
     extract_diagonal, gather, maximum, minimum, mul, neg, pad, reduce_max, reduce_min, reduce_prod,
     reduce_sum, reshape, scatter, select, sign, transpose, tril, triu, CpuBackend,
 };
-use crate::types::{DType, Tensor, TypedTensor};
+use crate::types::{DType, LayoutOrder, Tensor, TypedTensor};
 
 fn get_f64(t: &Tensor, idx: &[usize]) -> f64 {
     match t {
@@ -307,12 +307,38 @@ fn test_reshape() {
     ));
     let r = reshape(&t, &[3, 2]).unwrap();
     assert_eq!(r.shape(), &[3, 2]);
+    match &r {
+        Tensor::F64(inner) => {
+            assert_eq!(inner.strides(), &[1, 3]);
+            assert_eq!(inner.offset(), 0);
+            assert!(inner.is_contiguous_col_major());
+        }
+        _ => panic!("expected F64 tensor"),
+    }
     assert_eq!(get_f64(&r, &[0, 0]), 1.0);
     assert_eq!(get_f64(&r, &[1, 0]), 2.0);
     assert_eq!(get_f64(&r, &[2, 0]), 3.0);
     assert_eq!(get_f64(&r, &[0, 1]), 4.0);
     assert_eq!(get_f64(&r, &[1, 1]), 5.0);
     assert_eq!(get_f64(&r, &[2, 1]), 6.0);
+}
+
+#[test]
+fn test_reshape_preserves_row_major_metadata() {
+    let source = TypedTensor::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let row_major = source.to_contiguous(LayoutOrder::RowMajor).unwrap();
+    assert!(row_major.is_contiguous_row_major());
+
+    let r = reshape(&Tensor::F64(row_major), &[3, 2]).unwrap();
+    assert_eq!(r.shape(), &[3, 2]);
+    match &r {
+        Tensor::F64(inner) => {
+            assert_eq!(inner.strides(), &[2, 1]);
+            assert_eq!(inner.offset(), 0);
+            assert!(inner.is_contiguous_row_major());
+        }
+        _ => panic!("expected F64 tensor"),
+    }
 }
 
 #[test]
@@ -783,6 +809,15 @@ fn test_transpose() {
     ));
     let tr = transpose(&t, &[1, 0]).unwrap();
     assert_eq!(tr.shape(), &[3, 2]);
+    match &tr {
+        Tensor::F64(inner) => {
+            assert_eq!(inner.strides(), &[2, 1]);
+            assert_eq!(inner.offset(), 0);
+            assert!(!inner.is_contiguous_col_major());
+            assert!(inner.is_contiguous_row_major());
+        }
+        _ => panic!("expected F64 tensor"),
+    }
     assert_eq!(get_f64(&tr, &[0, 0]), 1.0);
     assert_eq!(get_f64(&tr, &[0, 1]), 2.0);
     assert_eq!(get_f64(&tr, &[1, 0]), 3.0);
@@ -796,6 +831,13 @@ fn test_broadcast_in_dim() {
     let scalar = Tensor::F64(TypedTensor::from_vec(vec![], vec![5.0]));
     let broadcast = broadcast_in_dim(&scalar, &[3], &[]).unwrap();
     assert_eq!(broadcast.shape(), &[3]);
+    match &broadcast {
+        Tensor::F64(inner) => {
+            assert_eq!(inner.strides(), &[0]);
+            assert_eq!(inner.offset(), 0);
+        }
+        _ => panic!("expected F64 tensor"),
+    }
     assert_eq!(get_f64(&broadcast, &[0]), 5.0);
     assert_eq!(get_f64(&broadcast, &[1]), 5.0);
     assert_eq!(get_f64(&broadcast, &[2]), 5.0);
@@ -803,10 +845,84 @@ fn test_broadcast_in_dim() {
     let v = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
     let m = broadcast_in_dim(&v, &[3, 2], &[0]).unwrap();
     assert_eq!(m.shape(), &[3, 2]);
+    match &m {
+        Tensor::F64(inner) => {
+            assert_eq!(inner.strides(), &[1, 0]);
+            assert_eq!(inner.offset(), 0);
+        }
+        _ => panic!("expected F64 tensor"),
+    }
     for j in 0..2 {
         assert_eq!(get_f64(&m, &[0, j]), 1.0);
         assert_eq!(get_f64(&m, &[1, j]), 2.0);
         assert_eq!(get_f64(&m, &[2, j]), 3.0);
+    }
+}
+
+#[test]
+fn test_reshape_accepts_fully_broadcast_scalar_view() {
+    let scalar = Tensor::F64(TypedTensor::from_vec(vec![], vec![5.0]));
+    let broadcast = broadcast_in_dim(&scalar, &[3, 2], &[]).unwrap();
+    let reshaped = reshape(&broadcast, &[6]).unwrap();
+
+    assert_eq!(reshaped.shape(), &[6]);
+    match &reshaped {
+        Tensor::F64(inner) => {
+            assert_eq!(inner.strides(), &[0]);
+            assert_eq!(inner.offset(), 0);
+        }
+        _ => panic!("expected f64 tensor"),
+    }
+    for i in 0..6 {
+        assert_eq!(get_f64(&reshaped, &[i]), 5.0);
+    }
+}
+
+#[test]
+fn test_reshape_accepts_singleton_insertion_for_noncontiguous_view() {
+    let base = Tensor::F64(TypedTensor::from_vec(
+        vec![2, 2, 5],
+        (0..20).map(|idx| idx as f64).collect(),
+    ));
+    let transposed = transpose(&base, &[2, 0, 1]).unwrap();
+    let reshaped = reshape(&transposed, &[5, 1, 2, 2]).unwrap();
+
+    assert_eq!(reshaped.shape(), &[5, 1, 2, 2]);
+    match &reshaped {
+        Tensor::F64(inner) => {
+            assert_eq!(inner.strides(), &[4, 0, 1, 2]);
+            assert_eq!(inner.offset(), 0);
+        }
+        _ => panic!("expected f64 tensor"),
+    }
+    for i in 0..5 {
+        for j in 0..2 {
+            for k in 0..2 {
+                assert_eq!(
+                    get_f64(&reshaped, &[i, 0, j, k]),
+                    get_f64(&transposed, &[i, j, k])
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_reshape_materializes_mixed_stride_broadcast_input() {
+    let vector = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
+    let non_contiguous = broadcast_in_dim(&vector, &[3, 2], &[0]).unwrap();
+    let reshaped = reshape(&non_contiguous, &[6]).unwrap();
+
+    assert_eq!(reshaped.shape(), &[6]);
+    match &reshaped {
+        Tensor::F64(inner) => {
+            assert_eq!(inner.strides(), &[1]);
+            assert_eq!(inner.offset(), 0);
+        }
+        _ => panic!("expected f64 tensor"),
+    }
+    for (index, expected) in [1.0, 2.0, 3.0, 1.0, 2.0, 3.0].into_iter().enumerate() {
+        assert_eq!(get_f64(&reshaped, &[index]), expected);
     }
 }
 
@@ -2005,6 +2121,30 @@ fn test_real_cholesky_returns_error_for_non_positive_definite_input() {
 }
 
 #[test]
+fn test_real_cholesky_accepts_row_major_view() {
+    let base = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![4.0, 1.0, 1.0, 3.0]));
+    let row_major_view = transpose(&base, &[1, 0]).unwrap();
+    match &row_major_view {
+        Tensor::F64(inner) => {
+            assert!(inner.is_contiguous_row_major());
+            assert!(!inner.is_contiguous_col_major());
+        }
+        _ => panic!("expected f64 tensor"),
+    }
+
+    let mut backend = CpuBackend::new();
+    let out = backend.cholesky(&row_major_view).unwrap();
+
+    assert_eq!(out.shape(), &[2, 2]);
+    let l = matrix_f64_from_tensor(&out, 2, 2);
+    let recon = matmul_f64(&l, &transpose_f64(&l, 2, 2), 2, 2, 2);
+    let expected = matrix_f64_from_tensor(&base, 2, 2);
+    for (actual, expected) in recon.iter().zip(expected.iter()) {
+        assert_f64_close_tol(*actual, *expected, 1.0e-10);
+    }
+}
+
+#[test]
 fn test_real_solve_returns_error_for_singular_matrix() {
     let a = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 2.0, 4.0]));
     let b = Tensor::F64(TypedTensor::from_vec(vec![2, 1], vec![1.0, 1.0]));
@@ -2263,6 +2403,26 @@ fn test_gather_with_implicit_index_vector_dim() {
     assert_eq!(get_f64(&out, &[0]), 50.0);
     assert_eq!(get_f64(&out, &[1]), 20.0);
     assert_eq!(get_f64(&out, &[2]), 10.0);
+}
+
+#[test]
+fn test_gather_accepts_transposed_index_tensor() {
+    let operand = Tensor::F64(TypedTensor::from_vec(vec![4], vec![10.0, 20.0, 30.0, 40.0]));
+    let starts_base = Tensor::F64(TypedTensor::from_vec(vec![2, 1], vec![2.0, 0.0]));
+    let start_indices = transpose(&starts_base, &[1, 0]).unwrap();
+    let config = GatherConfig {
+        offset_dims: vec![],
+        collapsed_slice_dims: vec![0],
+        start_index_map: vec![0],
+        index_vector_dim: 0,
+        slice_sizes: vec![1],
+    };
+
+    let out = gather(&operand, &start_indices, &config);
+
+    assert_eq!(out.shape(), &[2]);
+    assert_eq!(get_f64(&out, &[0]), 30.0);
+    assert_eq!(get_f64(&out, &[1]), 10.0);
 }
 
 #[test]

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -1,10 +1,11 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::Arc;
 
 use num_complex::{Complex32, Complex64};
 
 use crate::types::{
     col_major_strides, flat_to_multi, Buffer, BufferHandle, ComputeDevice, ConjElem, DType,
-    MemoryKind, Placement, Tensor, TypedTensor,
+    LayoutOrder, MemoryKind, Placement, Tensor, TypedTensor,
 };
 use crate::Error;
 
@@ -34,6 +35,97 @@ fn typed_tensor_rank_zero_access_and_mutation_work() {
 }
 
 #[test]
+fn cloned_host_tensors_use_copy_on_write_for_mutation() {
+    let original = TypedTensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    let mut cloned = original.clone();
+
+    cloned.host_data_mut()[0] = 9.0;
+
+    assert_eq!(original.host_data(), &[1.0, 2.0]);
+    assert_eq!(cloned.host_data(), &[9.0, 2.0]);
+}
+
+#[test]
+fn typed_tensor_constructors_populate_stride_metadata() {
+    let scalar = TypedTensor::from_vec(vec![], vec![1.25_f64]);
+    assert_eq!(scalar.strides(), &[] as &[isize]);
+    assert_eq!(scalar.offset(), 0);
+    assert!(scalar.is_contiguous_col_major());
+    assert!(scalar.is_contiguous_row_major());
+
+    let matrix = TypedTensor::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    assert_eq!(matrix.strides(), &[1, 2]);
+    assert_eq!(matrix.offset(), 0);
+    assert!(matrix.is_contiguous_col_major());
+    assert!(!matrix.is_contiguous_row_major());
+}
+
+#[test]
+fn typed_tensor_contiguity_predicates_distinguish_layouts() {
+    let col_major = TypedTensor::from_vec(vec![2, 3], vec![1.0_f64; 6]);
+    assert!(col_major.is_contiguous_col_major());
+    assert!(!col_major.is_contiguous_row_major());
+
+    let row_major = TypedTensor {
+        buffer: Buffer::Host(Arc::new(vec![1.0_f64; 6])),
+        shape: vec![2, 3],
+        strides: vec![3, 1],
+        offset: 0,
+        placement: Placement {
+            memory_kind: MemoryKind::UnpinnedHost,
+            resident_device: None,
+        },
+    };
+    assert!(!row_major.is_contiguous_col_major());
+    assert!(row_major.is_contiguous_row_major());
+
+    let non_contiguous = TypedTensor {
+        buffer: Buffer::Host(Arc::new(vec![1.0_f64; 12])),
+        shape: vec![2, 3],
+        strides: vec![2, 4],
+        offset: 1,
+        placement: Placement {
+            memory_kind: MemoryKind::UnpinnedHost,
+            resident_device: None,
+        },
+    };
+    assert!(!non_contiguous.is_contiguous_col_major());
+    assert!(!non_contiguous.is_contiguous_row_major());
+}
+
+#[test]
+fn typed_tensor_to_contiguous_supports_row_and_column_major() {
+    let source = TypedTensor {
+        buffer: Buffer::Host(Arc::new(vec![
+            1.0_f64, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 5.0, 0.0, 6.0,
+        ])),
+        shape: vec![2, 3],
+        strides: vec![2, 4],
+        offset: 0,
+        placement: Placement {
+            memory_kind: MemoryKind::UnpinnedHost,
+            resident_device: None,
+        },
+    };
+
+    let col_major = source.to_contiguous(LayoutOrder::ColumnMajor).unwrap();
+    assert!(col_major.is_contiguous_col_major());
+    assert_eq!(col_major.strides(), &[1, 2]);
+    assert_eq!(*col_major.get(&[0, 0]), 1.0);
+    assert_eq!(*col_major.get(&[1, 0]), 2.0);
+    assert_eq!(*col_major.get(&[0, 1]), 3.0);
+    assert_eq!(*col_major.get(&[1, 2]), 6.0);
+
+    let row_major = source.to_contiguous(LayoutOrder::RowMajor).unwrap();
+    assert!(row_major.is_contiguous_row_major());
+    assert_eq!(row_major.strides(), &[3, 1]);
+    assert_eq!(*row_major.get(&[0, 0]), 1.0);
+    assert_eq!(*row_major.get(&[1, 0]), 2.0);
+    assert_eq!(*row_major.get(&[0, 1]), 3.0);
+    assert_eq!(*row_major.get(&[1, 2]), 6.0);
+}
+
+#[test]
 fn typed_tensor_panics_cover_length_and_indexing_errors() {
     let mismatched = catch_unwind(|| TypedTensor::<f64>::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0]));
     assert!(mismatched.is_err());
@@ -58,6 +150,8 @@ fn backend_buffers_panic_when_host_access_is_requested() {
     let tensor = TypedTensor {
         buffer: Buffer::Backend(BufferHandle::<f64>::new(7)),
         shape: vec![1],
+        strides: vec![1],
+        offset: 0,
         placement: placement.clone(),
     };
     assert_eq!(
@@ -71,6 +165,8 @@ fn backend_buffers_panic_when_host_access_is_requested() {
     let mut mutable_tensor = TypedTensor {
         buffer: Buffer::Backend(BufferHandle::<f64>::new(8)),
         shape: vec![1],
+        strides: vec![1],
+        offset: 0,
         placement,
     };
     let host_data_mut = catch_unwind(AssertUnwindSafe(|| {

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -1,5 +1,7 @@
 use num_complex::Complex;
 use num_traits::{One, Zero};
+use std::sync::Arc;
+use strided_kernel::{copy_into, Identity, StridedArray, StridedView};
 
 /// Memory location for tensor storage.
 ///
@@ -90,17 +92,21 @@ impl<T> BufferHandle<T> {
 /// # Examples
 ///
 /// ```ignore
+/// use std::sync::Arc;
 /// use tenferro_tensor::Buffer;
 ///
-/// let host = Buffer::Host(vec![1.0_f64, 2.0]);
+/// let host = Buffer::Host(Arc::new(vec![1.0_f64, 2.0]));
 /// ```
 #[derive(Clone, Debug)]
 pub enum Buffer<T> {
-    Host(Vec<T>),
+    Host(Arc<Vec<T>>),
     Backend(BufferHandle<T>),
 }
 
-/// Contiguous column-major typed tensor storage.
+/// Stride-aware typed tensor storage.
+///
+/// Cloning a host-backed tensor shares the underlying storage handle until a
+/// mutable host access triggers copy-on-write.
 ///
 /// # Examples
 ///
@@ -114,7 +120,25 @@ pub enum Buffer<T> {
 pub struct TypedTensor<T> {
     pub buffer: Buffer<T>,
     pub shape: Vec<usize>,
+    pub strides: Vec<isize>,
+    pub offset: isize,
     pub placement: Placement,
+}
+
+/// Dense materialization order.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tensor::LayoutOrder;
+///
+/// let order = LayoutOrder::ColumnMajor;
+/// assert!(matches!(order, LayoutOrder::ColumnMajor));
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LayoutOrder {
+    ColumnMajor,
+    RowMajor,
 }
 
 /// Runtime scalar dtype tag.
@@ -172,6 +196,26 @@ pub fn col_major_strides(shape: &[usize]) -> Vec<isize> {
     strides
 }
 
+/// Row-major strides derived from a shape.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tensor::row_major_strides;
+///
+/// assert_eq!(row_major_strides(&[2, 3]), vec![3, 1]);
+/// ```
+pub fn row_major_strides(shape: &[usize]) -> Vec<isize> {
+    if shape.is_empty() {
+        return vec![];
+    }
+    let mut strides = vec![1isize; shape.len()];
+    for i in (0..shape.len() - 1).rev() {
+        strides[i] = strides[i + 1] * shape[i + 1] as isize;
+    }
+    strides
+}
+
 pub(crate) fn default_placement() -> Placement {
     Placement {
         memory_kind: MemoryKind::UnpinnedHost,
@@ -193,7 +237,9 @@ impl<T: Clone + Zero> TypedTensor<T> {
     pub fn zeros(shape: Vec<usize>) -> Self {
         let n: usize = shape.iter().product();
         Self {
-            buffer: Buffer::Host(vec![T::zero(); n]),
+            buffer: Buffer::Host(Arc::new(vec![T::zero(); n])),
+            strides: col_major_strides(&shape),
+            offset: 0,
             shape,
             placement: default_placement(),
         }
@@ -214,14 +260,16 @@ impl<T: Clone + One + Zero> TypedTensor<T> {
     pub fn ones(shape: Vec<usize>) -> Self {
         let n: usize = shape.iter().product();
         Self {
-            buffer: Buffer::Host(vec![T::one(); n]),
+            buffer: Buffer::Host(Arc::new(vec![T::one(); n])),
+            strides: col_major_strides(&shape),
+            offset: 0,
             shape,
             placement: default_placement(),
         }
     }
 }
 
-impl<T: Clone> TypedTensor<T> {
+impl<T> TypedTensor<T> {
     /// Create a tensor from a column-major buffer.
     ///
     /// # Examples
@@ -242,10 +290,68 @@ impl<T: Clone> TypedTensor<T> {
             n
         );
         Self {
-            buffer: Buffer::Host(data),
+            buffer: Buffer::Host(Arc::new(data)),
+            strides: col_major_strides(&shape),
+            offset: 0,
             shape,
             placement: default_placement(),
         }
+    }
+
+    /// Borrow the logical strides.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec(vec![2, 3], vec![0.0; 6]);
+    /// assert_eq!(t.strides(), &[1, 2]);
+    /// ```
+    pub fn strides(&self) -> &[isize] {
+        &self.strides
+    }
+
+    /// Base offset into the underlying storage.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec(vec![2], vec![1.0, 2.0]);
+    /// assert_eq!(t.offset(), 0);
+    /// ```
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+
+    /// Returns true when the tensor is contiguous in column-major order.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec(vec![2, 3], vec![0.0; 6]);
+    /// assert!(t.is_contiguous_col_major());
+    /// ```
+    pub fn is_contiguous_col_major(&self) -> bool {
+        self.offset == 0 && self.strides == col_major_strides(&self.shape)
+    }
+
+    /// Returns true when the tensor is contiguous in row-major order.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec(vec![2], vec![1.0, 2.0]);
+    /// assert!(t.is_contiguous_row_major());
+    /// ```
+    pub fn is_contiguous_row_major(&self) -> bool {
+        self.offset == 0 && self.strides == row_major_strides(&self.shape)
     }
 
     /// Number of elements in the tensor.
@@ -262,7 +368,11 @@ impl<T: Clone> TypedTensor<T> {
         self.shape.iter().product()
     }
 
-    /// Borrow the host buffer.
+    /// Borrow the underlying host storage buffer.
+    ///
+    /// This exposes raw storage order, not logical iteration order. For
+    /// non-contiguous tensors, use [`Self::get`] for indexed access or
+    /// [`Self::to_contiguous`] to materialize a dense layout first.
     ///
     /// # Examples
     ///
@@ -274,12 +384,15 @@ impl<T: Clone> TypedTensor<T> {
     /// ```
     pub fn host_data(&self) -> &[T] {
         match &self.buffer {
-            Buffer::Host(v) => v,
+            Buffer::Host(v) => v.as_slice(),
             Buffer::Backend(_) => panic!("host_data called on backend buffer"),
         }
     }
 
-    /// Mutably borrow the host buffer.
+    /// Mutably borrow the underlying host storage buffer.
+    ///
+    /// This triggers copy-on-write when the storage handle is shared by cloned
+    /// tensors or metadata-only views.
     ///
     /// # Examples
     ///
@@ -290,14 +403,17 @@ impl<T: Clone> TypedTensor<T> {
     /// t.host_data_mut()[0] = 3.0;
     /// assert_eq!(t.host_data(), &[3.0, 0.0]);
     /// ```
-    pub fn host_data_mut(&mut self) -> &mut [T] {
+    pub fn host_data_mut(&mut self) -> &mut [T]
+    where
+        T: Clone,
+    {
         match &mut self.buffer {
-            Buffer::Host(v) => v,
+            Buffer::Host(v) => Arc::make_mut(v).as_mut_slice(),
             Buffer::Backend(_) => panic!("host_data_mut called on backend buffer"),
         }
     }
 
-    /// Compute the linear column-major offset for an index.
+    /// Compute the storage offset for a logical multi-index.
     ///
     /// # Examples
     ///
@@ -309,14 +425,12 @@ impl<T: Clone> TypedTensor<T> {
     /// ```
     pub fn linear_offset(&self, indices: &[usize]) -> usize {
         assert_eq!(indices.len(), self.shape.len());
-        let mut offset = 0usize;
-        let mut stride = 1usize;
+        let mut offset = self.offset;
         for (i, &idx) in indices.iter().enumerate() {
             assert!(idx < self.shape[i], "index out of bounds");
-            offset += idx * stride;
-            stride *= self.shape[i];
+            offset += idx as isize * self.strides[i];
         }
-        offset
+        usize::try_from(offset).expect("tensor offset must be non-negative")
     }
 
     /// Borrow a single element by multi-index.
@@ -345,9 +459,73 @@ impl<T: Clone> TypedTensor<T> {
     /// *t.get_mut(&[0]) = 7.0;
     /// assert_eq!(t.host_data(), &[7.0]);
     /// ```
-    pub fn get_mut(&mut self, indices: &[usize]) -> &mut T {
+    pub fn get_mut(&mut self, indices: &[usize]) -> &mut T
+    where
+        T: Clone,
+    {
         let off = self.linear_offset(indices);
         &mut self.host_data_mut()[off]
+    }
+}
+
+impl<T: Copy + Default> TypedTensor<T> {
+    /// Materialize the tensor into a dense contiguous buffer in the requested order.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tensor::{LayoutOrder, TypedTensor};
+    ///
+    /// let t = TypedTensor::<f64>::from_vec(vec![2, 3], vec![1.0; 6]);
+    /// let row_major = t.to_contiguous(LayoutOrder::RowMajor).unwrap();
+    /// assert!(row_major.is_contiguous_row_major());
+    /// ```
+    pub fn to_contiguous(&self, order: LayoutOrder) -> crate::Result<Self> {
+        let strides = match order {
+            LayoutOrder::ColumnMajor => col_major_strides(&self.shape),
+            LayoutOrder::RowMajor => row_major_strides(&self.shape),
+        };
+
+        let data = match &self.buffer {
+            Buffer::Host(data) => data,
+            Buffer::Backend(_) => {
+                return Err(crate::Error::BackendFailure {
+                    op: "to_contiguous",
+                    message: "backend buffer materialization is not implemented".into(),
+                });
+            }
+        };
+
+        let src: StridedView<'_, T, Identity> =
+            StridedView::new(data, &self.shape, &self.strides, self.offset).map_err(|err| {
+                crate::Error::BackendFailure {
+                    op: "to_contiguous",
+                    message: err.to_string(),
+                }
+            })?;
+
+        let mut dst = StridedArray::<T>::from_parts(
+            vec![T::default(); self.n_elements()],
+            &self.shape,
+            &strides,
+            0,
+        )
+        .map_err(|err| crate::Error::BackendFailure {
+            op: "to_contiguous",
+            message: err.to_string(),
+        })?;
+        copy_into(&mut dst.view_mut(), &src).map_err(|err| crate::Error::BackendFailure {
+            op: "to_contiguous",
+            message: err.to_string(),
+        })?;
+
+        Ok(Self {
+            buffer: Buffer::Host(Arc::new(dst.into_data())),
+            shape: self.shape.clone(),
+            strides,
+            offset: 0,
+            placement: self.placement.clone(),
+        })
     }
 }
 

--- a/tenferro/src/buffer_pool.rs
+++ b/tenferro/src/buffer_pool.rs
@@ -102,17 +102,20 @@ impl BufferPool {
     }
 
     /// Number of buffers currently held in the pool.
+    #[inline(never)]
     pub fn len(&self) -> usize {
         self.pool.len()
     }
 
     /// Whether the pool is empty.
+    #[inline(never)]
     pub fn is_empty(&self) -> bool {
         self.pool.is_empty()
     }
 }
 
 impl Default for BufferPool {
+    #[inline(never)]
     fn default() -> Self {
         Self::new()
     }

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -1,6 +1,7 @@
 use super::buffer_pool::BufferPool;
 use crate::error::Result;
 use num_complex::{Complex32, Complex64};
+use std::sync::Arc;
 use tenferro_algebra::Semiring;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_tensor::cpu::structural::{
@@ -420,8 +421,12 @@ fn reclaim_tensor_buffer(tensor: Tensor, pool: &mut BufferPool) {
 }
 
 fn extract_host_bytes<T>(typed: TypedTensor<T>) -> Option<Vec<u8>> {
+    if !typed.is_contiguous_col_major() {
+        return None;
+    }
     match typed.buffer {
         Buffer::Host(data) => {
+            let data = Arc::try_unwrap(data).ok()?;
             let mut data = std::mem::ManuallyDrop::new(data);
             let ptr = data.as_mut_ptr() as *mut u8;
             let len = data.len() * std::mem::size_of::<T>();

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -18,7 +18,7 @@ use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::cpu::CpuBackend;
-use tenferro_tensor::{DType, DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
+use tenferro_tensor::{DType, DotGeneralConfig, LayoutOrder, Tensor, TensorBackend, TypedTensor};
 use tidu::{differentiate, transpose, LinearFragment};
 
 const TOL: f64 = 1e-6;
@@ -161,16 +161,24 @@ fn c64_tensor(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
     Tensor::C64(TypedTensor::from_vec(shape, data))
 }
 
-fn get_f64_data(tensor: &Tensor) -> &[f64] {
+fn get_f64_data(tensor: &Tensor) -> Vec<f64> {
     match tensor {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner
+            .to_contiguous(LayoutOrder::ColumnMajor)
+            .unwrap()
+            .host_data()
+            .to_vec(),
         _ => panic!("expected f64 tensor"),
     }
 }
 
-fn get_c64_data(tensor: &Tensor) -> &[Complex64] {
+fn get_c64_data(tensor: &Tensor) -> Vec<Complex64> {
     match tensor {
-        Tensor::C64(inner) => inner.host_data(),
+        Tensor::C64(inner) => inner
+            .to_contiguous(LayoutOrder::ColumnMajor)
+            .unwrap()
+            .host_data()
+            .to_vec(),
         _ => panic!("expected c64 tensor"),
     }
 }
@@ -191,7 +199,7 @@ fn concrete_dim_shape(shape: &[DimExpr]) -> Vec<usize> {
 
 fn eval_tensor(mut traced: TracedTensor) -> Tensor {
     let mut engine = Engine::new(CpuBackend::new());
-    traced.eval(&mut engine).unwrap().clone()
+    materialize_tensor(traced.eval(&mut engine).unwrap().clone())
 }
 
 fn eval_scalar(traced: TracedTensor) -> f64 {
@@ -328,7 +336,20 @@ fn eval_fragment_outputs(
         .collect();
     let mut backend = CpuBackend::new();
     let mut pool = BufferPool::new();
-    eval_exec_ir(&mut backend, &exec, inputs, &mut pool).unwrap()
+    eval_exec_ir(&mut backend, &exec, inputs, &mut pool)
+        .unwrap()
+        .into_iter()
+        .map(materialize_tensor)
+        .collect()
+}
+
+fn materialize_tensor(tensor: Tensor) -> Tensor {
+    match tensor {
+        Tensor::F32(inner) => Tensor::F32(inner.to_contiguous(LayoutOrder::ColumnMajor).unwrap()),
+        Tensor::F64(inner) => Tensor::F64(inner.to_contiguous(LayoutOrder::ColumnMajor).unwrap()),
+        Tensor::C32(inner) => Tensor::C32(inner.to_contiguous(LayoutOrder::ColumnMajor).unwrap()),
+        Tensor::C64(inner) => Tensor::C64(inner.to_contiguous(LayoutOrder::ColumnMajor).unwrap()),
+    }
 }
 
 fn scalar_f64_tensor(value: f64) -> Tensor {
@@ -1160,7 +1181,8 @@ fn sum_qr_r_real_parts_complex(data: &[Complex64]) -> f64 {
     sum_real_parts(get_c64_data(&outputs[1]))
 }
 
-fn sum_real_parts(values: &[Complex64]) -> f64 {
+fn sum_real_parts(values: impl AsRef<[Complex64]>) -> f64 {
+    let values = values.as_ref();
     values.iter().map(|value| value.re).sum()
 }
 
@@ -1253,7 +1275,8 @@ fn sum_triangular_solve_real_parts_complex(a: &[Complex64], b: &[Complex64]) -> 
     sum_real_parts(get_c64_data(&output))
 }
 
-fn assert_close_slice(actual: &[f64], expected: &[f64]) {
+fn assert_close_slice(actual: impl AsRef<[f64]>, expected: &[f64]) {
+    let actual = actual.as_ref();
     assert_eq!(actual.len(), expected.len());
     for (index, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
         assert!(
@@ -1263,7 +1286,8 @@ fn assert_close_slice(actual: &[f64], expected: &[f64]) {
     }
 }
 
-fn assert_close_slice_c64(actual: &[Complex64], expected: &[Complex64]) {
+fn assert_close_slice_c64(actual: impl AsRef<[Complex64]>, expected: &[Complex64]) {
+    let actual = actual.as_ref();
     assert_eq!(actual.len(), expected.len());
     for (index, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
         assert!(
@@ -1274,16 +1298,22 @@ fn assert_close_slice_c64(actual: &[Complex64], expected: &[Complex64]) {
 }
 
 fn assert_jvp_matches_finite_diff(
-    actual: &[f64],
+    actual: impl AsRef<[f64]>,
     base: &[f64],
     tangent: &[f64],
     f: impl Fn(&[f64]) -> Vec<f64>,
 ) {
+    let actual = actual.as_ref();
     let expected = finite_diff_tensor_directional(f, base, tangent, 1e-6);
     assert_close_slice(actual, &expected);
 }
 
-fn assert_grad_matches_finite_diff(actual: &[f64], base: &[f64], f: impl Fn(&[f64]) -> f64) {
+fn assert_grad_matches_finite_diff(
+    actual: impl AsRef<[f64]>,
+    base: &[f64],
+    f: impl Fn(&[f64]) -> f64,
+) {
+    let actual = actual.as_ref();
     assert_eq!(actual.len(), base.len());
     for index in 0..base.len() {
         let expected = finite_diff_scalar(&f, base, index, 1e-6);
@@ -1296,11 +1326,12 @@ fn assert_grad_matches_finite_diff(actual: &[f64], base: &[f64], f: impl Fn(&[f6
 }
 
 fn assert_grad_matches_finite_diff_lhs(
-    actual: &[f64],
+    actual: impl AsRef<[f64]>,
     lhs: &[f64],
     rhs: &[f64],
     f: &impl Fn(&[f64], &[f64]) -> f64,
 ) {
+    let actual = actual.as_ref();
     assert_eq!(actual.len(), lhs.len());
     for index in 0..lhs.len() {
         let expected = finite_diff_scalar_lhs(&f, lhs, rhs, index, 1e-6);
@@ -1313,11 +1344,12 @@ fn assert_grad_matches_finite_diff_lhs(
 }
 
 fn assert_grad_matches_finite_diff_rhs(
-    actual: &[f64],
+    actual: impl AsRef<[f64]>,
     lhs: &[f64],
     rhs: &[f64],
     f: &impl Fn(&[f64], &[f64]) -> f64,
 ) {
+    let actual = actual.as_ref();
     assert_eq!(actual.len(), rhs.len());
     for index in 0..rhs.len() {
         let expected = finite_diff_scalar_rhs(&f, lhs, rhs, index, 1e-6);
@@ -1330,12 +1362,13 @@ fn assert_grad_matches_finite_diff_rhs(
 }
 
 fn assert_grad_matches_complex_finite_diff(
-    actual: &[Complex64],
+    actual: impl AsRef<[Complex64]>,
     base: &[Complex64],
     indices: &[usize],
     tol: f64,
     f: impl Fn(&[Complex64]) -> f64,
 ) {
+    let actual = actual.as_ref();
     for &index in indices {
         let expected = finite_diff_complex(&f, base, index, 1e-6);
         assert!(
@@ -1347,12 +1380,13 @@ fn assert_grad_matches_complex_finite_diff(
 }
 
 fn assert_grad_matches_complex_finite_diff_lhs(
-    actual: &[Complex64],
+    actual: impl AsRef<[Complex64]>,
     lhs: &[Complex64],
     rhs: &[Complex64],
     tol: f64,
     f: &impl Fn(&[Complex64], &[Complex64]) -> f64,
 ) {
+    let actual = actual.as_ref();
     assert_eq!(actual.len(), lhs.len());
     for index in 0..lhs.len() {
         let expected = finite_diff_complex_lhs(f, lhs, rhs, index, 1e-6);
@@ -1365,12 +1399,13 @@ fn assert_grad_matches_complex_finite_diff_lhs(
 }
 
 fn assert_grad_matches_complex_finite_diff_rhs(
-    actual: &[Complex64],
+    actual: impl AsRef<[Complex64]>,
     lhs: &[Complex64],
     rhs: &[Complex64],
     tol: f64,
     f: &impl Fn(&[Complex64], &[Complex64]) -> f64,
 ) {
+    let actual = actual.as_ref();
     assert_eq!(actual.len(), rhs.len());
     for index in 0..rhs.len() {
         let expected = finite_diff_complex_rhs(f, lhs, rhs, index, 1e-6);
@@ -1987,7 +2022,7 @@ fn grad_exp() {
     let grad_tensor = eval_tensor(grad);
     let grad_data = get_f64_data(&grad_tensor);
     let expected: Vec<f64> = x_data.iter().map(|x| x.exp()).collect();
-    assert_close_slice(grad_data, &expected);
+    assert_close_slice(&grad_data, &expected);
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2006,7 +2041,7 @@ fn grad_log() {
     let grad_tensor = eval_tensor(grad);
     let grad_data = get_f64_data(&grad_tensor);
     let expected: Vec<f64> = x_data.iter().map(|x| 1.0 / x).collect();
-    assert_close_slice(grad_data, &expected);
+    assert_close_slice(&grad_data, &expected);
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2025,7 +2060,7 @@ fn grad_sin_cos() {
     let sin_grad_tensor = eval_tensor(sin_grad);
     let sin_grad_data = get_f64_data(&sin_grad_tensor);
     let expected_sin: Vec<f64> = x_data.iter().map(|x| x.cos()).collect();
-    assert_close_slice(sin_grad_data, &expected_sin);
+    assert_close_slice(&sin_grad_data, &expected_sin);
 
     let f_sin = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2039,7 +2074,7 @@ fn grad_sin_cos() {
     let cos_grad_tensor = eval_tensor(cos_grad);
     let cos_grad_data = get_f64_data(&cos_grad_tensor);
     let expected_cos: Vec<f64> = x_data.iter().map(|x| -x.sin()).collect();
-    assert_close_slice(cos_grad_data, &expected_cos);
+    assert_close_slice(&cos_grad_data, &expected_cos);
 
     let f_cos = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2070,8 +2105,8 @@ fn grad_div() {
         .zip(y_data.iter())
         .map(|(x, y)| -x / (y * y))
         .collect();
-    assert_close_slice(grad_x_data, &expected_x);
-    assert_close_slice(grad_y_data, &expected_y);
+    assert_close_slice(&grad_x_data, &expected_x);
+    assert_close_slice(&grad_y_data, &expected_y);
 
     let f = |lhs: &[f64], rhs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], lhs.to_vec()));
@@ -2092,7 +2127,7 @@ fn grad_sqrt() {
     let grad_tensor = eval_tensor(grad);
     let grad_data = get_f64_data(&grad_tensor);
     let expected: Vec<f64> = x_data.iter().map(|x| 0.5 / x.sqrt()).collect();
-    assert_close_slice(grad_data, &expected);
+    assert_close_slice(&grad_data, &expected);
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2111,7 +2146,7 @@ fn grad_tanh() {
     let grad_tensor = eval_tensor(grad);
     let grad_data = get_f64_data(&grad_tensor);
     let expected: Vec<f64> = x_data.iter().map(|x| 1.0 - x.tanh().powi(2)).collect();
-    assert_close_slice(grad_data, &expected);
+    assert_close_slice(&grad_data, &expected);
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2132,7 +2167,7 @@ fn grad_pow() {
     let grad_x_tensor = eval_tensor(grad_x);
     let grad_x_data = get_f64_data(&grad_x_tensor);
     let expected_x: Vec<f64> = x_data.iter().map(|x| 2.0 * x).collect();
-    assert_close_slice(grad_x_data, &expected_x);
+    assert_close_slice(&grad_x_data, &expected_x);
 
     let f = |lhs: &[f64], rhs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], lhs.to_vec()));
@@ -2158,7 +2193,7 @@ fn grad_pow_wrt_exponent() {
         .zip(y_data.iter())
         .map(|(x, y)| x.ln() * x.powf(*y))
         .collect();
-    assert_close_slice(grad_y_data, &expected_y);
+    assert_close_slice(&grad_y_data, &expected_y);
 
     let f = |lhs: &[f64], rhs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], lhs.to_vec()));
@@ -2178,7 +2213,7 @@ fn grad_abs() {
     let grad_tensor = eval_tensor(grad);
     let grad_data = get_f64_data(&grad_tensor);
     let expected = [-1.0, 1.0, 1.0];
-    assert_close_slice(grad_data, &expected);
+    assert_close_slice(&grad_data, &expected);
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2196,7 +2231,7 @@ fn grad_sign() {
 
     let grad_tensor = eval_tensor(grad);
     let grad_data = get_f64_data(&grad_tensor);
-    assert_close_slice(grad_data, &[0.0, 0.0, 0.0]);
+    assert_close_slice(&grad_data, &[0.0, 0.0, 0.0]);
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2215,7 +2250,7 @@ fn grad_rsqrt() {
     let grad_tensor = eval_tensor(grad);
     let grad_data = get_f64_data(&grad_tensor);
     let expected: Vec<f64> = x_data.iter().map(|x| -0.5 / (x * x.sqrt())).collect();
-    assert_close_slice(grad_data, &expected);
+    assert_close_slice(&grad_data, &expected);
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2234,7 +2269,7 @@ fn grad_expm1() {
     let grad_tensor = eval_tensor(grad);
     let grad_data = get_f64_data(&grad_tensor);
     let expected: Vec<f64> = x_data.iter().map(|x| x.exp()).collect();
-    assert_close_slice(grad_data, &expected);
+    assert_close_slice(&grad_data, &expected);
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2253,7 +2288,7 @@ fn grad_log1p() {
     let grad_tensor = eval_tensor(grad);
     let grad_data = get_f64_data(&grad_tensor);
     let expected: Vec<f64> = x_data.iter().map(|x| 1.0 / (x + 1.0)).collect();
-    assert_close_slice(grad_data, &expected);
+    assert_close_slice(&grad_data, &expected);
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor(f64_tensor(vec![3], xs.to_vec()));
@@ -2820,7 +2855,7 @@ fn grad_svd_values_repeated_singular_values_is_finite() {
         f64_tensor(vec![2, 2], a_data),
     );
 
-    for &value in get_f64_data(&grad) {
+    for value in get_f64_data(&grad) {
         assert!(value.is_finite(), "svd gradient not finite: {value}");
     }
 }
@@ -2836,7 +2871,7 @@ fn grad_eigh_values_degenerate_spectrum_is_finite() {
         f64_tensor(vec![2, 2], a_data),
     );
 
-    for &value in get_f64_data(&grad) {
+    for value in get_f64_data(&grad) {
         assert!(value.is_finite(), "eigh gradient not finite: {value}");
     }
 }

--- a/tenferro/tests/batched_linalg.rs
+++ b/tenferro/tests/batched_linalg.rs
@@ -2,7 +2,7 @@ use num_complex::Complex64;
 use tenferro::engine::Engine;
 use tenferro::traced::TracedTensor;
 use tenferro::{cholesky, qr, solve, svd, triangular_solve};
-use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend, TypedTensor};
+use tenferro_tensor::{cpu::CpuBackend, LayoutOrder, Tensor, TensorBackend, TypedTensor};
 
 const TOL: f64 = 1.0e-9;
 
@@ -10,9 +10,13 @@ fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec(shape, data))
 }
 
-fn get_f64_data(tensor: &Tensor) -> &[f64] {
+fn get_f64_data(tensor: &Tensor) -> Vec<f64> {
     match tensor {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner
+            .to_contiguous(LayoutOrder::ColumnMajor)
+            .unwrap()
+            .host_data()
+            .to_vec(),
         _ => panic!("expected f64 tensor"),
     }
 }
@@ -21,9 +25,13 @@ fn c64_tensor(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
     Tensor::C64(TypedTensor::from_vec(shape, data))
 }
 
-fn get_c64_data(tensor: &Tensor) -> &[Complex64] {
+fn get_c64_data(tensor: &Tensor) -> Vec<Complex64> {
     match tensor {
-        Tensor::C64(inner) => inner.host_data(),
+        Tensor::C64(inner) => inner
+            .to_contiguous(LayoutOrder::ColumnMajor)
+            .unwrap()
+            .host_data()
+            .to_vec(),
         _ => panic!("expected c64 tensor"),
     }
 }
@@ -34,7 +42,9 @@ fn eval(traced: TracedTensor) -> Tensor {
     traced.eval(&mut engine).unwrap().clone()
 }
 
-fn assert_close(actual: &[f64], expected: &[f64]) {
+fn assert_close(actual: impl AsRef<[f64]>, expected: impl AsRef<[f64]>) {
+    let actual = actual.as_ref();
+    let expected = expected.as_ref();
     assert_eq!(actual.len(), expected.len(), "length mismatch");
     for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
         let diff = (actual - expected).abs();
@@ -45,7 +55,9 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
     }
 }
 
-fn assert_close_c64(actual: &[Complex64], expected: &[Complex64]) {
+fn assert_close_c64(actual: impl AsRef<[Complex64]>, expected: impl AsRef<[Complex64]>) {
+    let actual = actual.as_ref();
+    let expected = expected.as_ref();
     assert_eq!(actual.len(), expected.len(), "length mismatch");
     for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
         let diff = (actual - expected).norm();
@@ -81,6 +93,24 @@ fn solve_supports_batched_vector_rhs() {
         ],
     ));
     let b = TracedTensor::from_tensor(f64_tensor(vec![2, 2], vec![4.0, 9.0, 8.0, 20.0]));
+
+    let out = eval(solve(&a, &b));
+
+    assert_eq!(out.shape(), &[2, 2]);
+    assert_close(get_f64_data(&out), &[2.0, 3.0, 2.0, 4.0]);
+}
+
+#[test]
+fn solve_accepts_noncontiguous_batched_vector_rhs() {
+    let a = TracedTensor::from_tensor(f64_tensor(
+        vec![2, 2, 2],
+        vec![
+            2.0, 0.0, 0.0, 3.0, //
+            4.0, 0.0, 0.0, 5.0,
+        ],
+    ));
+    let rhs_base = TracedTensor::from_tensor(f64_tensor(vec![2, 2], vec![4.0, 8.0, 9.0, 20.0]));
+    let b = rhs_base.transpose(&[1, 0]);
 
     let out = eval(solve(&a, &b));
 

--- a/tenferro/tests/cpu_backend.rs
+++ b/tenferro/tests/cpu_backend.rs
@@ -6,7 +6,7 @@ use tenferro::buffer_pool::BufferPool;
 use tenferro::einsum::einsum;
 use tenferro::engine::Engine;
 use tenferro::traced::TracedTensor;
-use tenferro_tensor::{cpu::CpuBackend, DotGeneralConfig, Tensor, TypedTensor};
+use tenferro_tensor::{cpu::CpuBackend, DotGeneralConfig, LayoutOrder, Tensor, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec(shape, data))
@@ -16,16 +16,24 @@ fn f32_tensor(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
     Tensor::F32(TypedTensor::from_vec(shape, data))
 }
 
-fn get_f64_data(t: &Tensor) -> &[f64] {
+fn get_f64_data(t: &Tensor) -> Vec<f64> {
     match t {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner
+            .to_contiguous(LayoutOrder::ColumnMajor)
+            .unwrap()
+            .host_data()
+            .to_vec(),
         _ => panic!("expected F64"),
     }
 }
 
-fn get_f32_data(t: &Tensor) -> &[f32] {
+fn get_f32_data(t: &Tensor) -> Vec<f32> {
     match t {
-        Tensor::F32(inner) => inner.host_data(),
+        Tensor::F32(inner) => inner
+            .to_contiguous(LayoutOrder::ColumnMajor)
+            .unwrap()
+            .host_data()
+            .to_vec(),
         _ => panic!("expected F32"),
     }
 }
@@ -266,6 +274,13 @@ fn test_buffer_pool_allocate_fresh() {
     let mut pool = BufferPool::new();
     let buf = pool.allocate(64);
     assert_eq!(buf.len(), 64);
+    assert!(pool.is_empty());
+}
+
+#[test]
+fn test_buffer_pool_default_is_empty() {
+    let pool = BufferPool::default();
+    assert_eq!(pool.len(), 0);
     assert!(pool.is_empty());
 }
 

--- a/tenferro/tests/exec_dispatch.rs
+++ b/tenferro/tests/exec_dispatch.rs
@@ -6,8 +6,8 @@ use tenferro_algebra::Standard;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_tensor::cpu::CpuBackend;
 use tenferro_tensor::{
-    CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
-    Tensor, TensorBackend, TypedTensor,
+    CompareDir, DType, DotGeneralConfig, GatherConfig, LayoutOrder, PadConfig, ScatterConfig,
+    SliceConfig, Tensor, TensorBackend, TypedTensor,
 };
 
 fn dim_shape(shape: &[usize]) -> Vec<DimExpr> {
@@ -20,16 +20,24 @@ fn scalar_tensor(value: f64) -> Tensor {
 
 fn scalar_value(tensor: &Tensor) -> f64 {
     match tensor {
-        Tensor::F64(inner) => inner.host_data()[0],
+        Tensor::F64(inner) => *inner.get(&[]),
         other => panic!("expected scalar f64 tensor, got {other:?}"),
     }
 }
 
 fn scalar_c64_value(tensor: &Tensor) -> Complex64 {
     match tensor {
-        Tensor::C64(inner) => inner.host_data()[0],
+        Tensor::C64(inner) => *inner.get(&[]),
         other => panic!("expected scalar c64 tensor, got {other:?}"),
     }
+}
+
+fn logical_f64_data(tensor: &TypedTensor<f64>) -> Vec<f64> {
+    tensor
+        .to_contiguous(LayoutOrder::ColumnMajor)
+        .unwrap()
+        .host_data()
+        .to_vec()
 }
 
 fn typed_scalar(value: f64) -> TypedTensor<f64> {
@@ -734,7 +742,7 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
         vec![typed_scalar(2.0), typed_scalar(3.0)],
     )
     .unwrap();
-    assert_eq!(add_out[0].host_data(), &[5.0]);
+    assert_eq!(logical_f64_data(&add_out[0]), &[5.0]);
 
     let mul_out = eval_semiring_ir::<_, Standard<f64>>(
         &mut backend,
@@ -742,7 +750,7 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
         vec![typed_scalar(2.0), typed_scalar(3.0)],
     )
     .unwrap();
-    assert_eq!(mul_out[0].host_data(), &[6.0]);
+    assert_eq!(logical_f64_data(&mul_out[0]), &[6.0]);
 
     let reduce_out = eval_semiring_ir::<_, Standard<f64>>(
         &mut backend,
@@ -751,7 +759,7 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
     )
     .unwrap();
     assert_eq!(reduce_out[0].shape, vec![2]);
-    assert_eq!(reduce_out[0].host_data(), &[3.0, 7.0]);
+    assert_eq!(logical_f64_data(&reduce_out[0]), &[3.0, 7.0]);
 
     let permute_out = eval_semiring_ir::<_, Standard<f64>>(
         &mut backend,
@@ -763,7 +771,10 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
     )
     .unwrap();
     assert_eq!(permute_out[0].shape, vec![3, 2]);
-    assert_eq!(permute_out[0].host_data(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
+    assert_eq!(
+        logical_f64_data(&permute_out[0]),
+        &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
+    );
 
     let reshape_out = eval_semiring_ir::<_, Standard<f64>>(
         &mut backend,
@@ -780,7 +791,10 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
     )
     .unwrap();
     assert_eq!(reshape_out[0].shape, vec![3, 2]);
-    assert_eq!(reshape_out[0].host_data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    assert_eq!(
+        logical_f64_data(&reshape_out[0]),
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    );
 
     let broadcast_out = eval_semiring_ir::<_, Standard<f64>>(
         &mut backend,
@@ -796,7 +810,7 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
     .unwrap();
     assert_eq!(broadcast_out[0].shape, vec![3, 2]);
     assert_eq!(
-        broadcast_out[0].host_data(),
+        logical_f64_data(&broadcast_out[0]).as_slice(),
         &[1.0, 2.0, 3.0, 1.0, 2.0, 3.0]
     );
 
@@ -816,7 +830,7 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
     )
     .unwrap();
     assert_eq!(extract_out[0].shape, vec![3]);
-    assert_eq!(extract_out[0].host_data(), &[1.0, 5.0, 9.0]);
+    assert_eq!(logical_f64_data(&extract_out[0]), &[1.0, 5.0, 9.0]);
 
     let embed_out = eval_semiring_ir::<_, Standard<f64>>(
         &mut backend,
@@ -832,7 +846,7 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
     .unwrap();
     assert_eq!(embed_out[0].shape, vec![3, 3]);
     assert_eq!(
-        embed_out[0].host_data(),
+        logical_f64_data(&embed_out[0]).as_slice(),
         &[1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0]
     );
 
@@ -856,7 +870,7 @@ fn eval_semiring_ir_executes_semiring_structural_and_gemm_ops() {
     )
     .unwrap();
     assert_eq!(gemm_out[0].shape, vec![2, 2]);
-    assert_eq!(gemm_out[0].host_data(), &[23.0, 34.0, 31.0, 46.0]);
+    assert_eq!(logical_f64_data(&gemm_out[0]), &[23.0, 34.0, 31.0, 46.0]);
 }
 
 #[test]

--- a/tenferro/tests/oracle_replay/compare.rs
+++ b/tenferro/tests/oracle_replay/compare.rs
@@ -1,5 +1,6 @@
 use num_complex::Complex64;
 use tenferro::Tensor;
+use tenferro_tensor::LayoutOrder;
 
 use crate::decode::{complex_tensor_data_as_col_major, tensor_data_as_col_major, TensorData};
 
@@ -50,9 +51,17 @@ pub fn compare_tensor(
     match actual {
         Tensor::F64(inner) => {
             let expected_data = tensor_data_as_col_major(expected)?;
-            allclose(inner.host_data(), &expected_data, rtol, atol)
+            let actual = inner
+                .to_contiguous(LayoutOrder::ColumnMajor)
+                .map_err(|err| err.to_string())?;
+            allclose(actual.host_data(), &expected_data, rtol, atol)
         }
-        Tensor::C64(inner) => compare_complex64(inner.host_data(), expected, rtol, atol),
+        Tensor::C64(inner) => {
+            let actual = inner
+                .to_contiguous(LayoutOrder::ColumnMajor)
+                .map_err(|err| err.to_string())?;
+            compare_complex64(actual.host_data(), expected, rtol, atol)
+        }
         _ => Err(format!(
             "unsupported actual tensor dtype {:?}",
             actual.dtype()

--- a/tenferro/tests/primitive_ops.rs
+++ b/tenferro/tests/primitive_ops.rs
@@ -2,15 +2,19 @@ use tenferro::engine::Engine;
 use tenferro::pow;
 use tenferro::traced::{eval_all, TracedTensor};
 use tenferro_tensor::cpu::CpuBackend;
-use tenferro_tensor::{DotGeneralConfig, Tensor, TypedTensor};
+use tenferro_tensor::{DotGeneralConfig, LayoutOrder, Tensor, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec(shape, data))
 }
 
-fn get_f64_data(t: &Tensor) -> &[f64] {
+fn get_f64_data(t: &Tensor) -> Vec<f64> {
     match t {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner
+            .to_contiguous(LayoutOrder::ColumnMajor)
+            .unwrap()
+            .host_data()
+            .to_vec(),
         _ => panic!("expected F64"),
     }
 }


### PR DESCRIPTION
## Summary
- make public `Tensor` / `TypedTensor` values stride-aware instead of assuming contiguous column-major storage everywhere
- convert structural ops and CPU execution paths to preserve layout metadata and materialize only at explicit boundaries
- update docs, rules, and tests for the new tensor/layout contract

## What Changed
- extend tensor storage metadata with strides and offsets, plus explicit contiguous materialization helpers
- make transpose and broadcast metadata-only where possible, and teach reshape/reduction/indexing/GEMM/linalg paths to respect non-contiguous tensors
- update exec/buffer-pool handling and test helpers to stop treating raw host storage as logical tensor order
- document the new stride-aware tensor model and explicit FFI materialization boundary in README, design docs, and repository rules

## Root Cause
The runtime previously treated contiguous column-major layout as a global invariant. That forced eager materialization at internal boundaries, made layout-sensitive paths reconstruct memory layout from shape alone, and broke once transpose/broadcast results started surviving as views.

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --release -q`
- `cargo llvm-cov clean --workspace && cargo llvm-cov --workspace --release --json --output-path coverage.json --no-clean -j1`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
