### PR TITLE
perf: eliminate zero-init + extend BufferPool to linalg

### DIFF
--- a/tenferro-tensor/src/buffer_pool.rs
+++ b/tenferro-tensor/src/buffer_pool.rs
@@ -189,6 +189,34 @@ impl BufferPool {
             + self.c32_pool.values().map(Vec::len).sum::<usize>()
     }
 
+    /// Acquire a typed vector with length 0 and at least `cap` capacity.
+    ///
+    /// Returned buffers come from the typed pool when possible and are ready
+    /// for push-based population.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_tensor::buffer_pool::BufferPool;
+    ///
+    /// let mut pool = BufferPool::new();
+    /// let mut buf = pool.acquire_with_capacity::<f64>(4);
+    /// buf.extend_from_slice(&[1.0, 2.0]);
+    /// assert_eq!(buf.len(), 2);
+    /// assert!(buf.capacity() >= 4);
+    /// ```
+    pub fn acquire_with_capacity<T: PoolScalar>(&mut self, cap: usize) -> Vec<T> {
+        if cap == 0 {
+            return Vec::new();
+        }
+
+        let mut buf = unsafe { T::pool_acquire(self, cap) };
+        // SAFETY: shrinking the length to zero does not read the buffer. The
+        // pool only stores `PoolScalar` values, which are `Copy`.
+        unsafe { buf.set_len(0) };
+        buf
+    }
+
     /// Whether all typed pools are empty.
     ///
     /// # Examples
@@ -272,6 +300,22 @@ mod tests {
     fn zero_len_not_pooled() {
         let mut pool = BufferPool::new();
         <f64 as PoolScalar>::pool_release(&mut pool, Vec::new());
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn acquire_with_capacity_reuses_buffer_as_empty_vec() {
+        let mut pool = BufferPool::new();
+
+        let buf = vec![1.0_f64; 8];
+        let ptr = buf.as_ptr();
+        let cap = buf.capacity();
+        <f64 as PoolScalar>::pool_release(&mut pool, buf);
+
+        let reused = pool.acquire_with_capacity::<f64>(8);
+        assert_eq!(reused.as_ptr(), ptr);
+        assert_eq!(reused.len(), 0);
+        assert_eq!(reused.capacity(), cap);
         assert!(pool.is_empty());
     }
 }

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -413,19 +413,23 @@ impl TensorBackend for CpuBackend {
 
     fn cholesky(&mut self, input: &Tensor) -> crate::Result<Tensor> {
         let ctx = Arc::clone(&self.ctx);
-        self.install(|| match input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => catch_backend_panic("cholesky", || linalg::cholesky(ctx.as_ref(), t))
-                .and_then(|result| result)
-                .map(Tensor::F64),
+            Tensor::F64(t) => {
+                catch_backend_panic("cholesky", || linalg::cholesky(ctx.as_ref(), buffers, t))
+                    .and_then(|result| result)
+                    .map(Tensor::F64)
+            }
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => {
-                catch_backend_panic("cholesky", || linalg::cholesky(t)).map(Tensor::F64)
+                catch_backend_panic("cholesky", || linalg::cholesky(buffers, t)).map(Tensor::F64)
             }
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => catch_backend_panic("cholesky", || linalg::cholesky(ctx.as_ref(), t))
-                .and_then(|result| result)
-                .map(Tensor::C64),
+            Tensor::C64(t) => {
+                catch_backend_panic("cholesky", || linalg::cholesky(ctx.as_ref(), buffers, t))
+                    .and_then(|result| result)
+                    .map(Tensor::C64)
+            }
             _ => Err(unsupported_dtype("cholesky", input.dtype())),
         })
     }
@@ -440,11 +444,12 @@ impl TensorBackend for CpuBackend {
         unit_diagonal: bool,
     ) -> crate::Result<Tensor> {
         let ctx = Arc::clone(&self.ctx);
-        self.install(|| match (a, b) {
+        self.install_with_pool(|buffers| match (a, b) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
                 Tensor::F64(linalg::triangular_solve(
                     ctx.as_ref(),
+                    buffers,
                     a,
                     b,
                     left_side,
@@ -456,6 +461,7 @@ impl TensorBackend for CpuBackend {
             #[cfg(feature = "cpu-blas")]
             (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
                 Tensor::F64(linalg::triangular_solve(
+                    buffers,
                     a,
                     b,
                     left_side,
@@ -468,6 +474,7 @@ impl TensorBackend for CpuBackend {
             (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
                 Tensor::C64(linalg::triangular_solve(
                     ctx.as_ref(),
+                    buffers,
                     a,
                     b,
                     left_side,
@@ -492,21 +499,24 @@ impl TensorBackend for CpuBackend {
 
     fn lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         let ctx = Arc::clone(&self.ctx);
-        self.install(|| match input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => catch_backend_panic("lu", || {
-                linalg::lu(ctx.as_ref(), t)
+                linalg::lu(ctx.as_ref(), buffers, t)
                     .into_iter()
                     .map(Tensor::F64)
                     .collect()
             }),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => catch_backend_panic("lu", || {
-                linalg::lu(t).into_iter().map(Tensor::F64).collect()
+                linalg::lu(buffers, t)
+                    .into_iter()
+                    .map(Tensor::F64)
+                    .collect()
             }),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => catch_backend_panic("lu", || {
-                linalg::lu(ctx.as_ref(), t)
+                linalg::lu(ctx.as_ref(), buffers, t)
                     .into_iter()
                     .map(Tensor::C64)
                     .collect()
@@ -517,21 +527,24 @@ impl TensorBackend for CpuBackend {
 
     fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         let ctx = Arc::clone(&self.ctx);
-        self.install(|| match input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => catch_backend_panic("svd", || {
-                linalg::svd(ctx.as_ref(), t)
+                linalg::svd(ctx.as_ref(), buffers, t)
                     .into_iter()
                     .map(Tensor::F64)
                     .collect()
             }),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => catch_backend_panic("svd", || {
-                linalg::svd(t).into_iter().map(Tensor::F64).collect()
+                linalg::svd(buffers, t)
+                    .into_iter()
+                    .map(Tensor::F64)
+                    .collect()
             }),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => catch_backend_panic("svd", || {
-                linalg::svd(ctx.as_ref(), t)
+                linalg::svd(ctx.as_ref(), buffers, t)
                     .into_iter()
                     .map(Tensor::C64)
                     .collect()
@@ -542,21 +555,24 @@ impl TensorBackend for CpuBackend {
 
     fn qr(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         let ctx = Arc::clone(&self.ctx);
-        self.install(|| match input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => catch_backend_panic("qr", || {
-                linalg::qr(ctx.as_ref(), t)
+                linalg::qr(ctx.as_ref(), buffers, t)
                     .into_iter()
                     .map(Tensor::F64)
                     .collect()
             }),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => catch_backend_panic("qr", || {
-                linalg::qr(t).into_iter().map(Tensor::F64).collect()
+                linalg::qr(buffers, t)
+                    .into_iter()
+                    .map(Tensor::F64)
+                    .collect()
             }),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => catch_backend_panic("qr", || {
-                linalg::qr(ctx.as_ref(), t)
+                linalg::qr(ctx.as_ref(), buffers, t)
                     .into_iter()
                     .map(Tensor::C64)
                     .collect()
@@ -567,21 +583,24 @@ impl TensorBackend for CpuBackend {
 
     fn eigh(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         let ctx = Arc::clone(&self.ctx);
-        self.install(|| match input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => catch_backend_panic("eigh", || {
-                linalg::eigh(ctx.as_ref(), t)
+                linalg::eigh(ctx.as_ref(), buffers, t)
                     .into_iter()
                     .map(Tensor::F64)
                     .collect()
             }),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => catch_backend_panic("eigh", || {
-                linalg::eigh(t).into_iter().map(Tensor::F64).collect()
+                linalg::eigh(buffers, t)
+                    .into_iter()
+                    .map(Tensor::F64)
+                    .collect()
             }),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => catch_backend_panic("eigh", || {
-                linalg::eigh(ctx.as_ref(), t)
+                linalg::eigh(ctx.as_ref(), buffers, t)
                     .into_iter()
                     .map(Tensor::C64)
                     .collect()
@@ -592,15 +611,15 @@ impl TensorBackend for CpuBackend {
 
     fn eig(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         let ctx = Arc::clone(&self.ctx);
-        self.install(|| {
+        self.install_with_pool(|buffers| {
             catch_backend_panic("eig", || {
                 #[cfg(feature = "cpu-faer")]
                 {
-                    linalg::eig(ctx.as_ref(), input)
+                    linalg::eig(ctx.as_ref(), buffers, input)
                 }
                 #[cfg(feature = "cpu-blas")]
                 {
-                    linalg::eig(input)
+                    linalg::eig(buffers, input)
                 }
             })
         })

--- a/tenferro-tensor/src/cpu/elementwise.rs
+++ b/tenferro-tensor/src/cpu/elementwise.rs
@@ -9,7 +9,7 @@ use crate::{
     types::{ConjElem, Tensor, TypedTensor},
 };
 
-use super::{tensor_from_array, typed_array, typed_view};
+use super::{tensor_from_array, typed_array_uninit, typed_view};
 
 macro_rules! dispatch_ternary_result {
     ($op:literal, $a:expr, $b:expr, $c:expr, |$x:ident, $y:ident, $z:ident| $body:expr) => {
@@ -329,7 +329,8 @@ where
     T: Copy + Clone + Zero + Add<Output = T>,
 {
     if lhs.shape == rhs.shape {
-        let mut out = typed_array(&lhs.shape, T::zero());
+        // SAFETY: zip_map2_into overwrites every output element.
+        let mut out = unsafe { typed_array_uninit(&lhs.shape) };
         zip_map2_into(
             &mut out.view_mut(),
             &typed_view(lhs),
@@ -343,7 +344,8 @@ where
         Ok(tensor_from_array(out))
     } else if lhs.shape.is_empty() {
         let scalar = lhs.host_data()[0];
-        let mut out = typed_array(&rhs.shape, T::zero());
+        // SAFETY: map_into overwrites every output element.
+        let mut out = unsafe { typed_array_uninit(&rhs.shape) };
         map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar + x).map_err(|err| {
             crate::Error::BackendFailure {
                 op: "add",
@@ -353,7 +355,8 @@ where
         Ok(tensor_from_array(out))
     } else if rhs.shape.is_empty() {
         let scalar = rhs.host_data()[0];
-        let mut out = typed_array(&lhs.shape, T::zero());
+        // SAFETY: map_into overwrites every output element.
+        let mut out = unsafe { typed_array_uninit(&lhs.shape) };
         map_into(&mut out.view_mut(), &typed_view(lhs), |x| x + scalar).map_err(|err| {
             crate::Error::BackendFailure {
                 op: "add",
@@ -375,7 +378,8 @@ where
     T: Copy + Clone + Zero + Mul<Output = T>,
 {
     if lhs.shape == rhs.shape {
-        let mut out = typed_array(&lhs.shape, T::zero());
+        // SAFETY: zip_map2_into overwrites every output element.
+        let mut out = unsafe { typed_array_uninit(&lhs.shape) };
         zip_map2_into(
             &mut out.view_mut(),
             &typed_view(lhs),
@@ -386,13 +390,15 @@ where
         Ok(tensor_from_array(out))
     } else if lhs.shape.is_empty() {
         let scalar = lhs.host_data()[0];
-        let mut out = typed_array(&rhs.shape, T::zero());
+        // SAFETY: map_into overwrites every output element.
+        let mut out = unsafe { typed_array_uninit(&rhs.shape) };
         map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar * x)
             .map_err(|err| backend_failure("mul", err))?;
         Ok(tensor_from_array(out))
     } else if rhs.shape.is_empty() {
         let scalar = rhs.host_data()[0];
-        let mut out = typed_array(&lhs.shape, T::zero());
+        // SAFETY: map_into overwrites every output element.
+        let mut out = unsafe { typed_array_uninit(&lhs.shape) };
         map_into(&mut out.view_mut(), &typed_view(lhs), |x| x * scalar)
             .map_err(|err| backend_failure("mul", err))?;
         Ok(tensor_from_array(out))
@@ -416,7 +422,8 @@ where
             rhs: rhs.shape.clone(),
         });
     }
-    let mut out = typed_array(&lhs.shape, T::zero());
+    // SAFETY: zip_map2_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&lhs.shape) };
     zip_map2_into(
         &mut out.view_mut(),
         &typed_view(lhs),
@@ -431,7 +438,8 @@ pub fn typed_neg<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Zero + Neg<Output = T>,
 {
-    let mut out = typed_array(&input.shape, T::zero());
+    // SAFETY: map_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&input.shape) };
     map_into(&mut out.view_mut(), &typed_view(input), |x| -x)
         .map_err(|err| backend_failure("neg", err))?;
     Ok(tensor_from_array(out))
@@ -441,7 +449,8 @@ pub fn typed_conj<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Zero + ConjElem,
 {
-    let mut out = typed_array(&input.shape, T::zero());
+    // SAFETY: map_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&input.shape) };
     map_into(&mut out.view_mut(), &typed_view(input), |x| x.conj_elem())
         .map_err(|err| backend_failure("conj", err))?;
     Ok(tensor_from_array(out))
@@ -451,7 +460,8 @@ pub(crate) fn typed_abs<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<
 where
     T: Tier2Elem,
 {
-    let mut out = typed_array(&input.shape, T::zero());
+    // SAFETY: map_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&input.shape) };
     map_into(&mut out.view_mut(), &typed_view(input), |x| x.abs_elem())
         .map_err(|err| backend_failure("abs", err))?;
     Ok(tensor_from_array(out))
@@ -461,7 +471,8 @@ pub(crate) fn typed_sign<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor
 where
     T: Tier2Elem,
 {
-    let mut out = typed_array(&input.shape, T::zero());
+    // SAFETY: map_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&input.shape) };
     map_into(&mut out.view_mut(), &typed_view(input), |x| x.sign_elem())
         .map_err(|err| backend_failure("sign", err))?;
     Ok(tensor_from_array(out))
@@ -481,7 +492,8 @@ where
             rhs: rhs.shape.clone(),
         });
     }
-    let mut out = typed_array(&lhs.shape, T::zero());
+    // SAFETY: zip_map2_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&lhs.shape) };
     zip_map2_into(
         &mut out.view_mut(),
         &typed_view(lhs),
@@ -506,7 +518,8 @@ where
             rhs: rhs.shape.clone(),
         });
     }
-    let mut out = typed_array(&lhs.shape, T::zero());
+    // SAFETY: zip_map2_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&lhs.shape) };
     zip_map2_into(
         &mut out.view_mut(),
         &typed_view(lhs),
@@ -532,7 +545,8 @@ where
             rhs: rhs.shape.clone(),
         });
     }
-    let mut out = typed_array(&lhs.shape, T::zero());
+    // SAFETY: zip_map2_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&lhs.shape) };
     zip_map2_into(
         &mut out.view_mut(),
         &typed_view(lhs),
@@ -565,7 +579,8 @@ where
             rhs: on_false.shape.clone(),
         });
     }
-    let mut out = typed_array(&pred.shape, T::zero());
+    // SAFETY: zip_map3_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&pred.shape) };
     zip_map3_into(
         &mut out.view_mut(),
         &typed_view(pred),
@@ -599,7 +614,8 @@ where
             rhs: upper.shape.clone(),
         });
     }
-    let mut out = typed_array(&input.shape, T::zero());
+    // SAFETY: zip_map3_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&input.shape) };
     zip_map3_into(
         &mut out.view_mut(),
         &typed_view(input),

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -108,6 +108,15 @@ pub fn reverse(input: &Tensor, axes: &[usize]) -> Tensor {
     dispatch_tensor!(input, tensor => typed_reverse(tensor, axes))
 }
 
+fn typed_tensor_uninit<T: Clone>(shape: Vec<usize>) -> TypedTensor<T> {
+    let n: usize = shape.iter().product();
+    let mut data = Vec::with_capacity(n);
+    // SAFETY: callers only use this helper for outputs that are fully written
+    // before any read.
+    unsafe { data.set_len(n) };
+    TypedTensor::from_vec(shape, data)
+}
+
 fn typed_slice<T: Copy + Clone>(
     input: &TypedTensor<T>,
     config: &SliceConfig,
@@ -430,7 +439,7 @@ fn typed_gather<T: Copy + Clone + Zero>(
         }
     }
 
-    let mut out = TypedTensor::zeros(out_shape.clone());
+    let mut out = typed_tensor_uninit(out_shape.clone());
     let mut out_idx = vec![0usize; out_rank];
     let mut batch_idx = vec![0usize; batch_shape.len()];
     let mut operand_idx = vec![0usize; operand.shape.len()];
@@ -621,7 +630,7 @@ fn typed_dynamic_slice<T: Copy + Clone + Zero>(
     }
 
     let out_shape = slice_sizes.to_vec();
-    let mut out = TypedTensor::zeros(out_shape.clone());
+    let mut out = typed_tensor_uninit(out_shape.clone());
     let mut out_idx = vec![0usize; out_shape.len()];
     let mut input_idx = vec![0usize; out_shape.len()];
 

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -5,16 +5,25 @@ use faer::{
 };
 use num_complex::Complex64;
 
+use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::cpu::CpuContext;
 use crate::{Buffer, Tensor, TypedTensor};
 
-pub(crate) trait FaerLinalg: Copy + Clone {
+pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
     fn parity_one() -> Self;
-    fn cholesky_2d(ctx: &CpuContext, input: &TypedTensor<Self>)
-        -> crate::Result<TypedTensor<Self>>;
-    fn lu_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>>;
+    fn cholesky_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> crate::Result<TypedTensor<Self>>;
+    fn lu_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>>;
     fn triangular_solve_2d(
         ctx: &CpuContext,
+        buffers: &mut BufferPool,
         a: &TypedTensor<Self>,
         b: &TypedTensor<Self>,
         left_side: bool,
@@ -22,9 +31,21 @@ pub(crate) trait FaerLinalg: Copy + Clone {
         transpose_a: bool,
         unit_diagonal: bool,
     ) -> TypedTensor<Self>;
-    fn svd_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>>;
-    fn qr_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>>;
-    fn eigh_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>>;
+    fn svd_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>>;
+    fn qr_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>>;
+    fn eigh_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>>;
 }
 
 fn matrix_dims<T>(input: &TypedTensor<T>, op: &str) -> (usize, usize) {
@@ -50,9 +71,12 @@ fn tensor_from_vec_with_template<T: Clone, U>(
     }
 }
 
-fn col_major_vec_from_mat<T: Copy>(mat: MatRef<'_, T>) -> Vec<T> {
+fn col_major_vec_from_mat<T: Copy + PoolScalar>(
+    buffers: &mut BufferPool,
+    mat: MatRef<'_, T>,
+) -> Vec<T> {
     let (rows, cols) = mat.shape();
-    let mut data = Vec::with_capacity(rows * cols);
+    let mut data = buffers.acquire_with_capacity::<T>(rows * cols);
     for j in 0..cols {
         for i in 0..rows {
             data.push(mat[(i, j)]);
@@ -61,9 +85,9 @@ fn col_major_vec_from_mat<T: Copy>(mat: MatRef<'_, T>) -> Vec<T> {
     data
 }
 
-fn vec_from_diag<T: Copy>(diag: DiagRef<'_, T>) -> Vec<T> {
+fn vec_from_diag<T: Copy + PoolScalar>(buffers: &mut BufferPool, diag: DiagRef<'_, T>) -> Vec<T> {
     let col = diag.column_vector();
-    let mut data = Vec::with_capacity(col.nrows());
+    let mut data = buffers.acquire_with_capacity::<T>(col.nrows());
     for i in 0..col.nrows() {
         data.push(col[i]);
     }
@@ -96,27 +120,30 @@ fn complex64_to_faer_slice_mut(data: &mut [Complex64]) -> &mut [faer::c64] {
     unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr().cast::<faer::c64>(), data.len()) }
 }
 
-fn complex_vec_from_real_diag(diag: DiagRef<'_, faer::c64>) -> Vec<Complex64> {
+fn complex_vec_from_real_diag(
+    buffers: &mut BufferPool,
+    diag: DiagRef<'_, faer::c64>,
+) -> Vec<Complex64> {
     let col = diag.column_vector();
-    let mut data = Vec::with_capacity(col.nrows());
+    let mut data = buffers.acquire_with_capacity::<Complex64>(col.nrows());
     for i in 0..col.nrows() {
         data.push(Complex64::new(col[i].re, 0.0));
     }
     data
 }
 
-fn complex_vec_from_diag(diag: DiagRef<'_, faer::c64>) -> Vec<Complex64> {
+fn complex_vec_from_diag(buffers: &mut BufferPool, diag: DiagRef<'_, faer::c64>) -> Vec<Complex64> {
     let col = diag.column_vector();
-    let mut data = Vec::with_capacity(col.nrows());
+    let mut data = buffers.acquire_with_capacity::<Complex64>(col.nrows());
     for i in 0..col.nrows() {
         data.push(Complex64::new(col[i].re, col[i].im));
     }
     data
 }
 
-fn complex_vec_from_mat(mat: MatRef<'_, faer::c64>) -> Vec<Complex64> {
+fn complex_vec_from_mat(buffers: &mut BufferPool, mat: MatRef<'_, faer::c64>) -> Vec<Complex64> {
     let (rows, cols) = mat.shape();
-    let mut data = Vec::with_capacity(rows * cols);
+    let mut data = buffers.acquire_with_capacity::<Complex64>(rows * cols);
     for j in 0..cols {
         for i in 0..rows {
             let value = mat[(i, j)];
@@ -172,13 +199,16 @@ fn complex_matrix_from_predicate(
 }
 
 fn real_eig_to_complex_outputs(
+    buffers: &mut BufferPool,
     u_real: MatRef<'_, f64>,
     s_re: DiagRef<'_, f64>,
     s_im: DiagRef<'_, f64>,
 ) -> (Vec<Complex64>, Vec<Complex64>) {
     let n = u_real.nrows();
-    let mut u = vec![Complex64::new(0.0, 0.0); n * n];
-    let mut s = vec![Complex64::new(0.0, 0.0); n];
+    // SAFETY: the loop below writes every element of `u` and `s` before any read.
+    let mut u = unsafe { <Complex64 as PoolScalar>::pool_acquire(buffers, n * n) };
+    // SAFETY: the loop below writes every element of `u` and `s` before any read.
+    let mut s = unsafe { <Complex64 as PoolScalar>::pool_acquire(buffers, n) };
     let mut j = 0;
     while j < n {
         if s_im[j] == 0.0 {
@@ -212,8 +242,13 @@ fn split_core_and_batch<'a, T>(
     input.shape.split_at(core_rank)
 }
 
-fn transpose_col_major_data<T: Copy>(data: &[T], rows: usize, cols: usize) -> Vec<T> {
-    let mut transposed = Vec::with_capacity(data.len());
+fn transpose_col_major_data<T: Copy + PoolScalar>(
+    buffers: &mut BufferPool,
+    data: &[T],
+    rows: usize,
+    cols: usize,
+) -> Vec<T> {
+    let mut transposed = buffers.acquire_with_capacity::<T>(data.len());
     for j in 0..rows {
         for i in 0..cols {
             transposed.push(data[j + i * rows]);
@@ -223,17 +258,18 @@ fn transpose_col_major_data<T: Copy>(data: &[T], rows: usize, cols: usize) -> Ve
 }
 
 fn batched_single<T, F>(
+    buffers: &mut BufferPool,
     input: &TypedTensor<T>,
     core_rank: usize,
     op: F,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Clone,
-    F: Fn(&TypedTensor<T>) -> crate::Result<TypedTensor<T>>,
+    T: Clone + PoolScalar,
+    F: Fn(&mut BufferPool, &TypedTensor<T>) -> crate::Result<TypedTensor<T>>,
 {
     let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, "batched_single");
     if batch_shape.is_empty() {
-        return op(input);
+        return op(buffers, input);
     }
 
     let slice_size: usize = core_shape.iter().product();
@@ -244,7 +280,7 @@ where
     );
 
     let mut out_core_shape: Option<Vec<usize>> = None;
-    let mut out_data = Vec::new();
+    let mut out_data: Option<Vec<T>> = None;
 
     for batch_idx in 0..batch_count {
         let start = batch_idx * slice_size;
@@ -254,7 +290,7 @@ where
             input.host_data()[start..end].to_vec(),
             input,
         );
-        let batch_output = op(&batch_input)?;
+        let batch_output = op(buffers, &batch_input)?;
 
         if let Some(expected_shape) = &out_core_shape {
             assert_eq!(
@@ -263,26 +299,39 @@ where
                 "batched_single: output core shape mismatch across batches"
             );
         } else {
-            out_data.reserve(batch_output.n_elements() * batch_count);
+            out_data =
+                Some(buffers.acquire_with_capacity::<T>(batch_output.n_elements() * batch_count));
             out_core_shape = Some(batch_output.shape.clone());
         }
 
-        out_data.extend_from_slice(batch_output.host_data());
+        out_data
+            .as_mut()
+            .expect("batched_single: missing output buffer")
+            .extend_from_slice(batch_output.host_data());
     }
 
     let mut out_shape = out_core_shape.expect("batched_single: missing output shape");
     out_shape.extend_from_slice(batch_shape);
-    Ok(tensor_from_vec_with_template(out_shape, out_data, input))
+    Ok(tensor_from_vec_with_template(
+        out_shape,
+        out_data.expect("batched_single: missing output data"),
+        input,
+    ))
 }
 
-fn batched_multi<T, F>(input: &TypedTensor<T>, core_rank: usize, op: F) -> Vec<TypedTensor<T>>
+fn batched_multi<T, F>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+    core_rank: usize,
+    op: F,
+) -> Vec<TypedTensor<T>>
 where
-    T: Clone,
-    F: Fn(&TypedTensor<T>) -> Vec<TypedTensor<T>>,
+    T: Clone + PoolScalar,
+    F: Fn(&mut BufferPool, &TypedTensor<T>) -> Vec<TypedTensor<T>>,
 {
     let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, "batched_multi");
     if batch_shape.is_empty() {
-        return op(input);
+        return op(buffers, input);
     }
 
     let slice_size: usize = core_shape.iter().product();
@@ -303,17 +352,19 @@ where
             input.host_data()[start..end].to_vec(),
             input,
         );
-        let batch_outputs = op(&batch_input);
+        let batch_outputs = op(buffers, &batch_input);
 
         if out_shapes.is_empty() {
             out_shapes = batch_outputs
                 .iter()
                 .map(|tensor| tensor.shape.clone())
                 .collect();
-            out_data = batch_outputs
-                .iter()
-                .map(|tensor| Vec::with_capacity(tensor.n_elements() * batch_count))
-                .collect();
+            let mut pooled_outputs = Vec::with_capacity(batch_outputs.len());
+            for tensor in &batch_outputs {
+                pooled_outputs
+                    .push(buffers.acquire_with_capacity::<T>(tensor.n_elements() * batch_count));
+            }
+            out_data = pooled_outputs;
         } else {
             assert_eq!(
                 batch_outputs.len(),
@@ -343,18 +394,19 @@ where
 }
 
 fn batched_multi_convert<InT, OutT, F>(
+    buffers: &mut BufferPool,
     input: &TypedTensor<InT>,
     core_rank: usize,
     op: F,
 ) -> Vec<TypedTensor<OutT>>
 where
     InT: Clone,
-    OutT: Clone,
-    F: Fn(&TypedTensor<InT>) -> Vec<TypedTensor<OutT>>,
+    OutT: Clone + PoolScalar,
+    F: Fn(&mut BufferPool, &TypedTensor<InT>) -> Vec<TypedTensor<OutT>>,
 {
     let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, "batched_multi");
     if batch_shape.is_empty() {
-        return op(input);
+        return op(buffers, input);
     }
 
     let slice_size: usize = core_shape.iter().product();
@@ -375,17 +427,19 @@ where
             input.host_data()[start..end].to_vec(),
             input,
         );
-        let batch_outputs = op(&batch_input);
+        let batch_outputs = op(buffers, &batch_input);
 
         if out_shapes.is_empty() {
             out_shapes = batch_outputs
                 .iter()
                 .map(|tensor| tensor.shape.clone())
                 .collect();
-            out_data = batch_outputs
-                .iter()
-                .map(|tensor| Vec::with_capacity(tensor.n_elements() * batch_count))
-                .collect();
+            let mut pooled_outputs = Vec::with_capacity(batch_outputs.len());
+            for tensor in &batch_outputs {
+                pooled_outputs
+                    .push(buffers.acquire_with_capacity::<OutT>(tensor.n_elements() * batch_count));
+            }
+            out_data = pooled_outputs;
         } else {
             assert_eq!(
                 batch_outputs.len(),
@@ -415,6 +469,7 @@ where
 }
 
 fn batched_binary<T, F>(
+    buffers: &mut BufferPool,
     a: &TypedTensor<T>,
     b: &TypedTensor<T>,
     core_rank_a: usize,
@@ -422,8 +477,8 @@ fn batched_binary<T, F>(
     op: F,
 ) -> TypedTensor<T>
 where
-    T: Clone,
-    F: Fn(&TypedTensor<T>, &TypedTensor<T>) -> TypedTensor<T>,
+    T: Clone + PoolScalar,
+    F: Fn(&mut BufferPool, &TypedTensor<T>, &TypedTensor<T>) -> TypedTensor<T>,
 {
     let (a_core_shape, a_batch_shape) = split_core_and_batch(a, core_rank_a, "batched_binary");
     let (b_core_shape, b_batch_shape) = split_core_and_batch(b, core_rank_b, "batched_binary");
@@ -433,7 +488,7 @@ where
     );
 
     if a_batch_shape.is_empty() {
-        return op(a, b);
+        return op(buffers, a, b);
     }
 
     let a_slice_size: usize = a_core_shape.iter().product();
@@ -445,7 +500,7 @@ where
     );
 
     let mut out_core_shape: Option<Vec<usize>> = None;
-    let mut out_data = Vec::new();
+    let mut out_data: Option<Vec<T>> = None;
 
     for batch_idx in 0..batch_count {
         let a_start = batch_idx * a_slice_size;
@@ -463,7 +518,7 @@ where
             b.host_data()[b_start..b_end].to_vec(),
             b,
         );
-        let batch_output = op(&batch_a, &batch_b);
+        let batch_output = op(buffers, &batch_a, &batch_b);
 
         if let Some(expected_shape) = &out_core_shape {
             assert_eq!(
@@ -472,16 +527,24 @@ where
                 "batched_binary: output core shape mismatch across batches"
             );
         } else {
-            out_data.reserve(batch_output.n_elements() * batch_count);
+            out_data =
+                Some(buffers.acquire_with_capacity::<T>(batch_output.n_elements() * batch_count));
             out_core_shape = Some(batch_output.shape.clone());
         }
 
-        out_data.extend_from_slice(batch_output.host_data());
+        out_data
+            .as_mut()
+            .expect("batched_binary: missing output buffer")
+            .extend_from_slice(batch_output.host_data());
     }
 
     let mut out_shape = out_core_shape.expect("batched_binary: missing output shape");
     out_shape.extend_from_slice(a_batch_shape);
-    tensor_from_vec_with_template(out_shape, out_data, b)
+    tensor_from_vec_with_template(
+        out_shape,
+        out_data.expect("batched_binary: missing output data"),
+        b,
+    )
 }
 
 impl FaerLinalg for f64 {
@@ -491,6 +554,7 @@ impl FaerLinalg for f64 {
 
     fn cholesky_2d(
         ctx: &CpuContext,
+        _buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> crate::Result<TypedTensor<Self>> {
         let n = square_matrix_dim(input, "cholesky");
@@ -522,7 +586,11 @@ impl FaerLinalg for f64 {
         ))
     }
 
-    fn lu_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
+    fn lu_2d(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>> {
         let (m, n) = matrix_dims(input, "lu");
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
@@ -574,6 +642,7 @@ impl FaerLinalg for f64 {
 
     fn triangular_solve_2d(
         ctx: &CpuContext,
+        buffers: &mut BufferPool,
         a: &TypedTensor<Self>,
         b: &TypedTensor<Self>,
         left_side: bool,
@@ -587,7 +656,8 @@ impl FaerLinalg for f64 {
 
         if left_side {
             assert_eq!(b_rows, n, "triangular_solve: rhs row count mismatch");
-            let mut rhs_data = b.host_data().to_vec();
+            let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
+            rhs_data.extend_from_slice(b.host_data());
             let rhs = MatMut::from_column_major_slice_mut(&mut rhs_data, n, b_cols);
             match (transpose_a, lower, unit_diagonal) {
                 (false, true, false) => {
@@ -651,7 +721,7 @@ impl FaerLinalg for f64 {
         } else {
             assert_eq!(b_cols, n, "triangular_solve: rhs column count mismatch");
             let nrhs = b_rows;
-            let mut rhs_transposed = transpose_col_major_data(b.host_data(), nrhs, n);
+            let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data(), nrhs, n);
             let rhs = MatMut::from_column_major_slice_mut(&mut rhs_transposed, n, nrhs);
             match (transpose_a, lower, unit_diagonal) {
                 (false, true, false) => {
@@ -711,12 +781,17 @@ impl FaerLinalg for f64 {
                     );
                 }
             }
-            let result = transpose_col_major_data(&rhs_transposed, n, nrhs);
+            let result = transpose_col_major_data(buffers, &rhs_transposed, n, nrhs);
+            <Self as PoolScalar>::pool_release(buffers, rhs_transposed);
             tensor_from_vec_with_template(vec![nrhs, n], result, b)
         }
     }
 
-    fn svd_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
+    fn svd_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>> {
         let (m, n) = matrix_dims(input, "svd");
         let k = m.min(n);
         let mat = MatRef::from_column_major_slice(input.host_data(), m, n);
@@ -743,10 +818,13 @@ impl FaerLinalg for f64 {
         )
         .unwrap_or_else(|_| panic!("svd: decomposition failed"));
 
-        let u =
-            tensor_from_vec_with_template(vec![m, k], col_major_vec_from_mat(u.as_ref()), input);
-        let s = tensor_from_vec_with_template(vec![k], vec_from_diag(s.as_ref()), input);
-        let mut vt_data = Vec::with_capacity(k * n);
+        let u = tensor_from_vec_with_template(
+            vec![m, k],
+            col_major_vec_from_mat(buffers, u.as_ref()),
+            input,
+        );
+        let s = tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), input);
+        let mut vt_data = buffers.acquire_with_capacity::<Self>(k * n);
         for j in 0..n {
             for i in 0..k {
                 vt_data.push(v[(j, i)]);
@@ -757,7 +835,11 @@ impl FaerLinalg for f64 {
         vec![u, s, vt]
     }
 
-    fn qr_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
+    fn qr_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>> {
         let (m, n) = matrix_dims(input, "qr");
         let k = m.min(n);
         let mat = MatRef::from_column_major_slice(input.host_data(), m, n);
@@ -800,8 +882,11 @@ impl FaerLinalg for f64 {
             ctx.faer_par(),
             stack,
         );
-        let q =
-            tensor_from_vec_with_template(vec![m, k], col_major_vec_from_mat(q.as_ref()), input);
+        let q = tensor_from_vec_with_template(
+            vec![m, k],
+            col_major_vec_from_mat(buffers, q.as_ref()),
+            input,
+        );
         let r = tensor_from_vec_with_template(
             vec![k, n],
             upper_triangle_vec_from_mat(qr.as_ref().get(..k, ..)),
@@ -811,7 +896,11 @@ impl FaerLinalg for f64 {
         vec![q, r]
     }
 
-    fn eigh_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
+    fn eigh_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>> {
         let n = square_matrix_dim(input, "eigh");
         let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
         let mut values = Diag::zeros(n);
@@ -833,10 +922,11 @@ impl FaerLinalg for f64 {
         )
         .unwrap_or_else(|_| panic!("eigh: decomposition failed"));
 
-        let values = tensor_from_vec_with_template(vec![n], vec_from_diag(values.as_ref()), input);
+        let values =
+            tensor_from_vec_with_template(vec![n], vec_from_diag(buffers, values.as_ref()), input);
         let vectors = tensor_from_vec_with_template(
             vec![n, n],
-            col_major_vec_from_mat(vectors.as_ref()),
+            col_major_vec_from_mat(buffers, vectors.as_ref()),
             input,
         );
 
@@ -851,6 +941,7 @@ impl FaerLinalg for Complex64 {
 
     fn cholesky_2d(
         ctx: &CpuContext,
+        _buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> crate::Result<TypedTensor<Self>> {
         let n = square_matrix_dim(input, "cholesky");
@@ -886,7 +977,11 @@ impl FaerLinalg for Complex64 {
         ))
     }
 
-    fn lu_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
+    fn lu_2d(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>> {
         let (m, n) = matrix_dims(input, "lu");
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
@@ -941,6 +1036,7 @@ impl FaerLinalg for Complex64 {
 
     fn triangular_solve_2d(
         ctx: &CpuContext,
+        buffers: &mut BufferPool,
         a: &TypedTensor<Self>,
         b: &TypedTensor<Self>,
         left_side: bool,
@@ -954,7 +1050,8 @@ impl FaerLinalg for Complex64 {
 
         if left_side {
             assert_eq!(b_rows, n, "triangular_solve: rhs row count mismatch");
-            let mut rhs_data = b.host_data().to_vec();
+            let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
+            rhs_data.extend_from_slice(b.host_data());
             let rhs = MatMut::from_column_major_slice_mut(
                 complex64_to_faer_slice_mut(&mut rhs_data),
                 n,
@@ -1022,7 +1119,7 @@ impl FaerLinalg for Complex64 {
         } else {
             assert_eq!(b_cols, n, "triangular_solve: rhs column count mismatch");
             let nrhs = b_rows;
-            let mut rhs_transposed = transpose_col_major_data(b.host_data(), nrhs, n);
+            let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data(), nrhs, n);
             let rhs = MatMut::from_column_major_slice_mut(
                 complex64_to_faer_slice_mut(&mut rhs_transposed),
                 n,
@@ -1086,12 +1183,17 @@ impl FaerLinalg for Complex64 {
                     );
                 }
             }
-            let result = transpose_col_major_data(&rhs_transposed, n, nrhs);
+            let result = transpose_col_major_data(buffers, &rhs_transposed, n, nrhs);
+            <Self as PoolScalar>::pool_release(buffers, rhs_transposed);
             tensor_from_vec_with_template(vec![nrhs, n], result, b)
         }
     }
 
-    fn svd_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
+    fn svd_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>> {
         let (m, n) = matrix_dims(input, "svd");
         let k = m.min(n);
         let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), m, n);
@@ -1118,10 +1220,17 @@ impl FaerLinalg for Complex64 {
         )
         .unwrap_or_else(|_| panic!("svd: decomposition failed"));
 
-        let u = tensor_from_vec_with_template(vec![m, k], complex_vec_from_mat(u.as_ref()), input);
-        let s =
-            tensor_from_vec_with_template(vec![k], complex_vec_from_real_diag(s.as_ref()), input);
-        let mut vt_data = Vec::with_capacity(k * n);
+        let u = tensor_from_vec_with_template(
+            vec![m, k],
+            complex_vec_from_mat(buffers, u.as_ref()),
+            input,
+        );
+        let s = tensor_from_vec_with_template(
+            vec![k],
+            complex_vec_from_real_diag(buffers, s.as_ref()),
+            input,
+        );
+        let mut vt_data = buffers.acquire_with_capacity::<Self>(k * n);
         for j in 0..n {
             for i in 0..k {
                 vt_data.push(v[(j, i)].conj());
@@ -1132,7 +1241,11 @@ impl FaerLinalg for Complex64 {
         vec![u, s, vt]
     }
 
-    fn qr_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
+    fn qr_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>> {
         let (m, n) = matrix_dims(input, "qr");
         let k = m.min(n);
         let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), m, n);
@@ -1175,7 +1288,11 @@ impl FaerLinalg for Complex64 {
             ctx.faer_par(),
             stack,
         );
-        let q = tensor_from_vec_with_template(vec![m, k], complex_vec_from_mat(q.as_ref()), input);
+        let q = tensor_from_vec_with_template(
+            vec![m, k],
+            complex_vec_from_mat(buffers, q.as_ref()),
+            input,
+        );
         let r = tensor_from_vec_with_template(
             vec![k, n],
             complex_matrix_from_predicate(qr.as_ref(), k, n, |row, col| row <= col),
@@ -1185,7 +1302,11 @@ impl FaerLinalg for Complex64 {
         vec![q, r]
     }
 
-    fn eigh_2d(ctx: &CpuContext, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
+    fn eigh_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>> {
         let n = square_matrix_dim(input, "eigh");
         let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), n, n);
         let mut values = Diag::zeros(n);
@@ -1209,12 +1330,12 @@ impl FaerLinalg for Complex64 {
 
         let values = tensor_from_vec_with_template(
             vec![n],
-            complex_vec_from_real_diag(values.as_ref()),
+            complex_vec_from_real_diag(buffers, values.as_ref()),
             input,
         );
         let vectors = tensor_from_vec_with_template(
             vec![n, n],
-            complex_vec_from_mat(vectors.as_ref()),
+            complex_vec_from_mat(buffers, vectors.as_ref()),
             input,
         );
 
@@ -1224,6 +1345,7 @@ impl FaerLinalg for Complex64 {
 
 pub(crate) fn cholesky<T: FaerLinalg>(
     ctx: &CpuContext,
+    buffers: &mut BufferPool,
     input: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&input.shape) {
@@ -1233,10 +1355,16 @@ pub(crate) fn cholesky<T: FaerLinalg>(
             input,
         ));
     }
-    batched_single(input, 2, |batch| T::cholesky_2d(ctx, batch))
+    batched_single(buffers, input, 2, |buffers, batch| {
+        T::cholesky_2d(ctx, buffers, batch)
+    })
 }
 
-pub(crate) fn lu<T: FaerLinalg>(ctx: &CpuContext, input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+pub(crate) fn lu<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> Vec<TypedTensor<T>> {
     if has_zero_dim(&input.shape) {
         let m = input.shape[0];
         let n = input.shape[1];
@@ -1266,11 +1394,14 @@ pub(crate) fn lu<T: FaerLinalg>(ctx: &CpuContext, input: &TypedTensor<T>) -> Vec
             ),
         ];
     }
-    batched_multi(input, 2, |batch| T::lu_2d(ctx, batch))
+    batched_multi(buffers, input, 2, |buffers, batch| {
+        T::lu_2d(ctx, buffers, batch)
+    })
 }
 
 pub(crate) fn triangular_solve<T: FaerLinalg>(
     ctx: &CpuContext,
+    buffers: &mut BufferPool,
     a: &TypedTensor<T>,
     b: &TypedTensor<T>,
     left_side: bool,
@@ -1281,12 +1412,25 @@ pub(crate) fn triangular_solve<T: FaerLinalg>(
     if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
         return tensor_from_vec_with_template(b.shape.clone(), Vec::new(), b);
     }
-    batched_binary(a, b, 2, 2, |a, b| {
-        T::triangular_solve_2d(ctx, a, b, left_side, lower, transpose_a, unit_diagonal)
+    batched_binary(buffers, a, b, 2, 2, |buffers, a, b| {
+        T::triangular_solve_2d(
+            ctx,
+            buffers,
+            a,
+            b,
+            left_side,
+            lower,
+            transpose_a,
+            unit_diagonal,
+        )
     })
 }
 
-pub(crate) fn svd<T: FaerLinalg>(ctx: &CpuContext, input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+pub(crate) fn svd<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> Vec<TypedTensor<T>> {
     if has_zero_dim(&input.shape) {
         let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "svd");
         let m = matrix_shape[0];
@@ -1310,10 +1454,16 @@ pub(crate) fn svd<T: FaerLinalg>(ctx: &CpuContext, input: &TypedTensor<T>) -> Ve
             ),
         ];
     }
-    batched_multi(input, 2, |batch| T::svd_2d(ctx, batch))
+    batched_multi(buffers, input, 2, |buffers, batch| {
+        T::svd_2d(ctx, buffers, batch)
+    })
 }
 
-pub(crate) fn qr<T: FaerLinalg>(ctx: &CpuContext, input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+pub(crate) fn qr<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> Vec<TypedTensor<T>> {
     if has_zero_dim(&input.shape) {
         let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "qr");
         let m = matrix_shape[0];
@@ -1332,10 +1482,16 @@ pub(crate) fn qr<T: FaerLinalg>(ctx: &CpuContext, input: &TypedTensor<T>) -> Vec
             ),
         ];
     }
-    batched_multi(input, 2, |batch| T::qr_2d(ctx, batch))
+    batched_multi(buffers, input, 2, |buffers, batch| {
+        T::qr_2d(ctx, buffers, batch)
+    })
 }
 
-pub(crate) fn eigh<T: FaerLinalg>(ctx: &CpuContext, input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+pub(crate) fn eigh<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> Vec<TypedTensor<T>> {
     if has_zero_dim(&input.shape) {
         let n = input.shape[0];
         let batch_shape = &input.shape[2..];
@@ -1352,10 +1508,16 @@ pub(crate) fn eigh<T: FaerLinalg>(ctx: &CpuContext, input: &TypedTensor<T>) -> V
             ),
         ];
     }
-    batched_multi(input, 2, |batch| T::eigh_2d(ctx, batch))
+    batched_multi(buffers, input, 2, |buffers, batch| {
+        T::eigh_2d(ctx, buffers, batch)
+    })
 }
 
-fn eig_real_2d(ctx: &CpuContext, input: &TypedTensor<f64>) -> Vec<TypedTensor<Complex64>> {
+fn eig_real_2d(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<f64>,
+) -> Vec<TypedTensor<Complex64>> {
     let n = square_matrix_dim(input, "eig");
     let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
     let mut u_real = Mat::zeros(n, n);
@@ -1380,7 +1542,8 @@ fn eig_real_2d(ctx: &CpuContext, input: &TypedTensor<f64>) -> Vec<TypedTensor<Co
         Default::default(),
     )
     .unwrap_or_else(|_| panic!("eig: decomposition failed"));
-    let (u, s) = real_eig_to_complex_outputs(u_real.as_ref(), s_re.as_ref(), s_im.as_ref());
+    let (u, s) =
+        real_eig_to_complex_outputs(buffers, u_real.as_ref(), s_re.as_ref(), s_im.as_ref());
 
     vec![
         tensor_from_vec_with_template(vec![n], s, input),
@@ -1388,7 +1551,11 @@ fn eig_real_2d(ctx: &CpuContext, input: &TypedTensor<f64>) -> Vec<TypedTensor<Co
     ]
 }
 
-fn eig_complex_2d(ctx: &CpuContext, input: &TypedTensor<Complex64>) -> Vec<TypedTensor<Complex64>> {
+fn eig_complex_2d(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<Complex64>,
+) -> Vec<TypedTensor<Complex64>> {
     let n = square_matrix_dim(input, "eig");
     let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), n, n);
     let mut u = Mat::zeros(n, n);
@@ -1413,12 +1580,12 @@ fn eig_complex_2d(ctx: &CpuContext, input: &TypedTensor<Complex64>) -> Vec<Typed
     .unwrap_or_else(|_| panic!("eig: decomposition failed"));
 
     vec![
-        tensor_from_vec_with_template(vec![n], complex_vec_from_diag(s.as_ref()), input),
-        tensor_from_vec_with_template(vec![n, n], complex_vec_from_mat(u.as_ref()), input),
+        tensor_from_vec_with_template(vec![n], complex_vec_from_diag(buffers, s.as_ref()), input),
+        tensor_from_vec_with_template(vec![n, n], complex_vec_from_mat(buffers, u.as_ref()), input),
     ]
 }
 
-pub(crate) fn eig(ctx: &CpuContext, input: &Tensor) -> Vec<Tensor> {
+pub(crate) fn eig(ctx: &CpuContext, buffers: &mut BufferPool, input: &Tensor) -> Vec<Tensor> {
     if has_zero_dim(input.shape()) {
         let n = input.shape()[0];
         let batch_shape = &input.shape()[2..];
@@ -1435,14 +1602,18 @@ pub(crate) fn eig(ctx: &CpuContext, input: &Tensor) -> Vec<Tensor> {
     }
 
     match input {
-        Tensor::F64(t) => batched_multi_convert(t, 2, |batch| eig_real_2d(ctx, batch))
-            .into_iter()
-            .map(Tensor::C64)
-            .collect(),
-        Tensor::C64(t) => batched_multi_convert(t, 2, |batch| eig_complex_2d(ctx, batch))
-            .into_iter()
-            .map(Tensor::C64)
-            .collect(),
+        Tensor::F64(t) => batched_multi_convert(buffers, t, 2, |buffers, batch| {
+            eig_real_2d(ctx, buffers, batch)
+        })
+        .into_iter()
+        .map(Tensor::C64)
+        .collect(),
+        Tensor::C64(t) => batched_multi_convert(buffers, t, 2, |buffers, batch| {
+            eig_complex_2d(ctx, buffers, batch)
+        })
+        .into_iter()
+        .map(Tensor::C64)
+        .collect(),
         _ => todo!("eig: unsupported dtype"),
     }
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg.rs
@@ -1,30 +1,32 @@
+use crate::buffer_pool::BufferPool;
 use crate::{Tensor, TypedTensor};
 
-pub(crate) fn cholesky(_input: &TypedTensor<f64>) -> TypedTensor<f64> {
+pub(crate) fn cholesky(_buffers: &mut BufferPool, _input: &TypedTensor<f64>) -> TypedTensor<f64> {
     todo!("lapack linalg cholesky")
 }
 
-pub(crate) fn lu(_input: &TypedTensor<f64>) -> Vec<TypedTensor<f64>> {
+pub(crate) fn lu(_buffers: &mut BufferPool, _input: &TypedTensor<f64>) -> Vec<TypedTensor<f64>> {
     todo!("lapack linalg lu")
 }
 
-pub(crate) fn svd(_input: &TypedTensor<f64>) -> Vec<TypedTensor<f64>> {
+pub(crate) fn svd(_buffers: &mut BufferPool, _input: &TypedTensor<f64>) -> Vec<TypedTensor<f64>> {
     todo!("lapack linalg svd")
 }
 
-pub(crate) fn qr(_input: &TypedTensor<f64>) -> Vec<TypedTensor<f64>> {
+pub(crate) fn qr(_buffers: &mut BufferPool, _input: &TypedTensor<f64>) -> Vec<TypedTensor<f64>> {
     todo!("lapack linalg qr")
 }
 
-pub(crate) fn eigh(_input: &TypedTensor<f64>) -> Vec<TypedTensor<f64>> {
+pub(crate) fn eigh(_buffers: &mut BufferPool, _input: &TypedTensor<f64>) -> Vec<TypedTensor<f64>> {
     todo!("lapack linalg eigh")
 }
 
-pub(crate) fn eig(_input: &Tensor) -> Vec<Tensor> {
+pub(crate) fn eig(_buffers: &mut BufferPool, _input: &Tensor) -> Vec<Tensor> {
     todo!("lapack linalg eig")
 }
 
 pub(crate) fn triangular_solve(
+    _buffers: &mut BufferPool,
     _a: &TypedTensor<f64>,
     _b: &TypedTensor<f64>,
     _left_side: bool,

--- a/tenferro-tensor/src/cpu/mod.rs
+++ b/tenferro-tensor/src/cpu/mod.rs
@@ -35,14 +35,6 @@ pub(crate) fn typed_view<T: Copy>(tensor: &TypedTensor<T>) -> StridedView<'_, T>
     }
 }
 
-#[allow(dead_code)]
-pub(crate) fn typed_array<T: Clone>(shape: &[usize], fill: T) -> StridedArray<T> {
-    let total: usize = shape.iter().product();
-    let strides = col_major_strides(shape);
-    StridedArray::from_parts(vec![fill; total], shape, &strides, 0)
-        .expect("column-major output array")
-}
-
 /// Create an output array WITHOUT initializing element values.
 ///
 /// # Safety

--- a/tenferro-tensor/src/cpu/mod.rs
+++ b/tenferro-tensor/src/cpu/mod.rs
@@ -35,11 +35,26 @@ pub(crate) fn typed_view<T: Copy>(tensor: &TypedTensor<T>) -> StridedView<'_, T>
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn typed_array<T: Clone>(shape: &[usize], fill: T) -> StridedArray<T> {
     let total: usize = shape.iter().product();
     let strides = col_major_strides(shape);
     StridedArray::from_parts(vec![fill; total], shape, &strides, 0)
         .expect("column-major output array")
+}
+
+/// Create an output array WITHOUT initializing element values.
+///
+/// # Safety
+/// Caller must write every element before reading. The returned array
+/// contains uninitialized data.
+pub(crate) unsafe fn typed_array_uninit<T>(shape: &[usize]) -> StridedArray<T> {
+    let total: usize = shape.iter().product();
+    let strides = col_major_strides(shape);
+    let mut data = Vec::with_capacity(total);
+    // SAFETY: caller guarantees every element is written before any read.
+    unsafe { data.set_len(total) };
+    StridedArray::from_parts(data, shape, &strides, 0).expect("column-major output array")
 }
 
 pub(crate) fn tensor_from_array<T: Clone>(array: StridedArray<T>) -> TypedTensor<T> {

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -7,7 +7,7 @@ use crate::{
     DType,
 };
 
-use super::{tensor_from_array, typed_array, typed_view};
+use super::{tensor_from_array, typed_array_uninit, typed_view};
 
 fn backend_failure(op: &'static str, err: impl ToString) -> crate::Error {
     crate::Error::BackendFailure {
@@ -186,7 +186,8 @@ pub fn typed_transpose<T: Copy + Zero + Clone>(
     let permuted = src
         .permute(perm)
         .map_err(|err| backend_failure("transpose", err))?;
-    let out = typed_array(permuted.dims(), T::zero());
+    // SAFETY: copy_into overwrites every output element.
+    let out = unsafe { typed_array_uninit(permuted.dims()) };
     copy_view_to_array("transpose", out, &permuted)
 }
 
@@ -255,7 +256,8 @@ pub fn typed_broadcast_in_dim<T: Copy + Zero + Clone>(
     let broadcast: StridedView<'_, T, Identity> = base
         .broadcast(shape)
         .map_err(|err| backend_failure("broadcast_in_dim", err))?;
-    let mut out = typed_array(shape, T::zero());
+    // SAFETY: copy_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(shape) };
     copy_into(&mut out.view_mut(), &broadcast)
         .map_err(|err| backend_failure("broadcast_in_dim", err))?;
     Ok(tensor_from_array(out))
@@ -266,7 +268,8 @@ where
     S: Copy,
     T: Copy + Clone + Zero,
 {
-    let mut out = typed_array(&tensor.shape, T::zero());
+    // SAFETY: map_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(&tensor.shape) };
     map_into(&mut out.view_mut(), &typed_view(tensor), f).expect("typed_convert");
     tensor_from_array(out)
 }
@@ -283,7 +286,8 @@ pub fn typed_extract_diagonal<T: Copy + Zero + Clone>(
     let diag = host_view(tensor)?
         .diagonal_view(&[(axis_a, axis_b)])
         .map_err(|err| backend_failure("extract_diagonal", err))?;
-    let mut out = typed_array(diag.dims(), T::zero());
+    // SAFETY: copy_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit(diag.dims()) };
     copy_into(&mut out.view_mut(), &diag)
         .map_err(|err| backend_failure("extract_diagonal", err))?;
     Ok(tensor_from_array(out))


### PR DESCRIPTION
## Summary

- **`typed_array_uninit`**: New unsafe helper that allocates without zero-fill. Used at 20+ sites where strided_kernel guarantees full overwrite.
- **Elementwise**: All 12+ ops (add, mul, neg, div, abs, sign, conj, max, min, compare, select, clamp) now use uninit allocation.
- **Structural**: transpose, broadcast, convert, extract_diag use uninit. embed_diagonal, tril/triu unchanged (zeros needed).
- **Indexing**: gather, dynamic_slice use uninit. scatter, pad unchanged (zeros needed).
- **Linalg pool**: `BufferPool::acquire_with_capacity` for push patterns. All linalg ops routed through `install_with_pool`. faer wrappers use pool-backed output vectors.

## Test plan

- [x] `cargo test --workspace --release`
- [x] `cargo fmt --all`
- [x] `cargo doc --workspace --no-deps`
- [ ] CI passes
- [ ] Coverage check

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)