### PR TITLE
feat: TensorScalar + TracedTensor::new + Tensor::as_slice

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -40,6 +40,37 @@
 - Execute faer-backed work only inside `ctx.install(...)` so the owned rayon context is preserved.
 - Use `Par::Seq` for one-thread contexts and `Par::rayon(0)` for multi-thread contexts so faer follows the current `CpuContext`.
 
+## Documentation Policy
+
+### Source of Truth
+
+- **Source code** is the source of truth for internal design (op catalog, backend contract, AD rules, compilation pipeline).
+- **Online docs** are user-facing only — how to use the `tenferro` facade crate.
+- **AGENTS.md** is the entry point for developers and AI agents. It contains pointers to source code locations.
+- Do NOT duplicate source-code-level information in online docs. If it can be learned by reading the source, put a pointer instead of a copy.
+- Development assumes AI agentic coding. Keep machine-readable sources (code + doc comments) authoritative.
+
+### User-Facing Docs
+
+- User docs target PyTorch/JAX users who interact with the `tenferro` facade crate.
+- All imports must use `use tenferro::{...}` — never reference internal crates (`tenferro-tensor`, `tenferro-ops`, `computegraph`, etc.) in user-facing docs.
+- Do NOT expose internal jargon (Fragment, StableHLO, ExecOp, ValRef, etc.) in user-facing pages.
+- Provide PyTorch/JAX equivalents when introducing tenferro concepts.
+
+### Doc Examples
+
+- Doc examples (`/// # Examples`) must NOT use `ignore` or `no_run` attributes.
+- Every example must compile AND run as a doctest.
+- Use `compile_fail` only for examples that intentionally demonstrate compile errors.
+- If an example cannot run as a doctest, refactor it until it can.
+
+## Generic Over Scalar Type
+
+- Use generic constructors with sealed traits instead of per-type functions.
+- Bad: `TracedTensor::from_f64(...)`, `TracedTensor::from_f32(...)`, etc.
+- Good: `TracedTensor::new<T: TensorScalar>(shape, data)` — type inference selects the variant.
+- Sealed traits (`TensorScalar`, `PoolScalar`, etc.) restrict to supported dtypes (f64, f32, Complex64, Complex32).
+
 ## Public API Convention
 
 - **Unary single-output ops**: methods on `TracedTensor` (e.g., `x.exp()`, `x.reshape(shape)`)

--- a/docs/plans/2026-04-11-docs-restructure-plan.md
+++ b/docs/plans/2026-04-11-docs-restructure-plan.md
@@ -1,0 +1,285 @@
+# Documentation Restructure Plan
+
+> **IMPORTANT**: Do NOT auto-implement. An agent must discuss the plan with a
+> human reviewer and get explicit approval before writing any code.
+
+## Principles
+
+1. **Source of truth = source code** — doc comments on types/traits/functions
+2. **Online docs = user-facing only** — `tenferro` facade crate の使い方
+3. **No internal jargon in user docs** — Fragment, StableHLO, ExecOp 等は出さない
+4. **All imports via `use tenferro::...`** — 内部 crate を直接参照しない
+5. **All examples run as doctests** — `ignore` / `no_run` 禁止
+6. **Internals page = pointer table** — 説明はソースコードの doc comments に
+7. **AI agentic coding 前提** — 開発者は AGENTS.md → ソースコード
+
+## Target site structure
+
+```
+tenferro-rs/ (http://tensor4all.org/tenferro-rs/)
+├── index.html                        ← site top (API + Design cards)
+├── api/                              ← Rustdoc (auto-generated, unchanged)
+└── design/                           ← Quarto-rendered pages (below)
+    ├── index.md                      ← tenferro とは + PyTorch/JAX 対応表
+    ├── getting-started/
+    │   ├── index.md                  ← インストール + 最初の例 (30秒)
+    │   ├── core-concepts.md          ← TracedTensor / Engine / eval
+    │   └── pytorch-jax-mapping.md    ← 操作対応表
+    ├── guides/
+    │   ├── tensor-operations.md      ← 作成、演算、reshape、broadcast、reduce
+    │   ├── einsum.md                 ← einsum の使い方
+    │   ├── linear-algebra.md         ← svd, qr, solve 等
+    │   ├── autodiff.md              ← grad, vjp, jvp
+    │   └── performance.md           ← column-major、スレッド数設定
+    ├── api/
+    │   └── index.md                  ← Rustdoc リンク (= 現 api_index.md)
+    └── internals/
+        └── index.md                  ← ポインタ表 + "AI agentic coding 前提"
+```
+
+## Step 1: Update REPOSITORY_RULES.md
+
+Add documentation example rules (already drafted):
+- `ignore` / `no_run` 禁止
+- All examples must run as doctests
+
+**Files**: `REPOSITORY_RULES.md`
+
+## Step 2: Create new page files
+
+### `docs/index.md` — Landing page (rewrite)
+
+Content:
+- "tenferro — General-purpose tensor computation in Rust"
+- 3-sentence description (lazy eval, einsum, AD)
+- PyTorch / JAX / tenferro comparison table (5 rows)
+- Links to Getting Started, Guides, API, Internals
+
+### `docs/getting-started/index.md` — Quick start (rewrite)
+
+Content:
+- Installation (Cargo.toml dependency)
+- "Hello einsum" — minimal working example (5 lines)
+- "Hello grad" — minimal gradient example (5 lines)
+- Links to core-concepts, guides
+
+Rules:
+- All imports: `use tenferro::{...}`
+- No `Tensor::F64(TypedTensor::from_vec(...))` — add convenience fn if needed
+- All examples: no `ignore`, must run as doctest
+
+### `docs/getting-started/core-concepts.md` — NEW
+
+Content:
+- TracedTensor: "operations record a graph, nothing executes yet"
+  - Compare: PyTorch eager vs JAX jit vs tenferro lazy
+- Engine: "holds backend + caches, executes graphs"
+- eval(): "materializes the result"
+- Typical flow diagram (text, no ASCII box art)
+
+Rules:
+- NO mention of Fragment, StableHLO, ExecProgram, computegraph
+- NO mention of tenferro-tensor, tenferro-ops, etc.
+
+### `docs/getting-started/pytorch-jax-mapping.md` — NEW
+
+Content:
+- Table: concept mapping (tensor creation, ops, einsum, autodiff, device)
+- Table: function mapping (matmul, reshape, transpose, broadcast, reduce, etc.)
+- Key differences section (column-major, lazy eval, engine ownership)
+
+### `docs/guides/tensor-operations.md` — NEW (replaces quick-start ops section)
+
+Content:
+- Creating tensors (from data, zeros, ones)
+- Elementwise: add, mul, exp, log, sin, ...
+- Shape manipulation: reshape, transpose, broadcast
+- Reduction: reduce_sum, reduce_prod
+- Slicing, indexing (if exposed)
+- All with runnable examples
+
+### `docs/guides/einsum.md` — rewrite of einsum-examples.md
+
+Content:
+- What is einsum (brief, with PyTorch/NumPy comparison)
+- Unary: transpose, trace, diagonal
+- Binary: matmul, outer product, batch matmul
+- N-ary: chain contraction, automatic path optimization
+- All examples runnable, imports via `use tenferro::{...}`
+
+### `docs/guides/linear-algebra.md` — NEW
+
+Content:
+- SVD, QR, Cholesky, Eigh, LU, Solve
+- Each with runnable example
+- Note: eval_all for multi-output ops
+
+### `docs/guides/autodiff.md` — rewrite of autodiff-examples.md
+
+Content:
+- grad (scalar loss → gradient)
+- vjp (vector-Jacobian product)
+- jvp (Jacobian-vector product)
+- Higher-order: HVP via jvp(vjp(...))
+- Gradient through einsum
+- Gradient through linalg
+- PyTorch comparison for each
+
+### `docs/guides/performance.md` — NEW
+
+Content:
+- Column-major storage: why, and what to watch out for
+- Thread count: `CpuBackend::with_threads(n)`
+- Buffer reuse: automatic via BufferPool
+- Einsum optimization: contraction path selection
+
+### `docs/api/index.md` — rewrite of api_index.md
+
+Content:
+- Brief: "tenferro is the main crate. Other crates are internal."
+- Link to tenferro rustdoc (primary)
+- Collapsed section: internal crate links (for contributors)
+
+### `docs/internals/index.md` — NEW
+
+Content:
+```markdown
+# Internals
+
+内部設計の Source of Truth はソースコードです。
+開発は AI agentic coding を前提としています。
+[AGENTS.md](https://github.com/tensor4all/tenferro-rs/blob/main/AGENTS.md)
+がエントリーポイントです。
+
+| Topic | Location |
+|---|---|
+| Op vocabulary | `tenferro-ops/src/std_tensor_op.rs` |
+| Backend contract | `tenferro-tensor/src/backend.rs` |
+| Execution session | `tenferro-tensor/src/backend.rs` |
+| AD rules | `tenferro-ops/src/ad/` |
+| Compilation pipeline | `tenferro/src/compiler.rs` |
+| Buffer pool | `tenferro-tensor/src/buffer_pool.rs` |
+| CPU context | `tenferro-tensor/src/cpu/context.rs` |
+| GPU design (future) | `docs/design/exec-session.md` |
+```
+
+## Step 3: Update `_quarto.yml`
+
+Replace sidebar with new structure. Remove all architecture/, spec/,
+design/ (except exec-session.md), oracle/, reference/ from render list.
+
+```yaml
+project:
+  type: website
+  output-dir: ../target/docs-site/design
+  render:
+    - index.md
+    - getting-started/**/*.md
+    - guides/**/*.md
+    - api/**/*.md
+    - internals/**/*.md
+
+website:
+  title: "tenferro"
+  sidebar:
+    style: docked
+    contents:
+      - index.md
+      - section: "Getting Started"
+        contents:
+          - getting-started/index.md
+          - getting-started/core-concepts.md
+          - getting-started/pytorch-jax-mapping.md
+      - section: "Guides"
+        contents:
+          - guides/tensor-operations.md
+          - guides/einsum.md
+          - guides/linear-algebra.md
+          - guides/autodiff.md
+          - guides/performance.md
+      - api/index.md
+      - internals/index.md
+```
+
+## Step 4: Move old docs out of render path
+
+Do NOT delete — move to `docs/_archive/` (or just remove from _quarto.yml
+render list). The files stay in git for history but are not rendered.
+
+Files to stop rendering:
+- `docs/architecture/` — all 6 files
+- `docs/spec/` — all 6 files
+- `docs/design/` — all except `exec-session.md` and `supported-ops.md`
+- `docs/oracle/` — both files
+- `docs/reference/` — all 9 files
+
+Keep rendering:
+- `docs/design/exec-session.md` — future GPU design (linked from internals)
+- `docs/design/supported-ops.md` — CPU/GPU coverage (linked from internals)
+
+## Step 5: Add convenience API to tenferro facade
+
+To make examples clean, add helpers if missing:
+
+```rust
+// tenferro/src/lib.rs or traced.rs
+impl TracedTensor {
+    /// Create a traced tensor from f64 data.
+    /// Equivalent to TracedTensor::from_tensor(Tensor::F64(TypedTensor::from_vec(shape, data)))
+    pub fn from_f64(shape: &[usize], data: &[f64]) -> Self { ... }
+}
+```
+
+This makes examples:
+```rust
+let a = TracedTensor::from_f64(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+```
+
+Instead of:
+```rust
+let a = TracedTensor::from_tensor(
+    Tensor::F64(TypedTensor::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
+);
+```
+
+## Step 6: Fix all examples to be runnable doctests
+
+Go through every example in the new docs and ensure:
+- No `ignore` or `no_run` attribute
+- Imports only from `use tenferro::{...}`
+- Each example compiles and runs
+
+## Step 7: Update check-docs-site.py if needed
+
+The script checks rustdoc output and api_index links. If `api_index.md`
+moves to `docs/api/index.md`, update the script's default path.
+
+## Step 8: Verify
+
+```bash
+cargo fmt --all
+cargo test --workspace --release   # includes doctests
+cargo doc --workspace --no-deps
+scripts/build_docs_site.sh
+python3 scripts/check-docs-site.py
+```
+
+## File change summary
+
+| Action | Files |
+|---|---|
+| **Rewrite** | `docs/index.md`, `docs/getting-started/index.md` |
+| **Rewrite** | `docs/getting-started/einsum-examples.md` → `docs/guides/einsum.md` |
+| **Rewrite** | `docs/getting-started/autodiff-examples.md` → `docs/guides/autodiff.md` |
+| **New** | `docs/getting-started/core-concepts.md` |
+| **New** | `docs/getting-started/pytorch-jax-mapping.md` |
+| **New** | `docs/guides/tensor-operations.md` |
+| **New** | `docs/guides/linear-algebra.md` |
+| **New** | `docs/guides/performance.md` |
+| **New** | `docs/api/index.md` |
+| **New** | `docs/internals/index.md` |
+| **Rewrite** | `docs/_quarto.yml` |
+| **Edit** | `REPOSITORY_RULES.md` (example rules) |
+| **Edit** | `tenferro/src/lib.rs` or `traced.rs` (convenience API) |
+| **Move** | Old docs out of render path |
+| **Edit** | `scripts/check-docs-site.py` (path update if needed) |

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -4,9 +4,29 @@ use num_complex::{Complex32, Complex64};
 
 use crate::types::{
     col_major_strides, flat_to_multi, Buffer, BufferHandle, ComputeDevice, ConjElem, DType,
-    MemoryKind, Placement, Tensor, TypedTensor,
+    MemoryKind, Placement, Tensor, TensorScalar, TypedTensor,
 };
 use crate::Error;
+
+fn tensor_scalar_roundtrip<T>(shape: Vec<usize>, data: Vec<T>)
+where
+    T: TensorScalar + PartialEq + std::fmt::Debug,
+{
+    let tensor = T::into_tensor(shape.clone(), data.clone());
+
+    assert_eq!(tensor.shape(), shape.as_slice());
+    assert_eq!(T::try_as_slice(&tensor), Some(data.as_slice()));
+    assert_eq!(tensor.as_slice::<T>(), Some(data.as_slice()));
+}
+
+macro_rules! tensor_scalar_roundtrip_test {
+    ($name:ident, $ty:ty, $shape:expr, $data:expr) => {
+        #[test]
+        fn $name() {
+            tensor_scalar_roundtrip::<$ty>($shape, $data);
+        }
+    };
+}
 
 #[test]
 fn col_major_helpers_cover_scalar_and_higher_rank_shapes() {
@@ -100,6 +120,41 @@ fn tensor_shape_and_dtype_cover_all_variants() {
     assert_eq!(c32_tensor.dtype(), DType::C32);
     assert_eq!(c64_tensor.shape(), &[1, 1]);
     assert_eq!(c64_tensor.dtype(), DType::C64);
+}
+
+tensor_scalar_roundtrip_test!(
+    tensor_scalar_roundtrip_f32,
+    f32,
+    vec![2],
+    vec![1.25_f32, -2.5_f32]
+);
+
+tensor_scalar_roundtrip_test!(
+    tensor_scalar_roundtrip_f64,
+    f64,
+    vec![2, 1],
+    vec![1.25_f64, -2.5_f64]
+);
+
+tensor_scalar_roundtrip_test!(
+    tensor_scalar_roundtrip_c32,
+    Complex32,
+    vec![2],
+    vec![Complex32::new(1.0, -0.5), Complex32::new(-2.0, 3.5)]
+);
+
+tensor_scalar_roundtrip_test!(
+    tensor_scalar_roundtrip_c64,
+    Complex64,
+    vec![1, 2],
+    vec![Complex64::new(1.0, -0.5), Complex64::new(-2.0, 3.5)]
+);
+
+#[test]
+fn tensor_as_slice_returns_none_for_dtype_mismatch() {
+    let tensor = <f64 as TensorScalar>::into_tensor(vec![2], vec![1.0, 2.0]);
+
+    assert_eq!(tensor.as_slice::<f32>(), None);
 }
 
 #[test]

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -1,4 +1,4 @@
-use num_complex::Complex;
+use num_complex::{Complex, Complex32, Complex64};
 use num_traits::{One, Zero};
 
 /// Memory location for tensor storage.
@@ -132,6 +132,88 @@ pub enum DType {
     F64,
     C32,
     C64,
+}
+
+/// Sealed trait for scalar types that can be stored in a [`Tensor`].
+///
+/// This trait is implemented for `f64`, `f32`, [`Complex64`], and
+/// [`Complex32`].
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::TensorScalar;
+///
+/// let tensor = <f64 as TensorScalar>::into_tensor(vec![2], vec![1.0, 2.0]);
+/// assert_eq!(tensor.as_slice::<f64>(), Some([1.0, 2.0].as_slice()));
+/// ```
+pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
+    /// Wrap typed data into a [`Tensor`] enum variant.
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor;
+
+    /// Try to borrow the host data from a [`Tensor`].
+    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]>;
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for f64 {}
+    impl Sealed for f32 {}
+    impl Sealed for num_complex::Complex64 {}
+    impl Sealed for num_complex::Complex32 {}
+}
+
+impl TensorScalar for f64 {
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::F64(TypedTensor::from_vec(shape, data))
+    }
+
+    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
+        match tensor {
+            Tensor::F64(t) => Some(t.host_data()),
+            _ => None,
+        }
+    }
+}
+
+impl TensorScalar for f32 {
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::F32(TypedTensor::from_vec(shape, data))
+    }
+
+    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
+        match tensor {
+            Tensor::F32(t) => Some(t.host_data()),
+            _ => None,
+        }
+    }
+}
+
+impl TensorScalar for Complex64 {
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::C64(TypedTensor::from_vec(shape, data))
+    }
+
+    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
+        match tensor {
+            Tensor::C64(t) => Some(t.host_data()),
+            _ => None,
+        }
+    }
+}
+
+impl TensorScalar for Complex32 {
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::C32(TypedTensor::from_vec(shape, data))
+    }
+
+    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
+        match tensor {
+            Tensor::C32(t) => Some(t.host_data()),
+            _ => None,
+        }
+    }
 }
 
 /// Dynamic tensor enum over the supported scalar types.
@@ -443,6 +525,23 @@ impl Tensor {
             Tensor::C32(_) => DType::C32,
             Tensor::C64(_) => DType::C64,
         }
+    }
+
+    /// Try to borrow the host data as a typed slice.
+    ///
+    /// Returns `None` if the tensor dtype does not match `T`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TypedTensor};
+    ///
+    /// let t = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
+    /// assert_eq!(t.as_slice::<f64>(), Some([1.0, 2.0, 3.0].as_slice()));
+    /// assert_eq!(t.as_slice::<f32>(), None);
+    /// ```
+    pub fn as_slice<T: TensorScalar>(&self) -> Option<&[T]> {
+        T::try_as_slice(self)
     }
 }
 

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -34,7 +34,7 @@ pub use linalg_api::{
 };
 pub use sym_dim::SymDim;
 pub use tenferro_tensor::cpu::CpuBackend;
-pub use tenferro_tensor::{DType, Tensor, TensorBackend, TypedTensor};
+pub use tenferro_tensor::{DType, Tensor, TensorBackend, TensorScalar, TypedTensor};
 pub use traced::TracedTensor;
 
 /// Matrix multiplication helper for rank-2 traced tensors.

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -12,7 +12,7 @@ use num_complex::{Complex32, Complex64};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_tensor::{DType, DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
+use tenferro_tensor::{DType, DotGeneralConfig, Tensor, TensorBackend, TensorScalar, TypedTensor};
 use tidu::{differentiate, transpose};
 
 use super::compiler::{compile_to_exec, lower_to_stablehlo};
@@ -245,6 +245,20 @@ impl TracedTensor {
             inputs_map: Arc::new(map),
             extra_roots: Vec::new(),
         }
+    }
+
+    /// Create a traced tensor from shape and data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::TracedTensor;
+    ///
+    /// let a = TracedTensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// assert_eq!(a.rank, 2);
+    /// ```
+    pub fn new<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Self {
+        Self::from_tensor(T::into_tensor(shape, data))
     }
 
     pub fn eval<B: TensorBackend>(&mut self, engine: &mut Engine<B>) -> Result<&Tensor> {

--- a/tenferro/tests/convenience_api.rs
+++ b/tenferro/tests/convenience_api.rs
@@ -1,0 +1,24 @@
+use tenferro::{CpuBackend, Engine, TensorScalar, TracedTensor};
+
+#[test]
+fn traced_tensor_new_and_tensor_as_slice_cover_common_f64_flow() {
+    let a = TracedTensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let b = TracedTensor::new(vec![2, 3], vec![6.0_f64, 5.0, 4.0, 3.0, 2.0, 1.0]);
+
+    let mut sum = &a + &b;
+    let mut engine = Engine::new(CpuBackend::new());
+    let result = sum.eval(&mut engine).unwrap();
+
+    assert_eq!(
+        result.as_slice::<f64>(),
+        Some([7.0, 7.0, 7.0, 7.0, 7.0, 7.0].as_slice())
+    );
+    assert_eq!(result.as_slice::<f32>(), None);
+}
+
+#[test]
+fn tensor_scalar_is_reexported_from_tenferro() {
+    let tensor = <f64 as TensorScalar>::into_tensor(vec![2], vec![1.0, 2.0]);
+
+    assert_eq!(tensor.as_slice::<f64>(), Some([1.0, 2.0].as_slice()));
+}


### PR DESCRIPTION
## Summary

Add convenience API for tensor creation and result extraction, targeting PyTorch/JAX users.

**Before:**
```rust
let a = TracedTensor::from_tensor(
    Tensor::F64(TypedTensor::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
);
match result {
    Tensor::F64(inner) => { let data = inner.host_data(); }
    _ => panic!(),
}
```

**After:**
```rust
let a = TracedTensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
let data = result.as_slice::<f64>().unwrap();
```

- `TensorScalar`: sealed trait (f64/f32/c64/c32) with `into_tensor`/`try_as_slice`
- `TracedTensor::new<T: TensorScalar>`: generic constructor
- `Tensor::as_slice<T: TensorScalar>`: typed result extraction
- REPOSITORY_RULES.md: doc policy + generic-over-scalar rule
- Docs restructure plan (`docs/plans/2026-04-11-docs-restructure-plan.md`)

## Test plan

- [x] `cargo test --workspace --release`
- [x] Doc examples run as doctests (no `ignore`)
- [x] `cargo doc --workspace --no-deps`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)