### PR TITLE
refactor: use symbolic DimExpr::InputDim for reduce/einsum input_shape

### DIFF
--- a/tenferro-einsum/src/builder.rs
+++ b/tenferro-einsum/src/builder.rs
@@ -93,7 +93,7 @@ fn reduce_val<Op: GraphOp + SemiringOps>(
         .map(|(_, &s)| s)
         .collect();
     let outputs = builder.add_op(
-        Op::reduce_sum(reduce_axes, DimExpr::from_concrete(&lv.shape)),
+        Op::reduce_sum(reduce_axes, DimExpr::input_shape(0, lv.shape.len())),
         vec![lv.val.clone()],
         OpMode::Primal,
     );

--- a/tenferro/src/linalg_api.rs
+++ b/tenferro/src/linalg_api.rs
@@ -690,7 +690,7 @@ fn reduce_prod(input: &TracedTensor, axes: &[usize]) -> TracedTensor {
     apply_unary(
         StdTensorOp::ReduceProd {
             axes: axes.to_vec(),
-            input_shape: input_shape_expr(input),
+            input_shape: DimExpr::input_shape(0, input.rank),
         },
         input,
         input.rank - axes.len(),
@@ -704,7 +704,7 @@ fn reduce_max(input: &TracedTensor, axes: &[usize]) -> TracedTensor {
     apply_unary(
         StdTensorOp::ReduceMax {
             axes: axes.to_vec(),
-            input_shape: input_shape_expr(input),
+            input_shape: DimExpr::input_shape(0, input.rank),
         },
         input,
         input.rank - axes.len(),
@@ -718,7 +718,7 @@ fn reduce_min(input: &TracedTensor, axes: &[usize]) -> TracedTensor {
     apply_unary(
         StdTensorOp::ReduceMin {
             axes: axes.to_vec(),
-            input_shape: input_shape_expr(input),
+            input_shape: DimExpr::input_shape(0, input.rank),
         },
         input,
         input.rank - axes.len(),


### PR DESCRIPTION
## Summary

- Reduce ops (ReduceProd/Max/Min) and einsum-emitted ReduceSum now store `DimExpr::input_shape(0, rank)` instead of `DimExpr::from_concrete()`
- Graph topology no longer depends on concrete tensor sizes for reductions

## Motivation

Phase 1c of symbolic-shape design. Makes reduction op graphs shape-agnostic — same compiled graph works for different input sizes. AD transpose rules already handle `DimExpr::InputDim` via `needs_shape_source` checks.

## Changes

- **`tenferro/src/linalg_api.rs`**: ReduceProd/Max/Min construction uses `DimExpr::input_shape`
- **`tenferro-einsum/src/builder.rs`**: einsum ReduceSum uses `DimExpr::input_shape`

Linalg ops (SVD/QR/LU) retain concrete `input_shape` for guard-based AD.

## Test plan

- [x] All workspace tests pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)