### PR TITLE
feat: add ergonomic eager API on Tensor and TypedTensor

### DIFF
--- a/tenferro-einsum/src/eager.rs
+++ b/tenferro-einsum/src/eager.rs
@@ -1,0 +1,497 @@
+use std::collections::{HashMap, HashSet};
+
+use tenferro_tensor::{DotGeneralConfig, Error, Result, Tensor, TensorBackend, TensorExec};
+
+use crate::{ContractionTree, Subscripts};
+
+const EAGER_EINSUM_OP: &str = "eager_einsum";
+
+enum TensorValue<'a> {
+    Borrowed(&'a Tensor),
+    Owned(Tensor),
+}
+
+impl TensorValue<'_> {
+    fn as_tensor(&self) -> &Tensor {
+        match self {
+            Self::Borrowed(tensor) => tensor,
+            Self::Owned(tensor) => tensor,
+        }
+    }
+
+    fn into_tensor(self) -> Tensor {
+        match self {
+            Self::Borrowed(tensor) => tensor.clone(),
+            Self::Owned(tensor) => tensor,
+        }
+    }
+}
+
+struct LabeledTensor<'a> {
+    tensor: TensorValue<'a>,
+    labels: Vec<u32>,
+}
+
+impl LabeledTensor<'_> {
+    fn tensor(&self) -> &Tensor {
+        self.tensor.as_tensor()
+    }
+
+    fn shape(&self) -> &[usize] {
+        self.tensor().shape()
+    }
+}
+
+fn eager_invalid_config(message: impl Into<String>) -> Error {
+    Error::InvalidConfig {
+        op: EAGER_EINSUM_OP,
+        message: message.into(),
+    }
+}
+
+fn take_labeled<'a>(
+    labeled: &mut [Option<LabeledTensor<'a>>],
+    index: usize,
+    role: &'static str,
+) -> Result<LabeledTensor<'a>> {
+    labeled
+        .get_mut(index)
+        .ok_or_else(|| eager_invalid_config(format!("missing {role} operand at index {index}")))?
+        .take()
+        .ok_or_else(|| eager_invalid_config(format!("missing {role} operand at index {index}")))
+}
+
+fn find_label_axis(labels: &[u32], label: u32) -> Result<usize> {
+    labels
+        .iter()
+        .position(|candidate| *candidate == label)
+        .ok_or_else(|| eager_invalid_config(format!("label {label} missing from tensor labels")))
+}
+
+fn label_size(label: u32, operands: &[&LabeledTensor<'_>]) -> Result<usize> {
+    for operand in operands {
+        if let Some(axis) = operand
+            .labels
+            .iter()
+            .position(|candidate| *candidate == label)
+        {
+            return Ok(operand.shape()[axis]);
+        }
+    }
+    Err(eager_invalid_config(format!(
+        "label {label} missing from eager einsum operands"
+    )))
+}
+
+fn reduce_tensor<'a>(
+    exec: &mut dyn TensorExec,
+    operand: LabeledTensor<'a>,
+    reduce_labels: &HashSet<u32>,
+) -> Result<LabeledTensor<'a>> {
+    if reduce_labels.is_empty() {
+        return Ok(operand);
+    }
+
+    let reduce_axes: Vec<usize> = operand
+        .labels
+        .iter()
+        .enumerate()
+        .filter(|(_, label)| reduce_labels.contains(label))
+        .map(|(axis, _)| axis)
+        .collect();
+    if reduce_axes.is_empty() {
+        return Ok(operand);
+    }
+
+    let reduce_set: HashSet<usize> = reduce_axes.iter().copied().collect();
+    let labels: Vec<u32> = operand
+        .labels
+        .iter()
+        .enumerate()
+        .filter(|(axis, _)| !reduce_set.contains(axis))
+        .map(|(_, label)| *label)
+        .collect();
+    let tensor = exec.reduce_sum(operand.tensor(), &reduce_axes)?;
+    Ok(LabeledTensor {
+        tensor: TensorValue::Owned(tensor),
+        labels,
+    })
+}
+
+fn diagonalize_repeated<'a>(
+    exec: &mut dyn TensorExec,
+    mut operand: LabeledTensor<'a>,
+) -> Result<LabeledTensor<'a>> {
+    loop {
+        let mut seen = HashMap::new();
+        let mut repeated_pair = None;
+        for (axis, label) in operand.labels.iter().copied().enumerate() {
+            if let Some(first_axis) = seen.insert(label, axis) {
+                repeated_pair = Some((first_axis, axis));
+                break;
+            }
+        }
+
+        let Some((axis_a, axis_b)) = repeated_pair else {
+            return Ok(operand);
+        };
+
+        let tensor = exec.extract_diagonal(operand.tensor(), axis_a, axis_b)?;
+        let mut labels = operand.labels;
+        labels.remove(axis_b);
+        operand = LabeledTensor {
+            tensor: TensorValue::Owned(tensor),
+            labels,
+        };
+    }
+}
+
+fn embed_repeated<'a>(
+    exec: &mut dyn TensorExec,
+    mut operand: LabeledTensor<'a>,
+    output_labels: &[u32],
+) -> Result<LabeledTensor<'a>> {
+    loop {
+        let mut embedded = false;
+        for &label in output_labels {
+            let current_count = operand
+                .labels
+                .iter()
+                .filter(|candidate| **candidate == label)
+                .count();
+            let output_count = output_labels
+                .iter()
+                .filter(|candidate| **candidate == label)
+                .count();
+            if output_count > current_count {
+                let axis_a = find_label_axis(&operand.labels, label)?;
+                let axis_b = axis_a + 1;
+                let tensor = exec.embed_diagonal(operand.tensor(), axis_a, axis_b)?;
+                let mut labels = operand.labels;
+                labels.insert(axis_b, label);
+                operand = LabeledTensor {
+                    tensor: TensorValue::Owned(tensor),
+                    labels,
+                };
+                embedded = true;
+                break;
+            }
+        }
+
+        if !embedded {
+            return Ok(operand);
+        }
+    }
+}
+
+fn transpose_to_labels<'a>(
+    exec: &mut dyn TensorExec,
+    operand: LabeledTensor<'a>,
+    target_labels: &[u32],
+) -> Result<LabeledTensor<'a>> {
+    if operand.labels == target_labels {
+        return Ok(operand);
+    }
+
+    let perm: Vec<usize> = target_labels
+        .iter()
+        .map(|label| find_label_axis(&operand.labels, *label))
+        .collect::<Result<_>>()?;
+    if perm
+        .iter()
+        .enumerate()
+        .all(|(axis, target)| axis == *target)
+    {
+        return Ok(operand);
+    }
+
+    let tensor = exec.transpose(operand.tensor(), &perm)?;
+    Ok(LabeledTensor {
+        tensor: TensorValue::Owned(tensor),
+        labels: target_labels.to_vec(),
+    })
+}
+
+fn outer_product<'a>(
+    exec: &mut dyn TensorExec,
+    lhs: LabeledTensor<'a>,
+    rhs: LabeledTensor<'a>,
+    batch_labels: &[u32],
+    lhs_free_labels: &[u32],
+    rhs_free_labels: &[u32],
+) -> Result<LabeledTensor<'a>> {
+    if lhs.labels == rhs.labels {
+        let tensor = exec.mul(lhs.tensor(), rhs.tensor())?;
+        return Ok(LabeledTensor {
+            tensor: TensorValue::Owned(tensor),
+            labels: lhs.labels,
+        });
+    }
+
+    let combined_labels: Vec<u32> = lhs_free_labels
+        .iter()
+        .chain(rhs_free_labels.iter())
+        .chain(batch_labels.iter())
+        .copied()
+        .collect();
+    let combined_shape: Vec<usize> = combined_labels
+        .iter()
+        .map(|label| label_size(*label, &[&lhs, &rhs]))
+        .collect::<Result<_>>()?;
+    let lhs_dims: Vec<usize> = lhs
+        .labels
+        .iter()
+        .map(|label| find_label_axis(&combined_labels, *label))
+        .collect::<Result<_>>()?;
+    let rhs_dims: Vec<usize> = rhs
+        .labels
+        .iter()
+        .map(|label| find_label_axis(&combined_labels, *label))
+        .collect::<Result<_>>()?;
+
+    let lhs_tensor = exec.broadcast_in_dim(lhs.tensor(), &combined_shape, &lhs_dims)?;
+    let rhs_tensor = exec.broadcast_in_dim(rhs.tensor(), &combined_shape, &rhs_dims)?;
+    let tensor = exec.mul(&lhs_tensor, &rhs_tensor)?;
+    Ok(LabeledTensor {
+        tensor: TensorValue::Owned(tensor),
+        labels: combined_labels,
+    })
+}
+
+fn binary_contract<'a>(
+    exec: &mut dyn TensorExec,
+    lhs: LabeledTensor<'a>,
+    rhs: LabeledTensor<'a>,
+    survive_labels: &[u32],
+    reorder_result: bool,
+) -> Result<LabeledTensor<'a>> {
+    let survive_set: HashSet<u32> = survive_labels.iter().copied().collect();
+    let rhs_label_set: HashSet<u32> = rhs.labels.iter().copied().collect();
+    let lhs_label_set: HashSet<u32> = lhs.labels.iter().copied().collect();
+
+    let lhs_reduce: HashSet<u32> = lhs
+        .labels
+        .iter()
+        .filter(|label| !rhs_label_set.contains(label) && !survive_set.contains(label))
+        .copied()
+        .collect();
+    let rhs_reduce: HashSet<u32> = rhs
+        .labels
+        .iter()
+        .filter(|label| !lhs_label_set.contains(label) && !survive_set.contains(label))
+        .copied()
+        .collect();
+
+    let lhs = reduce_tensor(exec, lhs, &lhs_reduce)?;
+    let rhs = reduce_tensor(exec, rhs, &rhs_reduce)?;
+
+    let lhs_label_set: HashSet<u32> = lhs.labels.iter().copied().collect();
+    let rhs_label_set: HashSet<u32> = rhs.labels.iter().copied().collect();
+
+    let mut batch_labels = Vec::new();
+    let mut contracting_labels = Vec::new();
+    let mut lhs_free_labels = Vec::new();
+    let mut rhs_free_labels = Vec::new();
+
+    for &label in &lhs.labels {
+        if rhs_label_set.contains(&label) {
+            if survive_set.contains(&label) {
+                if !batch_labels.contains(&label) {
+                    batch_labels.push(label);
+                }
+            } else if !contracting_labels.contains(&label) {
+                contracting_labels.push(label);
+            }
+        } else if !lhs_free_labels.contains(&label) {
+            lhs_free_labels.push(label);
+        }
+    }
+
+    for &label in &rhs.labels {
+        if !lhs_label_set.contains(&label) && !rhs_free_labels.contains(&label) {
+            rhs_free_labels.push(label);
+        }
+    }
+
+    let result = if contracting_labels.is_empty() {
+        outer_product(
+            exec,
+            lhs,
+            rhs,
+            &batch_labels,
+            &lhs_free_labels,
+            &rhs_free_labels,
+        )?
+    } else {
+        let lhs_contracting_dims: Vec<usize> = contracting_labels
+            .iter()
+            .map(|label| find_label_axis(&lhs.labels, *label))
+            .collect::<Result<_>>()?;
+        let rhs_contracting_dims: Vec<usize> = contracting_labels
+            .iter()
+            .map(|label| find_label_axis(&rhs.labels, *label))
+            .collect::<Result<_>>()?;
+        let lhs_batch_dims: Vec<usize> = batch_labels
+            .iter()
+            .map(|label| find_label_axis(&lhs.labels, *label))
+            .collect::<Result<_>>()?;
+        let rhs_batch_dims: Vec<usize> = batch_labels
+            .iter()
+            .map(|label| find_label_axis(&rhs.labels, *label))
+            .collect::<Result<_>>()?;
+        let labels: Vec<u32> = lhs_free_labels
+            .iter()
+            .chain(rhs_free_labels.iter())
+            .chain(batch_labels.iter())
+            .copied()
+            .collect();
+        let config = DotGeneralConfig {
+            lhs_contracting_dims,
+            rhs_contracting_dims,
+            lhs_batch_dims,
+            rhs_batch_dims,
+            lhs_rank: lhs.labels.len(),
+            rhs_rank: rhs.labels.len(),
+        };
+        let tensor = exec.dot_general(lhs.tensor(), rhs.tensor(), &config)?;
+        LabeledTensor {
+            tensor: TensorValue::Owned(tensor),
+            labels,
+        }
+    };
+
+    if !reorder_result {
+        return Ok(result);
+    }
+
+    let result_label_set: HashSet<u32> = result.labels.iter().copied().collect();
+    let target_labels: Vec<u32> = survive_labels
+        .iter()
+        .filter(|label| result_label_set.contains(label))
+        .copied()
+        .collect();
+    transpose_to_labels(exec, result, &target_labels)
+}
+
+fn eager_einsum_exec(
+    exec: &mut dyn TensorExec,
+    inputs: &[&Tensor],
+    tree: &ContractionTree,
+) -> Result<Tensor> {
+    let subscripts = &tree.subscripts;
+    let n_inputs = subscripts.inputs.len();
+    let output_labels = &subscripts.output;
+
+    let mut labeled: Vec<Option<LabeledTensor<'_>>> = inputs
+        .iter()
+        .zip(subscripts.inputs.iter())
+        .map(|(tensor, labels)| {
+            Some(LabeledTensor {
+                tensor: TensorValue::Borrowed(tensor),
+                labels: labels.clone(),
+            })
+        })
+        .collect();
+
+    for index in 0..labeled.len() {
+        let operand = take_labeled(&mut labeled, index, "input")?;
+        labeled[index] = Some(diagonalize_repeated(exec, operand)?);
+    }
+
+    if n_inputs == 1 || tree.step_count() == 0 {
+        let operand = take_labeled(&mut labeled, 0, "input")?;
+        let output_set: HashSet<u32> = output_labels.iter().copied().collect();
+        let reduce_labels: HashSet<u32> = operand
+            .labels
+            .iter()
+            .filter(|label| !output_set.contains(label))
+            .copied()
+            .collect();
+        let reduced = reduce_tensor(exec, operand, &reduce_labels)?;
+        let embedded = embed_repeated(exec, reduced, output_labels)?;
+        let reordered = transpose_to_labels(exec, embedded, output_labels)?;
+        return Ok(reordered.tensor.into_tensor());
+    }
+
+    for step_idx in 0..tree.step_count() {
+        let (left, right) = tree.step_pair(step_idx).ok_or_else(|| {
+            eager_invalid_config(format!("missing contraction pair for step {step_idx}"))
+        })?;
+        let (_, _, step_output_labels) = tree.step_subscripts(step_idx).ok_or_else(|| {
+            eager_invalid_config(format!(
+                "missing contraction subscripts for step {step_idx}"
+            ))
+        })?;
+        let lhs = take_labeled(&mut labeled, left, "lhs")?;
+        let rhs = take_labeled(&mut labeled, right, "rhs")?;
+        let result = binary_contract(
+            exec,
+            lhs,
+            rhs,
+            step_output_labels,
+            step_idx + 1 == tree.step_count(),
+        )?;
+        labeled.push(Some(result));
+    }
+
+    let final_index = n_inputs + tree.step_count() - 1;
+    let result = take_labeled(&mut labeled, final_index, "result")?;
+    let output_set: HashSet<u32> = output_labels.iter().copied().collect();
+    let extra_labels: HashSet<u32> = result
+        .labels
+        .iter()
+        .filter(|label| !output_set.contains(label))
+        .copied()
+        .collect();
+    let reduced = reduce_tensor(exec, result, &extra_labels)?;
+    let reordered = transpose_to_labels(exec, reduced, output_labels)?;
+    Ok(reordered.tensor.into_tensor())
+}
+
+/// Eager N-ary einsum on concrete [`Tensor`] values.
+///
+/// This applies the same contraction-tree optimization strategy used by the
+/// traced einsum path, but executes each contraction immediately against the
+/// provided backend context.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_einsum::eager_einsum;
+/// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+///
+/// let mut ctx = CpuBackend::new();
+/// let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+/// let b = Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+/// let c = eager_einsum(&mut ctx, &[&a, &b], "ij,jk->ik").unwrap();
+///
+/// assert_eq!(c.shape(), &[2, 2]);
+/// assert_eq!(c.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+/// ```
+pub fn eager_einsum(
+    ctx: &mut impl TensorBackend,
+    inputs: &[&Tensor],
+    subscripts: &str,
+) -> Result<Tensor> {
+    if inputs.is_empty() {
+        return Err(eager_invalid_config(
+            "eager einsum requires at least one input tensor",
+        ));
+    }
+
+    let subs = Subscripts::parse(subscripts)
+        .map_err(|err| eager_invalid_config(format!("invalid subscripts: {err}")))?;
+    if subs.inputs.len() != inputs.len() {
+        return Err(eager_invalid_config(format!(
+            "eager einsum subscripts expect {} inputs, got {}",
+            subs.inputs.len(),
+            inputs.len()
+        )));
+    }
+
+    let shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
+    let tree = ContractionTree::optimize(&subs, &shapes).map_err(|err| {
+        eager_invalid_config(format!("failed to optimize contraction tree: {err}"))
+    })?;
+    ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, &tree))
+}

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -36,12 +36,14 @@
 //! ```
 
 pub mod builder;
+mod eager;
 pub mod planning;
 pub mod syntax;
 pub(crate) mod util;
 
 // Re-exports for convenience
 pub use builder::build_einsum_fragment;
+pub use eager::eager_einsum;
 pub use planning::tree::{ContractionOptimizerOptions, ContractionTree};
 pub use syntax::nested::NestedEinsum;
 pub use syntax::subscripts::Subscripts;

--- a/tenferro-einsum/src/tests/eager_tests.rs
+++ b/tenferro-einsum/src/tests/eager_tests.rs
@@ -1,0 +1,77 @@
+use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend};
+
+use crate::eager_einsum;
+
+#[test]
+fn eager_einsum_executes_binary_and_ternary_contractions() {
+    let mut ctx = CpuBackend::new();
+    fn needs_backend(_ctx: &mut impl TensorBackend) {}
+    needs_backend(&mut ctx);
+
+    let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let b = Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let matmul = eager_einsum(&mut ctx, &[&a, &b], "ij,jk->ik").unwrap();
+    assert_eq!(matmul.shape(), &[2, 2]);
+    assert_eq!(
+        matmul.as_slice::<f64>(),
+        Some([22.0, 28.0, 49.0, 64.0].as_slice())
+    );
+
+    let c = Tensor::new(vec![2, 1], vec![1.0_f64, 2.0]);
+    let chain = eager_einsum(&mut ctx, &[&a, &b, &c], "ij,jk,kl->il").unwrap();
+    assert_eq!(chain.shape(), &[2, 1]);
+    assert_eq!(chain.as_slice::<f64>(), Some([120.0, 156.0].as_slice()));
+}
+
+#[test]
+fn eager_einsum_handles_outer_products_and_diagonal_patterns() {
+    let mut ctx = CpuBackend::new();
+
+    let lhs = Tensor::new(vec![2], vec![1.0_f64, 2.0]);
+    let rhs = Tensor::new(vec![3], vec![3.0_f64, 4.0, 5.0]);
+    let outer = eager_einsum(&mut ctx, &[&lhs, &rhs], "i,j->ij").unwrap();
+    assert_eq!(outer.shape(), &[2, 3]);
+    assert_eq!(
+        outer.as_slice::<f64>(),
+        Some([3.0, 6.0, 4.0, 8.0, 5.0, 10.0].as_slice())
+    );
+
+    let matrix = Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let diagonal = eager_einsum(&mut ctx, &[&matrix], "ii->i").unwrap();
+    let trace = eager_einsum(&mut ctx, &[&matrix], "ii->").unwrap();
+    assert_eq!(diagonal.shape(), &[2]);
+    assert_eq!(diagonal.as_slice::<f64>(), Some([1.0, 4.0].as_slice()));
+    assert_eq!(trace.shape(), &[] as &[usize]);
+    assert_eq!(trace.as_slice::<f64>(), Some([5.0].as_slice()));
+
+    let embedded = eager_einsum(&mut ctx, &[&lhs], "i->ii").unwrap();
+    assert_eq!(embedded.shape(), &[2, 2]);
+    assert_eq!(
+        embedded.as_slice::<f64>(),
+        Some([1.0, 0.0, 0.0, 2.0].as_slice())
+    );
+}
+
+#[test]
+fn eager_einsum_rejects_empty_inputs_and_operand_count_mismatch() {
+    let mut ctx = CpuBackend::new();
+    let tensor = Tensor::new(vec![2], vec![1.0_f64, 2.0]);
+
+    let empty = eager_einsum(&mut ctx, &[], "->").unwrap_err();
+    assert!(matches!(
+        empty,
+        tenferro_tensor::Error::InvalidConfig {
+            op: "eager_einsum",
+            ..
+        }
+    ));
+
+    let mismatch = eager_einsum(&mut ctx, &[&tensor], "i,j->ij").unwrap_err();
+    assert!(matches!(
+        mismatch,
+        tenferro_tensor::Error::InvalidConfig {
+            op: "eager_einsum",
+            ..
+        }
+    ));
+}

--- a/tenferro-einsum/src/tests/mod.rs
+++ b/tenferro-einsum/src/tests/mod.rs
@@ -1,2 +1,3 @@
 mod builder_tests;
+mod eager_tests;
 mod helper_tests;

--- a/tenferro-tensor/src/tests/eager_api_tests.rs
+++ b/tenferro-tensor/src/tests/eager_api_tests.rs
@@ -1,0 +1,129 @@
+use crate::{cpu::CpuBackend, Tensor, TensorBackend, TypedTensor};
+
+fn assert_close(actual: &[f64], expected: &[f64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    for (actual, expected) in actual.iter().zip(expected.iter()) {
+        assert!((actual - expected).abs() <= tol);
+    }
+}
+
+#[test]
+fn tensor_new_and_typed_tensor_as_slice_work() {
+    let tensor = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let typed = TypedTensor::<f64>::from_vec(vec![2], vec![7.0, 8.0]);
+
+    assert_eq!(tensor.shape(), &[2, 3]);
+    assert_eq!(
+        tensor.as_slice::<f64>(),
+        Some([1.0, 2.0, 3.0, 4.0, 5.0, 6.0].as_slice())
+    );
+    assert_eq!(typed.as_slice(), &[7.0, 8.0]);
+}
+
+#[test]
+fn eager_tensor_elementwise_and_structural_methods_match_backend_results() {
+    let mut ctx = CpuBackend::new();
+    fn needs_backend(_ctx: &mut impl TensorBackend) {}
+    needs_backend(&mut ctx);
+
+    let a = Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let b = Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]);
+    let sum = a.add(&b, &mut ctx).unwrap();
+    let product = a.mul(&b, &mut ctx).unwrap();
+    let negated = a.neg(&mut ctx).unwrap();
+
+    assert_eq!(sum.as_slice::<f64>(), Some([5.0, 7.0, 9.0].as_slice()));
+    assert_eq!(
+        product.as_slice::<f64>(),
+        Some([4.0, 10.0, 18.0].as_slice())
+    );
+    assert_eq!(
+        negated.as_slice::<f64>(),
+        Some([-1.0, -2.0, -3.0].as_slice())
+    );
+
+    let matrix = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let transposed = matrix.transpose(&[1, 0], &mut ctx).unwrap();
+    let reshaped = matrix.reshape(&[3, 2], &mut ctx).unwrap();
+    let reduced = matrix.reduce_sum(&[1], &mut ctx).unwrap();
+    let rhs = Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let matmul = matrix.matmul(&rhs, &mut ctx).unwrap();
+
+    assert_eq!(transposed.shape(), &[3, 2]);
+    assert_eq!(
+        transposed.as_slice::<f64>(),
+        Some([1.0, 3.0, 5.0, 2.0, 4.0, 6.0].as_slice())
+    );
+    assert_eq!(reshaped.shape(), &[3, 2]);
+    assert_eq!(
+        reshaped.as_slice::<f64>(),
+        Some([1.0, 2.0, 3.0, 4.0, 5.0, 6.0].as_slice())
+    );
+    assert_eq!(reduced.shape(), &[2]);
+    assert_eq!(reduced.as_slice::<f64>(), Some([9.0, 12.0].as_slice()));
+    assert_eq!(matmul.shape(), &[2, 2]);
+    assert_eq!(
+        matmul.as_slice::<f64>(),
+        Some([22.0, 28.0, 49.0, 64.0].as_slice())
+    );
+}
+
+#[test]
+fn eager_tensor_linalg_methods_return_expected_shapes_and_values() {
+    let mut ctx = CpuBackend::new();
+
+    let tall = Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let (u, s, vt) = tall.svd(&mut ctx).unwrap();
+    let (q, r) = tall.qr(&mut ctx).unwrap();
+    assert_eq!(u.shape(), &[3, 2]);
+    assert_eq!(s.shape(), &[2]);
+    assert_eq!(vt.shape(), &[2, 2]);
+    assert_eq!(q.shape(), &[3, 2]);
+    assert_eq!(r.shape(), &[2, 2]);
+
+    let permutation = Tensor::new(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]);
+    let (p, l, u, parity) = permutation.lu(&mut ctx).unwrap();
+    assert_eq!(p.shape(), &[2, 2]);
+    assert_eq!(l.shape(), &[2, 2]);
+    assert_eq!(u.shape(), &[2, 2]);
+    assert_eq!(parity.shape(), &[]);
+
+    let spd = Tensor::new(vec![2, 2], vec![4.0_f64, 2.0, 2.0, 5.0]);
+    let chol = spd.cholesky(&mut ctx).unwrap();
+    assert_eq!(chol.shape(), &[2, 2]);
+    assert_eq!(
+        chol.as_slice::<f64>(),
+        Some([2.0, 1.0, 0.0, 2.0].as_slice())
+    );
+
+    let (eigh_values, eigh_vectors) = spd.eigh(&mut ctx).unwrap();
+    assert_eq!(eigh_values.shape(), &[2]);
+    assert_eq!(eigh_vectors.shape(), &[2, 2]);
+
+    let diagonal = Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]);
+    let (eig_values, eig_vectors) = diagonal.eig(&mut ctx).unwrap();
+    assert_eq!(eig_values.shape(), &[2]);
+    assert_eq!(eig_vectors.shape(), &[2, 2]);
+
+    let a = Tensor::new(vec![2, 2], vec![2.0_f64, 1.0, 1.0, 2.0]);
+    let b = Tensor::new(vec![2, 1], vec![1.0_f64, 0.0]);
+    let x = a.solve(&b, &mut ctx).unwrap();
+    assert_eq!(x.shape(), &[2, 1]);
+    assert_close(
+        x.as_slice::<f64>().unwrap(),
+        &[2.0 / 3.0, -1.0 / 3.0],
+        1.0e-10,
+    );
+
+    let triangular = Tensor::new(vec![2, 2], vec![2.0_f64, 1.0, 0.0, 3.0]);
+    let rhs = Tensor::new(vec![2, 1], vec![2.0_f64, 7.0]);
+    let triangular_x = triangular
+        .triangular_solve(&rhs, true, true, false, false, &mut ctx)
+        .unwrap();
+    assert_eq!(triangular_x.shape(), &[2, 1]);
+    assert_close(
+        triangular_x.as_slice::<f64>().unwrap(),
+        &[1.0, 2.0],
+        1.0e-10,
+    );
+}

--- a/tenferro-tensor/src/tests/mod.rs
+++ b/tenferro-tensor/src/tests/mod.rs
@@ -2,4 +2,5 @@ mod backend_trait_tests;
 mod cpu_semiring_tests;
 mod cpu_stub_tests;
 mod cpu_tests;
+mod eager_api_tests;
 mod types_tests;

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -1,6 +1,8 @@
 use num_complex::{Complex, Complex32, Complex64};
 use num_traits::{One, Zero};
 
+use crate::{DotGeneralConfig, TensorBackend};
+
 /// Memory location for tensor storage.
 ///
 /// # Examples
@@ -361,6 +363,23 @@ impl<T: Clone> TypedTensor<T> {
         }
     }
 
+    /// View the tensor data as a flat slice.
+    ///
+    /// This is an alias for `host_data()` for API consistency with
+    /// `Tensor::as_slice`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec(vec![2], vec![1.0, 2.0]);
+    /// assert_eq!(t.as_slice(), &[1.0, 2.0]);
+    /// ```
+    pub fn as_slice(&self) -> &[T] {
+        self.host_data()
+    }
+
     /// Mutably borrow the host buffer.
     ///
     /// # Examples
@@ -489,6 +508,23 @@ pub(crate) use dispatch_binary;
 pub(crate) use dispatch_tensor;
 
 impl Tensor {
+    /// Create a tensor from a shape and flat data.
+    ///
+    /// This is the `Tensor`-level equivalent of `TypedTensor::<T>::from_vec`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// assert_eq!(t.shape(), &[2, 3]);
+    /// assert_eq!(t.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// ```
+    pub fn new<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Self {
+        T::into_tensor(shape, data)
+    }
+
     /// Tensor shape.
     ///
     /// # Examples
@@ -543,11 +579,360 @@ impl Tensor {
     pub fn as_slice<T: TensorScalar>(&self) -> Option<&[T]> {
         T::try_as_slice(self)
     }
+
+    /// Singular value decomposition: `A = U diag(S) Vt`.
+    ///
+    /// Returns `(U, S, Vt)` using the thin/economy SVD.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// let (u, s, vt) = a.svd(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(u.shape(), &[3, 2]);
+    /// assert_eq!(s.shape(), &[2]);
+    /// assert_eq!(vt.shape(), &[2, 2]);
+    /// ```
+    pub fn svd(&self, ctx: &mut impl TensorBackend) -> crate::Result<(Self, Self, Self)> {
+        ctx.with_exec_session(|exec| unpack_three("svd", exec.svd(self)?))
+    }
+
+    /// QR decomposition: `A = Q R`.
+    ///
+    /// Returns `(Q, R)` using the thin/economy QR decomposition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// let (q, r) = a.qr(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(q.shape(), &[3, 2]);
+    /// assert_eq!(r.shape(), &[2, 2]);
+    /// ```
+    pub fn qr(&self, ctx: &mut impl TensorBackend) -> crate::Result<(Self, Self)> {
+        ctx.with_exec_session(|exec| unpack_two("qr", exec.qr(self)?))
+    }
+
+    /// LU decomposition with partial pivoting: `P A = L U`.
+    ///
+    /// Returns `(P, L, U, parity)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]);
+    /// let (p, l, u, parity) = a.lu(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(p.shape(), &[2, 2]);
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// assert_eq!(u.shape(), &[2, 2]);
+    /// assert_eq!(parity.shape(), &[] as &[usize]);
+    /// ```
+    pub fn lu(&self, ctx: &mut impl TensorBackend) -> crate::Result<(Self, Self, Self, Self)> {
+        ctx.with_exec_session(|exec| unpack_four("lu", exec.lu(self)?))
+    }
+
+    /// Cholesky decomposition: `A = L L^T` or `A = L L^H` for complex inputs.
+    ///
+    /// Returns the lower-triangular factor `L`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]);
+    /// let l = a.cholesky(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// ```
+    pub fn cholesky(&self, ctx: &mut impl TensorBackend) -> crate::Result<Self> {
+        ctx.with_exec_session(|exec| exec.cholesky(self))
+    }
+
+    /// Symmetric or Hermitian eigendecomposition: `A = V diag(W) V^T`.
+    ///
+    /// Returns `(eigenvalues, eigenvectors)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]);
+    /// let (w, v) = a.eigh(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(w.shape(), &[2]);
+    /// assert_eq!(v.shape(), &[2, 2]);
+    /// ```
+    pub fn eigh(&self, ctx: &mut impl TensorBackend) -> crate::Result<(Self, Self)> {
+        ctx.with_exec_session(|exec| unpack_two("eigh", exec.eigh(self)?))
+    }
+
+    /// General eigendecomposition.
+    ///
+    /// Returns `(eigenvalues, eigenvectors)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]);
+    /// let (w, v) = a.eig(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(w.shape(), &[2]);
+    /// assert_eq!(v.shape(), &[2, 2]);
+    /// ```
+    pub fn eig(&self, ctx: &mut impl TensorBackend) -> crate::Result<(Self, Self)> {
+        ctx.with_exec_session(|exec| unpack_two("eig", exec.eig(self)?))
+    }
+
+    /// Solve `A x = b` for `x`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![2, 2], vec![2.0_f64, 1.0, 1.0, 2.0]);
+    /// let b = Tensor::new(vec![2, 1], vec![1.0_f64, 0.0]);
+    /// let x = a.solve(&b, &mut ctx).unwrap();
+    ///
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// ```
+    pub fn solve(&self, b: &Self, ctx: &mut impl TensorBackend) -> crate::Result<Self> {
+        ctx.solve(self, b)
+    }
+
+    /// Solve a triangular system.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![2, 2], vec![2.0_f64, 1.0, 0.0, 3.0]);
+    /// let b = Tensor::new(vec![2, 1], vec![2.0_f64, 7.0]);
+    /// let x = a
+    ///     .triangular_solve(&b, true, true, false, false, &mut ctx)
+    ///     .unwrap();
+    ///
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// ```
+    pub fn triangular_solve(
+        &self,
+        b: &Self,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+        ctx: &mut impl TensorBackend,
+    ) -> crate::Result<Self> {
+        ctx.with_exec_session(|exec| {
+            exec.triangular_solve(self, b, left_side, lower, transpose_a, unit_diagonal)
+        })
+    }
+
+    /// Elementwise addition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    /// let b = Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]);
+    /// let c = a.add(&b, &mut ctx).unwrap();
+    ///
+    /// assert_eq!(c.as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
+    /// ```
+    pub fn add(&self, other: &Self, ctx: &mut impl TensorBackend) -> crate::Result<Self> {
+        ctx.with_exec_session(|exec| exec.add(self, other))
+    }
+
+    /// Elementwise multiplication.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    /// let b = Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]);
+    /// let c = a.mul(&b, &mut ctx).unwrap();
+    ///
+    /// assert_eq!(c.as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
+    /// ```
+    pub fn mul(&self, other: &Self, ctx: &mut impl TensorBackend) -> crate::Result<Self> {
+        ctx.with_exec_session(|exec| exec.mul(self, other))
+    }
+
+    /// Negation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![3], vec![1.0_f64, -2.0, 3.0]);
+    /// let b = a.neg(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(b.as_slice::<f64>().unwrap(), &[-1.0, 2.0, -3.0]);
+    /// ```
+    pub fn neg(&self, ctx: &mut impl TensorBackend) -> crate::Result<Self> {
+        ctx.with_exec_session(|exec| exec.neg(self))
+    }
+
+    /// Transpose with an explicit permutation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    /// let b = a.transpose(&[1, 0], &mut ctx).unwrap();
+    ///
+    /// assert_eq!(b.shape(), &[2, 2]);
+    /// assert_eq!(b.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
+    /// ```
+    pub fn transpose(&self, perm: &[usize], ctx: &mut impl TensorBackend) -> crate::Result<Self> {
+        ctx.with_exec_session(|exec| exec.transpose(self, perm))
+    }
+
+    /// Reshape to a new shape with the same number of elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// let b = a.reshape(&[3, 2], &mut ctx).unwrap();
+    ///
+    /// assert_eq!(b.shape(), &[3, 2]);
+    /// assert_eq!(b.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// ```
+    pub fn reshape(&self, shape: &[usize], ctx: &mut impl TensorBackend) -> crate::Result<Self> {
+        ctx.with_exec_session(|exec| exec.reshape(self, shape))
+    }
+
+    /// Reduce sum over the specified axes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// let b = a.reduce_sum(&[1], &mut ctx).unwrap();
+    ///
+    /// assert_eq!(b.shape(), &[2]);
+    /// assert_eq!(b.as_slice::<f64>().unwrap(), &[9.0, 12.0]);
+    /// ```
+    pub fn reduce_sum(&self, axes: &[usize], ctx: &mut impl TensorBackend) -> crate::Result<Self> {
+        ctx.with_exec_session(|exec| exec.reduce_sum(self, axes))
+    }
+
+    /// Matrix multiplication for rank-2 tensors.
+    ///
+    /// This is a convenience wrapper around `dot_general`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// let b = Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// let c = a.matmul(&b, &mut ctx).unwrap();
+    ///
+    /// assert_eq!(c.shape(), &[2, 2]);
+    /// assert_eq!(c.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+    /// ```
+    pub fn matmul(&self, other: &Self, ctx: &mut impl TensorBackend) -> crate::Result<Self> {
+        let config = DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+            lhs_rank: self.shape().len(),
+            rhs_rank: other.shape().len(),
+        };
+        ctx.with_exec_session(|exec| exec.dot_general(self, other, &config))
+    }
 }
 
 pub(crate) fn flat_to_multi(mut flat: usize, shape: &[usize], out: &mut [usize]) {
     for i in 0..shape.len() {
         out[i] = flat % shape[i];
         flat /= shape[i];
+    }
+}
+
+fn invalid_output_count(op: &'static str, expected: usize, actual: usize) -> crate::Error {
+    crate::Error::BackendFailure {
+        op,
+        message: format!("expected {expected} output tensors, got {actual}"),
+    }
+}
+
+fn unpack_two(op: &'static str, results: Vec<Tensor>) -> crate::Result<(Tensor, Tensor)> {
+    let actual = results.len();
+    let mut iter = results.into_iter();
+    match (iter.next(), iter.next(), iter.next()) {
+        (Some(a), Some(b), None) => Ok((a, b)),
+        _ => Err(invalid_output_count(op, 2, actual)),
+    }
+}
+
+fn unpack_three(op: &'static str, results: Vec<Tensor>) -> crate::Result<(Tensor, Tensor, Tensor)> {
+    let actual = results.len();
+    let mut iter = results.into_iter();
+    match (iter.next(), iter.next(), iter.next(), iter.next()) {
+        (Some(a), Some(b), Some(c), None) => Ok((a, b, c)),
+        _ => Err(invalid_output_count(op, 3, actual)),
+    }
+}
+
+fn unpack_four(
+    op: &'static str,
+    results: Vec<Tensor>,
+) -> crate::Result<(Tensor, Tensor, Tensor, Tensor)> {
+    let actual = results.len();
+    let mut iter = results.into_iter();
+    match (
+        iter.next(),
+        iter.next(),
+        iter.next(),
+        iter.next(),
+        iter.next(),
+    ) {
+        (Some(a), Some(b), Some(c), Some(d), None) => Ok((a, b, c, d)),
+        _ => Err(invalid_output_count(op, 4, actual)),
     }
 }


### PR DESCRIPTION
## Summary

Add high-level eager methods on `Tensor` (and `TypedTensor::as_slice`) so users can perform non-traced operations without manually calling backend methods. All eager ops take `&mut impl TensorBackend`.

## New APIs

**Construction:**
- `Tensor::new<T>(shape, data)` — generic constructor
- `TypedTensor<T>::as_slice()` — alias for `host_data()`

**Linalg (on Tensor):**
`svd`, `qr`, `lu`, `cholesky`, `eigh`, `eig`, `solve`, `triangular_solve`

**Elementwise + structural (on Tensor):**
`add`, `mul`, `neg`, `transpose`, `reshape`, `reduce_sum`, `matmul`

**Einsum:**
`tenferro_einsum::eager_einsum(ctx, inputs, subscripts)` — N-ary eager einsum

## Motivation

Phase 3 of symbolic-shape design. Enables numpy-like eager usage for non-AD workloads (TCI inner loops, data preprocessing). Prerequisite for tensor4all-rs migration.

## Test plan

- [x] All workspace tests pass
- [x] New `eager_api_tests.rs` and `eager_tests.rs`
- [x] All methods have doc examples
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)