### PR TITLE
docs: add three-layer tensor model and eager operations guide

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -28,6 +28,7 @@ website:
           - getting-started/pytorch-jax-mapping.md
       - section: "Guides"
         contents:
+          - guides/eager-operations.md
           - guides/tensor-operations.md
           - guides/einsum.md
           - guides/linear-algebra.md

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -1,6 +1,64 @@
 # Core Concepts
 
-## TracedTensor: your tensor handle
+## Three tensor layers
+
+tenferro provides three tensor types for different use cases:
+
+| Layer | Type | Use case | Requires Engine? |
+|-------|------|----------|-----------------|
+| `TypedTensor<T>` | Statically typed | Direct computation, compile-time dtype safety | No (needs `CpuBackend`) |
+| `Tensor` | Dynamic dtype enum | Mixed-dtype workflows, FFI | No (needs `CpuBackend`) |
+| `TracedTensor` | Lazy graph handle | Automatic differentiation, graph optimization | Yes |
+
+Choose the simplest layer that meets your needs:
+
+- **No AD needed** -> `Tensor` + `CpuBackend`
+- **AD (grad/vjp/jvp) needed** -> `TracedTensor` + `Engine`
+- **Compile-time dtype safety** -> `TypedTensor<T>` + `CpuBackend`
+
+## TypedTensor<T>: statically typed storage
+
+`TypedTensor<T>` stores concrete tensor data with a compile-time scalar type.
+Use it when you want dtype safety in Rust code and you do not want runtime
+dtype dispatch.
+
+```rust
+use tenferro_tensor::{Tensor, TypedTensor};
+
+// Column-major buffer: columns are [1, 2], [3, 4], [5, 6].
+let typed = TypedTensor::<f64>::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+assert_eq!(typed.as_slice(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+// Wrap a typed tensor in the matching dynamic enum when you need `Tensor`.
+let dynamic = Tensor::F64(typed.clone());
+assert_eq!(dynamic.shape(), &[2, 3]);
+```
+
+## Tensor: eager computation
+
+`Tensor` holds concrete data and supports immediate computation. Every
+operation takes a backend context (`&mut impl TensorBackend`) and returns
+results immediately.
+
+```rust
+use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+
+let mut ctx = CpuBackend::new();
+
+// Column-major buffer: columns are [1, 2], [3, 4], [5, 6].
+let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+let b = Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+let c = a.matmul(&b, &mut ctx).unwrap();
+assert_eq!(c.shape(), &[2, 2]);
+
+let (_u, s, _vt) = a.svd(&mut ctx).unwrap();
+assert_eq!(s.shape(), &[2]); // min(2, 3) singular values
+```
+
+If you have used NumPy or PyTorch in eager mode, this is the familiar pattern.
+
+## TracedTensor: lazy computation with AD
 
 `TracedTensor` is the value you pass around in user code. You create it from a shape and flat data, then combine it with operations such as `+`, `*`, `reshape`, `transpose`, `einsum`, or `svd`.
 
@@ -22,15 +80,30 @@ Input data -> TracedTensor -> operations -> .eval(&mut engine) -> Tensor result
 
 ## Execution model comparison
 
-| Library | Typical mental model |
-|---|---|
-| PyTorch | Eager: each operation produces data immediately |
-| JAX | Usually eager arrays, with `jit` used to stage larger computations |
-| tenferro | Lazy by default: compose first, then call `eval` |
+| Library | Mental model | tenferro equivalent |
+|---|---|---|
+| NumPy | Eager, no AD | `Tensor` + `CpuBackend` |
+| PyTorch (eager) | Eager with autograd | `TracedTensor` + `Engine` |
+| JAX (`jit`) | Staged/lazy computation | `TracedTensor` + `Engine` |
 
-## Minimal example
+## Minimal examples
+
+### Eager (no AD)
 
 ```rust
+use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+
+let mut ctx = CpuBackend::new();
+let a = Tensor::new(vec![2], vec![1.0_f64, 2.0]);
+let b = Tensor::new(vec![2], vec![3.0_f64, 4.0]);
+let sum = a.add(&b, &mut ctx).unwrap();
+
+assert_eq!(sum.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+```
+
+### Lazy with AD
+
+```rust,ignore
 use tenferro::{CpuBackend, Engine, TracedTensor};
 
 let a = TracedTensor::new(vec![2], vec![1.0_f64, 2.0]);

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,14 +1,18 @@
 # Getting Started
 
-tenferro gives you a lazy tensor handle, an execution engine, and a small set of familiar tensor-building blocks. If you already know PyTorch or JAX, the main difference is that you build a computation first and explicitly evaluate it later.
+tenferro supports both eager tensor execution for direct computation and lazy
+traced tensors for automatic differentiation. If you already know NumPy,
+PyTorch, or JAX, choose the layer that matches the workflow you need.
 
 ## Installation
 
-Use a local checkout while the crate is still evolving:
+Use local checkouts while the crates are still evolving:
 
 ```toml
 [dependencies]
 tenferro = { path = "/path/to/tenferro-rs/tenferro" }
+tenferro-tensor = { path = "/path/to/tenferro-rs/tenferro-tensor" }
+tenferro-einsum = { path = "/path/to/tenferro-rs/tenferro-einsum" }
 ```
 
 Or switch to crates.io once published:
@@ -16,15 +20,41 @@ Or switch to crates.io once published:
 ```toml
 [dependencies]
 tenferro = "..."
+tenferro-tensor = "..."
+tenferro-einsum = "..."
 ```
 
-## Hello einsum
+## Hello eager
+
+This is the simplest way to use tenferro: direct computation without tracing or
+AD, similar to NumPy.
+
+```rust
+use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+
+let mut ctx = CpuBackend::new();
+
+// Column-major buffer: columns are [1, 2], [3, 4], [5, 6].
+let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+// SVD
+let (_u, s, _vt) = a.svd(&mut ctx).unwrap();
+assert_eq!(s.shape(), &[2]);
+
+// Matrix multiply
+let b = Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+let c = a.matmul(&b, &mut ctx).unwrap();
+assert_eq!(c.shape(), &[2, 2]);
+```
+
+## Hello einsum (lazy)
 
 This is the tenferro equivalent of `torch.einsum("ij,jk->ik", a, b)` or `jnp.einsum("ij,jk->ik", a, b)`.
 
-```rust
+```rust,ignore
 use tenferro::{einsum::einsum, CpuBackend, Engine, TracedTensor};
 
+// Column-major buffers: `a` has columns [1, 2], [3, 4], [5, 6].
 let a = TracedTensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
 let b = TracedTensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
@@ -40,7 +70,7 @@ assert_eq!(result.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 
 This is the tenferro equivalent of differentiating `sum(x * x)` in PyTorch or JAX.
 
-```rust
+```rust,ignore
 use tenferro::{CpuBackend, Engine, TracedTensor};
 
 let x = TracedTensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);
@@ -58,6 +88,7 @@ assert_eq!(result.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 
 - [Core concepts](./core-concepts.md)
 - [PyTorch and JAX mapping](./pytorch-jax-mapping.md)
+- [Eager operations guide](../guides/eager-operations.md)
 - [Tensor operations guide](../guides/tensor-operations.md)
 - [Einsum guide](../guides/einsum.md)
 - [Autodiff guide](../guides/autodiff.md)

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -6,6 +6,7 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 
 | Concept | PyTorch | JAX | tenferro |
 |---|---|---|---|
+| Eager tensor | `numpy.ndarray` | — | `Tensor` + `CpuBackend` |
 | Tensor handle | `torch.Tensor` | `jax.Array` / `jnp.ndarray` | `TracedTensor` |
 | Concrete result | `torch.Tensor` | `jax.Array` | `Tensor` returned by `.eval(&mut engine)` |
 | Execution | Eager by default | Eager arrays, often staged with `jit` | Lazy until `eval` |
@@ -15,20 +16,20 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 
 ## Function mapping
 
-| Task | PyTorch | JAX | tenferro |
-|---|---|---|---|
-| Create tensor | `torch.tensor(data)` | `jnp.array(data)` | `TracedTensor::new(shape, data)` |
-| Matrix multiply | `torch.matmul(a, b)` | `jnp.matmul(a, b)` | `tenferro::matmul(&a, &b)` |
-| Reshape | `x.reshape(shape)` | `jnp.reshape(x, shape)` | `x.reshape(&shape)` |
-| Transpose | `x.transpose(0, 1)` | `jnp.transpose(x, axes)` | `x.transpose(&perm)` |
-| Broadcast | `x.expand(...)` / implicit broadcast | implicit broadcast in many ops | `x.broadcast(&shape, &dims)` |
-| Reduce sum | `x.sum(dim=...)` | `jnp.sum(x, axis=...)` | `x.reduce_sum(&axes)` |
-| Einsum | `torch.einsum(spec, ...)` | `jnp.einsum(spec, ...)` | `einsum(&mut engine, inputs, spec)` |
-| SVD | `torch.linalg.svd(x)` | `jnp.linalg.svd(x)` | `tenferro::svd(&x)` |
-| QR | `torch.linalg.qr(x)` | `jnp.linalg.qr(x)` | `tenferro::qr(&x)` |
-| Cholesky | `torch.linalg.cholesky(x)` | `jnp.linalg.cholesky(x)` | `tenferro::cholesky(&x)` |
-| Solve | `torch.linalg.solve(a, b)` | `jnp.linalg.solve(a, b)` | `tenferro::solve(&a, &b)` |
-| Reverse-mode gradient | `torch.autograd.grad(loss, x)` | `jax.grad(f)(x)` | `loss.grad(&x)` |
+| Task | PyTorch | JAX | tenferro (eager) | tenferro (lazy/AD) |
+|---|---|---|---|---|
+| Create tensor | `torch.tensor(data)` | `jnp.array(data)` | `Tensor::new(shape, data)` | `TracedTensor::new(shape, data)` |
+| Matrix multiply | `torch.matmul(a, b)` | `jnp.matmul(a, b)` | `a.matmul(&b, &mut ctx)` | `tenferro::matmul(&a, &b)` |
+| Reshape | `x.reshape(shape)` | `jnp.reshape(x, shape)` | `x.reshape(&shape, &mut ctx)` | `x.reshape(&shape)` |
+| Transpose | `x.transpose(0, 1)` | `jnp.transpose(x, axes)` | `x.transpose(&perm, &mut ctx)` | `x.transpose(&perm)` |
+| Broadcast | `x.expand(...)` / implicit broadcast | implicit broadcast in many ops | backend-level op | `x.broadcast(&shape, &dims)` |
+| Reduce sum | `x.sum(dim=...)` | `jnp.sum(x, axis=...)` | `x.reduce_sum(&axes, &mut ctx)` | `x.reduce_sum(&axes)` |
+| Einsum | `torch.einsum(spec, ...)` | `jnp.einsum(spec, ...)` | `eager_einsum(&mut ctx, ...)` | `einsum(&mut engine, ...)` |
+| SVD | `torch.linalg.svd(x)` | `jnp.linalg.svd(x)` | `x.svd(&mut ctx)` | `tenferro::svd(&x)` |
+| QR | `torch.linalg.qr(x)` | `jnp.linalg.qr(x)` | `x.qr(&mut ctx)` | `tenferro::qr(&x)` |
+| Cholesky | `torch.linalg.cholesky(x)` | `jnp.linalg.cholesky(x)` | `x.cholesky(&mut ctx)` | `tenferro::cholesky(&x)` |
+| Solve | `torch.linalg.solve(a, b)` | `jnp.linalg.solve(a, b)` | `a.solve(&b, &mut ctx)` | `tenferro::solve(&a, &b)` |
+| Gradient | `torch.autograd.grad(...)` | `jax.grad(f)(x)` | N/A | `loss.grad(&x)` |
 
 ## Key differences
 
@@ -36,7 +37,7 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 
 tenferro stores dense tensors in column-major order. If you write:
 
-```rust
+```rust,ignore
 let a = TracedTensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
 ```
 

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -1,0 +1,167 @@
+# Eager Operations
+
+This guide covers using tenferro for direct computation without automatic
+differentiation: the path you would choose for NumPy-like workflows where you
+control the computation explicitly.
+
+## Setup
+
+```rust
+use tenferro_tensor::{Tensor, TypedTensor, TensorBackend, cpu::CpuBackend};
+
+let mut ctx = CpuBackend::new();
+```
+
+Every eager operation requires a backend context. `CpuBackend` is the standard
+CPU backend using the faer linear algebra library.
+
+Most eager operations are methods on `Tensor`. `TypedTensor<T>` is useful when
+you want compile-time dtype safety for construction or direct host-side data
+access.
+
+## Creating tensors
+
+```rust
+use tenferro_tensor::{Tensor, TypedTensor};
+
+// Dynamic dtype (`Tensor`)
+let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+// Static dtype (`TypedTensor`)
+let b = TypedTensor::<f64>::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+// Convert between layers for a specific dtype.
+let c = Tensor::F64(b.clone());
+assert_eq!(c.shape(), &[2, 3]);
+```
+
+The flat buffers above are in column-major order, so a `[2, 3]` tensor stores
+its columns as `[1, 2]`, `[3, 4]`, and `[5, 6]`.
+
+## Arithmetic
+
+```rust
+use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+
+let mut ctx = CpuBackend::new();
+let a = Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);
+let b = Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]);
+
+let sum = a.add(&b, &mut ctx).unwrap();
+let product = a.mul(&b, &mut ctx).unwrap();
+let negated = a.neg(&mut ctx).unwrap();
+
+assert_eq!(sum.as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
+assert_eq!(product.as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
+assert_eq!(negated.as_slice::<f64>().unwrap(), &[-1.0, -2.0, -3.0]);
+```
+
+## Linear algebra
+
+```rust
+use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+
+let mut ctx = CpuBackend::new();
+let a = Tensor::new(vec![3, 3], vec![
+    2.0_f64, 1.0, 0.0,
+    1.0, 3.0, 1.0,
+    0.0, 1.0, 2.0,
+]);
+
+// SVD
+let (_u, s, _vt) = a.svd(&mut ctx).unwrap();
+
+// QR
+let (_q, _r) = a.qr(&mut ctx).unwrap();
+
+// Cholesky (for positive definite matrices)
+let chol = a.cholesky(&mut ctx).unwrap();
+
+// Eigendecomposition (symmetric)
+let (eigenvalues, eigenvectors) = a.eigh(&mut ctx).unwrap();
+
+// Solve Ax = b
+let b = Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);
+let x = a.solve(&b, &mut ctx).unwrap();
+
+assert_eq!(s.shape(), &[3]);
+assert_eq!(chol.shape(), &[3, 3]);
+assert_eq!(eigenvalues.shape(), &[3]);
+assert_eq!(eigenvectors.shape(), &[3, 3]);
+assert_eq!(x.shape(), &[3]);
+```
+
+## Shape operations
+
+```rust
+use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+
+let mut ctx = CpuBackend::new();
+let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+// Transpose
+let at = a.transpose(&[1, 0], &mut ctx).unwrap();
+assert_eq!(at.shape(), &[3, 2]);
+
+// Reshape
+let flat = a.reshape(&[6], &mut ctx).unwrap();
+assert_eq!(flat.shape(), &[6]);
+
+// Reduce
+let col_sum = a.reduce_sum(&[0], &mut ctx).unwrap();
+assert_eq!(col_sum.shape(), &[3]);
+```
+
+## Einsum
+
+```rust
+use tenferro_einsum::eager_einsum;
+use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+
+let mut ctx = CpuBackend::new();
+
+// Column-major buffers: `a` has columns [1, 2], [3, 4], [5, 6].
+let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+let b = Tensor::new(vec![3, 4], vec![
+    1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0,
+    7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+]);
+
+let c = eager_einsum(&mut ctx, &[&a, &b], "ij,jk->ik").unwrap();
+assert_eq!(c.shape(), &[2, 4]);
+```
+
+## Extracting data
+
+```rust
+use tenferro_tensor::Tensor;
+
+let t = Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);
+let data: &[f64] = t.as_slice::<f64>().unwrap();
+assert_eq!(data, &[1.0, 2.0, 3.0]);
+```
+
+## Column-major storage
+
+tenferro stores tensors in column-major (Fortran) order. For a `[2, 3]` tensor
+with data `[1, 2, 3, 4, 5, 6]`, the layout is:
+
+```text
+Column 0: [1, 2]
+Column 1: [3, 4]
+Column 2: [5, 6]
+```
+
+This matches Fortran, Julia, and MATLAB conventions but differs from C/NumPy
+row-major order.
+
+## When to use eager vs lazy
+
+| Scenario | Recommended |
+|----------|-------------|
+| Data preprocessing | Eager (`Tensor` + `CpuBackend`) |
+| TCI inner loops | Eager |
+| Exploratory computation | Eager |
+| Need gradients (AD) | Lazy (`TracedTensor` + `Engine`) |
+| Need HVP / higher-order AD | Lazy |
+| GPU execution (future) | Lazy |


### PR DESCRIPTION
## Summary

- Document the three tensor layers: TypedTensor (static) / Tensor (dynamic) / TracedTensor (lazy+AD)
- Add eager examples alongside lazy examples in getting-started
- New `docs/guides/eager-operations.md` for non-AD workflows
- Update PyTorch/JAX mapping with eager+lazy columns

## Test plan

- [x] `cargo doc --workspace --no-deps`
- [x] `python3 scripts/check-docs-site.py`
- [x] `cargo test --doc --workspace --release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)