### PR TITLE
feat: checkpoint mechanism and DynamicTruncate op for iterative AD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = "1"
 serde_json = "1"
 chainrules-core = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2f2a8cc", package = "chainrules" }
 chainrules = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2f2a8cc" }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "ae8eb21" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "6e0dbcd" }
 strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722", features = ["parallel"] }
@@ -50,5 +50,3 @@ sha2 = "0.10"
 omeco = "0.2.4"
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "b361eac" }
 
-[patch."https://github.com/tensor4all/tidu-rs.git"]
-tidu = { path = "/home/shinaoka/tensor4all/tenferro-rs/.worktrees/tidu-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,6 @@ ndarray = "0.17.2"
 sha2 = "0.10"
 omeco = "0.2.4"
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "b361eac" }
+
+[patch."https://github.com/tensor4all/tidu-rs.git"]
+tidu = { path = "/home/shinaoka/tensor4all/tenferro-rs/.worktrees/tidu-rs" }

--- a/docs/superpowers/plans/2026-04-12-checkpoint-dynamic-truncate.md
+++ b/docs/superpowers/plans/2026-04-12-checkpoint-dynamic-truncate.md
@@ -1,0 +1,1644 @@
+# Checkpoint + DynamicTruncate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add checkpoint mechanism and DynamicTruncate/PadToMatch/ShapeOf ops for memory-efficient iterative TN AD with adaptive truncated SVD.
+
+**Architecture:** Checkpoint uses Arc-linked-list (`CheckpointNode`) to separate eval roots from AD roots. New ops (`DynamicTruncate`, `PadToMatch`, `ShapeOf`) form an adjoint trio. `tidu::differentiate()` gains an alias map parameter for tracing gradients through checkpoint boundaries.
+
+**Tech Stack:** Rust, tidu-rs (AD engine), computegraph-rs, tenferro-ops, tenferro-tensor, tenferro
+
+---
+
+## Task 1: tidu-rs — Add alias map to `differentiate()`
+
+**Files:**
+- Modify: `.worktrees/tidu-rs/src/differentiate.rs`
+- Modify: `.worktrees/tidu-rs/src/lib.rs`
+- Create: `.worktrees/tidu-rs/tests/checkpoint_alias_tests.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/checkpoint_alias_tests.rs
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chainrules::{ADKey, PrimitiveOp};
+use computegraph::fragment::FragmentBuilder;
+use computegraph::resolve::resolve;
+use computegraph::types::{GlobalValKey, OpMode, ValRef};
+use computegraph::LocalValId;
+use tidu::differentiate;
+
+// Use tidu's existing test op type (from tests/common/mod.rs)
+mod common;
+use common::TestOp;
+
+/// Checkpoint alias: differentiate through an aliased leaf back to the real input.
+///
+/// Graph:  x (leaf) -> Mul(x, x) -> y (checkpointed)
+///         y_alias (leaf) -> Mul(y_alias, 2) -> z
+///
+/// Alias: y_alias_key -> y_derived_key
+/// wrt: x
+///
+/// Expected: dz/dx = d(2*x^2)/dx = 4x
+#[test]
+fn differentiate_through_alias() {
+    // Build primal fragment: x -> x*x -> y
+    let mut builder = FragmentBuilder::<TestOp>::new();
+    let x_key = "x".to_string();
+    let x = builder.add_input(x_key.clone());
+    let y_outputs = builder.add_op(
+        TestOp::Mul,
+        vec![ValRef::Local(x), ValRef::Local(x)],
+        OpMode::Primal,
+    );
+    builder.set_outputs(y_outputs.clone());
+    let primal_frag = Arc::new(builder.build());
+    let y_key = primal_frag.vals()[y_outputs[0]].key.clone();
+
+    // Build post-checkpoint fragment: y_alias -> y_alias * 2 -> z
+    let mut builder2 = FragmentBuilder::<TestOp>::new();
+    let y_alias_key = "y_alias".to_string();
+    let y_alias = builder2.add_input(y_alias_key.clone());
+    let two = builder2.add_op(TestOp::Constant(2.0), vec![], OpMode::Primal);
+    let z_outputs = builder2.add_op(
+        TestOp::Mul,
+        vec![ValRef::Local(y_alias), ValRef::Local(two[0])],
+        OpMode::Primal,
+    );
+    builder2.set_outputs(z_outputs.clone());
+    let post_frag = Arc::new(builder2.build());
+    let z_key = post_frag.vals()[z_outputs[0]].key.clone();
+
+    // Resolve both fragments
+    let view = resolve(vec![post_frag, primal_frag]);
+
+    // Alias map: y_alias_key -> y_key (connects post-checkpoint to pre-checkpoint)
+    let mut aliases: HashMap<String, GlobalValKey<TestOp>> = HashMap::new();
+    aliases.insert(y_alias_key, y_key);
+
+    // Differentiate z w.r.t. x through the alias
+    let linear = differentiate(&view, &[z_key], &[x_key], 1, &mut (), &aliases);
+
+    // Should have an active tangent output (dz/dx is non-zero)
+    assert!(
+        linear.tangent_outputs[0].is_some(),
+        "gradient through alias should be active"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd .worktrees/tidu-rs && cargo test checkpoint_alias -- --nocapture`
+Expected: Compile error (differentiate doesn't accept aliases param yet)
+
+- [ ] **Step 3: Modify `differentiate()` signature to accept aliases**
+
+In `.worktrees/tidu-rs/src/differentiate.rs`, change the signature:
+
+```rust
+pub fn differentiate<Op: PrimitiveOp>(
+    view: &ResolvedView<Op>,
+    outputs: &[GlobalValKey<Op>],
+    wrt: &[Op::InputKey],
+    pass: DiffPassId,
+    ctx: &mut Op::ADContext,
+    aliases: &HashMap<Op::InputKey, GlobalValKey<Op>>,  // NEW
+) -> LinearFragment<Op>
+where
+    Op::InputKey: ADKey,
+{
+```
+
+- [ ] **Step 4: Modify `topological_order` to follow aliases**
+
+```rust
+fn topological_order<Op: GraphOp>(
+    view: &ResolvedView<Op>,
+    outputs: &[GlobalValKey<Op>],
+    aliases: &HashMap<Op::InputKey, GlobalValKey<Op>>,
+) -> Vec<GlobalValKey<Op>> {
+    fn visit<Op: GraphOp>(
+        key: &GlobalValKey<Op>,
+        view: &ResolvedView<Op>,
+        aliases: &HashMap<Op::InputKey, GlobalValKey<Op>>,
+        visited: &mut HashSet<GlobalValKey<Op>>,
+        order: &mut Vec<GlobalValKey<Op>>,
+    ) {
+        if !visited.insert(key.clone()) {
+            return;
+        }
+
+        match view.resolve_val(key) {
+            Some(ValDef::Produced { input_keys, .. }) => {
+                for input_key in input_keys {
+                    visit(&input_key, view, aliases, visited, order);
+                }
+            }
+            Some(ValDef::Input { key: input_key }) => {
+                // Follow alias if present
+                if let Some(aliased_key) = aliases.get(&input_key) {
+                    visit(aliased_key, view, aliases, visited, order);
+                }
+            }
+            None => {}
+        }
+
+        order.push(key.clone());
+    }
+
+    let mut visited = HashSet::new();
+    let mut order = Vec::new();
+    for output_key in outputs {
+        visit(output_key, view, aliases, &mut visited, &mut order);
+    }
+    order
+}
+```
+
+- [ ] **Step 5: Modify main differentiation loop to propagate tangents through aliases**
+
+In the main loop, replace the `ValDef::Input` arm:
+
+```rust
+ValDef::Input { key: input_key } => {
+    // Check if this input is aliased to a derived value
+    if let Some(aliased_key) = aliases.get(&input_key) {
+        // Use the tangent from the aliased value
+        let aliased_tangent = tangent_env.get(aliased_key).copied().flatten();
+        tangent_env.insert(key, aliased_tangent);
+    } else {
+        tangent_env.insert(key, None);
+    }
+}
+```
+
+- [ ] **Step 6: Update lib.rs re-export**
+
+No change needed — `differentiate` is already re-exported.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cd .worktrees/tidu-rs && cargo test checkpoint_alias -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 8: Add a test for HVP through alias (2nd-order)**
+
+```rust
+#[test]
+fn differentiate_through_alias_twice() {
+    // Same setup but differentiate twice (Forward-over-Forward through alias)
+    // This validates that aliases work in nested differentiation
+    // ... (build graph as above, differentiate once, then differentiate the linear fragment)
+    // The key check: aliases at the tangent level still connect properly
+}
+```
+
+- [ ] **Step 9: Run all tidu tests**
+
+Run: `cd .worktrees/tidu-rs && cargo test`
+Expected: All pass
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd .worktrees/tidu-rs && git add -A && git commit -m "feat: add alias map to differentiate() for checkpoint support"
+```
+
+---
+
+## Task 2: Add `[patch]` override for local tidu-rs development
+
+**Files:**
+- Modify: `Cargo.toml` (workspace root)
+
+- [ ] **Step 1: Add patch section**
+
+Add to end of workspace `Cargo.toml`:
+
+```toml
+[patch."https://github.com/tensor4all/tidu-rs.git"]
+tidu = { path = ".worktrees/tidu-rs" }
+```
+
+- [ ] **Step 2: Verify workspace builds**
+
+Run: `cargo build -p tenferro 2>&1 | tail -5`
+Expected: Build succeeds (may have warnings)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock && git commit -m "chore: add local tidu-rs patch for checkpoint development"
+```
+
+---
+
+## Task 3: Update tenferro `try_vjp()` to pass empty aliases (backward compat)
+
+**Files:**
+- Modify: `tenferro/src/traced.rs`
+
+- [ ] **Step 1: Update `try_vjp()` call to pass empty aliases**
+
+At line ~412, update the `differentiate` call:
+
+```rust
+let linear = differentiate(
+    &view,
+    std::slice::from_ref(&output_key),
+    std::slice::from_ref(&wrt_input_key),
+    next_pass_id(),
+    &mut ad_ctx,
+    &HashMap::new(),  // no aliases yet
+);
+```
+
+Add `use std::collections::HashMap;` import if not already present.
+
+- [ ] **Step 2: Verify all existing tests pass**
+
+Run: `cargo test --workspace --release 2>&1 | tail -10`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tenferro/src/traced.rs && git commit -m "refactor: pass empty aliases to differentiate (backward compat)"
+```
+
+---
+
+## Task 4: Add `CheckpointNode` struct and `checkpoint_chain` field
+
+**Files:**
+- Create: `tenferro/src/checkpoint.rs`
+- Modify: `tenferro/src/traced.rs`
+- Modify: `tenferro/src/lib.rs` (if mod declaration needed)
+
+- [ ] **Step 1: Create checkpoint module**
+
+```rust
+// tenferro/src/checkpoint.rs
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use computegraph::fragment::Fragment;
+use computegraph::types::GlobalValKey;
+use tenferro_ops::input_key::TensorInputKey;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_tensor::Tensor;
+
+/// A node in the persistent checkpoint linked list.
+///
+/// Each checkpoint captures the old computation fragment, the alias mapping
+/// from the new leaf key to the old derived key, and the concrete input data
+/// needed for re-evaluation of the old fragment during AD.
+#[derive(Clone, Debug)]
+pub(crate) struct CheckpointNode {
+    /// The old computation fragment (pre-checkpoint graph).
+    pub fragment: Arc<Fragment<StdTensorOp>>,
+    /// Maps new leaf key → old output GlobalValKey for AD continuation.
+    pub alias_key: TensorInputKey,
+    pub alias_target: GlobalValKey<StdTensorOp>,
+    /// Concrete input data from the old fragment's inputs_map.
+    pub old_inputs: HashMap<TensorInputKey, Tensor>,
+    /// Link to previous checkpoint (persistent linked list).
+    pub prev: Option<Arc<CheckpointNode>>,
+}
+
+impl CheckpointNode {
+    /// Collect all alias mappings from this node to the tail.
+    pub fn collect_aliases(&self) -> HashMap<TensorInputKey, GlobalValKey<StdTensorOp>> {
+        let mut aliases = HashMap::new();
+        let mut current: Option<&CheckpointNode> = Some(self);
+        while let Some(node) = current {
+            aliases.insert(node.alias_key.clone(), node.alias_target.clone());
+            current = node.prev.as_deref();
+        }
+        aliases
+    }
+
+    /// Collect all old fragments from this node to the tail.
+    pub fn collect_fragments(&self) -> Vec<Arc<Fragment<StdTensorOp>>> {
+        let mut fragments = Vec::new();
+        let mut current: Option<&CheckpointNode> = Some(self);
+        while let Some(node) = current {
+            fragments.push(node.fragment.clone());
+            current = node.prev.as_deref();
+        }
+        fragments
+    }
+
+    /// Collect all old input data from this node to the tail.
+    pub fn collect_inputs(&self) -> HashMap<TensorInputKey, Tensor> {
+        let mut inputs = HashMap::new();
+        let mut current: Option<&CheckpointNode> = Some(self);
+        while let Some(node) = current {
+            inputs.extend(node.old_inputs.iter().map(|(k, v)| (k.clone(), v.clone())));
+            current = node.prev.as_deref();
+        }
+        inputs
+    }
+}
+```
+
+- [ ] **Step 2: Add `checkpoint_chain` field to `TracedTensor`**
+
+In `tenferro/src/traced.rs`, add field to the struct (after `extra_roots`):
+
+```rust
+pub(crate) checkpoint_chain: Option<Arc<CheckpointNode>>,
+```
+
+Add import: `use crate::checkpoint::CheckpointNode;`
+
+- [ ] **Step 3: Add `mod checkpoint;` to tenferro/src/lib.rs**
+
+- [ ] **Step 4: Initialize `checkpoint_chain: None` in all TracedTensor constructors**
+
+Update `from_tensor()`, `apply_unary_with_dtype()`, `apply_nullary()`,
+`apply_binary()`, `apply_multi_output()`, `try_vjp()`, and `try_jvp()` to
+include `checkpoint_chain: None`.
+
+- [ ] **Step 5: Propagate `checkpoint_chain` in `apply_unary_with_dtype`**
+
+```rust
+checkpoint_chain: input.checkpoint_chain.clone(),
+```
+
+- [ ] **Step 6: Propagate `checkpoint_chain` in `apply_binary`**
+
+```rust
+// Merge checkpoint chains: prefer the longer one (both typically share)
+checkpoint_chain: lhs.checkpoint_chain.clone().or(rhs.checkpoint_chain.clone()),
+```
+
+- [ ] **Step 7: Propagate `checkpoint_chain` in `apply_multi_output`**
+
+```rust
+checkpoint_chain: input.checkpoint_chain.clone(),
+```
+
+- [ ] **Step 8: Verify build and all tests pass**
+
+Run: `cargo test --workspace --release 2>&1 | tail -10`
+Expected: All pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tenferro/src/checkpoint.rs tenferro/src/traced.rs tenferro/src/lib.rs
+git commit -m "feat: add CheckpointNode struct and checkpoint_chain field"
+```
+
+---
+
+## Task 5: Implement `checkpoint()` method
+
+**Files:**
+- Modify: `tenferro/src/traced.rs`
+- Create: `tenferro/tests/checkpoint.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tenferro/tests/checkpoint.rs
+use tenferro::engine::Engine;
+use tenferro::traced::TracedTensor;
+use tenferro::{CpuBackend, Tensor, TypedTensor};
+
+fn f64_scalar(val: f64) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(vec![], vec![val]))
+}
+
+fn get_f64_scalar(t: &Tensor) -> f64 {
+    match t {
+        Tensor::F64(inner) => inner.host_data()[0],
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn checkpoint_preserves_eval_value() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_scalar(3.0));
+    let mut y = &x * &x; // y = 9.0
+
+    y.checkpoint(&mut engine).unwrap();
+
+    let val = get_f64_scalar(y.data.as_ref().unwrap());
+    assert!((val - 9.0).abs() < 1e-12);
+}
+
+#[test]
+fn checkpoint_downstream_eval_uses_leaf() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_scalar(3.0));
+    let mut y = &x * &x; // y = 9.0
+
+    y.checkpoint(&mut engine).unwrap();
+
+    // z = y + 1.0 should only need to eval from y (leaf), not from x
+    let one = TracedTensor::from_tensor(f64_scalar(1.0));
+    let mut z = &y + &one;
+    let z_val = get_f64_scalar(z.eval(&mut engine).unwrap());
+    assert!((z_val - 10.0).abs() < 1e-12);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p tenferro --test checkpoint -- --nocapture`
+Expected: Compile error (checkpoint method doesn't exist)
+
+- [ ] **Step 3: Implement `checkpoint()` method**
+
+In `tenferro/src/traced.rs`, add the method to the `impl TracedTensor` block:
+
+```rust
+/// Evaluate and promote this tensor to a leaf for eval efficiency.
+///
+/// After checkpoint:
+/// - Forward eval: downstream ops start from this leaf (O(K) per step)
+/// - Backward AD: gradients flow through the old graph via checkpoint_chain
+///
+/// # Examples
+///
+/// ```ignore
+/// let mut y = &x * &x;
+/// y.checkpoint(&mut engine)?;
+/// // y is now a leaf; subsequent ops build small graphs
+/// ```
+pub fn checkpoint<B: TensorBackend>(&mut self, engine: &mut Engine<B>) -> Result<()> {
+    // 1. Evaluate to get concrete data
+    self.eval(engine)?;
+    let data = self.data.clone().expect("eval populates data");
+
+    // 2. Capture old state for AD
+    let old_fragment = self.fragment.clone();
+    let old_output_key = old_fragment.vals()[self.val].key.clone();
+    let old_inputs = (*self.inputs_map).clone();
+
+    // 3. Create new leaf key and fragment
+    let new_key = next_input_key();
+    let mut builder = FragmentBuilder::new();
+    let leaf_val = builder.add_input(new_key.clone());
+    builder.set_outputs(vec![leaf_val]);
+    let new_fragment = Arc::new(builder.build());
+
+    // 4. Build checkpoint node (prepend to chain)
+    let node = CheckpointNode {
+        fragment: old_fragment,
+        alias_key: new_key.clone(),
+        alias_target: old_output_key,
+        old_inputs,
+        prev: self.checkpoint_chain.take(),
+    };
+
+    // 5. Update self to be a leaf
+    self.fragment = new_fragment;
+    self.val = leaf_val;
+    // data stays as-is (already computed)
+    self.extra_roots = vec![];
+    self.checkpoint_chain = Some(Arc::new(node));
+
+    // 6. Rebuild inputs_map with new key + preserve old inputs for AD
+    let mut merged = HashMap::new();
+    if let Some(ref chain) = self.checkpoint_chain {
+        merged.extend(chain.collect_inputs());
+    }
+    merged.insert(new_key, data);
+    self.inputs_map = Arc::new(merged);
+
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p tenferro --test checkpoint -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tenferro/src/traced.rs tenferro/tests/checkpoint.rs
+git commit -m "feat: implement checkpoint() method on TracedTensor"
+```
+
+---
+
+## Task 6: Wire checkpoint_chain into `try_vjp()` for AD through checkpoints
+
+**Files:**
+- Modify: `tenferro/src/traced.rs`
+- Modify: `tenferro/tests/checkpoint.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// Add to tenferro/tests/checkpoint.rs
+const TOL: f64 = 1e-6;
+const FD_H: f64 = 1e-6;
+
+#[test]
+fn checkpoint_grad_correct() {
+    // f(x) = (x^2)^2 = x^4, with checkpoint after x^2
+    // df/dx = 4x^3
+    let x_val = 2.0_f64;
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let x = TracedTensor::from_tensor(f64_scalar(x_val));
+    let mut y = &x * &x; // x^2
+    y.checkpoint(&mut engine).unwrap();
+
+    let z = &y * &y; // (x^2)^2 = x^4
+    let grad = z.grad(&x).unwrap();
+    let mut grad_t = grad;
+    let grad_val = get_f64_scalar(grad_t.eval(&mut engine).unwrap());
+
+    // Finite difference
+    let f = |v: f64| v.powi(4);
+    let fd = (f(x_val + FD_H) - f(x_val - FD_H)) / (2.0 * FD_H);
+
+    assert!(
+        (grad_val - fd).abs() < TOL,
+        "grad={grad_val}, fd={fd}"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p tenferro --test checkpoint checkpoint_grad -- --nocapture`
+Expected: FAIL (grad returns None or incorrect value because alias not wired)
+
+- [ ] **Step 3: Update `try_vjp()` to use checkpoint_chain aliases**
+
+In `try_vjp()`, before calling `differentiate()`:
+
+```rust
+fn try_vjp(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> Option<TracedTensor> {
+    let wrt_input_key = leaf_input_key(wrt);
+    let output_key = self.fragment.vals()[self.val].key.clone();
+
+    // Collect checkpoint info for AD
+    let aliases = self
+        .checkpoint_chain
+        .as_ref()
+        .map(|c| c.collect_aliases())
+        .unwrap_or_default();
+    let checkpoint_fragments = self
+        .checkpoint_chain
+        .as_ref()
+        .map(|c| c.collect_fragments())
+        .unwrap_or_default();
+
+    // Include checkpoint fragments in resolve
+    let mut roots = self.resolve_roots();
+    roots.extend(checkpoint_fragments);
+
+    let view = resolve(roots);
+    let mut ad_ctx = ShapeGuardContext::default();
+    let linear = differentiate(
+        &view,
+        std::slice::from_ref(&output_key),
+        std::slice::from_ref(&wrt_input_key),
+        next_pass_id(),
+        &mut ad_ctx,
+        &aliases,
+    );
+    // ... rest unchanged
+```
+
+Also update the `inputs_map` construction to include checkpoint old_inputs:
+
+```rust
+    let mut inputs_map = (*self.inputs_map).clone();
+    if let Some(ref chain) = self.checkpoint_chain {
+        inputs_map.extend(chain.collect_inputs());
+    }
+    // ... existing cotangent and zero_tangent inserts ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p tenferro --test checkpoint checkpoint_grad -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tenferro/src/traced.rs tenferro/tests/checkpoint.rs
+git commit -m "feat: wire checkpoint_chain into try_vjp for AD through checkpoints"
+```
+
+---
+
+## Task 7: Checkpoint HVP test
+
+**Files:**
+- Modify: `tenferro/tests/checkpoint.rs`
+
+- [ ] **Step 1: Write HVP test**
+
+```rust
+#[test]
+fn checkpoint_hvp_correct() {
+    // f(x) = (x^2)^2 = x^4, checkpoint after x^2
+    // f'(x) = 4x^3
+    // f''(x) = 12x^2
+    // HVP = f''(x) * v
+    let x_val = 2.0_f64;
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let x = TracedTensor::from_tensor(f64_scalar(x_val));
+    let mut y = &x * &x;
+    y.checkpoint(&mut engine).unwrap();
+    let z = &y * &y;
+
+    // Forward-over-Reverse HVP
+    let grad = z.grad(&x).unwrap(); // f'(x) = 4x^3
+    let v = TracedTensor::from_tensor(f64_scalar(1.0));
+    let hv = grad.jvp(&x, &v); // f''(x) * v
+
+    let hv_val = get_f64_scalar(eval_tensor(hv.clone()));
+    let expected = 12.0 * x_val * x_val; // 48.0
+
+    assert!(
+        (hv_val - expected).abs() < TOL,
+        "HVP: actual={hv_val}, expected={expected}"
+    );
+
+    // Also verify against finite difference of gradient
+    let fd_grad = |v: f64| {
+        let x2 = TracedTensor::from_tensor(f64_scalar(v));
+        let mut y2 = &x2 * &x2;
+        y2.checkpoint(&mut Engine::new(CpuBackend::new())).unwrap();
+        let z2 = &y2 * &y2;
+        let g = z2.grad(&x2).unwrap();
+        get_f64_scalar(&eval_tensor(g))
+    };
+    let fd_hv = (fd_grad(x_val + FD_H) - fd_grad(x_val - FD_H)) / (2.0 * FD_H);
+    assert!(
+        (hv_val - fd_hv).abs() < TOL,
+        "HVP vs FD: actual={hv_val}, fd={fd_hv}"
+    );
+}
+
+fn eval_tensor(traced: TracedTensor) -> Tensor {
+    let mut engine = Engine::new(CpuBackend::new());
+    let mut t = traced;
+    t.eval(&mut engine).unwrap().clone()
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cargo test -p tenferro --test checkpoint checkpoint_hvp -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 3: Add multi-step checkpoint loop test**
+
+```rust
+#[test]
+fn checkpoint_loop_grad_correct() {
+    // f(a) = a * cos(a * cos(a * cos(x0)))  (3-step iteration)
+    // Checkpoint after each step
+    let a_val = 0.8_f64;
+    let x0 = 0.5_f64;
+    let steps = 3;
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let a = TracedTensor::from_tensor(f64_scalar(a_val));
+    let mut x = TracedTensor::from_tensor(f64_scalar(x0));
+
+    for _ in 0..steps {
+        x = &a * &x.cos();
+        x.checkpoint(&mut engine).unwrap();
+    }
+
+    let mut grad = x.grad(&a).unwrap();
+    let grad_val = get_f64_scalar(grad.eval(&mut engine).unwrap());
+
+    // Finite difference
+    let f_concrete = |a_v: f64| -> f64 {
+        let mut xc = x0;
+        for _ in 0..steps {
+            xc = a_v * xc.cos();
+        }
+        xc
+    };
+    let fd = (f_concrete(a_val + FD_H) - f_concrete(a_val - FD_H)) / (2.0 * FD_H);
+
+    assert!(
+        (grad_val - fd).abs() < TOL,
+        "loop grad: actual={grad_val}, fd={fd}"
+    );
+}
+```
+
+- [ ] **Step 4: Run all checkpoint tests**
+
+Run: `cargo test -p tenferro --test checkpoint -- --nocapture`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tenferro/tests/checkpoint.rs
+git commit -m "test: add HVP and multi-step loop tests for checkpoint"
+```
+
+---
+
+## Task 8: Add `ShapeOf` op (simplest new op — full pipeline)
+
+**Files:**
+- Modify: `tenferro-ops/src/std_tensor_op.rs`
+- Modify: `tenferro-ops/src/ad/mod.rs`
+- Modify: `tenferro/src/compiler.rs`
+- Modify: `tenferro/src/stablehlo.rs`
+- Modify: `tenferro/src/exec.rs`
+- Modify: `tenferro-tensor/src/backend.rs`
+- Modify: `tenferro-tensor/src/cpu/backend.rs` (or exec_session.rs)
+- Create: `tenferro/tests/shape_of.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tenferro/tests/shape_of.rs
+use tenferro::engine::Engine;
+use tenferro::traced::TracedTensor;
+use tenferro::{CpuBackend, Tensor, TypedTensor};
+
+fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(shape, data))
+}
+
+fn get_f64_scalar(t: &Tensor) -> f64 {
+    match t {
+        Tensor::F64(inner) => {
+            assert_eq!(inner.shape(), &[] as &[usize]);
+            inner.host_data()[0]
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn shape_of_returns_axis_size() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![3, 5, 7], vec![0.0; 105]));
+    let mut s0 = x.shape_of(0);
+    let mut s1 = x.shape_of(1);
+    let mut s2 = x.shape_of(2);
+
+    assert_eq!(get_f64_scalar(s0.eval(&mut engine).unwrap()), 3.0);
+    assert_eq!(get_f64_scalar(s1.eval(&mut engine).unwrap()), 5.0);
+    assert_eq!(get_f64_scalar(s2.eval(&mut engine).unwrap()), 7.0);
+}
+
+#[test]
+fn shape_of_grad_is_zero() {
+    let x = TracedTensor::from_tensor(f64_tensor(vec![4, 3], vec![0.0; 12]));
+    let s = x.shape_of(0);
+    // shape_of should not be differentiable
+    assert!(s.try_grad(&x).unwrap().is_none());
+}
+```
+
+- [ ] **Step 2: Add `ShapeOf` variant to `StdTensorOp`**
+
+In `tenferro-ops/src/std_tensor_op.rs`, add after `Reverse`:
+
+```rust
+/// Extract the size of a specific axis as a scalar f64 tensor.
+ShapeOf { axis: usize },
+```
+
+Update `n_inputs()`: add `Self::ShapeOf { .. } => 1,`
+Update `n_outputs()`: add `Self::ShapeOf { .. } => 1,` (in the existing 1-output match arm)
+
+- [ ] **Step 3: Add AD rules for ShapeOf**
+
+In `tenferro-ops/src/ad/mod.rs`, add to `linearize_non_semiring`:
+
+```rust
+StdTensorOp::ShapeOf { .. } => vec![None],  // shape doesn't depend on values
+```
+
+Add to `transpose_non_semiring`:
+
+```rust
+StdTensorOp::ShapeOf { .. } => vec![None],  // no gradient
+```
+
+- [ ] **Step 4: Add StableHloOp variant and lowering**
+
+In `tenferro/src/stablehlo.rs`, add variant:
+```rust
+ShapeOf { axis: usize },
+```
+
+In `tenferro/src/compiler.rs` `lower_to_stablehlo`, add:
+```rust
+StdTensorOp::ShapeOf { axis } => StableHloOp::ShapeOf { axis: *axis },
+```
+
+- [ ] **Step 5: Add ExecOp variant and compile**
+
+In `tenferro/src/exec.rs`, add variant:
+```rust
+ShapeOf { axis: usize },
+```
+
+In `compile_to_exec` (StableHloOp → ExecOp mapping), add:
+```rust
+StableHloOp::ShapeOf { axis } => ExecOp::ShapeOf { axis: *axis },
+```
+
+- [ ] **Step 6: Add execution dispatch**
+
+In `eval_exec_ir`, add to the match:
+
+```rust
+ExecOp::ShapeOf { axis } => {
+    let input = get(&slots, &inst.input_slots, 0)?;
+    let size = input.shape()[*axis] as f64;
+    Tensor::F64(TypedTensor::from_vec(vec![], vec![size]))
+}
+```
+
+Note: No backend trait method needed — this is purely metadata extraction.
+
+- [ ] **Step 7: Add `shape_of()` method on TracedTensor**
+
+In `tenferro/src/traced.rs`:
+
+```rust
+/// Extract the size of this tensor along `axis` as a scalar f64 TracedTensor.
+///
+/// The result is non-differentiable (gradient is always zero).
+///
+/// # Examples
+///
+/// ```ignore
+/// let size = x.shape_of(1); // scalar tensor with value x.shape[1]
+/// ```
+pub fn shape_of(&self, axis: usize) -> TracedTensor {
+    apply_unary_with_dtype(
+        StdTensorOp::ShapeOf { axis },
+        self,
+        0,            // scalar output (rank 0)
+        Some(vec![]), // shape_hint: scalar
+        DType::F64,
+    )
+}
+```
+
+- [ ] **Step 8: Run tests**
+
+Run: `cargo test -p tenferro --test shape_of -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tenferro-ops/src/std_tensor_op.rs tenferro-ops/src/ad/mod.rs \
+  tenferro/src/compiler.rs tenferro/src/stablehlo.rs tenferro/src/exec.rs \
+  tenferro/src/traced.rs tenferro/tests/shape_of.rs
+git commit -m "feat: add ShapeOf op (axis size extraction, non-differentiable)"
+```
+
+---
+
+## Task 9: Add `DynamicTruncate` op
+
+**Files:**
+- Modify: `tenferro-ops/src/std_tensor_op.rs`
+- Modify: `tenferro/src/compiler.rs`
+- Modify: `tenferro/src/stablehlo.rs`
+- Modify: `tenferro/src/exec.rs`
+- Create: `tenferro/tests/dynamic_truncate.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tenferro/tests/dynamic_truncate.rs
+use tenferro::engine::Engine;
+use tenferro::traced::TracedTensor;
+use tenferro::{CpuBackend, Tensor, TypedTensor};
+
+fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(shape, data))
+}
+
+fn f64_scalar(val: f64) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(vec![], vec![val]))
+}
+
+fn get_f64_data(t: &Tensor) -> Vec<f64> {
+    match t {
+        Tensor::F64(inner) => inner.host_data().to_vec(),
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn dynamic_truncate_basic() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![5], vec![1.0, 2.0, 3.0, 4.0, 5.0]));
+    let size = TracedTensor::from_tensor(f64_scalar(3.0));
+
+    let mut result = x.dynamic_truncate(&size, 0);
+    let data = get_f64_data(result.eval(&mut engine).unwrap());
+    assert_eq!(data, vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn dynamic_truncate_2d_axis1() {
+    let mut engine = Engine::new(CpuBackend::new());
+    // 2x4 matrix (col-major): [[1,2,3,4],[5,6,7,8]]
+    let x = TracedTensor::from_tensor(f64_tensor(vec![2, 4], vec![1.0,5.0, 2.0,6.0, 3.0,7.0, 4.0,8.0]));
+    let size = TracedTensor::from_tensor(f64_scalar(2.0));
+
+    let mut result = x.dynamic_truncate(&size, 1);
+    let out = result.eval(&mut engine).unwrap();
+    assert_eq!(out.shape(), &[2, 2]);
+    // First 2 columns: [[1,2],[5,6]] stored col-major: [1,5,2,6]
+    assert_eq!(get_f64_data(out), vec![1.0, 5.0, 2.0, 6.0]);
+}
+
+#[test]
+fn dynamic_truncate_clamps_oversize() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
+    let size = TracedTensor::from_tensor(f64_scalar(10.0)); // larger than axis
+
+    let mut result = x.dynamic_truncate(&size, 0);
+    let data = get_f64_data(result.eval(&mut engine).unwrap());
+    assert_eq!(data, vec![1.0, 2.0, 3.0]); // clamped to actual size
+}
+```
+
+- [ ] **Step 2: Add `DynamicTruncate` variant to `StdTensorOp`**
+
+```rust
+/// Truncate tensor along axis to first N elements (N from scalar input).
+DynamicTruncate { axis: usize },
+```
+
+Update `n_inputs()`: `Self::DynamicTruncate { .. } => 2,`
+Update `n_outputs()`: add to existing 1-output arm.
+
+- [ ] **Step 3: Add lowering pipeline (StableHlo + ExecOp)**
+
+StableHloOp:
+```rust
+DynamicTruncate { axis: usize },
+```
+
+Compiler `lower_to_stablehlo`:
+```rust
+StdTensorOp::DynamicTruncate { axis } => StableHloOp::DynamicTruncate { axis: *axis },
+```
+
+ExecOp:
+```rust
+DynamicTruncate { axis: usize },
+```
+
+`compile_to_exec`:
+```rust
+StableHloOp::DynamicTruncate { axis } => ExecOp::DynamicTruncate { axis: *axis },
+```
+
+- [ ] **Step 4: Add execution**
+
+In `eval_exec_ir`:
+
+```rust
+ExecOp::DynamicTruncate { axis } => {
+    let input = get(&slots, &inst.input_slots, 0)?;
+    let size_tensor = get(&slots, &inst.input_slots, 1)?;
+    // Extract scalar size and clamp
+    let size_f64 = match size_tensor {
+        Tensor::F64(t) => t.host_data()[0],
+        Tensor::F32(t) => t.host_data()[0] as f64,
+        _ => return Err(Error::Internal("DynamicTruncate size must be real".into())),
+    };
+    let size = (size_f64.round() as usize).min(input.shape()[*axis]);
+    // Build SliceConfig for 0..size along axis
+    let mut starts = vec![0i64; input.rank()];
+    let mut limits = input.shape().iter().map(|&d| d as i64).collect::<Vec<_>>();
+    let strides = vec![1i64; input.rank()];
+    limits[*axis] = size as i64;
+    let config = tenferro_tensor::SliceConfig { starts, limits, strides };
+    exec.slice(input, &config)?
+}
+```
+
+- [ ] **Step 5: Add `dynamic_truncate()` method on TracedTensor**
+
+```rust
+/// Truncate this tensor along `axis` to the first `size` elements.
+///
+/// `size` is a scalar TracedTensor whose value determines the truncation
+/// point at runtime. Non-integer values are rounded; values exceeding
+/// the axis length are clamped.
+///
+/// # Examples
+///
+/// ```ignore
+/// let truncated = x.dynamic_truncate(&size, 0);
+/// ```
+pub fn dynamic_truncate(&self, size: &TracedTensor, axis: usize) -> TracedTensor {
+    apply_binary(
+        StdTensorOp::DynamicTruncate { axis },
+        self,
+        size,
+        self.rank,
+        None, // shape_hint unknown along axis
+    )
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p tenferro --test dynamic_truncate -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tenferro-ops/src/std_tensor_op.rs tenferro/src/compiler.rs \
+  tenferro/src/stablehlo.rs tenferro/src/exec.rs tenferro/src/traced.rs \
+  tenferro/tests/dynamic_truncate.rs
+git commit -m "feat: add DynamicTruncate op (forward only)"
+```
+
+---
+
+## Task 10: Add `PadToMatch` op
+
+**Files:**
+- Modify: `tenferro-ops/src/std_tensor_op.rs`
+- Modify: `tenferro/src/compiler.rs`
+- Modify: `tenferro/src/stablehlo.rs`
+- Modify: `tenferro/src/exec.rs`
+- Modify: `tenferro/tests/dynamic_truncate.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// Add to tenferro/tests/dynamic_truncate.rs
+#[test]
+fn pad_to_match_basic() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
+    let reference = TracedTensor::from_tensor(f64_tensor(vec![5], vec![0.0; 5]));
+
+    let mut result = x.pad_to_match(&reference, 0);
+    let data = get_f64_data(result.eval(&mut engine).unwrap());
+    assert_eq!(data, vec![1.0, 2.0, 3.0, 0.0, 0.0]);
+}
+
+#[test]
+fn pad_to_match_no_op_when_same_size() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]));
+    let reference = TracedTensor::from_tensor(f64_tensor(vec![4], vec![0.0; 4]));
+
+    let mut result = x.pad_to_match(&reference, 0);
+    let data = get_f64_data(result.eval(&mut engine).unwrap());
+    assert_eq!(data, vec![1.0, 2.0, 3.0, 4.0]);
+}
+```
+
+- [ ] **Step 2: Add `PadToMatch` variant to `StdTensorOp`**
+
+```rust
+/// Pad tensor with zeros along axis to match reference tensor's size.
+PadToMatch { axis: usize },
+```
+
+Update `n_inputs()`: `Self::PadToMatch { .. } => 2,`
+Update `n_outputs()`: add to 1-output arm.
+
+- [ ] **Step 3: Add lowering pipeline**
+
+StableHloOp: `PadToMatch { axis: usize },`
+ExecOp: `PadToMatch { axis: usize },`
+Lowering: direct 1:1 mapping.
+
+- [ ] **Step 4: Add execution**
+
+```rust
+ExecOp::PadToMatch { axis } => {
+    let input = get(&slots, &inst.input_slots, 0)?;
+    let reference = get(&slots, &inst.input_slots, 1)?;
+    let target_size = reference.shape()[*axis];
+    let current_size = input.shape()[*axis];
+    if current_size >= target_size {
+        input.clone()
+    } else {
+        let pad_amount = target_size - current_size;
+        let mut low = vec![0i64; input.rank()];
+        let mut high = vec![0i64; input.rank()];
+        let interior = vec![0i64; input.rank()];
+        high[*axis] = pad_amount as i64;
+        let config = tenferro_tensor::PadConfig {
+            edge_padding_low: low,
+            edge_padding_high: high,
+            interior_padding: interior,
+        };
+        exec.pad(input, &config)?
+    }
+}
+```
+
+- [ ] **Step 5: Add `pad_to_match()` method on TracedTensor**
+
+```rust
+/// Pad this tensor with zeros along `axis` to match `reference.shape[axis]`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let padded = truncated.pad_to_match(&original, 0);
+/// ```
+pub fn pad_to_match(&self, reference: &TracedTensor, axis: usize) -> TracedTensor {
+    apply_binary(
+        StdTensorOp::PadToMatch { axis },
+        self,
+        reference,
+        self.rank,
+        reference.shape_hint.clone(),
+    )
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p tenferro --test dynamic_truncate pad_to_match -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tenferro-ops/src/std_tensor_op.rs tenferro/src/compiler.rs \
+  tenferro/src/stablehlo.rs tenferro/src/exec.rs tenferro/src/traced.rs \
+  tenferro/tests/dynamic_truncate.rs
+git commit -m "feat: add PadToMatch op (forward only)"
+```
+
+---
+
+## Task 11: AD rules for DynamicTruncate and PadToMatch
+
+**Files:**
+- Create: `tenferro-ops/src/ad/dynamic.rs`
+- Modify: `tenferro-ops/src/ad/mod.rs`
+- Modify: `tenferro/tests/dynamic_truncate.rs`
+
+- [ ] **Step 1: Write the failing AD test**
+
+```rust
+// Add to tenferro/tests/dynamic_truncate.rs
+const TOL: f64 = 1e-5;
+const FD_H: f64 = 1e-5;
+
+#[test]
+fn dynamic_truncate_vjp_correct() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x_data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let x = TracedTensor::from_tensor(f64_tensor(vec![5], x_data.clone()));
+    let size = TracedTensor::from_tensor(f64_scalar(3.0));
+
+    // f(x) = sum(truncate(x, 3)^2) = 1 + 4 + 9 = 14
+    let truncated = x.dynamic_truncate(&size, 0);
+    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+
+    let mut grad = loss.grad(&x).unwrap();
+    let grad_data = get_f64_data(grad.eval(&mut engine).unwrap());
+    // df/dx_i = 2*x_i for i<3, 0 for i>=3
+    assert_eq!(grad_data, vec![2.0, 4.0, 6.0, 0.0, 0.0]);
+}
+
+#[test]
+fn dynamic_truncate_jvp_correct() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x_data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let x = TracedTensor::from_tensor(f64_tensor(vec![5], x_data.clone()));
+    let size = TracedTensor::from_tensor(f64_scalar(3.0));
+
+    let truncated = x.dynamic_truncate(&size, 0);
+    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+
+    // JVP with direction v = [1,1,1,1,1]
+    let v = TracedTensor::from_tensor(f64_tensor(vec![5], vec![1.0; 5]));
+    let mut jvp_result = loss.jvp(&x, &v);
+    let jvp_val = get_f64_data(jvp_result.eval(&mut engine).unwrap())[0];
+
+    // Expected: dot(grad, v) = 2+4+6+0+0 = 12
+    assert!((jvp_val - 12.0).abs() < TOL, "jvp={jvp_val}, expected=12");
+}
+```
+
+- [ ] **Step 2: Create `dynamic.rs` AD rules module**
+
+```rust
+// tenferro-ops/src/ad/dynamic.rs
+use computegraph::fragment::FragmentBuilder;
+use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
+
+use crate::std_tensor_op::StdTensorOp;
+
+/// Linearize DynamicTruncate: apply same truncation to tangent.
+pub fn linearize_dynamic_truncate(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    axis: usize,
+) -> Vec<Option<LocalValId>> {
+    // input[0] = tensor (differentiable), input[1] = size (non-differentiable)
+    match tangent_in[0] {
+        Some(dx) => {
+            let out = builder.add_op(
+                StdTensorOp::DynamicTruncate { axis },
+                vec![
+                    ValRef::Local(dx),
+                    ValRef::External(primal_in[1].clone()), // same size
+                ],
+                OpMode::Linear {
+                    active_mask: vec![true, false],
+                },
+            );
+            vec![Some(out[0])]
+        }
+        None => vec![None],
+    }
+}
+
+/// Transpose DynamicTruncate: pad cotangent back to original size.
+pub fn transpose_dynamic_truncate(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    axis: usize,
+) -> Vec<Option<LocalValId>> {
+    match cotangent_out[0] {
+        Some(ct) => {
+            // Pad cotangent to match primal input[0]'s shape
+            let out = builder.add_op(
+                StdTensorOp::PadToMatch { axis },
+                vec![
+                    ValRef::Local(ct),
+                    inputs[0].clone(), // reference: original input tensor
+                ],
+                OpMode::Linear {
+                    active_mask: vec![true, false],
+                },
+            );
+            vec![Some(out[0]), None] // no gradient for size input
+        }
+        None => vec![None, None],
+    }
+}
+
+/// Linearize PadToMatch: apply same padding to tangent.
+pub fn linearize_pad_to_match(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    axis: usize,
+) -> Vec<Option<LocalValId>> {
+    match tangent_in[0] {
+        Some(dx) => {
+            let out = builder.add_op(
+                StdTensorOp::PadToMatch { axis },
+                vec![
+                    ValRef::Local(dx),
+                    ValRef::External(primal_in[1].clone()), // same reference
+                ],
+                OpMode::Linear {
+                    active_mask: vec![true, false],
+                },
+            );
+            vec![Some(out[0])]
+        }
+        None => vec![None],
+    }
+}
+
+/// Transpose PadToMatch: truncate cotangent to original (pre-pad) size.
+pub fn transpose_pad_to_match(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    axis: usize,
+) -> Vec<Option<LocalValId>> {
+    match cotangent_out[0] {
+        Some(ct) => {
+            // Get the original input's size along axis via ShapeOf
+            let size = builder.add_op(
+                StdTensorOp::ShapeOf { axis },
+                vec![inputs[0].clone()], // primal input[0]
+                OpMode::Linear {
+                    active_mask: vec![false],
+                },
+            );
+            // Truncate cotangent to that size
+            let out = builder.add_op(
+                StdTensorOp::DynamicTruncate { axis },
+                vec![ValRef::Local(ct), ValRef::Local(size[0])],
+                OpMode::Linear {
+                    active_mask: vec![true, false],
+                },
+            );
+            vec![Some(out[0]), None] // no gradient for reference input
+        }
+        None => vec![None, None],
+    }
+}
+```
+
+- [ ] **Step 3: Wire AD rules into dispatch**
+
+In `tenferro-ops/src/ad/mod.rs`:
+
+Add `mod dynamic;` after existing module declarations.
+
+In `linearize_non_semiring`, add:
+```rust
+StdTensorOp::DynamicTruncate { axis } => {
+    dynamic::linearize_dynamic_truncate(builder, primal_in, tangent_in, *axis)
+}
+StdTensorOp::PadToMatch { axis } => {
+    dynamic::linearize_pad_to_match(builder, primal_in, tangent_in, *axis)
+}
+StdTensorOp::ShapeOf { .. } => vec![None],
+```
+
+In `transpose_non_semiring`, add:
+```rust
+StdTensorOp::DynamicTruncate { axis } => {
+    dynamic::transpose_dynamic_truncate(builder, cotangent_out, inputs, *axis)
+}
+StdTensorOp::PadToMatch { axis } => {
+    dynamic::transpose_pad_to_match(builder, cotangent_out, inputs, *axis)
+}
+StdTensorOp::ShapeOf { .. } => vec![None],
+```
+
+- [ ] **Step 4: Run AD tests**
+
+Run: `cargo test -p tenferro --test dynamic_truncate -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tenferro-ops/src/ad/dynamic.rs tenferro-ops/src/ad/mod.rs \
+  tenferro/tests/dynamic_truncate.rs
+git commit -m "feat: add AD rules for DynamicTruncate and PadToMatch"
+```
+
+---
+
+## Task 12: HVP tests for DynamicTruncate
+
+**Files:**
+- Modify: `tenferro/tests/dynamic_truncate.rs`
+
+- [ ] **Step 1: Write HVP test**
+
+```rust
+#[test]
+fn dynamic_truncate_hvp_correct() {
+    // f(x) = sum(truncate(x, 3)^2) = x[0]^2 + x[1]^2 + x[2]^2
+    // Hessian = diag(2, 2, 2, 0, 0)
+    // HVP with v = [1,1,1,1,1] = [2, 2, 2, 0, 0]
+    let x_data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let x = TracedTensor::from_tensor(f64_tensor(vec![5], x_data.clone()));
+    let size = TracedTensor::from_tensor(f64_scalar(3.0));
+    let truncated = x.dynamic_truncate(&size, 0);
+    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+
+    // Forward-over-Reverse HVP
+    let grad = loss.grad(&x).unwrap();
+    let v = TracedTensor::from_tensor(f64_tensor(vec![5], vec![1.0; 5]));
+    let mut hv = grad.jvp(&x, &v);
+    let hv_data = get_f64_data(hv.eval(&mut engine).unwrap());
+
+    assert_eq!(hv_data.len(), 5);
+    for i in 0..3 {
+        assert!(
+            (hv_data[i] - 2.0).abs() < TOL,
+            "hv[{i}]={}, expected 2.0",
+            hv_data[i]
+        );
+    }
+    for i in 3..5 {
+        assert!(
+            hv_data[i].abs() < TOL,
+            "hv[{i}]={}, expected 0.0",
+            hv_data[i]
+        );
+    }
+}
+
+#[test]
+fn dynamic_truncate_hvp_finite_diff() {
+    let x_data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let v_data = vec![0.1, -0.2, 0.3, 0.4, -0.5];
+
+    // Finite difference of gradient in direction v
+    let compute_grad = |x_vals: &[f64]| -> Vec<f64> {
+        let mut engine = Engine::new(CpuBackend::new());
+        let x = TracedTensor::from_tensor(f64_tensor(vec![5], x_vals.to_vec()));
+        let size = TracedTensor::from_tensor(f64_scalar(3.0));
+        let truncated = x.dynamic_truncate(&size, 0);
+        let loss = (&truncated * &truncated).reduce_sum(&[0]);
+        let mut grad = loss.grad(&x).unwrap();
+        get_f64_data(grad.eval(&mut engine).unwrap())
+    };
+
+    let mut x_plus = x_data.clone();
+    let mut x_minus = x_data.clone();
+    for i in 0..5 {
+        x_plus[i] += FD_H * v_data[i];
+        x_minus[i] -= FD_H * v_data[i];
+    }
+    let grad_plus = compute_grad(&x_plus);
+    let grad_minus = compute_grad(&x_minus);
+    let fd_hv: Vec<f64> = grad_plus.iter().zip(&grad_minus).map(|(p, m)| (p - m) / (2.0 * FD_H)).collect();
+
+    // AD HVP
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![5], x_data));
+    let size = TracedTensor::from_tensor(f64_scalar(3.0));
+    let truncated = x.dynamic_truncate(&size, 0);
+    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+    let grad = loss.grad(&x).unwrap();
+    let v = TracedTensor::from_tensor(f64_tensor(vec![5], v_data));
+    let mut hv = grad.jvp(&x, &v);
+    let hv_data = get_f64_data(hv.eval(&mut engine).unwrap());
+
+    for i in 0..5 {
+        assert!(
+            (hv_data[i] - fd_hv[i]).abs() < TOL,
+            "HVP[{i}]: ad={}, fd={}",
+            hv_data[i],
+            fd_hv[i]
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p tenferro --test dynamic_truncate hvp -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tenferro/tests/dynamic_truncate.rs
+git commit -m "test: add HVP tests for DynamicTruncate"
+```
+
+---
+
+## Task 13: Integration test — checkpoint + DynamicTruncate
+
+**Files:**
+- Create: `tenferro/tests/checkpoint_truncate_integration.rs`
+
+- [ ] **Step 1: Write integration test**
+
+```rust
+//! Integration test: checkpoint + DynamicTruncate in iterative loop.
+use tenferro::engine::Engine;
+use tenferro::traced::TracedTensor;
+use tenferro::{CpuBackend, Tensor, TypedTensor};
+
+const TOL: f64 = 1e-4;
+const FD_H: f64 = 1e-5;
+
+fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(shape, data))
+}
+fn f64_scalar(val: f64) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(vec![], vec![val]))
+}
+fn get_f64_scalar(t: &Tensor) -> f64 {
+    match t { Tensor::F64(inner) => inner.host_data()[0], _ => panic!() }
+}
+
+/// Iterative computation with truncation + checkpoint:
+/// x_{k+1} = truncate(a * x_k, size=2)  (keep first 2 of 3 elements)
+/// loss = sum(x_final)
+#[test]
+fn checkpoint_truncate_loop_grad() {
+    let steps = 3;
+    let a_val = 0.5_f64;
+    let x0_data = vec![1.0, 2.0, 3.0];
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let a = TracedTensor::from_tensor(f64_scalar(a_val));
+    let size = TracedTensor::from_tensor(f64_scalar(2.0));
+    let mut x = TracedTensor::from_tensor(f64_tensor(vec![3], x0_data.clone()));
+
+    for _ in 0..steps {
+        // Scale by a (broadcast scalar * vector)
+        x = &a * &x;
+        // Truncate to first 2 elements
+        x = x.dynamic_truncate(&size, 0);
+        x.checkpoint(&mut engine).unwrap();
+    }
+
+    let loss = x.reduce_sum(&[0]);
+    let mut grad = loss.grad(&a).unwrap();
+    let grad_val = get_f64_scalar(grad.eval(&mut engine).unwrap());
+
+    // Finite difference
+    let f_concrete = |a_v: f64| -> f64 {
+        let mut xc = x0_data.clone();
+        for _ in 0..steps {
+            xc = xc.iter().map(|v| a_v * v).collect();
+            xc.truncate(2);
+        }
+        xc.iter().sum()
+    };
+    let fd = (f_concrete(a_val + FD_H) - f_concrete(a_val - FD_H)) / (2.0 * FD_H);
+
+    assert!(
+        (grad_val - fd).abs() < TOL,
+        "integration: grad={grad_val}, fd={fd}"
+    );
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cargo test -p tenferro --test checkpoint_truncate_integration -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tenferro/tests/checkpoint_truncate_integration.rs
+git commit -m "test: integration test for checkpoint + DynamicTruncate loop"
+```
+
+---
+
+## Task 14: Full workspace test pass and cleanup
+
+**Files:**
+- Modify: `Cargo.toml` (remove patch when tidu-rs PR is merged)
+
+- [ ] **Step 1: Run full workspace tests**
+
+Run: `cargo test --workspace --release`
+Expected: All pass
+
+- [ ] **Step 2: Check formatting**
+
+Run: `cargo fmt --all --check`
+Expected: No formatting issues
+
+- [ ] **Step 3: Build docs**
+
+Run: `cargo doc --workspace --no-deps 2>&1 | grep -i error`
+Expected: No doc errors
+
+- [ ] **Step 4: Final commit (if any fixups needed)**
+
+```bash
+git add -A && git commit -m "chore: fixups from full test pass"
+```
+
+---
+
+## Cross-repo Dependency Note
+
+Tasks 1-2 modify tidu-rs locally via worktree + `[patch]`. Before merging
+the tenferro-rs PR:
+
+1. Push tidu-rs changes and create a PR
+2. Merge tidu-rs PR
+3. Update `Cargo.toml` to point to new tidu-rs rev
+4. Remove `[patch]` section
+5. Run `cargo update -p tidu`
+
+This follows the cross-repo dependency protocol in AGENTS.md.

--- a/docs/superpowers/specs/2026-04-12-checkpoint-dynamic-truncate-design.md
+++ b/docs/superpowers/specs/2026-04-12-checkpoint-dynamic-truncate-design.md
@@ -1,0 +1,325 @@
+# Checkpoint + DynamicTruncate Design
+
+## Summary
+
+Add a checkpoint mechanism and dynamic truncation ops to enable memory-efficient
+backward passes through iterative TN computations with adaptive truncated SVD.
+
+Related issues: #690 (checkpoint), #691 (DynamicTruncate)
+
+## Implementation Order
+
+Checkpoint first, then DynamicTruncate. Checkpoint involves deeper graph/AD
+changes; DynamicTruncate builds on top.
+
+---
+
+## Part 1: Checkpoint Mechanism
+
+### API
+
+```rust
+impl TracedTensor {
+    /// Evaluate, cache, and promote to leaf for eval efficiency.
+    /// AD connectivity preserved via checkpoint_chain.
+    pub fn checkpoint(&mut self, engine: &mut Engine<impl TensorBackend>) -> Result<()>;
+}
+```
+
+### Data Structure: CheckpointNode
+
+```rust
+/// Persistent linked list of checkpoint metadata.
+/// Shared via Arc — O(1) propagation through downstream ops.
+pub(crate) struct CheckpointNode {
+    /// The old computation fragment (pre-checkpoint graph).
+    pub fragment: Arc<Fragment<StdTensorOp>>,
+    /// Maps the new leaf key → old output GlobalValKey for AD continuation.
+    pub alias: (TensorInputKey, GlobalValKey<StdTensorOp>),
+    /// Concrete input data needed to evaluate the old fragment.
+    pub old_inputs: HashMap<TensorInputKey, Tensor>,
+    /// Link to previous checkpoint (linked list).
+    pub prev: Option<Arc<CheckpointNode>>,
+}
+```
+
+New field on `TracedTensor`:
+
+```rust
+pub(crate) checkpoint_chain: Option<Arc<CheckpointNode>>,
+```
+
+### checkpoint() Implementation
+
+```rust
+pub fn checkpoint(&mut self, engine: &mut Engine<impl TensorBackend>) -> Result<()> {
+    // 1. Evaluate to get concrete data
+    self.eval(engine)?;
+    let data = self.data.clone().expect("eval populates data");
+
+    // 2. Capture old state
+    let old_fragment = self.fragment.clone();
+    let old_output_key = old_fragment.vals()[self.val].key.clone();
+    let old_inputs = (*self.inputs_map).clone();
+
+    // 3. Create new leaf
+    let new_key = next_input_key();
+    let mut builder = FragmentBuilder::new();
+    let leaf_val = builder.add_input(new_key.clone());
+    builder.set_outputs(vec![leaf_val]);
+    let new_fragment = Arc::new(builder.build());
+
+    // 4. Build checkpoint node (prepend to chain)
+    let node = CheckpointNode {
+        fragment: old_fragment,
+        alias: (new_key.clone(), old_output_key),
+        old_inputs,
+        prev: self.checkpoint_chain.take(),
+    };
+
+    // 5. Update self
+    self.fragment = new_fragment;
+    self.val = leaf_val;
+    self.data = Some(data.clone());
+    self.extra_roots = vec![];  // no longer needed for eval
+    self.checkpoint_chain = Some(Arc::new(node));
+
+    // 6. Merge inputs_map: keep old + add new checkpoint key
+    let mut merged = (*self.inputs_map).clone();
+    merged.insert(new_key, data);
+    self.inputs_map = Arc::new(merged);
+
+    Ok(())
+}
+```
+
+### Propagation
+
+In `apply_unary`, `apply_binary`, and other TracedTensor constructors:
+- Clone `checkpoint_chain` from operands (O(1) Arc clone)
+- For binary ops: if both operands have chains, keep the longer chain or merge
+  (in practice, iterative loops produce a single linear chain shared by all)
+
+### eval() Behavior
+
+`eval()` resolves only `vec![self.fragment.clone()]` — no checkpoint_chain
+traversal. Since the checkpointed tensor is a leaf, downstream eval is O(K)
+per step.
+
+### AD (grad/vjp) Behavior
+
+When `vjp()`/`grad()` is called:
+
+1. Walk `checkpoint_chain` to collect all fragments and aliases
+2. Build alias map: `HashMap<TensorInputKey, GlobalValKey>`
+3. Collect all old_inputs into a merged inputs_map
+4. Call `resolve()` with: `[self.fragment] + all checkpoint fragments`
+5. Pass alias map to `differentiate()`
+
+### tidu::differentiate() Changes
+
+Modify `differentiate()` to accept an alias map:
+
+```rust
+pub fn differentiate<Op: GraphOp + PrimitiveOp>(
+    view: &ResolvedView<Op>,
+    output_key: &GlobalValKey<Op>,
+    wrt_keys: &[Op::InputKey],
+    aliases: &HashMap<Op::InputKey, GlobalValKey<Op>>,  // NEW
+) -> Result<(Arc<Fragment<Op>>, GlobalValKey<Op>)>
+```
+
+When the traversal reaches `GlobalValKey::Input(key)`:
+- Check `aliases`. If `key` maps to a `GlobalValKey::Derived { ... }`, continue
+  traversal from that derived key (expanding the subgraph on demand).
+- This enables gradients to flow through checkpoint boundaries.
+
+HVP works recursively: when differentiating a graph that itself contains
+checkpoint aliases (from a previous differentiation pass), the same alias
+expansion logic applies at the tangent/cotangent level.
+
+---
+
+## Part 2: DynamicTruncate
+
+### Op Definition
+
+```rust
+StdTensorOp::DynamicTruncate { axis: usize }
+// input[0]: tensor to truncate
+// input[1]: scalar tensor (0-rank) — number of elements to keep along axis
+// n_inputs: 2, n_outputs: 1
+// output shape: runtime-determined (shape_hint = None along axis)
+```
+
+### ExecOp
+
+```rust
+ExecOp::DynamicTruncate { axis: usize }
+```
+
+Execution:
+1. Extract `size = input[1]` as usize (round to nearest integer, clamp to
+   `0..=input[0].shape[axis]`)
+2. Slice `input[0]` along `axis` from `0..size`
+3. Return sliced tensor
+
+### Lowering
+
+```
+StdTensorOp::DynamicTruncate { axis } → StableHloOp::DynamicTruncate { axis }
+                                       → ExecOp::DynamicTruncate { axis }
+```
+
+### AD Rules
+
+**Linearize (JVP):**
+```rust
+// tangent of DynamicTruncate = same truncation applied to tangent
+// size input (input[1]) is non-differentiable
+fn linearize(tangent_in, primal_in, axis) {
+    let dt = tangent_in[0]?;
+    DynamicTruncate(dt, primal_in[1], axis)  // same size
+    // tangent_in[1] → None (non-differentiable)
+}
+```
+
+**Transpose (VJP):**
+```rust
+// adjoint = pad cotangent back to original size
+fn transpose(cotangent_out, primal_inputs, axis) {
+    let ct = cotangent_out[0]?;
+    PadToMatch(ct, primal_inputs[0], axis)
+    // no gradient for size input
+}
+```
+
+---
+
+## Part 3: PadToMatch
+
+### Op Definition
+
+```rust
+StdTensorOp::PadToMatch { axis: usize }
+// input[0]: tensor to pad with zeros
+// input[1]: reference tensor (only shape used, values ignored)
+// n_inputs: 2, n_outputs: 1
+// output shape: same as input[0] except axis = input[1].shape[axis]
+```
+
+### ExecOp
+
+```rust
+ExecOp::PadToMatch { axis: usize }
+```
+
+Execution:
+1. `target_size = input[1].shape[axis]`
+2. `pad_amount = target_size - input[0].shape[axis]`
+3. Pad `input[0]` with zeros on the high side along `axis`
+
+### AD Rules
+
+**Linearize (JVP):**
+```rust
+fn linearize(tangent_in, primal_in, axis) {
+    let dt = tangent_in[0]?;
+    PadToMatch(dt, primal_in[1], axis)  // same padding
+    // tangent_in[1] → None
+}
+```
+
+**Transpose (VJP):**
+```rust
+fn transpose(cotangent_out, primal_inputs, axis) {
+    let ct = cotangent_out[0]?;
+    let size = ShapeOf(primal_inputs[0], axis);  // original pre-pad size
+    DynamicTruncate(ct, size, axis)
+    // no gradient for reference input
+}
+```
+
+---
+
+## Part 4: ShapeOf
+
+### Op Definition
+
+```rust
+StdTensorOp::ShapeOf { axis: usize }
+// input[0]: tensor
+// n_inputs: 1, n_outputs: 1
+// output: scalar tensor (0-rank) = input[0].shape[axis] as f64
+```
+
+### ExecOp
+
+```rust
+ExecOp::ShapeOf { axis: usize }
+```
+
+Execution: `output = Tensor::scalar(input[0].shape[axis] as f64)`
+
+### AD Rules
+
+```rust
+// Shape does not depend on tensor values
+fn linearize(tangent_in, ..) -> vec![None]
+fn transpose(cotangent_out, ..) -> vec![None]
+```
+
+---
+
+## Shape Handling
+
+DynamicTruncate output has runtime-determined shape. For the initial
+implementation:
+- `shape_hint` for the truncated axis = `None` (unknown)
+- Downstream ops that need shapes (NaryEinsum, DotGeneral) resolve shapes at
+  execution time from concrete tensors
+
+Future: add `SymDim::Dynamic` variant if static shape analysis becomes needed.
+
+---
+
+## Edge Cases
+
+- **size = 0**: DynamicTruncate produces empty tensor along axis. Valid.
+- **size > input.shape[axis]**: Clamp to input.shape[axis] (no-op truncation).
+- **size negative or non-integer**: Cast to usize with saturation (negative → 0).
+- **PadToMatch where input already matches**: pad_amount = 0, no-op. Valid.
+
+---
+
+## Testing Strategy
+
+| Test | Content |
+|------|---------|
+| checkpoint forward | eval after checkpoint is O(K), not O(kK) |
+| checkpoint grad | `loss.grad(&x0)` correct through checkpoint (finite-diff) |
+| checkpoint HVP | 2nd-order differentiation through checkpoint (finite-diff) |
+| checkpoint loop | L-step loop with sqrt(L) checkpoints, verify correctness |
+| DynamicTruncate forward | `[1,2,3,4,5]` + size=3 → `[1,2,3]` |
+| DynamicTruncate JVP | finite-diff verification |
+| DynamicTruncate VJP | finite-diff verification |
+| DynamicTruncate HVP | 2nd-order finite-diff |
+| PadToMatch forward | padding correctness |
+| PadToMatch JVP/VJP | finite-diff verification |
+| ShapeOf forward | extracts correct axis size |
+| Integration: truncated SVD | SVD + rank determination + DynamicTruncate pipeline |
+| Integration: checkpoint + DynamicTruncate | iterative sweep with adaptive truncation |
+
+All AD tests use finite-difference validation with appropriate tolerances.
+
+---
+
+## Open Items Resolved
+
+| Issue | Resolution |
+|-------|-----------|
+| inputs_map dropped | Merge, not replace |
+| extra_roots O(L^2) | checkpoint_chain (Arc linked list), eval doesn't touch |
+| tidu changes understated | Explicit: alias map arg + traversal expansion logic |
+| SymDim has no Unknown | shape_hint = None for initial impl |
+| PadToMatch transpose needs size | ShapeOf op |

--- a/tenferro-ops/src/ad/dynamic.rs
+++ b/tenferro-ops/src/ad/dynamic.rs
@@ -1,0 +1,95 @@
+use computegraph::fragment::FragmentBuilder;
+use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
+
+use crate::std_tensor_op::StdTensorOp;
+
+pub fn linearize_dynamic_truncate(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    axis: usize,
+) -> Vec<Option<LocalValId>> {
+    match tangent_in[0] {
+        Some(dx) => {
+            let out = builder.add_op(
+                StdTensorOp::DynamicTruncate { axis },
+                vec![ValRef::Local(dx), ValRef::External(primal_in[1].clone())],
+                OpMode::Linear {
+                    active_mask: vec![true, false],
+                },
+            );
+            vec![Some(out[0])]
+        }
+        None => vec![None],
+    }
+}
+
+pub fn transpose_dynamic_truncate(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    axis: usize,
+) -> Vec<Option<LocalValId>> {
+    match cotangent_out[0] {
+        Some(ct) => {
+            let out = builder.add_op(
+                StdTensorOp::PadToMatch { axis },
+                vec![ValRef::Local(ct), inputs[0].clone()],
+                OpMode::Linear {
+                    active_mask: vec![true, false],
+                },
+            );
+            vec![Some(out[0]), None]
+        }
+        None => vec![None, None],
+    }
+}
+
+pub fn linearize_pad_to_match(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    axis: usize,
+) -> Vec<Option<LocalValId>> {
+    match tangent_in[0] {
+        Some(dx) => {
+            let out = builder.add_op(
+                StdTensorOp::PadToMatch { axis },
+                vec![ValRef::Local(dx), ValRef::External(primal_in[1].clone())],
+                OpMode::Linear {
+                    active_mask: vec![true, false],
+                },
+            );
+            vec![Some(out[0])]
+        }
+        None => vec![None],
+    }
+}
+
+pub fn transpose_pad_to_match(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    axis: usize,
+) -> Vec<Option<LocalValId>> {
+    match cotangent_out[0] {
+        Some(ct) => {
+            let size = builder.add_op(
+                StdTensorOp::ShapeOf { axis },
+                vec![inputs[0].clone()],
+                OpMode::Linear {
+                    active_mask: vec![false],
+                },
+            );
+            let out = builder.add_op(
+                StdTensorOp::DynamicTruncate { axis },
+                vec![ValRef::Local(ct), ValRef::Local(size[0])],
+                OpMode::Linear {
+                    active_mask: vec![true, false],
+                },
+            );
+            vec![Some(out[0]), None]
+        }
+        None => vec![None, None],
+    }
+}

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -86,6 +86,7 @@ fn linearize_non_semiring(
         StdTensorOp::Tril { k } => structural::linearize_tril(builder, tangent_in, *k),
         StdTensorOp::Triu { k } => structural::linearize_triu(builder, tangent_in, *k),
         StdTensorOp::Pad(config) => structural::linearize_pad(builder, tangent_in, config),
+        StdTensorOp::ShapeOf { .. } => vec![None],
         StdTensorOp::Lu { input_shape } => {
             linalg::linearize_lu(builder, primal_out, tangent_in, input_shape, ctx)
         }
@@ -212,6 +213,7 @@ fn transpose_non_semiring(
         }
         StdTensorOp::Tril { k } => structural::transpose_tril(builder, cotangent_out, *k),
         StdTensorOp::Triu { k } => structural::transpose_triu(builder, cotangent_out, *k),
+        StdTensorOp::ShapeOf { .. } => vec![None],
         StdTensorOp::TriangularSolve {
             left_side,
             lower,

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -3,6 +3,7 @@ pub mod context;
 mod analytic;
 mod contraction;
 mod diagonal;
+mod dynamic;
 mod elementwise_tier2;
 mod linalg;
 mod semiring;
@@ -86,6 +87,12 @@ fn linearize_non_semiring(
         StdTensorOp::Tril { k } => structural::linearize_tril(builder, tangent_in, *k),
         StdTensorOp::Triu { k } => structural::linearize_triu(builder, tangent_in, *k),
         StdTensorOp::Pad(config) => structural::linearize_pad(builder, tangent_in, config),
+        StdTensorOp::DynamicTruncate { axis } => {
+            dynamic::linearize_dynamic_truncate(builder, primal_in, tangent_in, *axis)
+        }
+        StdTensorOp::PadToMatch { axis } => {
+            dynamic::linearize_pad_to_match(builder, primal_in, tangent_in, *axis)
+        }
         StdTensorOp::ShapeOf { .. } => vec![None],
         StdTensorOp::Lu { input_shape } => {
             linalg::linearize_lu(builder, primal_out, tangent_in, input_shape, ctx)
@@ -213,6 +220,12 @@ fn transpose_non_semiring(
         }
         StdTensorOp::Tril { k } => structural::transpose_tril(builder, cotangent_out, *k),
         StdTensorOp::Triu { k } => structural::transpose_triu(builder, cotangent_out, *k),
+        StdTensorOp::DynamicTruncate { axis } => {
+            dynamic::transpose_dynamic_truncate(builder, cotangent_out, inputs, *axis)
+        }
+        StdTensorOp::PadToMatch { axis } => {
+            dynamic::transpose_pad_to_match(builder, cotangent_out, inputs, *axis)
+        }
         StdTensorOp::ShapeOf { .. } => vec![None],
         StdTensorOp::TriangularSolve {
             left_side,

--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -103,6 +103,9 @@ pub enum StdTensorOp {
     Reverse {
         axes: Vec<usize>,
     },
+    ShapeOf {
+        axis: usize,
+    },
 
     // Tier 2: reductions
     ReduceProd {
@@ -316,6 +319,7 @@ impl Hash for StdTensorOp {
             }
             Self::Concatenate { axis } => axis.hash(state),
             Self::Reverse { axes } => axes.hash(state),
+            Self::ShapeOf { axis } => axis.hash(state),
             Self::ReduceProd { axes, input_shape }
             | Self::ReduceMax { axes, input_shape }
             | Self::ReduceMin { axes, input_shape } => {
@@ -374,7 +378,8 @@ impl GraphOp for StdTensorOp {
             | Self::Triu { .. }
             | Self::Slice(_)
             | Self::Pad(_)
-            | Self::Reverse { .. } => 1,
+            | Self::Reverse { .. }
+            | Self::ShapeOf { .. } => 1,
             Self::Reshape {
                 from_shape,
                 to_shape,
@@ -463,6 +468,7 @@ impl GraphOp for StdTensorOp {
             | Self::Pad(_)
             | Self::NaryEinsum { .. }
             | Self::Reverse { .. }
+            | Self::ShapeOf { .. }
             | Self::ReduceProd { .. }
             | Self::ReduceMax { .. }
             | Self::ReduceMin { .. } => 1,

--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -106,6 +106,12 @@ pub enum StdTensorOp {
     ShapeOf {
         axis: usize,
     },
+    DynamicTruncate {
+        axis: usize,
+    },
+    PadToMatch {
+        axis: usize,
+    },
 
     // Tier 2: reductions
     ReduceProd {
@@ -319,7 +325,9 @@ impl Hash for StdTensorOp {
             }
             Self::Concatenate { axis } => axis.hash(state),
             Self::Reverse { axes } => axes.hash(state),
-            Self::ShapeOf { axis } => axis.hash(state),
+            Self::ShapeOf { axis } | Self::DynamicTruncate { axis } | Self::PadToMatch { axis } => {
+                axis.hash(state)
+            }
             Self::ReduceProd { axes, input_shape }
             | Self::ReduceMax { axes, input_shape }
             | Self::ReduceMin { axes, input_shape } => {
@@ -380,6 +388,7 @@ impl GraphOp for StdTensorOp {
             | Self::Pad(_)
             | Self::Reverse { .. }
             | Self::ShapeOf { .. } => 1,
+            Self::DynamicTruncate { .. } | Self::PadToMatch { .. } => 2,
             Self::Reshape {
                 from_shape,
                 to_shape,
@@ -469,6 +478,8 @@ impl GraphOp for StdTensorOp {
             | Self::NaryEinsum { .. }
             | Self::Reverse { .. }
             | Self::ShapeOf { .. }
+            | Self::DynamicTruncate { .. }
+            | Self::PadToMatch { .. }
             | Self::ReduceProd { .. }
             | Self::ReduceMax { .. }
             | Self::ReduceMin { .. } => 1,

--- a/tenferro-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-ops/src/tests/std_tensor_op_tests.rs
@@ -415,6 +415,12 @@ fn test_std_tensor_op_remaining_input_output_counts() {
     assert_eq!(StdTensorOp::Slice(slice).n_outputs(), 1);
     assert_eq!(StdTensorOp::Reverse { axes: vec![0, 2] }.n_inputs(), 1);
     assert_eq!(StdTensorOp::Reverse { axes: vec![0, 2] }.n_outputs(), 1);
+    assert_eq!(StdTensorOp::ShapeOf { axis: 1 }.n_inputs(), 1);
+    assert_eq!(StdTensorOp::ShapeOf { axis: 1 }.n_outputs(), 1);
+    assert_eq!(StdTensorOp::DynamicTruncate { axis: 0 }.n_inputs(), 2);
+    assert_eq!(StdTensorOp::DynamicTruncate { axis: 0 }.n_outputs(), 1);
+    assert_eq!(StdTensorOp::PadToMatch { axis: 0 }.n_inputs(), 2);
+    assert_eq!(StdTensorOp::PadToMatch { axis: 0 }.n_outputs(), 1);
 }
 
 #[test]
@@ -735,6 +741,9 @@ fn test_std_tensor_op_hash_covers_remaining_variants() {
         },
         StdTensorOp::Concatenate { axis: 1 },
         StdTensorOp::Reverse { axes: vec![0] },
+        StdTensorOp::ShapeOf { axis: 0 },
+        StdTensorOp::DynamicTruncate { axis: 0 },
+        StdTensorOp::PadToMatch { axis: 0 },
         StdTensorOp::ReduceProd {
             axes: vec![0],
             input_shape: shape![2, 2],

--- a/tenferro/src/checkpoint.rs
+++ b/tenferro/src/checkpoint.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use computegraph::fragment::Fragment;
+use computegraph::types::GlobalValKey;
+use tenferro_ops::input_key::TensorInputKey;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_tensor::Tensor;
+
+#[derive(Clone)]
+pub(crate) struct CheckpointNode {
+    pub fragment: Arc<Fragment<StdTensorOp>>,
+    pub alias_key: TensorInputKey,
+    pub alias_target: GlobalValKey<StdTensorOp>,
+    pub old_inputs: HashMap<TensorInputKey, Tensor>,
+    pub prev: Option<Arc<CheckpointNode>>,
+}
+
+impl CheckpointNode {
+    pub(crate) fn collect_aliases(&self) -> HashMap<TensorInputKey, GlobalValKey<StdTensorOp>> {
+        let mut aliases = HashMap::new();
+        let mut current: Option<&CheckpointNode> = Some(self);
+        while let Some(node) = current {
+            aliases.insert(node.alias_key.clone(), node.alias_target.clone());
+            current = node.prev.as_deref();
+        }
+        aliases
+    }
+
+    pub(crate) fn collect_fragments(&self) -> Vec<Arc<Fragment<StdTensorOp>>> {
+        let mut fragments = Vec::new();
+        let mut current: Option<&CheckpointNode> = Some(self);
+        while let Some(node) = current {
+            fragments.push(node.fragment.clone());
+            current = node.prev.as_deref();
+        }
+        fragments
+    }
+
+    pub(crate) fn collect_inputs(&self) -> HashMap<TensorInputKey, Tensor> {
+        let mut inputs = HashMap::new();
+        let mut current: Option<&CheckpointNode> = Some(self);
+        while let Some(node) = current {
+            inputs.extend(
+                node.old_inputs
+                    .iter()
+                    .map(|(key, tensor)| (key.clone(), tensor.clone())),
+            );
+            current = node.prev.as_deref();
+        }
+        inputs
+    }
+}

--- a/tenferro/src/compiler.rs
+++ b/tenferro/src/compiler.rs
@@ -85,6 +85,7 @@ pub fn lower_to_stablehlo(prog: &CompiledProgram<StdTensorOp>) -> StableHloProgr
                 },
                 StdTensorOp::Pad(config) => StableHloOp::Pad(config.clone()),
                 StdTensorOp::Reverse { axes } => StableHloOp::Reverse { axes: axes.clone() },
+                StdTensorOp::ShapeOf { axis } => StableHloOp::ShapeOf { axis: *axis },
                 StdTensorOp::Cholesky { .. } => StableHloOp::Cholesky,
                 StdTensorOp::Lu { .. } => StableHloOp::CustomCall {
                     target: "lu".to_string(),
@@ -267,6 +268,7 @@ pub fn compile_to_exec(stablehlo: &StableHloProgram) -> ExecProgram {
                 },
                 StableHloOp::Pad(config) => ExecOp::Pad(config.clone()),
                 StableHloOp::Reverse { axes } => ExecOp::Reverse { axes: axes.clone() },
+                StableHloOp::ShapeOf { axis } => ExecOp::ShapeOf { axis: *axis },
                 StableHloOp::Cholesky => ExecOp::Cholesky,
                 StableHloOp::TriangularSolve {
                     left_side,

--- a/tenferro/src/compiler.rs
+++ b/tenferro/src/compiler.rs
@@ -86,6 +86,10 @@ pub fn lower_to_stablehlo(prog: &CompiledProgram<StdTensorOp>) -> StableHloProgr
                 StdTensorOp::Pad(config) => StableHloOp::Pad(config.clone()),
                 StdTensorOp::Reverse { axes } => StableHloOp::Reverse { axes: axes.clone() },
                 StdTensorOp::ShapeOf { axis } => StableHloOp::ShapeOf { axis: *axis },
+                StdTensorOp::DynamicTruncate { axis } => {
+                    StableHloOp::DynamicTruncate { axis: *axis }
+                }
+                StdTensorOp::PadToMatch { axis } => StableHloOp::PadToMatch { axis: *axis },
                 StdTensorOp::Cholesky { .. } => StableHloOp::Cholesky,
                 StdTensorOp::Lu { .. } => StableHloOp::CustomCall {
                     target: "lu".to_string(),
@@ -269,6 +273,8 @@ pub fn compile_to_exec(stablehlo: &StableHloProgram) -> ExecProgram {
                 StableHloOp::Pad(config) => ExecOp::Pad(config.clone()),
                 StableHloOp::Reverse { axes } => ExecOp::Reverse { axes: axes.clone() },
                 StableHloOp::ShapeOf { axis } => ExecOp::ShapeOf { axis: *axis },
+                StableHloOp::DynamicTruncate { axis } => ExecOp::DynamicTruncate { axis: *axis },
+                StableHloOp::PadToMatch { axis } => ExecOp::PadToMatch { axis: *axis },
                 StableHloOp::Cholesky => ExecOp::Cholesky,
                 StableHloOp::TriangularSolve {
                     left_side,

--- a/tenferro/src/einsum.rs
+++ b/tenferro/src/einsum.rs
@@ -341,6 +341,7 @@ fn build_symbolic_nary_einsum(
         shape_hint: None,
         inputs_map: Arc::new(merged),
         extra_roots,
+        checkpoint_chain: None,
     }
 }
 
@@ -498,6 +499,7 @@ fn build_traced_from_tree(
                 shape_hint: Some(out_shape.into_iter().map(SymDim::from).collect()),
                 inputs_map: Arc::new(merged),
                 extra_roots,
+                checkpoint_chain: None,
             }
         }
         ValRef::External(_) => {
@@ -515,6 +517,7 @@ fn build_traced_from_tree(
                         shape_hint: Some(out_shape.into_iter().map(SymDim::from).collect()),
                         inputs_map: inputs[i].inputs_map.clone(),
                         extra_roots: inputs[i].extra_roots.clone(),
+                        checkpoint_chain: inputs[i].checkpoint_chain.clone(),
                     };
                 }
             }

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -100,6 +100,12 @@ pub enum ExecOp {
     ShapeOf {
         axis: usize,
     },
+    DynamicTruncate {
+        axis: usize,
+    },
+    PadToMatch {
+        axis: usize,
+    },
     ReduceProd {
         axes: Vec<usize>,
     },
@@ -324,6 +330,54 @@ fn eval_exec_ir_inner(
                 let input = get(&slots, &inst.input_slots, 0)?;
                 let size = input.shape()[*axis] as f64;
                 Tensor::F64(TypedTensor::from_vec(vec![], vec![size]))
+            }
+            ExecOp::DynamicTruncate { axis } => {
+                let input = get(&slots, &inst.input_slots, 0)?;
+                let size_tensor = get(&slots, &inst.input_slots, 1)?;
+                let axis_extent = input.shape()[*axis];
+                let size_f64 = match size_tensor {
+                    Tensor::F64(inner) => inner.host_data()[0],
+                    Tensor::F32(inner) => inner.host_data()[0] as f64,
+                    _ => {
+                        return Err(Error::Internal(
+                            "DynamicTruncate size must be an f32 or f64 scalar".into(),
+                        ))
+                    }
+                };
+                let rounded_size = if size_f64.is_finite() {
+                    size_f64.round()
+                } else {
+                    0.0
+                };
+                let size = rounded_size.max(0.0).min(axis_extent as f64) as usize;
+                let rank = input.shape().len();
+                let mut limits = input.shape().to_vec();
+                limits[*axis] = size;
+                let config = SliceConfig {
+                    starts: vec![0; rank],
+                    limits,
+                    strides: vec![1; rank],
+                };
+                exec.slice(input, &config)?
+            }
+            ExecOp::PadToMatch { axis } => {
+                let input = get(&slots, &inst.input_slots, 0)?;
+                let reference = get(&slots, &inst.input_slots, 1)?;
+                let target_size = reference.shape()[*axis];
+                let current_size = input.shape()[*axis];
+                if current_size >= target_size {
+                    input.clone()
+                } else {
+                    let rank = input.shape().len();
+                    let mut high = vec![0i64; rank];
+                    high[*axis] = (target_size - current_size) as i64;
+                    let config = PadConfig {
+                        edge_padding_low: vec![0i64; rank],
+                        edge_padding_high: high,
+                        interior_padding: vec![0i64; rank],
+                    };
+                    exec.pad(input, &config)?
+                }
             }
             ExecOp::ReduceProd { axes } => {
                 exec.reduce_prod(get(&slots, &inst.input_slots, 0)?, axes)?

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -97,6 +97,9 @@ pub enum ExecOp {
     Reverse {
         axes: Vec<usize>,
     },
+    ShapeOf {
+        axis: usize,
+    },
     ReduceProd {
         axes: Vec<usize>,
     },
@@ -317,6 +320,11 @@ fn eval_exec_ir_inner(
                 exec.concatenate(&inputs, *axis)?
             }
             ExecOp::Reverse { axes } => exec.reverse(get(&slots, &inst.input_slots, 0)?, axes)?,
+            ExecOp::ShapeOf { axis } => {
+                let input = get(&slots, &inst.input_slots, 0)?;
+                let size = input.shape()[*axis] as f64;
+                Tensor::F64(TypedTensor::from_vec(vec![], vec![size]))
+            }
             ExecOp::ReduceProd { axes } => {
                 exec.reduce_prod(get(&slots, &inst.input_slots, 0)?, axes)?
             }

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -17,6 +17,7 @@
 
 use tenferro_tensor::DotGeneralConfig;
 
+mod checkpoint;
 pub mod compiler;
 pub mod einsum;
 pub mod engine;

--- a/tenferro/src/stablehlo.rs
+++ b/tenferro/src/stablehlo.rs
@@ -82,6 +82,9 @@ pub enum StableHloOp {
     Reverse {
         axes: Vec<usize>,
     },
+    ShapeOf {
+        axis: usize,
+    },
     // Additional reductions
     ReduceProd {
         axes: Vec<usize>,

--- a/tenferro/src/stablehlo.rs
+++ b/tenferro/src/stablehlo.rs
@@ -85,6 +85,12 @@ pub enum StableHloOp {
     ShapeOf {
         axis: usize,
     },
+    DynamicTruncate {
+        axis: usize,
+    },
+    PadToMatch {
+        axis: usize,
+    },
     // Additional reductions
     ReduceProd {
         axes: Vec<usize>,

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -21,6 +21,7 @@ use super::engine::Engine;
 use super::error::{Error, Result};
 use super::exec::eval_exec_ir;
 use super::sym_dim::SymDim;
+use crate::checkpoint::CheckpointNode;
 
 static NEXT_INPUT_ID: AtomicU64 = AtomicU64::new(0);
 static NEXT_DIFF_PASS_ID: AtomicU64 = AtomicU64::new(0);
@@ -53,6 +54,7 @@ pub struct TracedTensor {
     pub(crate) shape_hint: Option<Vec<SymDim>>,
     pub(crate) inputs_map: Arc<HashMap<TensorInputKey, Tensor>>,
     pub(crate) extra_roots: Vec<Arc<Fragment<StdTensorOp>>>,
+    pub(crate) checkpoint_chain: Option<Arc<CheckpointNode>>,
 }
 
 /// Compute a broadcast output shape following NumPy rules.
@@ -258,6 +260,7 @@ impl TracedTensor {
             shape_hint: Some(shape.into_iter().map(SymDim::from).collect()),
             inputs_map: Arc::new(map),
             extra_roots: Vec::new(),
+            checkpoint_chain: None,
         }
     }
 
@@ -397,6 +400,7 @@ impl TracedTensor {
             shape_hint: self.shape_hint.clone(),
             inputs_map: Arc::new(inputs_map),
             extra_roots,
+            checkpoint_chain: None,
         })
     }
 
@@ -465,6 +469,7 @@ impl TracedTensor {
             shape_hint: wrt.shape_hint.clone(),
             inputs_map: Arc::new(inputs_map),
             extra_roots,
+            checkpoint_chain: None,
         })
     }
 
@@ -1057,6 +1062,7 @@ pub(crate) fn apply_unary_with_dtype(
         shape_hint: out_shape_hint,
         inputs_map: input.inputs_map.clone(),
         extra_roots: input.extra_roots.clone(),
+        checkpoint_chain: input.checkpoint_chain.clone(),
     }
 }
 
@@ -1081,6 +1087,7 @@ pub(crate) fn apply_nullary(
         shape_hint,
         inputs_map: Arc::new(HashMap::new()),
         extra_roots: Vec::new(),
+        checkpoint_chain: None,
     }
 }
 
@@ -1115,6 +1122,10 @@ pub(crate) fn apply_binary(
         shape_hint: out_shape_hint,
         inputs_map: Arc::new(merged),
         extra_roots,
+        checkpoint_chain: lhs
+            .checkpoint_chain
+            .clone()
+            .or(rhs.checkpoint_chain.clone()),
     }
 }
 
@@ -1148,6 +1159,7 @@ pub(crate) fn apply_multi_output(
             shape_hint: Some(shape),
             inputs_map: input.inputs_map.clone(),
             extra_roots: input.extra_roots.clone(),
+            checkpoint_chain: input.checkpoint_chain.clone(),
         })
         .collect()
 }

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -377,6 +377,7 @@ impl TracedTensor {
             .data
             .clone()
             .ok_or_else(|| Error::Internal("checkpoint eval did not populate data".to_string()))?;
+        let concrete_shape_hint = Some(data.shape().iter().copied().map(SymDim::from).collect());
 
         let old_fragment = self.fragment.clone();
         let old_output_key = old_fragment.vals()[self.val].key.clone();
@@ -399,6 +400,7 @@ impl TracedTensor {
         self.fragment = new_fragment;
         self.val = leaf_val;
         self.extra_roots.clear();
+        self.shape_hint = concrete_shape_hint;
         self.checkpoint_chain = Some(Arc::new(node));
 
         let mut merged = HashMap::new();
@@ -1131,12 +1133,89 @@ impl TracedTensor {
     /// assert_eq!(cols.eval(&mut engine).unwrap().shape(), &[] as &[usize]);
     /// ```
     pub fn shape_of(&self, axis: usize) -> TracedTensor {
+        assert!(
+            axis < self.rank,
+            "axis {axis} out of bounds for rank {}",
+            self.rank
+        );
         apply_unary_with_dtype(
             StdTensorOp::ShapeOf { axis },
             self,
             0,
             Some(vec![]),
             DType::F64,
+        )
+    }
+
+    /// Truncate this tensor along `axis` to the first `size` elements.
+    ///
+    /// `size` is read at runtime from a scalar traced tensor. Values are
+    /// rounded to the nearest integer, clamped to `[0, self.shape[axis]]`,
+    /// and the output keeps the same element dtype as the input.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine, TracedTensor};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// let x = TracedTensor::new(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    /// let size = TracedTensor::new(vec![], vec![2.0_f64]);
+    /// let mut y = x.dynamic_truncate(&size, 0);
+    /// assert_eq!(y.eval(&mut engine).unwrap().shape(), &[2]);
+    /// ```
+    pub fn dynamic_truncate(&self, size: &TracedTensor, axis: usize) -> TracedTensor {
+        assert!(
+            axis < self.rank,
+            "axis {axis} out of bounds for rank {}",
+            self.rank
+        );
+        assert!(
+            size.rank == 0,
+            "dynamic_truncate size must be a scalar tensor, got rank {}",
+            size.rank
+        );
+        apply_binary(
+            StdTensorOp::DynamicTruncate { axis },
+            self,
+            size,
+            self.rank,
+            None,
+        )
+    }
+
+    /// Pad this tensor with zeros along `axis` to match `reference.shape[axis]`.
+    ///
+    /// If `reference` is smaller along that axis, this is a no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine, TracedTensor};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// let x = TracedTensor::new(vec![2], vec![1.0_f64, 2.0]);
+    /// let reference = TracedTensor::new(vec![4], vec![0.0_f64, 0.0, 0.0, 0.0]);
+    /// let mut y = x.pad_to_match(&reference, 0);
+    /// assert_eq!(y.eval(&mut engine).unwrap().shape(), &[4]);
+    /// ```
+    pub fn pad_to_match(&self, reference: &TracedTensor, axis: usize) -> TracedTensor {
+        assert!(
+            axis < self.rank,
+            "axis {axis} out of bounds for rank {}",
+            self.rank
+        );
+        assert!(
+            axis < reference.rank,
+            "reference axis {axis} out of bounds for rank {}",
+            reference.rank
+        );
+        apply_binary(
+            StdTensorOp::PadToMatch { axis },
+            self,
+            reference,
+            self.rank,
+            reference.shape_hint.clone(),
         )
     }
 }

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -370,6 +370,7 @@ impl TracedTensor {
             std::slice::from_ref(&wrt_input_key),
             next_pass_id(),
             &mut ad_ctx,
+            &HashMap::new(),
         );
         let tangent_output = linear.tangent_outputs[0]?;
         let tangent_input_key = linear_input_key(&linear.fragment, linear.tangent_inputs[0].1);
@@ -415,6 +416,7 @@ impl TracedTensor {
             std::slice::from_ref(&wrt_input_key),
             next_pass_id(),
             &mut ad_ctx,
+            &HashMap::new(),
         );
         let linear_tangent_input_ids: Vec<LocalValId> = linear
             .tangent_inputs

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -355,6 +355,62 @@ impl TracedTensor {
         Ok(self.try_vjp(wrt, &seed))
     }
 
+    /// Evaluate this tensor and replace its graph with a concrete leaf.
+    ///
+    /// This keeps downstream forward evaluation rooted at the concrete value
+    /// while retaining the original fragment chain for later reverse-mode AD.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine, TracedTensor};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// let x = TracedTensor::new(vec![], vec![3.0_f64]);
+    /// let mut y = &x * &x;
+    /// y.checkpoint(&mut engine).unwrap();
+    /// assert_eq!(y.eval(&mut engine).unwrap().shape(), &[] as &[usize]);
+    /// ```
+    pub fn checkpoint<B: TensorBackend>(&mut self, engine: &mut Engine<B>) -> Result<()> {
+        self.eval(engine)?;
+        let data = self
+            .data
+            .clone()
+            .ok_or_else(|| Error::Internal("checkpoint eval did not populate data".to_string()))?;
+
+        let old_fragment = self.fragment.clone();
+        let old_output_key = old_fragment.vals()[self.val].key.clone();
+        let old_inputs = (*self.inputs_map).clone();
+
+        let new_key = next_input_key();
+        let mut builder = FragmentBuilder::new();
+        let leaf_val = builder.add_input(new_key.clone());
+        builder.set_outputs(vec![leaf_val]);
+        let new_fragment = Arc::new(builder.build());
+
+        let node = CheckpointNode {
+            fragment: old_fragment,
+            alias_key: new_key.clone(),
+            alias_target: old_output_key,
+            old_inputs,
+            prev: self.checkpoint_chain.take(),
+        };
+
+        self.fragment = new_fragment;
+        self.val = leaf_val;
+        self.extra_roots.clear();
+        self.checkpoint_chain = Some(Arc::new(node));
+
+        let mut merged = HashMap::new();
+        if let Some(chain) = &self.checkpoint_chain {
+            merged.extend(chain.collect_inputs());
+        }
+        merged.insert(new_key, data);
+        self.inputs_map = Arc::new(merged);
+
+        Ok(())
+    }
+
     pub fn jvp(&self, wrt: &TracedTensor, tangent: &TracedTensor) -> TracedTensor {
         self.try_jvp(wrt, tangent)
             .unwrap_or_else(|| panic!("jvp output is inactive for {:?}", leaf_input_key(wrt)))

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -421,7 +421,19 @@ impl TracedTensor {
     pub fn try_jvp(&self, wrt: &TracedTensor, tangent: &TracedTensor) -> Option<TracedTensor> {
         let wrt_input_key = leaf_input_key(wrt);
         let output_key = self.fragment.vals()[self.val].key.clone();
-        let view = resolve(self.resolve_roots());
+        let aliases = self
+            .checkpoint_chain
+            .as_ref()
+            .map(|chain| chain.collect_aliases())
+            .unwrap_or_default();
+        let checkpoint_fragments = self
+            .checkpoint_chain
+            .as_ref()
+            .map(|chain| chain.collect_fragments())
+            .unwrap_or_default();
+        let mut roots = self.resolve_roots();
+        roots.extend(checkpoint_fragments.iter().cloned());
+        let view = resolve(roots);
         let mut ad_ctx = ShapeGuardContext::default();
         let linear = differentiate(
             &view,
@@ -429,12 +441,15 @@ impl TracedTensor {
             std::slice::from_ref(&wrt_input_key),
             next_pass_id(),
             &mut ad_ctx,
-            &HashMap::new(),
+            &aliases,
         );
         let tangent_output = linear.tangent_outputs[0]?;
         let tangent_input_key = linear_input_key(&linear.fragment, linear.tangent_inputs[0].1);
 
         let mut inputs_map = (*self.inputs_map).clone();
+        if let Some(chain) = &self.checkpoint_chain {
+            inputs_map.extend(chain.collect_inputs());
+        }
         inputs_map.insert(
             tangent_input_key,
             tangent
@@ -444,6 +459,7 @@ impl TracedTensor {
         );
 
         let mut extra_roots = vec![self.fragment.clone()];
+        extra_roots.extend(checkpoint_fragments);
         extra_roots.extend(self.extra_roots.iter().cloned());
 
         Some(TracedTensor {
@@ -456,7 +472,7 @@ impl TracedTensor {
             shape_hint: self.shape_hint.clone(),
             inputs_map: Arc::new(inputs_map),
             extra_roots,
-            checkpoint_chain: None,
+            checkpoint_chain: self.checkpoint_chain.clone(),
         })
     }
 
@@ -541,7 +557,7 @@ impl TracedTensor {
             shape_hint: wrt.shape_hint.clone(),
             inputs_map: Arc::new(inputs_map),
             extra_roots,
-            checkpoint_chain: None,
+            checkpoint_chain: self.checkpoint_chain.clone(),
         })
     }
 

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -1115,6 +1115,30 @@ impl TracedTensor {
     pub fn broadcast(&self, shape: &[usize], dims: &[usize]) -> TracedTensor {
         self.broadcast_in_dim(shape, dims)
     }
+
+    /// Return the runtime size of one axis as a scalar `f64` tensor.
+    ///
+    /// The result is metadata-derived and therefore has no gradient.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine, TracedTensor};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// let x = TracedTensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// let mut cols = x.shape_of(1);
+    /// assert_eq!(cols.eval(&mut engine).unwrap().shape(), &[] as &[usize]);
+    /// ```
+    pub fn shape_of(&self, axis: usize) -> TracedTensor {
+        apply_unary_with_dtype(
+            StdTensorOp::ShapeOf { axis },
+            self,
+            0,
+            Some(vec![]),
+            DType::F64,
+        )
+    }
 }
 
 pub(crate) fn apply_unary(

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -468,7 +468,19 @@ impl TracedTensor {
     fn try_vjp(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> Option<TracedTensor> {
         let wrt_input_key = leaf_input_key(wrt);
         let output_key = self.fragment.vals()[self.val].key.clone();
-        let view = resolve(self.resolve_roots());
+        let aliases = self
+            .checkpoint_chain
+            .as_ref()
+            .map(|chain| chain.collect_aliases())
+            .unwrap_or_default();
+        let checkpoint_fragments = self
+            .checkpoint_chain
+            .as_ref()
+            .map(|chain| chain.collect_fragments())
+            .unwrap_or_default();
+        let mut roots = self.resolve_roots();
+        roots.extend(checkpoint_fragments.iter().cloned());
+        let view = resolve(roots);
         let mut ad_ctx = ShapeGuardContext::default();
         let linear = differentiate(
             &view,
@@ -476,7 +488,7 @@ impl TracedTensor {
             std::slice::from_ref(&wrt_input_key),
             next_pass_id(),
             &mut ad_ctx,
-            &HashMap::new(),
+            &aliases,
         );
         let linear_tangent_input_ids: Vec<LocalValId> = linear
             .tangent_inputs
@@ -490,6 +502,9 @@ impl TracedTensor {
             linear_input_key(&transposed.fragment, transposed.tangent_inputs[0].1);
 
         let mut inputs_map = (*self.inputs_map).clone();
+        if let Some(chain) = &self.checkpoint_chain {
+            inputs_map.extend(chain.collect_inputs());
+        }
         inputs_map.insert(
             cotangent_input_key.clone(),
             cotangent
@@ -513,6 +528,7 @@ impl TracedTensor {
         }
 
         let mut extra_roots = vec![self.fragment.clone(), linear_fragment];
+        extra_roots.extend(checkpoint_fragments);
         extra_roots.extend(self.extra_roots.iter().cloned());
 
         Some(TracedTensor {

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -897,6 +897,7 @@ fn grad_from_fragment_with_inputs_and_cotangent(
         std::slice::from_ref(&input_key),
         0,
         &mut ad_ctx,
+        &HashMap::new(),
     );
     let transposed = transpose(&linear, &mut ad_ctx);
     let linear_fragment = Arc::new(linear.fragment);
@@ -963,6 +964,7 @@ fn jvp_from_fragment_with_inputs(
         std::slice::from_ref(&input_key),
         0,
         &mut ad_ctx,
+        &HashMap::new(),
     );
     let tangent_key = linear.tangent_outputs[0]
         .map(|id| linear.fragment.vals()[id].key.clone())

--- a/tenferro/tests/checkpoint.rs
+++ b/tenferro/tests/checkpoint.rs
@@ -14,6 +14,12 @@ fn get_f64_scalar(tensor: &Tensor) -> f64 {
     }
 }
 
+fn eval_tensor(traced: TracedTensor) -> Tensor {
+    let mut engine = Engine::new(CpuBackend::new());
+    let mut traced = traced;
+    traced.eval(&mut engine).unwrap().clone()
+}
+
 #[test]
 fn checkpoint_preserves_eval_value() {
     let mut engine = Engine::new(CpuBackend::new());
@@ -56,4 +62,72 @@ fn checkpoint_grad_correct() {
 
     let fd = (((x_value + FD_H).powi(4)) - ((x_value - FD_H).powi(4))) / (2.0 * FD_H);
     assert!((grad_value - fd).abs() < TOL, "grad={grad_value}, fd={fd}");
+}
+
+#[test]
+fn checkpoint_hvp_correct() {
+    let x_value = 2.0_f64;
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let x = TracedTensor::from_tensor(f64_scalar(x_value));
+    let mut y = &x * &x;
+    y.checkpoint(&mut engine).unwrap();
+    let z = &y * &y;
+
+    let grad = z.grad(&x).unwrap();
+    let v = TracedTensor::from_tensor(f64_scalar(1.0));
+    let hv = grad.jvp(&x, &v);
+    let hv_value = get_f64_scalar(&eval_tensor(hv));
+    let expected = 12.0 * x_value * x_value;
+    assert!(
+        (hv_value - expected).abs() < TOL,
+        "HVP: actual={hv_value}, expected={expected}"
+    );
+
+    let fd_grad = |value: f64| {
+        let x = TracedTensor::from_tensor(f64_scalar(value));
+        let mut y = &x * &x;
+        y.checkpoint(&mut Engine::new(CpuBackend::new())).unwrap();
+        let z = &y * &y;
+        let grad = z.grad(&x).unwrap();
+        get_f64_scalar(&eval_tensor(grad))
+    };
+    let fd_hv = (fd_grad(x_value + FD_H) - fd_grad(x_value - FD_H)) / (2.0 * FD_H);
+    assert!(
+        (hv_value - fd_hv).abs() < TOL,
+        "HVP: ad={hv_value}, fd={fd_hv}"
+    );
+}
+
+#[test]
+fn checkpoint_loop_grad_correct() {
+    let a_value = 0.8_f64;
+    let x0_value = 0.5_f64;
+    let steps = 3;
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let a = TracedTensor::from_tensor(f64_scalar(a_value));
+    let mut x = TracedTensor::from_tensor(f64_scalar(x0_value));
+
+    for _ in 0..steps {
+        x = &a * &x.cos();
+        x.checkpoint(&mut engine).unwrap();
+    }
+
+    let grad = x.grad(&a).unwrap();
+    let mut grad = grad;
+    let grad_value = get_f64_scalar(grad.eval(&mut engine).unwrap());
+
+    let f_concrete = |a_value: f64| {
+        let mut x = x0_value;
+        for _ in 0..steps {
+            x = a_value * x.cos();
+        }
+        x
+    };
+    let fd = (f_concrete(a_value + FD_H) - f_concrete(a_value - FD_H)) / (2.0 * FD_H);
+    assert!(
+        (grad_value - fd).abs() < TOL,
+        "loop grad: actual={grad_value}, fd={fd}"
+    );
 }

--- a/tenferro/tests/checkpoint.rs
+++ b/tenferro/tests/checkpoint.rs
@@ -1,0 +1,38 @@
+use tenferro::{CpuBackend, Engine, Tensor, TracedTensor, TypedTensor};
+
+fn f64_scalar(value: f64) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(vec![], vec![value]))
+}
+
+fn get_f64_scalar(tensor: &Tensor) -> f64 {
+    match tensor {
+        Tensor::F64(inner) => inner.host_data()[0],
+        other => panic!("expected F64 tensor, got {:?}", other.dtype()),
+    }
+}
+
+#[test]
+fn checkpoint_preserves_eval_value() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_scalar(3.0));
+    let mut y = &x * &x;
+
+    y.checkpoint(&mut engine).unwrap();
+
+    let value = get_f64_scalar(y.data.as_ref().expect("checkpoint should retain data"));
+    assert!((value - 9.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn checkpoint_downstream_eval_uses_leaf() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_scalar(3.0));
+    let mut y = &x * &x;
+
+    y.checkpoint(&mut engine).unwrap();
+
+    let one = TracedTensor::from_tensor(f64_scalar(1.0));
+    let mut z = &y + &one;
+    let value = get_f64_scalar(z.eval(&mut engine).unwrap());
+    assert!((value - 10.0).abs() < 1.0e-12);
+}

--- a/tenferro/tests/checkpoint.rs
+++ b/tenferro/tests/checkpoint.rs
@@ -1,5 +1,8 @@
 use tenferro::{CpuBackend, Engine, Tensor, TracedTensor, TypedTensor};
 
+const TOL: f64 = 1.0e-6;
+const FD_H: f64 = 1.0e-6;
+
 fn f64_scalar(value: f64) -> Tensor {
     Tensor::F64(TypedTensor::from_vec(vec![], vec![value]))
 }
@@ -35,4 +38,22 @@ fn checkpoint_downstream_eval_uses_leaf() {
     let mut z = &y + &one;
     let value = get_f64_scalar(z.eval(&mut engine).unwrap());
     assert!((value - 10.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn checkpoint_grad_correct() {
+    let x_value = 2.0_f64;
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let x = TracedTensor::from_tensor(f64_scalar(x_value));
+    let mut y = &x * &x;
+    y.checkpoint(&mut engine).unwrap();
+
+    let z = &y * &y;
+    let grad = z.grad(&x).unwrap();
+    let mut grad = grad;
+    let grad_value = get_f64_scalar(grad.eval(&mut engine).unwrap());
+
+    let fd = (((x_value + FD_H).powi(4)) - ((x_value - FD_H).powi(4))) / (2.0 * FD_H);
+    assert!((grad_value - fd).abs() < TOL, "grad={grad_value}, fd={fd}");
 }

--- a/tenferro/tests/checkpoint_truncate_integration.rs
+++ b/tenferro/tests/checkpoint_truncate_integration.rs
@@ -1,0 +1,56 @@
+use tenferro::{CpuBackend, Engine, Tensor, TracedTensor, TypedTensor};
+
+const TOL: f64 = 1.0e-4;
+const FD_H: f64 = 1.0e-5;
+
+fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(shape, data))
+}
+
+fn f64_scalar(value: f64) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(vec![], vec![value]))
+}
+
+fn get_f64_scalar(tensor: &Tensor) -> f64 {
+    match tensor {
+        Tensor::F64(inner) => inner.host_data()[0],
+        other => panic!("expected F64 tensor, got {:?}", other.dtype()),
+    }
+}
+
+#[test]
+fn checkpoint_truncate_loop_grad() {
+    let steps = 3;
+    let a_value = 0.5_f64;
+    let x0_data = vec![1.0, 2.0, 3.0];
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let a = TracedTensor::from_tensor(f64_scalar(a_value));
+    let size = TracedTensor::from_tensor(f64_scalar(2.0));
+    let mut x = TracedTensor::from_tensor(f64_tensor(vec![3], x0_data.clone()));
+
+    for _ in 0..steps {
+        x = &a * &x;
+        x = x.dynamic_truncate(&size, 0);
+        x.checkpoint(&mut engine).unwrap();
+    }
+
+    let loss = x.reduce_sum(&[0]);
+    let mut grad = loss.grad(&a).unwrap();
+    let grad_value = get_f64_scalar(grad.eval(&mut engine).unwrap());
+
+    let f_concrete = |a_value: f64| {
+        let mut x = x0_data.clone();
+        for _ in 0..steps {
+            x = x.into_iter().map(|value| a_value * value).collect();
+            x.truncate(2);
+        }
+        x.into_iter().sum::<f64>()
+    };
+    let fd = (f_concrete(a_value + FD_H) - f_concrete(a_value - FD_H)) / (2.0 * FD_H);
+
+    assert!(
+        (grad_value - fd).abs() < TOL,
+        "integration: grad={grad_value}, fd={fd}"
+    );
+}

--- a/tenferro/tests/dynamic_truncate.rs
+++ b/tenferro/tests/dynamic_truncate.rs
@@ -236,9 +236,6 @@ fn pad_to_match_hvp_correct() {
     let hv_data = get_f64_data(hv.eval(&mut engine).unwrap());
 
     for (i, val) in hv_data.iter().enumerate() {
-        assert!(
-            (*val - 2.0).abs() < TOL,
-            "HVP[{i}]={val}, expected=2.0"
-        );
+        assert!((*val - 2.0).abs() < TOL, "HVP[{i}]={val}, expected=2.0");
     }
 }

--- a/tenferro/tests/dynamic_truncate.rs
+++ b/tenferro/tests/dynamic_truncate.rs
@@ -1,0 +1,183 @@
+use tenferro::{CpuBackend, Engine, Tensor, TracedTensor, TypedTensor};
+
+const TOL: f64 = 1.0e-5;
+const FD_H: f64 = 1.0e-5;
+
+fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(shape, data))
+}
+
+fn f64_scalar(value: f64) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(vec![], vec![value]))
+}
+
+fn get_f64_data(tensor: &Tensor) -> Vec<f64> {
+    match tensor {
+        Tensor::F64(inner) => inner.host_data().to_vec(),
+        other => panic!("expected F64 tensor, got {:?}", other.dtype()),
+    }
+}
+
+#[test]
+fn dynamic_truncate_basic() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![5], vec![1.0, 2.0, 3.0, 4.0, 5.0]));
+    let size = TracedTensor::from_tensor(f64_scalar(3.0));
+
+    let mut result = x.dynamic_truncate(&size, 0);
+    let data = get_f64_data(result.eval(&mut engine).unwrap());
+    assert_eq!(data, vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn dynamic_truncate_2d_axis1() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(
+        vec![2, 4],
+        vec![1.0, 5.0, 2.0, 6.0, 3.0, 7.0, 4.0, 8.0],
+    ));
+    let size = TracedTensor::from_tensor(f64_scalar(2.0));
+
+    let mut result = x.dynamic_truncate(&size, 1);
+    let out = result.eval(&mut engine).unwrap();
+    assert_eq!(out.shape(), &[2, 2]);
+    assert_eq!(get_f64_data(out), vec![1.0, 5.0, 2.0, 6.0]);
+}
+
+#[test]
+fn dynamic_truncate_clamps_oversize() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
+    let size = TracedTensor::from_tensor(f64_scalar(10.0));
+
+    let mut result = x.dynamic_truncate(&size, 0);
+    let data = get_f64_data(result.eval(&mut engine).unwrap());
+    assert_eq!(data, vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn pad_to_match_basic() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
+    let reference = TracedTensor::from_tensor(f64_tensor(vec![5], vec![0.0; 5]));
+
+    let mut result = x.pad_to_match(&reference, 0);
+    let data = get_f64_data(result.eval(&mut engine).unwrap());
+    assert_eq!(data, vec![1.0, 2.0, 3.0, 0.0, 0.0]);
+}
+
+#[test]
+fn pad_to_match_no_op_when_same_size() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]));
+    let reference = TracedTensor::from_tensor(f64_tensor(vec![4], vec![0.0; 4]));
+
+    let mut result = x.pad_to_match(&reference, 0);
+    let data = get_f64_data(result.eval(&mut engine).unwrap());
+    assert_eq!(data, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn dynamic_truncate_vjp_correct() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![5], vec![1.0, 2.0, 3.0, 4.0, 5.0]));
+    let size = TracedTensor::from_tensor(f64_scalar(3.0));
+
+    let truncated = x.dynamic_truncate(&size, 0);
+    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+
+    let mut grad = loss.grad(&x).unwrap();
+    let grad_data = get_f64_data(grad.eval(&mut engine).unwrap());
+    assert_eq!(grad_data, vec![2.0, 4.0, 6.0, 0.0, 0.0]);
+}
+
+#[test]
+fn dynamic_truncate_jvp_correct() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![5], vec![1.0, 2.0, 3.0, 4.0, 5.0]));
+    let size = TracedTensor::from_tensor(f64_scalar(3.0));
+
+    let truncated = x.dynamic_truncate(&size, 0);
+    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+
+    let v = TracedTensor::from_tensor(f64_tensor(vec![5], vec![1.0; 5]));
+    let mut jvp_result = loss.jvp(&x, &v);
+    let jvp_value = get_f64_data(jvp_result.eval(&mut engine).unwrap())[0];
+    assert!(
+        (jvp_value - 12.0).abs() < TOL,
+        "jvp={jvp_value}, expected=12.0"
+    );
+}
+
+#[test]
+fn dynamic_truncate_hvp_correct() {
+    let mut engine = Engine::new(CpuBackend::new());
+
+    let x = TracedTensor::from_tensor(f64_tensor(vec![5], vec![1.0, 2.0, 3.0, 4.0, 5.0]));
+    let size = TracedTensor::from_tensor(f64_scalar(3.0));
+    let truncated = x.dynamic_truncate(&size, 0);
+    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+
+    let grad = loss.grad(&x).unwrap();
+    let v = TracedTensor::from_tensor(f64_tensor(vec![5], vec![1.0; 5]));
+    let mut hv = grad.jvp(&x, &v);
+    let hv_data = get_f64_data(hv.eval(&mut engine).unwrap());
+
+    assert_eq!(hv_data.len(), 5);
+    for (index, value) in hv_data.iter().copied().enumerate().take(3) {
+        assert!(
+            (value - 2.0).abs() < TOL,
+            "hv[{index}]={value}, expected 2.0"
+        );
+    }
+    for (index, value) in hv_data.iter().copied().enumerate().skip(3) {
+        assert!(value.abs() < TOL, "hv[{index}]={value}, expected 0.0");
+    }
+}
+
+#[test]
+fn dynamic_truncate_hvp_finite_diff() {
+    let x_data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let v_data = vec![0.1, -0.2, 0.3, 0.4, -0.5];
+
+    let compute_grad = |values: &[f64]| {
+        let mut engine = Engine::new(CpuBackend::new());
+        let x = TracedTensor::from_tensor(f64_tensor(vec![5], values.to_vec()));
+        let size = TracedTensor::from_tensor(f64_scalar(3.0));
+        let truncated = x.dynamic_truncate(&size, 0);
+        let loss = (&truncated * &truncated).reduce_sum(&[0]);
+        let mut grad = loss.grad(&x).unwrap();
+        get_f64_data(grad.eval(&mut engine).unwrap())
+    };
+
+    let mut x_plus = x_data.clone();
+    let mut x_minus = x_data.clone();
+    for (index, direction) in v_data.iter().copied().enumerate() {
+        x_plus[index] += FD_H * direction;
+        x_minus[index] -= FD_H * direction;
+    }
+    let grad_plus = compute_grad(&x_plus);
+    let grad_minus = compute_grad(&x_minus);
+    let fd_hv: Vec<f64> = grad_plus
+        .iter()
+        .zip(&grad_minus)
+        .map(|(plus, minus)| (plus - minus) / (2.0 * FD_H))
+        .collect();
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![5], x_data));
+    let size = TracedTensor::from_tensor(f64_scalar(3.0));
+    let truncated = x.dynamic_truncate(&size, 0);
+    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+    let grad = loss.grad(&x).unwrap();
+    let v = TracedTensor::from_tensor(f64_tensor(vec![5], v_data));
+    let mut hv = grad.jvp(&x, &v);
+    let hv_data = get_f64_data(hv.eval(&mut engine).unwrap());
+
+    for (index, (actual, expected)) in hv_data.iter().zip(&fd_hv).enumerate() {
+        assert!(
+            (*actual - *expected).abs() < TOL,
+            "HVP[{index}]: ad={actual}, fd={expected}"
+        );
+    }
+}

--- a/tenferro/tests/dynamic_truncate.rs
+++ b/tenferro/tests/dynamic_truncate.rs
@@ -181,3 +181,64 @@ fn dynamic_truncate_hvp_finite_diff() {
         );
     }
 }
+
+// ═══════════════════════════════════════════
+// PadToMatch AD tests
+// ═══════════════════════════════════════════
+
+#[test]
+fn pad_to_match_vjp_correct() {
+    // f(x) = sum(pad_to_match(x, ref, axis=0)^2)
+    // x = [1,2,3], ref has size 5 → padded = [1,2,3,0,0]
+    // loss = 1+4+9 = 14, grad = [2,4,6] (truncated back from [2,4,6,0,0])
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
+    let reference = TracedTensor::from_tensor(f64_tensor(vec![5], vec![0.0; 5]));
+
+    let padded = x.pad_to_match(&reference, 0);
+    let loss = (&padded * &padded).reduce_sum(&[0]);
+
+    let mut grad = loss.grad(&x).unwrap();
+    let grad_data = get_f64_data(grad.eval(&mut engine).unwrap());
+    assert_eq!(grad_data, vec![2.0, 4.0, 6.0]);
+}
+
+#[test]
+fn pad_to_match_jvp_correct() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
+    let reference = TracedTensor::from_tensor(f64_tensor(vec![5], vec![0.0; 5]));
+
+    let padded = x.pad_to_match(&reference, 0);
+    let loss = (&padded * &padded).reduce_sum(&[0]);
+
+    let v = TracedTensor::from_tensor(f64_tensor(vec![3], vec![1.0, 1.0, 1.0]));
+    let mut jvp_result = loss.jvp(&x, &v);
+    let jvp_val = get_f64_data(jvp_result.eval(&mut engine).unwrap())[0];
+    // dot(grad, v) = 2+4+6 = 12
+    assert!((jvp_val - 12.0).abs() < TOL, "jvp={jvp_val}, expected=12");
+}
+
+#[test]
+fn pad_to_match_hvp_correct() {
+    // f(x) = sum(pad(x,ref,0)^2) → Hessian = diag(2,2,2)
+    // HVP with v=[1,1,1] → [2,2,2]
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
+    let reference = TracedTensor::from_tensor(f64_tensor(vec![5], vec![0.0; 5]));
+
+    let padded = x.pad_to_match(&reference, 0);
+    let loss = (&padded * &padded).reduce_sum(&[0]);
+
+    let grad = loss.grad(&x).unwrap();
+    let v = TracedTensor::from_tensor(f64_tensor(vec![3], vec![1.0, 1.0, 1.0]));
+    let mut hv = grad.jvp(&x, &v);
+    let hv_data = get_f64_data(hv.eval(&mut engine).unwrap());
+
+    for (i, val) in hv_data.iter().enumerate() {
+        assert!(
+            (*val - 2.0).abs() < TOL,
+            "HVP[{i}]={val}, expected=2.0"
+        );
+    }
+}

--- a/tenferro/tests/shape_of.rs
+++ b/tenferro/tests/shape_of.rs
@@ -1,0 +1,35 @@
+use tenferro::{CpuBackend, Engine, Tensor, TracedTensor, TypedTensor};
+
+fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(shape, data))
+}
+
+fn get_f64_scalar(tensor: &Tensor) -> f64 {
+    match tensor {
+        Tensor::F64(inner) => {
+            assert_eq!(inner.shape.as_slice(), &[] as &[usize]);
+            inner.host_data()[0]
+        }
+        other => panic!("expected F64 tensor, got {:?}", other.dtype()),
+    }
+}
+
+#[test]
+fn shape_of_returns_axis_size() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor(f64_tensor(vec![3, 5, 7], vec![0.0; 105]));
+    let mut s0 = x.shape_of(0);
+    let mut s1 = x.shape_of(1);
+    let mut s2 = x.shape_of(2);
+
+    assert_eq!(get_f64_scalar(s0.eval(&mut engine).unwrap()), 3.0);
+    assert_eq!(get_f64_scalar(s1.eval(&mut engine).unwrap()), 5.0);
+    assert_eq!(get_f64_scalar(s2.eval(&mut engine).unwrap()), 7.0);
+}
+
+#[test]
+fn shape_of_grad_is_zero() {
+    let x = TracedTensor::from_tensor(f64_tensor(vec![4, 3], vec![0.0; 12]));
+    let s = x.shape_of(0);
+    assert!(s.try_grad(&x).unwrap().is_none());
+}


### PR DESCRIPTION
## Summary

- Add `checkpoint()` method on `TracedTensor` for memory-efficient backward passes through iterative computations (√L memory with √L checkpoints)
- Add `DynamicTruncate { axis }` op for runtime-determined tensor slicing (enables adaptive truncated SVD without eval barriers)
- Add `PadToMatch { axis }` op (exact adjoint of DynamicTruncate)
- Add `ShapeOf { axis }` op for extracting axis dimension as scalar tensor
- Extend `tidu::differentiate()` with alias map for gradient flow through checkpoint boundaries
- Full AD rules (linearize + transpose) for all new ops
- HVP (2nd-order) verified through checkpoints and DynamicTruncate

## Design

Uses `Arc<CheckpointNode>` persistent linked list for O(1) propagation through downstream ops. Eval uses only the current leaf fragment (O(K) per step). AD reconstructs full graph from checkpoint chain when `grad()`/`vjp()` is called.

DynamicTruncate and PadToMatch form an exact adjoint pair:
- `transpose(DynamicTruncate) = PadToMatch`
- `transpose(PadToMatch) = DynamicTruncate(ct, ShapeOf(primal_input, axis))`

## Test plan

- [x] Checkpoint preserves eval value
- [x] Checkpoint downstream eval uses leaf
- [x] Checkpoint grad correct (finite-diff verified)
- [x] Checkpoint HVP correct (finite-diff verified)
- [x] Checkpoint multi-step loop grad
- [x] DynamicTruncate forward (basic, 2D, clamp)
- [x] DynamicTruncate VJP (finite-diff)
- [x] DynamicTruncate JVP (finite-diff)
- [x] DynamicTruncate HVP (finite-diff)
- [x] PadToMatch forward (basic, no-op)
- [x] ShapeOf forward + grad-is-zero
- [x] Integration: checkpoint + DynamicTruncate loop

## Dependencies

This PR includes a local `[patch]` for tidu-rs with the alias map extension. Before merge:
1. Push tidu-rs changes → PR → merge
2. Update rev pin in `Cargo.toml`
3. Remove `[patch]` section

Closes #690, closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
