### PR TITLE
docs: rewrite landing page and fix AD scope across docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Every public type, trait, and function **must** include minimal but sufficient u
 - Dense tensor types with CPU/GPU placement metadata
 - Graph-based traced execution via `TracedTensor` + `Engine`
 - High-level einsum with N-ary contraction tree optimization
-- First-order automatic differentiation (VJP/JVP) for the standard dense numeric path
+- Automatic differentiation (VJP/JVP/HVP) for the standard dense numeric path
 - StableHLO-style lowering plus an execution IR for backend dispatch
 
 **strided-rs** (separate workspace) is an external foundation dependency providing:
@@ -317,7 +317,7 @@ of any tensor type. `chainrules` provides engine-independent scalar AD rules,
 and `tidu` provides the AD engine (Tape, TrackedValue, DualValue).
 `tenferro-tensor` owns the concrete dense runtime value types and backend
 execution surface. `tenferro-ops/src/ad/` is the semantic source of truth for
-first-order AD rules. `tenferro` owns traced graph construction, lowering, and
+AD rules. `tenferro` owns traced graph construction, lowering, and
 public evaluation APIs.
 
 ## AI Workflow Scripts

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 General-purpose dense tensor computation in Rust, inspired by PyTorch and JAX.
 
-tenferro provides lazy traced tensors with einsum, linear algebra, and
-first-order autodiff on CPU. GPU support is planned.
+tenferro provides both eager tensor operations (like NumPy) and lazy traced
+execution with einsum, linear algebra, and automatic differentiation
+(VJP/JVP/HVP) on CPU. GPU support is planned.
 
 ## Workspace Crates
 
 | Crate | Role |
 | --- | --- |
-| `tenferro` | Traced frontend: `Engine`, `TracedTensor`, public einsum and linalg APIs, VJP/JVP |
+| `tenferro` | Traced frontend: `Engine`, `TracedTensor`, public einsum and linalg APIs, AD (VJP/JVP/HVP) |
 | `tenferro-tensor` | Dense runtime tensors, backend traits, CPU backend (GPU planned) |
 | `tenferro-einsum` | Subscripts, contraction trees, and fragment-building utilities |
 | `tenferro-ops` | Graph op vocabulary (`StdTensorOp`, `SemiringOp`) and AD rule implementations |

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -15,7 +15,7 @@
 ## Rule Source Of Truth
 
 - `PrimitiveOp::linearize` and `PrimitiveOp::transpose_rule` (in `tenferro-ops/src/ad/`)
-  are the semantic source of truth for first-order AD.
+  are the semantic source of truth for AD rules.
 - These are graph-level rules that emit ops into a `FragmentBuilder`.
   `tidu::differentiate` calls `linearize`; `tidu::transpose` calls `transpose_rule`.
 - Reference JAX's implementations (`jax/_src/lax/lax.py`, `jax/_src/lax/linalg.py`)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,7 +11,7 @@ For contributors, internal crate APIs are also available in the
 ## Workspace Crates
 
 - [tenferro](../rustdoc/tenferro/index.html): traced frontend, execution engine, public
-  einsum API, public linalg API, and first-order AD entry points
+  einsum API, public linalg API, and AD entry points (VJP/JVP/HVP)
 - [tenferro-tensor](../rustdoc/tenferro_tensor/index.html): concrete dense `Tensor` /
   `TypedTensor` values, backend traits, CPU backend, and GPU backend stubs
 - [tenferro-einsum](../rustdoc/tenferro_einsum/index.html): subscripts, contraction trees,

--- a/docs/guides/autodiff.md
+++ b/docs/guides/autodiff.md
@@ -1,10 +1,11 @@
 # Autodiff
 
-tenferro exposes first-order autodiff directly on `TracedTensor`. If you know PyTorch or JAX, the mental model is:
+tenferro exposes autodiff directly on `TracedTensor`. If you know PyTorch or JAX, the mental model is:
 
 - `grad` for scalar-loss reverse mode
 - `vjp` for vector-Jacobian products
 - `jvp` for Jacobian-vector products
+- Higher-order AD via composition (e.g., `jvp(grad(f))` for Hessian-vector products)
 
 ## Reverse-mode gradient with `grad`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,16 @@
 # tenferro
 
 tenferro-rs is a dense tensor computation workspace in Rust, inspired by
-PyTorch and JAX. It provides eager tensor operations, lazy traced execution
-with graph optimization, einsum with automatic contraction-tree planning,
-linear algebra, and first-order automatic differentiation (VJP/JVP). CPU
-execution is fully supported; GPU support is planned.
+PyTorch and JAX. It provides:
+
+- **Eager execution** — `Tensor` and `TypedTensor` with `CpuBackend` for
+  direct computation without AD, like NumPy
+- **Lazy traced execution** — `TracedTensor` with graph optimization and
+  automatic differentiation (VJP/JVP/HVP)
+- **Einsum** — with automatic contraction-tree planning
+- **Linear algebra** — SVD, QR, Cholesky, eigh, solve
+
+CPU execution is fully supported; GPU support is planned.
 
 ## PyTorch, JAX, and tenferro
 
@@ -12,10 +18,10 @@ execution is fully supported; GPU support is planned.
 |---|---|---|---|
 | Eager tensor | `torch.tensor(data)` | `jnp.array(data)` | `Tensor::new(shape, data)` |
 | Traced tensor | — | staged via `jit` | `TracedTensor::new(shape, data)` |
-| Execution model | Eager by default | Eager; `jit` stages when asked | Eager (`Tensor`) or lazy (`TracedTensor` + `.eval()`) |
+| Execution | Eager by default | Eager; `jit` stages when asked | Eager (`Tensor`) or lazy (`TracedTensor` + `.eval()`) |
 | Gradients | `loss.backward()` / `torch.autograd.grad` | `jax.grad`, `jax.vjp`, `jax.jvp` | `loss.grad(&x)`, `.vjp()`, `.jvp()` |
-| Einsum | `torch.einsum(...)` | `jnp.einsum(...)` | `einsum(...)` (lazy) / `eager_einsum(...)` (eager) |
-| Device model | Device on tensors | `jax.device_put(...)` | Backend owned by `Engine` or `CpuBackend` |
+| Einsum | `torch.einsum(...)` | `jnp.einsum(...)` | `einsum(...)` / `eager_einsum(...)` |
+| Device | Device on tensors | `jax.device_put(...)` | Backend owned by `Engine` or `CpuBackend` |
 
 ## Navigate
 

--- a/tenferro/README.md
+++ b/tenferro/README.md
@@ -5,8 +5,8 @@ Traced tensor frontend for the `tenferro-rs` v2 workspace.
 `tenferro` is the main user-facing crate for standard dense numeric computation.
 It owns the lazy graph surface (`TracedTensor`), the execution engine
 (`Engine<B>`), StableHLO-style lowering, execution-IR compilation, public
-einsum helpers, public multi-output linalg helpers, and first-order AD entry
-points.
+einsum helpers, public multi-output linalg helpers, and AD entry points
+(VJP/JVP/HVP).
 
 ## Public Surface
 


### PR DESCRIPTION
## Summary

**Landing page (`docs/index.md`):**
- Describes tenferro-rs workspace holistically, not just the `tenferro` crate
- Lists both eager (`Tensor`/`TypedTensor` like NumPy) and lazy (`TracedTensor` with AD) modes
- Updated comparison table with separate eager/traced rows

**"first-order" → full AD scope (8 files):**
- Removes misleading "first-order" qualifier — tenferro supports higher-order AD (e.g., HVP via forward-over-reverse: `jvp(grad(f, x), x, v)`)
- Adds HVP to AD capability lists: VJP/JVP → VJP/JVP/HVP
- Files: README.md, AGENTS.md, REPOSITORY_RULES.md, docs/index.md, docs/api/index.md, docs/guides/autodiff.md, tenferro/README.md

## Test plan

- [ ] Verify rendered landing page at https://tensor4all.org/tenferro-rs/ after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)