### PR TITLE
feat: EagerTensor Phase 1 — Result returns, file split, multi-output helpers (#706)

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -10,6 +10,7 @@
     "tenferro-einsum/src/lib.rs": 65,
     "tenferro-tensor/src/cpu/exec_session.rs": 60,
     "tenferro-tensor/src/cpu/backend.rs": 78,
-    "tenferro/src/eager_exec.rs": 35
+    "tenferro/src/eager_exec.rs": 35,
+    "tenferro/src/eager_ops.rs": 60
   }
 }

--- a/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
+++ b/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
@@ -35,39 +35,26 @@ invokes `PrimitiveOp::linearize` / `transpose_rule`. For linalg ops like SVD,
 the transpose rule consumes all primal outputs (u, s, vt) from `saved_data`
 to produce cotangents for all inputs.
 
-This means multi-output ops need **one `GradNode` per output** that share
-the same `Arc`-wrapped data but carry distinct `output_idx`:
+This means multi-output ops need **one shared `Arc<GradNode>`** referenced
+by all output `EagerTensor`s:
 
-1. All nodes list all output keys in `primal_out_keys` (not just their own).
-2. All nodes share the same `saved_data` containing all output tensors.
-3. `topo_sort_grad_dag` deduplicates by `Arc` pointer — if all output
-   `EagerTensor`s point to the same `Arc<GradNode>`, the node is visited
-   once. However, `GradNode.output_idx` is a field on the struct, so each
-   output needs its own `GradNode` instance with a unique `output_idx`.
+1. The single `GradNode` lists all output keys in `primal_out_keys`.
+2. `saved_data` contains all input and output tensors.
+3. All output `EagerTensor`s hold `Arc::clone` of the same `GradNode`.
+4. `topo_sort_grad_dag` deduplicates by `Arc` pointer → the node is
+   visited exactly once.
+5. `backward_dag` processes the node once, collecting cotangents for
+   **all** outputs from `primal_out_keys` (L84-88), running transpose
+   once, and accumulating input cotangents once. This is correct even
+   when the loss depends on multiple outputs (e.g., `loss = f(u) + g(s)`).
 
-To avoid duplicating `saved_data`, we wrap it in `Arc`:
+`GradNode.output_idx` (field on the struct, L22 in `grad_node.rs`) is
+**not consumed** by `backward_dag` or `topo_sort_grad_dag`. It is set
+to 0 for the shared node. Each `EagerTensor` tracks its own output
+position via the index in the `Vec` returned by `multi_output_unary_op`.
 
-```rust
-pub struct GradNode<Op: GraphOp> {
-    pub op: Op,
-    pub primal_in_keys: Vec<GlobalValKey<Op>>,
-    pub primal_out_keys: Vec<GlobalValKey<Op>>,
-    pub saved_data: Arc<HashMap<GlobalValKey<Op>, Arc<Op::Operand>>>,  // shared
-    pub input_edges: Vec<GradEdge<Op>>,
-    pub output_idx: usize,  // unique per output
-}
-```
-
-This requires a change in `tidu::GradNode` to wrap `saved_data` in `Arc`.
-The change is backward-compatible: single-output ops create `Arc::new(map)`
-as before; multi-output ops clone the `Arc` for each output node.
-
-With separate `GradNode` instances per output, `topo_sort_grad_dag` may
-visit the SVD node up to 3 times (once per output). `backward_dag` will
-then process it multiple times, but only the first visit produces
-cotangent inputs (subsequent visits find cotangents already consumed).
-This is acceptable for correctness; an optimization to deduplicate can
-be added later if needed.
+**No changes to `tidu` are required.** The existing `GradNode` struct
+and `backward_dag` already support this pattern.
 
 Each output `EagerTensor` holds `Arc<GradNode>` pointing to the same node,
 plus its own `output_idx` to identify which output it represents. When
@@ -112,15 +99,18 @@ fn saved_forward_values_multi(
 ```
 exec_op_on_tensors(&op, &[input], backend) -> Vec<Tensor>  // e.g. [u, s, vt]
                          |
-      build Arc<saved_data> shared across all outputs:
-        saved_data = {input_keys..., derived(slot=0)->u, derived(slot=1)->s, derived(slot=2)->vt}
+      build ONE shared GradNode:
+        op              = Svd { eps, input_shape, input_dtype }
+        primal_in_keys  = [key_input]
+        primal_out_keys = [key_u, key_s, key_vt]
+        saved_data      = {key_input->input, derived(slot=0)->u, derived(slot=1)->s, derived(slot=2)->vt}
+        input_edges     = [edge_input]
+        output_idx      = 0  (unused by backward_dag)
                          |
-      build one GradNode per output:
-        node_u:  { op, primal_out_keys=[key_u,key_s,key_vt], saved_data=Arc::clone, output_idx=0 }
-        node_s:  { op, primal_out_keys=[key_u,key_s,key_vt], saved_data=Arc::clone, output_idx=1 }
-        node_vt: { op, primal_out_keys=[key_u,key_s,key_vt], saved_data=Arc::clone, output_idx=2 }
+      wrap in Arc<GradNode>
                          |
-      return Vec<EagerTensor> where each holds its own Arc<GradNode>
+      return Vec<EagerTensor> where ALL hold Arc::clone of the SAME GradNode
+      (each EagerTensor knows its output position from its Vec index)
 ```
 
 - When `!requires_grad`, `grad_node` is `None` for all outputs (zero overhead).
@@ -482,8 +472,7 @@ Tests:
 **Phase 1 (foundation):**
 - Change existing methods to `Result`
 - Split `eager.rs` → `eager.rs` + `eager_ops.rs`
-- Change `tidu::GradNode.saved_data` to `Arc<HashMap<...>>` for multi-output sharing
-- Add `multi_output_unary_op` (with `saved_forward_values_multi`), `ternary_op`, `nary_op` internal helpers
+- Add `multi_output_unary_op` (with `saved_forward_values_multi`, shared `Arc<GradNode>`), `ternary_op`, `nary_op` internal helpers
 - Make `EagerContext` public, add `with_backend` / `from_tensor_in` / `requires_grad_in`
 
 **Phase 2 (ops — parallelizable):**

--- a/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
+++ b/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
@@ -35,10 +35,39 @@ invokes `PrimitiveOp::linearize` / `transpose_rule`. For linalg ops like SVD,
 the transpose rule consumes all primal outputs (u, s, vt) from `saved_data`
 to produce cotangents for all inputs.
 
-This means multi-output ops need **one shared `GradNode`** that:
-1. Lists all output keys in `primal_out_keys` (not just one).
-2. Saves all output tensors in `saved_data` (one per `output_slot`).
-3. Is referenced by all output `EagerTensor`s (via `Arc`).
+This means multi-output ops need **one `GradNode` per output** that share
+the same `Arc`-wrapped data but carry distinct `output_idx`:
+
+1. All nodes list all output keys in `primal_out_keys` (not just their own).
+2. All nodes share the same `saved_data` containing all output tensors.
+3. `topo_sort_grad_dag` deduplicates by `Arc` pointer — if all output
+   `EagerTensor`s point to the same `Arc<GradNode>`, the node is visited
+   once. However, `GradNode.output_idx` is a field on the struct, so each
+   output needs its own `GradNode` instance with a unique `output_idx`.
+
+To avoid duplicating `saved_data`, we wrap it in `Arc`:
+
+```rust
+pub struct GradNode<Op: GraphOp> {
+    pub op: Op,
+    pub primal_in_keys: Vec<GlobalValKey<Op>>,
+    pub primal_out_keys: Vec<GlobalValKey<Op>>,
+    pub saved_data: Arc<HashMap<GlobalValKey<Op>, Arc<Op::Operand>>>,  // shared
+    pub input_edges: Vec<GradEdge<Op>>,
+    pub output_idx: usize,  // unique per output
+}
+```
+
+This requires a change in `tidu::GradNode` to wrap `saved_data` in `Arc`.
+The change is backward-compatible: single-output ops create `Arc::new(map)`
+as before; multi-output ops clone the `Arc` for each output node.
+
+With separate `GradNode` instances per output, `topo_sort_grad_dag` may
+visit the SVD node up to 3 times (once per output). `backward_dag` will
+then process it multiple times, but only the first visit produces
+cotangent inputs (subsequent visits find cotangents already consumed).
+This is acceptable for correctness; an optimization to deduplicate can
+be added later if needed.
 
 Each output `EagerTensor` holds `Arc<GradNode>` pointing to the same node,
 plus its own `output_idx` to identify which output it represents. When
@@ -83,20 +112,16 @@ fn saved_forward_values_multi(
 ```
 exec_op_on_tensors(&op, &[input], backend) -> Vec<Tensor>  // e.g. [u, s, vt]
                          |
-      build one shared GradNode with:
-        primal_out_keys = [key_u, key_s, key_vt]
-        saved_data      = {input_keys... , derived(slot=0) -> u, derived(slot=1) -> s, derived(slot=2) -> vt}
-        output_idx      = 0  (the node itself; each EagerTensor stores its own output_idx)
+      build Arc<saved_data> shared across all outputs:
+        saved_data = {input_keys..., derived(slot=0)->u, derived(slot=1)->s, derived(slot=2)->vt}
                          |
-      return Vec<EagerTensor> where each holds Arc::clone of the same GradNode
+      build one GradNode per output:
+        node_u:  { op, primal_out_keys=[key_u,key_s,key_vt], saved_data=Arc::clone, output_idx=0 }
+        node_s:  { op, primal_out_keys=[key_u,key_s,key_vt], saved_data=Arc::clone, output_idx=1 }
+        node_vt: { op, primal_out_keys=[key_u,key_s,key_vt], saved_data=Arc::clone, output_idx=2 }
+                         |
+      return Vec<EagerTensor> where each holds its own Arc<GradNode>
 ```
-
-Note: `GradNode.output_idx` is stored on the `EagerTensor`, not on the
-`GradNode` itself. The shared `GradNode` is traversed once during
-`topo_sort_grad_dag` (deduplicated by `Arc` pointer). Each `EagerTensor`
-knows its own `output_idx` for use by callers that need to identify which
-output they hold, but `backward_dag` does not use `output_idx` — it uses
-`primal_out_keys` to collect cotangents for all outputs.
 
 - When `!requires_grad`, `grad_node` is `None` for all outputs (zero overhead).
 
@@ -200,6 +225,14 @@ All follow the existing `unary_op` pattern. Each method constructs a
 
 `concatenate` is a static method taking `&[&Self]` since it has N inputs.
 Context merging follows the same pattern as `binary_op` extended to N inputs.
+
+Note: `StdTensorOp::Concatenate` currently lacks arity metadata, and
+`n_inputs()` / `n_outputs()` are `todo!()` in `std_tensor_op.rs`. As a
+prerequisite, add `n_inputs: usize` to `StdTensorOp::Concatenate` (or
+implement `n_inputs()` to return `None` and handle variable arity in the
+eager path). For the eager `nary_op` helper, the input count is known at
+call time from the slice length, so the `todo!()` does not block eager
+execution — it only matters for traced graph validation.
 
 ## Elementwise Ops
 
@@ -348,19 +381,45 @@ to know the input dtype and insert Convert ops when needed.
 
 **3. AD rules (`tenferro-ops/src/ad/linalg.rs`):**
 In `linearize_svd` and `linearize_eigh`, when `input_dtype` is complex:
-- Before operations that mix `s`/`w` (real) with complex matrices (U, Vt, V),
-  insert `StdTensorOp::Convert { to: input_dtype, from: real_dtype }` to
-  promote the real `s`/`w` to complex.
-- This follows the existing pattern in `linearize_eig` (lines 143-159 in
-  `linalg.rs`), which already inserts `Convert` ops for real→complex promotion.
+
+*Forward (linearize):*
+- At entry: Convert real primal `s`/`w` → complex before mixed-dtype
+  operations with complex U, Vt, V. Use `StdTensorOp::Convert { to:
+  input_dtype, from: real_dtype }`.
+- At exit: The tangent outputs `ds`/`dw` are complex (result of complex
+  arithmetic). Convert complex `ds`/`dw` → real at the output boundary
+  using `StdTensorOp::Convert { to: real_dtype, from: input_dtype }`,
+  since `s`/`w` are real-valued and their tangents must match.
+
+*Reverse (transpose):*
+- The cotangent seed for `s`/`w` arrives as real (matching the primal's
+  real dtype). The transpose rule must Convert it to complex before use
+  in internal complex arithmetic, then Convert the final cotangent for
+  the input `a` stays complex (matching `a`'s dtype).
+
+This follows the existing pattern in `linearize_eig` (lines 143-159 in
+`linalg.rs`), which already inserts `Convert` ops for dtype promotion.
 
 **4. Traced API (`tenferro/src/linalg_api.rs`):**
-`svd()` / `eigh()` construct `StdTensorOp::Svd` / `Eigh` — pass
-`input_dtype` from the traced tensor's metadata. Currently `TracedTensor`
-does not carry dtype, so `input_dtype` must be inferred from the primal
-tensor at graph construction time. This may require adding dtype to the
-`StdTensorOp` construction site, or deferring dtype resolution to
-compilation time via a `DType::Inferred` variant.
+`TracedTensor` already carries a `dtype: DType` field (`traced.rs:50`).
+`svd()` / `eigh()` pass `input_dtype: a.dtype` when constructing the op,
+following the existing pattern in `eig()` (`linalg_api.rs:251-252`).
+
+After `apply_multi_output`, output dtypes must be patched per-output.
+`apply_multi_output` currently stamps all outputs with the input dtype
+(`traced.rs:1324`). For complex SVD, the `s` output must have its dtype
+patched to the real counterpart:
+
+```rust
+// In svd() after apply_multi_output:
+let real_dtype = real_dtype_of(a.dtype); // C64→F64, C32→F32, Fxx→Fxx
+u.dtype = a.dtype;      // complex
+s.dtype = real_dtype;    // real
+vt.dtype = a.dtype;      // complex
+```
+
+This follows the existing pattern in `eig()` (`linalg_api.rs:261-262`)
+which manually patches output dtypes.
 
 **5. Eager path:**
 `EagerTensor` has the concrete `Tensor`, so `input_dtype` is known at
@@ -423,6 +482,7 @@ Tests:
 **Phase 1 (foundation):**
 - Change existing methods to `Result`
 - Split `eager.rs` → `eager.rs` + `eager_ops.rs`
+- Change `tidu::GradNode.saved_data` to `Arc<HashMap<...>>` for multi-output sharing
 - Add `multi_output_unary_op` (with `saved_forward_values_multi`), `ternary_op`, `nary_op` internal helpers
 - Make `EagerContext` public, add `with_backend` / `from_tensor_in` / `requires_grad_in`
 

--- a/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
+++ b/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
@@ -91,6 +91,13 @@ exec_op_on_tensors(&op, &[input], backend) -> Vec<Tensor>  // e.g. [u, s, vt]
       return Vec<EagerTensor> where each holds Arc::clone of the same GradNode
 ```
 
+Note: `GradNode.output_idx` is stored on the `EagerTensor`, not on the
+`GradNode` itself. The shared `GradNode` is traversed once during
+`topo_sort_grad_dag` (deduplicated by `Arc` pointer). Each `EagerTensor`
+knows its own `output_idx` for use by callers that need to identify which
+output they hold, but `backward_dag` does not use `output_idx` — it uses
+`primal_out_keys` to collect cotangents for all outputs.
+
 - When `!requires_grad`, `grad_node` is `None` for all outputs (zero overhead).
 
 Public linalg methods wrap this:
@@ -321,11 +328,43 @@ complex wrapper in faer_linalg is an unnecessary dtype promotion.
 tensor. E.g., for `Complex64` singular values, take `re` of each element
 and build a `TypedTensor<f64>`.
 
-**Decision: Option (A).** Change the faer backend so that SVD/eigh return
-real-dtype tensors for singular values / eigenvalues even when the input is
-complex. This aligns with NumPy/JAX/PyTorch behavior (e.g.,
-`np.linalg.svd(complex_matrix)` returns real singular values). The change
-is localized to `faer_linalg.rs` and `cpu/backend.rs`.
+**Decision: Change the full stack** so that SVD/eigh return real-dtype
+tensors for singular values / eigenvalues, matching NumPy/JAX/PyTorch
+behavior. This requires coordinated changes across backend, op definition,
+and AD rules.
+
+### Required changes for real-valued SVD s / Eigh w
+
+**1. Backend (`tenferro-tensor/src/cpu/linalg/faer_linalg.rs`, `cpu/backend.rs`):**
+Remove the complex wrapper around real singular values / eigenvalues. For
+complex SVD, return `[Tensor::C64(u), Tensor::F64(s), Tensor::C64(vt)]`
+instead of `[Tensor::C64(u), Tensor::C64(s_complex), Tensor::C64(vt)]`.
+Same for Eigh.
+
+**2. Op definition (`tenferro-ops/src/std_tensor_op.rs`):**
+Add `input_dtype: DType` to `StdTensorOp::Svd` and `StdTensorOp::Eigh`,
+following the existing pattern in `StdTensorOp::Eig`. This allows AD rules
+to know the input dtype and insert Convert ops when needed.
+
+**3. AD rules (`tenferro-ops/src/ad/linalg.rs`):**
+In `linearize_svd` and `linearize_eigh`, when `input_dtype` is complex:
+- Before operations that mix `s`/`w` (real) with complex matrices (U, Vt, V),
+  insert `StdTensorOp::Convert { to: input_dtype, from: real_dtype }` to
+  promote the real `s`/`w` to complex.
+- This follows the existing pattern in `linearize_eig` (lines 143-159 in
+  `linalg.rs`), which already inserts `Convert` ops for real→complex promotion.
+
+**4. Traced API (`tenferro/src/linalg_api.rs`):**
+`svd()` / `eigh()` construct `StdTensorOp::Svd` / `Eigh` — pass
+`input_dtype` from the traced tensor's metadata. Currently `TracedTensor`
+does not carry dtype, so `input_dtype` must be inferred from the primal
+tensor at graph construction time. This may require adding dtype to the
+`StdTensorOp` construction site, or deferring dtype resolution to
+compilation time via a `DType::Inferred` variant.
+
+**5. Eager path:**
+`EagerTensor` has the concrete `Tensor`, so `input_dtype` is known at
+construction: `self.data.dtype()`.
 
 ### Method signatures and crate placement
 
@@ -368,7 +407,7 @@ Split `eager.rs` (currently 631 lines) to keep files focused:
 | `eager.rs` | `EagerTensor` struct, `EagerContext` (pub), `new_leaf`, `new_result`, `backward()`, `detach()`, `data()`, `grad()`, internal helpers (`saved_forward_values`, `derived_output_key`, etc.) |
 | `eager_ops.rs` | All op methods: `unary_op`, `binary_op`, `ternary_op`, `multi_output_unary_op`, `nary_op`, and every public method (`add`, `mul`, ..., `svd`, `transpose`, etc.) |
 | `eager_einsum.rs` | `eager_einsum_ad` free function |
-| `eager_exec.rs` | Unchanged — `exec_op_on_tensors` |
+| `eager_exec.rs` | `exec_op_on_tensors` — add `NaryEinsum` branch (delegate to `eager_einsum`) |
 | `eager_emitter.rs` | Unchanged — `EagerEmitter` |
 
 Tests:
@@ -401,8 +440,11 @@ Tests:
 - Implement `NaryEinsum` branch in `eager_exec.rs` (delegate to `eager_einsum`)
 - `eager_einsum_ad` free function (stores `NaryEinsum` in `GradNode`)
 
-**Phase 5 (TypedTensor):**
-- Add `TensorScalar::Real` associated type + `try_into_typed` method
+**Phase 5 (real-dtype SVD/eigh + TypedTensor):**
+- Add `input_dtype: DType` to `StdTensorOp::Svd` and `StdTensorOp::Eigh`
 - Change faer backend to return real dtype for SVD/eigh singular values / eigenvalues
+- Update `linearize_svd` / `linearize_eigh` AD rules to insert `Convert` ops for real→complex promotion
+- Update `svd()` / `eigh()` in traced API (`linalg_api.rs`) and eager API to pass `input_dtype`
+- Add `TensorScalar::Real` associated type + `try_into_typed` method
 - Linalg convenience methods on `TypedTensor<T>` (in `tenferro-tensor`)
 - `typed_eager_einsum` free function (in `tenferro-einsum`)

--- a/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
+++ b/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
@@ -1,0 +1,232 @@
+# EagerTensor API Extensions for tensor4all-rs Migration
+
+**Issue:** #706
+
+**Goal:** Extend `EagerTensor` from 6 ops to full coverage of `StdTensorOp`,
+enabling tensor4all-rs to adopt it as the core tensor type. Also add
+`TypedTensor<T>` convenience methods.
+
+## Error Handling Convention
+
+All `EagerTensor` methods return `Result`. Operator overloads (`+`, `*`,
+unary `-`) unwrap internally and panic on error, matching PyTorch ergonomics.
+
+Existing methods (`add`, `mul`, `neg`, `exp`, `reduce_sum`, `dot_general`)
+change from `-> Self` to `-> Result<Self>`. This is a breaking change;
+existing tests and callers update to `.unwrap()`.
+
+## Multi-Output Op Pattern
+
+A new internal helper sits alongside `unary_op` and `binary_op`:
+
+```rust
+fn multi_output_unary_op(
+    &self,
+    op: StdTensorOp,
+    num_outputs: usize,
+) -> Result<Vec<Self>>
+```
+
+Behavior:
+- Calls `exec_op_on_tensors` which already returns `Vec<Tensor>`.
+- Assigns a unique `GlobalValKey` to each output.
+- When `requires_grad`, builds one `GradNode` per output, sharing the same
+  `op` / `primal_in_keys` / `saved_data` / `input_edges` but with distinct
+  `output_idx` (0, 1, 2, ...).
+- When `!requires_grad`, `grad_node` is `None` for all outputs (zero overhead).
+
+Public linalg methods wrap this:
+
+| Method | Returns | num_outputs |
+|--------|---------|-------------|
+| `svd()` | `Result<(Self, Self, Self)>` | 3 |
+| `qr()` | `Result<(Self, Self)>` | 2 |
+| `lu()` | `Result<(Self, Self, Self, Self)>` | 4 |
+| `eigh()` | `Result<(Self, Self)>` | 2 |
+| `eig()` | `Result<(Self, Self)>` | 2 |
+
+Single-output linalg (`cholesky`, `triangular_solve`) uses `unary_op` or
+`binary_op`.
+
+## EagerContext Public API
+
+`EagerContext<B>` becomes `pub struct`. New constructors:
+
+```rust
+impl<B: TensorBackend> EagerContext<B> {
+    pub fn with_backend(backend: B) -> Rc<Self>;
+}
+
+impl<B: TensorBackend> EagerTensor<B> {
+    pub fn from_tensor_in(tensor: Tensor, ctx: Rc<EagerContext<B>>) -> Self;
+    pub fn requires_grad_in(tensor: Tensor, ctx: Rc<EagerContext<B>>) -> Self;
+}
+```
+
+`with_backend` creates an `Rc<EagerContext<B>>`. The `_in` suffixed
+constructors take a shared context, avoiding repeated `absorb_from()` calls
+when creating many tensors in the same computation.
+
+Existing `from_tensor` and `requires_grad` (CpuBackend-only convenience)
+remain unchanged.
+
+## Einsum on EagerTensor
+
+New free function:
+
+```rust
+pub fn eager_einsum_ad<B: TensorBackend>(
+    inputs: &[&EagerTensor<B>],
+    subscripts: &str,
+) -> Result<EagerTensor<B>>
+```
+
+- Extracts `&Tensor` from each input.
+- Calls `tenferro_einsum::eager_einsum(ctx, tensors, subscripts)`.
+- Merges `EagerContext`s across all inputs (same `absorb_from` pattern as
+  `binary_op`).
+- Builds a `GradNode` with N input edges if any input has `requires_grad`.
+- The op stored in `GradNode` is `StdTensorOp::DotGeneral` for 2-input
+  contractions, or a sequence of `DotGeneral` ops following the contraction
+  tree for N-ary. The exact op depends on what `eager_einsum` lowers to
+  internally — we record the ops as the contraction tree executes them.
+
+**Alternative (simpler):** If recording the full contraction tree's ops is
+complex, an initial version can require that callers decompose N-ary einsum
+into pairwise `dot_general` calls themselves. The AD would then flow through
+the existing `binary_op` path. This defers the `eager_einsum_ad` wrapper to
+a follow-up.
+
+## Structural Ops
+
+All follow the existing `unary_op` pattern. Each method constructs a
+`StdTensorOp` variant and delegates:
+
+| Method | Signature | StdTensorOp |
+|--------|-----------|-------------|
+| `transpose` | `(&self, perm: &[usize]) -> Result<Self>` | `Transpose` |
+| `reshape` | `(&self, shape: &[usize]) -> Result<Self>` | `Reshape` |
+| `slice` | `(&self, config: SliceConfig) -> Result<Self>` | `Slice` |
+| `concatenate` | `(tensors: &[&Self], axis: usize) -> Result<Self>` | `Concatenate` |
+| `broadcast_in_dim` | `(&self, shape: &[usize], dims: &[usize]) -> Result<Self>` | `BroadcastInDim` |
+| `pad` | `(&self, config: PadConfig) -> Result<Self>` | `Pad` |
+| `reverse` | `(&self, axes: &[usize]) -> Result<Self>` | `Reverse` |
+| `gather` | `(&self, indices: &Self, config: GatherConfig) -> Result<Self>` | `Gather` |
+| `dynamic_slice` | `(&self, starts: &Self, sizes: &[usize]) -> Result<Self>` | `DynamicSlice` |
+
+`concatenate` is a static method taking `&[&Self]` since it has N inputs.
+Context merging follows the same pattern as `binary_op` extended to N inputs.
+
+## Elementwise Ops
+
+Unary ops (same pattern as `exp`):
+
+| Method | StdTensorOp |
+|--------|-------------|
+| `abs` | `Abs` |
+| `conj` | `Conj` |
+| `sign` | `Sign` |
+| `log` | `Log` |
+| `sqrt` | `Sqrt` |
+| `rsqrt` | `Rsqrt` |
+| `sin` | `Sin` |
+| `cos` | `Cos` |
+| `tanh` | `Tanh` |
+| `expm1` | `Expm1` |
+| `log1p` | `Log1p` |
+
+Binary ops (same pattern as `mul`):
+
+| Method | StdTensorOp |
+|--------|-------------|
+| `div` | `Div` |
+| `pow` | `Pow` |
+| `maximum` | `Maximum` |
+| `minimum` | `Minimum` |
+
+Ternary op:
+
+| Method | StdTensorOp |
+|--------|-------------|
+| `select` | `Select` |
+
+`select` needs a `ternary_op` internal helper (condition, on_true, on_false).
+
+## Diagonal Ops
+
+| Method | Signature | StdTensorOp |
+|--------|-----------|-------------|
+| `extract_diag` | `(&self, axis_a: usize, axis_b: usize) -> Result<Self>` | `ExtractDiag` |
+| `embed_diag` | `(&self, axis_a: usize, axis_b: usize) -> Result<Self>` | `EmbedDiag` |
+| `tril` | `(&self, k: i64) -> Result<Self>` | `Tril` |
+| `triu` | `(&self, k: i64) -> Result<Self>` | `Triu` |
+
+## Reduction Ops
+
+| Method | Signature | StdTensorOp |
+|--------|-----------|-------------|
+| `reduce_prod` | `(&self, axes: &[usize]) -> Result<Self>` | `ReduceProd` |
+| `reduce_max` | `(&self, axes: &[usize]) -> Result<Self>` | `ReduceMax` |
+| `reduce_min` | `(&self, axes: &[usize]) -> Result<Self>` | `ReduceMin` |
+
+## TypedTensor Convenience Methods (P2)
+
+Convenience methods on `TypedTensor<T>` wrapping free functions from
+`tenferro-tensor`. These take `&mut CpuBackend` and delegate to backend
+methods. No AD involvement.
+
+```rust
+impl<T: TensorScalar> TypedTensor<T> {
+    pub fn einsum(ctx: &mut CpuBackend, inputs: &[&Self], subscripts: &str) -> Result<Self>;
+    pub fn svd(&self, ctx: &mut CpuBackend) -> Result<(Self, TypedTensor<T::Real>, Self)>;
+    pub fn qr(&self, ctx: &mut CpuBackend) -> Result<(Self, Self)>;
+}
+```
+
+These live in `tenferro-tensor` since they don't depend on the traced/eager
+graph infrastructure. Exact method set TBD based on what tensor4all-rs
+actually needs — start with einsum + linalg decompositions.
+
+## File Structure
+
+Split `eager.rs` (currently 631 lines) to keep files focused:
+
+| File | Responsibility |
+|------|---------------|
+| `eager.rs` | `EagerTensor` struct, `EagerContext` (pub), `new_leaf`, `new_result`, `backward()`, `detach()`, `data()`, `grad()`, internal helpers (`saved_forward_values`, `derived_output_key`, etc.) |
+| `eager_ops.rs` | All op methods: `unary_op`, `binary_op`, `ternary_op`, `multi_output_unary_op`, `nary_op`, and every public method (`add`, `mul`, ..., `svd`, `transpose`, etc.) |
+| `eager_einsum.rs` | `eager_einsum_ad` free function |
+| `eager_exec.rs` | Unchanged — `exec_op_on_tensors` |
+| `eager_emitter.rs` | Unchanged — `EagerEmitter` |
+
+Tests:
+
+| File | Covers |
+|------|--------|
+| `tests/eager_tensor.rs` | Existing tests (updated for Result) + new elementwise/structural primal + AD tests |
+| `tests/eager_linalg.rs` | Multi-output linalg primal + AD tests |
+| `tests/eager_einsum_ad.rs` | `eager_einsum_ad` primal + AD tests |
+
+## Implementation Phases
+
+**Phase 1 (foundation):**
+- Change existing methods to `Result`
+- Split `eager.rs` → `eager.rs` + `eager_ops.rs`
+- Add `multi_output_unary_op`, `ternary_op`, `nary_op` internal helpers
+- Make `EagerContext` public, add `with_backend` / `from_tensor_in` / `requires_grad_in`
+
+**Phase 2 (ops — parallelizable):**
+- Structural ops (transpose, reshape, slice, etc.)
+- Elementwise ops (div, abs, log, sin, etc.)
+- Diagonal ops (extract_diag, embed_diag, tril, triu)
+- Additional reductions (reduce_prod, reduce_max, reduce_min)
+
+**Phase 3 (linalg):**
+- Multi-output: svd, qr, lu, eigh, eig
+- Single-output: cholesky, triangular_solve
+
+**Phase 4 (einsum):**
+- `eager_einsum_ad` free function
+
+**Phase 5 (TypedTensor):**
+- Convenience methods on `TypedTensor<T>`

--- a/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
+++ b/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
@@ -169,6 +169,34 @@ Ternary op:
 | `reduce_max` | `(&self, axes: &[usize]) -> Result<Self>` | `ReduceMax` |
 | `reduce_min` | `(&self, axes: &[usize]) -> Result<Self>` | `ReduceMin` |
 
+## TensorScalar::Real Associated Type
+
+`TensorScalar` gains a `Real` associated type so that decompositions
+returning real-valued outputs (e.g., singular values from SVD) can be
+properly typed:
+
+```rust
+pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
+    type Real: TensorScalar;
+
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor;
+    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]>;
+}
+```
+
+Implementations:
+
+| T | T::Real |
+|---|---------|
+| `f64` | `f64` |
+| `f32` | `f32` |
+| `Complex64` | `f64` |
+| `Complex32` | `f32` |
+
+This is a prerequisite for the `TypedTensor` convenience methods below and
+may also benefit existing code that currently uses `Tensor` (dynamic dtype)
+where `TypedTensor<T::Real>` would be more precise.
+
 ## TypedTensor Convenience Methods (P2)
 
 Convenience methods on `TypedTensor<T>` wrapping free functions from
@@ -184,8 +212,7 @@ impl<T: TensorScalar> TypedTensor<T> {
 ```
 
 These live in `tenferro-tensor` since they don't depend on the traced/eager
-graph infrastructure. Exact method set TBD based on what tensor4all-rs
-actually needs — start with einsum + linalg decompositions.
+graph infrastructure. Start with einsum + linalg decompositions.
 
 ## File Structure
 

--- a/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
+++ b/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
@@ -27,12 +27,70 @@ fn multi_output_unary_op(
 ) -> Result<Vec<Self>>
 ```
 
-Behavior:
-- Calls `exec_op_on_tensors` which already returns `Vec<Tensor>`.
-- Assigns a unique `GlobalValKey` to each output.
-- When `requires_grad`, builds one `GradNode` per output, sharing the same
-  `op` / `primal_in_keys` / `saved_data` / `input_edges` but with distinct
-  `output_idx` (0, 1, 2, ...).
+### How backward_dag processes multi-output ops
+
+`tidu::backward_dag` (backward.rs:83-95) iterates `node.primal_out_keys` to
+collect cotangents for all outputs, then calls `build_single_op_linear` which
+invokes `PrimitiveOp::linearize` / `transpose_rule`. For linalg ops like SVD,
+the transpose rule consumes all primal outputs (u, s, vt) from `saved_data`
+to produce cotangents for all inputs.
+
+This means multi-output ops need **one shared `GradNode`** that:
+1. Lists all output keys in `primal_out_keys` (not just one).
+2. Saves all output tensors in `saved_data` (one per `output_slot`).
+3. Is referenced by all output `EagerTensor`s (via `Arc`).
+
+Each output `EagerTensor` holds `Arc<GradNode>` pointing to the same node,
+plus its own `output_idx` to identify which output it represents. When
+`topo_sort_grad_dag` walks the DAG, `Arc` pointer deduplication ensures the
+shared node is visited exactly once.
+
+### Changes to saved_forward_values
+
+The current `saved_forward_values` helper stores only `output_slot: 0` via
+`derived_output_key`. For multi-output ops, it must store each output:
+
+```rust
+fn saved_forward_values_multi(
+    op: &StdTensorOp,
+    input_keys: &[GlobalValKey<StdTensorOp>],
+    inputs: &[Arc<Tensor>],
+    outputs: &[Arc<Tensor>],
+) -> HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>> {
+    let mut saved = HashMap::with_capacity(input_keys.len() + outputs.len());
+    for (key, value) in input_keys.iter().zip(inputs.iter()) {
+        saved.insert(key.clone(), Arc::clone(value));
+    }
+    for (slot, output) in outputs.iter().enumerate() {
+        saved.insert(
+            GlobalValKey::Derived {
+                op: GlobalOpKey {
+                    primitive: op.clone(),
+                    inputs: input_keys.to_vec(),
+                    mode: OpMode::Primal,
+                },
+                output_slot: slot,
+            },
+            Arc::clone(output),
+        );
+    }
+    saved
+}
+```
+
+### Construction flow
+
+```
+exec_op_on_tensors(&op, &[input], backend) -> Vec<Tensor>  // e.g. [u, s, vt]
+                         |
+      build one shared GradNode with:
+        primal_out_keys = [key_u, key_s, key_vt]
+        saved_data      = {input_keys... , derived(slot=0) -> u, derived(slot=1) -> s, derived(slot=2) -> vt}
+        output_idx      = 0  (the node itself; each EagerTensor stores its own output_idx)
+                         |
+      return Vec<EagerTensor> where each holds Arc::clone of the same GradNode
+```
+
 - When `!requires_grad`, `grad_node` is `None` for all outputs (zero overhead).
 
 Public linalg methods wrap this:
@@ -81,21 +139,40 @@ pub fn eager_einsum_ad<B: TensorBackend>(
 ) -> Result<EagerTensor<B>>
 ```
 
-- Extracts `&Tensor` from each input.
-- Calls `tenferro_einsum::eager_einsum(ctx, tensors, subscripts)`.
-- Merges `EagerContext`s across all inputs (same `absorb_from` pattern as
-  `binary_op`).
-- Builds a `GradNode` with N input edges if any input has `requires_grad`.
-- The op stored in `GradNode` is `StdTensorOp::DotGeneral` for 2-input
-  contractions, or a sequence of `DotGeneral` ops following the contraction
-  tree for N-ary. The exact op depends on what `eager_einsum` lowers to
-  internally — we record the ops as the contraction tree executes them.
+### Recording model
 
-**Alternative (simpler):** If recording the full contraction tree's ops is
-complex, an initial version can require that callers decompose N-ary einsum
-into pairwise `dot_general` calls themselves. The AD would then flow through
-the existing `binary_op` path. This defers the `eager_einsum_ad` wrapper to
-a follow-up.
+`GradNode` stores a single `Op`. The correct op to store is
+`StdTensorOp::NaryEinsum { subscripts, n_inputs }`, which already has
+linearize and transpose rules in `tenferro-ops/src/ad/contraction.rs`.
+
+The AD rules for `NaryEinsum` emit further `NaryEinsum` ops for each
+input's VJP (contracting the cotangent with the remaining primals). During
+eager backward, these emitted `NaryEinsum` ops reach `exec_op_on_tensors`,
+which currently has `todo!("NaryEinsum eager exec requires contraction tree
+planning")` at `eager_exec.rs:73-75`.
+
+**Required change in `eager_exec.rs`:** Implement the `NaryEinsum` branch
+by calling `tenferro_einsum::eager_einsum(backend, tensors, subscripts)`.
+This is a one-line delegation — the eager einsum implementation already
+handles contraction tree planning internally.
+
+### Construction flow
+
+```
+eager_einsum(backend, &[tensor_a, tensor_b, ...], subscripts) -> Tensor
+                         |
+      build GradNode with:
+        op              = NaryEinsum { subscripts, n_inputs }
+        primal_in_keys  = [key_a, key_b, ...]
+        primal_out_keys = [result_key]
+        saved_data      = {key_a -> a, key_b -> b, ..., derived(slot=0) -> result}
+        input_edges     = [edge_a, edge_b, ...]
+```
+
+### Context merging
+
+Merges `EagerContext`s across all N inputs using the same `absorb_from`
+pattern as `binary_op`, extended with a loop over all inputs.
 
 ## Structural Ops
 
@@ -199,20 +276,88 @@ where `TypedTensor<T::Real>` would be more precise.
 
 ## TypedTensor Convenience Methods (P2)
 
-Convenience methods on `TypedTensor<T>` wrapping free functions from
-`tenferro-tensor`. These take `&mut CpuBackend` and delegate to backend
-methods. No AD involvement.
+### Tensor ↔ TypedTensor conversion
+
+Backend linalg methods return `Tensor` (dynamic dtype). Typed convenience
+methods must safely convert results back to `TypedTensor<T>` or
+`TypedTensor<T::Real>`. Add a conversion method to `TensorScalar`:
 
 ```rust
-impl<T: TensorScalar> TypedTensor<T> {
-    pub fn einsum(ctx: &mut CpuBackend, inputs: &[&Self], subscripts: &str) -> Result<Self>;
-    pub fn svd(&self, ctx: &mut CpuBackend) -> Result<(Self, TypedTensor<T::Real>, Self)>;
-    pub fn qr(&self, ctx: &mut CpuBackend) -> Result<(Self, Self)>;
+pub trait TensorScalar: ... {
+    type Real: TensorScalar;
+
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor;
+    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]>;
+
+    /// Try to extract a `TypedTensor<Self>` from a dynamic `Tensor`.
+    /// Returns `None` if the dtype does not match.
+    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>>;
 }
 ```
 
-These live in `tenferro-tensor` since they don't depend on the traced/eager
-graph infrastructure. Start with einsum + linalg decompositions.
+`try_into_typed` is the inverse of `into_tensor`. For `f64` it matches
+`Tensor::F64(inner)`, for `Complex64` it matches `Tensor::C64(inner)`, etc.
+
+### Complex SVD / eigh: backend dtype contract
+
+The current faer backend converts real singular values / eigenvalues into
+complex tensors for complex inputs (e.g., `faer_linalg.rs:1228-1231`
+wraps real SVD singular values into `Tensor::C64`). For `TypedTensor<T>::svd`
+to return `TypedTensor<T::Real>`, the conversion uses `T::Real::try_into_typed`
+on the backend output. For complex SVD:
+
+- Backend returns `[Tensor::C64(u), Tensor::C64(s_complex), Tensor::C64(vt)]`
+- `s` conversion: `<f64 as TensorScalar>::try_into_typed(s_complex)` → `None`
+  because the tensor is `C64`, not `F64`.
+
+This means the typed wrapper needs to handle the current backend behavior.
+Two options:
+
+**(A) Change the backend** to return real dtype for inherently real outputs
+(singular values, eigenvalues). This is the correct long-term fix — the
+complex wrapper in faer_linalg is an unnecessary dtype promotion.
+
+**(B) Convert in the wrapper** by extracting the real parts from the complex
+tensor. E.g., for `Complex64` singular values, take `re` of each element
+and build a `TypedTensor<f64>`.
+
+**Decision: Option (A).** Change the faer backend so that SVD/eigh return
+real-dtype tensors for singular values / eigenvalues even when the input is
+complex. This aligns with NumPy/JAX/PyTorch behavior (e.g.,
+`np.linalg.svd(complex_matrix)` returns real singular values). The change
+is localized to `faer_linalg.rs` and `cpu/backend.rs`.
+
+### Method signatures and crate placement
+
+Linalg convenience methods live in `tenferro-tensor` (same crate as
+`TypedTensor`):
+
+```rust
+impl<T: TensorScalar> TypedTensor<T> {
+    pub fn svd(&self, ctx: &mut CpuBackend) -> Result<(Self, TypedTensor<T::Real>, Self)>;
+    pub fn qr(&self, ctx: &mut CpuBackend) -> Result<(Self, Self)>;
+    pub fn cholesky(&self, ctx: &mut CpuBackend) -> Result<Self>;
+    pub fn eigh(&self, ctx: &mut CpuBackend) -> Result<(TypedTensor<T::Real>, Self)>;
+}
+```
+
+**Einsum** convenience cannot live in `tenferro-tensor` because
+`eager_einsum` is in `tenferro-einsum`, and `tenferro-tensor` does not
+depend on `tenferro-einsum` (dependency flows the other direction). Instead,
+`TypedTensor::einsum` lives in `tenferro-einsum` as a free function or
+extension trait:
+
+```rust
+// In tenferro-einsum/src/eager.rs (or a new typed_eager.rs)
+pub fn typed_eager_einsum<T: TensorScalar>(
+    ctx: &mut CpuBackend,
+    inputs: &[&TypedTensor<T>],
+    subscripts: &str,
+) -> Result<TypedTensor<T>>
+```
+
+This wraps inputs via `T::into_tensor`, calls `eager_einsum`, and converts
+back via `T::try_into_typed`.
 
 ## File Structure
 
@@ -239,7 +384,7 @@ Tests:
 **Phase 1 (foundation):**
 - Change existing methods to `Result`
 - Split `eager.rs` → `eager.rs` + `eager_ops.rs`
-- Add `multi_output_unary_op`, `ternary_op`, `nary_op` internal helpers
+- Add `multi_output_unary_op` (with `saved_forward_values_multi`), `ternary_op`, `nary_op` internal helpers
 - Make `EagerContext` public, add `with_backend` / `from_tensor_in` / `requires_grad_in`
 
 **Phase 2 (ops — parallelizable):**
@@ -249,11 +394,15 @@ Tests:
 - Additional reductions (reduce_prod, reduce_max, reduce_min)
 
 **Phase 3 (linalg):**
-- Multi-output: svd, qr, lu, eigh, eig
+- Multi-output: svd, qr, lu, eigh, eig (using shared `GradNode` pattern)
 - Single-output: cholesky, triangular_solve
 
 **Phase 4 (einsum):**
-- `eager_einsum_ad` free function
+- Implement `NaryEinsum` branch in `eager_exec.rs` (delegate to `eager_einsum`)
+- `eager_einsum_ad` free function (stores `NaryEinsum` in `GradNode`)
 
 **Phase 5 (TypedTensor):**
-- Convenience methods on `TypedTensor<T>`
+- Add `TensorScalar::Real` associated type + `try_into_typed` method
+- Change faer backend to return real dtype for SVD/eigh singular values / eigenvalues
+- Linalg convenience methods on `TypedTensor<T>` (in `tenferro-tensor`)
+- `typed_eager_einsum` free function (in `tenferro-einsum`)

--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -5,25 +5,39 @@ use std::sync::Arc;
 
 use computegraph::fragment::Fragment;
 use computegraph::{GlobalOpKey, GlobalValKey, OpMode, ValRef};
-use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_tensor::cpu::CpuBackend;
-use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend};
-use tidu::{
-    backward_dag, topo_sort_grad_dag, BackwardCallbacks, GradEdge, GradNode, LinearFragment,
-};
+use tenferro_tensor::{Tensor, TensorBackend};
+use tidu::{backward_dag, topo_sort_grad_dag, BackwardCallbacks, GradNode, LinearFragment};
 
 use crate::eager_emitter::EagerEmitter;
 use crate::eager_exec::exec_op_on_tensors;
 use crate::error::{Error, Result};
 use crate::traced::next_input_key;
 
-type GradSlot = Rc<RefCell<Option<Arc<Tensor>>>>;
-type WeakGradSlot = Weak<RefCell<Option<Arc<Tensor>>>>;
+pub(crate) type GradSlot = Rc<RefCell<Option<Arc<Tensor>>>>;
+pub(crate) type WeakGradSlot = Weak<RefCell<Option<Arc<Tensor>>>>;
 
-struct EagerContext<B: TensorBackend> {
-    backend: RefCell<B>,
+/// Shared eager execution context for tensors on a backend.
+///
+/// Reusing one context lets eager tensors share backend state and gradient
+/// storage across a computation.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+///
+/// let ctx = EagerContext::with_backend(CpuBackend::new());
+/// let x = EagerTensor::from_tensor_in(Tensor::new(vec![1], vec![1.0_f64]), ctx.clone());
+/// let y = EagerTensor::from_tensor_in(Tensor::new(vec![1], vec![2.0_f64]), ctx);
+/// let z = &x + &y;
+///
+/// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[3.0]);
+/// ```
+pub struct EagerContext<B: TensorBackend> {
+    pub(crate) backend: RefCell<B>,
     grad_slots: RefCell<HashMap<GlobalValKey<StdTensorOp>, WeakGradSlot>>,
 }
 
@@ -35,13 +49,27 @@ impl<B: TensorBackend> EagerContext<B> {
         }
     }
 
-    fn register_grad_slot(&self, key: &GlobalValKey<StdTensorOp>, slot: &GradSlot) {
+    /// Create a shared eager execution context for the provided backend.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// assert_eq!(std::rc::Rc::strong_count(&ctx), 1);
+    /// ```
+    pub fn with_backend(backend: B) -> Rc<Self> {
+        Rc::new(Self::new(backend))
+    }
+
+    pub(crate) fn register_grad_slot(&self, key: &GlobalValKey<StdTensorOp>, slot: &GradSlot) {
         self.grad_slots
             .borrow_mut()
             .insert(key.clone(), Rc::downgrade(slot));
     }
 
-    fn absorb_from(&self, other: &Self) {
+    pub(crate) fn absorb_from(&self, other: &Self) {
         let other_slots = other.grad_slots.borrow();
         let mut slots = self.grad_slots.borrow_mut();
         for (key, slot) in other_slots.iter() {
@@ -83,26 +111,26 @@ impl<B: TensorBackend> EagerContext<B> {
 /// use tenferro::{EagerTensor, Tensor};
 ///
 /// let x = EagerTensor::requires_grad(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
-/// let loss = (&x * &x).reduce_sum(&[0]);
+/// let loss = (&x * &x).reduce_sum(&[0]).unwrap();
 /// let _cotangents = loss.backward().unwrap();
 ///
 /// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 /// ```
 #[derive(Clone)]
 pub struct EagerTensor<B: TensorBackend = CpuBackend> {
-    data: Arc<Tensor>,
-    key: GlobalValKey<StdTensorOp>,
-    grad_node: Option<Arc<GradNode<StdTensorOp>>>,
-    requires_grad: bool,
+    pub(crate) data: Arc<Tensor>,
+    pub(crate) key: GlobalValKey<StdTensorOp>,
+    pub(crate) grad_node: Option<Arc<GradNode<StdTensorOp>>>,
+    pub(crate) requires_grad: bool,
     grad_slot: GradSlot,
-    ctx: Rc<EagerContext<B>>,
+    pub(crate) ctx: Rc<EagerContext<B>>,
 }
 
 impl<B: TensorBackend> std::ops::Add for &EagerTensor<B> {
     type Output = EagerTensor<B>;
 
     fn add(self, rhs: &EagerTensor<B>) -> Self::Output {
-        EagerTensor::add(self, rhs)
+        EagerTensor::add(self, rhs).unwrap_or_else(|err| panic!("eager add failed: {}", err))
     }
 }
 
@@ -110,7 +138,7 @@ impl<B: TensorBackend> std::ops::Mul for &EagerTensor<B> {
     type Output = EagerTensor<B>;
 
     fn mul(self, rhs: &EagerTensor<B>) -> Self::Output {
-        EagerTensor::mul(self, rhs)
+        EagerTensor::mul(self, rhs).unwrap_or_else(|err| panic!("eager mul failed: {}", err))
     }
 }
 
@@ -118,7 +146,7 @@ impl<B: TensorBackend> std::ops::Neg for &EagerTensor<B> {
     type Output = EagerTensor<B>;
 
     fn neg(self) -> Self::Output {
-        EagerTensor::neg(self)
+        EagerTensor::neg(self).unwrap_or_else(|err| panic!("eager neg failed: {}", err))
     }
 }
 
@@ -135,7 +163,7 @@ impl EagerTensor<CpuBackend> {
     /// assert!(x.grad().is_none());
     /// ```
     pub fn from_tensor(tensor: Tensor) -> Self {
-        Self::new_leaf(Rc::new(EagerContext::new(CpuBackend::new())), tensor, false)
+        Self::from_tensor_in(tensor, EagerContext::with_backend(CpuBackend::new()))
     }
 
     /// Create a tracked eager leaf on the default CPU backend.
@@ -149,12 +177,44 @@ impl EagerTensor<CpuBackend> {
     /// assert!(x.grad().is_none());
     /// ```
     pub fn requires_grad(tensor: Tensor) -> Self {
-        Self::new_leaf(Rc::new(EagerContext::new(CpuBackend::new())), tensor, true)
+        Self::requires_grad_in(tensor, EagerContext::with_backend(CpuBackend::new()))
     }
 }
 
 impl<B: TensorBackend> EagerTensor<B> {
-    fn new_leaf(ctx: Rc<EagerContext<B>>, tensor: Tensor, requires_grad: bool) -> Self {
+    /// Create an untracked eager tensor inside an existing eager context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::new(vec![2], vec![1.0_f64, 2.0]), ctx);
+    ///
+    /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    pub fn from_tensor_in(tensor: Tensor, ctx: Rc<EagerContext<B>>) -> Self {
+        Self::new_leaf(ctx, tensor, false)
+    }
+
+    /// Create a tracked eager leaf inside an existing eager context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(Tensor::new(vec![2], vec![1.0_f64, 2.0]), ctx);
+    ///
+    /// assert!(x.grad().is_none());
+    /// ```
+    pub fn requires_grad_in(tensor: Tensor, ctx: Rc<EagerContext<B>>) -> Self {
+        Self::new_leaf(ctx, tensor, true)
+    }
+
+    pub(crate) fn new_leaf(ctx: Rc<EagerContext<B>>, tensor: Tensor, requires_grad: bool) -> Self {
         let key = eager_val_key();
         let grad_slot = Rc::new(RefCell::new(None));
         if requires_grad {
@@ -171,7 +231,7 @@ impl<B: TensorBackend> EagerTensor<B> {
         }
     }
 
-    fn new_result(
+    pub(crate) fn new_result(
         ctx: Rc<EagerContext<B>>,
         key: GlobalValKey<StdTensorOp>,
         tensor: Tensor,
@@ -235,7 +295,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// use tenferro::{EagerTensor, Tensor};
     ///
     /// let x = EagerTensor::requires_grad(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
-    /// let loss = x.exp().reduce_sum(&[0]);
+    /// let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
     ///
     /// let grad = x.grad().unwrap();
@@ -256,7 +316,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// use tenferro::{EagerTensor, Tensor};
     ///
     /// let x = EagerTensor::requires_grad(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
-    /// let loss = (&x + &x).reduce_sum(&[0]);
+    /// let loss = (&x + &x).reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
     ///
     /// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 2.0, 2.0]);
@@ -281,194 +341,9 @@ impl<B: TensorBackend> EagerTensor<B> {
         self.ctx.store_grads(&cotangents);
         Ok(cotangents)
     }
-
-    /// Elementwise addition.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro::{EagerTensor, Tensor};
-    ///
-    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
-    /// let y = EagerTensor::from_tensor(Tensor::new(vec![2], vec![3.0_f64, 4.0]));
-    /// let z = x.add(&y);
-    ///
-    /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[4.0, 6.0]);
-    /// ```
-    pub fn add(&self, other: &Self) -> Self {
-        self.binary_op(other, StdTensorOp::Add)
-    }
-
-    /// Elementwise multiplication.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro::{EagerTensor, Tensor};
-    ///
-    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
-    /// let y = EagerTensor::from_tensor(Tensor::new(vec![2], vec![3.0_f64, 4.0]));
-    /// let z = x.mul(&y);
-    ///
-    /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[3.0, 8.0]);
-    /// ```
-    pub fn mul(&self, other: &Self) -> Self {
-        self.binary_op(other, StdTensorOp::Mul)
-    }
-
-    /// Negate the tensor.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro::{EagerTensor, Tensor};
-    ///
-    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, -2.0]));
-    /// let y = x.neg();
-    ///
-    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[-1.0, 2.0]);
-    /// ```
-    pub fn neg(&self) -> Self {
-        self.unary_op(StdTensorOp::Neg)
-    }
-
-    /// Elementwise exponential.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro::{EagerTensor, Tensor};
-    ///
-    /// let x = EagerTensor::from_tensor(Tensor::new(vec![1], vec![0.0_f64]));
-    /// let y = x.exp();
-    ///
-    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0]);
-    /// ```
-    pub fn exp(&self) -> Self {
-        self.unary_op(StdTensorOp::Exp)
-    }
-
-    /// Reduce sum over the requested axes.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro::{EagerTensor, Tensor};
-    ///
-    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
-    /// let y = x.reduce_sum(&[0, 1]);
-    ///
-    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[10.0]);
-    /// ```
-    pub fn reduce_sum(&self, axes: &[usize]) -> Self {
-        self.unary_op(StdTensorOp::ReduceSum {
-            axes: axes.to_vec(),
-            input_shape: DimExpr::from_concrete(self.data.shape()),
-        })
-    }
-
-    /// Execute a dot-general contraction eagerly.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro::{DotGeneralConfig, EagerTensor, Tensor};
-    ///
-    /// let a = EagerTensor::from_tensor(Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]));
-    /// let b = EagerTensor::from_tensor(Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]));
-    /// let c = a.dot_general(&b, DotGeneralConfig {
-    ///     lhs_contracting_dims: vec![1],
-    ///     rhs_contracting_dims: vec![0],
-    ///     lhs_batch_dims: vec![],
-    ///     rhs_batch_dims: vec![],
-    ///     lhs_rank: 2,
-    ///     rhs_rank: 2,
-    /// });
-    ///
-    /// assert_eq!(c.data().shape(), &[2, 2]);
-    /// ```
-    pub fn dot_general(&self, other: &Self, config: DotGeneralConfig) -> Self {
-        self.binary_op(other, StdTensorOp::DotGeneral(config))
-    }
-
-    fn unary_op(&self, op: StdTensorOp) -> Self {
-        let output = exec_single_output(&op, &[self.data.as_ref()], &self.ctx);
-        let result_key = eager_val_key();
-        let input_aliases = vec![eager_val_key()];
-        let grad_node = self.requires_grad.then(|| {
-            Arc::new(GradNode {
-                op: op.clone(),
-                primal_in_keys: input_aliases.clone(),
-                primal_out_keys: vec![result_key.clone()],
-                saved_data: saved_forward_values(
-                    &op,
-                    &input_aliases,
-                    &[Arc::clone(&self.data)],
-                    Arc::new(output.clone()),
-                ),
-                input_edges: vec![GradEdge {
-                    node: self.grad_node.clone(),
-                    key: self.key.clone(),
-                    requires_grad: self.requires_grad,
-                }],
-                output_idx: 0,
-            })
-        });
-        Self::new_result(
-            self.ctx.clone(),
-            result_key,
-            output,
-            self.requires_grad,
-            grad_node,
-        )
-    }
-
-    fn binary_op(&self, other: &Self, op: StdTensorOp) -> Self {
-        if !Rc::ptr_eq(&self.ctx, &other.ctx) {
-            self.ctx.absorb_from(&other.ctx);
-        }
-
-        let output = exec_single_output(&op, &[self.data.as_ref(), other.data.as_ref()], &self.ctx);
-        let requires_grad = self.requires_grad || other.requires_grad;
-        let result_key = eager_val_key();
-        let input_aliases = vec![eager_val_key(), eager_val_key()];
-        let grad_node = requires_grad.then(|| {
-            Arc::new(GradNode {
-                op: op.clone(),
-                primal_in_keys: input_aliases.clone(),
-                primal_out_keys: vec![result_key.clone()],
-                saved_data: saved_forward_values(
-                    &op,
-                    &input_aliases,
-                    &[Arc::clone(&self.data), Arc::clone(&other.data)],
-                    Arc::new(output.clone()),
-                ),
-                input_edges: vec![
-                    GradEdge {
-                        node: self.grad_node.clone(),
-                        key: self.key.clone(),
-                        requires_grad: self.requires_grad,
-                    },
-                    GradEdge {
-                        node: other.grad_node.clone(),
-                        key: other.key.clone(),
-                        requires_grad: other.requires_grad,
-                    },
-                ],
-                output_idx: 0,
-            })
-        });
-        Self::new_result(
-            self.ctx.clone(),
-            result_key,
-            output,
-            requires_grad,
-            grad_node,
-        )
-    }
 }
 
-struct TenferroBackwardCallbacks<'a, B: TensorBackend> {
+pub(crate) struct TenferroBackwardCallbacks<'a, B: TensorBackend> {
     backend: &'a mut B,
 }
 
@@ -563,11 +438,11 @@ impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallba
     }
 }
 
-fn eager_val_key() -> GlobalValKey<StdTensorOp> {
+pub(crate) fn eager_val_key() -> GlobalValKey<StdTensorOp> {
     GlobalValKey::Input(next_input_key())
 }
 
-fn saved_forward_values(
+pub(crate) fn saved_forward_values(
     op: &StdTensorOp,
     input_keys: &[GlobalValKey<StdTensorOp>],
     inputs: &[Arc<Tensor>],
@@ -577,13 +452,32 @@ fn saved_forward_values(
     for (key, value) in input_keys.iter().zip(inputs.iter()) {
         saved.insert(key.clone(), Arc::clone(value));
     }
-    saved.insert(derived_output_key(op, input_keys), output);
+    saved.insert(derived_output_key(op, input_keys, 0), output);
     saved
 }
 
-fn derived_output_key(
+#[allow(dead_code)]
+pub(crate) fn saved_forward_values_multi(
     op: &StdTensorOp,
     input_keys: &[GlobalValKey<StdTensorOp>],
+    inputs: &[Arc<Tensor>],
+    output_keys: &[GlobalValKey<StdTensorOp>],
+    outputs: &[Arc<Tensor>],
+) -> HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>> {
+    let mut saved = HashMap::with_capacity(input_keys.len() + output_keys.len());
+    for (key, value) in input_keys.iter().zip(inputs.iter()) {
+        saved.insert(key.clone(), Arc::clone(value));
+    }
+    for (slot, (_key, output)) in output_keys.iter().zip(outputs.iter()).enumerate() {
+        saved.insert(derived_output_key(op, input_keys, slot), Arc::clone(output));
+    }
+    saved
+}
+
+pub(crate) fn derived_output_key(
+    op: &StdTensorOp,
+    input_keys: &[GlobalValKey<StdTensorOp>],
+    output_slot: usize,
 ) -> GlobalValKey<StdTensorOp> {
     GlobalValKey::Derived {
         op: GlobalOpKey {
@@ -591,29 +485,28 @@ fn derived_output_key(
             inputs: input_keys.to_vec(),
             mode: OpMode::Primal,
         },
-        output_slot: 0,
+        output_slot: output_slot as u8,
     }
 }
 
-fn exec_single_output<B: TensorBackend>(
+pub(crate) fn exec_single_output<B: TensorBackend>(
     op: &StdTensorOp,
     inputs: &[&Tensor],
     ctx: &EagerContext<B>,
-) -> Tensor {
+) -> Result<Tensor> {
     let mut backend = ctx.backend.borrow_mut();
-    let mut outputs = exec_op_on_tensors(op, inputs, &mut *backend)
-        .unwrap_or_else(|err| panic!("eager exec failed for {:?}: {}", op, err));
-    assert_eq!(
-        outputs.len(),
-        1,
-        "expected one eager output for {:?}, got {}",
-        op,
-        outputs.len()
-    );
-    outputs.remove(0)
+    let mut outputs = exec_op_on_tensors(op, inputs, &mut *backend)?;
+    if outputs.len() != 1 {
+        return Err(Error::Internal(format!(
+            "expected one eager output for {:?}, got {}",
+            op,
+            outputs.len()
+        )));
+    }
+    Ok(outputs.remove(0))
 }
 
-fn zero_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor {
+pub(crate) fn zero_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor {
     let neg = input
         .neg(backend)
         .unwrap_or_else(|err| panic!("zero_like neg failed: {}", err));
@@ -622,7 +515,7 @@ fn zero_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor
         .unwrap_or_else(|err| panic!("zero_like add failed: {}", err))
 }
 
-fn one_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor {
+pub(crate) fn one_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor {
     let zero = zero_like_tensor(input, backend);
     backend
         .exp(&zero)

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -1,0 +1,280 @@
+use std::rc::Rc;
+use std::sync::Arc;
+
+use tidu::{GradEdge, GradNode};
+
+use tenferro_ops::dim_expr::DimExpr;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend};
+
+use crate::eager::{
+    eager_val_key, exec_single_output, saved_forward_values, saved_forward_values_multi,
+    EagerTensor,
+};
+use crate::eager_exec::exec_op_on_tensors;
+use crate::error::{Error, Result};
+
+impl<B: TensorBackend> EagerTensor<B> {
+    /// Elementwise addition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
+    /// let y = EagerTensor::from_tensor(Tensor::new(vec![2], vec![3.0_f64, 4.0]));
+    /// let z = x.add(&y).unwrap();
+    ///
+    /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+    /// ```
+    pub fn add(&self, other: &Self) -> Result<Self> {
+        self.binary_op(other, StdTensorOp::Add)
+    }
+
+    /// Elementwise multiplication.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
+    /// let y = EagerTensor::from_tensor(Tensor::new(vec![2], vec![3.0_f64, 4.0]));
+    /// let z = x.mul(&y).unwrap();
+    ///
+    /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[3.0, 8.0]);
+    /// ```
+    pub fn mul(&self, other: &Self) -> Result<Self> {
+        self.binary_op(other, StdTensorOp::Mul)
+    }
+
+    /// Negate the tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, -2.0]));
+    /// let y = x.neg().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[-1.0, 2.0]);
+    /// ```
+    pub fn neg(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Neg)
+    }
+
+    /// Elementwise exponential.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![1], vec![0.0_f64]));
+    /// let y = x.exp().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0]);
+    /// ```
+    pub fn exp(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Exp)
+    }
+
+    /// Reduce sum over the requested axes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let y = x.reduce_sum(&[0, 1]).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[10.0]);
+    /// ```
+    pub fn reduce_sum(&self, axes: &[usize]) -> Result<Self> {
+        self.unary_op(StdTensorOp::ReduceSum {
+            axes: axes.to_vec(),
+            input_shape: DimExpr::from_concrete(self.data.shape()),
+        })
+    }
+
+    /// Execute a dot-general contraction eagerly.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{DotGeneralConfig, EagerTensor, Tensor};
+    ///
+    /// let a = EagerTensor::from_tensor(Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]));
+    /// let b = EagerTensor::from_tensor(Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]));
+    /// let c = a.dot_general(&b, DotGeneralConfig {
+    ///     lhs_contracting_dims: vec![1],
+    ///     rhs_contracting_dims: vec![0],
+    ///     lhs_batch_dims: vec![],
+    ///     rhs_batch_dims: vec![],
+    ///     lhs_rank: 2,
+    ///     rhs_rank: 2,
+    /// }).unwrap();
+    ///
+    /// assert_eq!(c.data().shape(), &[2, 2]);
+    /// ```
+    pub fn dot_general(&self, other: &Self, config: DotGeneralConfig) -> Result<Self> {
+        self.binary_op(other, StdTensorOp::DotGeneral(config))
+    }
+
+    pub(crate) fn unary_op(&self, op: StdTensorOp) -> Result<Self> {
+        let output = exec_single_output(&op, &[self.data.as_ref()], &self.ctx)?;
+        let result_key = eager_val_key();
+        let input_aliases = vec![eager_val_key()];
+        let grad_node = self.requires_grad.then(|| {
+            Arc::new(GradNode {
+                op: op.clone(),
+                primal_in_keys: input_aliases.clone(),
+                primal_out_keys: vec![result_key.clone()],
+                saved_data: saved_forward_values(
+                    &op,
+                    &input_aliases,
+                    &[Arc::clone(&self.data)],
+                    Arc::new(output.clone()),
+                ),
+                input_edges: vec![GradEdge {
+                    node: self.grad_node.clone(),
+                    key: self.key.clone(),
+                    requires_grad: self.requires_grad,
+                }],
+                output_idx: 0,
+            })
+        });
+        Ok(Self::new_result(
+            Rc::clone(&self.ctx),
+            result_key,
+            output,
+            self.requires_grad,
+            grad_node,
+        ))
+    }
+
+    pub(crate) fn binary_op(&self, other: &Self, op: StdTensorOp) -> Result<Self> {
+        Self::nary_op(&[self, other], op)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn multi_output_unary_op(
+        &self,
+        op: StdTensorOp,
+        num_outputs: usize,
+    ) -> Result<Vec<Self>> {
+        let outputs = {
+            let mut backend = self.ctx.backend.borrow_mut();
+            exec_op_on_tensors(&op, &[self.data.as_ref()], &mut *backend)?
+        };
+        if outputs.len() != num_outputs {
+            return Err(Error::Internal(format!(
+                "expected {} eager outputs for {:?}, got {}",
+                num_outputs,
+                op,
+                outputs.len()
+            )));
+        }
+
+        let outputs: Vec<Arc<Tensor>> = outputs.into_iter().map(Arc::new).collect();
+        let output_keys: Vec<_> = (0..num_outputs).map(|_| eager_val_key()).collect();
+        let input_aliases = vec![eager_val_key()];
+        let grad_node = self.requires_grad.then(|| {
+            Arc::new(GradNode {
+                op: op.clone(),
+                primal_in_keys: input_aliases.clone(),
+                primal_out_keys: output_keys.clone(),
+                saved_data: saved_forward_values_multi(
+                    &op,
+                    &input_aliases,
+                    &[Arc::clone(&self.data)],
+                    &output_keys,
+                    &outputs,
+                ),
+                input_edges: vec![GradEdge {
+                    node: self.grad_node.clone(),
+                    key: self.key.clone(),
+                    requires_grad: self.requires_grad,
+                }],
+                output_idx: 0,
+            })
+        });
+
+        Ok(output_keys
+            .into_iter()
+            .zip(outputs)
+            .map(|(output_key, output)| {
+                Self::new_result(
+                    Rc::clone(&self.ctx),
+                    output_key,
+                    output.as_ref().clone(),
+                    self.requires_grad,
+                    grad_node.clone(),
+                )
+            })
+            .collect())
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn ternary_op(&self, b: &Self, c: &Self, op: StdTensorOp) -> Result<Self> {
+        Self::nary_op(&[self, b, c], op)
+    }
+
+    pub(crate) fn nary_op(tensors: &[&Self], op: StdTensorOp) -> Result<Self> {
+        let Some(first) = tensors.first() else {
+            return Err(Error::Internal(
+                "nary eager op requires at least one input tensor".to_string(),
+            ));
+        };
+
+        let ctx = Rc::clone(&first.ctx);
+        for tensor in tensors.iter().skip(1) {
+            if !Rc::ptr_eq(&ctx, &tensor.ctx) {
+                ctx.absorb_from(&tensor.ctx);
+            }
+        }
+
+        let inputs: Vec<&Tensor> = tensors.iter().map(|tensor| tensor.data.as_ref()).collect();
+        let output = exec_single_output(&op, &inputs, &ctx)?;
+        let requires_grad = tensors.iter().any(|tensor| tensor.requires_grad);
+        let result_key = eager_val_key();
+        let input_aliases: Vec<_> = tensors.iter().map(|_| eager_val_key()).collect();
+        let input_data: Vec<_> = tensors
+            .iter()
+            .map(|tensor| Arc::clone(&tensor.data))
+            .collect();
+        let grad_node = requires_grad.then(|| {
+            Arc::new(GradNode {
+                op: op.clone(),
+                primal_in_keys: input_aliases.clone(),
+                primal_out_keys: vec![result_key.clone()],
+                saved_data: saved_forward_values(
+                    &op,
+                    &input_aliases,
+                    &input_data,
+                    Arc::new(output.clone()),
+                ),
+                input_edges: tensors
+                    .iter()
+                    .map(|tensor| GradEdge {
+                        node: tensor.grad_node.clone(),
+                        key: tensor.key.clone(),
+                        requires_grad: tensor.requires_grad,
+                    })
+                    .collect(),
+                output_idx: 0,
+            })
+        });
+
+        Ok(Self::new_result(
+            ctx,
+            result_key,
+            output,
+            requires_grad,
+            grad_node,
+        ))
+    }
+}

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -22,6 +22,7 @@ pub mod compiler;
 mod eager;
 mod eager_emitter;
 pub mod eager_exec;
+pub(crate) mod eager_ops;
 pub mod einsum;
 pub mod engine;
 pub mod error;
@@ -31,7 +32,7 @@ pub mod stablehlo;
 pub mod sym_dim;
 pub mod traced;
 
-pub use eager::EagerTensor;
+pub use eager::{EagerContext, EagerTensor};
 pub use engine::Engine;
 pub use linalg_api::{
     cholesky, convert, det, eig, eigh, eigh_with_eps, eigvals, eigvalsh, inv, lu, norm, pinv,

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -66,7 +66,11 @@ fn matmul_config() -> DotGeneralConfig {
 fn eager_matmul_sum(lhs: &[f64], rhs: &[f64]) -> f64 {
     let a = EagerTensor::from_tensor(Tensor::new(vec![2, 3], lhs.to_vec()));
     let b = EagerTensor::from_tensor(Tensor::new(vec![3, 2], rhs.to_vec()));
-    let loss = a.dot_general(&b, matmul_config()).reduce_sum(&[0, 1]);
+    let loss = a
+        .dot_general(&b, matmul_config())
+        .unwrap()
+        .reduce_sum(&[0, 1])
+        .unwrap();
     f64_data(loss.data())[0]
 }
 
@@ -74,7 +78,7 @@ fn eager_matmul_sum(lhs: &[f64], rhs: &[f64]) -> f64 {
 fn eager_x_squared_gradient_matches_finite_difference() {
     let x_data = vec![1.0, 2.0, 3.0];
     let x = EagerTensor::requires_grad(Tensor::new(vec![3], x_data.clone()));
-    let loss = (&x * &x).reduce_sum(&[0]);
+    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
     let grad = x.grad().unwrap();
 
@@ -98,7 +102,11 @@ fn eager_matmul_gradients_match_finite_difference() {
 
     let a = EagerTensor::requires_grad(Tensor::new(vec![2, 3], a_data.clone()));
     let b = EagerTensor::requires_grad(Tensor::new(vec![3, 2], b_data.clone()));
-    let loss = a.dot_general(&b, matmul_config()).reduce_sum(&[0, 1]);
+    let loss = a
+        .dot_general(&b, matmul_config())
+        .unwrap()
+        .reduce_sum(&[0, 1])
+        .unwrap();
     let _cotangents = loss.backward().unwrap();
 
     let grad_a = a.grad().unwrap();
@@ -120,7 +128,7 @@ fn eager_matmul_gradients_match_finite_difference() {
 #[test]
 fn eager_exp_gradient_matches_primal() {
     let x = EagerTensor::requires_grad(Tensor::new(vec![3], vec![0.0, 1.0, 2.0]));
-    let loss = x.exp().reduce_sum(&[0]);
+    let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
     let grad = x.grad().unwrap();
@@ -131,7 +139,7 @@ fn eager_exp_gradient_matches_primal() {
 #[test]
 fn eager_fan_out_accumulates_gradient() {
     let x = EagerTensor::requires_grad(Tensor::new(vec![3], vec![1.0, 2.0, 3.0]));
-    let loss = (&x + &x).reduce_sum(&[0]);
+    let loss = (&x + &x).reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
     let grad = x.grad().unwrap();
@@ -142,7 +150,7 @@ fn eager_fan_out_accumulates_gradient() {
 fn eager_detach_cuts_one_gradient_path() {
     let x = EagerTensor::requires_grad(Tensor::new(vec![3], vec![1.0, 2.0, 3.0]));
     let detached = x.detach();
-    let loss = (&detached * &x).reduce_sum(&[0]);
+    let loss = (&detached * &x).reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
     let grad = x.grad().unwrap();


### PR DESCRIPTION
## Summary

Phase 1 foundation for EagerTensor API extensions (#706):

- All `EagerTensor` methods now return `Result<Self>`; operator overloads (`+`, `*`, `-`) unwrap internally
- Split `eager.rs` (631 lines) into `eager.rs` (core, 280 lines) + `eager_ops.rs` (ops, 280 lines)
- Add `multi_output_unary_op` helper with shared `Arc<GradNode>` pattern for linalg decompositions
- Add `ternary_op` and `nary_op` helpers for `select` and `concatenate`
- Add `saved_forward_values_multi` for multi-output saved data with per-slot `derived_output_key`
- Make `EagerContext` public with `with_backend()` constructor
- Add `from_tensor_in()` / `requires_grad_in()` for shared context support

Design spec: `docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md`

## Test plan

- [x] `cargo test -p tenferro --release` — 22 passed
- [x] `cargo fmt --all`
- [x] `cargo doc -p tenferro --no-deps`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)