### PR TITLE
feat: EagerTensor full API extensions — Phase 2-5 (#706)

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -11,7 +11,6 @@
     "tenferro-tensor/src/cpu/exec_session.rs": 60,
     "tenferro-tensor/src/cpu/backend.rs": 78,
     "tenferro/src/eager_exec.rs": 35,
-    "tenferro/src/eager_ops.rs": 55,
-    "tenferro-einsum/src/typed_eager.rs": 70
+    "tenferro/src/eager_ops.rs": 60
   }
 }

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -11,6 +11,7 @@
     "tenferro-tensor/src/cpu/exec_session.rs": 60,
     "tenferro-tensor/src/cpu/backend.rs": 78,
     "tenferro/src/eager_exec.rs": 35,
-    "tenferro/src/eager_ops.rs": 60
+    "tenferro/src/eager_ops.rs": 55,
+    "tenferro-einsum/src/typed_eager.rs": 70
   }
 }

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -39,6 +39,7 @@ pub mod builder;
 mod eager;
 pub mod planning;
 pub mod syntax;
+mod typed_eager;
 pub(crate) mod util;
 
 // Re-exports for convenience
@@ -47,6 +48,7 @@ pub use eager::eager_einsum;
 pub use planning::tree::{ContractionOptimizerOptions, ContractionTree};
 pub use syntax::nested::NestedEinsum;
 pub use syntax::subscripts::Subscripts;
+pub use typed_eager::typed_eager_einsum;
 pub use util::{build_size_dict, compute_output_shape};
 
 #[cfg(test)]

--- a/tenferro-einsum/src/typed_eager.rs
+++ b/tenferro-einsum/src/typed_eager.rs
@@ -1,0 +1,43 @@
+use tenferro_tensor::{Error, Result, Tensor, TensorBackend, TensorScalar, TypedTensor};
+
+use crate::eager_einsum;
+
+fn tensor_scalar_dtype<T: TensorScalar>() -> tenferro_tensor::DType {
+    T::into_tensor(vec![0], Vec::new()).dtype()
+}
+
+/// Execute eager einsum over typed tensors and return a typed result.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_einsum::typed_eager_einsum;
+/// use tenferro_tensor::{cpu::CpuBackend, TypedTensor};
+///
+/// let mut ctx = CpuBackend::new();
+/// let a = TypedTensor::<f64>::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+/// let b = TypedTensor::<f64>::from_vec(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+///
+/// let c = typed_eager_einsum(&mut ctx, &[&a, &b], "ij,jk->ik").unwrap();
+///
+/// assert_eq!(c.shape, vec![2, 2]);
+/// assert_eq!(c.as_slice(), &[22.0, 28.0, 49.0, 64.0]);
+/// ```
+pub fn typed_eager_einsum<T: TensorScalar>(
+    ctx: &mut impl TensorBackend,
+    inputs: &[&TypedTensor<T>],
+    subscripts: &str,
+) -> Result<TypedTensor<T>> {
+    let tensors: Vec<Tensor> = inputs
+        .iter()
+        .map(|tensor| T::into_tensor(tensor.shape.clone(), tensor.host_data().to_vec()))
+        .collect();
+    let refs: Vec<&Tensor> = tensors.iter().collect();
+    let result = eager_einsum(ctx, &refs, subscripts)?;
+    let actual = result.dtype();
+    T::try_into_typed(result).ok_or_else(|| Error::DTypeMismatch {
+        op: "typed_eager_einsum",
+        lhs: actual,
+        rhs: tensor_scalar_dtype::<T>(),
+    })
+}

--- a/tenferro-einsum/tests/typed_eager.rs
+++ b/tenferro-einsum/tests/typed_eager.rs
@@ -1,0 +1,14 @@
+use tenferro_einsum::typed_eager_einsum;
+use tenferro_tensor::{cpu::CpuBackend, TypedTensor};
+
+#[test]
+fn typed_einsum_f64() {
+    let mut ctx = CpuBackend::new();
+    let lhs = TypedTensor::<f64>::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let rhs = TypedTensor::<f64>::from_vec(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let result = typed_eager_einsum(&mut ctx, &[&lhs, &rhs], "ij,jk->ik").unwrap();
+
+    assert_eq!(result.shape, vec![2, 2]);
+    assert_eq!(result.as_slice(), &[22.0, 28.0, 49.0, 64.0]);
+}

--- a/tenferro-einsum/tests/typed_eager.rs
+++ b/tenferro-einsum/tests/typed_eager.rs
@@ -1,5 +1,88 @@
 use tenferro_einsum::typed_eager_einsum;
-use tenferro_tensor::{cpu::CpuBackend, TypedTensor};
+use tenferro_tensor::{
+    cpu::CpuBackend, CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
+    SliceConfig, Tensor, TensorBackend, TypedTensor,
+};
+
+#[derive(Default)]
+struct WrongDTypeBackend;
+
+macro_rules! panic_backend_methods {
+    ($($name:ident($($arg:ident : $argty:ty),*) -> $ret:ty;)+) => {
+        $(
+            fn $name(&mut self, $($arg: $argty),*) -> $ret {
+                let _ = ($($arg),*);
+                panic!(concat!(stringify!($name), " should not be called in this test"))
+            }
+        )+
+    };
+}
+
+impl TensorBackend for WrongDTypeBackend {
+    panic_backend_methods! {
+        add(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        mul(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        neg(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        conj(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        div(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        abs(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        sign(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        maximum(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        minimum(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> tenferro_tensor::Result<Tensor>;
+        select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        exp(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        log(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        sin(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        cos(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        tanh(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        sqrt(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        rsqrt(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        pow(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        expm1(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        log1p(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        transpose(input: &Tensor, perm: &[usize]) -> tenferro_tensor::Result<Tensor>;
+        reshape(input: &Tensor, shape: &[usize]) -> tenferro_tensor::Result<Tensor>;
+        broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> tenferro_tensor::Result<Tensor>;
+        convert(input: &Tensor, to: DType) -> tenferro_tensor::Result<Tensor>;
+        extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> tenferro_tensor::Result<Tensor>;
+        embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> tenferro_tensor::Result<Tensor>;
+        tril(input: &Tensor, k: i64) -> tenferro_tensor::Result<Tensor>;
+        triu(input: &Tensor, k: i64) -> tenferro_tensor::Result<Tensor>;
+        reduce_sum(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+        reduce_prod(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+        reduce_max(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+        reduce_min(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+        gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> tenferro_tensor::Result<Tensor>;
+        scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> tenferro_tensor::Result<Tensor>;
+        slice(input: &Tensor, config: &SliceConfig) -> tenferro_tensor::Result<Tensor>;
+        dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+        pad(input: &Tensor, config: &PadConfig) -> tenferro_tensor::Result<Tensor>;
+        concatenate(inputs: &[&Tensor], axis: usize) -> tenferro_tensor::Result<Tensor>;
+        reverse(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+        cholesky(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+        triangular_solve(a: &Tensor, b: &Tensor, left_side: bool, lower: bool, transpose_a: bool, unit_diagonal: bool) -> tenferro_tensor::Result<Tensor>;
+        lu(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+        svd(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+        qr(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+        eigh(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+        eig(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+        solve(a: &Tensor, b: &Tensor) -> tenferro_tensor::Result<Tensor>;
+    }
+
+    fn dot_general(
+        &mut self,
+        _lhs: &Tensor,
+        _rhs: &Tensor,
+        _config: &DotGeneralConfig,
+    ) -> tenferro_tensor::Result<Tensor> {
+        Ok(Tensor::F64(TypedTensor::from_vec(
+            vec![2, 2],
+            vec![1.0, 2.0, 3.0, 4.0],
+        )))
+    }
+}
 
 #[test]
 fn typed_einsum_f64() {
@@ -11,4 +94,35 @@ fn typed_einsum_f64() {
 
     assert_eq!(result.shape, vec![2, 2]);
     assert_eq!(result.as_slice(), &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn typed_einsum_f64_three_operands() {
+    let mut ctx = CpuBackend::new();
+    let a = TypedTensor::<f64>::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let b = TypedTensor::<f64>::from_vec(vec![3, 2], vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0]);
+    let c = TypedTensor::<f64>::from_vec(vec![2, 2], vec![2.0, 0.0, 1.0, 3.0]);
+
+    let result = typed_eager_einsum(&mut ctx, &[&a, &b, &c], "ij,jk,kl->il").unwrap();
+
+    assert_eq!(result.shape, vec![2, 2]);
+    assert_eq!(result.as_slice(), &[152.0, 200.0, 385.0, 508.0]);
+}
+
+#[test]
+fn typed_einsum_reports_dtype_mismatch_from_backend_result() {
+    let mut ctx = WrongDTypeBackend;
+    let lhs = TypedTensor::<f32>::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let rhs = TypedTensor::<f32>::from_vec(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let err = typed_eager_einsum(&mut ctx, &[&lhs, &rhs], "ij,jk->ik").unwrap_err();
+
+    assert!(matches!(
+        err,
+        tenferro_tensor::Error::DTypeMismatch {
+            op: "typed_eager_einsum",
+            lhs: DType::F64,
+            rhs: DType::F32,
+        }
+    ));
 }

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -19,6 +19,7 @@ pub mod cpu;
 pub mod error;
 #[cfg(feature = "provider-inject")]
 pub mod inject;
+mod typed_linalg;
 pub mod types;
 pub mod validate;
 

--- a/tenferro-tensor/src/typed_linalg.rs
+++ b/tenferro-tensor/src/typed_linalg.rs
@@ -1,0 +1,125 @@
+use crate::{cpu::CpuBackend, Error, Result, Tensor, TensorScalar, TypedTensor};
+
+fn tensor_scalar_dtype<T: TensorScalar>() -> crate::DType {
+    T::into_tensor(vec![0], Vec::new()).dtype()
+}
+
+fn try_into_typed_result<T: TensorScalar>(
+    op: &'static str,
+    tensor: Tensor,
+) -> Result<TypedTensor<T>> {
+    let actual = tensor.dtype();
+    T::try_into_typed(tensor).ok_or_else(|| Error::DTypeMismatch {
+        op,
+        lhs: actual,
+        rhs: tensor_scalar_dtype::<T>(),
+    })
+}
+
+impl<T: TensorScalar> TypedTensor<T> {
+    /// Singular value decomposition: `A = U diag(S) Vt`.
+    ///
+    /// Returns `(U, S, Vt)` using the thin/economy SVD.
+    ///
+    /// For complex inputs, this wrapper expects the backend to return the
+    /// singular values as `TypedTensor<T::Real>`. If the backend still returns
+    /// a complex tensor for `S`, this method returns [`Error::DTypeMismatch`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{cpu::CpuBackend, TypedTensor};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0]);
+    /// let (u, s, vt) = a.svd(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(u.shape, vec![2, 2]);
+    /// assert_eq!(s.shape, vec![2]);
+    /// assert_eq!(vt.shape, vec![2, 2]);
+    /// ```
+    pub fn svd(&self, ctx: &mut CpuBackend) -> Result<(Self, TypedTensor<T::Real>, Self)> {
+        let tensor = T::into_tensor(self.shape.clone(), self.host_data().to_vec());
+        let (u, s, vt) = tensor.svd(ctx)?;
+        Ok((
+            try_into_typed_result("svd", u)?,
+            try_into_typed_result("svd", s)?,
+            try_into_typed_result("svd", vt)?,
+        ))
+    }
+
+    /// QR decomposition: `A = Q R`.
+    ///
+    /// Returns `(Q, R)` using the thin/economy QR decomposition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{cpu::CpuBackend, TypedTensor};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    /// let (q, r) = a.qr(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(q.shape, vec![2, 2]);
+    /// assert_eq!(r.shape, vec![2, 2]);
+    /// ```
+    pub fn qr(&self, ctx: &mut CpuBackend) -> Result<(Self, Self)> {
+        let tensor = T::into_tensor(self.shape.clone(), self.host_data().to_vec());
+        let (q, r) = tensor.qr(ctx)?;
+        Ok((
+            try_into_typed_result("qr", q)?,
+            try_into_typed_result("qr", r)?,
+        ))
+    }
+
+    /// Cholesky factorization: `A = L L^T` or `A = L L^H`.
+    ///
+    /// Returns the lower-triangular factor `L`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{cpu::CpuBackend, TypedTensor};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec(vec![2, 2], vec![4.0, 1.0, 1.0, 3.0]);
+    /// let l = a.cholesky(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(l.shape, vec![2, 2]);
+    /// ```
+    pub fn cholesky(&self, ctx: &mut CpuBackend) -> Result<Self> {
+        let tensor = T::into_tensor(self.shape.clone(), self.host_data().to_vec());
+        let factor = tensor.cholesky(ctx)?;
+        try_into_typed_result("cholesky", factor)
+    }
+
+    /// Symmetric or Hermitian eigendecomposition: `A = V diag(W) V^T`.
+    ///
+    /// Returns `(eigenvalues, eigenvectors)`.
+    ///
+    /// For complex inputs, this wrapper expects the backend to return the
+    /// eigenvalues as `TypedTensor<T::Real>`. If the backend still returns a
+    /// complex tensor for `W`, this method returns [`Error::DTypeMismatch`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{cpu::CpuBackend, TypedTensor};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec(vec![2, 2], vec![4.0, 1.0, 1.0, 3.0]);
+    /// let (w, v) = a.eigh(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(w.shape, vec![2]);
+    /// assert_eq!(v.shape, vec![2, 2]);
+    /// ```
+    pub fn eigh(&self, ctx: &mut CpuBackend) -> Result<(TypedTensor<T::Real>, Self)> {
+        let tensor = T::into_tensor(self.shape.clone(), self.host_data().to_vec());
+        let (w, v) = tensor.eigh(ctx)?;
+        Ok((
+            try_into_typed_result("eigh", w)?,
+            try_into_typed_result("eigh", v)?,
+        ))
+    }
+}

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -150,11 +150,30 @@ pub enum DType {
 /// assert_eq!(tensor.as_slice::<f64>(), Some([1.0, 2.0].as_slice()));
 /// ```
 pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
+    /// Real-valued counterpart of this scalar type.
+    type Real: TensorScalar;
+
     /// Wrap typed data into a [`Tensor`] enum variant.
     fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor;
 
     /// Try to borrow the host data from a [`Tensor`].
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]>;
+
+    /// Try to extract a [`TypedTensor<Self>`] from a dynamic [`Tensor`].
+    ///
+    /// Returns `None` if the tensor dtype does not match `Self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorScalar};
+    ///
+    /// let tensor = Tensor::new(vec![2], vec![1.0_f64, 2.0]);
+    /// let typed = <f64 as TensorScalar>::try_into_typed(tensor).unwrap();
+    ///
+    /// assert_eq!(typed.as_slice(), &[1.0, 2.0]);
+    /// ```
+    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>>;
 }
 
 mod private {
@@ -167,6 +186,8 @@ mod private {
 }
 
 impl TensorScalar for f64 {
+    type Real = f64;
+
     fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
         Tensor::F64(TypedTensor::from_vec(shape, data))
     }
@@ -177,9 +198,18 @@ impl TensorScalar for f64 {
             _ => None,
         }
     }
+
+    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
+        match tensor {
+            Tensor::F64(inner) => Some(inner),
+            _ => None,
+        }
+    }
 }
 
 impl TensorScalar for f32 {
+    type Real = f32;
+
     fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
         Tensor::F32(TypedTensor::from_vec(shape, data))
     }
@@ -190,9 +220,18 @@ impl TensorScalar for f32 {
             _ => None,
         }
     }
+
+    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
+        match tensor {
+            Tensor::F32(inner) => Some(inner),
+            _ => None,
+        }
+    }
 }
 
 impl TensorScalar for Complex64 {
+    type Real = f64;
+
     fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
         Tensor::C64(TypedTensor::from_vec(shape, data))
     }
@@ -203,9 +242,18 @@ impl TensorScalar for Complex64 {
             _ => None,
         }
     }
+
+    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
+        match tensor {
+            Tensor::C64(inner) => Some(inner),
+            _ => None,
+        }
+    }
 }
 
 impl TensorScalar for Complex32 {
+    type Real = f32;
+
     fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
         Tensor::C32(TypedTensor::from_vec(shape, data))
     }
@@ -213,6 +261,13 @@ impl TensorScalar for Complex32 {
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
         match tensor {
             Tensor::C32(t) => Some(t.host_data()),
+            _ => None,
+        }
+    }
+
+    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
+        match tensor {
+            Tensor::C32(inner) => Some(inner),
             _ => None,
         }
     }

--- a/tenferro-tensor/tests/typed_convenience.rs
+++ b/tenferro-tensor/tests/typed_convenience.rs
@@ -1,0 +1,48 @@
+use tenferro_tensor::{cpu::CpuBackend, TypedTensor};
+
+#[test]
+fn typed_svd_f64() {
+    let mut ctx = CpuBackend::new();
+    let input = TypedTensor::<f64>::from_vec(vec![2, 2], vec![3.0, 0.0, 0.0, 2.0]);
+
+    let (u, s, vt) = input.svd(&mut ctx).unwrap();
+
+    assert_eq!(u.shape, vec![2, 2]);
+    assert_eq!(s.shape, vec![2]);
+    assert_eq!(vt.shape, vec![2, 2]);
+    assert_eq!(s.as_slice(), &[3.0, 2.0]);
+}
+
+#[test]
+fn typed_qr_f64() {
+    let mut ctx = CpuBackend::new();
+    let input = TypedTensor::<f64>::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+
+    let (q, r) = input.qr(&mut ctx).unwrap();
+
+    assert_eq!(q.shape, vec![2, 2]);
+    assert_eq!(r.shape, vec![2, 2]);
+}
+
+#[test]
+fn typed_cholesky_f64() {
+    let mut ctx = CpuBackend::new();
+    let input = TypedTensor::<f64>::from_vec(vec![2, 2], vec![4.0, 0.0, 0.0, 9.0]);
+
+    let factor = input.cholesky(&mut ctx).unwrap();
+
+    assert_eq!(factor.shape, vec![2, 2]);
+    assert_eq!(factor.as_slice(), &[2.0, 0.0, 0.0, 3.0]);
+}
+
+#[test]
+fn typed_eigh_f64() {
+    let mut ctx = CpuBackend::new();
+    let input = TypedTensor::<f64>::from_vec(vec![2, 2], vec![2.0, 0.0, 0.0, 5.0]);
+
+    let (w, v) = input.eigh(&mut ctx).unwrap();
+
+    assert_eq!(w.shape, vec![2]);
+    assert_eq!(v.shape, vec![2, 2]);
+    assert_eq!(w.as_slice(), &[2.0, 5.0]);
+}

--- a/tenferro/src/eager_einsum.rs
+++ b/tenferro/src/eager_einsum.rs
@@ -1,0 +1,39 @@
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_tensor::TensorBackend;
+
+use crate::eager::EagerTensor;
+use crate::error::Result;
+
+/// Execute an einsum eagerly and record it for reverse-mode autodiff.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::eager_einsum::eager_einsum_ad;
+/// use tenferro::{EagerTensor, Tensor};
+///
+/// let a = EagerTensor::from_tensor(Tensor::new(
+///     vec![2, 3],
+///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+/// ));
+/// let b = EagerTensor::from_tensor(Tensor::new(
+///     vec![3, 2],
+///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+/// ));
+/// let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
+///
+/// assert_eq!(c.data().shape(), &[2, 2]);
+/// assert_eq!(c.data().as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+/// ```
+pub fn eager_einsum_ad<B: TensorBackend>(
+    inputs: &[&EagerTensor<B>],
+    subscripts: &str,
+) -> Result<EagerTensor<B>> {
+    EagerTensor::nary_op(
+        inputs,
+        StdTensorOp::NaryEinsum {
+            subscripts: subscripts.to_string(),
+            n_inputs: inputs.len(),
+        },
+    )
+}

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -15,6 +15,12 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
     inputs: &[&Tensor],
     backend: &mut B,
 ) -> Result<Vec<Tensor>> {
+    if let StdTensorOp::NaryEinsum { subscripts, .. } = op {
+        return Ok(vec![tenferro_einsum::eager_einsum(
+            backend, inputs, subscripts,
+        )?]);
+    }
+
     backend.with_exec_session(|exec| {
         let result = match op {
             StdTensorOp::Add => vec![exec.add(inputs[0], inputs[1])?],
@@ -72,7 +78,7 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
                 vec![exec.concatenate(inputs, *axis)?]
             }
             StdTensorOp::NaryEinsum { .. } => {
-                todo!("NaryEinsum eager exec requires contraction tree planning")
+                unreachable!("NaryEinsum is handled before opening an exec session")
             }
             StdTensorOp::Gather(config) => vec![exec.gather(inputs[0], inputs[1], config)?],
             StdTensorOp::Scatter(config) => {

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -5,7 +5,9 @@ use tidu::{GradEdge, GradNode};
 
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend};
+use tenferro_tensor::{
+    DotGeneralConfig, GatherConfig, PadConfig, SliceConfig, Tensor, TensorBackend,
+};
 
 use crate::eager::{
     eager_val_key, exec_single_output, saved_forward_values, saved_forward_values_multi,
@@ -122,6 +124,589 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     pub fn dot_general(&self, other: &Self, config: DotGeneralConfig) -> Result<Self> {
         self.binary_op(other, StdTensorOp::DotGeneral(config))
+    }
+
+    /// Permute tensor axes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(
+    ///     vec![2, 3],
+    ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    /// ));
+    /// let y = x.transpose(&[1, 0]).unwrap();
+    ///
+    /// assert_eq!(y.data().shape(), &[3, 2]);
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
+    /// ```
+    pub fn transpose(&self, perm: &[usize]) -> Result<Self> {
+        self.unary_op(StdTensorOp::Transpose {
+            perm: perm.to_vec(),
+        })
+    }
+
+    /// Reshape without changing element order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(
+    ///     vec![2, 3],
+    ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    /// ));
+    /// let y = x.reshape(&[6]).unwrap();
+    ///
+    /// assert_eq!(y.data().shape(), &[6]);
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    /// ```
+    pub fn reshape(&self, shape: &[usize]) -> Result<Self> {
+        self.unary_op(StdTensorOp::Reshape {
+            from_shape: DimExpr::from_concrete(self.data.shape()),
+            to_shape: DimExpr::from_concrete(shape),
+        })
+    }
+
+    /// Slice with explicit start, limit, and stride per axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, SliceConfig, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let y = x
+    ///     .slice(SliceConfig {
+    ///         starts: vec![1],
+    ///         limits: vec![3],
+    ///         strides: vec![1],
+    ///     })
+    ///     .unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[2.0, 3.0]);
+    /// ```
+    pub fn slice(&self, config: SliceConfig) -> Result<Self> {
+        self.unary_op(StdTensorOp::Slice(config))
+    }
+
+    /// Broadcast into a larger shape with explicit dimension placement.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    /// let y = x.broadcast_in_dim(&[3, 2], &[0]).unwrap();
+    ///
+    /// assert_eq!(y.data().shape(), &[3, 2]);
+    /// ```
+    pub fn broadcast_in_dim(&self, shape: &[usize], dims: &[usize]) -> Result<Self> {
+        self.unary_op(StdTensorOp::BroadcastInDim {
+            shape: DimExpr::from_concrete(shape),
+            dims: dims.to_vec(),
+        })
+    }
+
+    /// Pad with zeros using StableHLO-style edge and interior padding.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, PadConfig, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
+    /// let y = x
+    ///     .pad(PadConfig {
+    ///         edge_padding_low: vec![1],
+    ///         edge_padding_high: vec![1],
+    ///         interior_padding: vec![1],
+    ///     })
+    ///     .unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0, 1.0, 0.0, 2.0, 0.0]);
+    /// ```
+    pub fn pad(&self, config: PadConfig) -> Result<Self> {
+        self.unary_op(StdTensorOp::Pad(config))
+    }
+
+    /// Reverse the order of elements along the requested axes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let y = x.reverse(&[0]).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[4.0, 3.0, 2.0, 1.0]);
+    /// ```
+    pub fn reverse(&self, axes: &[usize]) -> Result<Self> {
+        self.unary_op(StdTensorOp::Reverse {
+            axes: axes.to_vec(),
+        })
+    }
+
+    /// Gather slices from `self` using integer start indices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, GatherConfig, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(
+    ///     vec![5],
+    ///     vec![10.0_f64, 20.0, 30.0, 40.0, 50.0],
+    /// ));
+    /// let indices = EagerTensor::from_tensor(Tensor::new(vec![3], vec![4.0_f64, 1.0, 0.0]));
+    /// let y = x
+    ///     .gather(
+    ///         &indices,
+    ///         GatherConfig {
+    ///             offset_dims: vec![],
+    ///             collapsed_slice_dims: vec![0],
+    ///             start_index_map: vec![0],
+    ///             index_vector_dim: 1,
+    ///             slice_sizes: vec![1],
+    ///         },
+    ///     )
+    ///     .unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[50.0, 20.0, 10.0]);
+    /// ```
+    pub fn gather(&self, indices: &Self, config: GatherConfig) -> Result<Self> {
+        self.binary_op(indices, StdTensorOp::Gather(config))
+    }
+
+    /// Slice using runtime start indices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]));
+    /// let starts = EagerTensor::from_tensor(Tensor::new(vec![1], vec![2.0_f64]));
+    /// let y = x.dynamic_slice(&starts, &[2]).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
+    /// ```
+    pub fn dynamic_slice(&self, starts: &Self, sizes: &[usize]) -> Result<Self> {
+        self.binary_op(
+            starts,
+            StdTensorOp::DynamicSlice {
+                slice_sizes: sizes.to_vec(),
+            },
+        )
+    }
+
+    /// Concatenate tensors along one axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
+    /// let y = EagerTensor::from_tensor(Tensor::new(vec![2], vec![3.0_f64, 4.0]));
+    /// let z = EagerTensor::concatenate(&[&x, &y], 0).unwrap();
+    ///
+    /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
+    /// ```
+    pub fn concatenate(tensors: &[&Self], axis: usize) -> Result<Self> {
+        Self::nary_op(tensors, StdTensorOp::Concatenate { axis })
+    }
+
+    /// Elementwise absolute value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![-1.0_f64, 2.0]));
+    /// let y = x.abs().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    pub fn abs(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Abs)
+    }
+
+    /// Elementwise complex conjugate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, -2.0]));
+    /// let y = x.conj().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, -2.0]);
+    /// ```
+    pub fn conj(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Conj)
+    }
+
+    /// Elementwise sign.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![-2.0_f64, 3.0]));
+    /// let y = x.sign().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[-1.0, 1.0]);
+    /// ```
+    pub fn sign(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Sign)
+    }
+
+    /// Elementwise natural logarithm.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![1], vec![1.0_f64]));
+    /// let y = x.log().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0]);
+    /// ```
+    pub fn log(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Log)
+    }
+
+    /// Elementwise square root.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![1], vec![4.0_f64]));
+    /// let y = x.sqrt().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[2.0]);
+    /// ```
+    pub fn sqrt(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Sqrt)
+    }
+
+    /// Elementwise reciprocal square root.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![1], vec![4.0_f64]));
+    /// let y = x.rsqrt().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.5]);
+    /// ```
+    pub fn rsqrt(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Rsqrt)
+    }
+
+    /// Elementwise sine.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![1], vec![0.0_f64]));
+    /// let y = x.sin().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0]);
+    /// ```
+    pub fn sin(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Sin)
+    }
+
+    /// Elementwise cosine.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![1], vec![0.0_f64]));
+    /// let y = x.cos().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0]);
+    /// ```
+    pub fn cos(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Cos)
+    }
+
+    /// Elementwise hyperbolic tangent.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![1], vec![0.0_f64]));
+    /// let y = x.tanh().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0]);
+    /// ```
+    pub fn tanh(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Tanh)
+    }
+
+    /// Elementwise `exp(x) - 1`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![1], vec![0.0_f64]));
+    /// let y = x.expm1().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0]);
+    /// ```
+    pub fn expm1(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Expm1)
+    }
+
+    /// Elementwise `log(1 + x)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![1], vec![0.0_f64]));
+    /// let y = x.log1p().unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0]);
+    /// ```
+    pub fn log1p(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Log1p)
+    }
+
+    /// Elementwise division.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![3], vec![8.0_f64, -6.0, 9.0]));
+    /// let y = EagerTensor::from_tensor(Tensor::new(vec![3], vec![2.0_f64, 3.0, 3.0]));
+    /// let z = x.div(&y).unwrap();
+    ///
+    /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[4.0, -2.0, 3.0]);
+    /// ```
+    pub fn div(&self, other: &Self) -> Result<Self> {
+        self.binary_op(other, StdTensorOp::Div)
+    }
+
+    /// Elementwise power.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let base = EagerTensor::from_tensor(Tensor::new(vec![2], vec![2.0_f64, 3.0]));
+    /// let exp = EagerTensor::from_tensor(Tensor::new(vec![2], vec![3.0_f64, 2.0]));
+    /// let y = base.pow(&exp).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[8.0, 9.0]);
+    /// ```
+    pub fn pow(&self, other: &Self) -> Result<Self> {
+        self.binary_op(other, StdTensorOp::Pow)
+    }
+
+    /// Elementwise maximum.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 5.0]));
+    /// let y = EagerTensor::from_tensor(Tensor::new(vec![2], vec![3.0_f64, 4.0]));
+    /// let z = x.maximum(&y).unwrap();
+    ///
+    /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[3.0, 5.0]);
+    /// ```
+    pub fn maximum(&self, other: &Self) -> Result<Self> {
+        self.binary_op(other, StdTensorOp::Maximum)
+    }
+
+    /// Elementwise minimum.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 5.0]));
+    /// let y = EagerTensor::from_tensor(Tensor::new(vec![2], vec![3.0_f64, 4.0]));
+    /// let z = x.minimum(&y).unwrap();
+    ///
+    /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[1.0, 4.0]);
+    /// ```
+    pub fn minimum(&self, other: &Self) -> Result<Self> {
+        self.binary_op(other, StdTensorOp::Minimum)
+    }
+
+    /// Select values from `on_true` or `on_false` using `condition`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let condition = EagerTensor::from_tensor(Tensor::new(vec![2], vec![0.0_f64, 1.0]));
+    /// let on_true = EagerTensor::from_tensor(Tensor::new(vec![2], vec![10.0_f64, 20.0]));
+    /// let on_false = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
+    /// let y = EagerTensor::select(&condition, &on_true, &on_false).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 20.0]);
+    /// ```
+    pub fn select(condition: &Self, on_true: &Self, on_false: &Self) -> Result<Self> {
+        condition.ternary_op(on_true, on_false, StdTensorOp::Select)
+    }
+
+    /// Extract the diagonal along two axes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(
+    ///     vec![3, 3],
+    ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+    /// ));
+    /// let y = x.extract_diag(0, 1).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 5.0, 9.0]);
+    /// ```
+    pub fn extract_diag(&self, axis_a: usize, axis_b: usize) -> Result<Self> {
+        self.unary_op(StdTensorOp::ExtractDiag { axis_a, axis_b })
+    }
+
+    /// Embed a vector or lower-rank tensor along a diagonal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    /// let y = x.embed_diag(0, 1).unwrap();
+    ///
+    /// assert_eq!(y.data().shape(), &[3, 3]);
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0]);
+    /// ```
+    pub fn embed_diag(&self, axis_a: usize, axis_b: usize) -> Result<Self> {
+        self.unary_op(StdTensorOp::EmbedDiag { axis_a, axis_b })
+    }
+
+    /// Keep the lower triangle and zero the rest.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let y = x.tril(0).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 2.0, 0.0, 4.0]);
+    /// ```
+    pub fn tril(&self, k: i64) -> Result<Self> {
+        self.unary_op(StdTensorOp::Tril { k })
+    }
+
+    /// Keep the upper triangle and zero the rest.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let y = x.triu(0).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 0.0, 3.0, 4.0]);
+    /// ```
+    pub fn triu(&self, k: i64) -> Result<Self> {
+        self.unary_op(StdTensorOp::Triu { k })
+    }
+
+    /// Reduce product over the requested axes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let y = x.reduce_prod(&[0, 1]).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[24.0]);
+    /// ```
+    pub fn reduce_prod(&self, axes: &[usize]) -> Result<Self> {
+        self.unary_op(StdTensorOp::ReduceProd {
+            axes: axes.to_vec(),
+            input_shape: DimExpr::from_concrete(self.data.shape()),
+        })
+    }
+
+    /// Reduce maximum over the requested axes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let y = x.reduce_max(&[0, 1]).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[4.0]);
+    /// ```
+    pub fn reduce_max(&self, axes: &[usize]) -> Result<Self> {
+        self.unary_op(StdTensorOp::ReduceMax {
+            axes: axes.to_vec(),
+            input_shape: DimExpr::from_concrete(self.data.shape()),
+        })
+    }
+
+    /// Reduce minimum over the requested axes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let y = x.reduce_min(&[0, 1]).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0]);
+    /// ```
+    pub fn reduce_min(&self, axes: &[usize]) -> Result<Self> {
+        self.unary_op(StdTensorOp::ReduceMin {
+            axes: axes.to_vec(),
+            input_shape: DimExpr::from_concrete(self.data.shape()),
+        })
     }
 
     pub(crate) fn unary_op(&self, op: StdTensorOp) -> Result<Self> {

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -6,7 +6,7 @@ use tidu::{GradEdge, GradNode};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{
-    DotGeneralConfig, GatherConfig, PadConfig, SliceConfig, Tensor, TensorBackend,
+    DType, DotGeneralConfig, GatherConfig, PadConfig, SliceConfig, Tensor, TensorBackend,
 };
 
 use crate::eager::{
@@ -707,6 +707,230 @@ impl<B: TensorBackend> EagerTensor<B> {
             axes: axes.to_vec(),
             input_shape: DimExpr::from_concrete(self.data.shape()),
         })
+    }
+
+    /// Singular value decomposition: `A = U diag(S) Vt`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]));
+    /// let (u, s, vt) = a.svd().unwrap();
+    ///
+    /// assert_eq!(u.data().shape(), &[2, 2]);
+    /// assert_eq!(s.data().shape(), &[2]);
+    /// assert_eq!(vt.data().shape(), &[2, 2]);
+    /// ```
+    pub fn svd(&self) -> Result<(Self, Self, Self)> {
+        let mut outputs = self
+            .multi_output_unary_op(
+                StdTensorOp::Svd {
+                    eps: 1.0e-12,
+                    input_shape: DimExpr::from_concrete(self.data.shape()),
+                },
+                3,
+            )?
+            .into_iter();
+        match (
+            outputs.next(),
+            outputs.next(),
+            outputs.next(),
+            outputs.next(),
+        ) {
+            (Some(u), Some(s), Some(vt), None) => Ok((u, s, vt)),
+            _ => Err(Error::Internal(
+                "svd eager op returned an unexpected number of outputs".to_string(),
+            )),
+        }
+    }
+
+    /// QR decomposition: `A = Q R`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]));
+    /// let (q, r) = a.qr().unwrap();
+    ///
+    /// assert_eq!(q.data().shape(), &[2, 2]);
+    /// assert_eq!(r.data().shape(), &[2, 2]);
+    /// ```
+    pub fn qr(&self) -> Result<(Self, Self)> {
+        let mut outputs = self
+            .multi_output_unary_op(
+                StdTensorOp::Qr {
+                    input_shape: DimExpr::from_concrete(self.data.shape()),
+                },
+                2,
+            )?
+            .into_iter();
+        match (outputs.next(), outputs.next(), outputs.next()) {
+            (Some(q), Some(r), None) => Ok((q, r)),
+            _ => Err(Error::Internal(
+                "qr eager op returned an unexpected number of outputs".to_string(),
+            )),
+        }
+    }
+
+    /// LU decomposition with partial pivoting: `P A = L U`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]));
+    /// let (p, l, u, parity) = a.lu().unwrap();
+    ///
+    /// assert_eq!(p.data().shape(), &[2, 2]);
+    /// assert_eq!(l.data().shape(), &[2, 2]);
+    /// assert_eq!(u.data().shape(), &[2, 2]);
+    /// assert_eq!(parity.data().shape(), &[] as &[usize]);
+    /// ```
+    pub fn lu(&self) -> Result<(Self, Self, Self, Self)> {
+        let mut outputs = self
+            .multi_output_unary_op(
+                StdTensorOp::Lu {
+                    input_shape: DimExpr::from_concrete(self.data.shape()),
+                },
+                4,
+            )?
+            .into_iter();
+        match (
+            outputs.next(),
+            outputs.next(),
+            outputs.next(),
+            outputs.next(),
+            outputs.next(),
+        ) {
+            (Some(p), Some(l), Some(u), Some(parity), None) => Ok((p, l, u, parity)),
+            _ => Err(Error::Internal(
+                "lu eager op returned an unexpected number of outputs".to_string(),
+            )),
+        }
+    }
+
+    /// Cholesky factorization: `A = L L^T` for real inputs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]));
+    /// let l = a.cholesky().unwrap();
+    ///
+    /// assert_eq!(l.data().shape(), &[2, 2]);
+    /// assert_eq!(l.data().as_slice::<f64>().unwrap(), &[1.0, 0.0, 0.0, 1.0]);
+    /// ```
+    pub fn cholesky(&self) -> Result<Self> {
+        self.unary_op(StdTensorOp::Cholesky {
+            input_shape: DimExpr::from_concrete(self.data.shape()),
+        })
+    }
+
+    /// Symmetric or Hermitian eigendecomposition: `A = V diag(W) V^T`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
+    /// let (values, vectors) = a.eigh().unwrap();
+    ///
+    /// assert_eq!(values.data().shape(), &[2]);
+    /// assert_eq!(vectors.data().shape(), &[2, 2]);
+    /// ```
+    pub fn eigh(&self) -> Result<(Self, Self)> {
+        let mut outputs = self
+            .multi_output_unary_op(
+                StdTensorOp::Eigh {
+                    eps: 1.0e-12,
+                    input_shape: DimExpr::from_concrete(self.data.shape()),
+                },
+                2,
+            )?
+            .into_iter();
+        match (outputs.next(), outputs.next(), outputs.next()) {
+            (Some(values), Some(vectors), None) => Ok((values, vectors)),
+            _ => Err(Error::Internal(
+                "eigh eager op returned an unexpected number of outputs".to_string(),
+            )),
+        }
+    }
+
+    /// General eigendecomposition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
+    /// let (values, vectors) = a.eig().unwrap();
+    ///
+    /// assert_eq!(values.data().shape(), &[2]);
+    /// assert_eq!(vectors.data().shape(), &[2, 2]);
+    /// ```
+    pub fn eig(&self) -> Result<(Self, Self)> {
+        let input_dtype: DType = self.data.dtype();
+        let mut outputs = self
+            .multi_output_unary_op(
+                StdTensorOp::Eig {
+                    input_dtype,
+                    input_shape: DimExpr::from_concrete(self.data.shape()),
+                },
+                2,
+            )?
+            .into_iter();
+        match (outputs.next(), outputs.next(), outputs.next()) {
+            (Some(values), Some(vectors), None) => Ok((values, vectors)),
+            _ => Err(Error::Internal(
+                "eig eager op returned an unexpected number of outputs".to_string(),
+            )),
+        }
+    }
+
+    /// Solve a triangular linear system.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]));
+    /// let b = EagerTensor::from_tensor(Tensor::new(vec![2, 1], vec![4.0_f64, 8.0]));
+    /// let x = a
+    ///     .triangular_solve(&b, true, true, false, false)
+    ///     .unwrap();
+    ///
+    /// assert_eq!(x.data().shape(), &[2, 1]);
+    /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[2.0, 2.0]);
+    /// ```
+    pub fn triangular_solve(
+        &self,
+        b: &Self,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> Result<Self> {
+        self.binary_op(
+            b,
+            StdTensorOp::TriangularSolve {
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+                lhs_shape: DimExpr::from_concrete(self.data.shape()),
+                rhs_shape: DimExpr::from_concrete(b.data.shape()),
+            },
+        )
     }
 
     pub(crate) fn unary_op(&self, op: StdTensorOp) -> Result<Self> {

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -15,7 +15,7 @@
 //! // ... build and execute traced computations
 //! ```
 
-pub use tenferro_tensor::DotGeneralConfig;
+pub use tenferro_tensor::{DotGeneralConfig, GatherConfig, PadConfig, SliceConfig};
 
 mod checkpoint;
 pub mod compiler;

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -20,6 +20,7 @@ pub use tenferro_tensor::{DotGeneralConfig, GatherConfig, PadConfig, SliceConfig
 mod checkpoint;
 pub mod compiler;
 mod eager;
+pub mod eager_einsum;
 mod eager_emitter;
 pub mod eager_exec;
 pub(crate) mod eager_ops;

--- a/tenferro/tests/eager_einsum_ad.rs
+++ b/tenferro/tests/eager_einsum_ad.rs
@@ -1,0 +1,47 @@
+use tenferro::eager_einsum::eager_einsum_ad;
+use tenferro::{EagerTensor, Tensor};
+
+fn f64_data(tensor: &Tensor) -> &[f64] {
+    tensor.as_slice::<f64>().unwrap()
+}
+
+#[test]
+fn eager_einsum_ad_matmul_primal_matches_expected_values() {
+    let a = EagerTensor::from_tensor(Tensor::new(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+    let b = EagerTensor::from_tensor(Tensor::new(
+        vec![3, 2],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+
+    let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
+
+    assert_eq!(c.data().shape(), &[2, 2]);
+    assert_eq!(f64_data(c.data()), &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn eager_einsum_ad_backward_populates_input_grads() {
+    let a = EagerTensor::requires_grad(Tensor::new(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+    let b = EagerTensor::requires_grad(Tensor::new(
+        vec![3, 2],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+
+    let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
+    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let _cotangents = loss.backward().unwrap();
+
+    let grad_a = a.grad().unwrap();
+    let grad_b = b.grad().unwrap();
+
+    assert_eq!(grad_a.shape(), &[2, 3]);
+    assert_eq!(grad_b.shape(), &[3, 2]);
+    assert_eq!(f64_data(grad_a.as_ref()), &[5.0, 5.0, 7.0, 7.0, 9.0, 9.0]);
+    assert_eq!(f64_data(grad_b.as_ref()), &[3.0, 7.0, 11.0, 3.0, 7.0, 11.0]);
+}

--- a/tenferro/tests/eager_linalg.rs
+++ b/tenferro/tests/eager_linalg.rs
@@ -1,7 +1,12 @@
+use num_complex::Complex64;
 use tenferro::{EagerTensor, Tensor};
 
 fn f64_data(tensor: &Tensor) -> &[f64] {
     tensor.as_slice::<f64>().unwrap()
+}
+
+fn c64_data(tensor: &Tensor) -> &[Complex64] {
+    tensor.as_slice::<Complex64>().unwrap()
 }
 
 #[test]
@@ -43,4 +48,63 @@ fn svd_gradient_smoke() {
     let grad = a.grad();
     assert!(grad.is_some());
     assert_eq!(grad.unwrap().shape(), &[2, 2]);
+}
+
+#[test]
+fn lu_returns_expected_factors_for_swap_matrix() {
+    let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]));
+    let (p, l, u, parity) = a.lu().unwrap();
+
+    assert_eq!(p.data().shape(), &[2, 2]);
+    assert_eq!(l.data().shape(), &[2, 2]);
+    assert_eq!(u.data().shape(), &[2, 2]);
+    assert_eq!(parity.data().shape(), &[] as &[usize]);
+
+    assert_eq!(f64_data(p.data()), &[0.0, 1.0, 1.0, 0.0]);
+    assert_eq!(f64_data(l.data()), &[1.0, 0.0, 0.0, 1.0]);
+    assert_eq!(f64_data(u.data()), &[1.0, 0.0, 0.0, 1.0]);
+    assert_eq!(f64_data(parity.data()), &[-1.0]);
+}
+
+#[test]
+fn eigh_returns_expected_values_for_diagonal_matrix() {
+    let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
+    let (values, vectors) = a.eigh().unwrap();
+
+    assert_eq!(values.data().shape(), &[2]);
+    assert_eq!(vectors.data().shape(), &[2, 2]);
+
+    let mut sorted = f64_data(values.data()).to_vec();
+    sorted.sort_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap_or(std::cmp::Ordering::Equal));
+    assert_eq!(sorted, vec![1.0, 3.0]);
+}
+
+#[test]
+fn eig_returns_expected_complex_values_for_diagonal_matrix() {
+    let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
+    let (values, vectors) = a.eig().unwrap();
+
+    assert_eq!(values.data().shape(), &[2]);
+    assert_eq!(vectors.data().shape(), &[2, 2]);
+
+    let mut sorted = c64_data(values.data()).to_vec();
+    sorted.sort_by(|lhs, rhs| {
+        lhs.re
+            .partial_cmp(&rhs.re)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    assert_eq!(
+        sorted,
+        vec![Complex64::new(1.0, 0.0), Complex64::new(3.0, 0.0)]
+    );
+}
+
+#[test]
+fn triangular_solve_returns_expected_solution() {
+    let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]));
+    let b = EagerTensor::from_tensor(Tensor::new(vec![2, 1], vec![4.0_f64, 8.0]));
+    let x = a.triangular_solve(&b, true, true, false, false).unwrap();
+
+    assert_eq!(x.data().shape(), &[2, 1]);
+    assert_eq!(f64_data(x.data()), &[2.0, 2.0]);
 }

--- a/tenferro/tests/eager_linalg.rs
+++ b/tenferro/tests/eager_linalg.rs
@@ -1,0 +1,46 @@
+use tenferro::{EagerTensor, Tensor};
+
+fn f64_data(tensor: &Tensor) -> &[f64] {
+    tensor.as_slice::<f64>().unwrap()
+}
+
+#[test]
+fn svd_returns_correct_shapes() {
+    let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]));
+    let (u, s, vt) = a.svd().unwrap();
+
+    assert_eq!(u.data().shape(), &[2, 2]);
+    assert_eq!(s.data().shape(), &[2]);
+    assert_eq!(vt.data().shape(), &[2, 2]);
+}
+
+#[test]
+fn qr_returns_correct_shapes() {
+    let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]));
+    let (q, r) = a.qr().unwrap();
+
+    assert_eq!(q.data().shape(), &[2, 2]);
+    assert_eq!(r.data().shape(), &[2, 2]);
+}
+
+#[test]
+fn cholesky_of_identity() {
+    let a = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]));
+    let l = a.cholesky().unwrap();
+
+    assert_eq!(l.data().shape(), &[2, 2]);
+    assert_eq!(f64_data(l.data()), &[1.0, 0.0, 0.0, 1.0]);
+}
+
+#[test]
+fn svd_gradient_smoke() {
+    let a = EagerTensor::requires_grad(Tensor::new(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 1.0]));
+    let (_, s, _) = a.svd().unwrap();
+    let loss = s.reduce_sum(&[0]).unwrap();
+
+    let _cotangents = loss.backward().unwrap();
+
+    let grad = a.grad();
+    assert!(grad.is_some());
+    assert_eq!(grad.unwrap().shape(), &[2, 2]);
+}

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -169,3 +169,75 @@ fn eager_untracked_tensor_behaves_like_plain_tensor() {
     assert!(y.grad().is_none());
     assert!(z.grad().is_none());
 }
+
+#[test]
+fn eager_structural_primal_ops_transpose_and_reshape() {
+    let x = EagerTensor::from_tensor(Tensor::new(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+
+    let transposed = x.transpose(&[1, 0]).unwrap();
+    assert_eq!(transposed.data().shape(), &[3, 2]);
+    assert_close_slice(
+        f64_data(transposed.data()),
+        &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0],
+        TOL,
+    );
+
+    let reshaped = x.reshape(&[6]).unwrap();
+    assert_eq!(reshaped.data().shape(), &[6]);
+    assert_close_slice(
+        f64_data(reshaped.data()),
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        TOL,
+    );
+}
+
+#[test]
+fn eager_elementwise_primal_ops_div_abs_and_sin() {
+    let x = EagerTensor::from_tensor(Tensor::new(vec![3], vec![8.0_f64, -6.0, 9.0]));
+    let y = EagerTensor::from_tensor(Tensor::new(vec![3], vec![2.0_f64, 3.0, 3.0]));
+
+    let div = x.div(&y).unwrap();
+    assert_close_slice(f64_data(div.data()), &[4.0, -2.0, 3.0], TOL);
+
+    let abs = x.abs().unwrap();
+    assert_close_slice(f64_data(abs.data()), &[8.0, 6.0, 9.0], TOL);
+
+    let angles = EagerTensor::from_tensor(Tensor::new(
+        vec![2],
+        vec![0.0_f64, std::f64::consts::FRAC_PI_2],
+    ));
+    let sin = angles.sin().unwrap();
+    assert_close_slice(f64_data(sin.data()), &[0.0, 1.0], TOL);
+}
+
+#[test]
+fn eager_diagonal_primal_ops_extract_diag_and_tril() {
+    let matrix = EagerTensor::from_tensor(Tensor::new(
+        vec![3, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+    ));
+    let diag = matrix.extract_diag(0, 1).unwrap();
+    assert_close_slice(f64_data(diag.data()), &[1.0, 5.0, 9.0], TOL);
+
+    let lower = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]))
+        .tril(0)
+        .unwrap();
+    assert_close_slice(f64_data(lower.data()), &[1.0, 2.0, 0.0, 4.0], TOL);
+}
+
+#[test]
+fn eager_reduction_primal_ops_reduce_prod() {
+    let x = EagerTensor::from_tensor(Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+
+    let prod = x.reduce_prod(&[0, 1]).unwrap();
+    assert_close_slice(f64_data(prod.data()), &[24.0], TOL);
+
+    let max = x.reduce_max(&[0, 1]).unwrap();
+    assert_close_slice(f64_data(max.data()), &[4.0], TOL);
+
+    let min = x.reduce_min(&[0, 1]).unwrap();
+    assert_close_slice(f64_data(min.data()), &[1.0], TOL);
+}

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -1,4 +1,5 @@
-use tenferro::{DotGeneralConfig, EagerTensor, Tensor};
+use num_complex::Complex64;
+use tenferro::{DotGeneralConfig, EagerTensor, GatherConfig, PadConfig, SliceConfig, Tensor};
 
 const FD_H: f64 = 1.0e-6;
 const TOL: f64 = 1.0e-5;
@@ -16,6 +17,10 @@ fn assert_close_slice(actual: &[f64], expected: &[f64], tol: f64) {
 
 fn f64_data(tensor: &Tensor) -> &[f64] {
     tensor.as_slice::<f64>().unwrap()
+}
+
+fn c64_data(tensor: &Tensor) -> &[Complex64] {
+    tensor.as_slice::<Complex64>().unwrap()
 }
 
 fn finite_diff_scalar(f: impl Fn(&[f64]) -> f64, x: &[f64], index: usize) -> f64 {
@@ -240,4 +245,201 @@ fn eager_reduction_primal_ops_reduce_prod() {
 
     let min = x.reduce_min(&[0, 1]).unwrap();
     assert_close_slice(f64_data(min.data()), &[1.0], TOL);
+}
+
+#[test]
+fn eager_slice_primal() {
+    let x = EagerTensor::from_tensor(Tensor::new(
+        vec![4, 3],
+        vec![
+            1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ],
+    ));
+
+    let y = x
+        .slice(SliceConfig {
+            starts: vec![0, 0],
+            limits: vec![4, 3],
+            strides: vec![2, 2],
+        })
+        .unwrap();
+
+    assert_eq!(y.data().shape(), &[2, 2]);
+    assert_close_slice(f64_data(y.data()), &[1.0, 3.0, 9.0, 11.0], TOL);
+}
+
+#[test]
+fn eager_broadcast_in_dim_primal() {
+    let x = EagerTensor::from_tensor(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let y = x.broadcast_in_dim(&[3, 2], &[0]).unwrap();
+
+    assert_eq!(y.data().shape(), &[3, 2]);
+    assert_close_slice(f64_data(y.data()), &[1.0, 2.0, 3.0, 1.0, 2.0, 3.0], TOL);
+}
+
+#[test]
+fn eager_pad_primal() {
+    let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
+    let y = x
+        .pad(PadConfig {
+            edge_padding_low: vec![1],
+            edge_padding_high: vec![1],
+            interior_padding: vec![1],
+        })
+        .unwrap();
+
+    assert_eq!(y.data().shape(), &[5]);
+    assert_close_slice(f64_data(y.data()), &[0.0, 1.0, 0.0, 2.0, 0.0], TOL);
+}
+
+#[test]
+fn eager_reverse_primal() {
+    let x = EagerTensor::from_tensor(Tensor::new(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    let y = x.reverse(&[0]).unwrap();
+
+    assert_close_slice(f64_data(y.data()), &[4.0, 3.0, 2.0, 1.0], TOL);
+}
+
+#[test]
+fn eager_concatenate_primal() {
+    let x = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
+    let y = EagerTensor::from_tensor(Tensor::new(vec![2], vec![3.0_f64, 4.0]));
+    let z = EagerTensor::concatenate(&[&x, &y], 0).unwrap();
+
+    assert_eq!(z.data().shape(), &[4]);
+    assert_close_slice(f64_data(z.data()), &[1.0, 2.0, 3.0, 4.0], TOL);
+}
+
+#[test]
+fn eager_gather_primal() {
+    let x = EagerTensor::from_tensor(Tensor::new(vec![5], vec![10.0_f64, 20.0, 30.0, 40.0, 50.0]));
+    let indices = EagerTensor::from_tensor(Tensor::new(vec![3], vec![4.0_f64, 1.0, 0.0]));
+    let y = x
+        .gather(
+            &indices,
+            GatherConfig {
+                offset_dims: vec![],
+                collapsed_slice_dims: vec![0],
+                start_index_map: vec![0],
+                index_vector_dim: 1,
+                slice_sizes: vec![1],
+            },
+        )
+        .unwrap();
+
+    assert_eq!(y.data().shape(), &[3]);
+    assert_close_slice(f64_data(y.data()), &[50.0, 20.0, 10.0], TOL);
+}
+
+#[test]
+fn eager_dynamic_slice_primal() {
+    let x = EagerTensor::from_tensor(Tensor::new(
+        vec![4, 4],
+        vec![
+            1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+            16.0,
+        ],
+    ));
+    let starts = EagerTensor::from_tensor(Tensor::new(vec![2], vec![2.0_f64, 3.0]));
+    let y = x.dynamic_slice(&starts, &[2, 2]).unwrap();
+
+    assert_eq!(y.data().shape(), &[2, 2]);
+    assert_close_slice(f64_data(y.data()), &[11.0, 12.0, 15.0, 16.0], TOL);
+}
+
+#[test]
+fn eager_conj_primal() {
+    let x = EagerTensor::from_tensor(Tensor::new(
+        vec![2],
+        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
+    ));
+    let y = x.conj().unwrap();
+
+    assert_eq!(
+        c64_data(y.data()),
+        &[Complex64::new(1.0, -2.0), Complex64::new(-3.0, -0.5)]
+    );
+}
+
+#[test]
+fn eager_analytic_primal_ops_sign_log_sqrt_rsqrt_cos_tanh_expm1_log1p() {
+    let sign_input = EagerTensor::from_tensor(Tensor::new(vec![3], vec![-2.0_f64, 0.0, 3.0]));
+    let sign = sign_input.sign().unwrap();
+    assert_close_slice(f64_data(sign.data()), &[-1.0, 0.0, 1.0], TOL);
+
+    let log_input =
+        EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, std::f64::consts::E]));
+    let log = log_input.log().unwrap();
+    assert_close_slice(f64_data(log.data()), &[0.0, 1.0], TOL);
+
+    let sqrt_input = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 4.0]));
+    let sqrt = sqrt_input.sqrt().unwrap();
+    let rsqrt = sqrt_input.rsqrt().unwrap();
+    assert_close_slice(f64_data(sqrt.data()), &[1.0, 2.0], TOL);
+    assert_close_slice(f64_data(rsqrt.data()), &[1.0, 0.5], TOL);
+
+    let angles =
+        EagerTensor::from_tensor(Tensor::new(vec![2], vec![0.0_f64, std::f64::consts::PI]));
+    let cos = angles.cos().unwrap();
+    assert_close_slice(f64_data(cos.data()), &[1.0, -1.0], TOL);
+
+    let tanh_input = EagerTensor::from_tensor(Tensor::new(vec![2], vec![0.0_f64, 1.0]));
+    let tanh = tanh_input.tanh().unwrap();
+    assert_close_slice(f64_data(tanh.data()), &[0.0, 1.0_f64.tanh()], TOL);
+
+    let expm1_input = EagerTensor::from_tensor(Tensor::new(vec![2], vec![0.0_f64, 1.0]));
+    let expm1 = expm1_input.expm1().unwrap();
+    assert_close_slice(f64_data(expm1.data()), &[0.0, 1.0_f64.exp_m1()], TOL);
+
+    let log1p_input = EagerTensor::from_tensor(Tensor::new(vec![2], vec![1.0_f64, 4.0]));
+    let log1p = log1p_input.log1p().unwrap();
+    assert_close_slice(f64_data(log1p.data()), &[2.0_f64.ln(), 5.0_f64.ln()], TOL);
+}
+
+#[test]
+fn eager_pow_maximum_and_minimum_primal() {
+    let base = EagerTensor::from_tensor(Tensor::new(vec![2], vec![2.0_f64, 9.0]));
+    let exp = EagerTensor::from_tensor(Tensor::new(vec![2], vec![3.0_f64, 0.5]));
+    let pow = base.pow(&exp).unwrap();
+    assert_close_slice(f64_data(pow.data()), &[8.0, 3.0], TOL);
+
+    let x = EagerTensor::from_tensor(Tensor::new(vec![3], vec![8.0_f64, -2.0, 9.0]));
+    let y = EagerTensor::from_tensor(Tensor::new(vec![3], vec![2.0_f64, 5.0, 3.0]));
+    let maximum = x.maximum(&y).unwrap();
+    let minimum = x.minimum(&y).unwrap();
+    assert_close_slice(f64_data(maximum.data()), &[8.0, 5.0, 9.0], TOL);
+    assert_close_slice(f64_data(minimum.data()), &[2.0, -2.0, 3.0], TOL);
+}
+
+#[test]
+fn eager_select_primal() {
+    let condition = EagerTensor::from_tensor(Tensor::new(vec![3], vec![0.0_f64, -1.0, 2.0]));
+    let on_true = EagerTensor::from_tensor(Tensor::new(vec![3], vec![10.0_f64, 20.0, 30.0]));
+    let on_false = EagerTensor::from_tensor(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let y = EagerTensor::select(&condition, &on_true, &on_false).unwrap();
+
+    assert_close_slice(f64_data(y.data()), &[1.0, 20.0, 30.0], TOL);
+}
+
+#[test]
+fn eager_embed_diag_and_triu_primal() {
+    let diagonal = EagerTensor::from_tensor(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let embedded = diagonal.embed_diag(0, 1).unwrap();
+    assert_eq!(embedded.data().shape(), &[3, 3]);
+    assert_close_slice(
+        f64_data(embedded.data()),
+        &[1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0],
+        TOL,
+    );
+
+    let matrix = EagerTensor::from_tensor(Tensor::new(
+        vec![3, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+    ));
+    let upper = matrix.triu(0).unwrap();
+    assert_close_slice(
+        f64_data(upper.data()),
+        &[1.0, 0.0, 0.0, 4.0, 5.0, 0.0, 7.0, 8.0, 9.0],
+        TOL,
+    );
 }


### PR DESCRIPTION
## Summary

Implements Phases 2-5 of the EagerTensor API extensions (#706), building on Phase 1 (#709).

**Phase 2 — Structural, elementwise, diagonal, reduction ops (+30 ops)**
- transpose, reshape, slice, concatenate, broadcast_in_dim, pad, reverse, gather, dynamic_slice
- div, abs, conj, sign, log, sqrt, rsqrt, sin, cos, tanh, expm1, log1p, pow, maximum, minimum, select
- extract_diag, embed_diag, tril, triu
- reduce_prod, reduce_max, reduce_min

**Phase 3 — Linalg ops with multi-output AD**
- Multi-output: svd, qr, lu, eigh, eig (shared `Arc<GradNode>` pattern)
- Single-output: cholesky, triangular_solve

**Phase 4 — Einsum with AD**
- `NaryEinsum` branch in `eager_exec.rs` (delegates to `eager_einsum`)
- `eager_einsum_ad` free function

**Phase 5 — TensorScalar::Real + TypedTensor convenience**
- `TensorScalar::Real` associated type + `try_into_typed`
- `TypedTensor<T>` linalg convenience: svd, qr, cholesky, eigh
- `typed_eager_einsum` in tenferro-einsum

Design spec: `docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md`

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace --release` — all pass
- [x] `cargo doc --workspace --no-deps`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)