### PR TITLE
[codex] make eager tensors Send+Sync and switch backward() to grad accumulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 General-purpose dense tensor computation in Rust, inspired by PyTorch and JAX.
 
-tenferro provides both eager tensor operations (like NumPy) and lazy traced
-execution with einsum, linear algebra, and automatic differentiation
-(VJP/JVP/HVP) on CPU. GPU support is planned.
+tenferro provides both eager tensor operations with scalar-loss reverse-mode
+autodiff and lazy traced execution with einsum, linear algebra, and transform
+AD (VJP/JVP/HVP) on CPU. GPU support is planned.
 
 ## Workspace Crates
 
 | Crate | Role |
 | --- | --- |
-| `tenferro` | Traced frontend: `Engine`, `TracedTensor`, public einsum and linalg APIs, AD (VJP/JVP/HVP) |
+| `tenferro` | User-facing facade: eager execution and scalar-loss reverse-mode AD via `EagerTensor` / `EagerContext`, plus traced execution and transform AD via `TracedTensor`, `Engine`, and public einsum/linalg APIs |
 | `tenferro-tensor` | Dense runtime tensors, backend traits, CPU backend (GPU planned) |
 | `tenferro-einsum` | Subscripts, contraction trees, and fragment-building utilities |
 | `tenferro-ops` | Graph op vocabulary (`StdTensorOp`, `SemiringOp`) and AD rule implementations |

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -9,8 +9,9 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 | Eager tensor | `numpy.ndarray` | — | `Tensor` + `CpuBackend` |
 | Tensor handle | `torch.Tensor` | `jax.Array` / `jnp.ndarray` | `TracedTensor` |
 | Concrete result | `torch.Tensor` | `jax.Array` | `Tensor` returned by `.eval(&mut engine)` |
-| Execution | Eager by default | Eager arrays, often staged with `jit` | Lazy until `eval` |
-| Gradients | `loss.backward()`, `torch.autograd.grad` | `jax.grad`, `jax.vjp`, `jax.jvp` | `.grad`, `.vjp`, `.jvp` |
+| Execution | Eager by default | Eager arrays, often staged with `jit` | Eager (`Tensor` / `EagerTensor`) or lazy traced (`TracedTensor` + `.eval()`) |
+| Eager gradients | `loss.backward()` | — | `EagerTensor::backward()` with accumulation |
+| Transform AD | `torch.autograd.grad(...)` | `jax.grad`, `jax.vjp`, `jax.jvp`, `hvp` via composition | `loss.grad(&x)`, `.vjp()`, `.jvp()` |
 | Device/runtime | Device is attached to tensors | Device is attached to arrays | Backend lives inside `Engine` |
 | Matrix contraction | `torch.einsum` | `jnp.einsum` | `tenferro::einsum::einsum` |
 
@@ -29,7 +30,10 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 | QR | `torch.linalg.qr(x)` | `jnp.linalg.qr(x)` | `x.qr(&mut ctx)` | `tenferro::qr(&x)` |
 | Cholesky | `torch.linalg.cholesky(x)` | `jnp.linalg.cholesky(x)` | `x.cholesky(&mut ctx)` | `tenferro::cholesky(&x)` |
 | Solve | `torch.linalg.solve(a, b)` | `jnp.linalg.solve(a, b)` | `a.solve(&b, &mut ctx)` | `tenferro::solve(&a, &b)` |
-| Gradient | `torch.autograd.grad(...)` | `jax.grad(f)(x)` | N/A | `loss.grad(&x)` |
+| Scalar-loss backward | `loss.backward()` | — | `loss.backward()` on `EagerTensor` | — |
+| Reverse-mode grad | `torch.autograd.grad(loss, x)` | `jax.grad(f)(x)` | — | `loss.grad(&x)` |
+| VJP | `torch.autograd.grad(..., grad_outputs=...)` | `jax.vjp` | — | `y.vjp(&x, &cotangent)` |
+| JVP | `torch.func.jvp` | `jax.jvp` | — | `y.jvp(&x, &tangent)` |
 
 ## Key differences
 
@@ -45,7 +49,16 @@ then the columns are `[1, 2]`, `[3, 4]`, and `[5, 6]`.
 
 ### Lazy evaluation
 
-PyTorch users usually expect every operation to execute immediately. JAX users often switch between eager execution and `jit`. tenferro stays lazy until you call `.eval(&mut engine)`.
+PyTorch users usually expect every operation to execute immediately. JAX users
+often switch between eager execution and `jit`. tenferro stays lazy until you
+call `.eval(&mut engine)`.
+
+### Autodiff split
+
+Eager tenferro matches PyTorch's scalar-loss `loss.backward()` workflow with
+accumulation semantics. Traced tenferro is the transform surface for
+`torch.autograd.grad`, `jax.grad`, `jax.vjp`, `jax.jvp`, and higher-order
+compositions such as HVPs.
 
 ### Engine ownership
 

--- a/docs/guides/autodiff.md
+++ b/docs/guides/autodiff.md
@@ -1,6 +1,9 @@
 # Autodiff
 
-tenferro exposes autodiff directly on `TracedTensor`. If you know PyTorch or JAX, the mental model is:
+tenferro exposes transform-oriented autodiff directly on `TracedTensor`.
+Eager tensors also support scalar-loss reverse-mode via `backward()`, but
+this page is about the traced APIs. If you know PyTorch or JAX, the mental
+model is:
 
 - `grad` for scalar-loss reverse mode
 - `vjp` for vector-Jacobian products
@@ -9,8 +12,11 @@ tenferro exposes autodiff directly on `TracedTensor`. If you know PyTorch or JAX
 
 ## Reverse-mode gradient with `grad`
 
-PyTorch equivalent: `torch.autograd.grad(loss, x)` or `loss.backward()`  
+PyTorch equivalent: `torch.autograd.grad(loss, x)`  
 JAX equivalent: `jax.grad(f)(x)`
+
+If you want eager scalar-loss accumulation instead, see the eager operations
+guide and use `EagerTensor::backward()`.
 
 ```rust
 use tenferro::{CpuBackend, Engine, TracedTensor};

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -1,19 +1,24 @@
 # Eager Operations
 
-This guide covers using tenferro for direct computation without automatic
-differentiation: the path you would choose for NumPy-like workflows where you
-control the computation explicitly.
+This guide covers using tenferro for direct computation with eager
+reverse-mode autodiff on scalar losses: the path you would choose for
+NumPy-like workflows where you control the computation explicitly and call
+`backward()` when you need gradients.
 
 ## Setup
 
 ```rust
-use tenferro_tensor::{Tensor, TypedTensor, TensorBackend, cpu::CpuBackend};
+use tenferro::{CpuBackend, Tensor, TypedTensor};
 
 let mut ctx = CpuBackend::new();
 ```
 
 Every eager operation requires a backend context. `CpuBackend` is the standard
 CPU backend using the faer linear algebra library.
+
+`EagerContext` is the gradient-owning wrapper for eager AD state. If you share
+one context across multiple tracked tensors, their gradients accumulate into
+the same state and you can reset them together with `clear_grads()`.
 
 Most eager operations are methods on `Tensor`. `TypedTensor<T>` is useful when
 you want compile-time dtype safety for construction or direct host-side data
@@ -22,7 +27,7 @@ access.
 ## Creating tensors
 
 ```rust
-use tenferro_tensor::{Tensor, TypedTensor};
+use tenferro::{Tensor, TypedTensor};
 
 // Dynamic dtype (`Tensor`)
 let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
@@ -41,7 +46,7 @@ its columns as `[1, 2]`, `[3, 4]`, and `[5, 6]`.
 ## Arithmetic
 
 ```rust
-use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+use tenferro::{CpuBackend, Tensor};
 
 let mut ctx = CpuBackend::new();
 let a = Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);
@@ -59,7 +64,7 @@ assert_eq!(negated.as_slice::<f64>().unwrap(), &[-1.0, -2.0, -3.0]);
 ## Linear algebra
 
 ```rust
-use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+use tenferro::{CpuBackend, Tensor};
 
 let mut ctx = CpuBackend::new();
 let a = Tensor::new(vec![3, 3], vec![
@@ -94,7 +99,7 @@ assert_eq!(x.shape(), &[3]);
 ## Shape operations
 
 ```rust
-use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+use tenferro::{CpuBackend, Tensor};
 
 let mut ctx = CpuBackend::new();
 let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
@@ -115,8 +120,8 @@ assert_eq!(col_sum.shape(), &[3]);
 ## Einsum
 
 ```rust
-use tenferro_einsum::eager_einsum;
-use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+use tenferro::eager_einsum::eager_einsum;
+use tenferro::{CpuBackend, Tensor};
 
 let mut ctx = CpuBackend::new();
 
@@ -134,7 +139,7 @@ assert_eq!(c.shape(), &[2, 4]);
 ## Extracting data
 
 ```rust
-use tenferro_tensor::Tensor;
+use tenferro::Tensor;
 
 let t = Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);
 let data: &[f64] = t.as_slice::<f64>().unwrap();
@@ -155,6 +160,39 @@ Column 2: [5, 6]
 This matches Fortran, Julia, and MATLAB conventions but differs from C/NumPy
 row-major order.
 
+## Eager reverse-mode gradients
+
+Eager tensors support scalar-loss reverse-mode autodiff with accumulation.
+Repeated `backward()` calls add to the existing gradients, and you clear them
+explicitly when you want a fresh pass.
+
+```rust
+use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+
+let ctx = EagerContext::with_backend(CpuBackend::new());
+let x = EagerTensor::requires_grad_in(Tensor::new(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
+let y = EagerTensor::requires_grad_in(Tensor::new(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
+
+let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+loss.backward().unwrap();
+assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
+
+let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+loss.backward().unwrap();
+assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[6.0, 8.0]);
+
+x.clear_grad();
+assert!(x.grad().is_none());
+
+let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+loss.backward().unwrap();
+assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
+
+ctx.clear_grads();
+assert!(x.grad().is_none());
+assert!(y.grad().is_none());
+```
+
 ## When to use eager vs lazy
 
 | Scenario | Recommended |
@@ -162,6 +200,6 @@ row-major order.
 | Data preprocessing | Eager (`Tensor` + `CpuBackend`) |
 | TCI inner loops | Eager |
 | Exploratory computation | Eager |
-| Need gradients (AD) | Lazy (`TracedTensor` + `Engine`) |
-| Need HVP / higher-order AD | Lazy |
+| Need scalar-loss reverse-mode gradients | Eager (`EagerTensor::backward()`) |
+| Need transform AD (`grad` / `vjp` / `jvp` / HVP) | Lazy traced (`TracedTensor` + `Engine`) |
 | GPU execution (future) | Lazy |

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,10 +3,11 @@
 tenferro-rs is a dense tensor computation workspace in Rust, inspired by
 PyTorch and JAX. It provides:
 
-- **Eager execution** — `Tensor` and `TypedTensor` with `CpuBackend` for
-  direct computation without AD, like NumPy
+- **Eager execution** — `Tensor`, `TypedTensor`, `EagerTensor`, and
+  `EagerContext` with `CpuBackend` for immediate computation and
+  scalar-loss reverse-mode via `backward()`
 - **Lazy traced execution** — `TracedTensor` with graph optimization and
-  automatic differentiation (VJP/JVP/HVP)
+  transform-oriented automatic differentiation (`grad`, `vjp`, `jvp`, HVP)
 - **Einsum** — with automatic contraction-tree planning
 - **Linear algebra** — SVD, QR, Cholesky, eigh, solve
 
@@ -18,8 +19,9 @@ CPU execution is fully supported; GPU support is planned.
 |---|---|---|---|
 | Eager tensor | `torch.tensor(data)` | `jnp.array(data)` | `Tensor::new(shape, data)` |
 | Traced tensor | — | staged via `jit` | `TracedTensor::new(shape, data)` |
-| Execution | Eager by default | Eager; `jit` stages when asked | Eager (`Tensor`) or lazy (`TracedTensor` + `.eval()`) |
-| Gradients | `loss.backward()` / `torch.autograd.grad` | `jax.grad`, `jax.vjp`, `jax.jvp` | `loss.grad(&x)`, `.vjp()`, `.jvp()` |
+| Execution | Eager by default | Eager; `jit` stages when asked | Eager (`Tensor` / `EagerTensor`) or lazy traced (`TracedTensor` + `.eval()`) |
+| Eager gradients | `loss.backward()` | — | `EagerTensor::backward()` with accumulation |
+| Transform AD | `torch.autograd.grad(...)` | `jax.grad`, `jax.vjp`, `jax.jvp`, `hvp` via composition | `loss.grad(&x)`, `.vjp()`, `.jvp()` |
 | Einsum | `torch.einsum(...)` | `jnp.einsum(...)` | `einsum(...)` / `eager_einsum(...)` |
 | Device | Device on tensors | `jax.device_put(...)` | Backend owned by `Engine` or `CpuBackend` |
 

--- a/docs/plans/2026-04-13-tenferro-eager-grad-accumulation-design.md
+++ b/docs/plans/2026-04-13-tenferro-eager-grad-accumulation-design.md
@@ -1,0 +1,310 @@
+# Tenferro Eager Gradient Accumulation Design
+
+**Date:** 2026-04-13
+
+**Status:** Proposed and approved
+
+## Goal
+
+Align `tenferro::EagerTensor` reverse-mode behavior with PyTorch accumulation
+semantics:
+
+- `backward()` accumulates into existing leaf gradients
+- gradient reset is explicit through public API
+- public docs describe the real eager AD contract instead of claiming eager has
+  no AD
+
+This design assumes the local `Arc<Mutex<...>>` eager context refactor is
+already in place on the current branch and builds on top of that shape.
+
+## Scope
+
+This design covers:
+
+- `EagerTensor::backward()` accumulation semantics
+- public gradient-reset APIs on `EagerTensor` and `EagerContext`
+- a public tracked-state getter on `EagerTensor`
+- eager rustdoc and user-facing docs updates
+- a small facade cleanup needed for user-facing eager docs
+
+This design does not cover:
+
+- traced AD (`TracedTensor::grad`, `vjp`, `jvp`, `hvp`)
+- backward compatibility shims for the old eager overwrite semantics
+- higher-order eager AD
+- backend-sharing helper APIs beyond the current context model
+- eliminating typed eager/linalg host-side copies
+
+## Current State
+
+The current eager AD surface is internally close to usable, but the public
+contract is mismatched in two important ways.
+
+### 1. `backward()` overwrites instead of accumulating
+
+Today `EagerTensor::backward()` does this:
+
+1. reject non-scalar outputs
+2. call `self.ctx.clear_grads()`
+3. run `backward_dag(...)`
+4. call `self.ctx.store_grads(&cotangents)`
+
+That means:
+
+- repeated `backward()` calls do **not** accumulate
+- untouched leaves are reset to `None`
+- the behavior does not match PyTorch users' mental model
+
+### 2. Public docs still claim eager has no AD
+
+User-facing docs currently say or imply:
+
+- eager mode is "without automatic differentiation"
+- "Need gradients (AD)" means switching to lazy/traced mode
+- PyTorch mapping tables do not describe eager `loss.backward()`
+
+That is stale once eager reverse-mode is treated as supported public surface.
+
+### 3. Eager docs currently need a facade cleanup
+
+Repository rules require user-facing docs to import from `tenferro`, not from
+internal crates such as `tenferro_tensor` or `tenferro_einsum`. The current
+eager guide still uses internal-crate imports. If eager docs are updated, the
+public surface must support that presentation cleanly.
+
+## Design Decision
+
+Adopt explicit PyTorch-style accumulation semantics for eager reverse-mode.
+
+### Public API
+
+`EagerTensor<B>` gains:
+
+```rust
+impl<B: TensorBackend> EagerTensor<B> {
+    pub fn tracks_grad(&self) -> bool;
+    pub fn clear_grad(&self);
+    pub fn grad(&self) -> Option<Arc<Tensor>>;
+    pub fn backward(&self) -> Result<HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>>;
+}
+```
+
+`EagerContext<B>` exposes:
+
+```rust
+impl<B: TensorBackend> EagerContext<B> {
+    pub fn with_backend(backend: B) -> Arc<Self>;
+    pub fn clear_grads(&self);
+}
+```
+
+`tenferro::eager_einsum` should expose both eager entry points needed by
+user-facing docs:
+
+```rust
+pub use tenferro_einsum::eager_einsum;
+pub fn eager_einsum_ad<B: TensorBackend>(...) -> Result<EagerTensor<B>>;
+```
+
+## Semantics
+
+### `backward()` accumulates
+
+`backward()` must no longer clear stored leaf gradients before the reverse
+pass.
+
+Instead:
+
+1. run the reverse pass and produce the fresh `cotangents` map for this call
+2. for each tracked live slot that appears in `cotangents`:
+   - if the slot is empty, store the fresh cotangent
+   - if the slot already contains a gradient, add the new cotangent into it
+3. for tracked live slots that do **not** appear in `cotangents`, leave them
+   unchanged
+
+This matches the PyTorch rule that gradients persist until the user clears
+them explicitly.
+
+### Explicit reset
+
+Users reset state explicitly:
+
+- `tensor.clear_grad()` clears one tracked tensor's stored gradient
+- `ctx.clear_grads()` clears all live tracked tensors registered in the shared
+  eager context
+
+Both operations are idempotent. Calling them on empty slots is a no-op.
+
+### Tracked-state query
+
+`tracks_grad()` exposes whether the eager tensor participates in reverse-mode
+tracking. This is needed by downstream migration code and by documentation.
+
+The name is intentionally not `requires_grad()` because the constructor family
+already uses `requires_grad(...)` as an associated function.
+
+### Return value of `backward()`
+
+`backward()` still returns the fresh cotangent map produced by the current
+reverse pass.
+
+Important distinction:
+
+- returned map = gradients from **this call**
+- `grad()` = accumulated leaf gradient storage after merging this call
+
+This preserves the current debugging value of the return result while making
+slot semantics PyTorch-compatible.
+
+## Implementation Notes
+
+### Root fix: replace overwrite logic, not just the clear call
+
+Removing `self.ctx.clear_grads()` is necessary but not sufficient.
+
+The current `store_grads(...)` helper overwrites every registered slot with:
+
+- `Some(cotangent)` when the key is present
+- `None` when the key is absent
+
+That still breaks accumulation and incorrectly clears untouched leaves.
+
+The actual fix is to replace overwrite storage with accumulation-aware storage.
+
+### Accumulation helper behavior
+
+The eager context should own an internal helper shaped like:
+
+```rust
+fn accumulate_grads(
+    &self,
+    cotangents: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
+    backend: &mut B,
+) -> Result<()>;
+```
+
+Behavior:
+
+- retain only live weak slots
+- skip keys missing from `cotangents`
+- set empty slots directly to the incoming cotangent
+- add incoming cotangents into existing slot values using backend-backed tensor
+  addition
+
+Using backend-backed tensor addition keeps accumulation generic over dtype and
+backend rather than hard-coding host-side scalar cases.
+
+### Detached and untracked tensors
+
+No special-case redesign is needed:
+
+- detached tensors still break the reverse graph
+- untracked tensors still never get registered slots
+- `clear_grad()` on an untracked tensor is a no-op
+
+### Shared-context behavior
+
+Accumulation is scoped to registered tracked tensors in the shared
+`EagerContext`. This is the correct eager mental model:
+
+- one context can own many leaves
+- repeated backwards across computations in that context accumulate until
+  explicitly cleared
+
+This also makes the new public `EagerContext::clear_grads()` meaningful.
+
+## Documentation Changes
+
+The public story should become:
+
+- eager mode supports immediate execution and scalar-loss reverse-mode with
+  `backward()`
+- traced mode remains the transform-oriented API for `grad`, `vjp`, `jvp`, and
+  `hvp`
+- eager gradients accumulate, just like PyTorch
+- users clear gradients explicitly between optimization steps
+
+The minimum docs set to update is:
+
+- `README.md`
+- `tenferro/README.md`
+- `docs/index.md`
+- `docs/guides/eager-operations.md`
+- `docs/guides/autodiff.md`
+- `docs/getting-started/pytorch-jax-mapping.md`
+- rustdoc in `tenferro/src/eager.rs`
+- rustdoc in `tenferro/src/eager_einsum.rs`
+
+User-facing pages must import from `tenferro`, not internal crates.
+
+## Testing Strategy
+
+Add or update tests for all public semantics that change:
+
+### Eager reverse-mode contract
+
+In `tenferro/tests/eager_tensor.rs`:
+
+- repeated `backward()` calls accumulate
+- `clear_grad()` resets one leaf without touching others
+- `EagerContext::clear_grads()` resets all live leaves in the shared context
+- untouched leaves retain prior accumulated gradients across unrelated backward
+  calls
+- detached and untracked tensors do not receive gradients
+- `tracks_grad()` reports the correct state
+
+### Eager einsum path
+
+In `tenferro/tests/eager_einsum_ad.rs`:
+
+- repeated eager einsum backwards accumulate across calls
+- context-level clear works for eager einsum leaves too
+
+### Thread-safety guard
+
+Add a small compile-time assertion that `EagerContext<CpuBackend>` and
+`EagerTensor<CpuBackend>` are `Send + Sync`. The local branch already moved to
+`Arc<Mutex<...>>`; the assertion prevents silent regressions.
+
+### Docs/rustdoc
+
+Doctests must demonstrate:
+
+- `backward()` accumulation
+- explicit `clear_grad()` / `clear_grads()`
+- eager vs traced AD positioning
+
+## Compatibility Policy
+
+No compatibility shim is needed.
+
+Do **not** preserve overwrite semantics behind alternate methods, flags, or
+deprecated entry points. The repository is early-stage and the target behavior
+is now explicit.
+
+## Deferred Follow-Ups
+
+These are useful but not required for this migration phase:
+
+- a backend-borrow helper such as `EagerContext::with_backend_mut(...)` if
+  downstream integration later proves it necessary
+- eliminating host-side clone conversions in
+  `tenferro-einsum/src/typed_eager.rs` and
+  `tenferro-tensor/src/typed_linalg.rs`
+
+They should be handled as separate follow-up work rather than folded into the
+gradient-semantics change.
+
+## Summary
+
+The correct upstream change is not "document the current overwrite behavior."
+It is to change eager reverse-mode to PyTorch-compatible accumulation semantics
+and make reset explicit.
+
+That requires:
+
+- `backward()` accumulation
+- public `clear_grad()` and `clear_grads()`
+- a public `tracks_grad()` getter
+- user-facing doc updates that describe eager AD honestly
+- a small facade cleanup so eager docs can stay on `tenferro` imports

--- a/docs/plans/2026-04-13-tenferro-eager-grad-accumulation-plan.md
+++ b/docs/plans/2026-04-13-tenferro-eager-grad-accumulation-plan.md
@@ -1,0 +1,456 @@
+# Tenferro Eager Gradient Accumulation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Change `tenferro::EagerTensor` to PyTorch-style gradient accumulation semantics, add explicit eager gradient reset APIs, and update public docs so eager reverse-mode AD is documented honestly.
+
+**Architecture:** Keep the current `Arc<EagerContext<B>>` + `Mutex<B>` runtime model. The root change is inside eager gradient-slot storage: `backward()` must stop clearing or overwriting slots and instead merge fresh cotangents into persistent per-leaf storage. Public docs should then position eager AD as scalar-loss reverse mode, while traced AD remains the transform-oriented path for `grad`, `vjp`, `jvp`, and `hvp`.
+
+**Tech Stack:** Rust 2021, `tenferro` facade crate, `tenferro-einsum`, `tenferro-tensor`, rustdoc doctests, mdBook/quarto docs, `cargo fmt`, `cargo test --release`, `cargo nextest`, `cargo llvm-cov`
+
+---
+
+### Task 1: Lock the eager accumulation contract with failing tests
+
+**Files:**
+- Modify: `tenferro/tests/eager_tensor.rs`
+- Modify: `tenferro/tests/eager_einsum_ad.rs`
+
+**Step 1: Add failing repeated-backward accumulation tests**
+
+Add a leaf test like:
+
+```rust
+#[test]
+fn eager_repeated_backward_accumulates_across_calls() {
+    let x = EagerTensor::requires_grad(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
+
+    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
+
+    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0, 12.0]);
+}
+```
+
+Also add:
+
+- `eager_clear_grad_resets_only_one_leaf`
+- `eager_context_clear_grads_resets_all_live_leaves`
+- `eager_unrelated_backward_keeps_existing_leaf_grad`
+- `eager_tracks_grad_reports_leaf_state`
+- a compile-time `assert_send_sync::<EagerTensor<CpuBackend>>()`
+- a compile-time `assert_send_sync::<EagerContext<CpuBackend>>()`
+
+**Step 2: Add failing eager einsum accumulation tests**
+
+Add a test like:
+
+```rust
+#[test]
+fn eager_einsum_ad_backward_accumulates_across_calls() {
+    let a = EagerTensor::requires_grad(Tensor::new(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+    let b = EagerTensor::requires_grad(Tensor::new(
+        vec![3, 2],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+
+    let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
+    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let _ = loss.backward().unwrap();
+    let grad_a_once = a.grad().unwrap();
+
+    let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
+    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let _ = loss.backward().unwrap();
+
+    let grad_a_twice = a.grad().unwrap();
+    assert_eq!(
+        grad_a_twice.as_slice::<f64>().unwrap(),
+        &grad_a_once
+            .as_slice::<f64>()
+            .unwrap()
+            .iter()
+            .map(|x| x * 2.0)
+            .collect::<Vec<_>>()
+    );
+}
+```
+
+Also add a context-level clear test that uses `EagerContext::with_backend(...)`
+plus `requires_grad_in(...)`.
+
+**Step 3: Run the focused tests to confirm they fail**
+
+Run:
+
+```bash
+cargo test -p tenferro --test eager_tensor --release
+cargo test -p tenferro --test eager_einsum_ad --release
+```
+
+Expected:
+
+- compile errors for missing `clear_grad`, `clear_grads`, or `tracks_grad`
+- assertion failures showing repeated `backward()` still overwrites instead of accumulating
+
+**Step 4: Commit the failing contract**
+
+```bash
+git add tenferro/tests/eager_tensor.rs \
+        tenferro/tests/eager_einsum_ad.rs
+git commit -m "test: lock eager grad accumulation contract"
+```
+
+### Task 2: Implement accumulation-aware gradient storage in `EagerContext`
+
+**Files:**
+- Modify: `tenferro/src/eager.rs`
+
+**Step 1: Replace overwrite storage with accumulation storage**
+
+Delete the old overwrite helper shape:
+
+```rust
+fn store_grads(&self, cotangents: &HashMap<...>) { ... }
+```
+
+Replace it with an accumulation-aware helper that:
+
+- retains only live grad slots
+- ignores tracked keys absent from `cotangents`
+- writes `Some(incoming.clone())` into empty slots
+- adds `incoming` into the existing gradient when the slot is already `Some(...)`
+
+Use backend-backed tensor addition rather than hard-coded host-side dtype
+special cases.
+
+**Step 2: Keep the backend lock through accumulation**
+
+Change `backward()` from:
+
+```rust
+self.ctx.clear_grads();
+...
+let cotangents = backward_dag(...);
+self.ctx.store_grads(&cotangents);
+```
+
+to:
+
+```rust
+let cotangents = backward_dag(...);
+self.ctx.accumulate_grads(&cotangents, &mut *backend)?;
+```
+
+Do not clear gradients inside `backward()`.
+
+**Step 3: Preserve the scalar-output guard and return value**
+
+Keep:
+
+- the existing non-scalar error path
+- the returned fresh `cotangents` map from the current reverse pass
+
+Do not change `backward()` into a pure side-effect API.
+
+**Step 4: Run the core eager tensor tests**
+
+Run:
+
+```bash
+cargo test -p tenferro --test eager_tensor --release
+```
+
+Expected: the accumulation semantics tests now pass.
+
+**Step 5: Commit**
+
+```bash
+git add tenferro/src/eager.rs
+git commit -m "feat: accumulate eager gradients across backward calls"
+```
+
+### Task 3: Add explicit reset and tracking APIs
+
+**Files:**
+- Modify: `tenferro/src/eager.rs`
+
+**Step 1: Expose `EagerContext::clear_grads()` publicly**
+
+Promote `clear_grads` to a documented public method:
+
+```rust
+impl<B: TensorBackend> EagerContext<B> {
+    pub fn clear_grads(&self) { ... }
+}
+```
+
+It should:
+
+- clear every live registered slot in the context
+- retain only live weak references
+- never panic on empty slots
+
+**Step 2: Add `EagerTensor::clear_grad()`**
+
+Add:
+
+```rust
+pub fn clear_grad(&self) {
+    *self.grad_slot.lock().unwrap() = None;
+}
+```
+
+This should be a no-op for untracked tensors and detached tensors with empty
+slots.
+
+**Step 3: Add `EagerTensor::tracks_grad()`**
+
+Add:
+
+```rust
+pub fn tracks_grad(&self) -> bool {
+    self.requires_grad
+}
+```
+
+Do not rename the existing constructors. The getter exists because a method
+named `requires_grad()` would collide with the constructor family.
+
+**Step 4: Update eager rustdoc examples in the same file**
+
+Revise `tenferro/src/eager.rs` docs so examples show:
+
+- `backward()` accumulation across two calls
+- `clear_grad()` on a single tensor
+- `clear_grads()` on a shared context
+- `tracks_grad()` returning `true` only for tracked leaves
+
+**Step 5: Run the full eager tests again**
+
+Run:
+
+```bash
+cargo test -p tenferro --test eager_tensor --release
+cargo test -p tenferro --test eager_einsum_ad --release
+cargo test -p tenferro --doc --release
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add tenferro/src/eager.rs
+git commit -m "feat: add eager grad reset and tracking apis"
+```
+
+### Task 4: Clean up the eager facade surface for user-facing docs
+
+**Files:**
+- Modify: `tenferro/src/eager_einsum.rs`
+
+**Step 1: Re-export eager primal einsum from the facade module**
+
+Add:
+
+```rust
+pub use tenferro_einsum::eager_einsum;
+```
+
+inside `tenferro::eager_einsum`, alongside `eager_einsum_ad`.
+
+This lets user-facing docs stay on `use tenferro::...` imports, which is
+required by `REPOSITORY_RULES.md`.
+
+**Step 2: Update the module-level rustdoc example**
+
+Show both eager execution and eager reverse-mode in `tenferro/src/eager_einsum.rs`.
+Keep examples small and runnable.
+
+**Step 3: Run focused docs/tests**
+
+Run:
+
+```bash
+cargo test -p tenferro --test eager_einsum_ad --release
+cargo test -p tenferro --doc --release
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add tenferro/src/eager_einsum.rs
+git commit -m "feat: expose eager einsum from the tenferro facade"
+```
+
+### Task 5: Update README, guides, and mapping docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `tenferro/README.md`
+- Modify: `docs/index.md`
+- Modify: `docs/guides/eager-operations.md`
+- Modify: `docs/guides/autodiff.md`
+- Modify: `docs/getting-started/pytorch-jax-mapping.md`
+
+**Step 1: Fix stale capability claims**
+
+Update all public wording that still says eager mode is "without automatic
+differentiation" or that "need gradients" always means traced mode.
+
+The new public positioning should be:
+
+- eager mode supports immediate execution plus scalar-loss reverse-mode via
+  `backward()`
+- traced mode remains the public transform-oriented AD surface for `grad`,
+  `vjp`, `jvp`, and `hvp`
+
+**Step 2: Add one canonical eager accumulation example**
+
+In `docs/guides/eager-operations.md`, include a compact example like:
+
+```rust
+use tenferro::{EagerTensor, Tensor};
+
+let x = EagerTensor::requires_grad(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
+let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+let _ = loss.backward().unwrap();
+assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+
+let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+let _ = loss.backward().unwrap();
+assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0]);
+
+x.clear_grad();
+assert!(x.grad().is_none());
+```
+
+Also update the "When to use eager vs lazy" table so it distinguishes:
+
+- eager `backward()` for scalar-loss reverse mode
+- traced `grad` / `vjp` / `jvp` / `hvp` for transform-oriented AD
+
+**Step 3: Fix user-facing imports**
+
+Replace internal-crate imports such as:
+
+```rust
+use tenferro_tensor::{...}
+use tenferro_einsum::eager_einsum;
+```
+
+with facade imports such as:
+
+```rust
+use tenferro::{CpuBackend, Tensor, TensorBackend, TypedTensor};
+use tenferro::eager_einsum::{eager_einsum, eager_einsum_ad};
+```
+
+Do not leave any user-facing doc page importing internal crates.
+
+**Step 4: Update the PyTorch/JAX mapping table**
+
+Make the mapping explicit:
+
+- PyTorch `loss.backward()` -> eager `loss.backward()` with accumulation
+- PyTorch `torch.autograd.grad(...)` -> traced `loss.grad(&x)`
+- JAX `jax.grad`, `jax.vjp`, `jax.jvp` -> traced transform APIs
+
+**Step 5: Run docs verification**
+
+Run:
+
+```bash
+cargo test -p tenferro --doc --release
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add README.md \
+        tenferro/README.md \
+        docs/index.md \
+        docs/guides/eager-operations.md \
+        docs/guides/autodiff.md \
+        docs/getting-started/pytorch-jax-mapping.md
+git commit -m "docs: describe eager gradient accumulation semantics"
+```
+
+### Task 6: Final verification and PR-readiness checks
+
+**Files:**
+- No intended source changes; only fix fallout if a verification step exposes one
+
+**Step 1: Format the workspace**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all --check
+```
+
+Expected: PASS.
+
+**Step 2: Run targeted eager verification one more time**
+
+Run:
+
+```bash
+cargo test -p tenferro --test eager_tensor --release
+cargo test -p tenferro --test eager_einsum_ad --release
+cargo test -p tenferro --doc --release
+```
+
+Expected: PASS.
+
+**Step 3: Run the repository-wide verification gates**
+
+Run:
+
+```bash
+cargo nextest run --workspace --release --no-fail-fast
+cargo test --doc --workspace --release
+cargo llvm-cov nextest --workspace --release --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+```
+
+Expected: PASS.
+
+**Step 4: Inspect the final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected:
+
+- only intended eager API / test / docs files are modified
+- no unrelated files are touched
+
+**Step 5: If verification fallout requires fixes, make one final focused commit**
+
+```bash
+git add -A
+git commit -m "fix: address eager grad accumulation verification fallout"
+```
+
+Only do this if a verification failure required code or docs changes.

--- a/tenferro/README.md
+++ b/tenferro/README.md
@@ -1,25 +1,43 @@
 # tenferro
 
-Traced tensor frontend for the `tenferro-rs` v2 workspace.
+User-facing tensor facade for the `tenferro-rs` v2 workspace.
 
-`tenferro` is the main user-facing crate for standard dense numeric computation.
-It owns the lazy graph surface (`TracedTensor`), the execution engine
+`tenferro` is the main public crate for standard dense numeric computation.
+It exposes eager execution through `EagerTensor` and `EagerContext`, including
+scalar-loss reverse-mode accumulation via `backward()`, and it exposes
+traced, transform-oriented AD through `TracedTensor` with `grad`, `vjp`,
+`jvp`, and HVP composition. The crate also owns the execution engine
 (`Engine<B>`), StableHLO-style lowering, execution-IR compilation, public
-einsum helpers, public multi-output linalg helpers, and AD entry points
-(VJP/JVP/HVP).
+einsum helpers, and public multi-output linalg helpers.
 
 ## Public Surface
 
 - `TracedTensor`
 - `Engine`
+- `EagerTensor`
+- `EagerContext`
 - `einsum::einsum` and `einsum::einsum_with`
+- `eager_einsum::eager_einsum` and `eager_einsum::eager_einsum_ad`
 - free linalg helpers such as `svd`, `qr`, `eigh`, `solve`, `cholesky`, and
   `triangular_solve`
+- `EagerTensor::backward`, `EagerTensor::clear_grad`, `EagerContext::clear_grads`
 - `TracedTensor::grad`, `TracedTensor::jvp`, `TracedTensor::vjp`
 - re-exported dense runtime types from `tenferro-tensor`:
   `Tensor`, `TypedTensor`, `DType`, `CpuBackend`
 
-## Example
+## Eager Example
+
+```rust
+use tenferro::{EagerTensor, Tensor};
+
+let x = EagerTensor::requires_grad(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
+let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+loss.backward().unwrap();
+
+assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+```
+
+## Traced Example
 
 ```rust
 use tenferro::{einsum::einsum, CpuBackend, Engine, Tensor, TracedTensor, TypedTensor};

--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -76,7 +76,28 @@ impl<B: TensorBackend> EagerContext<B> {
         }
     }
 
-    fn clear_grads(&self) {
+    /// Clear all live gradient slots tracked by this context.
+    ///
+    /// This resets the stored gradients to `None` without unregistering the
+    /// tensors, so future `backward()` calls can accumulate again.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
+    /// let y = EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx.clone());
+    /// let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+    /// let _ = loss.backward().unwrap();
+    ///
+    /// ctx.clear_grads();
+    ///
+    /// assert!(x.grad().is_none());
+    /// assert!(y.grad().is_none());
+    /// ```
+    pub fn clear_grads(&self) {
         self.grad_slots.lock().unwrap().retain(|_, slot| {
             if let Some(slot) = slot.upgrade() {
                 *slot.lock().unwrap() = None;
@@ -87,22 +108,53 @@ impl<B: TensorBackend> EagerContext<B> {
         });
     }
 
-    fn store_grads(&self, cotangents: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>) {
-        self.grad_slots.lock().unwrap().retain(|key, slot| {
-            let Some(slot) = slot.upgrade() else {
-                return false;
+    fn store_grads(
+        &self,
+        cotangents: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
+        backend: &mut B,
+    ) -> Result<()> {
+        let mut updates = Vec::new();
+        let mut staged = Vec::new();
+
+        {
+            let mut slots = self.grad_slots.lock().unwrap();
+            slots.retain(|key, slot| {
+                let Some(slot) = slot.upgrade() else {
+                    return false;
+                };
+
+                if let Some(incoming) = cotangents.get(key) {
+                    updates.push((slot, Arc::clone(incoming)));
+                }
+
+                true
+            });
+        }
+
+        for (slot, incoming) in updates {
+            let next = {
+                let current = slot.lock().unwrap();
+                match current.as_ref() {
+                    Some(existing) => Arc::new(existing.as_ref().add(incoming.as_ref(), backend)?),
+                    None => incoming,
+                }
             };
-            let value = cotangents.get(key).cloned();
-            *slot.lock().unwrap() = value;
-            true
-        });
+            staged.push((slot, next));
+        }
+
+        for (slot, next) in staged {
+            *slot.lock().unwrap() = Some(next);
+        }
+
+        Ok(())
     }
 }
 
 /// Eager tensor with reverse-mode autodiff over concrete tensor values.
 ///
 /// This executes each primitive immediately and records a lightweight reverse
-/// DAG for `backward()`.
+/// DAG for `backward()`. Gradients accumulate across repeated `backward()`
+/// calls until they are cleared explicitly.
 ///
 /// # Examples
 ///
@@ -112,8 +164,13 @@ impl<B: TensorBackend> EagerContext<B> {
 /// let x = EagerTensor::requires_grad(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
 /// let loss = (&x * &x).reduce_sum(&[0]).unwrap();
 /// let _cotangents = loss.backward().unwrap();
+/// let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+/// let _cotangents = loss.backward().unwrap();
 ///
-/// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
+/// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0, 12.0]);
+/// x.clear_grad();
+///
+/// assert!(x.grad().is_none());
 /// ```
 #[derive(Clone)]
 pub struct EagerTensor<B: TensorBackend = CpuBackend> {
@@ -286,7 +343,10 @@ impl<B: TensorBackend> EagerTensor<B> {
         self.data.as_ref()
     }
 
-    /// Return the accumulated gradient from the last `backward()` call.
+    /// Return the accumulated gradient currently stored for this tensor.
+    ///
+    /// The stored gradient accumulates across repeated `backward()` calls
+    /// until it is cleared explicitly.
     ///
     /// # Examples
     ///
@@ -304,10 +364,60 @@ impl<B: TensorBackend> EagerTensor<B> {
         self.grad_slot.lock().unwrap().clone()
     }
 
+    /// Clear the accumulated gradient stored for this tensor.
+    ///
+    /// This only affects this tensor's gradient slot. Other tensors in the
+    /// same context retain their gradients until they are cleared explicitly or
+    /// overwritten by later accumulation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
+    /// let y = EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx);
+    /// let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+    /// let _ = loss.backward().unwrap();
+    ///
+    /// x.clear_grad();
+    ///
+    /// assert!(x.grad().is_none());
+    /// assert!(y.grad().is_some());
+    /// ```
+    pub fn clear_grad(&self) {
+        *self.grad_slot.lock().unwrap() = None;
+    }
+
+    /// Report whether this tensor participates in gradient tracking.
+    ///
+    /// Tracked tensors keep a gradient slot in their eager context; untracked
+    /// tensors and detached tensors do not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let plain = EagerTensor::from_tensor_in(Tensor::new(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
+    /// let tracked = EagerTensor::requires_grad_in(Tensor::new(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
+    /// let detached = tracked.detach();
+    ///
+    /// assert!(!plain.tracks_grad());
+    /// assert!(tracked.tracks_grad());
+    /// assert!(!detached.tracks_grad());
+    /// ```
+    pub fn tracks_grad(&self) -> bool {
+        self.requires_grad
+    }
+
     /// Run reverse-mode AD from this scalar output.
     ///
     /// Returns the full cotangent map produced by the reverse pass and also
-    /// populates `grad()` for tracked eager tensors reachable from this output.
+    /// accumulates into `grad()` for tracked eager tensors reachable from this
+    /// output.
     ///
     /// # Examples
     ///
@@ -317,8 +427,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// let x = EagerTensor::requires_grad(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
     /// let loss = (&x + &x).reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
+    /// let loss = (&x + &x).reduce_sum(&[0]).unwrap();
+    /// let _cotangents = loss.backward().unwrap();
     ///
-    /// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 2.0, 2.0]);
+    /// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 4.0, 4.0]);
     /// ```
     pub fn backward(&self) -> Result<HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>> {
         if !self.data.shape().is_empty() {
@@ -326,8 +438,6 @@ impl<B: TensorBackend> EagerTensor<B> {
                 shape: self.data.shape().to_vec(),
             });
         }
-
-        self.ctx.clear_grads();
 
         let sorted = topo_sort_grad_dag(&self.grad_node);
         let mut backend = self.ctx.backend.lock().unwrap();
@@ -337,7 +447,7 @@ impl<B: TensorBackend> EagerTensor<B> {
         };
         let mut ad_ctx = ShapeGuardContext::default();
         let cotangents = backward_dag(&sorted, &self.key, seed, &mut callbacks, &mut ad_ctx);
-        self.ctx.store_grads(&cotangents);
+        self.ctx.store_grads(&cotangents, &mut *backend)?;
         Ok(cotangents)
     }
 }

--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -1,7 +1,5 @@
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::{Rc, Weak};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, Weak};
 
 use computegraph::fragment::Fragment;
 use computegraph::{GlobalOpKey, GlobalValKey, OpMode, ValRef};
@@ -16,8 +14,8 @@ use crate::eager_exec::exec_op_on_tensors;
 use crate::error::{Error, Result};
 use crate::traced::next_input_key;
 
-pub(crate) type GradSlot = Rc<RefCell<Option<Arc<Tensor>>>>;
-pub(crate) type WeakGradSlot = Weak<RefCell<Option<Arc<Tensor>>>>;
+pub(crate) type GradSlot = Arc<Mutex<Option<Arc<Tensor>>>>;
+pub(crate) type WeakGradSlot = Weak<Mutex<Option<Arc<Tensor>>>>;
 
 /// Shared eager execution context for tensors on a backend.
 ///
@@ -37,15 +35,15 @@ pub(crate) type WeakGradSlot = Weak<RefCell<Option<Arc<Tensor>>>>;
 /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[3.0]);
 /// ```
 pub struct EagerContext<B: TensorBackend> {
-    pub(crate) backend: RefCell<B>,
-    grad_slots: RefCell<HashMap<GlobalValKey<StdTensorOp>, WeakGradSlot>>,
+    pub(crate) backend: Mutex<B>,
+    grad_slots: Mutex<HashMap<GlobalValKey<StdTensorOp>, WeakGradSlot>>,
 }
 
 impl<B: TensorBackend> EagerContext<B> {
     fn new(backend: B) -> Self {
         Self {
-            backend: RefCell::new(backend),
-            grad_slots: RefCell::new(HashMap::new()),
+            backend: Mutex::new(backend),
+            grad_slots: Mutex::new(HashMap::new()),
         }
     }
 
@@ -57,30 +55,31 @@ impl<B: TensorBackend> EagerContext<B> {
     /// use tenferro::{CpuBackend, EagerContext};
     ///
     /// let ctx = EagerContext::with_backend(CpuBackend::new());
-    /// assert_eq!(std::rc::Rc::strong_count(&ctx), 1);
+    /// assert_eq!(std::sync::Arc::strong_count(&ctx), 1);
     /// ```
-    pub fn with_backend(backend: B) -> Rc<Self> {
-        Rc::new(Self::new(backend))
+    pub fn with_backend(backend: B) -> Arc<Self> {
+        Arc::new(Self::new(backend))
     }
 
     pub(crate) fn register_grad_slot(&self, key: &GlobalValKey<StdTensorOp>, slot: &GradSlot) {
         self.grad_slots
-            .borrow_mut()
-            .insert(key.clone(), Rc::downgrade(slot));
+            .lock()
+            .unwrap()
+            .insert(key.clone(), Arc::downgrade(slot));
     }
 
     pub(crate) fn absorb_from(&self, other: &Self) {
-        let other_slots = other.grad_slots.borrow();
-        let mut slots = self.grad_slots.borrow_mut();
+        let other_slots = other.grad_slots.lock().unwrap();
+        let mut slots = self.grad_slots.lock().unwrap();
         for (key, slot) in other_slots.iter() {
             slots.entry(key.clone()).or_insert_with(|| slot.clone());
         }
     }
 
     fn clear_grads(&self) {
-        self.grad_slots.borrow_mut().retain(|_, slot| {
+        self.grad_slots.lock().unwrap().retain(|_, slot| {
             if let Some(slot) = slot.upgrade() {
-                *slot.borrow_mut() = None;
+                *slot.lock().unwrap() = None;
                 true
             } else {
                 false
@@ -89,12 +88,12 @@ impl<B: TensorBackend> EagerContext<B> {
     }
 
     fn store_grads(&self, cotangents: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>) {
-        self.grad_slots.borrow_mut().retain(|key, slot| {
+        self.grad_slots.lock().unwrap().retain(|key, slot| {
             let Some(slot) = slot.upgrade() else {
                 return false;
             };
             let value = cotangents.get(key).cloned();
-            *slot.borrow_mut() = value;
+            *slot.lock().unwrap() = value;
             true
         });
     }
@@ -123,7 +122,7 @@ pub struct EagerTensor<B: TensorBackend = CpuBackend> {
     pub(crate) grad_node: Option<Arc<GradNode<StdTensorOp>>>,
     pub(crate) requires_grad: bool,
     grad_slot: GradSlot,
-    pub(crate) ctx: Rc<EagerContext<B>>,
+    pub(crate) ctx: Arc<EagerContext<B>>,
 }
 
 impl<B: TensorBackend> std::ops::Add for &EagerTensor<B> {
@@ -194,7 +193,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     ///
     /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
     /// ```
-    pub fn from_tensor_in(tensor: Tensor, ctx: Rc<EagerContext<B>>) -> Self {
+    pub fn from_tensor_in(tensor: Tensor, ctx: Arc<EagerContext<B>>) -> Self {
         Self::new_leaf(ctx, tensor, false)
     }
 
@@ -210,13 +209,13 @@ impl<B: TensorBackend> EagerTensor<B> {
     ///
     /// assert!(x.grad().is_none());
     /// ```
-    pub fn requires_grad_in(tensor: Tensor, ctx: Rc<EagerContext<B>>) -> Self {
+    pub fn requires_grad_in(tensor: Tensor, ctx: Arc<EagerContext<B>>) -> Self {
         Self::new_leaf(ctx, tensor, true)
     }
 
-    pub(crate) fn new_leaf(ctx: Rc<EagerContext<B>>, tensor: Tensor, requires_grad: bool) -> Self {
+    pub(crate) fn new_leaf(ctx: Arc<EagerContext<B>>, tensor: Tensor, requires_grad: bool) -> Self {
         let key = eager_val_key();
-        let grad_slot = Rc::new(RefCell::new(None));
+        let grad_slot = Arc::new(Mutex::new(None));
         if requires_grad {
             ctx.register_grad_slot(&key, &grad_slot);
         }
@@ -232,13 +231,13 @@ impl<B: TensorBackend> EagerTensor<B> {
     }
 
     pub(crate) fn new_result(
-        ctx: Rc<EagerContext<B>>,
+        ctx: Arc<EagerContext<B>>,
         key: GlobalValKey<StdTensorOp>,
         tensor: Tensor,
         requires_grad: bool,
         grad_node: Option<Arc<GradNode<StdTensorOp>>>,
     ) -> Self {
-        let grad_slot = Rc::new(RefCell::new(None));
+        let grad_slot = Arc::new(Mutex::new(None));
         if requires_grad {
             ctx.register_grad_slot(&key, &grad_slot);
         }
@@ -302,7 +301,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// assert_eq!(grad.shape(), &[2]);
     /// ```
     pub fn grad(&self) -> Option<Arc<Tensor>> {
-        self.grad_slot.borrow().clone()
+        self.grad_slot.lock().unwrap().clone()
     }
 
     /// Run reverse-mode AD from this scalar output.
@@ -331,7 +330,7 @@ impl<B: TensorBackend> EagerTensor<B> {
         self.ctx.clear_grads();
 
         let sorted = topo_sort_grad_dag(&self.grad_node);
-        let mut backend = self.ctx.backend.borrow_mut();
+        let mut backend = self.ctx.backend.lock().unwrap();
         let seed = Arc::new(one_like_tensor(self.data.as_ref(), &mut *backend));
         let mut callbacks = TenferroBackwardCallbacks {
             backend: &mut *backend,
@@ -494,7 +493,7 @@ pub(crate) fn exec_single_output<B: TensorBackend>(
     inputs: &[&Tensor],
     ctx: &EagerContext<B>,
 ) -> Result<Tensor> {
-    let mut backend = ctx.backend.borrow_mut();
+    let mut backend = ctx.backend.lock().unwrap();
     let mut outputs = exec_op_on_tensors(op, inputs, &mut *backend)?;
     if outputs.len() != 1 {
         return Err(Error::Internal(format!(

--- a/tenferro/src/eager_einsum.rs
+++ b/tenferro/src/eager_einsum.rs
@@ -1,8 +1,37 @@
+//! Eager einsum helpers exposed through the `tenferro` facade.
+//!
+//! This module provides both immediate eager execution on concrete tensors and
+//! eager reverse-mode autodiff on tracked tensors.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use tenferro::eager_einsum::{eager_einsum, eager_einsum_ad};
+//! use tenferro::{CpuBackend, EagerTensor, Tensor};
+//!
+//! let mut backend = CpuBackend::new();
+//! let a = Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);
+//! let b = Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]);
+//! let dot = eager_einsum(&mut backend, &[&a, &b], "i,i->").unwrap();
+//!
+//! assert_eq!(dot.as_slice::<f64>().unwrap(), &[32.0]);
+//!
+//! let x = EagerTensor::requires_grad(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
+//! let y = EagerTensor::requires_grad(Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]));
+//! let loss = eager_einsum_ad(&[&x, &y], "i,i->").unwrap();
+//! let _ = loss.backward().unwrap();
+//!
+//! assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 5.0, 6.0]);
+//! assert_eq!(y.grad().unwrap().as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0]);
+//! ```
+
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::TensorBackend;
 
 use crate::eager::EagerTensor;
 use crate::error::Result;
+
+pub use tenferro_einsum::eager_einsum;
 
 /// Execute an einsum eagerly and record it for reverse-mode autodiff.
 ///

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -1,4 +1,3 @@
-use std::rc::Rc;
 use std::sync::Arc;
 
 use tidu::{GradEdge, GradNode};
@@ -957,7 +956,7 @@ impl<B: TensorBackend> EagerTensor<B> {
             })
         });
         Ok(Self::new_result(
-            Rc::clone(&self.ctx),
+            Arc::clone(&self.ctx),
             result_key,
             output,
             self.requires_grad,
@@ -976,7 +975,7 @@ impl<B: TensorBackend> EagerTensor<B> {
         num_outputs: usize,
     ) -> Result<Vec<Self>> {
         let outputs = {
-            let mut backend = self.ctx.backend.borrow_mut();
+            let mut backend = self.ctx.backend.lock().unwrap();
             exec_op_on_tensors(&op, &[self.data.as_ref()], &mut *backend)?
         };
         if outputs.len() != num_outputs {
@@ -1017,7 +1016,7 @@ impl<B: TensorBackend> EagerTensor<B> {
             .zip(outputs)
             .map(|(output_key, output)| {
                 Self::new_result(
-                    Rc::clone(&self.ctx),
+                    Arc::clone(&self.ctx),
                     output_key,
                     output.as_ref().clone(),
                     self.requires_grad,
@@ -1039,9 +1038,9 @@ impl<B: TensorBackend> EagerTensor<B> {
             ));
         };
 
-        let ctx = Rc::clone(&first.ctx);
+        let ctx = Arc::clone(&first.ctx);
         for tensor in tensors.iter().skip(1) {
-            if !Rc::ptr_eq(&ctx, &tensor.ctx) {
+            if !Arc::ptr_eq(&ctx, &tensor.ctx) {
                 ctx.absorb_from(&tensor.ctx);
             }
         }

--- a/tenferro/tests/eager_einsum_ad.rs
+++ b/tenferro/tests/eager_einsum_ad.rs
@@ -1,5 +1,5 @@
 use tenferro::eager_einsum::eager_einsum_ad;
-use tenferro::{EagerTensor, Tensor};
+use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 
 fn f64_data(tensor: &Tensor) -> &[f64] {
     tensor.as_slice::<f64>().unwrap()
@@ -44,4 +44,75 @@ fn eager_einsum_ad_backward_populates_input_grads() {
     assert_eq!(grad_b.shape(), &[3, 2]);
     assert_eq!(f64_data(grad_a.as_ref()), &[5.0, 5.0, 7.0, 7.0, 9.0, 9.0]);
     assert_eq!(f64_data(grad_b.as_ref()), &[3.0, 7.0, 11.0, 3.0, 7.0, 11.0]);
+}
+
+#[test]
+fn eager_einsum_ad_repeated_backward_accumulates_across_calls() {
+    let a = EagerTensor::requires_grad(Tensor::new(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+    let b = EagerTensor::requires_grad(Tensor::new(
+        vec![3, 2],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+
+    let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
+    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let _ = loss.backward().unwrap();
+    assert_eq!(
+        f64_data(a.grad().unwrap().as_ref()),
+        &[5.0, 5.0, 7.0, 7.0, 9.0, 9.0]
+    );
+    assert_eq!(
+        f64_data(b.grad().unwrap().as_ref()),
+        &[3.0, 7.0, 11.0, 3.0, 7.0, 11.0]
+    );
+
+    let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
+    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let _ = loss.backward().unwrap();
+    assert_eq!(
+        f64_data(a.grad().unwrap().as_ref()),
+        &[10.0, 10.0, 14.0, 14.0, 18.0, 18.0]
+    );
+    assert_eq!(
+        f64_data(b.grad().unwrap().as_ref()),
+        &[6.0, 14.0, 22.0, 6.0, 14.0, 22.0]
+    );
+}
+
+#[test]
+fn eager_einsum_ad_context_clear_grads_resets_all_live_leaves() {
+    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let a = EagerTensor::requires_grad_in(
+        Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
+    let b = EagerTensor::requires_grad_in(
+        Tensor::new(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
+
+    let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
+    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let _ = loss.backward().unwrap();
+
+    ctx.clear_grads();
+
+    assert!(a.grad().is_none());
+    assert!(b.grad().is_none());
+
+    let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
+    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let _ = loss.backward().unwrap();
+
+    assert_eq!(
+        f64_data(a.grad().unwrap().as_ref()),
+        &[5.0, 5.0, 7.0, 7.0, 9.0, 9.0]
+    );
+    assert_eq!(
+        f64_data(b.grad().unwrap().as_ref()),
+        &[3.0, 7.0, 11.0, 3.0, 7.0, 11.0]
+    );
 }

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -1,5 +1,8 @@
 use num_complex::Complex64;
-use tenferro::{DotGeneralConfig, EagerTensor, GatherConfig, PadConfig, SliceConfig, Tensor};
+use tenferro::{
+    CpuBackend, DotGeneralConfig, EagerContext, EagerTensor, GatherConfig, PadConfig, SliceConfig,
+    Tensor,
+};
 
 const FD_H: f64 = 1.0e-6;
 const TOL: f64 = 1.0e-5;
@@ -22,6 +25,8 @@ fn f64_data(tensor: &Tensor) -> &[f64] {
 fn c64_data(tensor: &Tensor) -> &[Complex64] {
     tensor.as_slice::<Complex64>().unwrap()
 }
+
+fn assert_send_sync<T: Send + Sync>() {}
 
 fn finite_diff_scalar(f: impl Fn(&[f64]) -> f64, x: &[f64], index: usize) -> f64 {
     let mut plus = x.to_vec();
@@ -101,6 +106,19 @@ fn eager_x_squared_gradient_matches_finite_difference() {
 }
 
 #[test]
+fn eager_repeated_backward_accumulates_across_calls() {
+    let x = EagerTensor::requires_grad(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]));
+
+    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
+
+    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[4.0, 8.0, 12.0], TOL);
+}
+
+#[test]
 fn eager_matmul_gradients_match_finite_difference() {
     let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let b_data = vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
@@ -149,6 +167,93 @@ fn eager_fan_out_accumulates_gradient() {
 
     let grad = x.grad().unwrap();
     assert_close_slice(f64_data(grad.as_ref()), &[2.0, 2.0, 2.0], TOL);
+}
+
+#[test]
+fn eager_clear_grad_resets_only_one_leaf() {
+    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let x =
+        EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
+    let y =
+        EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx.clone());
+
+    let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+
+    x.clear_grad();
+
+    assert!(x.grad().is_none());
+    assert_close_slice(f64_data(y.grad().unwrap().as_ref()), &[1.0, 2.0, 3.0], TOL);
+
+    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+
+    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
+    assert_close_slice(f64_data(y.grad().unwrap().as_ref()), &[1.0, 2.0, 3.0], TOL);
+}
+
+#[test]
+fn eager_context_clear_grads_resets_all_live_leaves() {
+    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let x =
+        EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
+    let y =
+        EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx.clone());
+
+    let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+
+    ctx.clear_grads();
+
+    assert!(x.grad().is_none());
+    assert!(y.grad().is_none());
+
+    let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+
+    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[4.0, 5.0, 6.0], TOL);
+    assert_close_slice(f64_data(y.grad().unwrap().as_ref()), &[1.0, 2.0, 3.0], TOL);
+}
+
+#[test]
+fn eager_unrelated_backward_keeps_existing_leaf_grad() {
+    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let x =
+        EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
+    let y =
+        EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx.clone());
+
+    let loss_x = (&x * &x).reduce_sum(&[0]).unwrap();
+    let _ = loss_x.backward().unwrap();
+    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
+
+    let loss_y = (&y * &y).reduce_sum(&[0]).unwrap();
+    let _ = loss_y.backward().unwrap();
+
+    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
+    assert_close_slice(
+        f64_data(y.grad().unwrap().as_ref()),
+        &[8.0, 10.0, 12.0],
+        TOL,
+    );
+}
+
+#[test]
+fn eager_tracks_grad_reports_leaf_state() {
+    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let plain =
+        EagerTensor::from_tensor_in(Tensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
+    let leaf = EagerTensor::requires_grad_in(Tensor::new(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx);
+
+    assert!(!plain.tracks_grad());
+    assert!(leaf.tracks_grad());
+    assert!(!leaf.detach().tracks_grad());
+}
+
+#[test]
+fn eager_send_sync_contracts_compile() {
+    assert_send_sync::<EagerTensor<CpuBackend>>();
+    assert_send_sync::<EagerContext<CpuBackend>>();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- refactor `EagerTensor` internals from `Rc`/`RefCell` to `Arc`/`Mutex` so eager tensors and shared eager contexts are `Send + Sync`
- change eager `backward()` to match PyTorch-style accumulation semantics instead of implicitly clearing gradients on every call
- expose explicit gradient reset and state APIs via `EagerTensor::clear_grad()`, `EagerContext::clear_grads()`, and `EagerTensor::tracks_grad()`
- re-export eager einsum from the public facade, add accumulation-focused regression tests, and update the eager/autodiff docs plus migration design notes

## Why

The previous eager autograd behavior cleared gradients inside `backward()` before storing the latest cotangents. That made repeated `backward()` calls non-accumulating, differed from PyTorch semantics, and left the reset story implicit instead of explicit.

At the same time, eager tensors were not `Send + Sync`, which limited downstream usage and made it harder to treat eager execution as a first-class shared state API.

## User impact

- repeated eager `backward()` calls now accumulate gradients until users clear them explicitly
- users now have public APIs and docs for clearing a single tensor gradient or all gradients in a shared eager context
- the eager API surface now exposes `tracks_grad()` and public eager einsum imports from the `tenferro` facade
- documentation now clearly separates eager scalar-loss reverse mode from traced transform AD

## Validation

- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo fmt --all --check`
- `cargo clippy --workspace --release`