### PR TITLE
docs: fix Getting Started examples and tenferro-tensor rustdoc

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -103,7 +103,7 @@ assert_eq!(sum.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
 
 ### Lazy with AD
 
-```rust,ignore
+```rust
 use tenferro::{CpuBackend, Engine, TracedTensor};
 
 let a = TracedTensor::new(vec![2], vec![1.0_f64, 2.0]);

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -6,13 +6,12 @@ PyTorch, or JAX, choose the layer that matches the workflow you need.
 
 ## Installation
 
-Use local checkouts while the crates are still evolving:
+The `tenferro` crate re-exports everything you need. Use a local checkout
+while the crates are still evolving:
 
 ```toml
 [dependencies]
 tenferro = { path = "/path/to/tenferro-rs/tenferro" }
-tenferro-tensor = { path = "/path/to/tenferro-rs/tenferro-tensor" }
-tenferro-einsum = { path = "/path/to/tenferro-rs/tenferro-einsum" }
 ```
 
 Or switch to crates.io once published:
@@ -20,9 +19,10 @@ Or switch to crates.io once published:
 ```toml
 [dependencies]
 tenferro = "..."
-tenferro-tensor = "..."
-tenferro-einsum = "..."
 ```
+
+> If you only need eager tensor operations without tracing or AD, you can
+> depend on `tenferro-tensor` alone for a smaller build.
 
 ## Hello eager
 
@@ -30,11 +30,13 @@ This is the simplest way to use tenferro: direct computation without tracing or
 AD, similar to NumPy.
 
 ```rust
-use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+use tenferro_tensor::{Tensor, cpu::CpuBackend};
 
 let mut ctx = CpuBackend::new();
 
-// Column-major buffer: columns are [1, 2], [3, 4], [5, 6].
+// tenferro uses column-major (Fortran) storage, not row-major like NumPy.
+// For shape [2, 3] with data [1,2,3,4,5,6]:
+//   column 0 = [1, 2], column 1 = [3, 4], column 2 = [5, 6]
 let a = Tensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
 // SVD

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -53,7 +53,7 @@ assert_eq!(c.shape(), &[2, 2]);
 
 This is the tenferro equivalent of `torch.einsum("ij,jk->ik", a, b)` or `jnp.einsum("ij,jk->ik", a, b)`.
 
-```rust,ignore
+```rust
 use tenferro::{einsum::einsum, CpuBackend, Engine, TracedTensor};
 
 // Column-major buffers: `a` has columns [1, 2], [3, 4], [5, 6].
@@ -72,7 +72,7 @@ assert_eq!(result.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 
 This is the tenferro equivalent of differentiating `sum(x * x)` in PyTorch or JAX.
 
-```rust,ignore
+```rust
 use tenferro::{CpuBackend, Engine, TracedTensor};
 
 let x = TracedTensor::new(vec![3], vec![1.0_f64, 2.0, 3.0]);

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -41,7 +41,8 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 
 tenferro stores dense tensors in column-major order. If you write:
 
-```rust,ignore
+```rust
+use tenferro::TracedTensor;
 let a = TracedTensor::new(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
 ```
 

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -2,13 +2,13 @@
 //!
 //! # Examples
 //!
-//! ```ignore
-//! use tenferro_tensor::{cpu::CpuBackend, Tensor, TypedTensor};
+//! ```
+//! use tenferro_tensor::{Tensor, cpu::CpuBackend};
 //!
-//! let mut backend = CpuBackend::new();
-//! let a = Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.0, 2.0]));
-//! let b = Tensor::F64(TypedTensor::from_vec(vec![2], vec![3.0, 4.0]));
-//! let c = tenferro_tensor::cpu::add(&a, &b);
+//! let mut ctx = CpuBackend::new();
+//! let a = Tensor::new(vec![2], vec![1.0_f64, 2.0]);
+//! let b = Tensor::new(vec![2], vec![3.0_f64, 4.0]);
+//! let c = a.add(&b, &mut ctx).unwrap();
 //! assert_eq!(c.shape(), &[2]);
 //! ```
 


### PR DESCRIPTION
## Summary

Fix documentation issues found by automated feature testing.

- Simplify Installation section: show only `tenferro` as dependency (all three sub-crates were listed but only `tenferro` is needed)
- Remove unused `TensorBackend` import from eager example (caused compiler warning)
- Add explicit column-major storage note for NumPy/PyTorch users
- Update tenferro-tensor crate-level rustdoc from stale `Tensor::F64(TypedTensor::from_vec(...))` to `Tensor::new(...)` and make it a runnable doctest
- Remove `rust,ignore` from einsum, grad, core-concepts lazy, and pytorch-jax-mapping examples so they signal "this code should work"

All five Getting Started examples verified to compile and produce correct results.

## Test plan

- [x] `cargo test --doc -p tenferro-tensor` passes (29 passed)
- [x] `cargo test --doc -p tenferro` passes (66 passed)
- [x] `cargo doc --workspace --no-deps` builds clean
- [x] `python3 scripts/check-docs-site.py` passes
- [x] All doc examples manually verified (eager, einsum, grad, core-concepts lazy, pytorch-jax-mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)