### PR TITLE
feat: elementwise kernel fusion for CubeCL GPU backend

### DIFF
--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -6,6 +6,50 @@ use crate::config::{
 };
 use crate::{Buffer, Tensor, TypedTensor};
 
+/// Canonical elementwise fusion plan shared between segmented execution and backends.
+#[doc(hidden)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ElementwiseFusionPlan {
+    pub dtype: crate::DType,
+    pub n_inputs: usize,
+    pub outputs: Vec<usize>,
+    pub ops: Vec<ElementwiseFusionInst>,
+}
+
+/// One node in a canonical elementwise fusion plan.
+#[doc(hidden)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ElementwiseFusionInst {
+    pub op: ElementwiseFusionOp,
+    pub inputs: Vec<usize>,
+}
+
+/// Elementwise op kinds supported by backend fusion implementations.
+#[doc(hidden)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ElementwiseFusionOp {
+    Add,
+    Multiply,
+    Negate,
+    Conj,
+    Divide,
+    Abs,
+    Maximum,
+    Minimum,
+    Compare(CompareDir),
+    Select,
+    Clamp,
+    Exp,
+    Log,
+    Sin,
+    Cos,
+    Tanh,
+    Sqrt,
+    Rsqrt,
+    Pow,
+    Log1p,
+}
+
 pub(crate) fn typed_view<T: Copy>(tensor: &TypedTensor<T>) -> StridedView<'_, T> {
     match &tensor.buffer {
         Buffer::Host(data) => {
@@ -192,6 +236,15 @@ pub trait TensorExec {
     fn eig(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
 
     fn reclaim_buffer(&mut self, tensor: Tensor);
+
+    #[doc(hidden)]
+    fn execute_elementwise_fusion(
+        &mut self,
+        _inputs: &[&Tensor],
+        _plan: &ElementwiseFusionPlan,
+    ) -> crate::Result<Option<Vec<Tensor>>> {
+        Ok(None)
+    }
 }
 
 struct BackendExecAdapter<'a, B: TensorBackend + ?Sized> {
@@ -272,6 +325,10 @@ impl<B: TensorBackend + ?Sized> TensorExec for BackendExecAdapter<'_, B> {
         eigh(input: &Tensor) -> crate::Result<Vec<Tensor>>;
         eig(input: &Tensor) -> crate::Result<Vec<Tensor>>;
         reclaim_buffer(tensor: Tensor) -> ();
+        execute_elementwise_fusion(
+            inputs: &[&Tensor],
+            plan: &ElementwiseFusionPlan
+        ) -> crate::Result<Option<Vec<Tensor>>>;
     }
 }
 
@@ -482,6 +539,15 @@ pub trait TensorBackend {
     /// backend.reclaim_buffer(tensor);
     /// ```
     fn reclaim_buffer(&mut self, _tensor: Tensor) {}
+
+    #[doc(hidden)]
+    fn execute_elementwise_fusion(
+        &mut self,
+        _inputs: &[&Tensor],
+        _plan: &ElementwiseFusionPlan,
+    ) -> crate::Result<Option<Vec<Tensor>>> {
+        Ok(None)
+    }
 }
 
 /// Algebra-generic backend over typed tensors.

--- a/tenferro-tensor/src/cubecl/fusion/classify.rs
+++ b/tenferro-tensor/src/cubecl/fusion/classify.rs
@@ -1,0 +1,160 @@
+use cubecl::prelude::{AddressType, CubeElement, CubePrimitive};
+
+use crate::backend::{ElementwiseFusionOp, ElementwiseFusionPlan};
+use crate::{DType, Tensor, TypedTensor};
+
+pub(crate) struct ClassifiedFusion<'a, T> {
+    pub(crate) plan: &'a ElementwiseFusionPlan,
+    pub(crate) inputs: Vec<&'a TypedTensor<T>>,
+    pub(crate) output_shape: Vec<usize>,
+    pub(crate) n_elements: usize,
+    pub(crate) address_type: AddressType,
+}
+
+pub(crate) fn classify<'a, T>(
+    inputs: &[&'a Tensor],
+    plan: &'a ElementwiseFusionPlan,
+) -> crate::Result<Option<ClassifiedFusion<'a, T>>>
+where
+    T: FusionElement,
+{
+    if plan.dtype != T::DTYPE || plan.n_inputs != inputs.len() || plan.outputs.is_empty() {
+        return Ok(None);
+    }
+    if !plan.ops.iter().all(|inst| T::supports_op(&inst.op)) {
+        return Ok(None);
+    }
+
+    let mut typed_inputs = Vec::with_capacity(inputs.len());
+    for tensor in inputs {
+        typed_inputs.push(
+            T::tensor_ref(tensor).ok_or_else(|| crate::Error::BackendFailure {
+                op: "fused_elementwise",
+                message: format!(
+                    "plan dtype {:?} does not match runtime tensor dtype {:?}",
+                    plan.dtype,
+                    tensor.dtype()
+                ),
+            })?,
+        );
+    }
+
+    let Some(first) = typed_inputs.first() else {
+        return Ok(None);
+    };
+    for input in &typed_inputs[1..] {
+        if input.shape != first.shape {
+            return Err(crate::Error::ShapeMismatch {
+                op: "fused_elementwise",
+                lhs: first.shape.clone(),
+                rhs: input.shape.clone(),
+            });
+        }
+    }
+
+    let output_shape = first.shape.clone();
+    let n_elements = first.n_elements();
+    Ok(Some(ClassifiedFusion {
+        plan,
+        inputs: typed_inputs,
+        output_shape,
+        n_elements,
+        address_type: AddressType::from_len(n_elements),
+    }))
+}
+
+pub(crate) trait FusionElement: CubeElement + CubePrimitive + Clone + 'static {
+    const DTYPE: DType;
+
+    fn tensor_ref(tensor: &Tensor) -> Option<&TypedTensor<Self>>;
+
+    fn supports_op(op: &ElementwiseFusionOp) -> bool;
+}
+
+impl FusionElement for f32 {
+    const DTYPE: DType = DType::F32;
+
+    fn tensor_ref(tensor: &Tensor) -> Option<&TypedTensor<Self>> {
+        match tensor {
+            Tensor::F32(tensor) => Some(tensor),
+            _ => None,
+        }
+    }
+
+    fn supports_op(op: &ElementwiseFusionOp) -> bool {
+        matches!(
+            op,
+            ElementwiseFusionOp::Add
+                | ElementwiseFusionOp::Multiply
+                | ElementwiseFusionOp::Negate
+                | ElementwiseFusionOp::Divide
+                | ElementwiseFusionOp::Abs
+                | ElementwiseFusionOp::Maximum
+                | ElementwiseFusionOp::Minimum
+                | ElementwiseFusionOp::Compare(_)
+                | ElementwiseFusionOp::Select
+                | ElementwiseFusionOp::Clamp
+                | ElementwiseFusionOp::Exp
+                | ElementwiseFusionOp::Log
+                | ElementwiseFusionOp::Sin
+                | ElementwiseFusionOp::Cos
+                | ElementwiseFusionOp::Tanh
+                | ElementwiseFusionOp::Sqrt
+                | ElementwiseFusionOp::Rsqrt
+                | ElementwiseFusionOp::Pow
+                | ElementwiseFusionOp::Log1p
+        )
+    }
+}
+
+impl FusionElement for f64 {
+    const DTYPE: DType = DType::F64;
+
+    fn tensor_ref(tensor: &Tensor) -> Option<&TypedTensor<Self>> {
+        match tensor {
+            Tensor::F64(tensor) => Some(tensor),
+            _ => None,
+        }
+    }
+
+    fn supports_op(op: &ElementwiseFusionOp) -> bool {
+        <f32 as FusionElement>::supports_op(op)
+    }
+}
+
+impl FusionElement for num_complex::Complex32 {
+    const DTYPE: DType = DType::C32;
+
+    fn tensor_ref(tensor: &Tensor) -> Option<&TypedTensor<Self>> {
+        match tensor {
+            Tensor::C32(tensor) => Some(tensor),
+            _ => None,
+        }
+    }
+
+    fn supports_op(op: &ElementwiseFusionOp) -> bool {
+        matches!(
+            op,
+            ElementwiseFusionOp::Add
+                | ElementwiseFusionOp::Multiply
+                | ElementwiseFusionOp::Negate
+                | ElementwiseFusionOp::Conj
+                | ElementwiseFusionOp::Divide
+        )
+    }
+}
+
+impl FusionElement for num_complex::Complex64 {
+    const DTYPE: DType = DType::C64;
+
+    fn tensor_ref(tensor: &Tensor) -> Option<&TypedTensor<Self>> {
+        match tensor {
+            Tensor::C64(tensor) => Some(tensor),
+            _ => None,
+        }
+    }
+
+    fn supports_op(op: &ElementwiseFusionOp) -> bool {
+        <num_complex::Complex32 as FusionElement>::supports_op(op)
+    }
+}

--- a/tenferro-tensor/src/cubecl/fusion/codegen.rs
+++ b/tenferro-tensor/src/cubecl/fusion/codegen.rs
@@ -1,0 +1,307 @@
+use cubecl::ir::{
+    Arithmetic, BinaryOperator, Branch, Builtin, ClampOperator, Comparison, ConstantValue,
+    ElemType, If, IndexAssignOperator, IndexOperator, Instruction, ManagedVariable, Metadata,
+    Operator, Select, Type, UnaryOperator, Variable,
+};
+use cubecl::prelude::{
+    AddressType, CubeDim, CubeElement, CubePrimitive, KernelBuilder, KernelDefinition,
+    KernelSettings,
+};
+
+use crate::backend::{ElementwiseFusionOp, ElementwiseFusionPlan};
+
+const KERNEL_NAME: &str = "tenferro_fused_elementwise";
+
+pub(crate) fn build_kernel_definition<T>(
+    plan: &ElementwiseFusionPlan,
+    address_type: AddressType,
+    cube_dim: CubeDim,
+) -> KernelDefinition
+where
+    T: CubeElement + CubePrimitive + Clone,
+{
+    let mut builder = KernelBuilder::new();
+    address_type.register(&mut builder.scope);
+
+    let item = T::as_type(&builder.scope);
+    let mut input_arrays = Vec::with_capacity(plan.n_inputs);
+    for _ in 0..plan.n_inputs {
+        input_arrays.push(builder.input_array(item.clone()));
+    }
+    let mut output_arrays = Vec::with_capacity(plan.outputs.len());
+    for _ in &plan.outputs {
+        output_arrays.push(builder.output_array(item.clone()));
+    }
+
+    let absolute_pos = ManagedVariable::Plain(Variable::builtin(
+        Builtin::AbsolutePos,
+        usize::as_type(&builder.scope).storage_type(),
+    ));
+    let output_len = builder.scope.create_local(usize::as_type(&builder.scope));
+    builder.scope.register(Instruction::new(
+        Metadata::Length {
+            var: *output_arrays[0],
+        },
+        *output_len,
+    ));
+
+    let in_bounds = emit_bool_binary(
+        &mut builder.scope,
+        absolute_pos.clone(),
+        output_len.clone(),
+        Comparison::Lower,
+    );
+    let mut body = builder.scope.child();
+    let body = build_body::<T>(plan, &mut body, &input_arrays, &output_arrays, absolute_pos);
+    builder.scope.register(Branch::If(Box::new(If {
+        cond: *in_bounds,
+        scope: body,
+    })));
+
+    builder.build(
+        KernelSettings::default()
+            .kernel_name(KERNEL_NAME)
+            .address_type(address_type)
+            .cube_dim(cube_dim),
+    )
+}
+
+fn build_body<T>(
+    plan: &ElementwiseFusionPlan,
+    scope: &mut cubecl::prelude::Scope,
+    input_arrays: &[ManagedVariable],
+    output_arrays: &[ManagedVariable],
+    absolute_pos: ManagedVariable,
+) -> cubecl::ir::Scope
+where
+    T: CubeElement + CubePrimitive + Clone,
+{
+    let mut values = Vec::with_capacity(plan.n_inputs + plan.ops.len());
+    for array in input_arrays {
+        values.push(load_array_element(
+            scope,
+            array.clone(),
+            absolute_pos.clone(),
+        ));
+    }
+    for inst in &plan.ops {
+        let inputs = inst
+            .inputs
+            .iter()
+            .map(|&value| values[value].clone())
+            .collect::<Vec<_>>();
+        values.push(emit_op::<T>(scope, &inst.op, &inputs));
+    }
+    for (array, &value_id) in output_arrays.iter().zip(plan.outputs.iter()) {
+        store_array_element(
+            scope,
+            array.clone(),
+            absolute_pos.clone(),
+            values[value_id].clone(),
+        );
+    }
+    scope.clone()
+}
+
+fn emit_op<T>(
+    scope: &mut cubecl::prelude::Scope,
+    op: &ElementwiseFusionOp,
+    inputs: &[ManagedVariable],
+) -> ManagedVariable
+where
+    T: CubeElement + CubePrimitive + Clone,
+{
+    match op {
+        ElementwiseFusionOp::Add => {
+            emit_binary_arithmetic(scope, &inputs[0], &inputs[1], Arithmetic::Add)
+        }
+        ElementwiseFusionOp::Multiply => {
+            emit_binary_arithmetic(scope, &inputs[0], &inputs[1], Arithmetic::Mul)
+        }
+        ElementwiseFusionOp::Negate => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Neg),
+        ElementwiseFusionOp::Conj => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Conj),
+        ElementwiseFusionOp::Divide => {
+            emit_binary_arithmetic(scope, &inputs[0], &inputs[1], Arithmetic::Div)
+        }
+        ElementwiseFusionOp::Abs => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Abs),
+        ElementwiseFusionOp::Maximum => {
+            emit_binary_arithmetic(scope, &inputs[0], &inputs[1], Arithmetic::Max)
+        }
+        ElementwiseFusionOp::Minimum => {
+            emit_binary_arithmetic(scope, &inputs[0], &inputs[1], Arithmetic::Min)
+        }
+        ElementwiseFusionOp::Compare(dir) => {
+            let pred =
+                emit_bool_binary(scope, inputs[0].clone(), inputs[1].clone(), compare_op(dir));
+            emit_numeric_select::<T>(scope, pred, true)
+        }
+        ElementwiseFusionOp::Select => {
+            let zero = numeric_constant::<T>(scope, 0.0);
+            let pred = emit_bool_binary(scope, inputs[0].clone(), zero, Comparison::NotEqual);
+            emit_select(scope, pred, inputs[1].clone(), inputs[2].clone())
+        }
+        ElementwiseFusionOp::Clamp => emit_clamp(scope, &inputs[0], &inputs[1], &inputs[2]),
+        ElementwiseFusionOp::Exp => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Exp),
+        ElementwiseFusionOp::Log => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Log),
+        ElementwiseFusionOp::Sin => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Sin),
+        ElementwiseFusionOp::Cos => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Cos),
+        ElementwiseFusionOp::Tanh => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Tanh),
+        ElementwiseFusionOp::Sqrt => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Sqrt),
+        ElementwiseFusionOp::Rsqrt => {
+            emit_unary_arithmetic(scope, &inputs[0], Arithmetic::InverseSqrt)
+        }
+        ElementwiseFusionOp::Pow => {
+            emit_binary_arithmetic(scope, &inputs[0], &inputs[1], Arithmetic::Powf)
+        }
+        ElementwiseFusionOp::Log1p => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Log1p),
+    }
+}
+
+fn compare_op(dir: &crate::CompareDir) -> fn(BinaryOperator) -> Comparison {
+    match dir {
+        crate::CompareDir::Eq => Comparison::Equal,
+        crate::CompareDir::Lt => Comparison::Lower,
+        crate::CompareDir::Le => Comparison::LowerEqual,
+        crate::CompareDir::Gt => Comparison::Greater,
+        crate::CompareDir::Ge => Comparison::GreaterEqual,
+    }
+}
+
+fn emit_numeric_select<T>(
+    scope: &mut cubecl::prelude::Scope,
+    pred: ManagedVariable,
+    if_true: bool,
+) -> ManagedVariable
+where
+    T: CubeElement + CubePrimitive + Clone,
+{
+    let on_true = numeric_constant::<T>(scope, if if_true { 1.0 } else { 0.0 });
+    let on_false = numeric_constant::<T>(scope, if if_true { 0.0 } else { 1.0 });
+    emit_select(scope, pred, on_true, on_false)
+}
+
+fn numeric_constant<T>(scope: &cubecl::prelude::Scope, value: f64) -> ManagedVariable
+where
+    T: CubeElement + CubePrimitive + Clone,
+{
+    ManagedVariable::Plain(Variable::constant(
+        ConstantValue::Float(value),
+        T::as_type(scope),
+    ))
+}
+
+fn emit_unary_arithmetic(
+    scope: &mut cubecl::prelude::Scope,
+    input: &ManagedVariable,
+    op: fn(UnaryOperator) -> Arithmetic,
+) -> ManagedVariable {
+    let input = input.clone().consume();
+    let out = scope.create_local(input.ty);
+    scope.register(Instruction::new(op(UnaryOperator { input }), *out));
+    out
+}
+
+fn emit_binary_arithmetic(
+    scope: &mut cubecl::prelude::Scope,
+    lhs: &ManagedVariable,
+    rhs: &ManagedVariable,
+    op: fn(BinaryOperator) -> Arithmetic,
+) -> ManagedVariable {
+    let lhs = lhs.clone().consume();
+    let rhs = rhs.clone().consume();
+    let out = scope.create_local(lhs.ty);
+    scope.register(Instruction::new(op(BinaryOperator { lhs, rhs }), *out));
+    out
+}
+
+fn emit_bool_binary(
+    scope: &mut cubecl::prelude::Scope,
+    lhs: ManagedVariable,
+    rhs: ManagedVariable,
+    op: fn(BinaryOperator) -> Comparison,
+) -> ManagedVariable {
+    let lhs = lhs.consume();
+    let rhs = rhs.consume();
+    let out = scope.create_local(Type::scalar(ElemType::Bool));
+    scope.register(Instruction::new(op(BinaryOperator { lhs, rhs }), *out));
+    out
+}
+
+fn emit_select(
+    scope: &mut cubecl::prelude::Scope,
+    pred: ManagedVariable,
+    then_value: ManagedVariable,
+    else_value: ManagedVariable,
+) -> ManagedVariable {
+    let pred = pred.consume();
+    let then_value = then_value.consume();
+    let else_value = else_value.consume();
+    let out = scope.create_local(then_value.ty);
+    scope.register(Instruction::new(
+        Operator::Select(Select {
+            cond: pred,
+            then: then_value,
+            or_else: else_value,
+        }),
+        *out,
+    ));
+    out
+}
+
+fn emit_clamp(
+    scope: &mut cubecl::prelude::Scope,
+    input: &ManagedVariable,
+    lower: &ManagedVariable,
+    upper: &ManagedVariable,
+) -> ManagedVariable {
+    let input = input.clone().consume();
+    let min_value = lower.clone().consume();
+    let max_value = upper.clone().consume();
+    let out = scope.create_local(input.ty);
+    scope.register(Instruction::new(
+        Arithmetic::Clamp(ClampOperator {
+            input,
+            min_value,
+            max_value,
+        }),
+        *out,
+    ));
+    out
+}
+
+fn load_array_element(
+    scope: &mut cubecl::prelude::Scope,
+    array: ManagedVariable,
+    index: ManagedVariable,
+) -> ManagedVariable {
+    let array = array.consume();
+    let index = index.consume();
+    let out = scope.create_local(array.ty);
+    scope.register(Instruction::new(
+        Operator::UncheckedIndex(IndexOperator {
+            list: array,
+            index,
+            vector_size: 0,
+            unroll_factor: 1,
+        }),
+        *out,
+    ));
+    out
+}
+
+fn store_array_element(
+    scope: &mut cubecl::prelude::Scope,
+    array: ManagedVariable,
+    index: ManagedVariable,
+    value: ManagedVariable,
+) {
+    scope.register(Instruction::new(
+        Operator::UncheckedIndexAssign(IndexAssignOperator {
+            index: index.consume(),
+            value: value.consume(),
+            vector_size: 0,
+            unroll_factor: 1,
+        }),
+        array.consume(),
+    ));
+}

--- a/tenferro-tensor/src/cubecl/fusion/launch.rs
+++ b/tenferro-tensor/src/cubecl/fusion/launch.rs
@@ -1,0 +1,91 @@
+use std::marker::PhantomData;
+
+use cubecl::prelude::{CubeDim, CubeElement, CubeKernel, CubePrimitive, KernelId, KernelLauncher};
+
+use super::classify::ClassifiedFusion;
+use super::codegen::build_kernel_definition;
+use crate::backend::ElementwiseFusionPlan;
+use crate::cubecl::dispatch::{alloc_output, cube_count_for_len, cube_dim_1d};
+use crate::cubecl::runtime::CubeclRuntime;
+use crate::types::TypedTensor;
+
+pub(crate) fn launch<T>(
+    runtime: &CubeclRuntime,
+    classified: ClassifiedFusion<'_, T>,
+) -> crate::Result<Vec<TypedTensor<T>>>
+where
+    T: CubeElement + CubePrimitive + Clone,
+{
+    let mut outputs = Vec::with_capacity(classified.plan.outputs.len());
+    for _ in &classified.plan.outputs {
+        outputs.push(alloc_output::<T>(runtime, &classified.output_shape));
+    }
+    if classified.n_elements == 0 {
+        return Ok(outputs);
+    }
+
+    let settings = cubecl::prelude::KernelSettings::default().address_type(classified.address_type);
+    let mut launcher = KernelLauncher::new(settings);
+    let item = launcher.with_scope(|scope| T::as_type(scope));
+
+    for input in &classified.inputs {
+        let arg = crate::cubecl::dispatch::typed_tensor_array_arg(input, "fused_elementwise")?;
+        launcher.register_array(arg, item.clone());
+    }
+    for output in &outputs {
+        let arg = crate::cubecl::dispatch::typed_tensor_array_arg(output, "fused_elementwise")?;
+        launcher.register_array(arg, item.clone());
+    }
+
+    let kernel = FusedElementwiseKernel::<T> {
+        plan: classified.plan.clone(),
+        address_type: classified.address_type,
+        cube_dim: cube_dim_1d(),
+        _marker: PhantomData,
+    };
+    unsafe {
+        launcher.launch_unchecked(
+            cube_count_for_len(classified.n_elements),
+            kernel,
+            runtime.client(),
+        );
+    }
+    Ok(outputs)
+}
+
+#[derive(Clone)]
+struct FusedElementwiseKernel<T> {
+    plan: ElementwiseFusionPlan,
+    address_type: cubecl::prelude::AddressType,
+    cube_dim: CubeDim,
+    _marker: PhantomData<T>,
+}
+
+impl<T> cubecl::prelude::KernelMetadata for FusedElementwiseKernel<T>
+where
+    T: CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
+{
+    fn name(&self) -> &'static str {
+        "tenferro_fused_elementwise"
+    }
+
+    fn id(&self) -> KernelId {
+        KernelId::new::<Self>()
+            .info(self.plan.clone())
+            .cube_dim(self.cube_dim)
+            .address_type(self.address_type)
+    }
+
+    fn address_type(&self) -> cubecl::prelude::StorageType {
+        self.address_type.unsigned_type()
+    }
+}
+
+impl<T> CubeKernel for FusedElementwiseKernel<T>
+where
+    T: CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
+{
+    fn define(&self) -> cubecl::prelude::KernelDefinition {
+        build_kernel_definition::<T>(&self.plan, self.address_type, self.cube_dim)
+    }
+}

--- a/tenferro-tensor/src/cubecl/fusion/mod.rs
+++ b/tenferro-tensor/src/cubecl/fusion/mod.rs
@@ -1,0 +1,46 @@
+mod classify;
+mod codegen;
+mod launch;
+
+use classify::classify;
+
+use crate::backend::ElementwiseFusionPlan;
+use crate::cubecl::CubeclBackend;
+use crate::Tensor;
+
+pub(crate) fn execute_elementwise_fusion(
+    backend: &CubeclBackend,
+    inputs: &[&Tensor],
+    plan: &ElementwiseFusionPlan,
+) -> crate::Result<Option<Vec<Tensor>>> {
+    match plan.dtype {
+        crate::DType::F32 => {
+            let Some(classified) = classify::<f32>(inputs, plan)? else {
+                return Ok(None);
+            };
+            let outputs = launch::launch(backend.runtime(), classified)?;
+            Ok(Some(outputs.into_iter().map(Tensor::F32).collect()))
+        }
+        crate::DType::F64 => {
+            let Some(classified) = classify::<f64>(inputs, plan)? else {
+                return Ok(None);
+            };
+            let outputs = launch::launch(backend.runtime(), classified)?;
+            Ok(Some(outputs.into_iter().map(Tensor::F64).collect()))
+        }
+        crate::DType::C32 => {
+            let Some(classified) = classify::<num_complex::Complex32>(inputs, plan)? else {
+                return Ok(None);
+            };
+            let outputs = launch::launch(backend.runtime(), classified)?;
+            Ok(Some(outputs.into_iter().map(Tensor::C32).collect()))
+        }
+        crate::DType::C64 => {
+            let Some(classified) = classify::<num_complex::Complex64>(inputs, plan)? else {
+                return Ok(None);
+            };
+            let outputs = launch::launch(backend.runtime(), classified)?;
+            Ok(Some(outputs.into_iter().map(Tensor::C64).collect()))
+        }
+    }
+}

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -15,6 +15,7 @@ use crate::{Tensor, TypedTensor};
 
 mod dispatch;
 mod ffi;
+mod fusion;
 mod gemm;
 mod kernels;
 mod linalg;
@@ -2436,6 +2437,14 @@ impl TensorBackend for CubeclBackend {
 
     fn upload_host_tensor(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         upload_tensor(self.runtime(), tensor)
+    }
+
+    fn execute_elementwise_fusion(
+        &mut self,
+        inputs: &[&Tensor],
+        plan: &crate::ElementwiseFusionPlan,
+    ) -> crate::Result<Option<Vec<Tensor>>> {
+        fusion::execute_elementwise_fusion(self, inputs, plan)
     }
 }
 

--- a/tenferro-tensor/src/cubecl/tests/fusion_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/fusion_tests.rs
@@ -1,0 +1,226 @@
+use crate::backend::ElementwiseFusionPlan;
+use crate::config::CompareDir;
+use crate::{ElementwiseFusionInst, ElementwiseFusionOp, TensorBackend};
+
+use super::{assert_tensor_close, cpu_backend, download, gpu_backend, tensor_f64, upload};
+
+/// Build a plan for: out = (a + b) * a
+fn add_mul_plan() -> ElementwiseFusionPlan {
+    ElementwiseFusionPlan {
+        dtype: crate::DType::F64,
+        n_inputs: 2,
+        outputs: vec![3], // value index of final result
+        ops: vec![
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Add,
+                inputs: vec![0, 1], // a + b
+            },
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Multiply,
+                inputs: vec![2, 0], // (a+b) * a
+            },
+        ],
+    }
+}
+
+#[test]
+fn test_fused_add_mul_matches_cpu() {
+    let a = tensor_f64(vec![4], vec![1.0, 2.0, 3.0, 4.0]);
+    let b = tensor_f64(vec![4], vec![0.5, -1.0, 2.0, 0.0]);
+
+    let mut cpu = cpu_backend();
+    let sum = cpu.add(&a, &b).unwrap();
+    let expected = cpu.mul(&sum, &a).unwrap();
+
+    let mut gpu = gpu_backend();
+    let gpu_a = upload(&gpu, &a);
+    let gpu_b = upload(&gpu, &b);
+
+    let plan = add_mul_plan();
+    let result = gpu
+        .execute_elementwise_fusion(&[&gpu_a, &gpu_b], &plan)
+        .unwrap()
+        .expect("fusion should succeed for f64 add+mul");
+    assert_eq!(result.len(), 1);
+    let actual = download(&gpu, &result[0]);
+    assert_tensor_close(&actual, &expected, 1e-12);
+}
+
+/// Build a plan for: out = neg(a + b)
+fn add_neg_plan() -> ElementwiseFusionPlan {
+    ElementwiseFusionPlan {
+        dtype: crate::DType::F64,
+        n_inputs: 2,
+        outputs: vec![3],
+        ops: vec![
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Add,
+                inputs: vec![0, 1],
+            },
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Negate,
+                inputs: vec![2],
+            },
+        ],
+    }
+}
+
+#[test]
+fn test_fused_add_neg() {
+    let a = tensor_f64(vec![3], vec![1.0, -2.0, 3.0]);
+    let b = tensor_f64(vec![3], vec![4.0, 5.0, -6.0]);
+
+    let mut cpu = cpu_backend();
+    let sum = cpu.add(&a, &b).unwrap();
+    let expected = cpu.neg(&sum).unwrap();
+
+    let mut gpu = gpu_backend();
+    let gpu_a = upload(&gpu, &a);
+    let gpu_b = upload(&gpu, &b);
+
+    let plan = add_neg_plan();
+    let result = gpu
+        .execute_elementwise_fusion(&[&gpu_a, &gpu_b], &plan)
+        .unwrap()
+        .expect("fusion should succeed");
+    let actual = download(&gpu, &result[0]);
+    assert_tensor_close(&actual, &expected, 1e-12);
+}
+
+/// Plan with multiple outputs: both (a+b) and neg(a+b) are live.
+fn multi_output_plan() -> ElementwiseFusionPlan {
+    ElementwiseFusionPlan {
+        dtype: crate::DType::F64,
+        n_inputs: 2,
+        outputs: vec![2, 3], // sum and neg(sum)
+        ops: vec![
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Add,
+                inputs: vec![0, 1],
+            },
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Negate,
+                inputs: vec![2],
+            },
+        ],
+    }
+}
+
+#[test]
+fn test_fused_multi_output() {
+    let a = tensor_f64(vec![3], vec![1.0, 2.0, 3.0]);
+    let b = tensor_f64(vec![3], vec![4.0, 5.0, 6.0]);
+
+    let mut cpu = cpu_backend();
+    let sum_expected = cpu.add(&a, &b).unwrap();
+    let neg_expected = cpu.neg(&sum_expected).unwrap();
+
+    let mut gpu = gpu_backend();
+    let gpu_a = upload(&gpu, &a);
+    let gpu_b = upload(&gpu, &b);
+
+    let plan = multi_output_plan();
+    let result = gpu
+        .execute_elementwise_fusion(&[&gpu_a, &gpu_b], &plan)
+        .unwrap()
+        .expect("fusion should succeed for multi-output");
+    assert_eq!(result.len(), 2);
+    assert_tensor_close(&download(&gpu, &result[0]), &sum_expected, 1e-12);
+    assert_tensor_close(&download(&gpu, &result[1]), &neg_expected, 1e-12);
+}
+
+/// Plan with unary transcendentals: exp(sqrt(abs(a)))
+fn unary_chain_plan() -> ElementwiseFusionPlan {
+    ElementwiseFusionPlan {
+        dtype: crate::DType::F64,
+        n_inputs: 1,
+        outputs: vec![3],
+        ops: vec![
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Abs,
+                inputs: vec![0],
+            },
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Sqrt,
+                inputs: vec![1],
+            },
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Exp,
+                inputs: vec![2],
+            },
+        ],
+    }
+}
+
+#[test]
+fn test_fused_unary_chain() {
+    let a = tensor_f64(vec![4], vec![-4.0, 1.0, 9.0, 0.25]);
+
+    let mut cpu = cpu_backend();
+    let t1 = cpu.abs(&a).unwrap();
+    let t2 = cpu.sqrt(&t1).unwrap();
+    let expected = cpu.exp(&t2).unwrap();
+
+    let mut gpu = gpu_backend();
+    let gpu_a = upload(&gpu, &a);
+
+    let plan = unary_chain_plan();
+    let result = gpu
+        .execute_elementwise_fusion(&[&gpu_a], &plan)
+        .unwrap()
+        .expect("fusion should succeed for unary chain");
+    let actual = download(&gpu, &result[0]);
+    assert_tensor_close(&actual, &expected, 1e-10);
+}
+
+#[test]
+fn test_fused_empty_tensor() {
+    let a = tensor_f64(vec![0], vec![]);
+    let b = tensor_f64(vec![0], vec![]);
+
+    let mut gpu = gpu_backend();
+    let gpu_a = upload(&gpu, &a);
+    let gpu_b = upload(&gpu, &b);
+
+    let plan = add_mul_plan();
+    let result = gpu
+        .execute_elementwise_fusion(&[&gpu_a, &gpu_b], &plan)
+        .unwrap()
+        .expect("fusion should handle empty tensors");
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].shape(), &[0]);
+}
+
+/// Compare produces 0/1 output.
+fn compare_plan() -> ElementwiseFusionPlan {
+    ElementwiseFusionPlan {
+        dtype: crate::DType::F64,
+        n_inputs: 2,
+        outputs: vec![2],
+        ops: vec![ElementwiseFusionInst {
+            op: ElementwiseFusionOp::Compare(CompareDir::Gt),
+            inputs: vec![0, 1],
+        }],
+    }
+}
+
+#[test]
+fn test_fused_compare() {
+    let a = tensor_f64(vec![4], vec![1.0, 5.0, 3.0, 2.0]);
+    let b = tensor_f64(vec![4], vec![2.0, 3.0, 3.0, 4.0]);
+
+    let mut cpu = cpu_backend();
+    let expected = cpu.compare(&a, &b, &CompareDir::Gt).unwrap();
+
+    let mut gpu = gpu_backend();
+    let gpu_a = upload(&gpu, &a);
+    let gpu_b = upload(&gpu, &b);
+
+    let plan = compare_plan();
+    let result = gpu
+        .execute_elementwise_fusion(&[&gpu_a, &gpu_b], &plan)
+        .unwrap()
+        .expect("fusion should succeed for compare");
+    let actual = download(&gpu, &result[0]);
+    assert_tensor_close(&actual, &expected, 1e-12);
+}

--- a/tenferro-tensor/src/cubecl/tests/mod.rs
+++ b/tenferro-tensor/src/cubecl/tests/mod.rs
@@ -6,6 +6,7 @@ use crate::cubecl::{download_tensor, upload_tensor, CubeclBackend};
 use crate::{Tensor, TypedTensor};
 
 mod elementwise_tests;
+mod fusion_tests;
 mod gemm_tests;
 mod indexing_tests;
 mod linalg_tests;

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -32,7 +32,10 @@ pub mod rocm;
 #[cfg(feature = "cubecl")]
 pub mod cubecl;
 
-pub use backend::{default_exec_session, SemiringBackend, TensorBackend, TensorExec};
+pub use backend::{
+    default_exec_session, ElementwiseFusionInst, ElementwiseFusionOp, ElementwiseFusionPlan,
+    SemiringBackend, TensorBackend, TensorExec,
+};
 pub use config::*;
 pub use error::*;
 pub use types::*;

--- a/tenferro/src/segment.rs
+++ b/tenferro/src/segment.rs
@@ -1,15 +1,17 @@
 //! ExecProgram segmentation and segment-based dispatch.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::error::Result;
 use crate::exec::{
     collect_outputs, execute_ffi_instruction, execute_fusible_instruction,
     execute_host_instruction, initialize_slots, is_ffi_instruction, is_host_instruction,
     reclaim_last_use_inputs_backend, reclaim_last_use_inputs_exec, DispatchMode, ExecInstruction,
-    ExecProgram,
+    ExecOp, ExecProgram,
 };
-use tenferro_tensor::{Tensor, TensorBackend};
+use tenferro_tensor::{
+    ElementwiseFusionInst, ElementwiseFusionOp, ElementwiseFusionPlan, Tensor, TensorBackend,
+};
 
 /// A compiled execution segment.
 ///
@@ -143,8 +145,35 @@ pub fn eval_exec_segmented<B: TensorBackend>(
 
     for segment in &segments {
         match segment {
-            Segment::Fused { instructions, .. } => {
+            Segment::Fused {
+                instructions,
+                input_slots,
+                output_slots,
+                last_use,
+            } => {
                 backend.with_exec_session(|exec| -> Result<()> {
+                    if let Some(plan) =
+                        build_elementwise_fusion_plan(instructions, input_slots, output_slots)
+                    {
+                        let inputs = collect_segment_inputs(&slots, input_slots)?;
+                        if let Some(outputs) = exec.execute_elementwise_fusion(&inputs, &plan)? {
+                            if outputs.len() != output_slots.len() {
+                                return Err(crate::error::Error::Internal(format!(
+                                    "fused elementwise kernel produced {} outputs for {} slots",
+                                    outputs.len(),
+                                    output_slots.len()
+                                )));
+                            }
+                            for (slot, tensor) in
+                                output_slots.iter().copied().zip(outputs.into_iter())
+                            {
+                                slots[slot] = Some(tensor);
+                            }
+                            reclaim_segment_inputs_exec(&mut slots, input_slots, last_use, exec);
+                            return Ok(());
+                        }
+                    }
+
                     for inst in instructions {
                         let result = execute_fusible_instruction(exec, &slots, inst)?;
                         slots[inst.output_slots[0]] = Some(result);
@@ -228,5 +257,102 @@ fn build_fused_segment(program: &ExecProgram, start: usize, end: usize) -> Segme
         input_slots,
         output_slots,
         last_use,
+    }
+}
+
+fn collect_segment_inputs<'a>(
+    slots: &'a [Option<Tensor>],
+    input_slots: &[usize],
+) -> Result<Vec<&'a Tensor>> {
+    input_slots
+        .iter()
+        .map(|&slot| {
+            slots[slot]
+                .as_ref()
+                .ok_or(tenferro_tensor::Error::MissingValue { slot }.into())
+        })
+        .collect()
+}
+
+fn reclaim_segment_inputs_exec(
+    slots: &mut [Option<Tensor>],
+    input_slots: &[usize],
+    last_use: &[bool],
+    exec: &mut dyn tenferro_tensor::TensorExec,
+) {
+    for (&slot, &is_last_use) in input_slots.iter().zip(last_use.iter()) {
+        if is_last_use {
+            if let Some(tensor) = slots[slot].take() {
+                exec.reclaim_buffer(tensor);
+            }
+        }
+    }
+}
+
+fn build_elementwise_fusion_plan(
+    instructions: &[ExecInstruction],
+    input_slots: &[usize],
+    output_slots: &[usize],
+) -> Option<ElementwiseFusionPlan> {
+    let first = instructions.first()?;
+    let dtype = first.dtype;
+    let mut slot_to_value = HashMap::with_capacity(input_slots.len() + instructions.len());
+    for (value, &slot) in input_slots.iter().enumerate() {
+        slot_to_value.insert(slot, value);
+    }
+
+    let mut ops = Vec::with_capacity(instructions.len());
+    let mut next_value = input_slots.len();
+    for inst in instructions {
+        if inst.dtype != dtype || inst.output_slots.len() != 1 {
+            return None;
+        }
+        let op = map_exec_op_to_elementwise_fusion(&inst.op)?;
+        let inputs = inst
+            .input_slots
+            .iter()
+            .map(|slot| slot_to_value.get(slot).copied())
+            .collect::<Option<Vec<_>>>()?;
+        ops.push(ElementwiseFusionInst { op, inputs });
+        slot_to_value.insert(inst.output_slots[0], next_value);
+        next_value += 1;
+    }
+
+    let outputs = output_slots
+        .iter()
+        .map(|slot| slot_to_value.get(slot).copied())
+        .collect::<Option<Vec<_>>>()?;
+
+    Some(ElementwiseFusionPlan {
+        dtype,
+        n_inputs: input_slots.len(),
+        outputs,
+        ops,
+    })
+}
+
+fn map_exec_op_to_elementwise_fusion(op: &ExecOp) -> Option<ElementwiseFusionOp> {
+    match op {
+        ExecOp::Add => Some(ElementwiseFusionOp::Add),
+        ExecOp::Multiply => Some(ElementwiseFusionOp::Multiply),
+        ExecOp::Negate => Some(ElementwiseFusionOp::Negate),
+        ExecOp::Conj => Some(ElementwiseFusionOp::Conj),
+        ExecOp::Divide => Some(ElementwiseFusionOp::Divide),
+        ExecOp::Abs => Some(ElementwiseFusionOp::Abs),
+        ExecOp::Maximum => Some(ElementwiseFusionOp::Maximum),
+        ExecOp::Minimum => Some(ElementwiseFusionOp::Minimum),
+        ExecOp::Compare(dir) => Some(ElementwiseFusionOp::Compare(dir.clone())),
+        ExecOp::Select => Some(ElementwiseFusionOp::Select),
+        ExecOp::Clamp => Some(ElementwiseFusionOp::Clamp),
+        ExecOp::Exp => Some(ElementwiseFusionOp::Exp),
+        ExecOp::Log => Some(ElementwiseFusionOp::Log),
+        ExecOp::Sin => Some(ElementwiseFusionOp::Sin),
+        ExecOp::Cos => Some(ElementwiseFusionOp::Cos),
+        ExecOp::Tanh => Some(ElementwiseFusionOp::Tanh),
+        ExecOp::Sqrt => Some(ElementwiseFusionOp::Sqrt),
+        ExecOp::Rsqrt => Some(ElementwiseFusionOp::Rsqrt),
+        ExecOp::Pow => Some(ElementwiseFusionOp::Pow),
+        ExecOp::Log1p => Some(ElementwiseFusionOp::Log1p),
+        _ => None,
     }
 }


### PR DESCRIPTION
## Summary

- Add elementwise kernel fusion to the CubeCL GPU backend: consecutive elementwise ops in a `Segment::Fused` are compiled into a single GPU kernel via runtime cubecl IR (Scope) construction
- `segment.rs` builds `ElementwiseFusionPlan` from fused segments; `TensorBackend` gains `execute_elementwise_fusion()` with default fallback to per-op execution
- Supports 20 elementwise ops (Add, Mul, Div, Neg, Conj, Abs, Exp, Log, Sin, Cos, Tanh, Sqrt, Rsqrt, Pow, Log1p, Maximum, Minimum, Compare, Select, Clamp); complex limited to Add/Mul/Div/Neg/Conj
- Incorporates all 5 mandatory review findings: Comparison enum mapping, Sign/Expm1 exclusion, CubeDim/CubeCount distinction, multiple live outputs, Send+Sync safety

## Test plan

- [x] 6 GPU fusion tests pass (add+mul, add+neg, multi-output, unary chain, empty tensor, compare)
- [x] Full workspace tests pass (`cargo test --workspace --release`)
- [x] All existing cubecl tests still pass
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)