### PR TITLE
docs: document concrete vs symbolic shape modes (#658)

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -64,6 +64,15 @@ If you have used NumPy or PyTorch in eager mode, this is the familiar pattern.
 
 In PyTorch terms, a `TracedTensor` feels like a tensor object you can keep composing. In JAX terms, it is closer to building up a staged computation, except tenferro keeps the staging model explicit instead of hiding it behind `jit`.
 
+### Concrete vs symbolic shapes
+
+Each `TracedTensor` carries its shape in one of two modes:
+
+- **Concrete**: shape is known at graph-build time. Use `from_vec(shape, data)`, `from_tensor_concrete_shape(tensor)`, or `input_concrete_shape(dtype, shape)` for a placeholder with a fixed shape.
+- **Symbolic**: shape is only known at eval time. Use `from_tensor_symbolic_shape(tensor)` or `input_symbolic_shape(dtype, rank)` when the shape varies across calls (dynamic batch sizes, polymorphic graphs).
+
+The choice affects how N-ary einsum is lowered. All-concrete inputs let tenferro optimize the contraction path at build time and decompose into binary `DotGeneral` ops. Any symbolic input keeps a single `NaryEinsum` op in the graph and defers path optimization to eval time (cached per shape). See the [einsum guide](../guides/einsum.md#static-vs-symbolic-shapes) for examples.
+
 ## Engine: the executor
 
 `Engine` owns the backend that actually runs your computation. It also keeps reusable execution state, so the normal pattern is to build one engine and reuse it across many evaluations.

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -98,6 +98,40 @@ let result = out.eval(&mut engine).unwrap();
 assert_eq!(result.shape(), &[2, 2]);
 ```
 
+## Static vs symbolic shapes
+
+A `TracedTensor` carries its shape in one of two modes, chosen at construction time:
+
+| Mode | Constructor | When to use |
+| --- | --- | --- |
+| **Concrete (static)** | `from_vec`, `from_tensor_concrete_shape`, `input_concrete_shape(dtype, shape)` | Shape fixed at graph-build time. Enables build-time contraction path optimization, per-shape specialization |
+| **Symbolic** | `from_tensor_symbolic_shape`, `input_symbolic_shape(dtype, rank)` | Shape only known at eval time. Use for dynamic batch sizes, polymorphic graphs, or to defer path optimization |
+
+For N-ary einsum the mode propagates:
+
+- **All inputs have concrete shapes** → the contraction path is optimized at graph-build time and the einsum is decomposed into binary `DotGeneral` ops.
+- **Any input is symbolic** → the einsum is kept as a single `NaryEinsum` op; the contraction path is resolved at eval time from the actual input shapes.
+
+The engine caches optimized contraction trees keyed by `(subscripts, input shapes)`, so the eval-time cost is amortized across repeated calls with the same shapes.
+
+```rust
+use tenferro::{einsum::einsum, CpuBackend, Engine, Tensor, TracedTensor};
+use tenferro_tensor::DType;
+
+// One symbolic-shape input + one concrete-shape input.
+let a = TracedTensor::input_symbolic_shape(DType::F64, 2);
+let b = TracedTensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+let mut engine = Engine::new(CpuBackend::new());
+let mut c = einsum(&mut engine, &[&a, &b], "ij,jk->ik").unwrap();
+
+// Bind a concrete tensor to the symbolic leg at eval time.
+let a_concrete = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+let result = c.eval_with_inputs(&mut engine, &[(&a, &a_concrete)]).unwrap();
+
+assert_eq!(result.shape(), &[2, 2]);
+```
+
 ## Batched matrix multiply
 
 PyTorch and JAX users often put the batch axis first. In tenferro, trailing batch axes line up naturally with column-major storage, so this example keeps the batch dimension on the right.


### PR DESCRIPTION
## Summary

Fills the only remaining item from #658: user-facing documentation for the static/symbolic `TracedTensor` shape modes added in #734 and the N-ary einsum lowering behavior they control.

- `docs/getting-started/core-concepts.md`: adds a "Concrete vs symbolic shapes" subsection inside the TracedTensor section, with a cross-reference to the einsum guide.
- `docs/guides/einsum.md`: adds a "Static vs symbolic shapes" section with a constructor table, the propagation rule (all-concrete → decompose to `DotGeneral`, any-symbolic → keep `NaryEinsum`), and a runnable example using `input_symbolic_shape` + `eval_with_inputs`.

Closes #658.

## Test plan
- [x] `python3 scripts/check-docs-site.py` — 6 workspace crates verified
- [x] Example code pattern matches the passing test in `tenferro/tests/nary_einsum_cache.rs:96-104` (already shipped in #735)

🤖 Generated with [Claude Code](https://claude.com/claude-code)