### PR TITLE
feat(compiler): complete DotDecomposer using shape tracking (closes #729)

### DIFF
--- a/docs/spec/optimizer-passes.md
+++ b/docs/spec/optimizer-passes.md
@@ -39,12 +39,8 @@ without reconstructing shapes from scratch downstream.
 |---|---|---|
 | `DotDimensionSorter` | active | Sort contracting dimensions on `ExecOp::DotGeneral` to stabilize canonical order |
 | `TransposeFolding` | active | Fold producer `ExecOp::Transpose` into downstream `ExecOp::DotGeneral` dimension numbers |
-
-### Deferred pass
-
-| Pass | Status | Notes |
-|---|---|---|
-| `DotDecomposer` | deferred | Shape tracking is now available on `ExecInstruction`, but the canonicalization pass itself is still tracked in `tensor4all/tenferro-rs#729` |
+| `DotDecomposer` | active | Canonicalize `ExecOp::DotGeneral` into `[M?, K, B...] × [K, N?, B...] → [M?, N?, B...]` by emitting explicit `Transpose`/`Reshape` wrappers |
+| `DeadCodeElimination` | active | Drop instructions whose outputs are never consumed by a program output or later instruction (preserving side-effecting `ValidateNonsingular`) |
 
 ### Removed pass
 
@@ -170,24 +166,95 @@ transposes exposed by earlier folds.
 
 ### III.3 DotDecomposer
 
-**Scope:** planned for `ExecProgram`
-
-**Status:** deferred to `tensor4all/tenferro-rs#729`
+**Scope:** `ExecProgram`
 
 **Goal:** Canonicalize arbitrary `ExecOp::DotGeneral` contractions into a
-shape more directly consumable by backend GEMM paths.
+shape directly consumable by canonical batched GEMM kernels. Runs after
+`TransposeFolding`, so pre-existing foldable transposes are already absorbed
+when decomposition kicks in.
 
-The 1-layer IR refactor intentionally landed the prerequisites first:
+**Canonical form** (tenferro column-major with batch trailing, per
+`AGENTS.md`):
 
-- direct `StdTensorOp -> ExecProgram` lowering
-- per-instruction dtype inference
-- per-instruction `output_shapes`
+```text
+LHS shape: [M?, K, B0, B1, ...]
+  lhs_contracting_dims = [|free_L|']
+  lhs_batch_dims       = [|free_L|' + 1, ..., |free_L|' + nb]
+  |free_L|' = 1 if the original LHS had any free dim, else 0.
 
-That metadata is now available to support decomposition, reshape insertion,
-and downstream validation. The transformation itself is still out of scope for
-the current branch and is not part of the live compiler pipeline.
+RHS shape: [K, N?, B0, B1, ...]
+  rhs_contracting_dims = [0]
+  rhs_batch_dims       = [|free_R|' + 1, ..., |free_R|' + nb]
+  |free_R|' = 1 if the original RHS had any free dim, else 0.
+```
 
-### III.4 ReductionSimplification
+Output shape (from `shape_infer::dot_general_shape`): `[M?, N?, B0, B1, ...]`
+with 0-or-1 `M` dim, 0-or-1 `N` dim, and the batch sizes trailing.
+
+**When to fire:** any `ExecOp::DotGeneral` whose `(config, lhs_rank, rhs_rank)`
+is not already in canonical form.
+
+**Algorithm** per non-canonical DotGeneral (inputs: LHS and RHS slots with
+shapes in `slot_shapes`):
+
+1. **LHS Transpose** to target order `free_L ++ contracting_L ++ batch_L`.
+   Skip if already identity.
+2. **LHS Reshape** to `[M?, K, B...]` by merging multiple free/contracting
+   dims. Skip if `|free_L| ≤ 1` and `|contracting_L| == 1`.
+3. **RHS Transpose** to target order `contracting_R ++ free_R ++ batch_R`.
+   Skip if already identity.
+4. **RHS Reshape** to `[K, N?, B...]`. Same skip rule as LHS.
+5. **Canonical `DotGeneral`** with the dim-number positions described above.
+6. **Output Reshape** — the XLA Step 5 that the pre-#729 skeleton was
+   missing — restores the original output shape when either side had
+   multiple free dims. It takes the canonical DotGeneral output and the
+   original LHS and RHS slots as shape-providing inputs, so the dynamic
+   free-dim sizes can be recovered at runtime.
+
+Skipping the output Reshape (step 6) is what caused the historical
+downstream-Permute bug: downstream consumers would observe the merged rank
+instead of the expected unmerged rank, and subsequent `Transpose`/`Reshape`
+users would fall out of bounds. With the Reshape in place, downstream ops
+see the original output shape and no further rewriting is required.
+
+**Example** (single non-canonical case):
+
+```text
+Before:
+  DotGeneral lhs=[a, b, M, K1, K2] rhs=[a, b, K1, K2, N]
+             lhs_batch=[0, 1] rhs_batch=[0, 1]
+             lhs_cont=[3, 4]  rhs_cont=[2, 3]
+
+After:
+  Transpose(lhs, perm=[2, 3, 4, 0, 1])  -> [M, K1, K2, a, b]
+  Reshape(...)                           -> [M, K1*K2, a, b]
+  Transpose(rhs, perm=[2, 3, 4, 0, 1])  -> [K1, K2, N, a, b]
+  Reshape(...)                           -> [K1*K2, N, a, b]
+  DotGeneral(canonical)                  -> [M, N, a, b]
+```
+
+**Interaction with `TransposeFolding`:** `TransposeFolding` runs first and
+may leave dead `Transpose` producers (its folded-away producer is bypassed
+but not removed). The subsequent `DeadCodeElimination` reclaims that runtime
+cost. For programs where the user already wrote a canonical `Transpose →
+DotGeneral`, the fold+decomp combination is net-identity (the fold absorbs,
+the decomp re-emits), so the compiled result is equivalent to the input up
+to dead-code cleanup.
+
+### III.4 DeadCodeElimination
+
+**Scope:** `ExecProgram`
+
+**Purpose:** Remove instructions whose outputs are not consumed by any
+downstream instruction or program output. Preserves instructions with
+observable side effects (currently only `ExecOp::ValidateNonsingular`,
+which errors on singular matrices).
+
+**When to fire:** always. In practice, instructions die after
+`DotDecomposer` re-canonicalizes a DotGeneral whose upstream Transpose was
+already folded into dim-numbers by `TransposeFolding`.
+
+### III.5 ReductionSimplification
 
 `ReductionSimplification` no longer exists in the compiler. Historical notes
 about hoisting independent reductions remain useful background, but there is no
@@ -209,13 +276,21 @@ ExecProgram
     │
     │ 1. DotDimensionSorter
     │ 2. TransposeFolding (fixed point)
-    │ 3. populate_last_use
+    │ 3. DotDecomposer
+    │ 4. DeadCodeElimination
+    │ 5. populate_last_use
     ▼
 Ready for execution
 ```
 
-`DotDecomposer` is intentionally absent from this list until issue `#729`
-lands. `ReductionSimplification` is intentionally absent because the pass was
+`DotDecomposer` runs after `TransposeFolding` so that any pre-existing
+foldable transpose is absorbed into the DotGeneral dim numbers before the
+decomposition step canonicalizes the result. `DeadCodeElimination` runs last
+among the optimizations to remove bypassed instructions (typically
+`Transpose` producers the fold left behind) before `populate_last_use`
+records the final liveness map.
+
+`ReductionSimplification` is intentionally absent because the pass was
 deleted.
 
 ---
@@ -226,7 +301,7 @@ deleted.
 |---|---|
 | Contracting-dimension normalization during execution planning | Moved into `DotDimensionSorter` on `ExecProgram` |
 | Lazy transpose absorption around GEMM | Moved into `TransposeFolding` on `ExecProgram` |
-| Multi-step `DotGeneral` canonicalization | Deferred to `DotDecomposer` in `#729` |
+| Multi-step `DotGeneral` canonicalization | Implemented in `DotDecomposer` (#729) with the full XLA-style algorithm, including the output Reshape step |
 | Reduction hoisting before contraction | No dedicated pass today |
 | Linalg passthrough via string `CustomCall` | Removed; linalg ops are structured `ExecOp` variants |
 

--- a/tenferro/src/compiler.rs
+++ b/tenferro/src/compiler.rs
@@ -94,6 +94,8 @@ pub fn compile_std_to_exec(
     };
     dot_dimension_sorter(&mut program);
     transpose_folding(&mut program);
+    dot_decomposer(&mut program, input_shapes);
+    eliminate_dead_code(&mut program);
     populate_last_use(&mut program);
     program
 }
@@ -166,6 +168,8 @@ where
     };
     dot_dimension_sorter(&mut program);
     transpose_folding(&mut program);
+    dot_decomposer(&mut program, input_shapes);
+    eliminate_dead_code(&mut program);
     populate_last_use(&mut program);
     program
 }
@@ -588,4 +592,534 @@ fn fold_transpose_into_dot(
         new_config.rhs_batch_dims = config.rhs_batch_dims.iter().map(|&dim| perm[dim]).collect();
     }
     new_config
+}
+
+// ============================================================================
+// Pass 3: DotDecomposer
+// ============================================================================
+//
+// Canonicalize `ExecOp::DotGeneral` into a shape consumable by canonical
+// batched GEMM kernels. Runs after `transpose_folding` so that pre-existing
+// foldable transposes are already absorbed. Per-instruction `output_shapes`
+// (populated by `shape_infer`) gives the shapes needed to emit `Reshape`
+// instructions that merge free/contracting groups and restore the original
+// output shape.
+//
+// Canonical form (tenferro column-major with batch trailing):
+//
+//   LHS: [M?, K, B0, B1, ...]
+//     - lhs_contracting_dims = [|free_L|']
+//     - lhs_batch_dims       = [|free_L|' + 1, ..., |free_L|' + nb]
+//     where |free_L|' = 1 if the original LHS had any free dim, else 0.
+//
+//   RHS: [K, N?, B0, B1, ...]
+//     - rhs_contracting_dims = [0]
+//     - rhs_batch_dims       = [|free_R|' + 1, ..., |free_R|' + nb]
+//     where |free_R|' = 1 if the original RHS had any free dim, else 0.
+//
+// The XLA-style algorithm per non-canonical DotGeneral:
+//
+//   1. Transpose LHS to target order (free ++ contracting ++ batch).
+//   2. Reshape LHS to merge multiple free/contracting dims.
+//   3. Transpose RHS to target order (contracting ++ free ++ batch).
+//   4. Reshape RHS to merge multiple free/contracting dims.
+//   5. Emit canonical `DotGeneral`.
+//   6. Reshape output back to the original shape (required when either side
+//      had multiple free dims). Without this, downstream consumers would
+//      observe a rank-collapsed tensor.
+//
+// Only steps that are non-trivial for the specific operand are emitted.
+
+/// Canonicalize all non-canonical `DotGeneral` instructions in `program`.
+///
+/// `input_shapes` are the program-input shapes (matching `program.input_slots`).
+/// They are needed because `ExecProgram` does not otherwise carry input-slot
+/// shape metadata.
+pub fn dot_decomposer(program: &mut ExecProgram, input_shapes: &[Vec<DimExpr>]) {
+    assert_eq!(
+        program.input_slots.len(),
+        input_shapes.len(),
+        "dot_decomposer: input shape count must match input slot count"
+    );
+
+    let mut slot_shapes: Vec<Option<Vec<DimExpr>>> = vec![None; program.n_slots];
+    for (index, &slot) in program.input_slots.iter().enumerate() {
+        slot_shapes[slot] = Some(input_shapes[index].clone());
+    }
+    for instr in &program.instructions {
+        for (slot, shape) in instr.output_slots.iter().zip(instr.output_shapes.iter()) {
+            slot_shapes[*slot] = Some(shape.clone());
+        }
+    }
+
+    let mut new_instructions: Vec<ExecInstruction> = Vec::with_capacity(program.instructions.len());
+    let mut n_slots = program.n_slots;
+
+    for instr in &program.instructions {
+        if let ExecOp::DotGeneral(config) = &instr.op {
+            if instr.input_slots.len() == 2 && !config.lhs_contracting_dims.is_empty() {
+                let lhs_slot = instr.input_slots[0];
+                let rhs_slot = instr.input_slots[1];
+                let lhs_shape = require_slot_shape(&slot_shapes, lhs_slot);
+                let rhs_shape = require_slot_shape(&slot_shapes, rhs_slot);
+                if !is_dot_canonical(config, lhs_shape.len(), rhs_shape.len()) {
+                    decompose_dot(
+                        instr,
+                        config,
+                        lhs_slot,
+                        rhs_slot,
+                        lhs_shape,
+                        rhs_shape,
+                        &mut n_slots,
+                        &mut new_instructions,
+                    );
+                    continue;
+                }
+            }
+        }
+        new_instructions.push(instr.clone());
+    }
+
+    program.instructions = new_instructions;
+    program.n_slots = n_slots;
+}
+
+fn require_slot_shape(slot_shapes: &[Option<Vec<DimExpr>>], slot: usize) -> &[DimExpr] {
+    slot_shapes[slot]
+        .as_ref()
+        .unwrap_or_else(|| panic!("dot_decomposer: missing shape for slot {slot}"))
+        .as_slice()
+}
+
+/// Canonical form predicate for a `DotGeneral` with the given operand ranks.
+fn is_dot_canonical(config: &DotGeneralConfig, lhs_rank: usize, rhs_rank: usize) -> bool {
+    if config.lhs_contracting_dims.len() != 1 || config.rhs_contracting_dims.len() != 1 {
+        return false;
+    }
+    if config.lhs_batch_dims.len() != config.rhs_batch_dims.len() {
+        return false;
+    }
+    let nb = config.lhs_batch_dims.len();
+
+    // LHS: [M?, K, B...]. free_L is 0 or 1 elems.
+    let lhs_has_free = match lhs_rank.checked_sub(nb + 1) {
+        Some(0) => false,
+        Some(1) => true,
+        _ => return false,
+    };
+    let lhs_expected_contracting = if lhs_has_free { 1 } else { 0 };
+    let lhs_expected_batch: Vec<usize> =
+        ((lhs_expected_contracting + 1)..(lhs_expected_contracting + 1 + nb)).collect();
+    if config.lhs_contracting_dims != vec![lhs_expected_contracting]
+        || config.lhs_batch_dims != lhs_expected_batch
+    {
+        return false;
+    }
+
+    // RHS: [K, N?, B...]. free_R is 0 or 1 elems, contracting is always at 0.
+    let rhs_has_free = match rhs_rank.checked_sub(nb + 1) {
+        Some(0) => false,
+        Some(1) => true,
+        _ => return false,
+    };
+    let rhs_free_count = usize::from(rhs_has_free);
+    let rhs_expected_batch: Vec<usize> =
+        ((rhs_free_count + 1)..(rhs_free_count + 1 + nb)).collect();
+    if config.rhs_contracting_dims != vec![0] || config.rhs_batch_dims != rhs_expected_batch {
+        return false;
+    }
+
+    true
+}
+
+fn free_axes_of(rank: usize, contracting: &[usize], batch: &[usize]) -> Vec<usize> {
+    (0..rank)
+        .filter(|axis| !contracting.contains(axis) && !batch.contains(axis))
+        .collect()
+}
+
+fn product_of_input_dims(input_idx: usize, start: usize, end: usize) -> DimExpr {
+    assert!(end > start, "product_of_input_dims: empty range");
+    let mut result = DimExpr::InputDim {
+        input_idx,
+        axis: start,
+    };
+    for axis in (start + 1)..end {
+        result = DimExpr::mul(result, DimExpr::InputDim { input_idx, axis });
+    }
+    result
+}
+
+/// Emit decomposed instructions for a single non-canonical DotGeneral.
+#[allow(clippy::too_many_arguments)]
+fn decompose_dot(
+    instr: &ExecInstruction,
+    config: &DotGeneralConfig,
+    lhs_slot: usize,
+    rhs_slot: usize,
+    lhs_shape: &[DimExpr],
+    rhs_shape: &[DimExpr],
+    n_slots: &mut usize,
+    new_instructions: &mut Vec<ExecInstruction>,
+) {
+    let lhs_rank = lhs_shape.len();
+    let rhs_rank = rhs_shape.len();
+    let nb = config.lhs_batch_dims.len();
+    assert_eq!(
+        nb,
+        config.rhs_batch_dims.len(),
+        "dot_decomposer: mismatched batch dim count"
+    );
+
+    let lhs_free = free_axes_of(
+        lhs_rank,
+        &config.lhs_contracting_dims,
+        &config.lhs_batch_dims,
+    );
+    let rhs_free = free_axes_of(
+        rhs_rank,
+        &config.rhs_contracting_dims,
+        &config.rhs_batch_dims,
+    );
+    let fi_l = lhs_free.len();
+    let ci_l = config.lhs_contracting_dims.len();
+    let fi_r = rhs_free.len();
+    let ci_r = config.rhs_contracting_dims.len();
+
+    let lhs_target_perm: Vec<usize> = lhs_free
+        .iter()
+        .chain(config.lhs_contracting_dims.iter())
+        .chain(config.lhs_batch_dims.iter())
+        .copied()
+        .collect();
+    let (lhs_after_transpose_slot, lhs_after_transpose_shape) = emit_transpose_if_needed(
+        lhs_slot,
+        lhs_shape,
+        &lhs_target_perm,
+        instr.dtype,
+        n_slots,
+        new_instructions,
+    );
+
+    let (lhs_canon_slot, lhs_canon_shape) = if fi_l > 1 || ci_l > 1 {
+        emit_merge_reshape(
+            lhs_after_transpose_slot,
+            &lhs_after_transpose_shape,
+            fi_l,
+            ci_l,
+            nb,
+            instr.dtype,
+            n_slots,
+            new_instructions,
+        )
+    } else {
+        (lhs_after_transpose_slot, lhs_after_transpose_shape)
+    };
+
+    let rhs_target_perm: Vec<usize> = config
+        .rhs_contracting_dims
+        .iter()
+        .chain(rhs_free.iter())
+        .chain(config.rhs_batch_dims.iter())
+        .copied()
+        .collect();
+    let (rhs_after_transpose_slot, rhs_after_transpose_shape) = emit_transpose_if_needed(
+        rhs_slot,
+        rhs_shape,
+        &rhs_target_perm,
+        instr.dtype,
+        n_slots,
+        new_instructions,
+    );
+
+    let (rhs_canon_slot, rhs_canon_shape) = if fi_r > 1 || ci_r > 1 {
+        // For RHS the transpose target puts contracting first, then free.
+        emit_merge_reshape_rhs(
+            rhs_after_transpose_slot,
+            &rhs_after_transpose_shape,
+            fi_r,
+            ci_r,
+            nb,
+            instr.dtype,
+            n_slots,
+            new_instructions,
+        )
+    } else {
+        (rhs_after_transpose_slot, rhs_after_transpose_shape)
+    };
+
+    let lhs_free_count_canon = usize::from(fi_l > 0);
+    let rhs_free_count_canon = usize::from(fi_r > 0);
+    let canonical_config = DotGeneralConfig {
+        lhs_contracting_dims: vec![lhs_free_count_canon],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: ((lhs_free_count_canon + 1)..(lhs_free_count_canon + 1 + nb)).collect(),
+        rhs_batch_dims: ((rhs_free_count_canon + 1)..(rhs_free_count_canon + 1 + nb)).collect(),
+    };
+
+    let needs_output_reshape = fi_l > 1 || fi_r > 1;
+
+    let canonical_output_slot = if needs_output_reshape {
+        let s = *n_slots;
+        *n_slots += 1;
+        s
+    } else {
+        instr.output_slots[0]
+    };
+
+    // Compute canonical output shape directly: [M?, N?, batch...] referencing
+    // the canonical operand shapes we just built.
+    let mut canonical_output_shape: Vec<DimExpr> = Vec::new();
+    if fi_l > 0 {
+        canonical_output_shape.push(lhs_canon_shape[0].clone());
+    }
+    if fi_r > 0 {
+        canonical_output_shape.push(rhs_canon_shape[rhs_free_count_canon].clone());
+    }
+    for axis_offset in 0..nb {
+        canonical_output_shape
+            .push(lhs_canon_shape[lhs_free_count_canon + 1 + axis_offset].clone());
+    }
+
+    new_instructions.push(ExecInstruction {
+        op: ExecOp::DotGeneral(canonical_config),
+        input_slots: vec![lhs_canon_slot, rhs_canon_slot],
+        output_slots: vec![canonical_output_slot],
+        dtype: instr.dtype,
+        output_shapes: vec![canonical_output_shape],
+        last_use: Vec::new(),
+    });
+
+    if needs_output_reshape {
+        // Target output shape: original DotGeneral output =
+        //   [lhs_free_sizes..., rhs_free_sizes..., batch_sizes...]
+        // Expressed via `InputDim{1, axis}` (original LHS) and
+        // `InputDim{2, axis}` (original RHS) so the Reshape can evaluate
+        // dynamic sizes at runtime.
+        let mut to_shape: Vec<DimExpr> = Vec::new();
+        for &axis in &lhs_free {
+            to_shape.push(DimExpr::InputDim { input_idx: 1, axis });
+        }
+        for &axis in &rhs_free {
+            to_shape.push(DimExpr::InputDim { input_idx: 2, axis });
+        }
+        for &axis in &config.lhs_batch_dims {
+            to_shape.push(DimExpr::InputDim { input_idx: 1, axis });
+        }
+
+        // Metadata `output_shapes` uses the original DotGeneral output shape
+        // directly, which we cloned from `instr` above.
+        let metadata_shape = instr.output_shapes[0].clone();
+
+        new_instructions.push(ExecInstruction {
+            op: ExecOp::Reshape {
+                shape: to_shape.clone(),
+            },
+            input_slots: vec![canonical_output_slot, lhs_slot, rhs_slot],
+            output_slots: vec![instr.output_slots[0]],
+            dtype: instr.dtype,
+            output_shapes: vec![metadata_shape],
+            last_use: Vec::new(),
+        });
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_transpose_if_needed(
+    input_slot: usize,
+    input_shape: &[DimExpr],
+    target_perm: &[usize],
+    dtype: DType,
+    n_slots: &mut usize,
+    new_instructions: &mut Vec<ExecInstruction>,
+) -> (usize, Vec<DimExpr>) {
+    let is_identity = target_perm.iter().enumerate().all(|(i, &p)| i == p);
+    if is_identity {
+        return (input_slot, input_shape.to_vec());
+    }
+    let transposed_shape: Vec<DimExpr> = target_perm
+        .iter()
+        .map(|&axis| input_shape[axis].clone())
+        .collect();
+    let out_slot = *n_slots;
+    *n_slots += 1;
+    new_instructions.push(ExecInstruction {
+        op: ExecOp::Transpose {
+            perm: target_perm.to_vec(),
+        },
+        input_slots: vec![input_slot],
+        output_slots: vec![out_slot],
+        dtype,
+        output_shapes: vec![transposed_shape.clone()],
+        last_use: Vec::new(),
+    });
+    (out_slot, transposed_shape)
+}
+
+/// LHS merge: [free..., contracting..., batch...] -> [M?, K, batch...].
+#[allow(clippy::too_many_arguments)]
+fn emit_merge_reshape(
+    input_slot: usize,
+    input_shape: &[DimExpr],
+    fi: usize,
+    ci: usize,
+    nb: usize,
+    dtype: DType,
+    n_slots: &mut usize,
+    new_instructions: &mut Vec<ExecInstruction>,
+) -> (usize, Vec<DimExpr>) {
+    // Runtime `shape` (op parameter) uses `InputDim{0, axis}` referring to
+    // this Reshape's own input slot.
+    let mut to_shape: Vec<DimExpr> = Vec::new();
+    if fi > 0 {
+        if fi == 1 {
+            to_shape.push(DimExpr::InputDim {
+                input_idx: 0,
+                axis: 0,
+            });
+        } else {
+            to_shape.push(product_of_input_dims(0, 0, fi));
+        }
+    }
+    if ci == 1 {
+        to_shape.push(DimExpr::InputDim {
+            input_idx: 0,
+            axis: fi,
+        });
+    } else {
+        to_shape.push(product_of_input_dims(0, fi, fi + ci));
+    }
+    for k in 0..nb {
+        to_shape.push(DimExpr::InputDim {
+            input_idx: 0,
+            axis: fi + ci + k,
+        });
+    }
+
+    // Metadata `output_shapes` uses original-input DimExprs so downstream
+    // passes can reason about the resulting dims.
+    let mut output_shape_meta: Vec<DimExpr> = Vec::new();
+    if fi > 0 {
+        output_shape_meta.push(merge_span(input_shape, 0, fi));
+    }
+    output_shape_meta.push(merge_span(input_shape, fi, fi + ci));
+    for k in 0..nb {
+        output_shape_meta.push(input_shape[fi + ci + k].clone());
+    }
+
+    let out_slot = *n_slots;
+    *n_slots += 1;
+    new_instructions.push(ExecInstruction {
+        op: ExecOp::Reshape { shape: to_shape },
+        input_slots: vec![input_slot],
+        output_slots: vec![out_slot],
+        dtype,
+        output_shapes: vec![output_shape_meta.clone()],
+        last_use: Vec::new(),
+    });
+    (out_slot, output_shape_meta)
+}
+
+/// RHS merge: [contracting..., free..., batch...] -> [K, N?, batch...].
+#[allow(clippy::too_many_arguments)]
+fn emit_merge_reshape_rhs(
+    input_slot: usize,
+    input_shape: &[DimExpr],
+    fi: usize,
+    ci: usize,
+    nb: usize,
+    dtype: DType,
+    n_slots: &mut usize,
+    new_instructions: &mut Vec<ExecInstruction>,
+) -> (usize, Vec<DimExpr>) {
+    let mut to_shape: Vec<DimExpr> = Vec::new();
+    if ci == 1 {
+        to_shape.push(DimExpr::InputDim {
+            input_idx: 0,
+            axis: 0,
+        });
+    } else {
+        to_shape.push(product_of_input_dims(0, 0, ci));
+    }
+    if fi > 0 {
+        if fi == 1 {
+            to_shape.push(DimExpr::InputDim {
+                input_idx: 0,
+                axis: ci,
+            });
+        } else {
+            to_shape.push(product_of_input_dims(0, ci, ci + fi));
+        }
+    }
+    for k in 0..nb {
+        to_shape.push(DimExpr::InputDim {
+            input_idx: 0,
+            axis: ci + fi + k,
+        });
+    }
+
+    let mut output_shape_meta: Vec<DimExpr> = Vec::new();
+    output_shape_meta.push(merge_span(input_shape, 0, ci));
+    if fi > 0 {
+        output_shape_meta.push(merge_span(input_shape, ci, ci + fi));
+    }
+    for k in 0..nb {
+        output_shape_meta.push(input_shape[ci + fi + k].clone());
+    }
+
+    let out_slot = *n_slots;
+    *n_slots += 1;
+    new_instructions.push(ExecInstruction {
+        op: ExecOp::Reshape { shape: to_shape },
+        input_slots: vec![input_slot],
+        output_slots: vec![out_slot],
+        dtype,
+        output_shapes: vec![output_shape_meta.clone()],
+        last_use: Vec::new(),
+    });
+    (out_slot, output_shape_meta)
+}
+
+fn merge_span(shape: &[DimExpr], start: usize, end: usize) -> DimExpr {
+    assert!(end > start, "merge_span: empty range");
+    let mut result = shape[start].clone();
+    for axis in (start + 1)..end {
+        result = DimExpr::mul(result, shape[axis].clone());
+    }
+    result
+}
+
+// ============================================================================
+// Pass 4: DeadCodeElimination
+// ============================================================================
+//
+// Remove instructions whose outputs are never consumed by a program output
+// or by a later instruction. `transpose_folding` + `dot_decomposer` can leave
+// dead `Transpose` instructions (the folded-out producer is bypassed but
+// remains in the program), and DCE reclaims that wasted runtime work.
+
+/// Drop instructions with no downstream consumer. Preserves instructions with
+/// observable side effects (`ValidateNonsingular`).
+pub fn eliminate_dead_code(program: &mut ExecProgram) {
+    let mut live_slots: std::collections::HashSet<usize> =
+        program.output_slots.iter().copied().collect();
+    let mut keep = vec![false; program.instructions.len()];
+    for idx in (0..program.instructions.len()).rev() {
+        let instr = &program.instructions[idx];
+        let has_live_output = instr.output_slots.iter().any(|s| live_slots.contains(s));
+        let is_side_effecting = matches!(&instr.op, ExecOp::ValidateNonsingular);
+        if has_live_output || is_side_effecting {
+            keep[idx] = true;
+            for &slot in &instr.input_slots {
+                live_slots.insert(slot);
+            }
+        }
+    }
+    let new_instructions: Vec<ExecInstruction> = program
+        .instructions
+        .iter()
+        .enumerate()
+        .filter_map(|(i, instr)| keep[i].then(|| instr.clone()))
+        .collect();
+    program.instructions = new_instructions;
 }

--- a/tenferro/tests/compiler_passes.rs
+++ b/tenferro/tests/compiler_passes.rs
@@ -1,5 +1,8 @@
 use computegraph::compile::{CompiledProgram, Instruction};
-use tenferro::compiler::{compile_std_to_exec, dot_dimension_sorter, transpose_folding};
+use tenferro::compiler::{
+    compile_std_to_exec, dot_decomposer, dot_dimension_sorter, eliminate_dead_code,
+    transpose_folding,
+};
 use tenferro::exec::{ExecInstruction, ExecOp, ExecProgram};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -293,17 +296,421 @@ fn test_full_pipeline_transpose_matmul() {
         &[dim_shape(&[3, 2]), dim_shape(&[3, 4])],
     );
 
+    // `transpose_folding` absorbs the Transpose into DotGeneral dim-numbers,
+    // but `dot_decomposer` then canonicalizes the resulting non-canonical
+    // DotGeneral, re-emitting a Transpose. The final DotGeneral must be
+    // canonical: LHS rank 2 with one free dim -> contracting = [1].
     let dot_instr = exec
         .instructions
         .iter()
         .find(|instr| matches!(instr.op, ExecOp::DotGeneral(_)))
         .expect("expected DotGeneral after direct lowering");
-    assert_eq!(dot_instr.input_slots, vec![0, 1]);
     match &dot_instr.op {
         ExecOp::DotGeneral(config) => {
-            assert_eq!(config.lhs_contracting_dims, vec![0]);
+            assert_eq!(config.lhs_contracting_dims, vec![1]);
             assert_eq!(config.rhs_contracting_dims, vec![0]);
+            assert!(config.lhs_batch_dims.is_empty());
+            assert!(config.rhs_batch_dims.is_empty());
         }
         _ => panic!("expected DotGeneral"),
+    }
+
+    // The canonical DotGeneral's LHS must come from a Transpose on input 0,
+    // and the dead fold-then-decompose Transpose must have been eliminated.
+    let lhs_slot = dot_instr.input_slots[0];
+    let lhs_producer = exec
+        .instructions
+        .iter()
+        .find(|i| i.output_slots.contains(&lhs_slot))
+        .expect("LHS slot must have a producer");
+    match &lhs_producer.op {
+        ExecOp::Transpose { perm } => {
+            assert_eq!(perm, &vec![1, 0]);
+            assert_eq!(lhs_producer.input_slots, vec![0]);
+        }
+        other => panic!("expected Transpose producing LHS, got {other:?}"),
+    }
+    assert_eq!(dot_instr.input_slots[1], 1);
+    let transpose_count = exec
+        .instructions
+        .iter()
+        .filter(|i| matches!(i.op, ExecOp::Transpose { .. }))
+        .count();
+    assert_eq!(transpose_count, 1, "dead-code elimination failed");
+    assert_eq!(exec.instructions[0].output_shapes, vec![dim_shape(&[2, 3])]);
+}
+
+// ----------------------------------------------------------------------------
+// DotDecomposer tests
+// ----------------------------------------------------------------------------
+
+fn dot_general_exec_instr(
+    lhs_contracting_dims: Vec<usize>,
+    rhs_contracting_dims: Vec<usize>,
+    lhs_batch_dims: Vec<usize>,
+    rhs_batch_dims: Vec<usize>,
+    input_slots: Vec<usize>,
+    output_slot: usize,
+    output_shape: Vec<DimExpr>,
+) -> ExecInstruction {
+    ExecInstruction {
+        op: ExecOp::DotGeneral(DotGeneralConfig {
+            lhs_contracting_dims,
+            rhs_contracting_dims,
+            lhs_batch_dims,
+            rhs_batch_dims,
+        }),
+        input_slots,
+        output_slots: vec![output_slot],
+        dtype: DType::F64,
+        output_shapes: vec![output_shape],
+        last_use: Vec::new(),
+    }
+}
+
+#[test]
+fn test_dot_decomposer_already_canonical_is_noop() {
+    // LHS [M, K] rank 2, RHS [K, N] rank 2, cont=[1], rhs_cont=[0]. Canonical.
+    let instr = dot_general_exec_instr(
+        vec![1],
+        vec![0],
+        vec![],
+        vec![],
+        vec![0, 1],
+        2,
+        dim_shape(&[4, 6]),
+    );
+    let mut program = make_exec_program(vec![instr], vec![0, 1], vec![2], 3);
+
+    dot_decomposer(&mut program, &[dim_shape(&[4, 5]), dim_shape(&[5, 6])]);
+
+    assert_eq!(program.instructions.len(), 1);
+    assert_eq!(program.n_slots, 3);
+}
+
+#[test]
+fn test_dot_decomposer_multi_contracting_dim() {
+    // LHS [a, b, M, K1, K2] rank 5, RHS [a, b, K1, K2, N] rank 5,
+    // lhs_batch=[0, 1], rhs_batch=[0, 1], lhs_cont=[3, 4], rhs_cont=[2, 3].
+    // Output: [M, N, a, b] (free_L=[M], free_R=[N], batch=[a, b]).
+    let instr = dot_general_exec_instr(
+        vec![3, 4],
+        vec![2, 3],
+        vec![0, 1],
+        vec![0, 1],
+        vec![0, 1],
+        2,
+        dim_shape(&[7, 11, 2, 3]),
+    );
+    let mut program = make_exec_program(vec![instr], vec![0, 1], vec![2], 3);
+
+    dot_decomposer(
+        &mut program,
+        &[dim_shape(&[2, 3, 7, 4, 5]), dim_shape(&[2, 3, 4, 5, 11])],
+    );
+
+    // Expected instruction chain:
+    //   Transpose(slot 0) -> N1        // [M, K1, K2, a, b]
+    //   Reshape(N1)       -> N2        // [M, K1*K2, a, b]
+    //   Transpose(slot 1) -> N3        // [K1, K2, N, a, b]
+    //   Reshape(N3)       -> N4        // [K1*K2, N, a, b]
+    //   DotGeneral(N2, N4) -> slot 2   // canonical, [M, N, a, b]
+    // No output Reshape because fi_L = fi_R = 1.
+    assert_eq!(program.instructions.len(), 5);
+
+    assert!(matches!(
+        program.instructions[0].op,
+        ExecOp::Transpose { .. }
+    ));
+    assert!(matches!(program.instructions[1].op, ExecOp::Reshape { .. }));
+    assert!(matches!(
+        program.instructions[2].op,
+        ExecOp::Transpose { .. }
+    ));
+    assert!(matches!(program.instructions[3].op, ExecOp::Reshape { .. }));
+    let dot = &program.instructions[4];
+    assert_eq!(dot.output_slots, vec![2]);
+    match &dot.op {
+        ExecOp::DotGeneral(config) => {
+            assert_eq!(config.lhs_contracting_dims, vec![1]);
+            assert_eq!(config.rhs_contracting_dims, vec![0]);
+            assert_eq!(config.lhs_batch_dims, vec![2, 3]);
+            assert_eq!(config.rhs_batch_dims, vec![2, 3]);
+        }
+        _ => panic!("expected canonical DotGeneral"),
+    }
+}
+
+#[test]
+fn test_dot_decomposer_multi_free_dim_emits_output_reshape() {
+    // LHS [M1, M2, K] rank 3, RHS [K, N] rank 2, no batch,
+    // lhs_cont=[2], rhs_cont=[0]. free_L=[0, 1] (multi-free).
+    // Output: [M1, M2, N].
+    let instr = dot_general_exec_instr(
+        vec![2],
+        vec![0],
+        vec![],
+        vec![],
+        vec![0, 1],
+        2,
+        dim_shape(&[2, 3, 5]),
+    );
+    let mut program = make_exec_program(vec![instr], vec![0, 1], vec![2], 3);
+
+    dot_decomposer(&mut program, &[dim_shape(&[2, 3, 4]), dim_shape(&[4, 5])]);
+
+    // Expected: merge Reshape for LHS (no Transpose needed), canonical
+    // DotGeneral, output Reshape.
+    assert_eq!(program.instructions.len(), 3);
+
+    let reshape_lhs = &program.instructions[0];
+    assert!(matches!(reshape_lhs.op, ExecOp::Reshape { .. }));
+    assert_eq!(reshape_lhs.input_slots, vec![0]);
+
+    let dot = &program.instructions[1];
+    match &dot.op {
+        ExecOp::DotGeneral(config) => {
+            assert_eq!(config.lhs_contracting_dims, vec![1]);
+            assert_eq!(config.rhs_contracting_dims, vec![0]);
+            assert!(config.lhs_batch_dims.is_empty());
+            assert!(config.rhs_batch_dims.is_empty());
+        }
+        _ => panic!("expected canonical DotGeneral"),
+    }
+
+    let out_reshape = &program.instructions[2];
+    match &out_reshape.op {
+        ExecOp::Reshape { .. } => {}
+        _ => panic!("expected output Reshape"),
+    }
+    // Output Reshape must carry the original LHS/RHS as shape providers so
+    // the dynamic axes can be recovered at runtime.
+    assert_eq!(out_reshape.input_slots.len(), 3);
+    assert_eq!(out_reshape.input_slots[1], 0);
+    assert_eq!(out_reshape.input_slots[2], 1);
+    assert_eq!(out_reshape.output_slots, vec![2]);
+}
+
+#[test]
+fn test_dot_decomposer_noncanonical_dot_then_permute_downstream() {
+    // A non-canonical DotGeneral whose output is consumed by a downstream
+    // Transpose must still produce the original output shape after the
+    // decomp, so the downstream Transpose doesn't fall out of bounds.
+    //
+    // LHS [a, M, K] rank 3, RHS [a, K, N] rank 3, lhs_batch=[0], rhs_batch=[0],
+    // lhs_cont=[2], rhs_cont=[1]. Canonical-by-shape but batch is leading;
+    // decomp must canonicalize to batch-trailing.
+    let dot = dot_general_exec_instr(
+        vec![2],
+        vec![1],
+        vec![0],
+        vec![0],
+        vec![0, 1],
+        2,
+        dim_shape(&[3, 5, 7]), // [M, N, a]
+    );
+    let downstream = make_exec_instr(
+        ExecOp::Transpose {
+            perm: vec![2, 0, 1],
+        },
+        vec![2],
+        vec![3],
+    );
+    let mut program = make_exec_program(vec![dot, downstream], vec![0, 1], vec![3], 4);
+
+    dot_decomposer(
+        &mut program,
+        &[dim_shape(&[7, 3, 4]), dim_shape(&[7, 4, 5])],
+    );
+
+    // Downstream Transpose must still refer to the same slot (the original
+    // DotGeneral output slot) and must still see the original [M, N, a]
+    // shape.
+    let downstream = program
+        .instructions
+        .iter()
+        .find(|i| matches!(&i.op, ExecOp::Transpose { perm } if perm == &vec![2, 0, 1]))
+        .expect("downstream Transpose must be preserved");
+    assert_eq!(downstream.input_slots, vec![2]);
+}
+
+#[test]
+fn test_dot_decomposer_noncanonical_dot_then_dot_downstream() {
+    // First DotGeneral non-canonical, feeds its output as LHS to a second
+    // DotGeneral. The decomp must not break the second DotGeneral's
+    // dimension contract on the shared slot.
+    //
+    // Op 0: LHS [a, M1, M2, K] rank 4, RHS [a, K, N] rank 3,
+    //       lhs_batch=[0], rhs_batch=[0], lhs_cont=[3], rhs_cont=[1].
+    //       Output: [M1, M2, N, a] rank 4.
+    //
+    // Op 1: DotGeneral(Output_0 [M1, M2, N, a] rank 4, RHS2 [a, N, P] rank 3,
+    //       lhs_batch=[3], rhs_batch=[0], lhs_cont=[2], rhs_cont=[1]).
+    //       Output: [M1, M2, P, a].
+    let first = dot_general_exec_instr(
+        vec![3],
+        vec![1],
+        vec![0],
+        vec![0],
+        vec![0, 1],
+        2,
+        dim_shape(&[3, 4, 5, 6]),
+    );
+    let second = dot_general_exec_instr(
+        vec![2],
+        vec![1],
+        vec![3],
+        vec![0],
+        vec![2, 3],
+        4,
+        dim_shape(&[3, 4, 7, 6]),
+    );
+    let mut program = make_exec_program(vec![first, second], vec![0, 1, 3], vec![4], 5);
+
+    dot_decomposer(
+        &mut program,
+        &[
+            dim_shape(&[6, 3, 4, 8]), // LHS 0: [a, M1, M2, K]
+            dim_shape(&[6, 8, 5]),    // RHS 0: [a, K, N]
+            dim_shape(&[6, 5, 7]),    // RHS 1: [a, N, P]
+        ],
+    );
+
+    // Two canonical DotGenerals must be present after decomp, and the
+    // first dot's output (slot 2) must still be consumed somewhere in the
+    // decomposed program (possibly via an intermediate Reshape rather than
+    // directly by the second DotGeneral).
+    let dot_count = program
+        .instructions
+        .iter()
+        .filter(|i| matches!(i.op, ExecOp::DotGeneral(_)))
+        .count();
+    assert_eq!(dot_count, 2);
+    for i in program
+        .instructions
+        .iter()
+        .filter(|i| matches!(i.op, ExecOp::DotGeneral(_)))
+    {
+        match &i.op {
+            ExecOp::DotGeneral(config) => {
+                assert_eq!(config.lhs_contracting_dims.len(), 1);
+                assert_eq!(config.rhs_contracting_dims.len(), 1);
+            }
+            _ => unreachable!(),
+        }
+    }
+    let slot2_has_consumer = program
+        .instructions
+        .iter()
+        .any(|i| i.input_slots.contains(&2));
+    assert!(
+        slot2_has_consumer,
+        "slot 2 (first-dot output) must still be consumed"
+    );
+    // Final output slot still resolves in the program.
+    let produces_slot_4 = program
+        .instructions
+        .iter()
+        .any(|i| i.output_slots.contains(&4));
+    assert!(produces_slot_4, "final output slot 4 must be produced");
+}
+
+#[test]
+fn test_eliminate_dead_code_removes_unused_transpose() {
+    // A Transpose whose output is never consumed must be removed.
+    let transpose = make_exec_instr(ExecOp::Transpose { perm: vec![1, 0] }, vec![0], vec![2]);
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let dot = make_exec_instr(ExecOp::DotGeneral(config), vec![0, 1], vec![3]);
+    let mut program = make_exec_program(vec![transpose, dot], vec![0, 1], vec![3], 4);
+
+    eliminate_dead_code(&mut program);
+
+    assert_eq!(program.instructions.len(), 1);
+    assert!(matches!(program.instructions[0].op, ExecOp::DotGeneral(_)));
+}
+
+#[test]
+fn test_full_pipeline_multi_free_dim_decomp_runs_correctly() {
+    // End-to-end: build a traced graph with multiple free dims, compile,
+    // and run it through the CPU backend. Compare the output to the
+    // equivalent matmul result.
+    use tenferro::{CpuBackend, Tensor, TypedTensor};
+
+    // LHS [M1, M2, K] * RHS [K, N] => [M1, M2, N]. The compile pipeline
+    // should emit a canonical DotGeneral + output Reshape. Run end-to-end
+    // to verify numerical correctness.
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![2],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let program = CompiledProgram {
+        instructions: vec![make_std_instr(
+            StdTensorOp::DotGeneral {
+                config,
+                lhs_rank: 3,
+                rhs_rank: 2,
+            },
+            vec![0, 1],
+            vec![2],
+        )],
+        input_slots: vec![0, 1],
+        output_slots: vec![2],
+        n_slots: 3,
+    };
+
+    let exec = compile_std_to_exec(
+        &program,
+        &[DType::F64, DType::F64],
+        &[dim_shape(&[2, 3, 4]), dim_shape(&[4, 5])],
+    );
+
+    // Build concrete inputs: LHS = sequential 0..24, reshaped as [2, 3, 4];
+    //                       RHS = sequential 0..20, reshaped as [4, 5].
+    let lhs_data: Vec<f64> = (0..24).map(|x| x as f64).collect();
+    let rhs_data: Vec<f64> = (0..20).map(|x| x as f64).collect();
+    let lhs = Tensor::F64(TypedTensor::<f64>::from_vec(
+        vec![2, 3, 4],
+        lhs_data.clone(),
+    ));
+    let rhs = Tensor::F64(TypedTensor::<f64>::from_vec(vec![4, 5], rhs_data.clone()));
+
+    let mut backend = CpuBackend::default();
+    let mut outputs = tenferro::exec::eval_exec_ir(&mut backend, &exec, vec![lhs, rhs])
+        .expect("executing decomposed program must not fail");
+    let out = outputs.remove(0);
+    let typed = match &out {
+        Tensor::F64(inner) => inner,
+        other => panic!("expected F64 tensor, got {other:?}"),
+    };
+    assert_eq!(typed.shape, vec![2, 3, 5]);
+
+    // Reference: column-major (tenferro storage convention) matmul.
+    // For LHS shape [2, 3, 4], flat index = m1 + 2*m2 + 6*k.
+    // For RHS shape [4, 5], flat index = k + 4*n.
+    // For output shape [2, 3, 5], flat index = m1 + 2*m2 + 6*n.
+    let mut expected = vec![0.0f64; 2 * 3 * 5];
+    for m1 in 0..2 {
+        for m2 in 0..3 {
+            for n in 0..5 {
+                let mut acc = 0.0;
+                for k in 0..4 {
+                    acc += lhs_data[m1 + 2 * m2 + 6 * k] * rhs_data[k + 4 * n];
+                }
+                expected[m1 + 2 * m2 + 6 * n] = acc;
+            }
+        }
+    }
+    for (i, (got, want)) in typed.host_data().iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (got - want).abs() < 1e-9,
+            "index {i}: got {got}, expected {want}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Re-enables the `DotDecomposer` pass using per-instruction `output_shapes` from the 1-layer IR refactor (#732). Canonicalizes `ExecOp::DotGeneral` into `LHS [M?, K, B...] × RHS [K, N?, B...] -> OUT [M?, N?, B...]` via explicit Transpose + Reshape + canonical DotGeneral + output Reshape.
- Fixes the historical downstream-Permute bug by emitting the XLA Step 5 output Reshape that restores the original output shape whenever either side had multiple free dims. Downstream consumers now see the original rank.
- Pipeline is now `DotDimensionSorter -> TransposeFolding -> DotDecomposer -> DeadCodeElimination -> populate_last_use`. The new `DeadCodeElimination` pass reclaims `Transpose` producers that `TransposeFolding` bypasses (preserving `ValidateNonsingular`).

## Test plan

- [x] `cargo test -p tenferro --test compiler_passes --release` — 16 tests, including new multi-contracting-dim, multi-free-dim (exercises output Reshape), non-canonical-dot-then-Permute, non-canonical-dot-then-DotGeneral, DCE, and end-to-end column-major correctness.
- [x] `cargo test --workspace --release` — all tests pass.
- [x] `cargo fmt --all --check`
- [x] `cargo llvm-cov --workspace --release --json --output-path coverage.json && python3 scripts/check-coverage.py coverage.json` — all files meet thresholds.
- [x] `cargo doc --workspace --no-deps && python3 scripts/check-docs-site.py`

Closes #729.

🤖 Generated with [Claude Code](https://claude.com/claude-code)