### PR TITLE
Use integer tensors for indexing ops

### DIFF
--- a/tenferro-ops/src/ad/indexing.rs
+++ b/tenferro-ops/src/ad/indexing.rs
@@ -353,6 +353,7 @@ fn zero_bytes(dtype: DType) -> Vec<u8> {
     match dtype {
         DType::F32 => 0.0_f32.to_le_bytes().to_vec(),
         DType::F64 => 0.0_f64.to_le_bytes().to_vec(),
+        DType::I64 => 0_i64.to_le_bytes().to_vec(),
         DType::C32 => {
             let mut bytes = Vec::with_capacity(8);
             bytes.extend_from_slice(&0.0_f32.to_le_bytes());

--- a/tenferro-ops/src/ad/linalg.rs
+++ b/tenferro-ops/src/ad/linalg.rs
@@ -179,6 +179,7 @@ pub fn linearize_eig(
             },
         )[0],
         DType::C64 | DType::C32 => da,
+        DType::I64 => return vec![None, None],
     };
 
     let dav = matmul_linear(

--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -187,6 +187,22 @@ impl StdTensorOp {
         }
     }
 
+    /// Create an `i64` scalar constant op.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tenferro_ops::std_tensor_op::StdTensorOp;
+    ///
+    /// let op = StdTensorOp::constant_i64(7);
+    /// ```
+    pub fn constant_i64(value: i64) -> Self {
+        Self::Constant {
+            dtype: DType::I64,
+            bytes: value.to_le_bytes().to_vec(),
+        }
+    }
+
     /// Create a `Complex64` scalar constant op.
     ///
     /// # Examples

--- a/tenferro-tensor/src/buffer_pool.rs
+++ b/tenferro-tensor/src/buffer_pool.rs
@@ -35,6 +35,7 @@ use num_complex::{Complex32, Complex64};
 pub struct BufferPool {
     f64_pool: BTreeMap<usize, Vec<Vec<f64>>>,
     f32_pool: BTreeMap<usize, Vec<Vec<f32>>>,
+    i64_pool: BTreeMap<usize, Vec<Vec<i64>>>,
     c64_pool: BTreeMap<usize, Vec<Vec<Complex64>>>,
     c32_pool: BTreeMap<usize, Vec<Vec<Complex32>>>,
 }
@@ -99,6 +100,7 @@ mod private {
 
     impl Sealed for f64 {}
     impl Sealed for f32 {}
+    impl Sealed for i64 {}
     impl Sealed for num_complex::Complex64 {}
     impl Sealed for num_complex::Complex32 {}
 }
@@ -149,6 +151,7 @@ macro_rules! impl_pool_scalar {
 
 impl_pool_scalar!(f64, f64_pool);
 impl_pool_scalar!(f32, f32_pool);
+impl_pool_scalar!(i64, i64_pool);
 impl_pool_scalar!(Complex64, c64_pool);
 impl_pool_scalar!(Complex32, c32_pool);
 
@@ -167,6 +170,7 @@ impl BufferPool {
         Self {
             f64_pool: BTreeMap::new(),
             f32_pool: BTreeMap::new(),
+            i64_pool: BTreeMap::new(),
             c64_pool: BTreeMap::new(),
             c32_pool: BTreeMap::new(),
         }
@@ -186,6 +190,7 @@ impl BufferPool {
     pub fn len(&self) -> usize {
         self.f64_pool.values().map(Vec::len).sum::<usize>()
             + self.f32_pool.values().map(Vec::len).sum::<usize>()
+            + self.i64_pool.values().map(Vec::len).sum::<usize>()
             + self.c64_pool.values().map(Vec::len).sum::<usize>()
             + self.c32_pool.values().map(Vec::len).sum::<usize>()
     }
@@ -231,6 +236,7 @@ impl BufferPool {
     pub fn is_empty(&self) -> bool {
         self.f64_pool.is_empty()
             && self.f32_pool.is_empty()
+            && self.i64_pool.is_empty()
             && self.c64_pool.is_empty()
             && self.c32_pool.is_empty()
     }

--- a/tenferro-tensor/src/cpu/analytic.rs
+++ b/tenferro-tensor/src/cpu/analytic.rs
@@ -135,6 +135,10 @@ macro_rules! define_unary_analytic_op {
             match input {
                 Tensor::F32(t) => Ok(Tensor::F32($typed_fn(t)?)),
                 Tensor::F64(t) => Ok(Tensor::F64($typed_fn(t)?)),
+                Tensor::I64(_) => Err(crate::Error::BackendFailure {
+                    op: stringify!($dispatch_fn),
+                    message: "unsupported dtype I64".into(),
+                }),
                 Tensor::C32(t) => Ok(Tensor::C32($typed_fn(t)?)),
                 Tensor::C64(t) => Ok(Tensor::C64($typed_fn(t)?)),
             }

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -727,6 +727,7 @@ impl TensorBackend for CpuBackend {
         match tensor {
             Tensor::F32(t) => reclaim_typed(&mut self.buffers, t),
             Tensor::F64(t) => reclaim_typed(&mut self.buffers, t),
+            Tensor::I64(t) => reclaim_typed(&mut self.buffers, t),
             Tensor::C32(t) => reclaim_typed(&mut self.buffers, t),
             Tensor::C64(t) => reclaim_typed(&mut self.buffers, t),
         }
@@ -787,6 +788,7 @@ fn zeros_like_tensor(input: &Tensor) -> Tensor {
     match input {
         Tensor::F32(t) => Tensor::F32(TypedTensor::zeros(t.shape.clone())),
         Tensor::F64(t) => Tensor::F64(TypedTensor::zeros(t.shape.clone())),
+        Tensor::I64(t) => Tensor::I64(TypedTensor::zeros(t.shape.clone())),
         Tensor::C32(t) => Tensor::C32(TypedTensor::zeros(t.shape.clone())),
         Tensor::C64(t) => Tensor::C64(TypedTensor::zeros(t.shape.clone())),
     }

--- a/tenferro-tensor/src/cpu/elementwise.rs
+++ b/tenferro-tensor/src/cpu/elementwise.rs
@@ -238,6 +238,10 @@ pub fn neg(input: &Tensor) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_neg(t)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_neg(t)?)),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "neg",
+            message: "unsupported dtype I64".into(),
+        }),
         Tensor::C32(t) => Ok(Tensor::C32(typed_neg(t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_neg(t)?)),
     }
@@ -247,6 +251,10 @@ pub fn conj(input: &Tensor) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_conj(t)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_conj(t)?)),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "conj",
+            message: "unsupported dtype I64".into(),
+        }),
         Tensor::C32(t) => Ok(Tensor::C32(typed_conj(t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_conj(t)?)),
     }
@@ -256,6 +264,10 @@ pub fn abs(input: &Tensor) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_abs(t)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_abs(t)?)),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "abs",
+            message: "unsupported dtype I64".into(),
+        }),
         Tensor::C32(t) => Ok(Tensor::C32(typed_abs(t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_abs(t)?)),
     }
@@ -265,6 +277,10 @@ pub fn sign(input: &Tensor) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_sign(t)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_sign(t)?)),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "sign",
+            message: "unsupported dtype I64".into(),
+        }),
         Tensor::C32(t) => Ok(Tensor::C32(typed_sign(t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_sign(t)?)),
     }

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -346,6 +346,7 @@ impl TensorExec for CpuExecSession<'_> {
         match tensor {
             Tensor::F32(t) => reclaim_typed(self.buffers, t),
             Tensor::F64(t) => reclaim_typed(self.buffers, t),
+            Tensor::I64(t) => reclaim_typed(self.buffers, t),
             Tensor::C32(t) => reclaim_typed(self.buffers, t),
             Tensor::C64(t) => reclaim_typed(self.buffers, t),
         }

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -27,6 +27,15 @@ impl TensorAsTyped<f64> for Tensor {
     }
 }
 
+impl TensorAsTyped<i64> for Tensor {
+    fn as_typed(&self) -> Option<&TypedTensor<i64>> {
+        match self {
+            Tensor::I64(tensor) => Some(tensor),
+            _ => None,
+        }
+    }
+}
+
 impl TensorAsTyped<num_complex::Complex<f32>> for Tensor {
     fn as_typed(&self) -> Option<&TypedTensor<num_complex::Complex<f32>>> {
         match self {
@@ -73,6 +82,7 @@ pub fn try_slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> 
     match input {
         Tensor::F32(tensor) => Ok(Tensor::F32(typed_slice(tensor, config)?)),
         Tensor::F64(tensor) => Ok(Tensor::F64(typed_slice(tensor, config)?)),
+        Tensor::I64(tensor) => Ok(Tensor::I64(typed_slice(tensor, config)?)),
         Tensor::C32(tensor) => Ok(Tensor::C32(typed_slice(tensor, config)?)),
         Tensor::C64(tensor) => Ok(Tensor::C64(typed_slice(tensor, config)?)),
     }
@@ -91,6 +101,7 @@ pub fn try_pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(tensor) => Ok(Tensor::F32(typed_pad(tensor, config)?)),
         Tensor::F64(tensor) => Ok(Tensor::F64(typed_pad(tensor, config)?)),
+        Tensor::I64(tensor) => Ok(Tensor::I64(typed_pad(tensor, config)?)),
         Tensor::C32(tensor) => Ok(Tensor::C32(typed_pad(tensor, config)?)),
         Tensor::C64(tensor) => Ok(Tensor::C64(typed_pad(tensor, config)?)),
     }
@@ -113,6 +124,9 @@ pub fn try_concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>
             t, inputs, axis,
         )?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_concatenate_from_dyn_inputs(
+            t, inputs, axis,
+        )?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_concatenate_from_dyn_inputs(
             t, inputs, axis,
         )?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_concatenate_from_dyn_inputs(
@@ -353,6 +367,10 @@ struct IndexTensor {
 
 fn index_tensor(tensor: &Tensor) -> IndexTensor {
     match tensor {
+        Tensor::I64(t) => IndexTensor {
+            shape: t.shape.clone(),
+            values: t.host_data().to_vec(),
+        },
         Tensor::F32(t) => IndexTensor {
             shape: t.shape.clone(),
             values: t.host_data().iter().map(|&value| value as i64).collect(),

--- a/tenferro-tensor/src/cpu/reduction.rs
+++ b/tenferro-tensor/src/cpu/reduction.rs
@@ -34,6 +34,7 @@ pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_sum(t, axes)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_sum(t, axes)?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_reduce_sum(t, axes)?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_sum(t, axes)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_sum(t, axes)?)),
     }
@@ -43,6 +44,7 @@ pub fn reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_prod(t, axes)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_prod(t, axes)?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_reduce_prod(t, axes)?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_prod(t, axes)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_prod(t, axes)?)),
     }
@@ -56,7 +58,7 @@ pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(tensor) => Ok(Tensor::F32(typed_reduce_max(tensor, axes)?)),
         Tensor::F64(tensor) => Ok(Tensor::F64(typed_reduce_max(tensor, axes)?)),
-        Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+        Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
             op: "reduce_max",
             message: format!("unsupported dtype {:?}", input.dtype()),
         }),
@@ -71,7 +73,7 @@ pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(tensor) => Ok(Tensor::F32(typed_reduce_min(tensor, axes)?)),
         Tensor::F64(tensor) => Ok(Tensor::F64(typed_reduce_min(tensor, axes)?)),
-        Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+        Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
             op: "reduce_min",
             message: format!("unsupported dtype {:?}", input.dtype()),
         }),

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -91,6 +91,7 @@ pub fn transpose(input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_transpose(t, perm)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_transpose(t, perm)?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_transpose(t, perm)?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_transpose(t, perm)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_transpose(t, perm)?)),
     }
@@ -100,6 +101,7 @@ pub fn reshape(input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_reshape(t, shape)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_reshape(t, shape)?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_reshape(t, shape)?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_reshape(t, shape)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_reshape(t, shape)?)),
     }
@@ -109,6 +111,7 @@ pub fn broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> crat
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_broadcast_in_dim(t, shape, dims)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_broadcast_in_dim(t, shape, dims)?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_broadcast_in_dim(t, shape, dims)?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_broadcast_in_dim(t, shape, dims)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_broadcast_in_dim(t, shape, dims)?)),
     }
@@ -118,24 +121,37 @@ pub fn convert(input: &Tensor, to: DType) -> Tensor {
     match (input, to) {
         (Tensor::F32(t), DType::F32) => Tensor::F32(t.clone()),
         (Tensor::F32(t), DType::F64) => Tensor::F64(typed_convert(t, |x| x as f64)),
+        (Tensor::F32(t), DType::I64) => Tensor::I64(typed_convert(t, |x| x as i64)),
         (Tensor::F32(t), DType::C32) => Tensor::C32(typed_convert(t, |x| Complex32::new(x, 0.0))),
         (Tensor::F32(t), DType::C64) => {
             Tensor::C64(typed_convert(t, |x| Complex64::new(x as f64, 0.0)))
         }
         (Tensor::F64(t), DType::F32) => Tensor::F32(typed_convert(t, |x| x as f32)),
         (Tensor::F64(t), DType::F64) => Tensor::F64(t.clone()),
+        (Tensor::F64(t), DType::I64) => Tensor::I64(typed_convert(t, |x| x as i64)),
         (Tensor::F64(t), DType::C32) => {
             Tensor::C32(typed_convert(t, |x| Complex32::new(x as f32, 0.0)))
         }
         (Tensor::F64(t), DType::C64) => Tensor::C64(typed_convert(t, |x| Complex64::new(x, 0.0))),
+        (Tensor::I64(t), DType::F32) => Tensor::F32(typed_convert(t, |x| x as f32)),
+        (Tensor::I64(t), DType::F64) => Tensor::F64(typed_convert(t, |x| x as f64)),
+        (Tensor::I64(t), DType::I64) => Tensor::I64(t.clone()),
+        (Tensor::I64(t), DType::C32) => {
+            Tensor::C32(typed_convert(t, |x| Complex32::new(x as f32, 0.0)))
+        }
+        (Tensor::I64(t), DType::C64) => {
+            Tensor::C64(typed_convert(t, |x| Complex64::new(x as f64, 0.0)))
+        }
         (Tensor::C32(t), DType::F32) => Tensor::F32(typed_convert(t, |z| z.re)),
         (Tensor::C32(t), DType::F64) => Tensor::F64(typed_convert(t, |z| z.re as f64)),
+        (Tensor::C32(t), DType::I64) => Tensor::I64(typed_convert(t, |z| z.re as i64)),
         (Tensor::C32(t), DType::C32) => Tensor::C32(t.clone()),
         (Tensor::C32(t), DType::C64) => Tensor::C64(typed_convert(t, |z| {
             Complex64::new(z.re as f64, z.im as f64)
         })),
         (Tensor::C64(t), DType::F32) => Tensor::F32(typed_convert(t, |z| z.re as f32)),
         (Tensor::C64(t), DType::F64) => Tensor::F64(typed_convert(t, |z| z.re)),
+        (Tensor::C64(t), DType::I64) => Tensor::I64(typed_convert(t, |z| z.re as i64)),
         (Tensor::C64(t), DType::C32) => Tensor::C32(typed_convert(t, |z| {
             Complex32::new(z.re as f32, z.im as f32)
         })),
@@ -147,6 +163,7 @@ pub fn extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_extract_diagonal(t, axis_a, axis_b)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_extract_diagonal(t, axis_a, axis_b)?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_extract_diagonal(t, axis_a, axis_b)?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_extract_diagonal(t, axis_a, axis_b)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_extract_diagonal(t, axis_a, axis_b)?)),
     }
@@ -156,6 +173,7 @@ pub fn embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Re
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_embed_diagonal(t, axis_a, axis_b)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_embed_diagonal(t, axis_a, axis_b)?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_embed_diagonal(t, axis_a, axis_b)?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_embed_diagonal(t, axis_a, axis_b)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_embed_diagonal(t, axis_a, axis_b)?)),
     }
@@ -165,6 +183,7 @@ pub fn tril(input: &Tensor, k: i64) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_tril(t, k)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_tril(t, k)?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_tril(t, k)?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_tril(t, k)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_tril(t, k)?)),
     }
@@ -174,6 +193,7 @@ pub fn triu(input: &Tensor, k: i64) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_triu(t, k)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_triu(t, k)?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_triu(t, k)?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_triu(t, k)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_triu(t, k)?)),
     }

--- a/tenferro-tensor/src/cubecl/fusion/mod.rs
+++ b/tenferro-tensor/src/cubecl/fusion/mod.rs
@@ -42,5 +42,6 @@ pub(crate) fn execute_elementwise_fusion(
             let outputs = launch::launch(backend.runtime(), classified)?;
             Ok(Some(outputs.into_iter().map(Tensor::C64).collect()))
         }
+        crate::DType::I64 => Ok(None),
     }
 }

--- a/tenferro-tensor/src/cubecl/linalg.rs
+++ b/tenferro-tensor/src/cubecl/linalg.rs
@@ -75,6 +75,10 @@ pub(super) fn cholesky(backend: &mut CubeclBackend, input: &Tensor) -> crate::Re
         Tensor::F64(t) => cholesky_typed(backend, t).map(Tensor::F64),
         Tensor::C32(t) => cholesky_typed(backend, t).map(Tensor::C32),
         Tensor::C64(t) => cholesky_typed(backend, t).map(Tensor::C64),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "cholesky",
+            message: "unsupported dtype I64".into(),
+        }),
     }
 }
 
@@ -150,6 +154,10 @@ pub(super) fn lu(backend: &mut CubeclBackend, input: &Tensor) -> crate::Result<V
                 Tensor::C64(parity),
             ]
         }),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "lu",
+            message: "unsupported dtype I64".into(),
+        }),
     }
 }
 
@@ -163,6 +171,10 @@ pub(super) fn svd(backend: &mut CubeclBackend, input: &Tensor) -> crate::Result<
             .map(|(u, s, vt)| vec![Tensor::C32(u), Tensor::F32(s), Tensor::C32(vt)]),
         Tensor::C64(t) => svd_typed(backend, t)
             .map(|(u, s, vt)| vec![Tensor::C64(u), Tensor::F64(s), Tensor::C64(vt)]),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "svd",
+            message: "unsupported dtype I64".into(),
+        }),
     }
 }
 
@@ -172,6 +184,10 @@ pub(super) fn qr(backend: &mut CubeclBackend, input: &Tensor) -> crate::Result<V
         Tensor::F64(t) => qr_typed(backend, t).map(|(q, r)| vec![Tensor::F64(q), Tensor::F64(r)]),
         Tensor::C32(t) => qr_typed(backend, t).map(|(q, r)| vec![Tensor::C32(q), Tensor::C32(r)]),
         Tensor::C64(t) => qr_typed(backend, t).map(|(q, r)| vec![Tensor::C64(q), Tensor::C64(r)]),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "qr",
+            message: "unsupported dtype I64".into(),
+        }),
     }
 }
 
@@ -181,6 +197,10 @@ pub(super) fn eigh(backend: &mut CubeclBackend, input: &Tensor) -> crate::Result
         Tensor::F64(t) => eigh_typed(backend, t).map(|(w, v)| vec![Tensor::F64(w), Tensor::F64(v)]),
         Tensor::C32(t) => eigh_typed(backend, t).map(|(w, v)| vec![Tensor::F32(w), Tensor::C32(v)]),
         Tensor::C64(t) => eigh_typed(backend, t).map(|(w, v)| vec![Tensor::F64(w), Tensor::C64(v)]),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "eigh",
+            message: "unsupported dtype I64".into(),
+        }),
     }
 }
 
@@ -1161,6 +1181,7 @@ fn zeros_like_tensor(input: &Tensor) -> Tensor {
     match input {
         Tensor::F32(t) => Tensor::F32(TypedTensor::zeros(t.shape.clone())),
         Tensor::F64(t) => Tensor::F64(TypedTensor::zeros(t.shape.clone())),
+        Tensor::I64(t) => Tensor::I64(TypedTensor::zeros(t.shape.clone())),
         Tensor::C32(t) => Tensor::C32(TypedTensor::zeros(t.shape.clone())),
         Tensor::C64(t) => Tensor::C64(TypedTensor::zeros(t.shape.clone())),
     }

--- a/tenferro-tensor/src/cubecl/memory.rs
+++ b/tenferro-tensor/src/cubecl/memory.rs
@@ -25,6 +25,7 @@ pub fn upload_tensor(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<Tenso
     match tensor {
         Tensor::F64(t) => upload_typed::<f64>(client, rt.device_ordinal(), t).map(Tensor::F64),
         Tensor::F32(t) => upload_typed::<f32>(client, rt.device_ordinal(), t).map(Tensor::F32),
+        Tensor::I64(t) => upload_typed::<i64>(client, rt.device_ordinal(), t).map(Tensor::I64),
         Tensor::C64(t) => {
             upload_typed::<Complex64>(client, rt.device_ordinal(), t).map(Tensor::C64)
         }
@@ -49,6 +50,7 @@ pub fn download_tensor(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<Ten
     match tensor {
         Tensor::F64(t) => download_typed::<f64>(client, t).map(Tensor::F64),
         Tensor::F32(t) => download_typed::<f32>(client, t).map(Tensor::F32),
+        Tensor::I64(t) => download_typed::<i64>(client, t).map(Tensor::I64),
         Tensor::C64(t) => download_typed::<Complex64>(client, t).map(Tensor::C64),
         Tensor::C32(t) => download_typed::<Complex32>(client, t).map(Tensor::C32),
     }
@@ -145,6 +147,7 @@ fn cubecl_handle(tensor: &Tensor) -> crate::Result<cubecl::server::Handle> {
     match tensor {
         Tensor::F64(t) => cubecl_handle_from_buffer(&t.buffer),
         Tensor::F32(t) => cubecl_handle_from_buffer(&t.buffer),
+        Tensor::I64(t) => cubecl_handle_from_buffer(&t.buffer),
         Tensor::C64(t) => cubecl_handle_from_buffer(&t.buffer),
         Tensor::C32(t) => cubecl_handle_from_buffer(&t.buffer),
     }

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -80,7 +80,7 @@ use crate::backend::TensorBackend;
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use crate::{Tensor, TypedTensor};
+use crate::{Buffer, Tensor, TypedTensor};
 
 mod dispatch;
 mod ffi;
@@ -101,6 +101,13 @@ use kernels::{diagonal, elementwise, indexing, reduction, structural};
 
 pub use memory::{device_ptr, download_tensor, upload_tensor};
 pub use runtime::{gpu_available, CubeclRuntime};
+
+fn unsupported_dtype(op: &'static str, dtype: crate::DType) -> crate::Error {
+    crate::Error::BackendFailure {
+        op,
+        message: format!("unsupported dtype {dtype:?}"),
+    }
+}
 
 /// CubeCL-based GPU backend.
 ///
@@ -146,6 +153,39 @@ impl CubeclBackend {
     /// ```
     pub fn runtime(&self) -> &CubeclRuntime {
         &self.rt
+    }
+
+    fn i64_indices_as_f64(&self, indices: &TypedTensor<i64>) -> crate::Result<TypedTensor<f64>> {
+        let host_values = match &indices.buffer {
+            Buffer::Host(data) => data.clone(),
+            Buffer::Cubecl(_) => {
+                let downloaded = download_tensor(self.runtime(), &Tensor::I64(indices.clone()))?;
+                downloaded
+                    .as_slice::<i64>()
+                    .expect("downloaded I64 tensor")
+                    .to_vec()
+            }
+            Buffer::Backend(_) => {
+                return Err(crate::Error::BackendFailure {
+                    op: "index_tensor",
+                    message: "backend buffers are not supported for CubeCL index conversion".into(),
+                })
+            }
+        };
+        let converted = Tensor::F64(TypedTensor::from_vec(
+            indices.shape.clone(),
+            host_values.into_iter().map(|value| value as f64).collect(),
+        ));
+        match &indices.buffer {
+            Buffer::Cubecl(_) => match upload_tensor(self.runtime(), &converted)? {
+                Tensor::F64(tensor) => Ok(tensor),
+                _ => unreachable!("upload preserves dtype"),
+            },
+            _ => match converted {
+                Tensor::F64(tensor) => Ok(tensor),
+                _ => unreachable!("constructed F64 tensor"),
+            },
+        }
     }
 
     fn cutensor_handle(&self) -> crate::Result<&ffi::cutensor::CutensorHandle> {
@@ -1309,6 +1349,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::C64),
+            Tensor::I64(_) => Err(unsupported_dtype("neg", input.dtype())),
         }
     }
 
@@ -1316,6 +1357,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(tensor) => Ok(Tensor::F32(tensor.clone())),
             Tensor::F64(tensor) => Ok(Tensor::F64(tensor.clone())),
+            Tensor::I64(_) => Err(unsupported_dtype("conj", input.dtype())),
             Tensor::C32(tensor) => launch_unary(
                 self.runtime(),
                 tensor,
@@ -1439,7 +1481,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "abs",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -1472,7 +1514,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "sign",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -1752,7 +1794,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "exp",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -1785,7 +1827,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "log",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -1818,7 +1860,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "sin",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -1851,7 +1893,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "cos",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -1884,7 +1926,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "tanh",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -1917,7 +1959,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "sqrt",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -1950,7 +1992,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "rsqrt",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -2027,7 +2069,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "expm1",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -2060,7 +2102,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "log1p",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -2071,6 +2113,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.transpose_typed(t, perm).map(Tensor::F32),
             Tensor::F64(t) => self.transpose_typed(t, perm).map(Tensor::F64),
+            Tensor::I64(t) => self.transpose_typed(t, perm).map(Tensor::I64),
             Tensor::C32(t) => self.transpose_typed(t, perm).map(Tensor::C32),
             Tensor::C64(t) => self.transpose_typed(t, perm).map(Tensor::C64),
         }
@@ -2097,6 +2140,11 @@ impl TensorBackend for CubeclBackend {
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
             })),
+            Tensor::I64(t) => Ok(Tensor::I64(TypedTensor {
+                buffer: t.buffer.clone(),
+                shape: shape.to_vec(),
+                placement: t.placement.clone(),
+            })),
             Tensor::C32(t) => Ok(Tensor::C32(TypedTensor {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
@@ -2119,6 +2167,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.broadcast_typed(t, shape, dims).map(Tensor::F32),
             Tensor::F64(t) => self.broadcast_typed(t, shape, dims).map(Tensor::F64),
+            Tensor::I64(t) => self.broadcast_typed(t, shape, dims).map(Tensor::I64),
             Tensor::C32(t) => self.broadcast_typed(t, shape, dims).map(Tensor::C32),
             Tensor::C64(t) => self.broadcast_typed(t, shape, dims).map(Tensor::C64),
         }
@@ -2130,22 +2179,28 @@ impl TensorBackend for CubeclBackend {
             (Tensor::F32(t), crate::DType::F64) => {
                 self.convert_float_to_float::<f32, f64>(t).map(Tensor::F64)
             }
+            (Tensor::F32(_), crate::DType::I64) => Err(unsupported_dtype("convert", to)),
             (Tensor::F32(t), crate::DType::C32) => self.convert_f32_to_c32(t).map(Tensor::C32),
             (Tensor::F32(t), crate::DType::C64) => self.convert_f32_to_c64(t).map(Tensor::C64),
             (Tensor::F64(t), crate::DType::F32) => {
                 self.convert_float_to_float::<f64, f32>(t).map(Tensor::F32)
             }
             (Tensor::F64(t), crate::DType::F64) => Ok(Tensor::F64(t.clone())),
+            (Tensor::F64(_), crate::DType::I64) => Err(unsupported_dtype("convert", to)),
             (Tensor::F64(t), crate::DType::C32) => self.convert_f64_to_c32(t).map(Tensor::C32),
             (Tensor::F64(t), crate::DType::C64) => self.convert_f64_to_c64(t).map(Tensor::C64),
+            (Tensor::I64(_), crate::DType::I64) => Ok(input.clone()),
+            (Tensor::I64(_), _) => Err(unsupported_dtype("convert", input.dtype())),
             (Tensor::C32(t), crate::DType::F32) => self.convert_c32_to_f32(t).map(Tensor::F32),
             (Tensor::C32(t), crate::DType::F64) => self.convert_c32_to_f64(t).map(Tensor::F64),
+            (Tensor::C32(_), crate::DType::I64) => Err(unsupported_dtype("convert", to)),
             (Tensor::C32(t), crate::DType::C32) => Ok(Tensor::C32(t.clone())),
             (Tensor::C32(t), crate::DType::C64) => self
                 .convert_complex_to_complex::<Complex32, Complex64>(t)
                 .map(Tensor::C64),
             (Tensor::C64(t), crate::DType::F32) => self.convert_c64_to_f32(t).map(Tensor::F32),
             (Tensor::C64(t), crate::DType::F64) => self.convert_c64_to_f64(t).map(Tensor::F64),
+            (Tensor::C64(_), crate::DType::I64) => Err(unsupported_dtype("convert", to)),
             (Tensor::C64(t), crate::DType::C32) => self
                 .convert_complex_to_complex::<Complex64, Complex32>(t)
                 .map(Tensor::C32),
@@ -2166,6 +2221,9 @@ impl TensorBackend for CubeclBackend {
             Tensor::F64(t) => self
                 .extract_diagonal_typed(t, axis_a, axis_b)
                 .map(Tensor::F64),
+            Tensor::I64(t) => self
+                .extract_diagonal_typed(t, axis_a, axis_b)
+                .map(Tensor::I64),
             Tensor::C32(t) => self
                 .extract_diagonal_typed(t, axis_a, axis_b)
                 .map(Tensor::C32),
@@ -2188,6 +2246,9 @@ impl TensorBackend for CubeclBackend {
             Tensor::F64(t) => self
                 .embed_diagonal_typed(t, axis_a, axis_b)
                 .map(Tensor::F64),
+            Tensor::I64(t) => self
+                .embed_diagonal_typed(t, axis_a, axis_b)
+                .map(Tensor::I64),
             Tensor::C32(t) => self
                 .embed_diagonal_typed(t, axis_a, axis_b)
                 .map(Tensor::C32),
@@ -2201,6 +2262,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.tril_typed(t, k).map(Tensor::F32),
             Tensor::F64(t) => self.tril_typed(t, k).map(Tensor::F64),
+            Tensor::I64(t) => self.tril_typed(t, k).map(Tensor::I64),
             Tensor::C32(t) => self.tril_typed(t, k).map(Tensor::C32),
             Tensor::C64(t) => self.tril_typed(t, k).map(Tensor::C64),
         }
@@ -2210,6 +2272,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.triu_typed(t, k).map(Tensor::F32),
             Tensor::F64(t) => self.triu_typed(t, k).map(Tensor::F64),
+            Tensor::I64(t) => self.triu_typed(t, k).map(Tensor::I64),
             Tensor::C32(t) => self.triu_typed(t, k).map(Tensor::C32),
             Tensor::C64(t) => self.triu_typed(t, k).map(Tensor::C64),
         }
@@ -2219,6 +2282,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.reduce_sum_float_typed(t, axes).map(Tensor::F32),
             Tensor::F64(t) => self.reduce_sum_float_typed(t, axes).map(Tensor::F64),
+            Tensor::I64(_) => Err(unsupported_dtype("reduce_sum", input.dtype())),
             Tensor::C32(t) => self.reduce_sum_complex_typed(t, axes).map(Tensor::C32),
             Tensor::C64(t) => self.reduce_sum_complex_typed(t, axes).map(Tensor::C64),
         }
@@ -2228,6 +2292,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.reduce_prod_float_typed(t, axes).map(Tensor::F32),
             Tensor::F64(t) => self.reduce_prod_float_typed(t, axes).map(Tensor::F64),
+            Tensor::I64(_) => Err(unsupported_dtype("reduce_prod", input.dtype())),
             Tensor::C32(t) => self.reduce_prod_complex_typed(t, axes).map(Tensor::C32),
             Tensor::C64(t) => self.reduce_prod_complex_typed(t, axes).map(Tensor::C64),
         }
@@ -2237,7 +2302,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.reduce_max_typed(t, axes).map(Tensor::F32),
             Tensor::F64(t) => self.reduce_max_typed(t, axes).map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "reduce_max",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -2248,7 +2313,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.reduce_min_typed(t, axes).map(Tensor::F32),
             Tensor::F64(t) => self.reduce_min_typed(t, axes).map(Tensor::F64),
-            Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
+            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
                 op: "reduce_min",
                 message: format!("unsupported dtype {:?}", input.dtype()),
             }),
@@ -2295,10 +2360,31 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(operand), Tensor::F64(indices)) => {
                 self.gather_typed(operand, indices, config).map(Tensor::C64)
             }
+            (Tensor::F32(operand), Tensor::I64(indices)) => {
+                let indices = self.i64_indices_as_f64(indices)?;
+                self.gather_typed(operand, &indices, config)
+                    .map(Tensor::F32)
+            }
+            (Tensor::F64(operand), Tensor::I64(indices)) => {
+                let indices = self.i64_indices_as_f64(indices)?;
+                self.gather_typed(operand, &indices, config)
+                    .map(Tensor::F64)
+            }
+            (Tensor::C32(operand), Tensor::I64(indices)) => {
+                let indices = self.i64_indices_as_f64(indices)?;
+                self.gather_typed(operand, &indices, config)
+                    .map(Tensor::C32)
+            }
+            (Tensor::C64(operand), Tensor::I64(indices)) => {
+                let indices = self.i64_indices_as_f64(indices)?;
+                self.gather_typed(operand, &indices, config)
+                    .map(Tensor::C64)
+            }
             (_, Tensor::C32(_) | Tensor::C64(_)) => Err(crate::Error::BackendFailure {
                 op: "gather",
                 message: "complex index tensors are not supported".into(),
             }),
+            (Tensor::I64(_), _) => Err(unsupported_dtype("gather", operand.dtype())),
         }
     }
 
@@ -2334,6 +2420,26 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(operand), Tensor::F64(indices), Tensor::C64(updates)) => self
                 .scatter_complex_typed(operand, indices, updates, config)
                 .map(Tensor::C64),
+            (Tensor::F32(operand), Tensor::I64(indices), Tensor::F32(updates)) => {
+                let indices = self.i64_indices_as_f64(indices)?;
+                self.scatter_float_typed(operand, &indices, updates, config)
+                    .map(Tensor::F32)
+            }
+            (Tensor::F64(operand), Tensor::I64(indices), Tensor::F64(updates)) => {
+                let indices = self.i64_indices_as_f64(indices)?;
+                self.scatter_float_typed(operand, &indices, updates, config)
+                    .map(Tensor::F64)
+            }
+            (Tensor::C32(operand), Tensor::I64(indices), Tensor::C32(updates)) => {
+                let indices = self.i64_indices_as_f64(indices)?;
+                self.scatter_complex_typed(operand, &indices, updates, config)
+                    .map(Tensor::C32)
+            }
+            (Tensor::C64(operand), Tensor::I64(indices), Tensor::C64(updates)) => {
+                let indices = self.i64_indices_as_f64(indices)?;
+                self.scatter_complex_typed(operand, &indices, updates, config)
+                    .map(Tensor::C64)
+            }
             (_, Tensor::C32(_) | Tensor::C64(_), _) => Err(crate::Error::BackendFailure {
                 op: "scatter",
                 message: "complex index tensors are not supported".into(),
@@ -2351,6 +2457,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.slice_typed(t, config).map(Tensor::F32),
             Tensor::F64(t) => self.slice_typed(t, config).map(Tensor::F64),
+            Tensor::I64(t) => self.slice_typed(t, config).map(Tensor::I64),
             Tensor::C32(t) => self.slice_typed(t, config).map(Tensor::C32),
             Tensor::C64(t) => self.slice_typed(t, config).map(Tensor::C64),
         }
@@ -2387,10 +2494,31 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(input), Tensor::F64(starts)) => self
                 .dynamic_slice_typed(input, starts, slice_sizes)
                 .map(Tensor::C64),
+            (Tensor::F32(input), Tensor::I64(starts)) => {
+                let starts = self.i64_indices_as_f64(starts)?;
+                self.dynamic_slice_typed(input, &starts, slice_sizes)
+                    .map(Tensor::F32)
+            }
+            (Tensor::F64(input), Tensor::I64(starts)) => {
+                let starts = self.i64_indices_as_f64(starts)?;
+                self.dynamic_slice_typed(input, &starts, slice_sizes)
+                    .map(Tensor::F64)
+            }
+            (Tensor::C32(input), Tensor::I64(starts)) => {
+                let starts = self.i64_indices_as_f64(starts)?;
+                self.dynamic_slice_typed(input, &starts, slice_sizes)
+                    .map(Tensor::C32)
+            }
+            (Tensor::C64(input), Tensor::I64(starts)) => {
+                let starts = self.i64_indices_as_f64(starts)?;
+                self.dynamic_slice_typed(input, &starts, slice_sizes)
+                    .map(Tensor::C64)
+            }
             (_, Tensor::C32(_) | Tensor::C64(_)) => Err(crate::Error::BackendFailure {
                 op: "dynamic_slice",
                 message: "complex index tensors are not supported".into(),
             }),
+            (Tensor::I64(_), _) => Err(unsupported_dtype("dynamic_slice", input.dtype())),
         }
     }
 
@@ -2398,6 +2526,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.pad_typed(t, config).map(Tensor::F32),
             Tensor::F64(t) => self.pad_typed(t, config).map(Tensor::F64),
+            Tensor::I64(t) => self.pad_typed(t, config).map(Tensor::I64),
             Tensor::C32(t) => self.pad_typed(t, config).map(Tensor::C32),
             Tensor::C64(t) => self.pad_typed(t, config).map(Tensor::C64),
         }
@@ -2432,6 +2561,16 @@ impl TensorBackend for CubeclBackend {
                     .collect();
                 self.concatenate_typed(&typed?, axis).map(Tensor::F64)
             }
+            Tensor::I64(_) => {
+                let typed: crate::Result<Vec<&TypedTensor<i64>>> = inputs
+                    .iter()
+                    .map(|tensor| match tensor {
+                        Tensor::I64(t) => Ok(t),
+                        _ => Err(dtype_mismatch("concatenate", first, tensor)),
+                    })
+                    .collect();
+                self.concatenate_typed(&typed?, axis).map(Tensor::I64)
+            }
             Tensor::C32(_) => {
                 let typed: crate::Result<Vec<&TypedTensor<Complex32>>> = inputs
                     .iter()
@@ -2459,6 +2598,7 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.reverse_typed(t, axes).map(Tensor::F32),
             Tensor::F64(t) => self.reverse_typed(t, axes).map(Tensor::F64),
+            Tensor::I64(t) => self.reverse_typed(t, axes).map(Tensor::I64),
             Tensor::C32(t) => self.reverse_typed(t, axes).map(Tensor::C32),
             Tensor::C64(t) => self.reverse_typed(t, axes).map(Tensor::C64),
         }

--- a/tenferro-tensor/src/cubecl/tests/indexing_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/indexing_tests.rs
@@ -4,7 +4,7 @@ use crate::TensorBackend;
 
 use super::{
     assert_tensor_close, cpu_backend, diagonal_scatter_config, download, gpu_backend,
-    simple_gather_config, tensor_f64, upload,
+    simple_gather_config, tensor_f64, tensor_i64, upload,
 };
 
 #[test]
@@ -26,7 +26,7 @@ fn test_cubecl_slice_dynamic_slice_and_pad_match_cpu() {
         edge_padding_high: vec![1, 0],
         interior_padding: vec![0, 1],
     };
-    let starts = tensor_f64(vec![2], vec![2.0, 3.0]);
+    let starts = tensor_i64(vec![2], vec![2, 3]);
 
     let mut cpu = cpu_backend();
     let mut gpu = gpu_backend();
@@ -53,13 +53,13 @@ fn test_cubecl_slice_dynamic_slice_and_pad_match_cpu() {
 #[ignore]
 fn test_cubecl_gather_and_scatter_match_cpu() {
     let operand = tensor_f64(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]);
-    let start_indices = tensor_f64(vec![3, 1], vec![0.0, 2.0, 4.0]);
+    let start_indices = tensor_i64(vec![3, 1], vec![0, 2, 4]);
 
     let scatter_operand = tensor_f64(
         vec![3, 3],
         vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0],
     );
-    let scatter_indices = tensor_f64(vec![3, 2], vec![0.0, 1.0, 2.0, 0.0, 1.0, 2.0]);
+    let scatter_indices = tensor_i64(vec![3, 2], vec![0, 1, 2, 0, 1, 2]);
     let updates = tensor_f64(vec![3], vec![5.0, 6.0, 7.0]);
 
     let mut cpu = cpu_backend();
@@ -103,7 +103,7 @@ fn test_cubecl_gather_and_scatter_match_cpu() {
 #[ignore]
 fn test_cubecl_scatter_skips_invalid_windows_like_cpu() {
     let operand = tensor_f64(vec![4], vec![9.0, 8.0, 7.0, 6.0]);
-    let scatter_indices = tensor_f64(vec![3, 1], vec![-1.0, 2.0, 4.0]);
+    let scatter_indices = tensor_i64(vec![3, 1], vec![-1, 2, 4]);
     let updates = tensor_f64(vec![3], vec![5.0, 6.0, 7.0]);
     let config = ScatterConfig {
         update_window_dims: vec![],

--- a/tenferro-tensor/src/cubecl/tests/mod.rs
+++ b/tenferro-tensor/src/cubecl/tests/mod.rs
@@ -38,6 +38,10 @@ fn tensor_f64(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec(shape, data))
 }
 
+fn tensor_i64(shape: Vec<usize>, data: Vec<i64>) -> Tensor {
+    Tensor::I64(TypedTensor::from_vec(shape, data))
+}
+
 fn tensor_c32(shape: Vec<usize>, data: Vec<Complex32>) -> Tensor {
     Tensor::C32(TypedTensor::from_vec(shape, data))
 }

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -2312,10 +2312,28 @@ fn test_gather_1d_indices() {
         vec![5],
         vec![10.0, 20.0, 30.0, 40.0, 50.0],
     ));
-    let start_indices = Tensor::F64(TypedTensor::from_vec(vec![3, 1], vec![0.0, 2.0, 4.0]));
+    let start_indices = Tensor::from_vec(vec![3, 1], vec![0_i64, 2, 4]);
 
     let out = gather(&operand, &start_indices, &simple_gather_config());
 
+    assert_eq!(out.shape(), &[3]);
+    assert_eq!(get_f64(&out, &[0]), 10.0);
+    assert_eq!(get_f64(&out, &[1]), 30.0);
+    assert_eq!(get_f64(&out, &[2]), 50.0);
+}
+
+#[test]
+fn test_gather_accepts_i64_indices() {
+    let operand = Tensor::F64(TypedTensor::from_vec(
+        vec![5],
+        vec![10.0, 20.0, 30.0, 40.0, 50.0],
+    ));
+    let start_indices = Tensor::from_vec(vec![3, 1], vec![0_i64, 2, 4]);
+
+    let out = gather(&operand, &start_indices, &simple_gather_config());
+
+    assert_eq!(start_indices.dtype(), DType::I64);
+    assert_eq!(start_indices.as_slice::<i64>(), Some([0, 2, 4].as_slice()));
     assert_eq!(out.shape(), &[3]);
     assert_eq!(get_f64(&out, &[0]), 10.0);
     assert_eq!(get_f64(&out, &[1]), 30.0);
@@ -2328,7 +2346,7 @@ fn test_gather_with_implicit_index_vector_dim() {
         vec![5],
         vec![10.0, 20.0, 30.0, 40.0, 50.0],
     ));
-    let start_indices = Tensor::F64(TypedTensor::from_vec(vec![3], vec![4.0, 1.0, 0.0]));
+    let start_indices = Tensor::from_vec(vec![3], vec![4_i64, 1, 0]);
     let config = GatherConfig {
         offset_dims: vec![],
         collapsed_slice_dims: vec![0],
@@ -2345,12 +2363,29 @@ fn test_gather_with_implicit_index_vector_dim() {
 }
 
 #[test]
+fn test_scatter_accepts_i64_indices() {
+    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3]));
+    let scatter_indices = Tensor::from_vec(vec![3, 2], vec![0_i64, 1, 2, 0, 1, 2]);
+    let updates = Tensor::F64(TypedTensor::from_vec(vec![3], vec![5.0, 6.0, 7.0]));
+
+    let out = scatter(
+        &operand,
+        &scatter_indices,
+        &updates,
+        &diagonal_scatter_config(),
+    );
+
+    assert_eq!(scatter_indices.dtype(), DType::I64);
+    assert_eq!(out.shape(), &[3, 3]);
+    assert_eq!(get_f64(&out, &[0, 0]), 5.0);
+    assert_eq!(get_f64(&out, &[1, 1]), 6.0);
+    assert_eq!(get_f64(&out, &[2, 2]), 7.0);
+}
+
+#[test]
 fn test_scatter_to_diagonal() {
     let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3]));
-    let scatter_indices = Tensor::F64(TypedTensor::from_vec(
-        vec![3, 2],
-        vec![0.0, 1.0, 2.0, 0.0, 1.0, 2.0],
-    ));
+    let scatter_indices = Tensor::from_vec(vec![3, 2], vec![0_i64, 1, 2, 0, 1, 2]);
     let updates = Tensor::F64(TypedTensor::from_vec(vec![3], vec![5.0, 6.0, 7.0]));
 
     let out = scatter(
@@ -2371,7 +2406,7 @@ fn test_scatter_to_diagonal() {
 #[test]
 fn test_scatter_skips_negative_and_out_of_bounds_windows() {
     let operand = Tensor::F64(TypedTensor::zeros(vec![4]));
-    let scatter_indices = Tensor::F64(TypedTensor::from_vec(vec![3, 1], vec![-1.0, 2.0, 4.0]));
+    let scatter_indices = Tensor::from_vec(vec![3, 1], vec![-1_i64, 2, 4]);
     let updates = Tensor::F64(TypedTensor::from_vec(vec![3], vec![5.0, 6.0, 7.0]));
     let config = ScatterConfig {
         update_window_dims: vec![],
@@ -2437,10 +2472,30 @@ fn test_dynamic_slice_clamps_starts() {
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         ],
     ));
-    let starts = Tensor::F64(TypedTensor::from_vec(vec![2], vec![2.0, 3.0]));
+    let starts = Tensor::from_vec(vec![2], vec![2_i64, 3]);
 
     let out = dynamic_slice(&input, &starts, &[2, 2]);
 
+    assert_eq!(out.shape(), &[2, 2]);
+    assert_eq!(get_f64(&out, &[0, 0]), 11.0);
+    assert_eq!(get_f64(&out, &[1, 0]), 12.0);
+    assert_eq!(get_f64(&out, &[0, 1]), 15.0);
+    assert_eq!(get_f64(&out, &[1, 1]), 16.0);
+}
+
+#[test]
+fn test_dynamic_slice_accepts_i64_starts() {
+    let input = Tensor::F64(TypedTensor::from_vec(
+        vec![4, 4],
+        vec![
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
+        ],
+    ));
+    let starts = Tensor::from_vec(vec![2], vec![2_i64, 3]);
+
+    let out = dynamic_slice(&input, &starts, &[2, 2]);
+
+    assert_eq!(starts.dtype(), DType::I64);
     assert_eq!(out.shape(), &[2, 2]);
     assert_eq!(get_f64(&out, &[0, 0]), 11.0);
     assert_eq!(get_f64(&out, &[1, 0]), 12.0);
@@ -2489,6 +2544,7 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
     let mut backend = CpuBackend::new();
     let f32_input = Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.25_f32, -2.5_f32]));
     let f64_input = Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.25_f64, -2.5_f64]));
+    let i64_input = Tensor::I64(TypedTensor::from_vec(vec![2], vec![1_i64, -2_i64]));
     let c32_input = Tensor::C32(TypedTensor::from_vec(
         vec![2],
         vec![Complex32::new(1.25, -0.5), Complex32::new(-2.5, 4.0)],
@@ -2501,18 +2557,27 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
     let cases = [
         (&f32_input, DType::F32),
         (&f32_input, DType::F64),
+        (&f32_input, DType::I64),
         (&f32_input, DType::C32),
         (&f32_input, DType::C64),
         (&f64_input, DType::F32),
         (&f64_input, DType::F64),
+        (&f64_input, DType::I64),
         (&f64_input, DType::C32),
         (&f64_input, DType::C64),
+        (&i64_input, DType::F32),
+        (&i64_input, DType::F64),
+        (&i64_input, DType::I64),
+        (&i64_input, DType::C32),
+        (&i64_input, DType::C64),
         (&c32_input, DType::F32),
         (&c32_input, DType::F64),
+        (&c32_input, DType::I64),
         (&c32_input, DType::C32),
         (&c32_input, DType::C64),
         (&c64_input, DType::F32),
         (&c64_input, DType::F64),
+        (&c64_input, DType::I64),
         (&c64_input, DType::C32),
         (&c64_input, DType::C64),
     ];
@@ -2525,6 +2590,7 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
         match (input.dtype(), &output) {
             (DType::F32, Tensor::F32(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
             (DType::F32, Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
+            (DType::F32, Tensor::I64(inner)) => assert_eq!(inner.host_data(), &[1, -2]),
             (DType::F32, Tensor::C32(inner)) => assert_eq!(
                 inner.host_data(),
                 &[Complex32::new(1.25, 0.0), Complex32::new(-2.5, 0.0)]
@@ -2535,6 +2601,7 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
             ),
             (DType::F64, Tensor::F32(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
             (DType::F64, Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
+            (DType::F64, Tensor::I64(inner)) => assert_eq!(inner.host_data(), &[1, -2]),
             (DType::F64, Tensor::C32(inner)) => assert_eq!(
                 inner.host_data(),
                 &[Complex32::new(1.25, 0.0), Complex32::new(-2.5, 0.0)]
@@ -2543,8 +2610,20 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
                 inner.host_data(),
                 &[Complex64::new(1.25, 0.0), Complex64::new(-2.5, 0.0)]
             ),
+            (DType::I64, Tensor::F32(inner)) => assert_eq!(inner.host_data(), &[1.0, -2.0]),
+            (DType::I64, Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[1.0, -2.0]),
+            (DType::I64, Tensor::I64(inner)) => assert_eq!(inner.host_data(), &[1, -2]),
+            (DType::I64, Tensor::C32(inner)) => assert_eq!(
+                inner.host_data(),
+                &[Complex32::new(1.0, 0.0), Complex32::new(-2.0, 0.0)]
+            ),
+            (DType::I64, Tensor::C64(inner)) => assert_eq!(
+                inner.host_data(),
+                &[Complex64::new(1.0, 0.0), Complex64::new(-2.0, 0.0)]
+            ),
             (DType::C32, Tensor::F32(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
             (DType::C32, Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
+            (DType::C32, Tensor::I64(inner)) => assert_eq!(inner.host_data(), &[1, -2]),
             (DType::C32, Tensor::C32(inner)) => assert_eq!(
                 inner.host_data(),
                 &[Complex32::new(1.25, -0.5), Complex32::new(-2.5, 4.0)]
@@ -2555,6 +2634,7 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
             ),
             (DType::C64, Tensor::F32(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
             (DType::C64, Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
+            (DType::C64, Tensor::I64(inner)) => assert_eq!(inner.host_data(), &[1, -2]),
             (DType::C64, Tensor::C32(inner)) => assert_eq!(
                 inner.host_data(),
                 &[Complex32::new(1.25, -0.5), Complex32::new(-2.5, 4.0)]
@@ -2709,7 +2789,7 @@ fn test_backend_gather_scatter_dynamic_slice_dispatch() {
         vec![5],
         vec![10.0, 20.0, 30.0, 40.0, 50.0],
     ));
-    let start_indices = Tensor::F64(TypedTensor::from_vec(vec![3, 1], vec![0.0, 2.0, 4.0]));
+    let start_indices = Tensor::from_vec(vec![3, 1], vec![0_i64, 2, 4]);
     let gathered = backend
         .gather(&operand, &start_indices, &simple_gather_config())
         .unwrap();
@@ -2718,10 +2798,7 @@ fn test_backend_gather_scatter_dynamic_slice_dispatch() {
     assert_eq!(get_f64(&gathered, &[2]), 50.0);
 
     let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3]));
-    let scatter_indices = Tensor::F64(TypedTensor::from_vec(
-        vec![3, 2],
-        vec![0.0, 1.0, 2.0, 0.0, 1.0, 2.0],
-    ));
+    let scatter_indices = Tensor::from_vec(vec![3, 2], vec![0_i64, 1, 2, 0, 1, 2]);
     let updates = Tensor::F64(TypedTensor::from_vec(vec![3], vec![5.0, 6.0, 7.0]));
     let scattered = backend
         .scatter(
@@ -2741,7 +2818,7 @@ fn test_backend_gather_scatter_dynamic_slice_dispatch() {
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         ],
     ));
-    let starts = Tensor::F64(TypedTensor::from_vec(vec![2], vec![2.0, 3.0]));
+    let starts = Tensor::from_vec(vec![2], vec![2_i64, 3]);
     let ds = backend.dynamic_slice(&input, &starts, &[2, 2]).unwrap();
     assert_eq!(ds.shape(), &[2, 2]);
     assert_eq!(get_f64(&ds, &[0, 0]), 11.0);

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -173,13 +173,14 @@ pub struct TypedTensor<T> {
 pub enum DType {
     F32,
     F64,
+    I64,
     C32,
     C64,
 }
 
 /// Sealed trait for scalar types that can be stored in a [`Tensor`].
 ///
-/// This trait is implemented for `f64`, `f32`, [`Complex64`], and
+/// This trait is implemented for `f64`, `f32`, `i64`, [`Complex64`], and
 /// [`Complex32`].
 ///
 /// # Examples
@@ -234,6 +235,7 @@ mod private {
 
     impl Sealed for f64 {}
     impl Sealed for f32 {}
+    impl Sealed for i64 {}
     impl Sealed for num_complex::Complex64 {}
     impl Sealed for num_complex::Complex32 {}
 }
@@ -285,6 +287,32 @@ impl TensorScalar for f32 {
     fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
         match tensor {
             Tensor::F32(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
+impl TensorScalar for i64 {
+    type Real = i64;
+
+    fn dtype() -> DType {
+        DType::I64
+    }
+
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::I64(TypedTensor::from_vec(shape, data))
+    }
+
+    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
+        match tensor {
+            Tensor::I64(t) => Some(t.host_data()),
+            _ => None,
+        }
+    }
+
+    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
+        match tensor {
+            Tensor::I64(inner) => Some(inner),
             _ => None,
         }
     }
@@ -356,6 +384,7 @@ impl TensorScalar for Complex32 {
 pub enum Tensor {
     F32(TypedTensor<f32>),
     F64(TypedTensor<f64>),
+    I64(TypedTensor<i64>),
     C32(TypedTensor<Complex<f32>>),
     C64(TypedTensor<Complex<f64>>),
 }
@@ -391,6 +420,24 @@ impl From<TypedTensor<f64>> for Tensor {
 impl From<TypedTensor<f32>> for Tensor {
     fn from(t: TypedTensor<f32>) -> Self {
         Tensor::F32(t)
+    }
+}
+
+/// Wrap an `i64` [`TypedTensor`] into the corresponding [`Tensor`] variant.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{DType, Tensor, TypedTensor};
+///
+/// let typed = TypedTensor::from_vec(vec![2], vec![1_i64, 2]);
+/// let tensor: Tensor = typed.into();
+/// assert_eq!(tensor.dtype(), DType::I64);
+/// assert_eq!(tensor.shape(), &[2]);
+/// ```
+impl From<TypedTensor<i64>> for Tensor {
+    fn from(t: TypedTensor<i64>) -> Self {
+        Tensor::I64(t)
     }
 }
 
@@ -702,6 +749,7 @@ macro_rules! dispatch_tensor {
         match $self {
             Tensor::F32($inner) => Tensor::F32($body),
             Tensor::F64($inner) => Tensor::F64($body),
+            Tensor::I64(_) => panic!("I64 data tensors are not supported by this operation"),
             Tensor::C32($inner) => Tensor::C32($body),
             Tensor::C64($inner) => Tensor::C64($body),
         }
@@ -713,6 +761,9 @@ macro_rules! dispatch_binary {
         match ($lhs, $rhs) {
             (Tensor::F32($a), Tensor::F32($b)) => Tensor::F32($body),
             (Tensor::F64($a), Tensor::F64($b)) => Tensor::F64($body),
+            (Tensor::I64(_), Tensor::I64(_)) => {
+                panic!("I64 data tensors are not supported by this operation")
+            }
             (Tensor::C32($a), Tensor::C32($b)) => Tensor::C32($body),
             (Tensor::C64($a), Tensor::C64($b)) => Tensor::C64($body),
             _ => panic!("dtype mismatch in binary op"),
@@ -755,6 +806,7 @@ impl Tensor {
         match self {
             Tensor::F32(t) => &t.shape,
             Tensor::F64(t) => &t.shape,
+            Tensor::I64(t) => &t.shape,
             Tensor::C32(t) => &t.shape,
             Tensor::C64(t) => &t.shape,
         }
@@ -774,6 +826,7 @@ impl Tensor {
         match self {
             Tensor::F32(_) => DType::F32,
             Tensor::F64(_) => DType::F64,
+            Tensor::I64(_) => DType::I64,
             Tensor::C32(_) => DType::C32,
             Tensor::C64(_) => DType::C64,
         }

--- a/tenferro-tensor/src/validate/mod.rs
+++ b/tenferro-tensor/src/validate/mod.rs
@@ -123,6 +123,10 @@ pub fn validate_nonsingular_u(u: &Tensor) -> Result<()> {
         Tensor::F32(t) => check_singular_diagonal(t),
         Tensor::C64(t) => check_singular_diagonal(t),
         Tensor::C32(t) => check_singular_diagonal(t),
+        Tensor::I64(_) => Err(Error::BackendFailure {
+            op: "solve",
+            message: "unsupported dtype I64".into(),
+        }),
     }
 }
 

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -223,6 +223,10 @@ fn constant_tensor(dtype: DType, bytes: &[u8]) -> Tensor {
             vec![],
             vec![f32::from_le_bytes(exact_bytes::<4>(dtype, bytes))],
         )),
+        DType::I64 => Tensor::I64(TypedTensor::from_vec(
+            vec![],
+            vec![i64::from_le_bytes(exact_bytes::<8>(dtype, bytes))],
+        )),
         DType::C64 => {
             let data = exact_bytes::<16>(dtype, bytes);
             let mut re_bytes = [0u8; 8];

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -274,7 +274,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     ///     vec![5],
     ///     vec![10.0_f64, 20.0, 30.0, 40.0, 50.0],
     /// ));
-    /// let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![4.0_f64, 1.0, 0.0]));
+    /// let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![4_i64, 1, 0]));
     /// let y = x
     ///     .gather(
     ///         &indices,
@@ -302,7 +302,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// use tenferro::{EagerTensor, ScatterConfig, Tensor};
     ///
     /// let operand = EagerTensor::from_tensor(Tensor::from_vec(vec![4], vec![0.0_f64, 0.0, 0.0, 0.0]));
-    /// let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![1.0_f64, 3.0]));
+    /// let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![1_i64, 3]));
     /// let updates = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![5.0_f64, 7.0]));
     /// let result = operand
     ///     .scatter(
@@ -331,7 +331,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// use tenferro::{EagerTensor, Tensor};
     ///
     /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]));
-    /// let starts = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![2.0_f64]));
+    /// let starts = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![2_i64]));
     /// let y = x.dynamic_slice(&starts, &[2]).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[3.0, 4.0]);

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -783,6 +783,10 @@ pub(crate) fn constant_tensor(dtype: DType, bytes: &[u8]) -> Tensor {
             vec![],
             vec![f32::from_le_bytes(exact_bytes::<4>(dtype, bytes))],
         )),
+        DType::I64 => Tensor::I64(TypedTensor::from_vec(
+            vec![],
+            vec![i64::from_le_bytes(exact_bytes::<8>(dtype, bytes))],
+        )),
         DType::C64 => {
             let data = exact_bytes::<16>(dtype, bytes);
             let mut re_bytes = [0u8; 8];

--- a/tenferro/src/linalg_api.rs
+++ b/tenferro/src/linalg_api.rs
@@ -485,6 +485,7 @@ fn eig_output_dtype(dtype: DType) -> DType {
     match dtype {
         DType::F64 | DType::C64 => DType::C64,
         DType::F32 | DType::C32 => DType::C32,
+        DType::I64 => DType::I64,
     }
 }
 
@@ -500,6 +501,12 @@ fn scalar_real(dtype: DType, value: f64) -> TracedTensor {
             StdTensorOp::constant_f32(value as f32),
             0,
             DType::F32,
+            Some(vec![]),
+        ),
+        DType::I64 => apply_nullary(
+            StdTensorOp::constant_i64(value as i64),
+            0,
+            DType::I64,
             Some(vec![]),
         ),
         DType::C64 => apply_nullary(
@@ -561,6 +568,7 @@ fn default_pinv_rtol(dtype: DType, max_dim: usize) -> f64 {
     let eps = match dtype {
         DType::F32 | DType::C32 => f32::EPSILON as f64,
         DType::F64 | DType::C64 => f64::EPSILON,
+        DType::I64 => 0.0,
     };
     eps * max_dim as f64
 }

--- a/tenferro/src/shape_infer.rs
+++ b/tenferro/src/shape_infer.rs
@@ -26,6 +26,7 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         StdTensorOp::Eig { input_dtype, .. } => match input_dtype {
             DType::F32 | DType::C32 => DType::C32,
             DType::F64 | DType::C64 => DType::C64,
+            DType::I64 => DType::I64,
         },
         StdTensorOp::Extension(ext) => extension_first_output_dtype(ext.as_ref(), input_dtypes),
         StdTensorOp::Add

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -1079,6 +1079,7 @@ impl TracedTensor {
         let op = match self.dtype {
             DType::F64 => StdTensorOp::constant_f64(factor),
             DType::F32 => StdTensorOp::constant_f32(factor as f32),
+            DType::I64 => StdTensorOp::constant_i64(factor as i64),
             DType::C64 => StdTensorOp::constant_c64(Complex64::new(factor, 0.0)),
             DType::C32 => StdTensorOp::constant_c32(Complex32::new(factor as f32, 0.0)),
         };
@@ -1103,7 +1104,7 @@ impl TracedTensor {
                 self,
                 StdTensorOp::constant_c32(Complex32::new(factor.re as f32, factor.im as f32)),
             ),
-            DType::F32 | DType::F64 => {
+            DType::F32 | DType::F64 | DType::I64 => {
                 panic!(
                     "scale_complex only supports complex tensors; use scale_real for real tensors"
                 )
@@ -2119,6 +2120,7 @@ fn ones_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
     match dtype {
         DType::F32 => Tensor::F32(TypedTensor::ones(shape)),
         DType::F64 => Tensor::F64(TypedTensor::ones(shape)),
+        DType::I64 => Tensor::I64(TypedTensor::ones(shape)),
         DType::C32 => Tensor::C32(TypedTensor::ones(shape)),
         DType::C64 => Tensor::C64(TypedTensor::ones(shape)),
     }
@@ -2128,6 +2130,7 @@ fn zeros_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
     match dtype {
         DType::F32 => Tensor::F32(TypedTensor::zeros(shape)),
         DType::F64 => Tensor::F64(TypedTensor::zeros(shape)),
+        DType::I64 => Tensor::I64(TypedTensor::zeros(shape)),
         DType::C32 => Tensor::C32(TypedTensor::zeros(shape)),
         DType::C64 => Tensor::C64(TypedTensor::zeros(shape)),
     }

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -163,6 +163,10 @@ fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec(shape, data))
 }
 
+fn i64_tensor(shape: Vec<usize>, data: Vec<i64>) -> Tensor {
+    Tensor::I64(TypedTensor::from_vec(shape, data))
+}
+
 fn c64_tensor(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
     Tensor::C64(TypedTensor::from_vec(shape, data))
 }
@@ -994,6 +998,7 @@ fn zeros_by_dtype(dtype: DType, shape: Vec<usize>) -> Tensor {
     match dtype {
         DType::F32 => Tensor::F32(TypedTensor::zeros(shape)),
         DType::F64 => Tensor::F64(TypedTensor::zeros(shape)),
+        DType::I64 => Tensor::I64(TypedTensor::zeros(shape)),
         DType::C32 => Tensor::C32(TypedTensor::zeros(shape)),
         DType::C64 => Tensor::C64(TypedTensor::zeros(shape)),
     }
@@ -3005,13 +3010,13 @@ fn grad_gather_reduce_sum_accumulates_indices_correctly() {
         build_gather_reduce_sum_fragment(operand_key.clone(), indices_key.clone(), config, vec![0]);
 
     let operand_data = vec![10.0_f64, 20.0, 30.0, 40.0, 50.0];
-    let indices_data = vec![2.0_f64, 4.0, 0.0, 2.0, 2.0];
+    let indices_data = vec![2_i64, 4, 0, 2, 2];
     let mut inputs_map = HashMap::new();
     inputs_map.insert(
         operand_key.clone(),
         f64_tensor(vec![5], operand_data.clone()),
     );
-    inputs_map.insert(indices_key, f64_tensor(vec![5, 1], indices_data));
+    inputs_map.insert(indices_key, i64_tensor(vec![5, 1], indices_data));
 
     let grad = grad_from_fragment_with_inputs(fragment, loss_key, operand_key, inputs_map);
     assert_eq!(grad.shape(), &[5]);
@@ -3074,11 +3079,11 @@ fn grad_scatter_reduce_sum_wrt_updates_is_ones() {
     );
 
     let operand_data = vec![0.0_f64, 0.0, 0.0, 0.0];
-    let indices_data = vec![1.0_f64, 3.0, 0.0];
+    let indices_data = vec![1_i64, 3, 0];
     let updates_data = vec![5.0_f64, 7.0, 9.0];
     let mut inputs_map = HashMap::new();
     inputs_map.insert(operand_key, f64_tensor(vec![4], operand_data));
-    inputs_map.insert(indices_key, f64_tensor(vec![3, 1], indices_data));
+    inputs_map.insert(indices_key, i64_tensor(vec![3, 1], indices_data));
     inputs_map.insert(
         updates_key.clone(),
         f64_tensor(vec![3], updates_data.clone()),

--- a/tenferro/tests/eager_linalg_tests.rs
+++ b/tenferro/tests/eager_linalg_tests.rs
@@ -318,7 +318,7 @@ fn eager_elementwise_forward_surface_smoke() {
 #[test]
 fn eager_elementwise_scatter_forward_updates_operand() {
     let operand = EagerTensor::from_tensor(Tensor::from_vec(vec![4], vec![0.0_f64, 0.0, 0.0, 0.0]));
-    let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![1.0_f64, 3.0]));
+    let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![1_i64, 3]));
     let updates = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![5.0_f64, 4.0]));
     let result = operand
         .scatter(

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -435,7 +435,7 @@ fn eager_gather_primal() {
         vec![5],
         vec![10.0_f64, 20.0, 30.0, 40.0, 50.0],
     ));
-    let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![4.0_f64, 1.0, 0.0]));
+    let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![4_i64, 1, 0]));
     let y = x
         .gather(
             &indices,
@@ -462,7 +462,7 @@ fn eager_dynamic_slice_primal() {
             16.0,
         ],
     ));
-    let starts = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![2.0_f64, 3.0]));
+    let starts = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![2_i64, 3]));
     let y = x.dynamic_slice(&starts, &[2, 2]).unwrap();
 
     assert_eq!(y.data().shape(), &[2, 2]);

--- a/tenferro/tests/oracle_replay/main.rs
+++ b/tenferro/tests/oracle_replay/main.rs
@@ -941,6 +941,7 @@ fn cotangent_scalar(
         let aligned_cotangent = match output.tensor.dtype {
             DType::C32 | DType::C64 => aligned_cotangent.conj(),
             DType::F32 | DType::F64 => aligned_cotangent,
+            DType::I64 => continue,
         };
         let axes: Vec<usize> = (0..output.tensor.rank).collect();
         scalar_terms.push((&output.tensor * &aligned_cotangent).reduce_sum(&axes));
@@ -1071,6 +1072,7 @@ fn zero_traced_tensor(dtype: DType, shape: Vec<usize>) -> TracedTensor {
     let tensor = match dtype {
         DType::F32 => Tensor::F32(TypedTensor::<f32>::zeros(shape)),
         DType::F64 => Tensor::F64(TypedTensor::<f64>::zeros(shape)),
+        DType::I64 => Tensor::I64(TypedTensor::<i64>::zeros(shape)),
         DType::C32 => Tensor::C32(TypedTensor::<Complex32>::zeros(shape)),
         DType::C64 => Tensor::C64(TypedTensor::<Complex64>::zeros(shape)),
     };


### PR DESCRIPTION
## Summary

- Add an `I64` tensor dtype and host/GPU transfer support so index tensors can be represented as integers.
- Teach CPU gather, scatter, and dynamic_slice to accept `I64` index operands while preserving legacy float index handling.
- Update indexing tests and eager examples to use integer index tensors, including CubeCL ignored indexing tests.

Closes #753.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo check -p tenferro-tensor --features cubecl`
- `cargo test -p tenferro-tensor --release cpu_tests`
- `cargo test -p tenferro --release eager_gather_primal`
- `cargo test -p tenferro --release eager_dynamic_slice_primal`
- `cargo test -p tenferro --release grad_gather_reduce_sum_accumulates_indices_correctly`
- `cargo test -p tenferro --release grad_scatter_reduce_sum_wrt_updates_is_ones`