### PR TITLE
[codex] Add full-pivot LU solve injection path

### DIFF
--- a/.github/workflows/CI_rs_selfhost.yml
+++ b/.github/workflows/CI_rs_selfhost.yml
@@ -27,11 +27,13 @@ jobs:
       - name: Run doc tests
         run: cargo test --doc --workspace --release
 
-  # PRs from the same repository: run heavy CI on self-hosted runner
+  # PRs from the same repository: normally run heavy CI on self-hosted runner.
+  # Temporarily use GitHub-hosted runners while the self-hosted pool is down.
   ci-maintainer:
     name: CI (same-repo PR / self-hosted heavy / ${{ matrix.backend }})
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, linux, x64]
+    # runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +52,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      # Note: Disable this step when runs-on is self-hosted.
+      - name: Install BLAS/LAPACK runtime libraries
+        if: matrix.backend == 'cpu-blas'
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
       - name: Install cargo-nextest
         run: |
           set -euo pipefail

--- a/.github/workflows/CI_rs_selfhost.yml
+++ b/.github/workflows/CI_rs_selfhost.yml
@@ -48,20 +48,20 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/../target-${{ matrix.backend }}
       CARGO_PROFILE_RELEASE_DEBUG: 0
       RUSTFLAGS: ${{ matrix.rustflags }}
+      # Keep hosted fallback runs within the repository runner timeout. The
+      # dedicated coverage job uses the same cap while still exercising every
+      # oracle replay path enough for per-file coverage enforcement.
+      ORACLE_REPLAY_CASE_LIMIT: "100"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       # Note: Disable this step when runs-on is self-hosted.
       - name: Install BLAS/LAPACK runtime libraries
         if: matrix.backend == 'cpu-blas'
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
-      - name: Install cargo-nextest
-        run: |
-          set -euo pipefail
-          if ! cargo nextest --version >/dev/null 2>&1; then
-            cargo install cargo-nextest --locked
-          fi
+      - uses: taiki-e/install-action@nextest
       - name: Verify BLAS/LAPACK runtime libraries
         if: matrix.backend == 'cpu-blas'
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cblas-inject = "0.1.0"
 blas-src = { version = "0.14", default-features = false }
 lapack = "0.20"
 lapack-src = "0.13"
-lapack-inject = "0.1.0"
+lapack-inject = "0.1.1"
 cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12000"] }
 cubecl = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96", features = ["cuda"] }
 cubecl-cuda = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96" }

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -130,3 +130,30 @@ let result = x.eval(&mut engine).unwrap();
 assert_eq!(result.shape(), &[2, 1]);
 assert_eq!(result.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
 ```
+
+## Complete-pivot LU solve
+
+`full_piv_lu_solve` solves `A x = b` using LU factorization with complete
+pivoting. This path is useful when the selected CPU backend provides complete
+pivoting and you want the solve primitive to stay backend-dispatched.
+
+```rust
+use tenferro::{full_piv_lu, full_piv_lu_solve, CpuBackend, Engine, TracedTensor};
+
+let a = TracedTensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]);
+let b = TracedTensor::from_vec(vec![2, 1], vec![-1.0_f64, 5.0]);
+
+let (mut p, mut l, mut u, mut q, mut parity) = full_piv_lu(&a);
+let mut x = full_piv_lu_solve(&a, &b);
+
+let mut engine = Engine::new(CpuBackend::new());
+let factors =
+    tenferro::traced::eval_all(&mut engine, &mut [&mut p, &mut l, &mut u, &mut q, &mut parity])
+        .unwrap();
+let result = x.eval(&mut engine).unwrap();
+
+assert_eq!(factors[0].shape(), &[2, 2]);
+assert_eq!(factors[4].shape(), &[] as &[usize]);
+assert_eq!(result.shape(), &[2, 1]);
+assert_eq!(result.as_slice::<f64>().unwrap(), &[4.0, -1.0]);
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ PyTorch and JAX. It provides:
 - **Lazy traced execution** — `TracedTensor` with graph optimization and
   transform-oriented automatic differentiation (`grad`, `vjp`, `jvp`, HVP)
 - **Einsum** — with automatic contraction-tree planning
-- **Linear algebra** — SVD, QR, Cholesky, eigh, solve
+- **Linear algebra** — SVD, QR, Cholesky, eigh, LU, solve
 
 CPU execution is fully supported; GPU support is planned.
 

--- a/tenferro-einsum/tests/typed_eager.rs
+++ b/tenferro-einsum/tests/typed_eager.rs
@@ -64,6 +64,8 @@ impl TensorBackend for WrongDTypeBackend {
         cholesky(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
         triangular_solve(a: &Tensor, b: &Tensor, left_side: bool, lower: bool, transpose_a: bool, unit_diagonal: bool) -> tenferro_tensor::Result<Tensor>;
         lu(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+        full_piv_lu(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+        full_piv_lu_solve(a: &Tensor, b: &Tensor, transpose_a: bool) -> tenferro_tensor::Result<Tensor>;
         svd(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
         qr(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
         eigh(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;

--- a/tenferro-ops/src/ad/linalg.rs
+++ b/tenferro-ops/src/ad/linalg.rs
@@ -256,6 +256,59 @@ pub fn linearize_triangular_solve(
     vec![Some(out[0])]
 }
 
+pub fn linearize_full_piv_lu_solve(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    primal_out: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    transpose_a: bool,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    let lhs_rank = ctx.shape_of(&ValRef::External(primal_in[0].clone())).len();
+    let rhs_rank = ctx.shape_of(&ValRef::External(primal_in[1].clone())).len();
+    assert!(
+        lhs_rank >= 2 && rhs_rank >= 2,
+        "linearize_full_piv_lu_solve: expected matrix operands"
+    );
+    assert_eq!(
+        lhs_rank, rhs_rank,
+        "linearize_full_piv_lu_solve: rank mismatch between lhs and rhs"
+    );
+    let rank = lhs_rank;
+    let mut rhs_tangent = tangent_in[1];
+
+    if let Some(da) = tangent_in[0] {
+        let d_op_a = if transpose_a {
+            transpose_matrix_linear(builder, da, rank)
+        } else {
+            da
+        };
+        let x = ValRef::External(primal_out[0].clone());
+        let correction = matmul_linear(builder, ValRef::Local(d_op_a), x, vec![true, false], rank);
+        let neg_correction = linear_neg(builder, correction);
+        rhs_tangent = Some(match rhs_tangent {
+            Some(db) => linear_add(builder, db, neg_correction),
+            None => neg_correction,
+        });
+    }
+
+    let Some(rhs_tangent) = rhs_tangent else {
+        return vec![None];
+    };
+
+    let out = builder.add_op(
+        StdTensorOp::FullPivLuSolve { transpose_a },
+        vec![
+            ValRef::External(primal_in[0].clone()),
+            ValRef::Local(rhs_tangent),
+        ],
+        OpMode::Linear {
+            active_mask: vec![false, true],
+        },
+    );
+    vec![Some(out[0])]
+}
+
 fn triangular_solve_rhs_tangent(
     builder: &mut FragmentBuilder<StdTensorOp>,
     primal_out: &[GlobalValKey<StdTensorOp>],
@@ -838,6 +891,39 @@ pub fn transpose_triangular_solve(
                 lower,
                 transpose_a: !transpose_a,
                 unit_diagonal,
+            },
+            vec![ValRef::Local(conjugated_a), ValRef::Local(ct)],
+            OpMode::Linear {
+                active_mask: vec![false, true],
+            },
+        );
+        result[1] = Some(out[0]);
+    }
+
+    result
+}
+
+pub fn transpose_full_piv_lu_solve(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+    transpose_a: bool,
+) -> Vec<Option<LocalValId>> {
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None, None];
+    };
+    let OpMode::Linear { active_mask } = mode else {
+        return vec![None, None];
+    };
+
+    let mut result = vec![None, None];
+    if active_mask[1] {
+        let conjugated_a =
+            emitter.add_op(StdTensorOp::Conj, vec![inputs[0].clone()], OpMode::Primal)[0];
+        let out = emitter.add_op(
+            StdTensorOp::FullPivLuSolve {
+                transpose_a: !transpose_a,
             },
             vec![ValRef::Local(conjugated_a), ValRef::Local(ct)],
             OpMode::Linear {

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -130,6 +130,15 @@ pub fn linearize(
 
         // Linalg family.
         StdTensorOp::Lu => linalg::linearize_lu(builder, primal_in, primal_out, tangent_in, ctx),
+        StdTensorOp::FullPivLu => vec![None, None, None, None, None],
+        StdTensorOp::FullPivLuSolve { transpose_a } => linalg::linearize_full_piv_lu_solve(
+            builder,
+            primal_in,
+            primal_out,
+            tangent_in,
+            *transpose_a,
+            ctx,
+        ),
         StdTensorOp::TriangularSolve {
             left_side,
             lower,
@@ -289,6 +298,9 @@ pub fn transpose_rule(
             *transpose_a,
             *unit_diagonal,
         ),
+        StdTensorOp::FullPivLuSolve { transpose_a } => {
+            linalg::transpose_full_piv_lu_solve(emitter, cotangent_out, inputs, mode, *transpose_a)
+        }
         StdTensorOp::ValidateNonsingular => vec![cotangent_out[0]],
 
         // Extension substrate.

--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -128,6 +128,10 @@ pub enum StdTensorOp {
     // Linalg
     Cholesky,
     Lu,
+    FullPivLu,
+    FullPivLuSolve {
+        transpose_a: bool,
+    },
     Svd {
         eps: f64,
     },
@@ -257,6 +261,7 @@ impl PartialEq for StdTensorOp {
             | (Self::Log1p, Self::Log1p)
             | (Self::Cholesky, Self::Cholesky)
             | (Self::Lu, Self::Lu)
+            | (Self::FullPivLu, Self::FullPivLu)
             | (Self::Qr, Self::Qr)
             | (Self::ValidateNonsingular, Self::ValidateNonsingular) => true,
             (Self::DotGeneral { config: a }, Self::DotGeneral { config: b }) => a == b,
@@ -337,6 +342,9 @@ impl PartialEq for StdTensorOp {
             (Self::Svd { eps: a }, Self::Svd { eps: b })
             | (Self::Eigh { eps: a }, Self::Eigh { eps: b }) => a.to_bits() == b.to_bits(),
             (Self::Eig { input_dtype: a }, Self::Eig { input_dtype: b }) => a == b,
+            (Self::FullPivLuSolve { transpose_a: a }, Self::FullPivLuSolve { transpose_a: b }) => {
+                a == b
+            }
             (
                 Self::TriangularSolve {
                     left_side: lsa,
@@ -387,7 +395,10 @@ impl Hash for StdTensorOp {
             Self::Svd { eps } => {
                 hash_f64(*eps, state);
             }
-            Self::Qr | Self::Cholesky | Self::Lu => {}
+            Self::Qr | Self::Cholesky | Self::Lu | Self::FullPivLu => {}
+            Self::FullPivLuSolve { transpose_a } => {
+                transpose_a.hash(state);
+            }
             Self::Eig { input_dtype } => {
                 input_dtype.hash(state);
             }
@@ -529,12 +540,13 @@ impl GraphOp for StdTensorOp {
             Self::Compare(_) => 2,
             Self::Cholesky
             | Self::Lu
+            | Self::FullPivLu
             | Self::Svd { .. }
             | Self::Qr
             | Self::Eigh { .. }
             | Self::Eig { .. }
             | Self::ValidateNonsingular => 1,
-            Self::TriangularSolve { .. } => 2,
+            Self::TriangularSolve { .. } | Self::FullPivLuSolve { .. } => 2,
             Self::Extension(op) => ExtensionOp::n_inputs(op.as_ref()),
         }
     }
@@ -587,8 +599,12 @@ impl GraphOp for StdTensorOp {
             | Self::ReduceProd { .. }
             | Self::ReduceMax { .. }
             | Self::ReduceMin { .. } => 1,
-            Self::Cholesky | Self::TriangularSolve { .. } | Self::ValidateNonsingular => 1,
+            Self::Cholesky
+            | Self::TriangularSolve { .. }
+            | Self::FullPivLuSolve { .. }
+            | Self::ValidateNonsingular => 1,
             Self::Lu => 4,
+            Self::FullPivLu => 5,
             Self::Svd { .. } => 3,  // U, S, Vt
             Self::Qr => 2,          // Q, R
             Self::Eigh { .. } => 2, // eigenvalues, eigenvectors

--- a/tenferro-tensor/Cargo.toml
+++ b/tenferro-tensor/Cargo.toml
@@ -12,7 +12,7 @@ default = ["cpu-faer"]
 cpu-faer = ["dep:faer"]
 cpu-blas = ["dep:cblas-sys", "dep:lapack"]
 provider-src = ["cpu-blas", "dep:blas-src", "dep:cblas-src", "dep:lapack-src"]
-provider-inject = ["cpu-blas", "dep:cblas-inject"]
+provider-inject = ["cpu-blas", "dep:cblas-inject", "dep:lapack-inject"]
 src-openblas = ["provider-src", "blas-src/openblas"]
 src-accelerate = ["provider-src", "blas-src/accelerate"]
 src-intel-mkl-dynamic-parallel = ["provider-src", "blas-src/intel-mkl-dynamic-parallel"]
@@ -30,6 +30,7 @@ thiserror.workspace = true
 faer = { workspace = true, optional = true }
 cblas-sys = { workspace = true, optional = true }
 cblas-inject = { workspace = true, optional = true }
+lapack-inject = { workspace = true, optional = true }
 cblas-src = { workspace = true, optional = true }
 blas-src = { workspace = true, optional = true }
 lapack = { workspace = true, optional = true }

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -193,6 +193,13 @@ pub trait TensorExec {
         unit_diagonal: bool,
     ) -> crate::Result<Tensor>;
     fn lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
+    fn full_piv_lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
+    fn full_piv_lu_solve(
+        &mut self,
+        a: &Tensor,
+        b: &Tensor,
+        transpose_a: bool,
+    ) -> crate::Result<Tensor>;
     fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
     fn qr(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
     fn eigh(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
@@ -283,6 +290,8 @@ impl<B: TensorBackend + ?Sized> TensorExec for BackendExecAdapter<'_, B> {
             unit_diagonal: bool
         ) -> crate::Result<Tensor>;
         lu(input: &Tensor) -> crate::Result<Vec<Tensor>>;
+        full_piv_lu(input: &Tensor) -> crate::Result<Vec<Tensor>>;
+        full_piv_lu_solve(a: &Tensor, b: &Tensor, transpose_a: bool) -> crate::Result<Tensor>;
         svd(input: &Tensor) -> crate::Result<Vec<Tensor>>;
         qr(input: &Tensor) -> crate::Result<Vec<Tensor>>;
         eigh(input: &Tensor) -> crate::Result<Vec<Tensor>>;
@@ -427,6 +436,13 @@ pub trait TensorBackend {
         unit_diagonal: bool,
     ) -> crate::Result<Tensor>;
     fn lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
+    fn full_piv_lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
+    fn full_piv_lu_solve(
+        &mut self,
+        a: &Tensor,
+        b: &Tensor,
+        transpose_a: bool,
+    ) -> crate::Result<Tensor>;
     fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
     fn qr(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;
     fn eigh(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>>;

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -551,6 +551,104 @@ impl TensorBackend for CpuBackend {
         })
     }
 
+    fn full_piv_lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        #[cfg(feature = "cpu-faer")]
+        let ctx = Arc::clone(&self.ctx);
+        self.install_with_pool(|buffers| match input {
+            #[cfg(feature = "cpu-faer")]
+            Tensor::F64(t) => catch_backend_panic("full_piv_lu", || {
+                linalg::full_piv_lu(ctx.as_ref(), buffers, t)
+                    .into_iter()
+                    .map(Tensor::F64)
+                    .collect()
+            }),
+            #[cfg(feature = "cpu-blas")]
+            Tensor::F64(t) => catch_backend_panic("full_piv_lu", || {
+                linalg::full_piv_lu(buffers, t)
+                    .into_iter()
+                    .map(Tensor::F64)
+                    .collect()
+            }),
+            #[cfg(feature = "cpu-blas")]
+            Tensor::C64(t) => catch_backend_panic("full_piv_lu", || {
+                linalg::full_piv_lu(buffers, t)
+                    .into_iter()
+                    .map(Tensor::C64)
+                    .collect()
+            }),
+            #[cfg(feature = "cpu-faer")]
+            Tensor::C64(t) => catch_backend_panic("full_piv_lu", || {
+                linalg::full_piv_lu(ctx.as_ref(), buffers, t)
+                    .into_iter()
+                    .map(Tensor::C64)
+                    .collect()
+            }),
+            _ => Err(unsupported_dtype("full_piv_lu", input.dtype())),
+        })
+    }
+
+    fn full_piv_lu_solve(
+        &mut self,
+        a: &Tensor,
+        b: &Tensor,
+        transpose_a: bool,
+    ) -> crate::Result<Tensor> {
+        if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
+            return Ok(zeros_like_tensor(b));
+        }
+
+        let (rhs, restore_shape) = if let Some(matrix_rhs_shape) = batched_vector_rhs_shape(a, b) {
+            (
+                self.reshape(b, &matrix_rhs_shape)?,
+                Some(b.shape().to_vec()),
+            )
+        } else {
+            (b.clone(), None)
+        };
+
+        #[cfg(feature = "cpu-faer")]
+        let ctx = Arc::clone(&self.ctx);
+        let result = self.install_with_pool(|buffers| match (a, &rhs) {
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+                linalg::full_piv_lu_solve(ctx.as_ref(), buffers, a, b, transpose_a).map(Tensor::F64)
+            })
+            .and_then(|result| result),
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+                linalg::full_piv_lu_solve(buffers, a, b, transpose_a).map(Tensor::F64)
+            })
+            .and_then(|result| result),
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+                linalg::full_piv_lu_solve(buffers, a, b, transpose_a).map(Tensor::C64)
+            })
+            .and_then(|result| result),
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+                linalg::full_piv_lu_solve(ctx.as_ref(), buffers, a, b, transpose_a).map(Tensor::C64)
+            })
+            .and_then(|result| result),
+            _ => {
+                if a.dtype() != rhs.dtype() {
+                    Err(crate::Error::DTypeMismatch {
+                        op: "full_piv_lu_solve",
+                        lhs: a.dtype(),
+                        rhs: rhs.dtype(),
+                    })
+                } else {
+                    Err(unsupported_dtype("full_piv_lu_solve", a.dtype()))
+                }
+            }
+        })?;
+
+        if let Some(shape) = restore_shape {
+            self.reshape(&result, &shape)
+        } else {
+            Ok(result)
+        }
+    }
+
     fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -248,6 +248,7 @@ impl TensorExec for CpuExecSession<'_> {
     // Linalg — macro-generated dtype dispatch
     linalg_single!(cholesky);
     linalg_multi!(lu);
+    linalg_multi!(full_piv_lu);
     linalg_multi!(svd);
     linalg_multi!(qr);
     linalg_multi!(eigh);
@@ -337,6 +338,49 @@ impl TensorExec for CpuExecSession<'_> {
                     })
                 } else {
                     Err(unsupported_dtype("triangular_solve", a.dtype()))
+                }
+            }
+        }
+    }
+
+    fn full_piv_lu_solve(
+        &mut self,
+        a: &Tensor,
+        b: &Tensor,
+        transpose_a: bool,
+    ) -> crate::Result<Tensor> {
+        match (a, b) {
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+                linalg::full_piv_lu_solve(self.ctx, self.buffers, a, b, transpose_a)
+                    .map(Tensor::F64)
+            })
+            .and_then(|result| result),
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+                linalg::full_piv_lu_solve(self.ctx, self.buffers, a, b, transpose_a)
+                    .map(Tensor::C64)
+            })
+            .and_then(|result| result),
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+                linalg::full_piv_lu_solve(self.buffers, a, b, transpose_a).map(Tensor::F64)
+            })
+            .and_then(|result| result),
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+                linalg::full_piv_lu_solve(self.buffers, a, b, transpose_a).map(Tensor::C64)
+            })
+            .and_then(|result| result),
+            _ => {
+                if a.dtype() != b.dtype() {
+                    Err(crate::Error::DTypeMismatch {
+                        op: "full_piv_lu_solve",
+                        lhs: a.dtype(),
+                        rhs: b.dtype(),
+                    })
+                } else {
+                    Err(unsupported_dtype("full_piv_lu_solve", a.dtype()))
                 }
             }
         }

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -21,6 +21,18 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> Vec<TypedTensor<Self>>;
+    fn full_piv_lu_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>>;
+    fn full_piv_lu_solve_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        a: &TypedTensor<Self>,
+        b: &TypedTensor<Self>,
+        transpose_a: bool,
+    ) -> crate::Result<TypedTensor<Self>>;
     fn triangular_solve_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -178,6 +190,15 @@ fn lower_triangle_vec_from_mat<T: Copy + Default>(mat: MatRef<'_, T>) -> Vec<T> 
 fn upper_triangle_vec_from_mat<T: Copy + Default>(mat: MatRef<'_, T>) -> Vec<T> {
     let (rows, cols) = mat.shape();
     matrix_from_predicate(mat, rows, cols, |row, col| row <= col)
+}
+
+fn permutation_matrix<T: Copy + Default>(perm: &[usize], one: T) -> Vec<T> {
+    let n = perm.len();
+    let mut data = vec![T::default(); n * n];
+    for (row, &source) in perm.iter().enumerate() {
+        data[row + source * n] = one;
+    }
+    data
 }
 
 fn complex_matrix_from_predicate(
@@ -547,6 +568,90 @@ where
     )
 }
 
+fn batched_binary_result<T, F>(
+    buffers: &mut BufferPool,
+    a: &TypedTensor<T>,
+    b: &TypedTensor<T>,
+    core_rank_a: usize,
+    core_rank_b: usize,
+    op: F,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: Clone + PoolScalar,
+    F: Fn(&mut BufferPool, &TypedTensor<T>, &TypedTensor<T>) -> crate::Result<TypedTensor<T>>,
+{
+    let (a_core_shape, a_batch_shape) =
+        split_core_and_batch(a, core_rank_a, "batched_binary_result");
+    let (b_core_shape, b_batch_shape) =
+        split_core_and_batch(b, core_rank_b, "batched_binary_result");
+    assert_eq!(
+        a_batch_shape, b_batch_shape,
+        "batched_binary_result: batch shape mismatch"
+    );
+
+    if a_batch_shape.is_empty() {
+        return op(buffers, a, b);
+    }
+
+    let a_slice_size: usize = a_core_shape.iter().product();
+    let b_slice_size: usize = b_core_shape.iter().product();
+    let batch_count: usize = a_batch_shape.iter().product();
+    assert!(
+        batch_count > 0,
+        "batched_binary_result: zero-sized batch dims are unsupported"
+    );
+
+    let mut out_core_shape: Option<Vec<usize>> = None;
+    let mut out_data: Option<Vec<T>> = None;
+
+    for batch_idx in 0..batch_count {
+        let a_start = batch_idx * a_slice_size;
+        let a_end = a_start + a_slice_size;
+        let b_start = batch_idx * b_slice_size;
+        let b_end = b_start + b_slice_size;
+
+        let batch_a = tensor_from_vec_with_template(
+            a_core_shape.to_vec(),
+            a.host_data()[a_start..a_end].to_vec(),
+            a,
+        );
+        let batch_b = tensor_from_vec_with_template(
+            b_core_shape.to_vec(),
+            b.host_data()[b_start..b_end].to_vec(),
+            b,
+        );
+        let batch_output = op(buffers, &batch_a, &batch_b)?;
+
+        if let Some(expected_shape) = &out_core_shape {
+            assert_eq!(
+                batch_output.shape.as_slice(),
+                expected_shape.as_slice(),
+                "batched_binary_result: output core shape mismatch across batches"
+            );
+        } else {
+            out_data =
+                Some(buffers.acquire_with_capacity::<T>(batch_output.n_elements() * batch_count));
+            out_core_shape = Some(batch_output.shape.clone());
+        }
+
+        match &mut out_data {
+            Some(data) => data.extend_from_slice(batch_output.host_data()),
+            None => panic!("batched_binary_result: missing output buffer"),
+        }
+    }
+
+    let mut out_shape = match out_core_shape {
+        Some(shape) => shape,
+        None => panic!("batched_binary_result: missing output shape"),
+    };
+    out_shape.extend_from_slice(a_batch_shape);
+    let out_data = match out_data {
+        Some(data) => data,
+        None => panic!("batched_binary_result: missing output data"),
+    };
+    Ok(tensor_from_vec_with_template(out_shape, out_data, b))
+}
+
 impl FaerLinalg for f64 {
     fn parity_one() -> Self {
         1.0
@@ -638,6 +743,139 @@ impl FaerLinalg for f64 {
             tensor_from_vec_with_template(vec![k, n], u_data, input),
             tensor_from_vec_with_template(vec![], vec![parity], input),
         ]
+    }
+
+    fn full_piv_lu_2d(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>> {
+        let n = square_matrix_dim(input, "full_piv_lu");
+        let mut lu = Mat::zeros(n, n);
+        lu.copy_from(MatRef::from_column_major_slice(input.host_data(), n, n));
+        let mut row_perm = vec![0usize; n];
+        let mut row_perm_inv = vec![0usize; n];
+        let mut col_perm = vec![0usize; n];
+        let mut col_perm_inv = vec![0usize; n];
+        let mut mem = MemBuffer::new(
+            faer::linalg::lu::full_pivoting::factor::lu_in_place_scratch::<usize, Self>(
+                n,
+                n,
+                ctx.faer_par(),
+                Default::default(),
+            ),
+        );
+        let stack = MemStack::new(&mut mem);
+        let info = faer::linalg::lu::full_pivoting::factor::lu_in_place(
+            lu.as_mut(),
+            &mut row_perm,
+            &mut row_perm_inv,
+            &mut col_perm,
+            &mut col_perm_inv,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .0;
+
+        let mut l_data = lower_triangle_vec_from_mat(lu.as_ref());
+        for i in 0..n {
+            l_data[i + i * n] = 1.0;
+        }
+        let u_data = upper_triangle_vec_from_mat(lu.as_ref());
+        let parity = if info.transposition_count % 2 == 0 {
+            1.0
+        } else {
+            -1.0
+        };
+
+        vec![
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, 1.0), input),
+            tensor_from_vec_with_template(vec![n, n], l_data, input),
+            tensor_from_vec_with_template(vec![n, n], u_data, input),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, 1.0), input),
+            tensor_from_vec_with_template(vec![], vec![parity], input),
+        ]
+    }
+
+    fn full_piv_lu_solve_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        a: &TypedTensor<Self>,
+        b: &TypedTensor<Self>,
+        transpose_a: bool,
+    ) -> crate::Result<TypedTensor<Self>> {
+        let n = square_matrix_dim(a, "full_piv_lu_solve");
+        let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve");
+        assert_eq!(b_rows, n, "full_piv_lu_solve: rhs row count mismatch");
+
+        let mut lu = Mat::zeros(n, n);
+        lu.copy_from(MatRef::from_column_major_slice(a.host_data(), n, n));
+        let mut row_perm = vec![0usize; n];
+        let mut row_perm_inv = vec![0usize; n];
+        let mut col_perm = vec![0usize; n];
+        let mut col_perm_inv = vec![0usize; n];
+        let mut mem = MemBuffer::new(
+            faer::linalg::lu::full_pivoting::factor::lu_in_place_scratch::<usize, Self>(
+                n,
+                n,
+                ctx.faer_par(),
+                Default::default(),
+            ),
+        );
+        let stack = MemStack::new(&mut mem);
+        let (_, row_perm_ref, col_perm_ref) = faer::linalg::lu::full_pivoting::factor::lu_in_place(
+            lu.as_mut(),
+            &mut row_perm,
+            &mut row_perm_inv,
+            &mut col_perm,
+            &mut col_perm_inv,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        );
+        for i in 0..n {
+            if lu[(i, i)] == 0.0 {
+                return Err(crate::Error::BackendFailure {
+                    op: "full_piv_lu_solve",
+                    message: "matrix is singular".into(),
+                });
+            }
+        }
+
+        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
+        rhs_data.extend_from_slice(b.host_data());
+        let rhs = MatMut::from_column_major_slice_mut(&mut rhs_data, n, b_cols);
+        let mut mem = MemBuffer::new(
+            faer::linalg::lu::full_pivoting::solve::solve_in_place_scratch::<usize, Self>(
+                n,
+                b_cols,
+                ctx.faer_par(),
+            ),
+        );
+        let stack = MemStack::new(&mut mem);
+        if transpose_a {
+            faer::linalg::lu::full_pivoting::solve::solve_transpose_in_place(
+                lu.as_ref(),
+                lu.as_ref(),
+                row_perm_ref,
+                col_perm_ref,
+                rhs,
+                ctx.faer_par(),
+                stack,
+            );
+        } else {
+            faer::linalg::lu::full_pivoting::solve::solve_in_place(
+                lu.as_ref(),
+                lu.as_ref(),
+                row_perm_ref,
+                col_perm_ref,
+                rhs,
+                ctx.faer_par(),
+                stack,
+            );
+        }
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
     }
 
     fn triangular_solve_2d(
@@ -1034,6 +1272,153 @@ impl FaerLinalg for Complex64 {
         ]
     }
 
+    fn full_piv_lu_2d(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> Vec<TypedTensor<Self>> {
+        let n = square_matrix_dim(input, "full_piv_lu");
+        let mut lu = Mat::zeros(n, n);
+        lu.copy_from(MatRef::from_column_major_slice(
+            complex64_to_faer_slice(input.host_data()),
+            n,
+            n,
+        ));
+        let mut row_perm = vec![0usize; n];
+        let mut row_perm_inv = vec![0usize; n];
+        let mut col_perm = vec![0usize; n];
+        let mut col_perm_inv = vec![0usize; n];
+        let mut mem = MemBuffer::new(
+            faer::linalg::lu::full_pivoting::factor::lu_in_place_scratch::<usize, faer::c64>(
+                n,
+                n,
+                ctx.faer_par(),
+                Default::default(),
+            ),
+        );
+        let stack = MemStack::new(&mut mem);
+        let info = faer::linalg::lu::full_pivoting::factor::lu_in_place(
+            lu.as_mut(),
+            &mut row_perm,
+            &mut row_perm_inv,
+            &mut col_perm,
+            &mut col_perm_inv,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .0;
+
+        let mut l_data = complex_matrix_from_predicate(lu.as_ref(), n, n, |row, col| row >= col);
+        for i in 0..n {
+            l_data[i + i * n] = Complex64::new(1.0, 0.0);
+        }
+        let u_data = complex_matrix_from_predicate(lu.as_ref(), n, n, |row, col| row <= col);
+        let one = Complex64::new(1.0, 0.0);
+        let parity = if info.transposition_count % 2 == 0 {
+            one
+        } else {
+            Complex64::new(-1.0, 0.0)
+        };
+
+        vec![
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, one), input),
+            tensor_from_vec_with_template(vec![n, n], l_data, input),
+            tensor_from_vec_with_template(vec![n, n], u_data, input),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, one), input),
+            tensor_from_vec_with_template(vec![], vec![parity], input),
+        ]
+    }
+
+    fn full_piv_lu_solve_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        a: &TypedTensor<Self>,
+        b: &TypedTensor<Self>,
+        transpose_a: bool,
+    ) -> crate::Result<TypedTensor<Self>> {
+        let n = square_matrix_dim(a, "full_piv_lu_solve");
+        let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve");
+        assert_eq!(b_rows, n, "full_piv_lu_solve: rhs row count mismatch");
+
+        let mut lu = Mat::zeros(n, n);
+        lu.copy_from(MatRef::from_column_major_slice(
+            complex64_to_faer_slice(a.host_data()),
+            n,
+            n,
+        ));
+        let mut row_perm = vec![0usize; n];
+        let mut row_perm_inv = vec![0usize; n];
+        let mut col_perm = vec![0usize; n];
+        let mut col_perm_inv = vec![0usize; n];
+        let mut mem = MemBuffer::new(
+            faer::linalg::lu::full_pivoting::factor::lu_in_place_scratch::<usize, faer::c64>(
+                n,
+                n,
+                ctx.faer_par(),
+                Default::default(),
+            ),
+        );
+        let stack = MemStack::new(&mut mem);
+        let (_, row_perm_ref, col_perm_ref) = faer::linalg::lu::full_pivoting::factor::lu_in_place(
+            lu.as_mut(),
+            &mut row_perm,
+            &mut row_perm_inv,
+            &mut col_perm,
+            &mut col_perm_inv,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        );
+        for i in 0..n {
+            let value = lu[(i, i)];
+            if value.re == 0.0 && value.im == 0.0 {
+                return Err(crate::Error::BackendFailure {
+                    op: "full_piv_lu_solve",
+                    message: "matrix is singular".into(),
+                });
+            }
+        }
+
+        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
+        rhs_data.extend_from_slice(b.host_data());
+        let rhs = MatMut::from_column_major_slice_mut(
+            complex64_to_faer_slice_mut(&mut rhs_data),
+            n,
+            b_cols,
+        );
+        let mut mem = MemBuffer::new(
+            faer::linalg::lu::full_pivoting::solve::solve_in_place_scratch::<usize, faer::c64>(
+                n,
+                b_cols,
+                ctx.faer_par(),
+            ),
+        );
+        let stack = MemStack::new(&mut mem);
+        if transpose_a {
+            faer::linalg::lu::full_pivoting::solve::solve_transpose_in_place(
+                lu.as_ref(),
+                lu.as_ref(),
+                row_perm_ref,
+                col_perm_ref,
+                rhs,
+                ctx.faer_par(),
+                stack,
+            );
+        } else {
+            faer::linalg::lu::full_pivoting::solve::solve_in_place(
+                lu.as_ref(),
+                lu.as_ref(),
+                row_perm_ref,
+                col_perm_ref,
+                rhs,
+                ctx.faer_par(),
+                stack,
+            );
+        }
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
+    }
+
     fn triangular_solve_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -1400,6 +1785,71 @@ pub(crate) fn lu<T: FaerLinalg>(
     }
     batched_multi(buffers, input, 2, |buffers, batch| {
         T::lu_2d(ctx, buffers, batch)
+    })
+}
+
+pub(crate) fn full_piv_lu<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> Vec<TypedTensor<T>> {
+    if has_zero_dim(&input.shape) {
+        let n = input.shape[0];
+        let batch_shape = &input.shape[2..];
+        let parity_elements = if batch_shape.is_empty() {
+            1
+        } else {
+            batch_shape.iter().product()
+        };
+        return vec![
+            tensor_from_vec_with_template(
+                matrix_with_batch_shape(n, n, batch_shape),
+                Vec::new(),
+                input,
+            ),
+            tensor_from_vec_with_template(
+                matrix_with_batch_shape(n, n, batch_shape),
+                Vec::new(),
+                input,
+            ),
+            tensor_from_vec_with_template(
+                matrix_with_batch_shape(n, n, batch_shape),
+                Vec::new(),
+                input,
+            ),
+            tensor_from_vec_with_template(
+                matrix_with_batch_shape(n, n, batch_shape),
+                Vec::new(),
+                input,
+            ),
+            tensor_from_vec_with_template(
+                batch_shape.to_vec(),
+                vec![T::parity_one(); parity_elements],
+                input,
+            ),
+        ];
+    }
+    batched_multi(buffers, input, 2, |buffers, batch| {
+        T::full_piv_lu_2d(ctx, buffers, batch)
+    })
+}
+
+pub(crate) fn full_piv_lu_solve<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    a: &TypedTensor<T>,
+    b: &TypedTensor<T>,
+    transpose_a: bool,
+) -> crate::Result<TypedTensor<T>> {
+    if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
+        return Ok(tensor_from_vec_with_template(
+            b.shape.clone(),
+            Vec::new(),
+            b,
+        ));
+    }
+    batched_binary_result(buffers, a, b, 2, 2, |buffers, a, b| {
+        T::full_piv_lu_solve_2d(ctx, buffers, a, b, transpose_a)
     })
 }
 

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg.rs
@@ -1,6 +1,7 @@
 mod cholesky;
 mod eig;
 mod eigh;
+mod full_piv_lu;
 mod helpers;
 mod lu;
 mod qr;
@@ -10,6 +11,7 @@ mod triangular_solve;
 pub(crate) use cholesky::cholesky;
 pub(crate) use eig::eig;
 pub(crate) use eigh::eigh;
+pub(crate) use full_piv_lu::{full_piv_lu, full_piv_lu_solve};
 pub(crate) use lu::lu;
 pub(crate) use qr::qr;
 pub(crate) use svd::svd;

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -1,0 +1,465 @@
+use num_complex::Complex64;
+
+use crate::buffer_pool::BufferPool;
+use crate::TypedTensor;
+
+use super::helpers::{
+    dim_i32, has_zero_dim, leading_upper_triangle_from_lapack, lower_triangle_from_lapack,
+    matrix_dims, matrix_with_batch_shape, panic_on_lapack_error, square_matrix_dim,
+    tensor_from_vec_with_template, transpose_col_major_data,
+};
+
+extern "C" {
+    #[link_name = "dgetc2_"]
+    fn dgetc2_ffi(
+        n: *const i32,
+        a: *mut f64,
+        lda: *const i32,
+        ipiv: *mut i32,
+        jpiv: *mut i32,
+        info: *mut i32,
+    );
+
+    #[link_name = "dgesc2_"]
+    fn dgesc2_ffi(
+        n: *const i32,
+        a: *const f64,
+        lda: *const i32,
+        rhs: *mut f64,
+        ipiv: *const i32,
+        jpiv: *const i32,
+        scale: *mut f64,
+    );
+
+    #[link_name = "zgetc2_"]
+    fn zgetc2_ffi(
+        n: *const i32,
+        a: *mut Complex64,
+        lda: *const i32,
+        ipiv: *mut i32,
+        jpiv: *mut i32,
+        info: *mut i32,
+    );
+
+    #[link_name = "zgesc2_"]
+    fn zgesc2_ffi(
+        n: *const i32,
+        a: *const Complex64,
+        lda: *const i32,
+        rhs: *mut Complex64,
+        ipiv: *const i32,
+        jpiv: *const i32,
+        scale: *mut f64,
+    );
+}
+
+pub(crate) trait LapackFullPivLu: Clone + Copy + Default {
+    fn one() -> Self;
+    fn negative_one() -> Self;
+    fn getc2(
+        n: i32,
+        data: &mut [Self],
+        lda: i32,
+        ipiv: &mut [i32],
+        jpiv: &mut [i32],
+        info: &mut i32,
+    );
+    fn gesc2(
+        n: i32,
+        data: &[Self],
+        lda: i32,
+        rhs: &mut [Self],
+        ipiv: &[i32],
+        jpiv: &[i32],
+        scale: &mut f64,
+    );
+    fn apply_inverse_scale(rhs: &mut [Self], scale: f64);
+}
+
+impl LapackFullPivLu for f64 {
+    fn one() -> Self {
+        1.0
+    }
+
+    fn negative_one() -> Self {
+        -1.0
+    }
+
+    fn getc2(
+        n: i32,
+        data: &mut [Self],
+        lda: i32,
+        ipiv: &mut [i32],
+        jpiv: &mut [i32],
+        info: &mut i32,
+    ) {
+        unsafe {
+            dgetc2_ffi(
+                &n,
+                data.as_mut_ptr(),
+                &lda,
+                ipiv.as_mut_ptr(),
+                jpiv.as_mut_ptr(),
+                info,
+            );
+        }
+    }
+
+    fn gesc2(
+        n: i32,
+        data: &[Self],
+        lda: i32,
+        rhs: &mut [Self],
+        ipiv: &[i32],
+        jpiv: &[i32],
+        scale: &mut f64,
+    ) {
+        unsafe {
+            dgesc2_ffi(
+                &n,
+                data.as_ptr(),
+                &lda,
+                rhs.as_mut_ptr(),
+                ipiv.as_ptr(),
+                jpiv.as_ptr(),
+                scale,
+            );
+        }
+    }
+
+    fn apply_inverse_scale(rhs: &mut [Self], scale: f64) {
+        if scale != 1.0 {
+            for value in rhs {
+                *value /= scale;
+            }
+        }
+    }
+}
+
+impl LapackFullPivLu for Complex64 {
+    fn one() -> Self {
+        Complex64::new(1.0, 0.0)
+    }
+
+    fn negative_one() -> Self {
+        Complex64::new(-1.0, 0.0)
+    }
+
+    fn getc2(
+        n: i32,
+        data: &mut [Self],
+        lda: i32,
+        ipiv: &mut [i32],
+        jpiv: &mut [i32],
+        info: &mut i32,
+    ) {
+        unsafe {
+            zgetc2_ffi(
+                &n,
+                data.as_mut_ptr(),
+                &lda,
+                ipiv.as_mut_ptr(),
+                jpiv.as_mut_ptr(),
+                info,
+            );
+        }
+    }
+
+    fn gesc2(
+        n: i32,
+        data: &[Self],
+        lda: i32,
+        rhs: &mut [Self],
+        ipiv: &[i32],
+        jpiv: &[i32],
+        scale: &mut f64,
+    ) {
+        unsafe {
+            zgesc2_ffi(
+                &n,
+                data.as_ptr(),
+                &lda,
+                rhs.as_mut_ptr(),
+                ipiv.as_ptr(),
+                jpiv.as_ptr(),
+                scale,
+            );
+        }
+    }
+
+    fn apply_inverse_scale(rhs: &mut [Self], scale: f64) {
+        if scale != 1.0 {
+            for value in rhs {
+                *value /= scale;
+            }
+        }
+    }
+}
+
+fn permutation_from_lapack_pivots(pivots: &[i32], op: &str) -> Vec<usize> {
+    let mut permutation: Vec<usize> = (0..pivots.len()).collect();
+    for (idx, &pivot_one_based) in pivots.iter().enumerate() {
+        let pivot = match usize::try_from(pivot_one_based - 1) {
+            Ok(pivot) if pivot < pivots.len() => pivot,
+            _ => panic!("{op}: LAPACK getc2 returned invalid pivot index"),
+        };
+        if pivot != idx {
+            permutation.swap(idx, pivot);
+        }
+    }
+    permutation
+}
+
+fn permutation_matrix<T: LapackFullPivLu>(permutation: &[usize]) -> Vec<T> {
+    let n = permutation.len();
+    let mut data = vec![T::default(); n * n];
+    for (row, &source) in permutation.iter().enumerate() {
+        data[row + source * n] = T::one();
+    }
+    data
+}
+
+fn factor_getc2<T: LapackFullPivLu>(
+    op: &'static str,
+    data: &mut [T],
+    n: usize,
+) -> (Vec<i32>, Vec<i32>, i32) {
+    let n_i32 = dim_i32(n, op);
+    let mut ipiv = vec![0_i32; n];
+    let mut jpiv = vec![0_i32; n];
+    let mut info = 0;
+    T::getc2(n_i32, data, n_i32, &mut ipiv, &mut jpiv, &mut info);
+    panic_on_lapack_error(op, "getc2", info.min(0));
+    (ipiv, jpiv, info)
+}
+
+fn full_piv_lu_2d<T: LapackFullPivLu>(
+    _buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> Vec<TypedTensor<T>> {
+    let n = square_matrix_dim(input, "full_piv_lu");
+    let mut lu = input.host_data().to_vec();
+    let (ipiv, jpiv, _info) = factor_getc2("full_piv_lu", &mut lu, n);
+
+    let row_perm = permutation_from_lapack_pivots(&ipiv, "full_piv_lu");
+    let col_perm = permutation_from_lapack_pivots(&jpiv, "full_piv_lu");
+    let p_data = permutation_matrix::<T>(&row_perm);
+    let q_data = permutation_matrix::<T>(&col_perm);
+    let mut l_data = lower_triangle_from_lapack(&lu, n, n);
+    for index in 0..n {
+        l_data[index + index * n] = T::one();
+    }
+    let u_data = leading_upper_triangle_from_lapack(&lu, n, n, n);
+    let row_swap_count = ipiv
+        .iter()
+        .enumerate()
+        .filter(|(idx, row)| **row != (*idx as i32 + 1))
+        .count();
+    let col_swap_count = jpiv
+        .iter()
+        .enumerate()
+        .filter(|(idx, col)| **col != (*idx as i32 + 1))
+        .count();
+    let parity = if (row_swap_count + col_swap_count) % 2 == 0 {
+        T::one()
+    } else {
+        T::negative_one()
+    };
+
+    vec![
+        tensor_from_vec_with_template(vec![n, n], p_data, input),
+        tensor_from_vec_with_template(vec![n, n], l_data, input),
+        tensor_from_vec_with_template(vec![n, n], u_data, input),
+        tensor_from_vec_with_template(vec![n, n], q_data, input),
+        tensor_from_vec_with_template(vec![], vec![parity], input),
+    ]
+}
+
+fn solve_2d<T: LapackFullPivLu>(
+    _buffers: &mut BufferPool,
+    a: &TypedTensor<T>,
+    b: &TypedTensor<T>,
+    transpose_a: bool,
+) -> crate::Result<TypedTensor<T>> {
+    let n = square_matrix_dim(a, "full_piv_lu_solve");
+    let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve");
+    assert_eq!(b_rows, n, "full_piv_lu_solve: rhs row count mismatch");
+
+    let mut lu = if transpose_a {
+        transpose_col_major_data(a.host_data(), n, n)
+    } else {
+        a.host_data().to_vec()
+    };
+    let (ipiv, jpiv, info) = factor_getc2("full_piv_lu_solve", &mut lu, n);
+    if info > 0 {
+        return Err(crate::Error::BackendFailure {
+            op: "full_piv_lu_solve",
+            message: "matrix is singular".into(),
+        });
+    }
+
+    let mut rhs = b.host_data().to_vec();
+    let n_i32 = dim_i32(n, "full_piv_lu_solve");
+    for col in 0..b_cols {
+        let start = col * n;
+        let end = start + n;
+        let mut scale = 1.0;
+        T::gesc2(
+            n_i32,
+            &lu,
+            n_i32,
+            &mut rhs[start..end],
+            &ipiv,
+            &jpiv,
+            &mut scale,
+        );
+        T::apply_inverse_scale(&mut rhs[start..end], scale);
+    }
+
+    Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs, b))
+}
+
+fn batched_binary_result<T, F>(
+    buffers: &mut BufferPool,
+    a: &TypedTensor<T>,
+    b: &TypedTensor<T>,
+    op: F,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: Clone,
+    F: Fn(&mut BufferPool, &TypedTensor<T>, &TypedTensor<T>) -> crate::Result<TypedTensor<T>>,
+{
+    let (a_core_shape, a_batch_shape) =
+        super::helpers::split_core_and_batch(a, 2, "batched_binary_result");
+    let (b_core_shape, b_batch_shape) =
+        super::helpers::split_core_and_batch(b, 2, "batched_binary_result");
+    assert_eq!(
+        a_batch_shape, b_batch_shape,
+        "batched_binary_result: batch shape mismatch"
+    );
+
+    if a_batch_shape.is_empty() {
+        return op(buffers, a, b);
+    }
+
+    let a_slice_size: usize = a_core_shape.iter().product();
+    let b_slice_size: usize = b_core_shape.iter().product();
+    let batch_count: usize = a_batch_shape.iter().product();
+    assert!(
+        batch_count > 0,
+        "batched_binary_result: zero-sized batch dims are unsupported"
+    );
+
+    let mut out_core_shape: Option<Vec<usize>> = None;
+    let mut out_data: Option<Vec<T>> = None;
+
+    for batch_idx in 0..batch_count {
+        let a_start = batch_idx * a_slice_size;
+        let a_end = a_start + a_slice_size;
+        let b_start = batch_idx * b_slice_size;
+        let b_end = b_start + b_slice_size;
+
+        let batch_a = tensor_from_vec_with_template(
+            a_core_shape.to_vec(),
+            a.host_data()[a_start..a_end].to_vec(),
+            a,
+        );
+        let batch_b = tensor_from_vec_with_template(
+            b_core_shape.to_vec(),
+            b.host_data()[b_start..b_end].to_vec(),
+            b,
+        );
+        let batch_output = op(buffers, &batch_a, &batch_b)?;
+
+        if let Some(expected_shape) = &out_core_shape {
+            assert_eq!(
+                batch_output.shape.as_slice(),
+                expected_shape.as_slice(),
+                "batched_binary_result: output core shape mismatch across batches"
+            );
+        } else {
+            out_data = Some(Vec::with_capacity(batch_output.n_elements() * batch_count));
+            out_core_shape = Some(batch_output.shape.clone());
+        }
+
+        match &mut out_data {
+            Some(data) => data.extend_from_slice(batch_output.host_data()),
+            None => panic!("batched_binary_result: missing output buffer"),
+        }
+    }
+
+    let mut out_shape = match out_core_shape {
+        Some(shape) => shape,
+        None => panic!("batched_binary_result: missing output shape"),
+    };
+    out_shape.extend_from_slice(a_batch_shape);
+    Ok(tensor_from_vec_with_template(
+        out_shape,
+        match out_data {
+            Some(data) => data,
+            None => panic!("batched_binary_result: missing output data"),
+        },
+        b,
+    ))
+}
+
+pub(crate) fn full_piv_lu<T: LapackFullPivLu>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> Vec<TypedTensor<T>> {
+    if has_zero_dim(&input.shape) {
+        let n = input.shape[0];
+        let batch_shape = &input.shape[2..];
+        let parity_elements = if batch_shape.is_empty() {
+            1
+        } else {
+            batch_shape.iter().product()
+        };
+        return vec![
+            tensor_from_vec_with_template(
+                matrix_with_batch_shape(n, n, batch_shape),
+                Vec::new(),
+                input,
+            ),
+            tensor_from_vec_with_template(
+                matrix_with_batch_shape(n, n, batch_shape),
+                Vec::new(),
+                input,
+            ),
+            tensor_from_vec_with_template(
+                matrix_with_batch_shape(n, n, batch_shape),
+                Vec::new(),
+                input,
+            ),
+            tensor_from_vec_with_template(
+                matrix_with_batch_shape(n, n, batch_shape),
+                Vec::new(),
+                input,
+            ),
+            tensor_from_vec_with_template(
+                batch_shape.to_vec(),
+                vec![T::one(); parity_elements],
+                input,
+            ),
+        ];
+    }
+    super::helpers::batched_multi(buffers, input, full_piv_lu_2d)
+}
+
+pub(crate) fn full_piv_lu_solve<T: LapackFullPivLu>(
+    buffers: &mut BufferPool,
+    a: &TypedTensor<T>,
+    b: &TypedTensor<T>,
+    transpose_a: bool,
+) -> crate::Result<TypedTensor<T>> {
+    if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
+        return Ok(tensor_from_vec_with_template(
+            b.shape.clone(),
+            Vec::new(),
+            b,
+        ));
+    }
+    batched_binary_result(buffers, a, b, |buffers, a, b| {
+        solve_2d(buffers, a, b, transpose_a)
+    })
+}

--- a/tenferro-tensor/src/cpu/linalg/mod.rs
+++ b/tenferro-tensor/src/cpu/linalg/mod.rs
@@ -6,6 +6,10 @@ pub mod lapack_linalg;
 
 #[cfg(feature = "cpu-faer")]
 pub(crate) use faer_linalg::{cholesky, eig, eigh, lu, qr, svd, triangular_solve};
+#[cfg(feature = "cpu-faer")]
+pub(crate) use faer_linalg::{full_piv_lu, full_piv_lu_solve};
 
 #[cfg(feature = "cpu-blas")]
 pub(crate) use lapack_linalg::{cholesky, eig, eigh, lu, qr, svd, triangular_solve};
+#[cfg(feature = "cpu-blas")]
+pub(crate) use lapack_linalg::{full_piv_lu, full_piv_lu_solve};

--- a/tenferro-tensor/src/cubecl/linalg.rs
+++ b/tenferro-tensor/src/cubecl/linalg.rs
@@ -153,6 +153,28 @@ pub(super) fn lu(backend: &mut CubeclBackend, input: &Tensor) -> crate::Result<V
     }
 }
 
+pub(super) fn full_piv_lu(
+    _backend: &mut CubeclBackend,
+    _input: &Tensor,
+) -> crate::Result<Vec<Tensor>> {
+    Err(crate::Error::BackendFailure {
+        op: "full_piv_lu",
+        message: "complete-pivoting LU is not implemented for the CubeCL backend".into(),
+    })
+}
+
+pub(super) fn full_piv_lu_solve(
+    _backend: &mut CubeclBackend,
+    _a: &Tensor,
+    _b: &Tensor,
+    _transpose_a: bool,
+) -> crate::Result<Tensor> {
+    Err(crate::Error::BackendFailure {
+        op: "full_piv_lu_solve",
+        message: "complete-pivoting LU solve is not implemented for the CubeCL backend".into(),
+    })
+}
+
 pub(super) fn svd(backend: &mut CubeclBackend, input: &Tensor) -> crate::Result<Vec<Tensor>> {
     match input {
         Tensor::F32(t) => svd_typed(backend, t)

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -2484,6 +2484,19 @@ impl TensorBackend for CubeclBackend {
         linalg::lu(self, input)
     }
 
+    fn full_piv_lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        linalg::full_piv_lu(self, input)
+    }
+
+    fn full_piv_lu_solve(
+        &mut self,
+        a: &Tensor,
+        b: &Tensor,
+        transpose_a: bool,
+    ) -> crate::Result<Tensor> {
+        linalg::full_piv_lu_solve(self, a, b, transpose_a)
+    }
+
     fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         linalg::svd(self, input)
     }

--- a/tenferro-tensor/src/inject.rs
+++ b/tenferro-tensor/src/inject.rs
@@ -5,6 +5,7 @@
 //! - `provider-inject`
 
 use cblas_inject::{CgemmFnPtr, DgemmFnPtr, SgemmFnPtr, ZgemmFnPtr};
+use lapack_inject::{Dgesc2FnPtr, Dgetc2FnPtr, Zgesc2FnPtr, Zgetc2FnPtr};
 
 /// Set of CBLAS GEMM function pointers to register in one call.
 ///
@@ -92,5 +93,99 @@ pub unsafe fn register_blas_gemm_fn_ptrs(ptrs: BlasGemmFnPtrSet) {
     }
     if let Some(f) = ptrs.zgemm {
         unsafe { cblas_inject::register_zgemm(f) };
+    }
+}
+
+/// Set of LAPACK complete-pivoting LU function pointers to register.
+///
+/// tenferro currently uses `xGETC2` for the factorization and `xGESC2` for
+/// solves. Any field set to `None` is skipped.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tensor::inject::{
+///     register_lapack_full_piv_lu_fn_ptrs, LapackFullPivLuFnPtrSet,
+/// };
+///
+/// unsafe {
+///     register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet {
+///         dgetc2: Some(dgetc2_ptr),
+///         dgesc2: Some(dgesc2_ptr),
+///         ..LapackFullPivLuFnPtrSet::new()
+///     });
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LapackFullPivLuFnPtrSet {
+    /// Fortran `dgetc2` function pointer.
+    pub dgetc2: Option<Dgetc2FnPtr>,
+    /// Fortran `dgesc2` function pointer.
+    pub dgesc2: Option<Dgesc2FnPtr>,
+    /// Fortran `zgetc2` function pointer.
+    pub zgetc2: Option<Zgetc2FnPtr>,
+    /// Fortran `zgesc2` function pointer.
+    pub zgesc2: Option<Zgesc2FnPtr>,
+}
+
+impl LapackFullPivLuFnPtrSet {
+    /// Create an empty set (all pointers are `None`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::inject::LapackFullPivLuFnPtrSet;
+    ///
+    /// let ptrs = LapackFullPivLuFnPtrSet::new();
+    /// assert!(ptrs.dgetc2.is_none());
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            dgetc2: None,
+            dgesc2: None,
+            zgetc2: None,
+            zgesc2: None,
+        }
+    }
+}
+
+/// Register LAPACK complete-pivoting LU function pointers in one call.
+///
+/// This is a thin bulk wrapper over `lapack-inject`'s per-symbol
+/// `register_*` functions.
+///
+/// # Safety
+///
+/// Each provided function pointer must have the exact Fortran LAPACK ABI
+/// expected by `lapack-inject`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tensor::inject::{
+///     register_lapack_full_piv_lu_fn_ptrs, LapackFullPivLuFnPtrSet,
+/// };
+///
+/// unsafe {
+///     register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet {
+///         dgetc2: Some(dgetc2_ptr),
+///         dgesc2: Some(dgesc2_ptr),
+///         zgetc2: Some(zgetc2_ptr),
+///         zgesc2: Some(zgesc2_ptr),
+///     });
+/// }
+/// ```
+pub unsafe fn register_lapack_full_piv_lu_fn_ptrs(ptrs: LapackFullPivLuFnPtrSet) {
+    if let Some(f) = ptrs.dgetc2 {
+        unsafe { lapack_inject::register_dgetc2(f) };
+    }
+    if let Some(f) = ptrs.dgesc2 {
+        unsafe { lapack_inject::register_dgesc2(f) };
+    }
+    if let Some(f) = ptrs.zgetc2 {
+        unsafe { lapack_inject::register_zgetc2(f) };
+    }
+    if let Some(f) = ptrs.zgesc2 {
+        unsafe { lapack_inject::register_zgesc2(f) };
     }
 }

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -52,6 +52,8 @@ extern crate blas_src as _;
 extern crate cblas_inject as _;
 #[cfg(feature = "provider-src")]
 extern crate cblas_src as _;
+#[cfg(feature = "provider-inject")]
+extern crate lapack_inject as _;
 #[cfg(feature = "provider-src")]
 extern crate lapack_src as _;
 

--- a/tenferro-tensor/src/rocm/mod.rs
+++ b/tenferro-tensor/src/rocm/mod.rs
@@ -210,6 +210,17 @@ macro_rules! impl_stub_backend {
             fn lu(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " lu"))
             }
+            fn full_piv_lu(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
+                todo!(concat!($label, " full_piv_lu"))
+            }
+            fn full_piv_lu_solve(
+                &mut self,
+                _a: &Tensor,
+                _b: &Tensor,
+                _transpose_a: bool,
+            ) -> crate::Result<Tensor> {
+                todo!(concat!($label, " full_piv_lu_solve"))
+            }
             fn svd(&mut self, _input: &Tensor) -> crate::Result<Vec<Tensor>> {
                 todo!(concat!($label, " svd"))
             }

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -859,6 +859,32 @@ impl Tensor {
         ctx.with_exec_session(|exec| unpack_four("lu", exec.lu(self)?))
     }
 
+    /// LU decomposition with complete pivoting: `P A Q^T = L U`.
+    ///
+    /// Returns `(P, L, U, Q, parity)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]);
+    /// let (p, l, u, q, parity) = a.full_piv_lu(&mut ctx).unwrap();
+    ///
+    /// assert_eq!(p.shape(), &[2, 2]);
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// assert_eq!(u.shape(), &[2, 2]);
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(parity.shape(), &[] as &[usize]);
+    /// ```
+    pub fn full_piv_lu(
+        &self,
+        ctx: &mut impl TensorBackend,
+    ) -> crate::Result<(Self, Self, Self, Self, Self)> {
+        ctx.with_exec_session(|exec| unpack_five("full_piv_lu", exec.full_piv_lu(self)?))
+    }
+
     /// Cholesky decomposition: `A = L L^T` or `A = L L^H` for complex inputs.
     ///
     /// Returns the lower-triangular factor `L`.
@@ -934,6 +960,25 @@ impl Tensor {
     /// ```
     pub fn solve(&self, b: &Self, ctx: &mut impl TensorBackend) -> crate::Result<Self> {
         ctx.solve(self, b)
+    }
+
+    /// Solve `A x = b` using complete-pivoting LU factorization.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorBackend, cpu::CpuBackend};
+    ///
+    /// let mut ctx = CpuBackend::new();
+    /// let a = Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]);
+    /// let b = Tensor::from_vec(vec![2, 1], vec![-1.0_f64, 5.0]);
+    /// let x = a.full_piv_lu_solve(&b, &mut ctx).unwrap();
+    ///
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// assert_eq!(x.as_slice::<f64>().unwrap(), &[4.0, -1.0]);
+    /// ```
+    pub fn full_piv_lu_solve(&self, b: &Self, ctx: &mut impl TensorBackend) -> crate::Result<Self> {
+        ctx.full_piv_lu_solve(self, b, false)
     }
 
     /// Solve a triangular system.
@@ -1148,5 +1193,24 @@ fn unpack_four(
     ) {
         (Some(a), Some(b), Some(c), Some(d), None) => Ok((a, b, c, d)),
         _ => Err(invalid_output_count(op, 4, actual)),
+    }
+}
+
+fn unpack_five(
+    op: &'static str,
+    results: Vec<Tensor>,
+) -> crate::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
+    let actual = results.len();
+    let mut iter = results.into_iter();
+    match (
+        iter.next(),
+        iter.next(),
+        iter.next(),
+        iter.next(),
+        iter.next(),
+        iter.next(),
+    ) {
+        (Some(a), Some(b), Some(c), Some(d), Some(e), None) => Ok((a, b, c, d, e)),
+        _ => Err(invalid_output_count(op, 5, actual)),
     }
 }

--- a/tenferro-tensor/tests/full_piv_lu.rs
+++ b/tenferro-tensor/tests/full_piv_lu.rs
@@ -1,0 +1,88 @@
+use tenferro_tensor::{cpu::CpuBackend, DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
+
+fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
+    Tensor::F64(TypedTensor::from_vec(shape, data))
+}
+
+fn f64_data(tensor: &Tensor) -> &[f64] {
+    tensor.as_slice::<f64>().expect("expected f64 tensor")
+}
+
+fn matmul(backend: &mut CpuBackend, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+    backend
+        .dot_general(
+            lhs,
+            rhs,
+            &DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        )
+        .unwrap()
+}
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).abs() <= 1.0e-10,
+            "index {index}: expected {expected}, got {actual}"
+        );
+    }
+}
+
+#[test]
+fn full_piv_lu_reconstructs_permuted_matrix() {
+    let a = f64_tensor(vec![2, 2], vec![0.0, 2.0, 1.0, 3.0]);
+    let mut backend = CpuBackend::new();
+
+    let (p, l, u, q, parity) = a.full_piv_lu(&mut backend).unwrap();
+    let pa = matmul(&mut backend, &p, &a);
+    let qt = backend.transpose(&q, &[1, 0]).unwrap();
+    let paqt = matmul(&mut backend, &pa, &qt);
+    let lu = matmul(&mut backend, &l, &u);
+
+    assert_eq!(p.shape(), &[2, 2]);
+    assert_eq!(l.shape(), &[2, 2]);
+    assert_eq!(u.shape(), &[2, 2]);
+    assert_eq!(q.shape(), &[2, 2]);
+    assert_eq!(parity.shape(), &[] as &[usize]);
+    assert_close(f64_data(&paqt), f64_data(&lu));
+}
+
+#[test]
+fn full_piv_lu_uses_column_pivot_when_max_pivot_is_off_column() {
+    let a = f64_tensor(vec![2, 2], vec![1.0, 2.0, 100.0, 3.0]);
+    let mut backend = CpuBackend::new();
+
+    let (_p, _l, u, q, _parity) = a.full_piv_lu(&mut backend).unwrap();
+
+    assert_close(f64_data(&q), &[0.0, 1.0, 1.0, 0.0]);
+    assert_close(&f64_data(&u)[..1], &[100.0]);
+}
+
+#[test]
+fn full_piv_lu_solve_returns_expected_solution() {
+    let a = f64_tensor(vec![2, 2], vec![0.0, 2.0, 1.0, 3.0]);
+    let b = f64_tensor(vec![2, 1], vec![-1.0, 5.0]);
+    let mut backend = CpuBackend::new();
+
+    let x = a.full_piv_lu_solve(&b, &mut backend).unwrap();
+
+    assert_eq!(x.shape(), &[2, 1]);
+    assert_close(f64_data(&x), &[4.0, -1.0]);
+}
+
+#[test]
+fn full_piv_lu_solve_accepts_vector_rhs() {
+    let a = f64_tensor(vec![2, 2], vec![0.0, 2.0, 1.0, 3.0]);
+    let b = f64_tensor(vec![2], vec![-1.0, 5.0]);
+    let mut backend = CpuBackend::new();
+
+    let x = a.full_piv_lu_solve(&b, &mut backend).unwrap();
+
+    assert_eq!(x.shape(), &[2]);
+    assert_close(f64_data(&x), &[4.0, -1.0]);
+}

--- a/tenferro-tensor/tests/inject_tests.rs
+++ b/tenferro-tensor/tests/inject_tests.rs
@@ -5,17 +5,27 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Once;
 
 use tenferro_tensor::cpu::CpuBackend;
-use tenferro_tensor::inject::{register_blas_gemm_fn_ptrs, BlasGemmFnPtrSet};
+use tenferro_tensor::inject::{
+    register_blas_gemm_fn_ptrs, register_lapack_full_piv_lu_fn_ptrs, BlasGemmFnPtrSet,
+    LapackFullPivLuFnPtrSet,
+};
 use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
 
 static REGISTER_ONCE: Once = Once::new();
 static DGEMM_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DGETC2_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DGESC2_CALLS: AtomicUsize = AtomicUsize::new(0);
 
 fn register_test_ptrs_once() {
     REGISTER_ONCE.call_once(|| unsafe {
         register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet {
             dgemm: Some(test_dgemm),
             ..BlasGemmFnPtrSet::new()
+        });
+        register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet {
+            dgetc2: Some(test_dgetc2),
+            dgesc2: Some(test_dgesc2),
+            ..LapackFullPivLuFnPtrSet::new()
         });
     });
 }
@@ -61,6 +71,43 @@ unsafe extern "C" fn test_dgemm(
     }
 }
 
+unsafe extern "C" fn test_dgetc2(
+    n: *const lapack_inject::lapackint,
+    _a: *mut f64,
+    _lda: *const lapack_inject::lapackint,
+    ipiv: *mut lapack_inject::lapackint,
+    jpiv: *mut lapack_inject::lapackint,
+    info: *mut lapack_inject::lapackint,
+) {
+    DGETC2_CALLS.fetch_add(1, Ordering::SeqCst);
+    let n = unsafe { *n as usize };
+    for index in 0..n {
+        let one_based = (index + 1) as lapack_inject::lapackint;
+        unsafe {
+            *ipiv.add(index) = one_based;
+            *jpiv.add(index) = one_based;
+        }
+    }
+    unsafe {
+        *info = 0;
+    }
+}
+
+unsafe extern "C" fn test_dgesc2(
+    _n: *const lapack_inject::lapackint,
+    _a: *const f64,
+    _lda: *const lapack_inject::lapackint,
+    _rhs: *mut f64,
+    _ipiv: *const lapack_inject::lapackint,
+    _jpiv: *const lapack_inject::lapackint,
+    scale: *mut f64,
+) {
+    DGESC2_CALLS.fetch_add(1, Ordering::SeqCst);
+    unsafe {
+        *scale = 1.0;
+    }
+}
+
 #[test]
 fn provider_inject_dot_general_uses_registered_blas() {
     register_test_ptrs_once();
@@ -84,6 +131,26 @@ fn provider_inject_dot_general_uses_registered_blas() {
     assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
     match c {
         Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[19.0, 43.0, 22.0, 50.0]),
+        _ => panic!("expected f64 tensor"),
+    }
+}
+
+#[test]
+fn provider_inject_full_piv_lu_solve_uses_registered_lapack() {
+    register_test_ptrs_once();
+    DGETC2_CALLS.store(0, Ordering::SeqCst);
+    DGESC2_CALLS.store(0, Ordering::SeqCst);
+
+    let a = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0]));
+    let b = Tensor::F64(TypedTensor::from_vec(vec![2, 1], vec![4.0, 8.0]));
+
+    let mut backend = CpuBackend::new();
+    let x = backend.full_piv_lu_solve(&a, &b, false);
+
+    assert_eq!(DGETC2_CALLS.load(Ordering::SeqCst), 1);
+    assert_eq!(DGESC2_CALLS.load(Ordering::SeqCst), 1);
+    match x {
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[4.0, 8.0]),
         _ => panic!("expected f64 tensor"),
     }
 }

--- a/tenferro/src/compiler/mod.rs
+++ b/tenferro/src/compiler/mod.rs
@@ -201,6 +201,10 @@ fn std_to_exec_op(op: &StdTensorOp) -> ExecOp {
         StdTensorOp::PadToMatch { axis } => ExecOp::PadToMatch { axis: *axis },
         StdTensorOp::Cholesky { .. } => ExecOp::Cholesky,
         StdTensorOp::Lu { .. } => ExecOp::Lu,
+        StdTensorOp::FullPivLu { .. } => ExecOp::FullPivLu,
+        StdTensorOp::FullPivLuSolve { transpose_a } => ExecOp::FullPivLuSolve {
+            transpose_a: *transpose_a,
+        },
         StdTensorOp::Svd { eps, .. } => ExecOp::Svd { eps: *eps },
         StdTensorOp::Qr { .. } => ExecOp::Qr,
         StdTensorOp::Eigh { eps, .. } => ExecOp::Eigh { eps: *eps },

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -120,6 +120,10 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
             StdTensorOp::Svd { .. } => exec.svd(inputs[0])?,
             StdTensorOp::Qr { .. } => exec.qr(inputs[0])?,
             StdTensorOp::Lu { .. } => exec.lu(inputs[0])?,
+            StdTensorOp::FullPivLu { .. } => exec.full_piv_lu(inputs[0])?,
+            StdTensorOp::FullPivLuSolve { transpose_a } => {
+                vec![exec.full_piv_lu_solve(inputs[0], inputs[1], *transpose_a)?]
+            }
             StdTensorOp::Eigh { .. } => exec.eigh(inputs[0])?,
             StdTensorOp::Eig { .. } => exec.eig(inputs[0])?,
             StdTensorOp::ShapeOf { axis } => {

--- a/tenferro/src/eager_ops_linalg.rs
+++ b/tenferro/src/eager_ops_linalg.rs
@@ -90,6 +90,58 @@ impl<B: TensorBackend> EagerTensor<B> {
         }
     }
 
+    /// LU decomposition with complete pivoting: `P A Q^T = L U`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]));
+    /// let (p, l, u, q, parity) = a.full_piv_lu().unwrap();
+    ///
+    /// assert_eq!(p.data().shape(), &[2, 2]);
+    /// assert_eq!(l.data().shape(), &[2, 2]);
+    /// assert_eq!(u.data().shape(), &[2, 2]);
+    /// assert_eq!(q.data().shape(), &[2, 2]);
+    /// assert_eq!(parity.data().shape(), &[] as &[usize]);
+    /// ```
+    pub fn full_piv_lu(&self) -> Result<(Self, Self, Self, Self, Self)> {
+        let mut outputs = self
+            .multi_output_unary_op(StdTensorOp::FullPivLu, 5)?
+            .into_iter();
+        match (
+            outputs.next(),
+            outputs.next(),
+            outputs.next(),
+            outputs.next(),
+            outputs.next(),
+            outputs.next(),
+        ) {
+            (Some(p), Some(l), Some(u), Some(q), Some(parity), None) => Ok((p, l, u, q, parity)),
+            _ => Err(Error::Internal(
+                "full_piv_lu eager op returned an unexpected number of outputs".to_string(),
+            )),
+        }
+    }
+
+    /// Solve `A x = b` using complete-pivoting LU factorization.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]));
+    /// let b = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![-1.0_f64, 5.0]));
+    /// let x = a.full_piv_lu_solve(&b).unwrap();
+    ///
+    /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[4.0, -1.0]);
+    /// ```
+    pub fn full_piv_lu_solve(&self, b: &Self) -> Result<Self> {
+        self.binary_op(b, StdTensorOp::FullPivLuSolve { transpose_a: false })
+    }
+
     /// Cholesky factorization: `A = L L^T` for real inputs.
     ///
     /// # Examples

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -119,6 +119,10 @@ pub enum ExecOp {
     },
     Qr,
     Lu,
+    FullPivLu,
+    FullPivLuSolve {
+        transpose_a: bool,
+    },
     Eigh {
         eps: f64,
     },
@@ -218,6 +222,8 @@ pub(crate) fn is_ffi_instruction(inst: &ExecInstruction) -> bool {
             | ExecOp::Svd { .. }
             | ExecOp::Qr
             | ExecOp::Lu
+            | ExecOp::FullPivLu
+            | ExecOp::FullPivLuSolve { .. }
             | ExecOp::Eigh { .. }
             | ExecOp::Eig
             | ExecOp::TriangularSolve { .. }
@@ -554,6 +560,18 @@ pub(crate) fn execute_ffi_instruction<B: TensorBackend>(
         ExecOp::Lu => {
             let results = backend.lu(get(slots, &inst.input_slots, 0)?)?;
             assign_multi_output(slots, inst, results, "lu")?;
+        }
+        ExecOp::FullPivLu => {
+            let results = backend.full_piv_lu(get(slots, &inst.input_slots, 0)?)?;
+            assign_multi_output(slots, inst, results, "full_piv_lu")?;
+        }
+        ExecOp::FullPivLuSolve { transpose_a } => {
+            let result = backend.full_piv_lu_solve(
+                get(slots, &inst.input_slots, 0)?,
+                get(slots, &inst.input_slots, 1)?,
+                *transpose_a,
+            )?;
+            slots[inst.output_slots[0]] = Some(result);
         }
         ExecOp::Eigh { .. } => {
             let results = backend.eigh(get(slots, &inst.input_slots, 0)?)?;

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -41,8 +41,9 @@ pub mod traced;
 pub use eager::{EagerContext, EagerTensor};
 pub use engine::Engine;
 pub use linalg_api::{
-    cholesky, convert, det, eig, eigh, eigh_with_eps, eigvals, eigvalsh, inv, lu, norm, pinv,
-    pinv_with_rtol, qr, slogdet, solve, svd, svd_with_eps, triangular_solve,
+    cholesky, convert, det, eig, eigh, eigh_with_eps, eigvals, eigvalsh, full_piv_lu,
+    full_piv_lu_solve, inv, lu, norm, pinv, pinv_with_rtol, qr, slogdet, solve, svd, svd_with_eps,
+    triangular_solve,
 };
 pub use sym_dim::SymDim;
 pub use tenferro_tensor::cpu::CpuBackend;

--- a/tenferro/src/linalg_api.rs
+++ b/tenferro/src/linalg_api.rs
@@ -197,6 +197,77 @@ pub fn lu(a: &TracedTensor) -> (TracedTensor, TracedTensor, TracedTensor, Traced
     }
 }
 
+/// LU decomposition with complete pivoting.
+///
+/// Returns `(P, L, U, Q, parity)` where `P @ A @ Q.T = L @ U`.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::{full_piv_lu, CpuBackend, Engine, Tensor, TracedTensor};
+///
+/// let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(
+///     vec![2, 2],
+///     vec![0.0_f64, 2.0, 1.0, 3.0],
+/// ));
+/// let (mut p, mut l, mut u, mut q, mut parity) = full_piv_lu(&a);
+///
+/// let mut engine = Engine::new(CpuBackend::new());
+/// let outputs = tenferro::traced::eval_all(
+///     &mut engine,
+///     &mut [&mut p, &mut l, &mut u, &mut q, &mut parity],
+/// )
+/// .unwrap();
+///
+/// assert_eq!(outputs[0].shape(), &[2, 2]);
+/// assert_eq!(outputs[4].shape(), &[] as &[usize]);
+/// ```
+pub fn full_piv_lu(
+    a: &TracedTensor,
+) -> (
+    TracedTensor,
+    TracedTensor,
+    TracedTensor,
+    TracedTensor,
+    TracedTensor,
+) {
+    let shape = concrete_shape(a);
+    let n = shape[0];
+    let batch = &shape[2..];
+    let mut p_shape = vec![n, n];
+    p_shape.extend_from_slice(batch);
+    let mut l_shape = vec![n, n];
+    l_shape.extend_from_slice(batch);
+    let mut u_shape = vec![n, n];
+    u_shape.extend_from_slice(batch);
+    let mut q_shape = vec![n, n];
+    q_shape.extend_from_slice(batch);
+    let parity_shape = batch.to_vec();
+    let mut results = apply_multi_output(
+        StdTensorOp::FullPivLu,
+        a,
+        vec![
+            sym_shape(&p_shape),
+            sym_shape(&l_shape),
+            sym_shape(&u_shape),
+            sym_shape(&q_shape),
+            sym_shape(&parity_shape),
+        ],
+    )
+    .into_iter();
+    match (
+        results.next(),
+        results.next(),
+        results.next(),
+        results.next(),
+        results.next(),
+        results.next(),
+    ) {
+        (Some(p), Some(l), Some(u), Some(q), Some(parity), None) => (p, l, u, q, parity),
+        _ => unreachable!("full_piv_lu must produce exactly five outputs"),
+    }
+}
+
 /// Non-symmetric eigendecomposition.
 ///
 /// For real `f64` input, both outputs are `Complex64`.
@@ -270,6 +341,57 @@ pub fn solve(a: &TracedTensor, b: &TracedTensor) -> TracedTensor {
         x2d.reshape(&b_shape)
     } else {
         do_solve(a, b)
+    }
+}
+
+/// Solve a linear system using complete-pivoting LU factorization.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::{full_piv_lu_solve, CpuBackend, Engine, Tensor, TracedTensor};
+///
+/// let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(
+///     vec![2, 2],
+///     vec![0.0_f64, 2.0, 1.0, 3.0],
+/// ));
+/// let b = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(
+///     vec![2, 1],
+///     vec![-1.0_f64, 5.0],
+/// ));
+/// let mut x = full_piv_lu_solve(&a, &b);
+///
+/// let mut engine = Engine::new(CpuBackend::new());
+/// let out = x.eval(&mut engine).unwrap();
+///
+/// assert_eq!(out.shape(), &[2, 1]);
+/// assert_eq!(out.as_slice::<f64>().unwrap(), &[4.0, -1.0]);
+/// ```
+pub fn full_piv_lu_solve(a: &TracedTensor, b: &TracedTensor) -> TracedTensor {
+    let a_shape = concrete_shape(a);
+    let b_shape = concrete_shape(b);
+    if has_zero_dim(&a_shape) || has_zero_dim(&b_shape) {
+        return zeros_like(b);
+    }
+
+    if let Some(matrix_rhs_shape) = batched_vector_rhs_shape(a, b) {
+        let b2d = b.reshape(&matrix_rhs_shape);
+        let x2d = apply_binary(
+            StdTensorOp::FullPivLuSolve { transpose_a: false },
+            a,
+            &b2d,
+            matrix_rhs_shape.len(),
+            Some(sym_shape(&matrix_rhs_shape)),
+        );
+        x2d.reshape(&b_shape)
+    } else {
+        apply_binary(
+            StdTensorOp::FullPivLuSolve { transpose_a: false },
+            a,
+            b,
+            b.rank,
+            b.shape_hint.clone(),
+        )
     }
 }
 

--- a/tenferro/src/shape_infer.rs
+++ b/tenferro/src/shape_infer.rs
@@ -71,6 +71,8 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         | StdTensorOp::NaryEinsum { .. }
         | StdTensorOp::Cholesky { .. }
         | StdTensorOp::Lu { .. }
+        | StdTensorOp::FullPivLu { .. }
+        | StdTensorOp::FullPivLuSolve { .. }
         | StdTensorOp::Svd { .. }
         | StdTensorOp::Qr { .. }
         | StdTensorOp::Eigh { .. }
@@ -188,12 +190,15 @@ pub fn infer_output_shapes(op: &StdTensorOp, input_shapes: &[&[DimExpr]]) -> Vec
             *axis,
         )],
         StdTensorOp::Lu { .. } => lu_shapes(require_input(op, input_shapes, 0)),
+        StdTensorOp::FullPivLu { .. } => full_piv_lu_shapes(require_input(op, input_shapes, 0)),
         StdTensorOp::Svd { .. } => svd_shapes(require_input(op, input_shapes, 0)),
         StdTensorOp::Qr { .. } => qr_shapes(require_input(op, input_shapes, 0)),
         StdTensorOp::Eigh { .. } | StdTensorOp::Eig { .. } => {
             eig_like_shapes(require_input(op, input_shapes, 0))
         }
-        StdTensorOp::TriangularSolve { .. } => vec![require_input(op, input_shapes, 1).to_vec()],
+        StdTensorOp::TriangularSolve { .. } | StdTensorOp::FullPivLuSolve { .. } => {
+            vec![require_input(op, input_shapes, 1).to_vec()]
+        }
         StdTensorOp::Extension(ext) => {
             let metas = infer_extension_output_meta(ext.as_ref(), &[], input_shapes);
             metas.into_iter().map(|(_dtype, shape)| shape).collect()
@@ -637,6 +642,19 @@ fn lu_shapes(input_shape: &[DimExpr]) -> Vec<Vec<DimExpr>> {
     let mut u_shape = vec![k, n.clone()];
     u_shape.extend_from_slice(batch);
     vec![p_shape, l_shape, u_shape, batch.to_vec()]
+}
+
+fn full_piv_lu_shapes(input_shape: &[DimExpr]) -> Vec<Vec<DimExpr>> {
+    let (n, _, batch) = matrix_parts(input_shape);
+    let mut p_shape = vec![n.clone(), n.clone()];
+    p_shape.extend_from_slice(batch);
+    let mut l_shape = vec![n.clone(), n.clone()];
+    l_shape.extend_from_slice(batch);
+    let mut u_shape = vec![n.clone(), n.clone()];
+    u_shape.extend_from_slice(batch);
+    let mut q_shape = vec![n.clone(), n.clone()];
+    q_shape.extend_from_slice(batch);
+    vec![p_shape, l_shape, u_shape, q_shape, batch.to_vec()]
 }
 
 fn eig_like_shapes(input_shape: &[DimExpr]) -> Vec<Vec<DimExpr>> {

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -290,6 +290,10 @@ fn triangular_solve_op(_lhs_shape: Vec<usize>, _rhs_shape: Vec<usize>) -> StdTen
     }
 }
 
+fn full_piv_lu_solve_op(_lhs_shape: Vec<usize>, _rhs_shape: Vec<usize>) -> StdTensorOp {
+    StdTensorOp::FullPivLuSolve { transpose_a: false }
+}
+
 fn solve_dot_general_config(rank: usize) -> DotGeneralConfig {
     let batch_dims: Vec<usize> = (2..rank).collect();
     DotGeneralConfig {
@@ -787,6 +791,32 @@ fn build_triangular_solve_sum_fragment() -> (
     (Arc::new(builder.build()), a_key, b_key, loss_key)
 }
 
+fn build_full_piv_lu_solve_sum_fragment() -> (
+    Arc<Fragment<StdTensorOp>>,
+    TensorInputKey,
+    TensorInputKey,
+    GlobalValKey<StdTensorOp>,
+) {
+    let a_key = tensor_input_key(38_000);
+    let b_key = tensor_input_key(38_001);
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let a = builder.add_input(a_key.clone());
+    let b = builder.add_input(b_key.clone());
+    let solve = builder.add_op(
+        full_piv_lu_solve_op(vec![2, 2], vec![2, 1]),
+        vec![ValRef::Local(a), ValRef::Local(b)],
+        OpMode::Primal,
+    );
+    let loss = builder.add_op(
+        StdTensorOp::ReduceSum { axes: vec![0, 1] },
+        vec![ValRef::Local(solve[0])],
+        OpMode::Primal,
+    );
+    let loss_key = builder.global_key(loss[0]).clone();
+    builder.set_outputs(vec![loss[0]]);
+    (Arc::new(builder.build()), a_key, b_key, loss_key)
+}
+
 fn build_solve_real_sum_fragment() -> (
     Arc<Fragment<StdTensorOp>>,
     TensorInputKey,
@@ -1241,6 +1271,14 @@ fn sum_triangular_solve(a: &[f64], b: &[f64]) -> f64 {
         false,
     )
     .unwrap();
+    get_f64_data(&out).iter().sum()
+}
+
+fn sum_full_piv_lu_solve(a: &[f64], b: &[f64]) -> f64 {
+    let mut backend = CpuBackend::new();
+    let a_tensor = f64_tensor(vec![2, 2], a.to_vec());
+    let b_tensor = f64_tensor(vec![2, 1], b.to_vec());
+    let out = TensorBackend::full_piv_lu_solve(&mut backend, &a_tensor, &b_tensor, false).unwrap();
     get_f64_data(&out).iter().sum()
 }
 
@@ -2576,6 +2614,32 @@ fn grad_solve_matches_finite_diff() {
 
     assert_grad_matches_finite_diff_lhs(grad_a_data, &a_data, &b_data, &sum_solve);
     assert_grad_matches_finite_diff_rhs(grad_b_data, &a_data, &b_data, &sum_solve);
+}
+
+#[test]
+fn grad_full_piv_lu_solve_matches_finite_diff() {
+    let a_data = vec![0.2, 2.0, 1.0, 3.0];
+    let b_data = vec![-1.0, 5.0];
+    let (fragment, a_key, b_key, loss_key) = build_full_piv_lu_solve_sum_fragment();
+
+    let mut a_inputs = HashMap::new();
+    a_inputs.insert(a_key.clone(), f64_tensor(vec![2, 2], a_data.clone()));
+    a_inputs.insert(b_key.clone(), f64_tensor(vec![2, 1], b_data.clone()));
+    let grad_a =
+        grad_from_fragment_with_inputs(fragment.clone(), loss_key.clone(), a_key, a_inputs);
+    let grad_a_data = get_f64_data(&grad_a);
+
+    let mut b_inputs = HashMap::new();
+    b_inputs.insert(
+        tensor_input_key(38_000),
+        f64_tensor(vec![2, 2], a_data.clone()),
+    );
+    b_inputs.insert(b_key.clone(), f64_tensor(vec![2, 1], b_data.clone()));
+    let grad_b = grad_from_fragment_with_inputs(fragment, loss_key, b_key, b_inputs);
+    let grad_b_data = get_f64_data(&grad_b);
+
+    assert_grad_matches_finite_diff_lhs(grad_a_data, &a_data, &b_data, &sum_full_piv_lu_solve);
+    assert_grad_matches_finite_diff_rhs(grad_b_data, &a_data, &b_data, &sum_full_piv_lu_solve);
 }
 
 #[test]

--- a/tenferro/tests/eager_linalg.rs
+++ b/tenferro/tests/eager_linalg.rs
@@ -79,6 +79,28 @@ fn lu_returns_expected_factors_for_swap_matrix() {
 }
 
 #[test]
+fn full_piv_lu_returns_expected_shapes() {
+    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]));
+    let (p, l, u, q, parity) = a.full_piv_lu().unwrap();
+
+    assert_eq!(p.data().shape(), &[2, 2]);
+    assert_eq!(l.data().shape(), &[2, 2]);
+    assert_eq!(u.data().shape(), &[2, 2]);
+    assert_eq!(q.data().shape(), &[2, 2]);
+    assert_eq!(parity.data().shape(), &[] as &[usize]);
+}
+
+#[test]
+fn full_piv_lu_solve_returns_expected_solution() {
+    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]));
+    let b = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![-1.0_f64, 5.0]));
+    let x = a.full_piv_lu_solve(&b).unwrap();
+
+    assert_eq!(x.data().shape(), &[2, 1]);
+    assert_eq!(f64_data(x.data()), &[4.0, -1.0]);
+}
+
+#[test]
 fn eigh_returns_expected_values_for_diagonal_matrix() {
     let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
     let (values, vectors) = a.eigh().unwrap();

--- a/tenferro/tests/exec_dispatch.rs
+++ b/tenferro/tests/exec_dispatch.rs
@@ -309,6 +309,24 @@ impl TensorBackend for FakeTensorBackend {
             scalar_tensor(41.5),
         ])
     }
+    fn full_piv_lu(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
+        self.calls.push("full_piv_lu");
+        Ok(vec![
+            scalar_tensor(41.75),
+            scalar_tensor(42.0),
+            scalar_tensor(42.25),
+            scalar_tensor(42.5),
+            scalar_tensor(42.75),
+        ])
+    }
+    fn full_piv_lu_solve(
+        &mut self,
+        _a: &Tensor,
+        _b: &Tensor,
+        _transpose_a: bool,
+    ) -> tenferro_tensor::Result<Tensor> {
+        self.result("full_piv_lu_solve", 41.625)
+    }
     fn svd(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         self.calls.push("svd");
         Ok(vec![scalar_tensor(42.0), scalar_tensor(42.5)])
@@ -456,6 +474,12 @@ fn eval_exec_ir_dispatches_tensor_ops_to_backend_methods() {
             2,
             "triangular_solve",
             40.5,
+        ),
+        (
+            ExecOp::FullPivLuSolve { transpose_a: false },
+            2,
+            "full_piv_lu_solve",
+            41.625,
         ),
     ];
 
@@ -629,6 +653,16 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
     assert_eq!(scalar_value(&outputs[1]), 41.0);
     assert_eq!(scalar_value(&outputs[2]), 41.25);
     assert_eq!(scalar_value(&outputs[3]), 41.5);
+
+    backend.calls.clear();
+
+    // Full-pivot LU: 1 input, 5 outputs
+    let program = multi_output_program(ExecOp::FullPivLu, 1, 5);
+    let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)]).unwrap();
+    assert_eq!(backend.calls, vec!["full_piv_lu"]);
+    assert_eq!(outputs.len(), 5);
+    assert_eq!(scalar_value(&outputs[0]), 41.75);
+    assert_eq!(scalar_value(&outputs[4]), 42.75);
 
     backend.calls.clear();
 

--- a/tenferro/tests/linalg_api.rs
+++ b/tenferro/tests/linalg_api.rs
@@ -2,8 +2,8 @@ use num_complex::Complex64;
 use tenferro::engine::Engine;
 use tenferro::traced::{eval_all, TracedTensor};
 use tenferro::{
-    cholesky, det, eig, eigh, inv, lu, norm, pinv, pinv_with_rtol, qr, slogdet, solve, svd,
-    triangular_solve,
+    cholesky, det, eig, eigh, full_piv_lu, full_piv_lu_solve, inv, lu, norm, pinv, pinv_with_rtol,
+    qr, slogdet, solve, svd, triangular_solve,
 };
 use tenferro_tensor::{cpu::CpuBackend, Tensor, TypedTensor};
 
@@ -103,6 +103,39 @@ fn lu_free_function_returns_four_outputs() {
     assert_eq!(results[2].shape(), &[2, 2]);
     assert_eq!(results[3].shape(), &[] as &[usize]);
     assert_eq!(get_f64_data(&results[3]), &[-1.0]);
+}
+
+#[test]
+fn full_piv_lu_free_function_returns_five_outputs() {
+    let a =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![0.0, 2.0, 1.0, 3.0]));
+    let (mut p, mut l, mut u, mut q, mut parity) = full_piv_lu(&a);
+    let mut engine = Engine::new(CpuBackend::new());
+    let results = eval_all(
+        &mut engine,
+        &mut [&mut p, &mut l, &mut u, &mut q, &mut parity],
+    )
+    .unwrap();
+
+    assert_eq!(results[0].shape(), &[2, 2]);
+    assert_eq!(results[1].shape(), &[2, 2]);
+    assert_eq!(results[2].shape(), &[2, 2]);
+    assert_eq!(results[3].shape(), &[2, 2]);
+    assert_eq!(results[4].shape(), &[] as &[usize]);
+}
+
+#[test]
+fn full_piv_lu_solve_free_function_eval() {
+    let a =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![0.0, 2.0, 1.0, 3.0]));
+    let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![-1.0, 5.0]));
+    let mut x = full_piv_lu_solve(&a, &b);
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let out = x.eval(&mut engine).unwrap();
+
+    assert_eq!(out.shape(), &[2, 1]);
+    assert_eq!(get_f64_data(out), &[4.0, -1.0]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- bump lapack-inject to 0.1.1 and wire provider-inject to register LAPACK complete-pivot LU symbols
- add backend-dispatched full_piv_lu and full_piv_lu_solve paths for faer, LAPACK, traced, eager, and exec dispatch
- add graph-level AD rules for full_piv_lu_solve plus finite-difference coverage and complete-pivot regression tests
- document the new traced API in the linear algebra guide

## Validation
- cargo fmt --all --check
- cargo test -p tenferro-tensor --test full_piv_lu
- cargo test -p tenferro --test ad grad_full_piv_lu_solve_matches_finite_diff
- cargo test -p tenferro-tensor --test inject_tests --release --no-default-features --features "cpu-blas,provider-inject"
- cargo tree -p tenferro-tensor --no-default-features --features "cpu-blas,provider-inject" -i faer (confirmed faer not present)
- python3 scripts/check-docs-site.py
- cargo test --workspace --release
- cargo llvm-cov --workspace --release --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
