### PR TITLE
fix: handle singleton BLAS GEMM leading dimensions

### DIFF
--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -570,8 +570,9 @@ where
 
 #[cfg(feature = "cpu-blas")]
 fn normalize_singleton_stride(stride: isize, extent: usize, fallback: usize) -> isize {
-    if extent == 1 && stride == 0 {
-        fallback.max(1) as isize
+    if extent == 1 {
+        let fallback = fallback.max(1) as isize;
+        stride.max(fallback)
     } else {
         stride
     }

--- a/tenferro-tensor/tests/inject_tests.rs
+++ b/tenferro-tensor/tests/inject_tests.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::c_char;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Once;
+use std::sync::{Mutex, Once};
 
 use tenferro_tensor::cpu::CpuBackend;
 use tenferro_tensor::inject::{
@@ -12,6 +12,7 @@ use tenferro_tensor::inject::{
 use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
 
 static REGISTER_ONCE: Once = Once::new();
+static TEST_LOCK: Mutex<()> = Mutex::new(());
 static DGEMM_CALLS: AtomicUsize = AtomicUsize::new(0);
 static DGETC2_CALLS: AtomicUsize = AtomicUsize::new(0);
 static DGESC2_CALLS: AtomicUsize = AtomicUsize::new(0);
@@ -110,6 +111,9 @@ unsafe extern "C" fn test_dgesc2(
 
 #[test]
 fn provider_inject_dot_general_uses_registered_blas() {
+    let _guard = TEST_LOCK
+        .lock()
+        .expect("provider-inject test lock poisoned");
     register_test_ptrs_once();
     DGEMM_CALLS.store(0, Ordering::SeqCst);
 
@@ -136,7 +140,40 @@ fn provider_inject_dot_general_uses_registered_blas() {
 }
 
 #[test]
+fn provider_inject_dot_general_singleton_contract_uses_registered_blas() {
+    let _guard = TEST_LOCK
+        .lock()
+        .expect("provider-inject test lock poisoned");
+    register_test_ptrs_once();
+    DGEMM_CALLS.store(0, Ordering::SeqCst);
+
+    let a = Tensor::F64(TypedTensor::from_vec(vec![1, 2], vec![1.0, 2.0]));
+    let b = Tensor::F64(TypedTensor::from_vec(vec![1, 2], vec![3.0, 4.0]));
+
+    let mut backend = CpuBackend::new();
+    let c = backend.dot_general(
+        &a,
+        &b,
+        &DotGeneralConfig {
+            lhs_contracting_dims: vec![0],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        },
+    );
+
+    assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
+    match c {
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[3.0, 6.0, 4.0, 8.0]),
+        _ => panic!("expected f64 tensor"),
+    }
+}
+
+#[test]
 fn provider_inject_full_piv_lu_solve_uses_registered_lapack() {
+    let _guard = TEST_LOCK
+        .lock()
+        .expect("provider-inject test lock poisoned");
     register_test_ptrs_once();
     DGETC2_CALLS.store(0, Ordering::SeqCst);
     DGESC2_CALLS.store(0, Ordering::SeqCst);


### PR DESCRIPTION
## Summary
- normalize singleton GEMM strides so BLAS leading dimensions stay valid when a fused axis has extent 1
- add a provider-inject regression test for a singleton contracted dimension
- serialize provider-inject tests that share global injected function pointers and counters

## Root cause
The cpu-blas GEMM path could pass a singleton-axis stride such as `lda = 1` for an `m x 1` NoTrans operand with `m > 1`. BLAS still requires `lda >= max(1, m)` even though the second column is never read, so provider-inject builds panicked during Tensor4all.jl split/truncation workflows.

## Validation
- `cargo fmt --all --check`
- `cargo test -p tenferro-tensor --test inject_tests --release --no-default-features --features 'cpu-blas,provider-inject'`
- `cargo test -p tenferro-tensor --test full_piv_lu`
- `cargo test -p tenferro --test ad grad_full_piv_lu_solve_matches_finite_diff`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`