### PR TITLE
fix: handle transposed singleton BLAS RHS

### DIFF
--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -506,9 +506,9 @@ where
         });
     }
 
-    let a_rs = normalize_singleton_stride(dims.a_rs, dims.m, 1);
+    let a_rs = normalize_singleton_stride(dims.a_rs, dims.m, dims.k);
     let a_cs = normalize_singleton_stride(dims.a_cs, dims.k, dims.m);
-    let b_rs = normalize_singleton_stride(dims.b_rs, dims.k, 1);
+    let b_rs = normalize_singleton_stride(dims.b_rs, dims.k, dims.n);
     let b_cs = normalize_singleton_stride(dims.b_cs, dims.n, dims.k);
     let c_rs = normalize_singleton_stride(dims.c_rs, dims.m, 1);
     let c_cs = normalize_singleton_stride(dims.c_cs, dims.n, dims.m);

--- a/tenferro-tensor/tests/inject_tests.rs
+++ b/tenferro-tensor/tests/inject_tests.rs
@@ -32,8 +32,8 @@ fn register_test_ptrs_once() {
 }
 
 unsafe extern "C" fn test_dgemm(
-    _transa: *const c_char,
-    _transb: *const c_char,
+    transa: *const c_char,
+    transb: *const c_char,
     m: *const cblas_inject::blasint,
     n: *const cblas_inject::blasint,
     k: *const cblas_inject::blasint,
@@ -55,13 +55,23 @@ unsafe extern "C" fn test_dgemm(
     let lda = unsafe { *lda as usize };
     let ldb = unsafe { *ldb as usize };
     let ldc = unsafe { *ldc as usize };
+    let transa = unsafe { *transa as u8 as char };
+    let transb = unsafe { *transb as u8 as char };
 
     for j in 0..n {
         for i in 0..m {
             let mut sum = 0.0;
             for p in 0..k {
-                let av = unsafe { *a.add(i + p * lda) };
-                let bv = unsafe { *b.add(p + j * ldb) };
+                let av = match transa {
+                    'N' | 'n' => unsafe { *a.add(i + p * lda) },
+                    'T' | 't' | 'C' | 'c' => unsafe { *a.add(p + i * lda) },
+                    _ => panic!("unexpected transa flag {transa}"),
+                };
+                let bv = match transb {
+                    'N' | 'n' => unsafe { *b.add(p + j * ldb) },
+                    'T' | 't' | 'C' | 'c' => unsafe { *b.add(j + p * ldb) },
+                    _ => panic!("unexpected transb flag {transb}"),
+                };
                 sum += av * bv;
             }
             let c_ptr = unsafe { c.add(i + j * ldc) };
@@ -165,6 +175,39 @@ fn provider_inject_dot_general_singleton_contract_uses_registered_blas() {
     assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
     match c {
         Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[3.0, 6.0, 4.0, 8.0]),
+        _ => panic!("expected f64 tensor"),
+    }
+}
+
+#[test]
+fn provider_inject_dot_general_rhs_singleton_contract_uses_registered_blas() {
+    let _guard = TEST_LOCK
+        .lock()
+        .expect("provider-inject test lock poisoned");
+    register_test_ptrs_once();
+    DGEMM_CALLS.store(0, Ordering::SeqCst);
+
+    let a = Tensor::F64(TypedTensor::from_vec(vec![1], vec![2.0]));
+    let b = Tensor::F64(TypedTensor::from_vec(
+        vec![2, 1, 2],
+        vec![3.0, 4.0, 5.0, 6.0],
+    ));
+
+    let mut backend = CpuBackend::new();
+    let c = backend.dot_general(
+        &a,
+        &b,
+        &DotGeneralConfig {
+            lhs_contracting_dims: vec![0],
+            rhs_contracting_dims: vec![1],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        },
+    );
+
+    assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
+    match c {
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[6.0, 8.0, 10.0, 12.0]),
         _ => panic!("expected f64 tensor"),
     }
 }


### PR DESCRIPTION
## Summary
- extend the cpu-blas singleton-stride normalization from #758 to the `Trans B` orientation
- update the provider-inject GEMM test double to honor `N/T/C` transpose flags
- add a regression for a RHS singleton contracted dimension with fused free dimensions

## Root cause
#758 fixed singleton leading dimensions for the `NoTrans A` case seen in Tensor4all.jl `split_to`. The full Tensor4all.jl provider-inject suite exposed the symmetric RHS case: when the contracted RHS axis has extent 1 and fused free dimensions make BLAS choose `Trans B`, BLAS still requires `ldb >= max(1, n)` even though the singleton contracted axis is not traversed.

## Validation
- `cargo fmt --all --check`
- `cargo test -p tenferro-tensor --test inject_tests --release --no-default-features --features 'cpu-blas,provider-inject'`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Follow-up to #758.