### PR TITLE
[codex] Add runtime ABI provider registration for inject backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,11 @@ libloading = "0.8"
 faer = "0.24"
 cblas-sys = "0.1"
 cblas-src = "0.1.3"
-cblas-inject = "0.1.0"
+cblas-inject = { git = "https://github.com/shinaoka/cblas-inject", rev = "e150b3d2ccc5af7635e3d13e0f35aa5acdfffca3" }
 blas-src = { version = "0.14", default-features = false }
 lapack = "0.20"
 lapack-src = "0.13"
-lapack-inject = "0.1.1"
+lapack-inject = { git = "https://github.com/shinaoka/lapack-inject.git", rev = "059d520fc8715cd40270fe42e70c18682671516d" }
 cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12000"] }
 cubecl = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96", features = ["cuda"] }
 cubecl-cuda = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96" }

--- a/tenferro-tensor/src/inject.rs
+++ b/tenferro-tensor/src/inject.rs
@@ -1,11 +1,232 @@
-//! Runtime BLAS function-pointer registration for `provider-inject`.
+//! Runtime BLAS/LAPACK function-pointer registration for `provider-inject`.
 //!
 //! This module is available only with:
 //! - `cpu-blas`
 //! - `provider-inject`
+//!
+//! ## ABI conventions
+//!
+//! tenferro itself is an LP64 consumer (it calls BLAS/LAPACK through normal
+//! `i32` integer arguments).  This module registers *provider* function
+//! pointers that may use either LP64 (`i32`) or ILP64 (`i64`).
+//!
+//! - [`ProviderAbi::Lp64`] -- provider uses 32-bit BLAS/LAPACK integer
+//!   arguments (same as tenferro's own consumer ABI).
+//! - [`ProviderAbi::Ilp64`] -- provider uses 64-bit BLAS/LAPACK integer
+//!   arguments (e.g. libblastrampoline configured with 64-bit integer
+//!   providers).  tenferro's consumer path remains LP64; the `cblas-inject`
+//!   and `lapack-inject` crates transparently bridge the integer types.
+//!
+//! ## Existing typed wrappers vs raw-pointer API
+//!
+//! - [`register_blas_gemm_fn_ptrs`] and
+//!   [`register_lapack_full_piv_lu_fn_ptrs`] accept typed LP64 function
+//!   pointers and remain available for backwards compatibility.
+//! - The new raw-pointer entry points
+//!   ([`register_blas_gemm_provider_ptrs`],
+//!   [`register_lapack_provider_ptrs`]) accept opaque `*const c_void`
+//!   pointers together with a [`ProviderAbi`] selector.  They cover the
+//!   full GEMM and LAPACK surface.
+
+use std::ffi::c_void;
 
 use cblas_inject::{CgemmFnPtr, DgemmFnPtr, SgemmFnPtr, ZgemmFnPtr};
-use lapack_inject::{Dgesc2FnPtr, Dgetc2FnPtr, Zgesc2FnPtr, Zgetc2FnPtr};
+use lapack_inject::{Dgesc2Lp64FnPtr, Dgetc2Lp64FnPtr, Zgesc2Lp64FnPtr, Zgetc2Lp64FnPtr};
+
+// --- Public types --------------------------------------------------------
+
+/// Integer ABI used by provider function pointers.
+///
+/// tenferro itself is always an LP64 BLAS/LAPACK consumer.  This enum
+/// describes the ABI of the *provider* pointers being registered.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::inject::ProviderAbi;
+///
+/// assert_eq!(ProviderAbi::Lp64, ProviderAbi::Lp64);
+/// assert_ne!(ProviderAbi::Lp64, ProviderAbi::Ilp64);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderAbi {
+    /// Provider uses 32-bit BLAS/LAPACK integer arguments.
+    Lp64,
+    /// Provider uses 64-bit BLAS/LAPACK integer arguments.
+    Ilp64,
+}
+
+/// Error returned while registering runtime provider pointers.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::inject::ProviderRegistrationError;
+///
+/// let err = ProviderRegistrationError::NullPointer { symbol: "dgemm" };
+/// assert_eq!(err.to_string(), "dgemm provider pointer is null");
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ProviderRegistrationError {
+    /// The `Some` pointer field contained a raw null pointer where a
+    /// non-null function pointer was required.
+    #[error("{symbol} provider pointer is null")]
+    NullPointer { symbol: &'static str },
+    /// The underlying inject crate reported that a symbol was already registered.
+    #[error("{symbol} provider pointer is already registered")]
+    AlreadyRegistered { symbol: &'static str },
+    /// The underlying inject crate returned an unknown status code.
+    #[error("{symbol} provider registration returned status {status}")]
+    UnknownStatus { symbol: &'static str, status: i32 },
+}
+
+// --- Raw-pointer provider sets -------------------------------------------
+
+/// Set of BLAS GEMM provider pointers (opaque `*const c_void`) to register.
+///
+/// Any field set to `None` is skipped.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::inject::BlasGemmProviderPtrSet;
+///
+/// let ptrs = BlasGemmProviderPtrSet {
+///     dgemm: Some(std::ptr::null()),
+///     ..BlasGemmProviderPtrSet::new()
+/// };
+/// assert!(ptrs.dgemm.is_some());
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BlasGemmProviderPtrSet {
+    /// Fortran `sgemm` raw function pointer.
+    pub sgemm: Option<*const c_void>,
+    /// Fortran `dgemm` raw function pointer.
+    pub dgemm: Option<*const c_void>,
+    /// Fortran `cgemm` raw function pointer.
+    pub cgemm: Option<*const c_void>,
+    /// Fortran `zgemm` raw function pointer.
+    pub zgemm: Option<*const c_void>,
+}
+
+impl BlasGemmProviderPtrSet {
+    /// Create an empty set (all pointers are `None`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::inject::BlasGemmProviderPtrSet;
+    ///
+    /// let ptrs = BlasGemmProviderPtrSet::new();
+    /// assert!(ptrs.dgemm.is_none());
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            sgemm: None,
+            dgemm: None,
+            cgemm: None,
+            zgemm: None,
+        }
+    }
+}
+
+/// Set of LAPACK provider pointers (opaque `*const c_void`) to register.
+///
+/// Any field set to `None` is skipped.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::inject::LapackProviderPtrSet;
+///
+/// let ptrs = LapackProviderPtrSet {
+///     dgesvd: Some(std::ptr::null()),
+///     ..LapackProviderPtrSet::new()
+/// };
+/// assert!(ptrs.dgesvd.is_some());
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LapackProviderPtrSet {
+    /// Fortran `dgesvd` raw function pointer.
+    pub dgesvd: Option<*const c_void>,
+    /// Fortran `zgesvd` raw function pointer.
+    pub zgesvd: Option<*const c_void>,
+    /// Fortran `dgeqrf` raw function pointer.
+    pub dgeqrf: Option<*const c_void>,
+    /// Fortran `zgeqrf` raw function pointer.
+    pub zgeqrf: Option<*const c_void>,
+    /// Fortran `dorgqr` raw function pointer.
+    pub dorgqr: Option<*const c_void>,
+    /// Fortran `zungqr` raw function pointer.
+    pub zungqr: Option<*const c_void>,
+    /// Fortran `dtrtrs` raw function pointer.
+    pub dtrtrs: Option<*const c_void>,
+    /// Fortran `ztrtrs` raw function pointer.
+    pub ztrtrs: Option<*const c_void>,
+    /// Fortran `dpotrf` raw function pointer.
+    pub dpotrf: Option<*const c_void>,
+    /// Fortran `zpotrf` raw function pointer.
+    pub zpotrf: Option<*const c_void>,
+    /// Fortran `dgetrf` raw function pointer.
+    pub dgetrf: Option<*const c_void>,
+    /// Fortran `zgetrf` raw function pointer.
+    pub zgetrf: Option<*const c_void>,
+    /// Fortran `dsyev` raw function pointer.
+    pub dsyev: Option<*const c_void>,
+    /// Fortran `zheev` raw function pointer.
+    pub zheev: Option<*const c_void>,
+    /// Fortran `dgeev` raw function pointer.
+    pub dgeev: Option<*const c_void>,
+    /// Fortran `zgeev` raw function pointer.
+    pub zgeev: Option<*const c_void>,
+    /// Fortran `dgetc2` raw function pointer.
+    pub dgetc2: Option<*const c_void>,
+    /// Fortran `dgesc2` raw function pointer.
+    pub dgesc2: Option<*const c_void>,
+    /// Fortran `zgetc2` raw function pointer.
+    pub zgetc2: Option<*const c_void>,
+    /// Fortran `zgesc2` raw function pointer.
+    pub zgesc2: Option<*const c_void>,
+}
+
+impl LapackProviderPtrSet {
+    /// Create an empty set (all pointers are `None`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::inject::LapackProviderPtrSet;
+    ///
+    /// let ptrs = LapackProviderPtrSet::new();
+    /// assert!(ptrs.dgesvd.is_none());
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            dgesvd: None,
+            zgesvd: None,
+            dgeqrf: None,
+            zgeqrf: None,
+            dorgqr: None,
+            zungqr: None,
+            dtrtrs: None,
+            ztrtrs: None,
+            dpotrf: None,
+            zpotrf: None,
+            dgetrf: None,
+            zgetrf: None,
+            dsyev: None,
+            zheev: None,
+            dgeev: None,
+            zgeev: None,
+            dgetc2: None,
+            dgesc2: None,
+            zgetc2: None,
+            zgesc2: None,
+        }
+    }
+}
+
+// --- Typed function-pointer sets (compatibility wrappers) ----------------
 
 /// Set of CBLAS GEMM function pointers to register in one call.
 ///
@@ -57,6 +278,92 @@ impl BlasGemmFnPtrSet {
     }
 }
 
+/// Set of LAPACK complete-pivoting LU function pointers to register.
+///
+/// tenferro currently uses `xGETC2` for the factorization and `xGESC2` for
+/// solves. Any field set to `None` is skipped.
+///
+/// # Examples
+///
+/// ```ignore
+/// use tenferro_tensor::inject::{
+///     register_lapack_full_piv_lu_fn_ptrs, LapackFullPivLuFnPtrSet,
+/// };
+///
+/// unsafe {
+///     register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet {
+///         dgetc2: Some(dgetc2_ptr),
+///         dgesc2: Some(dgesc2_ptr),
+///         ..LapackFullPivLuFnPtrSet::new()
+///     });
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LapackFullPivLuFnPtrSet {
+    /// Fortran `dgetc2` LP64 function pointer.
+    pub dgetc2: Option<Dgetc2Lp64FnPtr>,
+    /// Fortran `dgesc2` LP64 function pointer.
+    pub dgesc2: Option<Dgesc2Lp64FnPtr>,
+    /// Fortran `zgetc2` LP64 function pointer.
+    pub zgetc2: Option<Zgetc2Lp64FnPtr>,
+    /// Fortran `zgesc2` LP64 function pointer.
+    pub zgesc2: Option<Zgesc2Lp64FnPtr>,
+}
+
+impl LapackFullPivLuFnPtrSet {
+    /// Create an empty set (all pointers are `None`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::inject::LapackFullPivLuFnPtrSet;
+    ///
+    /// let ptrs = LapackFullPivLuFnPtrSet::new();
+    /// assert!(ptrs.dgetc2.is_none());
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            dgetc2: None,
+            dgesc2: None,
+            zgetc2: None,
+            zgesc2: None,
+        }
+    }
+}
+
+// --- Status helpers ------------------------------------------------------
+
+/// Map a `cblas-inject` status code to a `Result`.
+fn blas_registration_status(
+    symbol: &'static str,
+    status: i32,
+) -> Result<(), ProviderRegistrationError> {
+    match status {
+        0 => Ok(()),
+        1 => Err(ProviderRegistrationError::NullPointer { symbol }),
+        2 => Err(ProviderRegistrationError::AlreadyRegistered { symbol }),
+        _ => Err(ProviderRegistrationError::UnknownStatus { symbol, status }),
+    }
+}
+
+/// Map a `lapack-inject` status code to a `Result`.
+///
+/// lapack-inject typed registration functions accept non-null function
+/// pointers; tenferro null-checks the raw pointer before `transmute`, so
+/// status 1 (null pointer) is never returned here.
+fn lapack_registration_status(
+    symbol: &'static str,
+    status: i32,
+) -> Result<(), ProviderRegistrationError> {
+    match status {
+        0 => Ok(()),
+        2 => Err(ProviderRegistrationError::AlreadyRegistered { symbol }),
+        _ => Err(ProviderRegistrationError::UnknownStatus { symbol, status }),
+    }
+}
+
+// --- Compatibility wrappers (typed LP64) ---------------------------------
+
 /// Register CBLAS GEMM function pointers in one call.
 ///
 /// This is a thin bulk wrapper over `cblas-inject`'s per-symbol
@@ -96,59 +403,6 @@ pub unsafe fn register_blas_gemm_fn_ptrs(ptrs: BlasGemmFnPtrSet) {
     }
 }
 
-/// Set of LAPACK complete-pivoting LU function pointers to register.
-///
-/// tenferro currently uses `xGETC2` for the factorization and `xGESC2` for
-/// solves. Any field set to `None` is skipped.
-///
-/// # Examples
-///
-/// ```ignore
-/// use tenferro_tensor::inject::{
-///     register_lapack_full_piv_lu_fn_ptrs, LapackFullPivLuFnPtrSet,
-/// };
-///
-/// unsafe {
-///     register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet {
-///         dgetc2: Some(dgetc2_ptr),
-///         dgesc2: Some(dgesc2_ptr),
-///         ..LapackFullPivLuFnPtrSet::new()
-///     });
-/// }
-/// ```
-#[derive(Debug, Clone, Copy, Default)]
-pub struct LapackFullPivLuFnPtrSet {
-    /// Fortran `dgetc2` function pointer.
-    pub dgetc2: Option<Dgetc2FnPtr>,
-    /// Fortran `dgesc2` function pointer.
-    pub dgesc2: Option<Dgesc2FnPtr>,
-    /// Fortran `zgetc2` function pointer.
-    pub zgetc2: Option<Zgetc2FnPtr>,
-    /// Fortran `zgesc2` function pointer.
-    pub zgesc2: Option<Zgesc2FnPtr>,
-}
-
-impl LapackFullPivLuFnPtrSet {
-    /// Create an empty set (all pointers are `None`).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::inject::LapackFullPivLuFnPtrSet;
-    ///
-    /// let ptrs = LapackFullPivLuFnPtrSet::new();
-    /// assert!(ptrs.dgetc2.is_none());
-    /// ```
-    pub const fn new() -> Self {
-        Self {
-            dgetc2: None,
-            dgesc2: None,
-            zgetc2: None,
-            zgesc2: None,
-        }
-    }
-}
-
 /// Register LAPACK complete-pivoting LU function pointers in one call.
 ///
 /// This is a thin bulk wrapper over `lapack-inject`'s per-symbol
@@ -177,15 +431,361 @@ impl LapackFullPivLuFnPtrSet {
 /// ```
 pub unsafe fn register_lapack_full_piv_lu_fn_ptrs(ptrs: LapackFullPivLuFnPtrSet) {
     if let Some(f) = ptrs.dgetc2 {
-        unsafe { lapack_inject::register_dgetc2(f) };
+        unsafe { lapack_inject::register_dgetc2_lp64(f) };
     }
     if let Some(f) = ptrs.dgesc2 {
-        unsafe { lapack_inject::register_dgesc2(f) };
+        unsafe { lapack_inject::register_dgesc2_lp64(f) };
     }
     if let Some(f) = ptrs.zgetc2 {
-        unsafe { lapack_inject::register_zgetc2(f) };
+        unsafe { lapack_inject::register_zgetc2_lp64(f) };
     }
     if let Some(f) = ptrs.zgesc2 {
-        unsafe { lapack_inject::register_zgesc2(f) };
+        unsafe { lapack_inject::register_zgesc2_lp64(f) };
     }
+}
+
+// --- Raw-pointer BLAS GEMM registration ----------------------------------
+
+/// Register BLAS GEMM provider pointers with a selected ABI.
+///
+/// Accepts opaque `*const c_void` pointers and dispatches to the
+/// appropriate `cblas-inject` LP64 or ILP64 registration function.
+///
+/// # Safety
+///
+/// Each provided pointer must be a valid function pointer with the Fortran
+/// BLAS ABI for the corresponding scalar type and integer width.
+/// Passing a null pointer for a `Some` field returns
+/// [`ProviderRegistrationError::NullPointer`] instead of calling into the
+/// provider crate.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::inject::{
+///     register_blas_gemm_provider_ptrs, BlasGemmProviderPtrSet, ProviderAbi,
+///     ProviderRegistrationError,
+/// };
+///
+/// let err = unsafe {
+///     register_blas_gemm_provider_ptrs(
+///         ProviderAbi::Ilp64,
+///         BlasGemmProviderPtrSet {
+///             dgemm: Some(std::ptr::null()),
+///             ..BlasGemmProviderPtrSet::new()
+///         },
+///     )
+/// }
+/// .unwrap_err();
+/// assert_eq!(
+///     err,
+///     ProviderRegistrationError::NullPointer { symbol: "dgemm" }
+/// );
+/// ```
+pub unsafe fn register_blas_gemm_provider_ptrs(
+    abi: ProviderAbi,
+    ptrs: BlasGemmProviderPtrSet,
+) -> Result<(), ProviderRegistrationError> {
+    macro_rules! register_one {
+        ($field:ident, $symbol:literal, $lp64_fn:path, $ilp64_fn:path) => {
+            if let Some(ptr) = ptrs.$field {
+                if ptr.is_null() {
+                    return Err(ProviderRegistrationError::NullPointer { symbol: $symbol });
+                }
+                let status = match abi {
+                    ProviderAbi::Lp64 => unsafe { $lp64_fn(ptr) },
+                    ProviderAbi::Ilp64 => unsafe { $ilp64_fn(ptr) },
+                };
+                blas_registration_status($symbol, status)?;
+            }
+        };
+    }
+
+    register_one!(
+        sgemm,
+        "sgemm",
+        cblas_inject::cblas_inject_register_sgemm_lp64,
+        cblas_inject::cblas_inject_register_sgemm_ilp64
+    );
+    register_one!(
+        dgemm,
+        "dgemm",
+        cblas_inject::cblas_inject_register_dgemm_lp64,
+        cblas_inject::cblas_inject_register_dgemm_ilp64
+    );
+    register_one!(
+        cgemm,
+        "cgemm",
+        cblas_inject::cblas_inject_register_cgemm_lp64,
+        cblas_inject::cblas_inject_register_cgemm_ilp64
+    );
+    register_one!(
+        zgemm,
+        "zgemm",
+        cblas_inject::cblas_inject_register_zgemm_lp64,
+        cblas_inject::cblas_inject_register_zgemm_ilp64
+    );
+
+    Ok(())
+}
+
+// --- Raw-pointer LAPACK registration -------------------------------------
+
+/// Register a single LAPACK symbol with transmute and null-check.
+macro_rules! register_lapack_symbol {
+    ($abi:expr, $symbol:literal, $raw:expr, $lp64_ty:ty, $ilp64_ty:ty,
+     $lp64_reg:path, $ilp64_reg:path) => {{
+        let raw = $raw;
+        if raw.is_null() {
+            return Err(ProviderRegistrationError::NullPointer { symbol: $symbol });
+        }
+        let status = match $abi {
+            ProviderAbi::Lp64 => {
+                let f = unsafe { std::mem::transmute::<*const std::ffi::c_void, $lp64_ty>(raw) };
+                unsafe { $lp64_reg(f) }
+            }
+            ProviderAbi::Ilp64 => {
+                let f = unsafe { std::mem::transmute::<*const std::ffi::c_void, $ilp64_ty>(raw) };
+                unsafe { $ilp64_reg(f) }
+            }
+        };
+        lapack_registration_status($symbol, status)?;
+    }};
+}
+
+/// Register LAPACK provider pointers with a selected ABI.
+///
+/// Accepts opaque `*const c_void` pointers and dispatches to the
+/// appropriate `lapack-inject` LP64 or ILP64 registration function.
+///
+/// # Safety
+///
+/// Each provided pointer must be a valid function pointer with the Fortran
+/// LAPACK ABI for the corresponding scalar type and integer width.
+/// Passing a null pointer for a `Some` field returns
+/// [`ProviderRegistrationError::NullPointer`] instead of calling into the
+/// provider crate.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::inject::{
+///     register_lapack_provider_ptrs, LapackProviderPtrSet, ProviderAbi,
+///     ProviderRegistrationError,
+/// };
+///
+/// let err = unsafe {
+///     register_lapack_provider_ptrs(
+///         ProviderAbi::Ilp64,
+///         LapackProviderPtrSet {
+///             dgesvd: Some(std::ptr::null()),
+///             ..LapackProviderPtrSet::new()
+///         },
+///     )
+/// }
+/// .unwrap_err();
+/// assert_eq!(
+///     err,
+///     ProviderRegistrationError::NullPointer { symbol: "dgesvd" }
+/// );
+/// ```
+pub unsafe fn register_lapack_provider_ptrs(
+    abi: ProviderAbi,
+    ptrs: LapackProviderPtrSet,
+) -> Result<(), ProviderRegistrationError> {
+    use lapack_inject::{
+        register_dgeev_ilp64, register_dgeev_lp64, register_dgeqrf_ilp64, register_dgeqrf_lp64,
+        register_dgesc2_ilp64, register_dgesc2_lp64, register_dgesvd_ilp64, register_dgesvd_lp64,
+        register_dgetc2_ilp64, register_dgetc2_lp64, register_dgetrf_ilp64, register_dgetrf_lp64,
+        register_dorgqr_ilp64, register_dorgqr_lp64, register_dpotrf_ilp64, register_dpotrf_lp64,
+        register_dsyev_ilp64, register_dsyev_lp64, register_dtrtrs_ilp64, register_dtrtrs_lp64,
+        register_zgeev_ilp64, register_zgeev_lp64, register_zgeqrf_ilp64, register_zgeqrf_lp64,
+        register_zgesc2_ilp64, register_zgesc2_lp64, register_zgesvd_ilp64, register_zgesvd_lp64,
+        register_zgetc2_ilp64, register_zgetc2_lp64, register_zgetrf_ilp64, register_zgetrf_lp64,
+        register_zheev_ilp64, register_zheev_lp64, register_zpotrf_ilp64, register_zpotrf_lp64,
+        register_ztrtrs_ilp64, register_ztrtrs_lp64, register_zungqr_ilp64, register_zungqr_lp64,
+        DgeevIlp64FnPtr, DgeevLp64FnPtr, DgeqrfIlp64FnPtr, DgeqrfLp64FnPtr, Dgesc2Ilp64FnPtr,
+        Dgesc2Lp64FnPtr, DgesvdIlp64FnPtr, DgesvdLp64FnPtr, Dgetc2Ilp64FnPtr, Dgetc2Lp64FnPtr,
+        DgetrfIlp64FnPtr, DgetrfLp64FnPtr, DorgqrIlp64FnPtr, DorgqrLp64FnPtr, DpotrfIlp64FnPtr,
+        DpotrfLp64FnPtr, DsyevIlp64FnPtr, DsyevLp64FnPtr, DtrtrsIlp64FnPtr, DtrtrsLp64FnPtr,
+        ZgeevIlp64FnPtr, ZgeevLp64FnPtr, ZgeqrfIlp64FnPtr, ZgeqrfLp64FnPtr, Zgesc2Ilp64FnPtr,
+        Zgesc2Lp64FnPtr, ZgesvdIlp64FnPtr, ZgesvdLp64FnPtr, Zgetc2Ilp64FnPtr, Zgetc2Lp64FnPtr,
+        ZgetrfIlp64FnPtr, ZgetrfLp64FnPtr, ZheevIlp64FnPtr, ZheevLp64FnPtr, ZpotrfIlp64FnPtr,
+        ZpotrfLp64FnPtr, ZtrtrsIlp64FnPtr, ZtrtrsLp64FnPtr, ZungqrIlp64FnPtr, ZungqrLp64FnPtr,
+    };
+
+    macro_rules! register_field {
+        ($field:ident, $symbol:literal,
+         $lp64_ty:ident, $ilp64_ty:ident,
+         $lp64_reg:ident, $ilp64_reg:ident) => {
+            if let Some(raw) = ptrs.$field {
+                register_lapack_symbol!(
+                    abi, $symbol, raw, $lp64_ty, $ilp64_ty, $lp64_reg, $ilp64_reg
+                );
+            }
+        };
+    }
+
+    register_field!(
+        dgesvd,
+        "dgesvd",
+        DgesvdLp64FnPtr,
+        DgesvdIlp64FnPtr,
+        register_dgesvd_lp64,
+        register_dgesvd_ilp64
+    );
+    register_field!(
+        zgesvd,
+        "zgesvd",
+        ZgesvdLp64FnPtr,
+        ZgesvdIlp64FnPtr,
+        register_zgesvd_lp64,
+        register_zgesvd_ilp64
+    );
+    register_field!(
+        dgeqrf,
+        "dgeqrf",
+        DgeqrfLp64FnPtr,
+        DgeqrfIlp64FnPtr,
+        register_dgeqrf_lp64,
+        register_dgeqrf_ilp64
+    );
+    register_field!(
+        zgeqrf,
+        "zgeqrf",
+        ZgeqrfLp64FnPtr,
+        ZgeqrfIlp64FnPtr,
+        register_zgeqrf_lp64,
+        register_zgeqrf_ilp64
+    );
+    register_field!(
+        dorgqr,
+        "dorgqr",
+        DorgqrLp64FnPtr,
+        DorgqrIlp64FnPtr,
+        register_dorgqr_lp64,
+        register_dorgqr_ilp64
+    );
+    register_field!(
+        zungqr,
+        "zungqr",
+        ZungqrLp64FnPtr,
+        ZungqrIlp64FnPtr,
+        register_zungqr_lp64,
+        register_zungqr_ilp64
+    );
+    register_field!(
+        dtrtrs,
+        "dtrtrs",
+        DtrtrsLp64FnPtr,
+        DtrtrsIlp64FnPtr,
+        register_dtrtrs_lp64,
+        register_dtrtrs_ilp64
+    );
+    register_field!(
+        ztrtrs,
+        "ztrtrs",
+        ZtrtrsLp64FnPtr,
+        ZtrtrsIlp64FnPtr,
+        register_ztrtrs_lp64,
+        register_ztrtrs_ilp64
+    );
+    register_field!(
+        dpotrf,
+        "dpotrf",
+        DpotrfLp64FnPtr,
+        DpotrfIlp64FnPtr,
+        register_dpotrf_lp64,
+        register_dpotrf_ilp64
+    );
+    register_field!(
+        zpotrf,
+        "zpotrf",
+        ZpotrfLp64FnPtr,
+        ZpotrfIlp64FnPtr,
+        register_zpotrf_lp64,
+        register_zpotrf_ilp64
+    );
+    register_field!(
+        dgetrf,
+        "dgetrf",
+        DgetrfLp64FnPtr,
+        DgetrfIlp64FnPtr,
+        register_dgetrf_lp64,
+        register_dgetrf_ilp64
+    );
+    register_field!(
+        zgetrf,
+        "zgetrf",
+        ZgetrfLp64FnPtr,
+        ZgetrfIlp64FnPtr,
+        register_zgetrf_lp64,
+        register_zgetrf_ilp64
+    );
+    register_field!(
+        dsyev,
+        "dsyev",
+        DsyevLp64FnPtr,
+        DsyevIlp64FnPtr,
+        register_dsyev_lp64,
+        register_dsyev_ilp64
+    );
+    register_field!(
+        zheev,
+        "zheev",
+        ZheevLp64FnPtr,
+        ZheevIlp64FnPtr,
+        register_zheev_lp64,
+        register_zheev_ilp64
+    );
+    register_field!(
+        dgeev,
+        "dgeev",
+        DgeevLp64FnPtr,
+        DgeevIlp64FnPtr,
+        register_dgeev_lp64,
+        register_dgeev_ilp64
+    );
+    register_field!(
+        zgeev,
+        "zgeev",
+        ZgeevLp64FnPtr,
+        ZgeevIlp64FnPtr,
+        register_zgeev_lp64,
+        register_zgeev_ilp64
+    );
+    register_field!(
+        dgetc2,
+        "dgetc2",
+        Dgetc2Lp64FnPtr,
+        Dgetc2Ilp64FnPtr,
+        register_dgetc2_lp64,
+        register_dgetc2_ilp64
+    );
+    register_field!(
+        dgesc2,
+        "dgesc2",
+        Dgesc2Lp64FnPtr,
+        Dgesc2Ilp64FnPtr,
+        register_dgesc2_lp64,
+        register_dgesc2_ilp64
+    );
+    register_field!(
+        zgetc2,
+        "zgetc2",
+        Zgetc2Lp64FnPtr,
+        Zgetc2Ilp64FnPtr,
+        register_zgetc2_lp64,
+        register_zgetc2_ilp64
+    );
+    register_field!(
+        zgesc2,
+        "zgesc2",
+        Zgesc2Lp64FnPtr,
+        Zgesc2Ilp64FnPtr,
+        register_zgesc2_lp64,
+        register_zgesc2_ilp64
+    );
+
+    Ok(())
 }

--- a/tenferro-tensor/tests/inject_dual_abi_tests.rs
+++ b/tenferro-tensor/tests/inject_dual_abi_tests.rs
@@ -1,0 +1,345 @@
+#![cfg(all(feature = "cpu-blas", feature = "provider-inject"))]
+
+use std::ffi::c_char;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use tenferro_tensor::cpu::CpuBackend;
+use tenferro_tensor::inject::{
+    register_blas_gemm_provider_ptrs, register_lapack_provider_ptrs, BlasGemmProviderPtrSet,
+    LapackProviderPtrSet, ProviderAbi, ProviderRegistrationError,
+};
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
+
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+// --- GEMM ILP64 counters and fake ----------------------------------------
+
+static DGEMM_ILP64_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DGEMM_ILP64_REGISTERED: AtomicBool = AtomicBool::new(false);
+
+unsafe extern "C" fn test_dgemm_ilp64(
+    transa: *const c_char,
+    transb: *const c_char,
+    m: *const i64,
+    n: *const i64,
+    k: *const i64,
+    alpha: *const f64,
+    a: *const f64,
+    lda: *const i64,
+    b: *const f64,
+    ldb: *const i64,
+    beta: *const f64,
+    c: *mut f64,
+    ldc: *const i64,
+) {
+    DGEMM_ILP64_CALLS.fetch_add(1, Ordering::SeqCst);
+    let m = unsafe { *m as usize };
+    let n = unsafe { *n as usize };
+    let k = unsafe { *k as usize };
+    let alpha = unsafe { *alpha };
+    let beta = unsafe { *beta };
+    let lda = unsafe { *lda as usize };
+    let ldb = unsafe { *ldb as usize };
+    let ldc = unsafe { *ldc as usize };
+    let transa = unsafe { *transa as u8 as char };
+    let transb = unsafe { *transb as u8 as char };
+
+    for j in 0..n {
+        for i in 0..m {
+            let mut sum = 0.0;
+            for p in 0..k {
+                let av = match transa {
+                    'N' | 'n' => unsafe { *a.add(i + p * lda) },
+                    'T' | 't' | 'C' | 'c' => unsafe { *a.add(p + i * lda) },
+                    _ => panic!("unexpected transa flag {transa}"),
+                };
+                let bv = match transb {
+                    'N' | 'n' => unsafe { *b.add(p + j * ldb) },
+                    'T' | 't' | 'C' | 'c' => unsafe { *b.add(j + p * ldb) },
+                    _ => panic!("unexpected transb flag {transb}"),
+                };
+                sum += av * bv;
+            }
+            let c_ptr = unsafe { c.add(i + j * ldc) };
+            unsafe {
+                *c_ptr = alpha * sum + beta * *c_ptr;
+            }
+        }
+    }
+}
+
+// --- LAPACK full-pivot LU ILP64 counters and fakes -----------------------
+
+static DGETC2_ILP64_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DGESC2_ILP64_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DGETC2_ILP64_REGISTERED: AtomicBool = AtomicBool::new(false);
+static DGESC2_ILP64_REGISTERED: AtomicBool = AtomicBool::new(false);
+
+unsafe extern "C" fn test_dgetc2_ilp64(
+    n: *const i64,
+    _a: *mut f64,
+    lda: *const i64,
+    ipiv: *mut i64,
+    jpiv: *mut i64,
+    info: *mut i64,
+) {
+    let _ = lda;
+    DGETC2_ILP64_CALLS.fetch_add(1, Ordering::SeqCst);
+    let n = unsafe { *n as usize };
+    for index in 0..n {
+        let one_based = (index + 1) as i64;
+        unsafe {
+            *ipiv.add(index) = one_based;
+            *jpiv.add(index) = one_based;
+        }
+    }
+    unsafe {
+        *info = 0;
+    }
+}
+
+unsafe extern "C" fn test_dgesc2_ilp64(
+    _n: *const i64,
+    _a: *const f64,
+    _lda: *const i64,
+    _rhs: *mut f64,
+    _ipiv: *const i64,
+    _jpiv: *const i64,
+    scale: *mut f64,
+) {
+    DGESC2_ILP64_CALLS.fetch_add(1, Ordering::SeqCst);
+    unsafe {
+        *scale = 1.0;
+    }
+}
+
+// --- LAPACK QR ILP64 counters and fakes ----------------------------------
+
+static DGEQRF_ILP64_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DORGQR_ILP64_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DGEQRF_ILP64_REGISTERED: AtomicBool = AtomicBool::new(false);
+static DORGQR_ILP64_REGISTERED: AtomicBool = AtomicBool::new(false);
+
+unsafe extern "C" fn test_dgeqrf_ilp64(
+    m: *const i64,
+    n: *const i64,
+    _a: *mut f64,
+    lda: *const i64,
+    tau: *mut f64,
+    work: *mut f64,
+    lwork: *const i64,
+    info: *mut i64,
+) {
+    let _ = lda;
+    DGEQRF_ILP64_CALLS.fetch_add(1, Ordering::SeqCst);
+
+    let lwork_val = unsafe { *lwork };
+    if lwork_val == -1 {
+        unsafe {
+            *work = 1.0;
+            *info = 0;
+        }
+        return;
+    }
+
+    let m_val = unsafe { *m as usize };
+    let n_val = unsafe { *n as usize };
+    let k_val = m_val.min(n_val);
+    for i in 0..k_val {
+        unsafe {
+            *tau.add(i) = 0.0;
+        }
+    }
+    unsafe {
+        *info = 0;
+    }
+}
+
+unsafe extern "C" fn test_dorgqr_ilp64(
+    _m: *const i64,
+    _n: *const i64,
+    _k: *const i64,
+    _a: *mut f64,
+    _lda: *const i64,
+    _tau: *const f64,
+    work: *mut f64,
+    lwork: *const i64,
+    info: *mut i64,
+) {
+    DORGQR_ILP64_CALLS.fetch_add(1, Ordering::SeqCst);
+
+    let lwork_val = unsafe { *lwork };
+    if lwork_val == -1 {
+        unsafe {
+            *work = 1.0;
+            *info = 0;
+        }
+        return;
+    }
+
+    unsafe {
+        *info = 0;
+    }
+}
+
+// --- Test: ILP64 GEMM provider reaches LP64 consumer ---------------------
+
+#[test]
+fn ilp64_gemm_provider_reaches_lp64_consumer() {
+    let _guard = TEST_LOCK.lock().expect("test lock poisoned");
+
+    if !DGEMM_ILP64_REGISTERED.swap(true, Ordering::SeqCst) {
+        unsafe {
+            register_blas_gemm_provider_ptrs(
+                ProviderAbi::Ilp64,
+                BlasGemmProviderPtrSet {
+                    dgemm: Some(test_dgemm_ilp64 as *const std::ffi::c_void),
+                    ..BlasGemmProviderPtrSet::new()
+                },
+            )
+            .expect("dgemm ilp64 registration should succeed");
+        }
+    }
+
+    DGEMM_ILP64_CALLS.store(0, Ordering::SeqCst);
+
+    let a = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0]));
+    let b = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![5.0, 7.0, 6.0, 8.0]));
+
+    let mut backend = CpuBackend::new();
+    let c = backend.dot_general(
+        &a,
+        &b,
+        &DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        },
+    );
+
+    assert_eq!(DGEMM_ILP64_CALLS.load(Ordering::SeqCst), 1);
+    match c {
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[19.0, 43.0, 22.0, 50.0]),
+        _ => panic!("expected f64 tensor"),
+    }
+}
+
+// --- Test: ILP64 LAPACK full-pivot LU provider bridges integer arrays ----
+
+#[test]
+fn ilp64_lapack_full_piv_lu_bridges_integer_arrays() {
+    let _guard = TEST_LOCK.lock().expect("test lock poisoned");
+
+    if !DGETC2_ILP64_REGISTERED.swap(true, Ordering::SeqCst) {
+        unsafe {
+            register_lapack_provider_ptrs(
+                ProviderAbi::Ilp64,
+                LapackProviderPtrSet {
+                    dgetc2: Some(test_dgetc2_ilp64 as *const std::ffi::c_void),
+                    dgesc2: Some(test_dgesc2_ilp64 as *const std::ffi::c_void),
+                    ..LapackProviderPtrSet::new()
+                },
+            )
+            .expect("ilp64 full-piv-lu registration should succeed");
+        }
+        DGESC2_ILP64_REGISTERED.store(true, Ordering::SeqCst);
+    }
+
+    DGETC2_ILP64_CALLS.store(0, Ordering::SeqCst);
+    DGESC2_ILP64_CALLS.store(0, Ordering::SeqCst);
+
+    let a = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0]));
+    let b = Tensor::F64(TypedTensor::from_vec(vec![2, 1], vec![4.0, 8.0]));
+
+    let mut backend = CpuBackend::new();
+    let x = backend.full_piv_lu_solve(&a, &b, false);
+
+    assert_eq!(DGETC2_ILP64_CALLS.load(Ordering::SeqCst), 1);
+    assert_eq!(DGESC2_ILP64_CALLS.load(Ordering::SeqCst), 1);
+    match x {
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[4.0, 8.0]),
+        _ => panic!("expected f64 tensor"),
+    }
+}
+
+// --- Test: ILP64 LAPACK workspace-query routine (QR) ---------------------
+
+#[test]
+fn ilp64_lapack_qr_workspace_query() {
+    let _guard = TEST_LOCK.lock().expect("test lock poisoned");
+
+    if !DGEQRF_ILP64_REGISTERED.swap(true, Ordering::SeqCst) {
+        unsafe {
+            register_lapack_provider_ptrs(
+                ProviderAbi::Ilp64,
+                LapackProviderPtrSet {
+                    dgeqrf: Some(test_dgeqrf_ilp64 as *const std::ffi::c_void),
+                    dorgqr: Some(test_dorgqr_ilp64 as *const std::ffi::c_void),
+                    ..LapackProviderPtrSet::new()
+                },
+            )
+            .expect("ilp64 qr registration should succeed");
+        }
+        DORGQR_ILP64_REGISTERED.store(true, Ordering::SeqCst);
+    }
+
+    DGEQRF_ILP64_CALLS.store(0, Ordering::SeqCst);
+    DORGQR_ILP64_CALLS.store(0, Ordering::SeqCst);
+
+    let a = Tensor::F64(TypedTensor::from_vec(vec![2, 1], vec![1.0, 2.0]));
+
+    let mut backend = CpuBackend::new();
+    let result = backend.qr(&a);
+
+    assert!(result.is_ok(), "qr should succeed, got {:?}", result.err());
+    assert_eq!(DGEQRF_ILP64_CALLS.load(Ordering::SeqCst), 2);
+    assert_eq!(DORGQR_ILP64_CALLS.load(Ordering::SeqCst), 2);
+}
+
+// --- Test: null pointer error for BLAS dgemm -----------------------------
+
+#[test]
+fn blas_gemm_null_pointer_error() {
+    let _guard = TEST_LOCK.lock().expect("test lock poisoned");
+
+    let err = unsafe {
+        register_blas_gemm_provider_ptrs(
+            ProviderAbi::Ilp64,
+            BlasGemmProviderPtrSet {
+                dgemm: Some(std::ptr::null()),
+                ..BlasGemmProviderPtrSet::new()
+            },
+        )
+    }
+    .unwrap_err();
+
+    assert_eq!(
+        err,
+        ProviderRegistrationError::NullPointer { symbol: "dgemm" }
+    );
+}
+
+// --- Test: null pointer error for LAPACK dpotrf --------------------------
+
+#[test]
+fn lapack_null_pointer_error() {
+    let _guard = TEST_LOCK.lock().expect("test lock poisoned");
+
+    let err = unsafe {
+        register_lapack_provider_ptrs(
+            ProviderAbi::Ilp64,
+            LapackProviderPtrSet {
+                dpotrf: Some(std::ptr::null()),
+                ..LapackProviderPtrSet::new()
+            },
+        )
+    }
+    .unwrap_err();
+
+    assert_eq!(
+        err,
+        ProviderRegistrationError::NullPointer { symbol: "dpotrf" }
+    );
+}


### PR DESCRIPTION
## Summary
- add runtime LP64/ILP64 provider registration APIs for `provider-inject`
- bridge raw BLAS GEMM and LAPACK function pointers through `cblas-inject` / `lapack-inject`
- keep existing typed LP64 compatibility wrappers for downstream callers
- add provider-inject integration tests covering ILP64 GEMM, full-pivot LU, QR workspace query, and null-pointer errors

## Dependency state
- Refs #760
- Depends on https://github.com/shinaoka/lapack-inject/pull/6
- Temporarily pins `cblas-inject` and `lapack-inject` to git revisions that expose the runtime ABI registration surface. Before merge/release, replace these with published crate versions.
- Auto-merge is intentionally not enabled while this depends on unpublished provider revisions.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p tenferro-tensor --no-default-features --features cpu-blas,provider-inject`
- `cargo test -p tenferro-tensor --no-default-features --features cpu-blas,provider-inject --test inject_tests --test inject_dual_abi_tests`
- `cargo test -p tenferro-tensor --no-default-features --features cpu-blas,provider-inject --doc inject::`
- `cargo test --workspace --release`
- `cargo test --doc --workspace --release`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`

## Notes
Implementation was delegated to `opencode` per maintainer request, then reviewed and adjusted locally.

`scripts/create-pr.sh` was not used because `scripts/check-agent-assets.sh --quiet` currently reports unrelated managed-asset drift in `scripts/build_docs_site.sh`, `scripts/check-docs-site.py`, and `.github/workflows/docs.yml`. `scripts/check-repo-settings.sh --quiet` passes.
