### PR TITLE
[codex] Address CPU validation, AD boundaries, linalg safety, and docs

### DIFF
--- a/docs/design/contraction-pipeline.md
+++ b/docs/design/contraction-pipeline.md
@@ -1,278 +1,122 @@
 # Binary Contraction Pipeline
 
-This document details the binary contraction pipeline: how two tensors are
-contracted in a single step of an N-ary contraction tree. It covers copy
-elision, copy strategy experiments, and the recommended decomposition into
-core primitives.
+This document describes the current binary step used inside an N-ary einsum
+contraction tree. It is implemented through `tenferro-einsum` planning and the
+`TensorBackend::dot_general` execution surface in `tenferro-tensor`.
 
-See [tensor-prims.md](./tensor-prims.md) for the semiring-core / fast-path
-traits and
-[einsum.md](./einsum.md) for how binary contractions fit into the N-ary
-einsum engine.
+See [einsum.md](./einsum.md) for the N-ary API and
+[tensor-prims.md](./tensor-prims.md) for the current tensor backend protocol.
 
 ---
 
-## Historical Problem: Eager Reorder + BatchedGemm Is Suboptimal
+## Step Inputs
 
-When an einsum contraction tree is executed step by step, each step typically
-involves:
+Each pairwise step receives:
 
-1. Reordering input operands into GEMM-compatible layout
-2. Executing GEMM
-3. Reordering the output for the next step
+- left operand labels,
+- right operand labels,
+- output labels for this intermediate or final result,
+- label sizes from the tree's size dictionary.
 
-In the old design, decomposing this into separate eager reordering and
-`SemiringCoreDescriptor::BatchedGemm` calls forced materialization before the backend
-could reason about layout. This was suboptimal because:
+Repeated labels are normalized before ordinary pairwise contraction. Strict
+binary lowering only accepts non-repeated labels; repeated-label cases fall back
+to the general path.
 
-- **Unnecessary copies**: The contraction backend can often skip the copy
-  entirely when strides are already compatible (`try_fuse_group` in strided-rs).
-  A standalone reorder primitive cannot know this.
+## Label Classification
 
-- **Wrong copy strategy**: When a copy is needed, there are two iteration
-  orders — source-stride-order and destination-stride-order (HPTT). The
-  optimal choice depends on cache state, which a standalone reorder primitive
-  cannot know.
+For a binary contraction, labels are classified into:
 
----
+| Class | Meaning |
+| --- | --- |
+| left free | appears only in the left operand and survives |
+| right free | appears only in the right operand and survives |
+| batch | appears in both operands and survives |
+| contraction | appears in both operands and does not survive |
+| pre-reduced | appears in one operand and does not survive |
 
-## Two Approaches
+Pre-reduced labels are reduced before the `dot_general` step.
 
-### Approach A: `Contract` Extended Operation
+## Column-Major Layout
 
-`SemiringFastPathDescriptor::Contract` fuses permutation and GEMM into a single primitive,
-matching cuTENSOR's `cutensorContract`. It is an **extended operation**
-(dynamically queried via `has_extension_for`) because not all backends need to
-implement it.
+tenferro uses column-major storage. The canonical `DotGeneral` output order is:
 
-The einsum layer queries `TensorSemiringFastPath::has_fast_path(...)`:
-- **Available**: emit `Contract`, backend handles everything internally.
-- **Not available**: fall back to core ops decomposition (Approach B).
-
-Backend advantages:
-- CPU: `try_fuse_group` copy elision, HPTT copy, global allocator reuse
-- GPU: maps directly to `cutensorContract` (single kernel launch)
-
-### Approach B: `permute` view + `MakeContiguous` + `BatchedGemm`
-
-The argument for `Contract` assumes that decomposing reordering +
-`BatchedGemm` forces materialization. This assumption breaks if we
-distinguish **two kinds of permutation**:
-
-- `Tensor::permute()`: metadata-only reordering (zero-copy, Tensor layer)
-- `SemiringCoreDescriptor::MakeContiguous`: explicit materialization when a packed
-  buffer is actually required
-
-If the einsum layer uses `permute` views to reorder axes, then `BatchedGemm`
-receives a `StridedView` with arbitrary strides. A `MakeContiguous` prim
-bridges this gap.
-
----
-
-## Recommended Pipeline (Approach B, for CPU)
-
-```
-1. Axis classification (einsum layer)
-   Classify modes into batch, lo (left-output), ro (right-output), sum (contracted).
-
-2. permute (Tensor layer, zero-copy)
-   Reorder to canonical layout:
-   A → [lo, sum, batch], B → [sum, ro, batch], C → [lo, ro, batch]
-   Metadata-only: strides are reordered, no data movement.
-
-3. MakeContiguous (Prims layer, conditional copy)
-   Check full-tensor contiguity via try_fuse on all dimensions.
-   - Contiguous (col-major or row-major): no-op, pass through.
-   - Not contiguous: copy to col-major buffer.
-
-4. BatchedGemm (Prims layer, contiguous input)
-   Inputs are guaranteed contiguous. N/T is determined by stride layout:
-   - stride[0] = 1 → col-major → CblasNoTrans
-   - stride[-1] = 1 → row-major → CblasTrans
+```text
+lhs_free..., rhs_free..., batch...
 ```
 
-### `MakeContiguous` Prim Descriptor
+The strict binary lowering tracks GEMM-like metadata with compute dimensions on
+the left and batch dimensions on the right:
 
-```rust
-SemiringCoreDescriptor::MakeContiguous
+```text
+lhs matrix dims: lhs_free..., contract...
+rhs matrix dims: contract..., rhs_free...
+output dims:     lhs_free..., rhs_free..., batch...
 ```
 
-No parameters needed. The operation:
-1. Checks if all elements are packed without gaps (either col-major or
-   row-major)
-2. If yes: no-op (the backend returns immediately)
-3. If no: copies to col-major layout (tenferro convention)
+Batch-last placement means each batch slice occupies a contiguous block in
+column-major layout, which is the convention used by the CPU GEMM path.
 
-Since `permute` already reorders axes into canonical order, full-tensor
-contiguity implies group-level fusability. There is no need for per-group
-`try_fuse_group` checks — a single full-tensor check suffices.
+## Strict Binary Lowering
 
-### Why This Works Without Copy Elision Loss
+`tenferro-einsum/src/planning/strict_binary.rs` detects dense binary
+contractions that can be represented as one canonical `DotGeneral` plus a final
+output transpose if needed.
 
-The key insight is that `permute` produces a non-contiguous `StridedView`
-with reordered strides, not a materialized copy. `MakeContiguous` then checks
-whether the data is already packed:
+The strict plan records:
 
-- **Intermediate results** from previous contraction steps are typically
-  allocated as col-major buffers. After `permute`, the strides change but
-  the data is still packed (just in row-major order relative to the new axis
-  names). `MakeContiguous` detects this and skips the copy. This is equivalent
-  to `try_fuse_group` succeeding in the current strided-einsum2 design.
+- left and right free labels,
+- contraction labels,
+- batch labels,
+- operand permutations,
+- `m`, `k`, and `n`,
+- canonical output dimensions,
+- final output permutation.
 
-- **Original input tensors** may have arbitrary strides (from slicing,
-  broadcasting, etc.). These genuinely need copying, which `MakeContiguous`
-  handles.
+It returns `None` for patterns it should not own, including repeated labels.
+That is not an error; the general path handles those semantics.
 
----
+## General Path
 
-## GPU: Use `Contract` Extended Op
+The eager executor and graph builder use the general path when strict binary
+lowering does not apply:
 
-For GPU backends, `cutensorContract` accepts arbitrary strides natively
-and fuses permutation + GEMM in a single kernel launch. The decomposed path
-(Approach B) would require a separate contiguify kernel followed by GEMM —
-two kernel launches with a synchronization point. For GPU backends, `Contract`
-as an extended op remains preferable.
+1. Extract diagonals for repeated input labels.
+2. Reduce labels that no longer survive.
+3. Broadcast and multiply for pure outer/Hadamard-like cases.
+4. Use `dot_general` for ordinary contractions.
+5. Embed repeated output labels with `embed_diagonal`.
+6. Transpose to the requested output label order.
 
----
+This path favors correctness and broad semantics. Backend-specific performance
+comes from the lower `TensorBackend` implementation of `dot_general`, reduction,
+transpose, and diagonal operations.
 
-## Trade-offs
+## CPU Execution
 
-| Aspect | `Contract` (Approach A) | `permute` + `MakeContiguous` + `BatchedGemm` (Approach B) |
-|---|---|---|
-| Copy elision | Backend-internal `try_fuse_group` per group | Full-tensor contiguity check (slightly conservative) |
-| Backend complexity | Must implement full contraction pipeline | Only `MakeContiguous` + `BatchedGemm` (simpler) |
-| GPU compatibility | Maps directly to `cutensorContract` | Requires 2 kernel launches (contiguify + GEMM) |
-| API surface | Extended op, dynamically queried | Core ops only, no extension mechanism needed |
+CPU execution is handled by `CpuBackend`:
 
-**Conservative case**: When dimension groups are independently fusable but the
-full tensor is not contiguous (gap between groups), `MakeContiguous` copies
-unnecessarily. In practice this rarely occurs because intermediate results are
-col-major allocated and `permute` preserves packed layout.
+- elementwise/reduction/structural work uses strided-kernel and dedicated CPU
+  implementations,
+- `dot_general` uses the selected CPU GEMM backend (`cpu-faer` or `cpu-blas`),
+- faer-backed work runs inside `CpuContext::install` through
+  `CpuExecSession`.
 
-### Recommendation
+## CubeCL/CUDA Execution
 
-- **CPU backend**: Use `permute` + `MakeContiguous` + `BatchedGemm`.
-  Simpler implementation, no extended op needed, minimal performance gap.
-- **GPU backend**: Use `Contract` extended op mapping to `cutensorContract`.
-  Single kernel launch, no intermediate buffer.
+When a compiled program is evaluated with `CubeclBackend`, the same graph-level
+ops run on GPU if supported:
 
----
+- `dot_general` can route through CubeCL/CUDA and cuTENSOR/cuBLAS-backed paths,
+- structural and reduction steps use CubeCL kernels where implemented,
+- unsupported dtypes or operations return `BackendFailure`.
 
-## strided-einsum2 Six-Step Pipeline (Reference)
+There is no current separate direct `CudaBackend` contraction pipeline. Future
+GPU contraction improvements should extend `CubeclBackend` and preserve the
+explicit placement policy described in [gpu-backend-design.md](./gpu-backend-design.md).
 
-The current strided-einsum2 implementation uses a six-step pipeline for the
-`Contract` extended operation on CPU:
+## Planner Safety
 
-```
-1. Trace pre-reduction
-   Sum out axes appearing only in one operand before GEMM.
-   Conjugation materialized during reduce (conj flag -> false for GEMM).
-
-2. Permutation to canonical order
-   A[left, contracted, batch], B[contracted, right, batch], C[left, right, batch]
-   Batch-last for column-major contiguity.
-
-3. Element-wise bypass
-   If contracted, left, and right are all empty (pure Hadamard product),
-   call zip_map2_into instead of GEMM.
-
-4. Fusability check (try_fuse_group)
-   Test whether dimension groups can be fused into a single contiguous
-   dimension without copying. Sorts (dim, stride) pairs by |stride|
-   ascending and verifies stride[i] * dim[i] == stride[i+1].
-   If fusable → zero-copy metadata extraction.
-   If not → allocate col-major buffer and copy.
-
-5. GEMM dispatch
-   Call selected backend: faer::bgemm or cblas::dgemm/zgemm.
-   Naive loop fallback for non-Scalar types (integers, tropical).
-
-6. Copy-back
-   If output was non-contiguous, copy from internal buffer back to
-   the original strided destination.
-```
-
-Steps 1-4 are analyzed during `plan_contraction`. Steps 5-6 are executed
-during `contract`.
-
-### CPU Contraction Plan (for Contract extended op)
-
-```rust
-pub struct CpuContractionPlan {
-    a_perm: Vec<usize>,
-    b_perm: Vec<usize>,
-    c_perm: Vec<usize>,
-    a_fusable: bool,
-    b_fusable: bool,
-    batch_size: usize,
-    left_size: usize,
-    right_size: usize,
-    contract_size: usize,
-    gemm: GemmDispatch,  // Faer | Cblas | Naive
-    workspace_size: usize,
-    elementwise_bypass: bool,
-    blocking: Option<BlockingPlan>,
-}
-```
-
----
-
-## Copy Strategy Experiments
-
-### Source-stride-order vs HPTT (destination-stride-order)
-
-A permutation copy must traverse the same elements in two different stride
-orders (source and destination). The question is which order to follow:
-
-| | Source-stride-order | HPTT (dst-stride-order) |
-|---|---|---|
-| Reads | Sequential (hardware prefetcher effective) | Scattered |
-| Writes | Scattered (absorbed by write-combining buffers) | Sequential + cache-blocked |
-
-**Source-stride-order** iterates in ascending source stride, giving
-sequential reads exploited by the hardware prefetcher. Scattered
-destination writes are absorbed by write-combining buffers.
-
-**HPTT (destination-stride-order)** gives sequential writes with
-cache-blocked reads, which is better when source data is warm in cache.
-
-### Experiment Results
-
-Three experiments characterize the copy strategy landscape:
-
-1. **Flatten HPTT recursion** (`perf/flatten-hptt-recursion`): Replaced
-   recursive ComputeNode traversal with flat odometer — **no improvement**
-   (±3% noise). Recursion overhead is not a bottleneck.
-
-2. **Source-order vs HPTT** (`perf/src-vs-dst-order`): With copy elision
-   disabled, HPTT is 16–43% faster on most workloads (lm_*, str_*,
-   mera_closed). Source-order is 27–30% faster only for degenerate
-   many-small-dims cases (tn_focus/tn_light). On `mera_open`, the two
-   strategies perform identically (±2%).
-
-3. **Eager HPTT** (`perf/eager-hptt-permute`): Eagerly materializing all
-   permutations via HPTT causes 26–31% regression on `mera_open` — entirely
-   due to copy elision loss, not copy strategy.
-
-### Benchmark Evidence (Lazy vs Eager)
-
-Results on AMD EPYC 7713P (faer backend):
-
-| Instance | Lazy 1T | Eager 1T | Regression |
-|---|---|---|---|
-| mera_open (opt_flops) | 918 ms | 1199 ms | **+31%** |
-| mera_open (opt_size) | 918 ms | 1159 ms | **+26%** |
-| tensor network instances | ~285 ms | ~287 ms | ~0% |
-
-The `mera_open` regression is caused by eager permutation forcing copies at
-every step, even when `try_fuse_group` would have skipped them.
-
-### Conclusion
-
-**Copy elision is the dominant optimization.** When copies are unavoidable,
-HPTT is the better default thanks to cache-blocked tiling. An adaptive
-strategy switching to source-order for degenerate many-small-dims cases
-could provide the best of both worlds.
-
-See `strided-rs/docs/src-vs-dst-order-experiment.md` and
-`strided-rs/docs/eager-hptt-experiment.md` for full results.
+Contraction planning must not rely on debug-only assertions for semantic
+validity. Missing label sizes, invalid explicit paths, duplicate live operands,
+and rank/shape mismatches are normal `Result` errors so debug and release builds
+behave the same.

--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -1,553 +1,181 @@
-# Einsum
+# Einsum Design
 
-High-level einsum API on `Tensor<T>`. Supports string notation with
-parenthesized contraction order, integer label notation, and pre-optimized
-contraction trees.
+tenferro has two current einsum surfaces:
 
-See [contraction-pipeline.md](./contraction-pipeline.md) for the binary
-contraction pipeline details and [tensor-prims.md](./tensor-prims.md)
-for the semiring-core / semiring-fast-path protocol families that `einsum`
-depends on.
+- `tenferro::einsum::{einsum, einsum_with}` builds lazy traced graphs over
+  `TracedTensor`.
+- `tenferro_einsum::{eager_einsum, eager_einsum_owned}` executes immediately
+  over concrete `Tensor` values and is used by runtime N-ary execution.
 
----
+The implementation is split between:
 
-## Public API
+- `tenferro/src/einsum.rs` for the user-facing traced facade, contraction
+  strategy selection, symbolic-shape handling, and engine cache integration,
+- `tenferro/src/exec.rs` for runtime `NaryEinsum` execution,
+- `tenferro-einsum/src/syntax/` for subscript and nested-order parsing,
+- `tenferro-einsum/src/planning/` for contraction tree planning and per-step
+  lowering plans,
+- `tenferro-einsum/src/builder.rs` for graph-fragment lowering,
+- `tenferro-einsum/src/eager.rs` for concrete eager execution.
 
-### Subscripts
-
-```rust
-/// Einsum subscripts using integer labels (omeinsum-rs compatible).
-#[derive(Debug, Clone)]
-pub struct Subscripts {
-    pub inputs: Vec<Vec<u32>>,
-    pub output: Vec<u32>,
-}
-
-impl Subscripts {
-    /// Create from integer label arrays.
-    pub fn new(inputs: &[&[u32]], output: &[u32]) -> Self;
-
-    /// Parse from string notation: "ij,jk->ik"
-    /// Supports parenthesized order: "ij,(jk,kl)->il"
-    pub fn parse(notation: &str) -> Result<Self>;
-}
-```
-
-> **Status: Implemented.** Parenthesized notation
-> (e.g. `"ij,(jk,kl)->il"`) is preserved through `NestedEinsum` and executed in
-> the requested contraction order.
-
-The production module layout is also intentionally split:
-
-- `src/api/borrowed.rs` for allocating eager entrypoints
-- `src/api/owned.rs` for consuming variants
-- `src/api/into.rs` for accumulating `_into` variants
-- `src/ad/reverse_rule.rs`, `src/ad/tracked.rs`, and `src/ad/rules.rs` for AD
-  machinery
-
-### ContractionTree
-
-```rust
-pub struct ContractionTree { /* internal */ }
-
-impl ContractionTree {
-    /// Automatically optimize contraction order (cost-based heuristic).
-    pub fn optimize(subscripts: &Subscripts, shapes: &[&[usize]]) -> Result<Self>;
-
-    /// Manually specify pairwise contraction sequence.
-    pub fn from_pairs(
-        subscripts: &Subscripts,
-        shapes: &[&[usize]],
-        pairs: &[(usize, usize)],
-    ) -> Result<Self>;
-}
-```
-
-### Three API Levels
-
-```rust
-/// Level 1: String notation — parse + optimize + execute.
-pub fn einsum<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &str,
-    operands: &[&Tensor<T>],
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-
-/// Level 2: Pre-built subscripts — optimize + execute.
-pub fn einsum_with_subscripts<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &Subscripts,
-    operands: &[&Tensor<T>],
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-
-/// Level 3: Pre-optimized tree — execute only.
-pub fn einsum_with_plan<T, A, B>(
-    ctx: &mut B::Context,
-    tree: &ContractionTree,
-    operands: &[&Tensor<T>],
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-```
-
-| Level | Parsing | Optimization | Execution | Use case |
-|-------|---------|-------------|-----------|----------|
-| `einsum` | Yes | Yes | Yes | One-off, convenience |
-| `einsum_with_subscripts` | Cached | Yes | Yes | Same pattern, varying shapes |
-| `einsum_with_plan` | Cached | Cached | Yes | Hot loops, same shapes |
-
-All functions take `ctx: &mut B::Context` for explicit backend context
-passing (thread pool, plan cache). `size_dict` provides dimension sizes
-for output labels not present in any input (generative einsum).
-
-### Accumulating Variants
-
-Each allocating function has an `_into` counterpart with BLAS-style scaling:
-
-```rust
-/// output = alpha * einsum(operands) + beta * output
-pub fn einsum_into<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &str,
-    operands: &[&Tensor<T>],
-    alpha: T,
-    beta: T,
-    output: &mut Tensor<T>,
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<()>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-
-pub fn einsum_with_subscripts_into<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &Subscripts,
-    operands: &[&Tensor<T>],
-    alpha: T,
-    beta: T,
-    output: &mut Tensor<T>,
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<()>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-
-pub fn einsum_with_plan_into<T, A, B>(
-    ctx: &mut B::Context,
-    tree: &ContractionTree,
-    operands: &[&Tensor<T>],
-    alpha: T,
-    beta: T,
-    output: &mut Tensor<T>,
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<()>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-```
-
-The `_into` variants eliminate output allocation per call and enable
-accumulation semantics that map directly to the primitive families'
-`execute` alpha/beta contract.
-
-### Consuming Variants
-
-```rust
-/// Level 1: Consuming — input buffers may be reused.
-pub fn einsum_owned<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &str,
-    operands: Vec<Tensor<T>>,
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-
-/// Level 2: Consuming — optimize + execute.
-pub fn einsum_with_subscripts_owned<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &Subscripts,
-    operands: Vec<Tensor<T>>,
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-
-/// Level 3: Consuming — execute only.
-pub fn einsum_with_plan_owned<T, A, B>(
-    ctx: &mut B::Context,
-    tree: &ContractionTree,
-    operands: Vec<Tensor<T>>,
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-```
-
-Input tensors are moved. The implementation may reuse their buffers for
-intermediate results, avoiding allocation in contraction trees. Buffer
-reuse is deterministic — Rust ownership guarantees no other references.
-
-> **Status: Not yet implemented.** The `_owned` variants currently delegate
-> to the borrowed API without buffer reuse. Ownership is accepted but
-> buffers are not reused for intermediates.
-
-### Summary: Nine API Functions
-
-| | Allocating | Accumulating (`_into`) | Consuming (`_owned`) |
-|---|---|---|---|
-| String notation | `einsum` | `einsum_into` | `einsum_owned` |
-| Pre-built subscripts | `einsum_with_subscripts` | `einsum_with_subscripts_into` | `einsum_with_subscripts_owned` |
-| Pre-optimized tree | `einsum_with_plan` | `einsum_with_plan_into` | `einsum_with_plan_owned` |
-
-All 9 functions share the same generic signature pattern `<T, A, B>` with
-`ctx: &mut B::Context` and `size_dict: Option<&HashMap<u32, usize>>`.
+Historical design notes that refer to direct `CudaBackend`/`RocmBackend`,
+`tenferro-prims`, or the old nine-function einsum API are not current.
 
 ---
 
-## User Examples
+## Public Traced API
+
+The facade crate exposes lazy traced einsum:
+
+```rust,ignore
+use tenferro::{einsum::einsum, CpuBackend, Engine, TracedTensor};
+
+let a = TracedTensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+let b = TracedTensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+let mut engine = Engine::new(CpuBackend::new());
+let mut c = einsum(&mut engine, &[&a, &b], "ij,jk->ik")?;
+let result = c.eval(&mut engine)?;
+```
+
+`einsum_with` accepts an explicit `EinsumOptimize` strategy:
+
+| Strategy | Meaning |
+| --- | --- |
+| `Auto(ContractionOptimizerOptions)` | TreeSA/omeco path optimization with configured score |
+| `False` | left-to-right contraction |
+| `Nested(NestedEinsum)` | explicit parenthesized contraction tree |
+| `Path(Vec<(usize, usize)>)` | JAX-compatible shrinking-list path |
+| `Tree(ContractionTree)` | precomputed tree |
+
+`EinsumOptimize::default()` is time-optimized automatic planning.
+
+## Concrete Eager API
+
+`tenferro-einsum` owns immediate execution over `Tensor` values:
 
 ```rust
-use tenferro_einsum::{einsum, einsum_owned, Subscripts, ContractionTree};
-use tenferro_tensor::{Tensor, MemoryOrder};
-use tenferro_device::LogicalMemorySpace;
-use tenferro_prims::{CpuBackend, CpuContext};
+use tenferro_einsum::eager_einsum;
+use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend};
 
-let col = MemoryOrder::ColumnMajor;
-let mut ctx = CpuContext::new(4);
+let mut ctx = CpuBackend::new();
+let a = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+let b = Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+let c = eager_einsum(&mut ctx, &[&a, &b], "ij,jk->ik").unwrap();
 
-let a = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
-let b = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
-
-// Matrix multiplication
-let c = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", &[&a, &b], None).unwrap();
-
-// Trace
-let tr = einsum::<Standard<f64>, CpuBackend>(&mut ctx, "ii->", &[&a], None).unwrap();
-
-// Batch matrix multiplication
-let ba = Tensor::<f64>::zeros(&[10, 3, 4], LogicalMemorySpace::MainMemory, col);
-let bb = Tensor::<f64>::zeros(&[10, 4, 5], LogicalMemorySpace::MainMemory, col);
-let bc =
-    einsum::<Standard<f64>, CpuBackend>(&mut ctx, "bij,bjk->bik", &[&ba, &bb], None).unwrap();
-
-// Explicit contraction order via parentheses
-let d = einsum::<Standard<f64>, CpuBackend>(
-    &mut ctx, "ij,(jk,kl)->il", &[&a, &b, &c], None,
-).unwrap();
-
-// Integer label notation (for programmatic use)
-let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
-let c = einsum_with_subscripts::<Standard<f64>, CpuBackend>(
-    &mut ctx,
-    &subs,
-    &[&a, &b],
-    None,
-)
-.unwrap();
-
-// Pre-optimized tree (hot loops)
-let tree = ContractionTree::optimize(&subs, &[&[2, 2], &[2, 2]]).unwrap();
-for _ in 0..n_steps {
-    let c = einsum_with_plan::<Standard<f64>, CpuBackend>(&mut ctx, &tree, &[&a, &b], None)
-        .unwrap();
-}
-
-// Consuming variant: operands moved, buffers reused
-let x = Tensor::<f64>::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], col).unwrap();
-let y = Tensor::<f64>::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], col).unwrap();
-let z =
-    einsum_owned::<Standard<f64>, CpuBackend>(&mut ctx, "ij,jk->ik", vec![x, y], None).unwrap();
+assert_eq!(c.shape(), &[2, 2]);
 ```
 
----
+`eager_einsum_owned` consumes inputs and lets the backend reclaim eligible
+buffers after their last use. Downstream runtime code should use these N-ary
+entrypoints rather than depending on binary lowering internals.
 
-## N-ary Contraction (Internal)
+## Subscripts And Repeated Labels
 
-For N > 2 inputs, the einsum engine uses contraction tree optimization
-to find the optimal pairwise contraction order.
+`Subscripts::parse` accepts NumPy/PyTorch-style labels. Parentheses are
+validated and stripped by `Subscripts::parse`; use `NestedEinsum::parse` or pass
+parenthesized notation through the higher-level traced facade when contraction
+order must be preserved.
 
-### Dispatch Strategy
+Repeated-label semantics follow the usual einsum rules:
 
-```rust
-fn einsum_impl<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &Subscripts,
-    operands: &[&Tensor<T>],
-    size_dict: Option<&HashMap<u32, usize>>,
-) -> Result<Tensor<T>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>,
-{
-    match operands.len() {
-        0 => Err(Error::InvalidArgument("no inputs".into())),
-        1 => single_tensor_op::<T, A, B>(ctx, operands[0], &subscripts),
-        2 => binary_contraction::<T, A, B>(ctx, operands[0], operands[1], &subscripts),
-        _ => {
-            let tree = ContractionTree::optimize(&subscripts, ...)?;
-            execute_tree::<T, A, B>(ctx, &tree, operands)
-        }
-    }
-}
+| Pattern | Meaning |
+| --- | --- |
+| `ii->` | extract the diagonal, then reduce it to a scalar trace |
+| `ii->i` | extract the diagonal |
+| `iij->ij` | extract the diagonal across the first two axes and preserve `j` |
+| `i->ii` | embed the vector on a diagonal matrix |
+
+The implementation applies these rules before ordinary contraction:
+
+1. `diagonalize_repeated` repeatedly applies `extract_diagonal` to duplicate
+   labels within one operand.
+2. Labels absent from the output or from later live operands are reduced with
+   `reduce_sum`.
+3. `embed_repeated` applies `embed_diagonal` when the output repeats a label
+   more often than the current value.
+4. `transpose_to_labels` restores requested output order.
+
+Strict binary/GEMM lowering intentionally rejects repeated labels and returns
+`None`. Those cases stay on the general eager/builder path, which handles
+diagonalization explicitly.
+
+## Static And Symbolic Shapes
+
+The traced facade chooses the lowering mode from input shape availability:
+
+| Inputs | Build-time behavior | Runtime behavior |
+| --- | --- | --- |
+| All concrete shapes | optimize the contraction tree at graph build time and lower into ordinary graph ops where possible | execute the lowered graph |
+| Any symbolic shape | emit one `NaryEinsum` op | optimize from actual input shapes at eval time |
+
+`Engine` caches automatic contraction trees by `(subscripts, input shapes)` so
+repeated symbolic-shape evaluations with the same concrete shapes amortize
+planning cost.
+
+## Planning
+
+`ContractionTree` records the pairwise contraction sequence, live operand
+labels, size dictionary, and compiled step plans. Automatic planning first asks
+omeco/TreeSA for a path. If omeco does not return one, the local self-greedy
+fallback chooses the pair with the smallest intermediate output size.
+
+Planner invariants are checked with normal `Result` propagation:
+
+- input rank and shape labels are validated by `build_size_dict`,
+- explicit paths must reference distinct live operands,
+- the final explicit path must leave exactly one live value,
+- contraction-cost labels must have known sizes.
+
+## Lowering And Execution
+
+Each pairwise step classifies labels into:
+
+- left-only free labels,
+- right-only free labels,
+- shared batch labels that survive,
+- shared contraction labels that are reduced.
+
+When a strict binary plan applies, the step caches the canonical matrix/GEMM
+layout metadata. When it does not apply, the builder and eager executor use the
+general path of diagonalization, reductions, broadcast/outer product, and
+`DotGeneral`.
+
+Column-major ordering matters. For GEMM-like steps, compute dimensions stay on
+the left and batch dimensions stay on the right so each batch slice remains a
+contiguous block for the underlying tensor backend.
+
+## GPU Interaction
+
+Einsum itself remains backend-agnostic at the graph level. GPU execution happens
+when a compiled program is evaluated with `CubeclBackend` from
+`tenferro-tensor/src/cubecl/`.
+
+Current GPU status:
+
+- CUDA uses CubeCL/CubeCL-CUDA under the `cubecl` feature.
+- cuTENSOR/cuBLAS paths cover selected contractions and GEMM-like operations.
+- ROCm is a stub and not a supported execution path.
+- Complex CubeCL expansion is blocked on upstream CubeCL support and is not part
+  of this batch.
+- GPU benchmarking is outside this batch.
+
+## AD
+
+Graph-level AD rules for einsum are sourced from `tenferro-ops/src/ad/` through
+the primitive operations produced by einsum lowering. New linalg-specific AD
+rules and oracle families are separate work; this document only describes the
+einsum lowering surface.
+
+## Tests
+
+Primary local checks for this surface are:
+
+```bash
+cargo test -p tenferro-einsum
+cargo test -p tenferro --test ad
+cargo test -p tenferro --doc
 ```
 
-### Binary Contraction Decomposition
-
-For each binary contraction, the engine chooses between:
-
-**Path A — Contract fast path available** (`TensorSemiringFastPath::has_fast_path(Contract)`):
-```
-let desc = SemiringFastPathDescriptor::Contract { modes_a, modes_b, modes_c };
-let plan = B::plan(&mut ctx, &desc, &shapes)?;
-B::execute(&mut ctx, &plan, alpha, &[&a, &b], beta, &mut c)?;
-→ backend handles diag, trace, permute, GEMM internally
-```
-
-**Path B — Core ops only** (decompose into primitives):
-```
-1. diag(a, paired_axes)        // zero-copy stride trick on Tensor<T>
-2. diag(b, paired_axes)        // zero-copy stride trick on Tensor<T>
-3. trace/reduce(a, trace_axes) // TensorSemiringCore::Trace / ReduceAdd
-4. trace/reduce(b, trace_axes)
-5. permute(a, canonical)  // zero-copy metadata on Tensor<T>
-6. permute(b, canonical)
-7. make_contiguous(a)          // TensorSemiringCore::MakeContiguous
-8. make_contiguous(b)          // TensorSemiringCore::MakeContiguous
-9. batched_gemm(a, b, c)       // plan + execute BatchedGemm
-```
-
-See [contraction-pipeline.md](./contraction-pipeline.md) for details on
-the `permute + MakeContiguous + BatchedGemm` pipeline.
-
-> **Status: Not yet implemented.** Path B (core-op decomposition) is not
-> implemented. If the backend does not support the `Contract` extension,
-> `binary_contraction` returns an error. See #141.
-
-**Example: `"iij,jkk->ik"`**:
-```
-1. a' = a.diagonal([(0,1)])    → a'[i,j]    (zero-copy)
-2. b' = b.diagonal([(1,2)])    → b'[j,k]    (zero-copy)
-3. (no trace/reduce needed)
-4. a'' = a'.permute([i,j])  → canonical  (zero-copy)
-5. b'' = b'.permute([j,k])  → canonical  (zero-copy)
-6. make_contiguous(a'')          → conditional copy
-7. make_contiguous(b'')          → conditional copy
-8. batched_gemm(a'', b'', c)   → c[i,k]     (computation)
-```
-
-### Single-Tensor Decomposition (Unary Operations)
-
-| Einsum | Decomposition |
-|--------|--------------|
-| `ii→` (full trace) | `trace(A, [(0,1)])` |
-| `ii→i` (diagonal) | `diag(A, [(0,1)])` (zero-copy on Tensor) |
-| `iij→j` (partial trace) | `diag(A, [(0,1)])` → `reduce(A', axis=0)` |
-| `ij→ji` (transpose) | `permute(A, [1,0])` |
-| `i→ij` (broadcast) | `repeat(A, j_dim)` (zero-copy on Tensor) |
-| `i→ii` (embed diagonal) | `anti_diag(A, [(0,1)])` |
-| `ij→i` (sum axis) | `reduce_add(A, axis=1)` |
-
-### Systematic Unary Lowering with Primitive Families
-
-To support trace and generative output patterns uniformly, unary lowering should
-follow a fixed classification and rewrite pipeline.
-
-1. Parse one-input subscripts and build `size_dict` (including optional user
-   sizes for labels not present in input).
-2. Count input/output occurrences per label.
-3. Classify labels:
-   - `extract_labels`: repeated in input and present in output
-   - `trace_labels`: repeated in input and absent from output
-   - `generative_labels`: absent from input and present in output
-   - `duplicate_output_labels`: repeated in output
-4. Lower in stages:
-   - `diag` (Tensor view op) for `extract_labels`
-   - `trace` (`SemiringCoreDescriptor::Trace`) for `trace_labels`
-   - `reduce_add` (`SemiringCoreDescriptor::ReduceAdd`) for non-output residual labels
-   - `permute` (Tensor view op) to canonical output order
-   - `MakeContiguous` only when a downstream kernel needs packed storage
-   - `repeat` (Tensor broadcast) for non-duplicate generative labels
-   - `anti_diag` / `anti_trace` for output duplication and scalar-to-diagonal
-     materialization
-
-This keeps primitive-family usage explicit while preserving zero-copy
-transformations (`diag`, `repeat`) at the Tensor layer.
-
-### Pattern-to-Primitive Mapping
-
-| Pattern | Expected semantics | Lowering |
-|--------|---------------------|----------|
-| `ii->` | $\sum_i A_{ii}$ | `Trace(paired=[(0,1)])` |
-| `iijj->` | $\sum_{i,j} A_{iijj}$ | `Trace` with two independent components |
-| `ii->i` | diagonal extraction | `diag([(0,1)])` |
-| `iij->j` | partial trace | `diag([(0,1)])` then `Reduce` |
-| `i->ii` | vector to diagonal matrix | `AntiDiag(paired=[(0,1)])` |
-| `->ii` | scalar to identity-like diagonal | scalar input + generative diagonal via `AntiTrace`/`AntiDiag` with unanchored component |
-| `->iii` | scalar to superdiagonal 3-tensor | scalar input + one 3-axis equality component |
-
-### End-to-End Unary Flow
-
-```
-subscripts + operand + optional size_dict
-    -> classify labels (extract / trace / generative / duplicate)
-    -> normalize with Tensor view ops (diag, repeat where applicable)
-    -> execute prim plans (Trace, Reduce, MakeContiguous where needed, AntiDiag, AntiTrace)
-    -> final tensor with requested output label multiplicities
-```
-
-The critical requirement is that `Trace`, `AntiTrace`, and `AntiDiag` execute
-one loop variable per equality-component, not one global diagonal index.
-Without that, multi-pair trace (`iijj->`) and generative diagonal (`->ii`,
-`->iii`) are under-specified.
-
----
-
-## Algebra Dispatch
-
-`Standard` is a typed algebra `Standard<T>(PhantomData<T>)` where `A::Scalar`
-carries the scalar type. `HasAlgebra` is UX sugar for default algebra inference
-— it lets the compiler infer `A = Standard<T>` from `T: HasAlgebra<Algebra = A>`
-without spelling out the algebra explicitly at call sites.
-
-Backend selection is determined by `T: HasAlgebra → infers algebra A`:
-
-```rust
-// impl<S: Scalar> TensorSemiringCore<Standard<S>> for CpuBackend  → faer/cblas GEMM  [current]
-// impl TensorSemiringCore<MaxPlus> for CpuBackend                 → tropical-gemm (tenferro-ext-tropical)
-// impl<S: Scalar> TensorSemiringCore<Standard<S>> for CudaBackend → cuTENSOR   [partial]
-// impl<S: Scalar> TensorSemiringCore<Standard<S>> for RocmBackend → hipTensor  [stub]
-// impl TensorSemiringCore<MyAlgebra> for CpuBackend               → user-provided kernels
-```
-
-See [algebra.md](./algebra.md) for `HasAlgebra` and `Semiring` details.
-
----
-
-## Automatic Differentiation
-
-### Five AD Functions
-
-The einsum AD API provides five functions for different AD modes:
-
-```rust
-/// Tracked einsum (reverse-mode AD via tape).
-pub fn tracked_einsum<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &str,
-    operands: &[&TrackedValue<Tensor<T>>],
-) -> AdResult<TrackedValue<Tensor<T>>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>,
-    Tensor<T>: Differentiable;
-```
-
-`tracked_einsum` records einsum operations onto the AD tape via
-`tape.record_op()`. Calling `tape.pullback()` computes gradients through
-einsum, and end-to-end pullback tests exist (see `tracked_einsum_matmul_pullback`
-in `tenferro-einsum/tests/einsum_tests.rs`).
-
-```rust
-/// Dual einsum (forward-mode JVP propagation).
-pub fn dual_einsum<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &str,
-    operands: &[&DualValue<Tensor<T>>],
-) -> AdResult<DualValue<Tensor<T>>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>,
-    Tensor<T>: Differentiable;
-
-/// Reverse-mode rule (rrule) for einsum without building a global tape.
-/// Returns one gradient tensor per input operand.
-pub fn einsum_rrule<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &str,
-    operands: &[&Tensor<T>],
-    cotangent: &Tensor<T>,
-) -> Result<Vec<Tensor<T>>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-
-/// Forward-mode rule (frule) for einsum without building a global tape.
-/// Inputs without tangent should use `None`.
-pub fn einsum_frule<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &str,
-    primals: &[&Tensor<T>],
-    tangents: &[Option<&Tensor<T>>],
-) -> Result<Tensor<T>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-
-/// Local HVP rule for einsum (forward-over-reverse).
-/// Returns (gradient, hvp) pairs for each input operand.
-pub fn einsum_hvp<T, A, B>(
-    ctx: &mut B::Context,
-    subscripts: &str,
-    primals: &[&Tensor<T>],
-    tangents: &[Option<&Tensor<T>>],
-    cotangent: &Tensor<T>,
-    cotangent_tangent: &Tensor<T>,
-) -> Result<Vec<(Tensor<T>, Tensor<T>)>>
-where
-    T: Scalar + HasAlgebra<Algebra = A>,
-    B: EinsumBackend<A>;
-```
-
-All AD functions take `ctx: &mut B::Context` and `B: EinsumBackend<A>`,
-matching the non-AD einsum functions.
-
-### Adjoint Rules
-
-Each forward operation has a clean adjoint:
-
-**Matrix multiply** (`"ij,jk->ik"`):
-
-Forward: $C_{ik} = \operatorname{batched\_gemm}(A_{ij},\; B_{jk})$
-
-Backward:
-
-$$\bar{A}_{ij} = \operatorname{batched\_gemm}(\bar{C}_{ik},\; B^\top_{kj})$$
-
-$$\bar{B}_{jk} = \operatorname{batched\_gemm}(A^\top_{ji},\; \bar{C}_{ik})$$
-
-**Partial trace** (`"iij->j"`):
-
-Forward: $y_j = \operatorname{reduce}(\operatorname{diag}(A, [(0,1)]),\; \text{axis}=0)$
-
-Backward:
-
-$$\bar{A} = \operatorname{anti\_diag}(\operatorname{repeat}(\bar{y},\; i_{\text{dim}}),\; [(0,1)])$$
-
-Both VJP and JVP go through the semiring primitive families, working on CPU and
-GPU uniformly (once GPU backends are available).
-
-> **Status: Not yet implemented.** GPU backends (`CudaBackend`, `RocmBackend`)
-> are API stubs that return errors. AD rules currently execute on CPU only.
-> See #141.
-
-### Optimizations from strided-opteinsum (Future)
-
-- **Borrowed-view passthrough**: Leaf nodes return borrows, not clones.
-- **Permutation-only detection**: Metadata-only transformation for
-  nodes that only permute axes (no contraction).
-- **Direct root write**: Final contraction writes into user's output
-  buffer (no extra allocation).
+GPU-specific execution tests require CUDA and are ignored by default; see
+[gpu-backend-design.md](./gpu-backend-design.md) for the command.

--- a/docs/design/exec-session.md
+++ b/docs/design/exec-session.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-`TensorExec` is the execution-time primitive surface. All ops run within a
-backend-owned execution scope — rayon pool for CPU, CUDA stream for GPU.
-Individual ops must NOT re-enter the backend's execution context.
+`TensorExec` is the execution-time primitive surface. Ops run within a
+backend-owned execution scope when the backend has one, such as the owned rayon
+pool used by CPU execution. Individual ops must not re-enter the same backend
+scope.
 
 `TensorBackend::with_exec_session` creates the scope. `eval_exec_ir` runs
 inside the session.
@@ -61,49 +62,29 @@ impl TensorBackend for CpuBackend {
 `CpuExecSession` implements `TensorExec` by calling kernel functions
 directly — no `install()` or `install_with_pool()` per op.
 
-### CUDA (future)
+### CubeCL/CUDA
 
-The same pattern maps to CUDA execution:
+`CubeclBackend` is the current CUDA GPU backend. It uses CubeCL/CubeCL-CUDA and
+runtime-loaded CUDA libraries from `tenferro-tensor/src/cubecl/`.
 
-| CPU | CUDA |
+Today `CubeclBackend` does not define a separate exec-session struct. It uses
+the default `TensorBackend::with_exec_session` adapter, so each `TensorExec`
+call forwards to the backend method. The backend method launches CubeCL kernels
+or calls the relevant cuTENSOR/cuSOLVER/cuBLAS wrapper against the backend's
+`CubeclRuntime`.
+
+| CPU concept | CubeCL/CUDA concept |
 |---|---|
-| `CpuContext` (rayon ThreadPool) | `CudaContext` (device + stream) |
-| `ctx.install()` | `cudaSetDevice()` + stream selection |
-| `BufferPool` (host `Vec<T>`) | `DeviceBufferPool` (cudaMalloc reuse) |
+| `CpuContext` (rayon ThreadPool) | `CubeclRuntime` (CUDA device/client) |
+| `ctx.install()` | CubeCL launch through the stored runtime |
+| `BufferPool` (host `Vec<T>`) | CubeCL device buffers plus upload/download helpers |
 | `Par::rayon(0)` | kernel launch on stream |
-| per-step `install()` overhead | per-step `cudaSetDevice()` overhead |
+| per-step `install()` overhead | per-kernel launch/runtime dispatch overhead |
 
-```rust
-// Future CUDA implementation (not yet implemented)
-struct CudaExecSession<'a> {
-    stream: &'a CudaStream,
-    device_pool: &'a mut DeviceBufferPool,
-}
-
-impl TensorExec for CudaExecSession<'_> {
-    fn dot_general(&mut self, lhs, rhs, config) -> Result<Tensor> {
-        // cuBLAS handle bound to stream — no per-op stream switch
-        cublas::gemm(self.stream, self.device_pool, lhs, rhs, config)
-    }
-}
-
-impl TensorBackend for CudaBackend {
-    fn with_exec_session<R: Send>(
-        &mut self,
-        f: impl FnOnce(&mut dyn TensorExec) -> R + Send,
-    ) -> R {
-        self.device.set_current();
-        let mut pool = std::mem::take(&mut self.device_pool);
-        let mut session = CudaExecSession {
-            stream: &self.stream,
-            device_pool: &mut pool,
-        };
-        let result = f(&mut session);
-        self.device_pool = pool;
-        result
-    }
-}
-```
+Future CubeCL work may introduce a dedicated GPU exec session if there is a
+measurable benefit from binding temporary workspace, stream state, or device
+buffer pooling across an entire compiled program. That should extend
+`CubeclBackend`; it should not add a separate `CudaBackend` type.
 
 ### Default (no-op)
 

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -1,416 +1,160 @@
 # GPU Backend Design
 
-This document details the GPU backend design for tenferro-rs, covering
-both CUDA (cuTENSOR) and ROCm (hipTENSOR) backends.
+This document describes the current GPU backend in tenferro-rs. The active
+implementation is the CubeCL backend in `tenferro-tensor/src/cubecl/`, gated by
+the `cubecl` feature. It targets NVIDIA CUDA devices through CubeCL and
+CubeCL-CUDA, with CUDA library support for cuTENSOR, cuSOLVER, and cuBLAS.
 
-**Purpose**: Detect potential problems before implementation begins.
-Define the types, modules, and API mapping needed for GPU support.
+GPU support is partial and experimental. CUDA allocation, explicit CPU/GPU
+transfer, many structural/elementwise/reduction kernels, selected cuTENSOR
+contractions, and selected cuSOLVER/cuBLAS linear algebra paths exist. HIP/ROCm
+is still a feature stub and is not a supported execution path.
 
-See [tensor-prims.md](./tensor-prims.md) for the semiring/scalar/analytic
-primitive families and the plan-cache key policy that applies to both CPU and
-GPU backends.
+See also:
 
----
-
-## Design Principles
-
-1. **Two separate backends** — `CudaBackend` and `RocmBackend` as distinct
-   types in `tenferro-prims`. Subtle API differences and future custom
-   kernel needs justify separate implementations over a unified vtable.
-2. **Runtime dlopen** — `libloading` loads cuTENSOR/hipTENSOR shared
-   libraries at runtime. No compile-time GPU SDK dependency. Caller
-   (Julia/Python) provides the `.so` path.
-3. **Layer 1 core infrastructure** — GPU backends are not extensions
-   (unlike `tenferro-ext-tropical`). They live in `tenferro-prims` alongside
-   `CpuBackend`.
-4. **Family-native primitives** — each GPU backend implements
-   `TensorSemiringCore<Standard<S>>`, `TensorSemiringFastPath<Standard<S>>`,
-   and additional families as coverage grows. `einsum` remains backend-agnostic
-   via `EinsumBackend`.
-5. **Prims basic + Contract first** — the minimum set for einsum to work.
-6. **cuTENSOR v2 API** — describe → plan → execute pattern, matching
-   tenferro's family-descriptor → plan → execute model.
-7. **Naming convention** — platform names (`Cuda`, `Rocm`), not API
-   names (`Hip`). `ComputeDevice::Hip` renamed to `ComputeDevice::Rocm`.
+- `tenferro-tensor/src/cubecl/` for the implementation,
+- `AGENTS.md` for the current GPU status and local test command,
+- [backend-contract.md](../spec/backend-contract.md) for placement rules,
+- [tensor-prims.md](./tensor-prims.md) for tensor operation families.
 
 ---
 
-## Module Structure
+## Current Module Structure
 
-```
-tenferro-prims/src/
-    lib.rs          — family traits, descriptors, shared types
-    cpu/mod.rs      — CpuBackend, CpuContext, CpuPlan
-    cpu/planning.rs      — semiring-core / fast-path planning
-    cpu/execution.rs     — semiring execution dispatch
-    cpu/batched_gemm.rs  — CPU GEMM execution paths
-    cpu/contract.rs      — contract fallback + GEMM specialization
-    cpu/reduction.rs     — reduce/trace/anti-trace/anti-diag kernels
-    cpu/gemm_support.rs  — shared GEMM helpers and dtype dispatch
-    cpu/scratch.rs       — BLAS scratch-pool management
-    cuda/mod.rs     — CudaBackend, CudaContext, CudaPlan
-    cuda/planning.rs     — cuTENSOR descriptor/plan builders
-    cuda/execution.rs    — family dispatch for plan/execute
-    cuda/scalar_type.rs  — scalar dtype/compute-descriptor mapping
-    cuda/wrappers.rs     — RAII wrappers for cuTENSOR handles/descriptors/plans
-    rocm.rs         — RocmBackend, RocmContext, RocmPlan, RocmTensorVtable
-    registry.rs     — BackendRegistry
-```
-The current CPU backend is already split under `src/cpu/` for the same
-reason as CUDA: planning, execution, scratch management, and contract/GEMM
-specialization should not collapse back into one dispatcher file.
-
----
-
-## Key Types
-
-### CudaBackend / RocmBackend
-
-```rust
-// cuda/mod.rs
-pub struct CudaBackend {
-    vtable: CutensorVtable,
-    handle: *mut c_void,    // cutensorHandle_t
-    _lib: libloading::Library,
-}
-
-pub struct CudaContext {
-    stream: *mut c_void,    // cudaStream_t
-    workspace: Vec<u8>,     // GPU workspace (resizable)
-    plan_cache: PlanCache,
-}
-
-pub enum CudaPlan<T: ScalarBase> {
-    Contract { plan_handle: *mut c_void, workspace_size: usize, _marker: PhantomData<T> },
-    Reduce { plan_handle: *mut c_void, workspace_size: usize, _marker: PhantomData<T> },
-    Trace { plan_handle: *mut c_void, workspace_size: usize, _marker: PhantomData<T> },
-    AntiTrace { _marker: PhantomData<T> },  // Composed via Contract(eye, ∂C)
-    AntiDiag { _marker: PhantomData<T> },   // Composed via Contract(eye, ∂C)
-    ElementwiseUnary { _marker: PhantomData<T> },
-    ElementwiseMul { _marker: PhantomData<T> },
-    BatchedGemm { _marker: PhantomData<T> },  // Via Contract subset
-    MakeContiguous { _marker: PhantomData<T> },  // explicit materialization path
-}
-
-impl<S: ScalarBase> TensorSemiringCore<Standard<S>> for CudaBackend {
-    type Plan = CudaPlan<S>;
-    type Context = CudaContext;
-    // ...
-}
+```text
+tenferro-tensor/src/cubecl/
+    mod.rs                 CubeclBackend and TensorBackend implementation
+    runtime.rs             CubeCL/CUDA runtime initialization and stream access
+    memory.rs              upload_tensor, download_tensor, device pointer bridge
+    dispatch.rs            shared launch helpers and dtype dispatch
+    kernels/               CubeCL kernels for elementwise, reductions, indexing,
+                            diagonal, and structural ops
+    fusion/                fused elementwise classification and code generation
+    gemm.rs                cuTENSOR/cuBLAS-backed contraction support
+    linalg.rs              cuSOLVER/cuBLAS-backed linalg support
+    ffi/                   runtime-loaded CUDA library bindings
+    tests/                 ignored GPU tests
 ```
 
-`RocmBackend` follows the same structure with `RocmTensorVtable`,
-`RocmContext`, `RocmPlan`.
+The backend type is `CubeclBackend`. There are no separate in-tree
+`CudaBackend` and `RocmBackend` implementations. CUDA is selected by enabling
+the `cubecl` feature, which depends on the workspace-pinned CubeCL fork and the
+CubeCL CUDA runtime.
 
-### BackendRegistry
+## Dependency Source
 
-```rust
-// registry.rs
-pub struct BackendRegistry {
-    pub cpu: CpuBackend,
-    pub cuda: Option<CudaBackend>,
-    pub rocm: Option<RocmBackend>,
-}
+The workspace intentionally depends on the `shinaoka/cubecl` fork:
 
-impl BackendRegistry {
-    pub fn new() -> Self { /* CPU only */ }
-    pub fn load_cutensor(&mut self, path: &str) -> Result<()> { ... }
-    pub fn load_hiptensor(&mut self, path: &str) -> Result<()> { ... }
-}
+```toml
+cubecl = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96", features = ["cuda"] }
+cubecl-cuda = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96" }
+cubecl-runtime = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96" }
 ```
 
----
+Keep this fork dependency until upstream CubeCL has the required support and the
+workspace is deliberately migrated. Do not replace it with crates.io CubeCL as
+part of unrelated GPU or documentation work.
 
-## cuTENSOR / hipTENSOR API Mapping
+## Runtime And Library Loading
 
-### Family Descriptor → GPU API
+`CubeclRuntime::new(device_ordinal)` initializes CUDA and creates the CubeCL
+CUDA client for one device. GPU kernels are JIT-compiled by CubeCL, so local
+CUDA toolkit configuration matters.
 
-| Family descriptor | cuTENSOR v2 API | hipTENSOR API | Notes |
-|---|---|---|---|
-| `SemiringFastPathDescriptor::Contract` | `cutensorContract` | `hiptensorContraction` | 最優先。einsum動作に必須 |
-| Tensor view `permute` + optional materialize | metadata-only + optional `cutensorPermute`/copy | 同左 | `Permute` prim は削除済み |
-| `SemiringCoreDescriptor::ReduceAdd` | `cutensorReduce` | `hiptensorReduction` | |
-| `SemiringCoreDescriptor::Trace` | `cutensorReduce` on diagonal | `hiptensorReduction` on diagonal | stride trick + reduce |
-| `SemiringCoreDescriptor::BatchedGemm` | Contract subset (mode制限) | 同左 | Contract経由 |
-| `SemiringCoreDescriptor::MakeContiguous` | 不要 | 不要 | GPU はstrideをネイティブに受け付け |
-| `SemiringCoreDescriptor::AntiTrace` | Contract(eye, ∂C) | 同左 | コアprimだがContract合成で実装 |
-| `SemiringCoreDescriptor::AntiDiag` | Contract(eye, ∂C) | 同左 | 同上 |
-| `ScalarPrimsDescriptor::*` | `cutensorElementwiseTrinary` / reduction APIs | 同等API | scalar family |
-| `SemiringFastPathDescriptor::ElementwiseBinary` | `cutensorElementwiseBinary` | `hiptensorElementwiseBinary` | semiring fast path |
+cuTENSOR, cuSOLVER, and cuBLAS are loaded lazily through the FFI layer. The
+backend first uses default soname/path candidates and allows explicit override
+with these variables:
 
-### AntiTrace / AntiDiag の GPU 実装
+| Variable | Library |
+| --- | --- |
+| `TENFERRO_CUTENSOR_PATH` | cuTENSOR |
+| `TENFERRO_CUSOLVER_PATH` | cuSOLVER |
+| `TENFERRO_CUBLAS_PATH` | cuBLAS |
 
-AntiTrace と AntiDiag はコアプリミティブ（全バックエンド実装必須）だが、
-GPU ではカスタムカーネルを書かずに Contract で合成できる。
+Local GPU test runs should also set:
 
-```
-anti_trace: ∂C[j,k] → ∂A[i,j,i',k] = eye[i,i'] × ∂C[j,k]
-anti_diag:  ∂C[i,j] → ∂A[i,i',j]   = eye[i,i'] × ∂C[i,j]
-```
+| Variable | Purpose |
+| --- | --- |
+| `CUDA_PATH` | CUDA toolkit root used by CubeCL/NVRTC |
+| `LD_LIBRARY_PATH` | CUDA, cuTENSOR, cuSOLVER, and cuBLAS library lookup |
+| `CUBECL_DEBUG_LOG=0` | Suppress generated-kernel log spam |
 
-どちらも `Contract(eye(I), ∂C)` で表現可能。cuTENSOR/hipTENSOR が
-ネイティブに処理する。CPU 側は単純ループで実装し、strided-einsum2 に
-依存しない。
+## Device Transfer Policy
 
-### Vtable 設計
+tenferro follows the PyTorch convention: no implicit CPU/GPU transfer at tensor
+API boundaries. Callers upload tensors before GPU backend operations and
+download results explicitly when host access is needed.
 
-```rust
-// CutensorVtable — cuTENSOR v2 function pointers
-struct CutensorVtable {
-    // Handle lifecycle
-    create: Symbol<unsafe extern "C" fn(*mut cutensorHandle_t) -> cutensorStatus_t>,
-    destroy: Symbol<unsafe extern "C" fn(cutensorHandle_t) -> cutensorStatus_t>,
+```rust,ignore
+use tenferro_tensor::cubecl::{download_tensor, upload_tensor, CubeclBackend};
+use tenferro_tensor::{Tensor, TensorBackend};
 
-    // Tensor descriptor
-    create_tensor_descriptor: Symbol<unsafe extern "C" fn(...) -> cutensorStatus_t>,
-    destroy_tensor_descriptor: Symbol<unsafe extern "C" fn(...) -> cutensorStatus_t>,
+let mut backend = CubeclBackend::new(0)?;
+let a = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+let b = Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]);
 
-    // Contraction (highest priority)
-    create_contraction_descriptor: Symbol<unsafe extern "C" fn(...) -> cutensorStatus_t>,
-    create_contraction_plan: Symbol<unsafe extern "C" fn(...) -> cutensorStatus_t>,
-    contract: Symbol<unsafe extern "C" fn(...) -> cutensorStatus_t>,
-
-    // Permutation
-    create_permutation: Symbol<unsafe extern "C" fn(...) -> cutensorStatus_t>,
-    permute: Symbol<unsafe extern "C" fn(...) -> cutensorStatus_t>,
-
-    // Reduction
-    create_reduction: Symbol<unsafe extern "C" fn(...) -> cutensorStatus_t>,
-    reduce: Symbol<unsafe extern "C" fn(...) -> cutensorStatus_t>,
-
-    // Element-wise
-    elementwise_binary: Symbol<unsafe extern "C" fn(...) -> cutensorStatus_t>,
-}
+let gpu_a = upload_tensor(backend.runtime(), &a)?;
+let gpu_b = upload_tensor(backend.runtime(), &b)?;
+let gpu_c = backend.add(&gpu_a, &gpu_b)?;
+let cpu_c = download_tensor(backend.runtime(), &gpu_c)?;
 ```
 
-`RocmTensorVtable` も同構造。関数名プレフィックスが `hiptensor` に変わる。
+The execution pipeline handles placement internally for compiled programs:
+constants are uploaded through `upload_host_tensor()`, metadata-only operations
+read metadata without bulk host transfer, and host-dependent scalar cases
+download only the required scalar values.
 
----
+Error behavior:
 
-## Tensor Clone / Conj Strategy
+| Case | Behavior |
+| --- | --- |
+| GPU op receives a CPU tensor | `Error::BackendFailure` with an upload hint |
+| CPU op receives a GPU tensor | panic, treated as a programming error |
+| `TypedTensor::host_data()` on a GPU buffer | panic with a diagnostic |
 
-### 方針: Arc 共有 + PyTorch パターン
+## Implemented Coverage
 
-`DataBuffer<T>` は `Arc<BufferInner<T>>` で内部ストレージを共有する。
-PyTorch と同じセマンティクス:
+The CubeCL backend implements enough of `TensorBackend` to run a growing subset
+of compiled tensor programs on CUDA. Coverage includes:
 
-| 操作 | PyTorch | tenferro | コスト |
-|------|---------|----------|--------|
-| 浅いコピー | `tensor.clone()` (view) | `tensor.clone()` | O(1), Arc refcount++ |
-| 深いコピー | `tensor.detach().clone()` | `MakeContiguous` / explicit materialize | O(n) |
-| 共役 | `tensor.conj()` (lazy) | `tensor.conj()` / `tensor.into_conj()` | O(1), flag flip |
-| 共役実体化 | `torch.resolve_conj()` | `Backend::resolve_conj()` | O(n) |
-| 共役チェック | `tensor.is_conj()` | `tensor.is_conjugated()` | O(1) |
+| Category | Current status |
+| --- | --- |
+| Allocation/transfer | CUDA allocation, upload, download, raw pointer bridge |
+| Elementwise | many float ops; selected complex ops; unsupported complex analytic ops return `BackendFailure` |
+| Reductions | sum/prod for real and complex; min/max for real |
+| Structural | transpose, reshape, broadcast, reverse, concatenate, diagonal extraction/embedding, triangular masks |
+| Indexing | selected gather/scatter/slice/pad/reverse paths through CubeCL kernels |
+| Contraction | cuTENSOR/cuBLAS-backed paths for supported real dtypes |
+| Linalg | cuSOLVER/cuBLAS-backed SVD, QR, Cholesky, LU, Eigh, and triangular solve where supported |
 
-### 設計
+General eigendecomposition (`eig`, LAPACK `dgeev` style) is not provided by
+cuSOLVER. `CubeclBackend::eig` returns `BackendFailure`; users must explicitly
+download to CPU and call the CPU backend.
 
-```rust
-// tenferro-tensor: DataBuffer は Arc で共有
-pub struct DataBuffer<T> {
-    inner: Arc<BufferInner<T>>,
-}
+Complex CubeCL support is intentionally not expanded in this batch because the
+required CubeCL support is being handled upstream.
 
-// clone() = Arc refcount++（浅いコピー）
-// conj() = Arc refcount++ + conjugated flag flip（lazy）
-// as_mut_slice() は Arc::get_mut で排他性チェック
+## Unsupported And Deferred Work
+
+The following are intentionally outside the current batch:
+
+- GPU benchmark work,
+- HIP/ROCm implementation,
+- replacing the CubeCL fork,
+- broad complex kernel expansion before upstream CubeCL support lands,
+- making every CPU tensor op have a GPU implementation,
+- changing the public placement contract.
+
+## Tests
+
+GPU tests are ignored so regular CPU-only test runs remain portable. Run them on
+a CUDA machine with:
+
+```sh
+CUBECL_DEBUG_LOG=0 \
+CUDA_PATH=/usr/local/cuda-12.0 \
+LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH \
+  cargo test -p tenferro-tensor --features cubecl -- --ignored
 ```
 
-### 利点
-
-- `Differentiable::Tangent: Clone` が自然に満たされる
-- `conj()` が CPU/GPU 統一的に lazy（PyTorch 準拠）
-- `clone_tensor()` が不要（浅い clone は Tensor で完結）
-- 深いコピーは既存の prims 操作で表現可能
-- tenferro-prims → tenferro-tensor 依存は `resolve_conj()` のみ
-
-### 依存関係への影響
-
-`resolve_conj()` が `Tensor<T>` を引数に取るため、`tenferro-prims` →
-`tenferro-tensor` の依存が追加される。
-
-```
-tenferro-algebra
-    ├────────────────────┐
-    ↓                    ↓
-tenferro-prims ──→ tenferro-tensor   (prims depends on tensor)
-    │                    │
-    └──────────┬─────────┘
-               ↓
-          tenferro-einsum
-```
-
----
-
-## GPU Memory and DataBuffer
-
-### DataBuffer GPU variant
-
-```rust
-// tenferro-tensor/src/buffer.rs
-enum BufferInner<T> {
-    Owned(Vec<T>),                    // CPU, Rust-owned
-    External { ptr, len, release },   // CPU, externally-owned (DLPack)
-    Gpu {                             // GPU device memory
-        device_ptr: *mut T,
-        len: usize,
-        space: LogicalMemorySpace,    // GpuMemory { device_id }
-        release: Option<Box<dyn FnOnce() + Send>>,
-    },
-}
-```
-
-- `as_slice()` — CPU バッファ用。GPU variant ではエラーを返す。
-  この関数はそもそも CPU バッファのデータアクセスが目的。
-- `as_device_ptr()` — GPU バッファ用。デバイスポインタを返す。
-  cuTENSOR/hipTENSOR FFI に渡す。
-- GPU メモリの alloc/free は vtable 経由（`cudaMalloc`/`cudaFree` 等）。
-  release callback に GPU free 関数を設定。
-
-### CompletionEvent
-
-```rust
-// tenferro-tensor/src/completion_event.rs
-pub struct CompletionEvent {
-    inner: CompletionEventInner,
-}
-
-enum CompletionEventInner {
-    Noop,                           // CPU (既存)
-    Cuda { event: *mut c_void },    // cudaEvent_t
-    Rocm { event: *mut c_void },    // hipEvent_t
-}
-```
-
-- `record(stream)`: イベントを stream に記録
-- `wait()`: CPU 側で完了を待機
-- `is_complete()`: 非ブロッキング完了チェック
-- stream/event の create/destroy も vtable 経由
-
----
-
-## Conjugation on GPU
-
-`Tensor::conj()` は現在すでに lazy で、`Arc` 共有のまま
-`conjugated` フラグを反転するだけである。
-
-### 対応方針
-
-cuTENSOR は tensor descriptor に `CUTENSOR_OP_CONJ` を指定でき、
-lazy conjugation をネイティブにサポートする。
-
-1. **Tensor の conjugated フラグを維持** — メタデータのみ（zero-cost）
-2. **plan() 時に descriptor に CONJ op を設定** — cuTENSOR が内部処理
-3. **materialize が必要な場合** — `resolve_conj()` などの explicit path を使う
-
-standalone `conj()` 自体は CPU/GPU とも lazy のままでよい。実データ化が
-必要な場面だけ explicit materialization path を通す。
-
----
-
-## POC Skeleton Changes
-
-| 変更 | ファイル | 内容 |
-|------|---------|------|
-| `ComputeDevice::Hip` → `Rocm` | tenferro-device/src/lib.rs | enum variant 名変更、doc 更新 |
-| CudaBackend stub | tenferro-prims/src/lib.rs | 型定義 + `todo!()` |
-| RocmBackend stub | tenferro-prims/src/lib.rs | 型定義 + `todo!()` |
-| BackendRegistry stub | tenferro-prims/src/lib.rs | 型定義 |
-| CpuBackend 分離 | tenferro-prims/src/cpu/ | planning / execution / GEMM / scratch を分離 |
-| DataBuffer Gpu variant | tenferro-tensor/src/buffer.rs | BufferInner に Gpu 追加 |
-| CompletionEvent 拡張 | tenferro-tensor/src/completion_event.rs | Cuda/Rocm variant 追加 |
-| libloading 依存追加 | workspace Cargo.toml | workspace dependency |
-| Tensor conjugated flag | tenferro-tensor/src/tensor/mod.rs | lazy conjugation 用 |
-| Arc\<BufferInner\> | tenferro-tensor/src/buffer.rs | DataBuffer を Arc 共有に変更。clone() は浅い、conj() は lazy |
-| resolve_conj stubs | tenferro-prims/src/lib.rs | 各バックエンドに resolve_conj() 追加 |
-| `ScalarUnaryOp::Conj` | tenferro-prims scalar family | resolve_conj 用の scalar unary op |
-| prims → tensor dep | tenferro-prims/Cargo.toml | resolve_conj が Tensor<T> を扱うため |
-
----
-
-## Tropical GPU Path: Custom Kernels
-
-cuTENSOR and hipTENSOR implement standard arithmetic only (`+`, `*`, `f32`,
-`f64`, complex). They have no mechanism for user-defined semiring operations
-such as `(max, +)` or `(max, ×)`. Tropical algebra GPU support therefore
-requires a **separate custom kernel path**, independent of the cuTENSOR path.
-
-### Boundary between the two paths
-
-| Algebra | GPU path | Library |
-|---------|----------|---------|
-| `Standard<f32/f64/Complex>` | cuTENSOR / hipTENSOR | dlopen at runtime |
-| `MaxPlus<T>`, `MinPlus<T>`, `MaxMul<T>` | custom kernels | separate integration target |
-| User-defined algebra | custom kernels (user-provided) | user crate |
-
-The `CudaBackend` / `RocmBackend` types implement the standard primitive
-families (`TensorSemiringCore<Standard<S>>`, `TensorSemiringFastPath<Standard<S>>`,
-and standard scalar/analytic families) only. They do not implement the same
-families for `MaxPlus<S>` or any other
-non-standard algebra — that would be a type error at compile time.
-
-### Tropical GPU implementation target
-
-For tropical argmax-capable GPU flows the integration target is a library
-such as `tropical-gemm-cuda` (or an equivalent CUDA/HIP kernel library).
-The expected integration shape is:
-
-```rust
-// tenferro-ext-tropical (future GPU support)
-pub struct TropicalCudaBackend {
-    _lib: libloading::Library,   // tropical-gemm-cuda.so, loaded at runtime
-}
-
-impl TensorSemiringCore<MaxPlus<f64>> for TropicalCudaBackend {
-    // delegates to tropical-gemm-cuda kernels, not cuTENSOR
-    type Plan = TropicalCudaPlan<f64>;
-    …
-}
-```
-
-This backend lives in `tenferro-ext-tropical`, not in `tenferro-prims`, preserving
-the same separation used for the CPU tropical path.
-
-### Argmax state for AD
-
-Tropical argmax-capable variants (e.g. max-plus Viterbi) need to store the
-argmax index tensor alongside the result so that the backward pass can
-reconstruct the gradient path. This is algebra-specific state that cuTENSOR
-cannot carry; it must be allocated and managed by the custom kernel. When
-designing the tropical GPU backend, the plan type must accommodate an optional
-argmax buffer:
-
-**Tie-break contract**: The argmax buffer must store the smallest linear index
-when ties occur. Custom GPU kernels must implement this deterministically
-(e.g., via `atomicMin` on the index when values are equal).
-
-```rust
-enum TropicalCudaPlan<T: ScalarBase> {
-    Contract {
-        // argmax buffer allocated on GPU alongside the output
-        argmax_device_ptr: Option<*mut u64>,
-        …
-        _marker: PhantomData<T>,
-    },
-    …
-}
-```
-
----
-
-## Problem Catalog
-
-| ID | Problem | Severity | Resolution |
-|---|---|---|---|
-| G1 | GPU メモリ管理 | Medium | DataBuffer に Gpu variant 追加。`as_slice()` は CPU 用（GPU ではエラー）。`as_device_ptr()` を追加。alloc/free は vtable 経由 |
-| G2 | Workspace 管理 | Medium | GpuContext 内に可変長 workspace。`plan()` が必要サイズ報告、`execute()` が自動拡張 |
-| G3 | Stream/Event 同期 | Medium | CompletionEvent に Cuda/Rocm variant。vtable 経由で record/wait |
-| G4 | Plan cache key に stride 含む | Low | cuTENSOR plan は stride 依存。PlanCacheKey に shapes + strides 含める |
-| G5 | FFI エラー処理 | Medium | vtable 呼び出しの status code を `Error::DeviceError` に map |
-| G6 | cuTENSOR v1→v2 API 差異 | Low | v2 ベース（describe → plan → execute）で統一 |
-| G7 | hipTENSOR 成熟度 | Medium | JIT 未対応、block-sparse 未対応。制限事項として記録 |
-| G8 | カスタムカーネル (将来) | Low | AntiTrace/AntiDiag は Contract 合成で対応。将来カーネルが必要になれば別クレート |
-| G9 | Multi-GPU | Low | GpuContext = per-device。複数 GPU = 複数 Context |
-| G10 | `ComputeDevice::Hip` → `Rocm` rename | Low | POC 修正で対応 |
-| G11 | Conjugation on GPU | Medium | cuTENSOR は `CUTENSOR_OP_CONJ` でlazy conjugation をサポート。Tensor に conjugated フラグ追加。standalone `conj()` は CPU 転送が必要 |
-| G12 | strided-einsum2 / omeinsum-rs 廃止 | — | 両方廃止予定。アルゴリズムは参考元として参照するが依存しない。tenferro-prims / tenferro-einsum に自前実装 |
-| G13 | Tensor Clone / Conj | Medium | DataBuffer を `Arc<BufferInner>` で共有。clone() は浅い（refcount++）。conj() は lazy（flag flip + refcount++）。深いコピーは `MakeContiguous` などの materialize path 経由。resolve_conj() を各バックエンドに提供。PyTorch 準拠 |
+These tests are correctness tests, not benchmarks.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -11,7 +11,7 @@ architecture see [Architecture](../architecture/). For normative specs see
 | [supported-ops.md](./supported-ops.md) | Crate-by-crate inventory of supported primal and AD operations |
 | [device.md](./device.md) | tenferro-device: memory spaces, compute devices, error types |
 | [tensor.md](./tensor.md) | Tensor representation, ownership model |
-| [tensor-prims.md](./tensor-prims.md) | Tensor primitive protocol families |
+| [tensor-prims.md](./tensor-prims.md) | Tensor backend protocol and execution surface |
 | [algebra.md](./algebra.md) | HasAlgebra, Semiring, tropical and user-defined algebra |
 | [einsum.md](./einsum.md) | Einsum public API, N-ary contraction tree, algebra dispatch |
 | [contraction-pipeline.md](./contraction-pipeline.md) | Binary contraction pipeline, copy elision |

--- a/docs/design/inplace-indexing.md
+++ b/docs/design/inplace-indexing.md
@@ -6,7 +6,7 @@ Add safe and backend-portable support for partial in-place tensor updates
 (`x[idx] = value`) in tenferro-rs, aligned with the existing layered design:
 
 - `tenferro-tensor`: views/ownership metadata
-- `tenferro-prims`: backend execution protocol
+- `tenferro-tensor::TensorBackend`: backend execution protocol
 - `chainrules` integration: AD safety rules
 
 ## Reference Behavior (PyTorch C++)
@@ -28,8 +28,8 @@ version counters.
 
 - Zero-copy view ops (`select`, `narrow`, `permute`, `diagonal`, `broadcast`).
 - Shared-buffer ownership model (`Arc<BufferInner<T>>`).
-- Family-based backend protocol (`TensorSemiringCore` / dedicated primitive families).
-- Existing output in-place style API (`einsum_into` family).
+- Backend protocol surface (`TensorBackend` / `TensorExec`).
+- Existing out-parameter and buffer-reuse patterns in backend execution.
 
 ### Missing pieces
 
@@ -60,7 +60,7 @@ impl<T: Scalar> Tensor<T> {
 }
 ```
 
-### Primitive family extension (Phase 2+)
+### Backend extension (Phase 2+)
 
 ```rust
 pub enum IndexingDescriptor {
@@ -69,23 +69,8 @@ pub enum IndexingDescriptor {
     },
 }
 
-pub trait TensorIndexingPrims<Alg: Semiring> {
-    type Plan;
-    type Context;
-
-    fn plan(
-        ctx: &mut Self::Context,
-        desc: &IndexingDescriptor,
-        shapes: &[&[usize]],
-    ) -> Result<Self::Plan>;
-
-    fn execute<T: ScalarBase>(
-        ctx: &mut Self::Context,
-        plan: &Self::Plan,
-        inputs: &[&Tensor<T>],
-        output: &mut Tensor<T>,
-    ) -> Result<()>;
-}
+// Future shape: add an index_put-style method to TensorBackend/TensorExec
+// once mutation/version-counter semantics are specified.
 ```
 
 ## Execution Model
@@ -102,7 +87,8 @@ existing view + contiguous/copy logic.
 ### Path B: advanced indexing (Phase 2+)
 
 - Normalize tensor/mask indices.
-- Dispatch to backend `TensorIndexingPrims` if available.
+- Dispatch to a backend `TensorBackend`/`TensorExec` indexing method if
+  available.
 - Fallback behavior:
   - CPU backend: reference implementation.
   - Backends without extension: return explicit `Error::DeviceError` or use
@@ -165,15 +151,15 @@ crate boundaries (`chainrules-core` independent from tensor internals).
 ## GPU Notes
 
 - API should be backend-neutral from day one.
-- CUDA/ROCm kernels for advanced indexing can be added incrementally behind
-  `TensorIndexingPrims`.
+- CubeCL/CUDA kernels for advanced indexing can be added incrementally behind
+  the existing backend traits. ROCm remains a stub until explicitly implemented.
 - Deterministic behavior with duplicate indices should be explicitly specified
   (especially for `accumulate=true`).
 
 ## Rollout Plan
 
 1. Phase 1: `set_item_` basic indexing only (CPU), AD-unsafe cases rejected.
-2. Phase 2: add `TensorIndexingPrims` + `IndexingDescriptor::IndexPut`.
+2. Phase 2: add a backend indexing method and `IndexingDescriptor::IndexPut`.
 3. Phase 3: version counter + view/in-place safety checks for AD.
 4. Phase 4: GPU advanced indexing kernels and deterministic policy completion.
 

--- a/docs/design/supported-ops.md
+++ b/docs/design/supported-ops.md
@@ -1,290 +1,138 @@
-# Supported Operations by Crate
+# Supported Operations By Crate
 
-This page is the deployable reference for what each operation-bearing crate
-currently supports. It is intentionally operational, not aspirational: items
-listed here are implemented today, while unsupported families are called out
-explicitly.
+This page is the implementation-facing inventory for the current workspace. It
+is operational, not aspirational: unsupported families are called out
+explicitly. The public user docs still focus on the `tenferro` facade crate.
 
-Crates such as `tenferro-algebra` and `tenferro-device` define types and
-protocols rather than user-visible operation families, so they are omitted
-here.
+---
 
 ## `tenferro-tensor`
 
-### Structural tensor operations
+`tenferro-tensor` owns dense tensor storage, dtype dispatch, backend traits, CPU
+execution, and the optional CubeCL GPU backend.
 
-- Shape/view: `reshape`, `reshape_owned`, `permute`, `broadcast`
-- Matrix helpers: `transpose_last2`, `diagonal`
-- Indexing/view selection: `slice_axis`, `select_axis`
-- Materialization helpers: `to_tensor`, `to_owned`, contiguous conversion APIs
+### Tensor Values
 
-## `tenferro-prims`
+- `Tensor` dynamic dtype wrapper for `F32`, `F64`, `I64`, `C32`, and `C64`.
+- `TypedTensor<T>` typed dense tensor payload.
+- Host buffers by default; CubeCL device buffers behind the `cubecl` feature.
 
-### Semiring families
+### Backend Surface
 
-- `TensorSemiringCore`: `BatchedGemm`, `ReduceAdd`, `Trace`, `AntiTrace`, `AntiDiag`, `MakeContiguous`
-- `TensorSemiringFastPath`: `Contract`, `ElementwiseBinary::{Add, Mul}`
+`TensorBackend` / `TensorExec` currently cover:
 
-### Scalar family
+- Elementwise: add, multiply, negate, conjugate, divide, abs, sign, maximum,
+  minimum, compare, select, clamp.
+- Analytic: exp, log, sin, cos, tanh, sqrt, rsqrt, pow, expm1, log1p.
+- Structural: transpose, reshape, broadcast, convert, diagonal
+  extraction/embedding, triangular masks.
+- Reductions: sum, product, max, min.
+- Contraction: `dot_general`.
+- Indexing: gather, scatter, slice, dynamic slice, pad, concatenate, reverse.
+- Linalg: Cholesky, triangular solve, LU, full-pivot LU, full-pivot LU solve,
+  SVD, QR, symmetric/Hermitian eigendecomposition, and general eigendecomposition
+  where the backend supports it.
+- Placement: explicit host/device upload and download hooks.
+- Optional backend elementwise fusion.
 
-`TensorScalarPrims` currently exposes:
+### CPU Status
 
-- Unary: `Neg`, `Conj`, `Abs`, `Reciprocal`, `Real`, `Imag`, `Square`
-- Binary: `Add`, `Sub`, `Mul`, `Div`, `Maximum`, `Minimum`, `ClampMin`, `ClampMax`
-- Reductions: `Sum`, `Prod`, `Mean`, `Max`, `Min`
+The CPU backend is the main complete backend. Exactly one CPU feature must be
+enabled:
 
-Predicate/select-style tensor ops are intentionally absent here today. `Where`
-and the AD surface for branch-select families need a dedicated boolean/predicate
-substrate before they can be added cleanly.
+- `cpu-faer` for faer-backed GEMM/linalg,
+- `cpu-blas` for BLAS/LAPACK-backed GEMM/linalg.
 
-### Analytic family
+Elementwise, reductions, structural operations, indexing, `dot_general`, and
+dense linalg are implemented on CPU for the supported dtype subset of each op.
 
-`TensorAnalyticPrims` currently exposes:
+### CubeCL/CUDA Status
 
-- Unary: `Sqrt`, `Rsqrt`, `Exp`, `Expm1`, `Log`, `Log1p`, `Sin`, `Cos`, `Tan`, `Tanh`, `Asin`, `Acos`, `Atan`, `Sinh`, `Cosh`, `Asinh`, `Acosh`, `Atanh`
-- Binary: `Pow`, `Atan2`, `Hypot`, `Xlogy`
-- Reductions: `Var`, `Std`
+The `cubecl` feature enables `cubecl::CubeclBackend`, backed by CubeCL/CubeCL-CUDA
+and runtime-loaded cuTENSOR, cuSOLVER, and cuBLAS.
 
-### Runtime status
+Implemented GPU coverage is partial:
 
-- CPU: semiring/scalar/analytic families are implemented.
-- CUDA: semiring core/fast path are implemented. Scalar/analytic families execute GPU-resident on real `f32`/`f64`, plus the complex subset listed below on `Complex32`/`Complex64`.
-- ROCm: backend symbols exist as truthful stubs; support predicates remain false and planning/execution return unsupported errors.
+- explicit upload/download and device pointer bridge,
+- many elementwise operations on real dtypes and selected complex operations,
+- reductions including sum/product for real and complex and min/max for real,
+- structural operations including transpose, reshape, broadcast, reverse,
+  concatenate, diagonal extraction/embedding, and triangular masks,
+- selected indexing operations,
+- selected cuTENSOR/cuBLAS contraction paths,
+- selected cuSOLVER/cuBLAS linalg paths.
 
-CUDA scalar-family subset:
+Unsupported GPU operations and unsupported dtypes return `BackendFailure`.
+`eig` is not provided by cuSOLVER and permanently returns `BackendFailure` on
+CubeCL. ROCm is only a feature stub.
 
-- real `f32`/`f64`: full scalar inventory
-- complex `Complex32`/`Complex64`: unary `Neg`, `Conj`, `Abs`, `Reciprocal`, `Real`, `Imag`, `Square`; binary `Add`, `Sub`, `Mul`, `Div`; reductions `Sum`, `Prod`, `Mean`
-- real-only on CUDA: `Maximum`, `Minimum`, `ClampMin`, `ClampMax`, `Max`, `Min`
-  Phase-1 does not define an ordering for complex tensors, so ordered scalar
-  ops stay real-only.
+## `tenferro-ops`
 
-CUDA analytic-family subset:
+`tenferro-ops` owns the graph operation vocabulary and graph-level AD rules.
 
-- real `f32`/`f64`: full analytic inventory
-- complex `Complex32`/`Complex64`: all analytic unary ops plus binary `Pow` and `Xlogy`
-- real-only on CUDA: `Atan2`, `Hypot`, `Var`, `Std`
-  Complex `Var`/`Std` are intentionally unsupported in phase-1 because the
-  runtime does not commit to a canonical real-valued complex reduction
-  contract; callers must compose their chosen statistic explicitly.
-
-## `tenferro-linalg-prims`
-
-### Backend-facing kernel families
-
-`TensorLinalgPrims` currently covers the low-level factorization and solve
-contracts used by `tenferro-linalg`:
-
-- `qr`
-- `svd`
-- `lu`
-- `eigen`
-- `eig`
-- `lstsq`
-- `cholesky`
-- `solve`
-- `solve_triangular`
-
-The backend-facing dtype contract is `KernelLinalgScalar`, with LAPACK-specific
-eig helpers isolated behind `LapackEigScalar`.
+- `StdTensorOp` is the mainline operation vocabulary.
+- `PrimitiveOp::linearize` and `PrimitiveOp::transpose_rule` are the semantic
+  source of truth for AD rules.
+- The `ExtensionOp` boundary exists for registered extension operations.
+- Non-mainline semiring/algebra graph surfaces remain transitional and should
+  not be extended by new work.
 
 ## `tenferro-einsum`
 
-### Primal
+`tenferro-einsum` owns subscript parsing, contraction planning, graph-fragment
+lowering, and eager concrete execution.
 
-- `einsum`
-- `einsum_with_subscripts`
-- `einsum_with_plan`
-- corresponding `_into`, `_owned`, and plan-based variants
+Implemented:
 
-### AD
+- `Subscripts::parse` and integer-label `Subscripts::new`.
+- `NestedEinsum::parse` for parenthesized contraction order.
+- `ContractionTree::optimize`, `optimize_with_options`, and `from_pairs`.
+- `build_einsum_fragment` for traced graph lowering.
+- `eager_einsum` and `eager_einsum_owned` for concrete `Tensor` execution.
+- Repeated-label semantics:
+  - `ii->` trace,
+  - `ii->i` diagonal extraction,
+  - `iij->ij` higher-rank diagonal extraction,
+  - `i->ii` diagonal embedding.
 
-- `einsum_rrule`
-- `einsum_frule`
-- `einsum_hvp`
-
-## `tenferro-linalg`
-
-### Primal
-
-- Decompositions: `svd`, `qr`, `lu`, `lu_factor`, `lu_factor_ex`, `cholesky`, `cholesky_ex`, `eigen`, `eig`
-- Solvers: `solve`, `solve_ex`, `solve_triangular`, `lu_solve`, `lstsq`
-- Matrix utilities: `inv`, `inv_ex`, `det`, `slogdet`, `pinv`, `matrix_exp`, `matrix_power`, `norm`, `cond`
-- Tensorized helpers: `cross`, `householder_product`, `vander`, `tensorinv`, `tensorsolve`
-
-### Stateless AD rules
-
-`_rrule` and `_frule` are implemented for:
-
-- `svd`
-- `qr`
-- `lu`
-- `eigen`
-- `lstsq`
-- `cholesky`
-- `solve`
-- `solve_triangular`
-- `inv`
-- `det`
-- `slogdet`
-- `eig`
-- `pinv`
-- `matrix_exp`
-- `norm`
-
-### AD gaps
-
-The following public primal ops do not yet have stateless linalg AD rules:
-
-- `*_ex` result-struct variants
-- `lu_factor`
-- `lu_factor_ex`
-- `lu_solve`
-- `matrix_power`
-- `cond`
-- `cross`
-- `householder_product`
-- `vander`
-- `tensorinv`
-- `tensorsolve`
+Strict binary lowering is an optimization only. It rejects repeated-label
+patterns and lets the general path handle diagonalization.
 
 ## `tenferro`
 
-### Structured tensor helpers
+`tenferro` is the user-facing facade.
 
-- `StructuredTensor::to_dense`
-- `StructuredTensor::einsum_with_subscripts`
+Implemented public surfaces include:
 
-### Eager AD tensor entrypoints
+- `TracedTensor` graph construction and evaluation through `Engine`.
+- `EagerTensor` / `EagerContext` for eager scalar-loss reverse-mode workflows.
+- Lazy traced `einsum` and `einsum_with`.
+- Public linalg free functions such as `svd`, `qr`, `cholesky`, `solve`,
+  `triangular_solve`, `lu`, `full_piv_lu`, `eig`, `eigh`, `pinv`, `det`,
+  `slogdet`, and `norm`.
+- Public AD transforms such as VJP/JVP/HVP over supported traced dense numeric
+  paths.
+- Compiled execution through `ExecProgram` / `eval_exec_ir`.
 
-`tenferro::Tensor` currently exposes these eager methods:
+The facade is CPU-first. It can evaluate through `CubeclBackend` when the
+program uses GPU-supported operations and tensors are placed explicitly by the
+execution pipeline or caller. Unsupported GPU ops return errors rather than
+silently falling back to CPU.
 
-- Einsum: `einsum`
-- Reductions: `sum`, `mean`, `var`, `std`
-- Scalar pointwise:
-  `add`, `atan2`, `pow`, `hypot`,
-  `sqrt`, `exp`, `expm1`, `log`, `log1p`,
-  `sin`, `cos`, `tanh`,
-  `asin`, `acos`, `atan`,
-  `sinh`, `cosh`, `asinh`, `acosh`, `atanh`
-- Linalg: `svd`, `qr`, `lu`, `eigen`, `lstsq`, `cholesky`, `solve`, `inv`, `det`, `slogdet`, `eig`, `pinv`, `matrix_exp`, `solve_triangular`, `norm`
+## `tenferro-device`
 
-### Builder-based AD surface
+`tenferro-device` owns shared device and error infrastructure:
 
-Internal builder APIs are implemented for:
+- logical memory spaces,
+- compute device metadata,
+- common `Error` and `Result` types,
+- conversions from lower-level strided errors.
 
-- Einsum: `einsum_ad`
-- Scalar/reduction:
-  `add_ad`, `atan2_ad`, `pow_ad`, `hypot_ad`,
-  `sqrt_ad`, `exp_ad`, `expm1_ad`, `log_ad`, `log1p_ad`,
-  `sin_ad`, `cos_ad`, `tanh_ad`,
-  `asin_ad`, `acos_ad`, `atan_ad`,
-  `sinh_ad`, `cosh_ad`, `asinh_ad`, `acosh_ad`, `atanh_ad`,
-  `sum_ad`, `mean_ad`, `var_ad`, `std_ad`
-- Linalg: `svd_ad`, `qr_ad`, `lu_ad`, `eigen_ad`, `lstsq_ad`, `cholesky_ad`, `solve_ad`, `inv_ad`, `det_ad`, `slogdet_ad`, `eig_ad`, `pinv_ad`, `matrix_exp_ad`, `solve_triangular_ad`, `norm_ad`
-  - `eig_ad` is real-input-only at the public frontend; forward mode is supported, but reverse mode is intentionally rejected because the output becomes complex while the frontend tape stays homogeneous
+## AD Support Notes
 
-### Complex linalg AD coverage
+Current mainline AD coverage is intentionally narrower than primal execution.
+Rules must live in `tenferro-ops/src/ad/` and must have corresponding
+oracle/finite-difference coverage before being treated as supported mainline AD.
 
-For current public `tenferro::Tensor` behavior, complex linalg support splits
-into three buckets: full AD for a small subset, primal-only complex execution
-for several ops whose stateless rules are still real-only, and some entrypoints
-that remain real-input-only today.
-
-| Operation | `tenferro::Tensor` with complex input | `tenferro-linalg` stateless AD | Notes |
-| --- | --- | --- | --- |
-| `svd` | primal + forward + reverse | complex-capable `_frule` / `_rrule` | singular values remain real |
-| `solve`, `solve_triangular` | primal + forward + reverse | complex-capable `_frule` / `_rrule` | operands must share dtype |
-| `qr`, `lu` | primal + forward + reverse | complex-capable `_frule` / `_rrule` | follows the real-loss/Wirtinger reverse convention used elsewhere |
-| `eigen`, `cholesky`, `inv`, `matrix_exp` | primal only | current `_frule` / `_rrule` are real-only | the dynamic wrapper rejects non-primal complex tensors |
-| `det`, `slogdet`, `pinv`, `norm`, `lstsq` | complex input unsupported | current `_frule` / `_rrule` are real-only | use real tensors only today |
-| `eig` | complex input unsupported; real-input eager reverse is also unsupported | `eig_frule` / `eig_rrule` exist for real inputs | the frontend still lacks a mixed real-to-complex reverse bridge |
-
-### Runtime status
-
-- API contract: runtime-generic across CPU, CUDA, and ROCm
-- internal tidu-backed einsum helpers remain backend-parametric over `tenferro-einsum::EinsumBackend`; runtime selection still happens through the frontend runtime context type
-- Structured tensor materialization and compressed einsum reuse the same einsum runtime-dispatch layer rather than maintaining separate CPU/CUDA/ROCm builder paths
-- Builder execution uses an explicit default-runtime holder, and reverse-mode bookkeeping stays on one homogeneous runtime-typed graph
-- `Tensor` is the canonical public payload for downstream tensor algebra; implicit result-type promotion happens inside mixed-dtype tensor ops (`complex` beats `real`, 64-bit beats 32-bit), explicit numeric casts use `to_scalar_type(...)`, and `detach()` drops AD metadata without switching to a second public tensor type
-- Actual execution today:
-  - CPU paths are implemented for the operations listed above
-  - CUDA and ROCm dispatch report unsupported capability for scalar/analytic and most linalg families rather than assuming CPU-only execution
-  - mixed-dtype reverse propagation is supported when operands share one reverse graph; pullbacks cast gradients back to each input dtype
-  - linalg entry points are dense-only at the `tenferro` frontend layer; non-dense structured inputs return a runtime error instead of silently materializing dense fallbacks
-
-## `tenferro-capi`
-
-### C-API surface
-
-The exported C surface currently focuses on a narrow, stable subset:
-
-- Einsum entrypoints
-- SVD entrypoints
-- AD rule entrypoints for the supported FFI tensor/value wrappers
-
-## `tenferro-ext-burn`
-
-### Burn bridge surface
-
-- Checked helpers: `try_einsum`, `try_burn_to_tenferro`, `try_tenferro_to_burn`
-- Convenience wrappers: `einsum`, `burn_to_tenferro`, `tenferro_to_burn`
-- Backend extension trait: `TensorNetworkOps`
-
-### Runtime status
-
-- Current execution lowers through CPU tenferro tensors after checked conversion.
-- `NdArray<f64>` forward execution and `Autodiff<B, C>` backward execution are implemented.
-- Invalid subscripts, malformed nested einsum trees, and conversion failures now flow through checked helpers before any public panic-wrapper boundary.
-
-## `tenferro-ext-mdarray`
-
-### mdarray bridge surface
-
-- Checked helpers: `try_mdarray_to_tensor`, `try_tensor_to_mdarray`
-- Convenience wrappers: `mdarray_to_tensor`, `tensor_to_mdarray`
-
-### Runtime status
-
-- Both conversion directions are eager copy paths.
-- Zero-copy interoperability is intentionally unsupported.
-- Conversion helpers are CPU-buffer oriented and reject non-owned/non-CPU materialization through checked errors.
-
-## Non-mainline substrates (scheduled for Stage 6 removal)
-
-Per design_v3, the following graph/backend surfaces are **non-mainline** and
-are retained only for Stage 2-6 compatibility. They are not the architectural
-source of truth for the traced AD substrate — the mainline op vocabulary is
-`StdTensorOp` in `tenferro-ops`. These surfaces are scheduled for removal when
-the `ExtensionOp` mechanism lands in Stage 6.
-
-| Item | Crate | Role | Removal |
-| --- | --- | --- | --- |
-| `SemiringOp<Alg>` | `tenferro-ops` | Algebra-generic traced graph op with its own compile path, separate from `StdTensorOp` | Stage 6 |
-| `SemiringOps` (trait) | `tenferro-ops` | Shared constructor vocabulary kept so `SemiringOp` and `StdTensorOp` look symmetric | Stage 6 |
-| `SemiringBackend<Alg>` | `tenferro-tensor` | Algebra-generic backend that executes `SemiringOp` over typed tensors | Stage 6 |
-
-New code must not extend these surfaces. Lower tropical / semiring use cases
-through compositions of core `StdTensorOp` primitives (e.g. max-plus via
-`BroadcastInDim + Add + ReduceMax`) today, and through the `ExtensionOp`
-mechanism once Stage 6 lands. See
-[`design_v3/30-algebra-and-tropical.md`](./design_v3/30-algebra-and-tropical.md)
-("Recommended Fate Of `SemiringOp`") and
-[`design_v3/90-migration-plan.md`](./design_v3/90-migration-plan.md) Stage 6
-for the normative retirement plan.
-
-## `chainrules`
-
-This external crate provides the scalar formula basis reused by
-`tenferro` tensor-level wrappers.
-
-- Arithmetic: `add`, `sub`, `mul`, `div` with matching `*_rrule` / `*_frule`
-- Unary analytic/scalar: `conj`, `sqrt`, `exp`, `log`
-- Binary analytic: `atan2`
-- Power helpers: `powf`, `powi`
-
-The broader tensor-level analytic families in `tenferro` are built
-from these scalar formulas plus runtime-generic tensor primitives. They are not
-all exported directly from `chainrules`.
-
-For formula details, see [AD Formula Notes](../AD/index.md).
+Linalg AD for new matrix rules is separate work from the structural/einsum and
+CubeCL documentation updates covered here.

--- a/docs/design/tensor-prims.md
+++ b/docs/design/tensor-prims.md
@@ -1,178 +1,133 @@
-# Tensor Prims Protocol Families
+# Tensor Backend Protocol
 
-`tenferro-prims` is the execution substrate for tensor operations that are
-valid over a semiring or over standard scalar arithmetic. The primitive layer
-now uses smaller protocol families directly so `einsum`, tropical algebra,
-scalar math, and linalg can depend on only the capabilities they actually
-need.
+This file keeps the historical `tensor-prims.md` name, but the current
+implementation no longer has a separate `tenferro-prims` crate or the old
+`TensorPrims` protocol families. Dense tensor execution is owned by
+`tenferro-tensor`.
+
+The current backend protocol is:
+
+- `TensorBackend`: standalone dense tensor operations plus long-lived backend
+  state,
+- `TensorExec`: execution-session surface used by compiled-program evaluation,
+- `ElementwiseFusionPlan`: optional fused elementwise execution plan shared by
+  segmentation and GPU fusion.
+
+---
 
 ## Layering
 
-```
-TensorStructural (tenferro-tensor views)
-    permute, reshape, broadcast, diagonal, narrow
+```text
+tenferro / tenferro-ops
+    traced graph, shape inference, AD rules, ExecProgram
         │
         ▼
-TensorSemiringCore<Alg>
-    BatchedGemm, ReduceAdd, Trace, AntiTrace, AntiDiag, MakeContiguous
+tenferro-einsum
+    Subscripts, ContractionTree, build_einsum_fragment, eager_einsum
         │
-        ├── required by tenferro-einsum
-        └── sufficient for tropical + minimal AD support
-
-TensorSemiringFastPath<Alg>
-    Contract, ElementwiseBinary { Add, Mul }
+        ▼
+tenferro-tensor
+    Tensor, TypedTensor, TensorBackend, TensorExec
         │
-        └── optional performance paths, never required for correctness
-
-TensorScalarPrims<Alg>
-    pointwise unary/binary ops and scalar reductions for standard arithmetic
-
-TensorAnalyticPrims<Alg>
-    exp/log/trig/pow/variance-style vocabulary
+        ├── cpu::CpuBackend
+        └── cubecl::CubeclBackend (feature = "cubecl")
 ```
 
-The key design rule is:
+There is exactly one dense runtime tensor type family (`Tensor` /
+`TypedTensor`) and one backend trait surface. Higher layers should depend on
+`TensorBackend`/`TensorExec`, not on a backend-specific context or deleted
+primitive-family traits.
 
-- `tenferro-einsum` may depend on `TensorSemiringCore` only.
-- `TensorSemiringFastPath` is optional and must not change semantics.
-- Structural view operations stay in `tenferro-tensor`, not in prims.
-- Scalar and analytic vocabulary must not leak into semiring-only backends.
+## Backend Operation Surface
 
-## Execute Contract
+`TensorBackend` and `TensorExec` expose the operations needed by the compiled
+execution pipeline:
 
-All prim families keep the BLAS/cuTENSOR-style contract:
+| Category | Examples |
+| --- | --- |
+| Elementwise | `add`, `mul`, `neg`, `div`, `abs`, `maximum`, `minimum`, `compare`, `select`, `clamp` |
+| Analytic | `exp`, `log`, `sin`, `cos`, `tanh`, `sqrt`, `rsqrt`, `pow`, `expm1`, `log1p` |
+| Structural | `transpose`, `reshape`, `broadcast_in_dim`, `convert`, `extract_diagonal`, `embed_diagonal`, `tril`, `triu` |
+| Reductions | `reduce_sum`, `reduce_prod`, `reduce_max`, `reduce_min` |
+| Contraction | `dot_general` |
+| Indexing | `gather`, `scatter`, `slice`, `dynamic_slice`, `pad`, `concatenate`, `reverse` |
+| Linalg | `cholesky`, `triangular_solve`, `lu`, `full_piv_lu`, `full_piv_lu_solve`, `svd`, `qr`, `eigh`, `eig` |
+| Placement | `upload_host_tensor`, `download_to_host` |
+| Memory reuse | `reclaim_buffer` |
+
+Each backend may return a typed unsupported error for operations or dtypes it
+does not support. Higher layers must not silently fall back across devices.
+
+## CPU Backend
+
+`cpu::CpuBackend` is always present when exactly one CPU feature is enabled:
+
+- `cpu-faer` for faer-backed GEMM/linalg,
+- `cpu-blas` for BLAS/LAPACK-backed GEMM/linalg.
+
+CPU execution uses strided-kernel for elementwise/reduction/structural work and
+faer or BLAS/LAPACK for GEMM and linalg. `CpuContext` owns the rayon policy and
+is the single source of truth for faer parallelism.
+
+`CpuBackend::with_exec_session` installs the owned rayon pool once and runs the
+whole compiled program through `CpuExecSession`, avoiding per-op pool entry.
+
+## CubeCL Backend
+
+`cubecl::CubeclBackend` is the current GPU backend under the `cubecl` feature.
+It targets NVIDIA CUDA through CubeCL/CubeCL-CUDA and uses runtime-loaded
+cuTENSOR, cuSOLVER, and cuBLAS where needed.
+
+Important design points:
+
+- GPU tensors must be explicitly uploaded with `upload_tensor`.
+- Host access must explicitly download with `download_tensor`.
+- `upload_host_tensor` and `download_to_host` are used by the compiled
+  execution pipeline for placement-aware execution.
+- GPU operations receiving CPU tensors return `BackendFailure` with an upload
+  hint.
+- CPU operations receiving GPU tensors panic because that is a programming
+  error at the backend boundary.
+- ROCm is only a feature stub today.
+
+See [gpu-backend-design.md](./gpu-backend-design.md) for the CubeCL-specific
+module layout and test command.
+
+## Elementwise Fusion
+
+`ElementwiseFusionPlan` is the canonical backend-neutral description of fused
+elementwise work. Backends opt in by overriding
+`execute_elementwise_fusion`; the default implementation returns `Ok(None)`,
+allowing the segmented execution pipeline to run individual ops.
+
+CubeCL implements this hook through `tenferro-tensor/src/cubecl/fusion/` for
+eligible GPU-resident plans. CPU currently relies on the ordinary op sequence.
+
+## Einsum And DotGeneral
+
+Einsum lowering produces graph operations and ultimately `dot_general`,
+reductions, broadcasts, transposes, and diagonal operations over the same
+`TensorBackend` surface. The old semiring fast-path/core split is not part of
+the current mainline implementation.
+
+For column-major layout, contraction lowering keeps compute dimensions on the
+left and batch dimensions on the right:
 
 ```text
-output <- alpha * op(inputs) + beta * output
+lhs: [lhs_free..., contract..., batch...]
+rhs: [contract..., rhs_free..., batch...]
+out: [lhs_free..., rhs_free..., batch...]
 ```
 
-This contract is preserved even for the new family traits so existing high
-performance lowering strategies remain valid.
+This convention preserves contiguous per-batch slices for the GEMM-like backend
+path.
 
-## Why `Permute` Leaves Prims
+## Linalg
 
-`Tensor::permute()` is already a zero-copy structural view. Keeping an eager
-`Permute` execution primitive in the required core would force semiring-only
-backends to implement a materializing reorder that is not needed for
-correctness. The redesign therefore treats:
+Linalg is not a separate backend crate today. Dense linalg operations are part
+of `TensorBackend`, with CPU implementations under `tenferro-tensor/src/cpu`
+and CubeCL/CUDA implementations under `tenferro-tensor/src/cubecl/linalg.rs`.
 
-- `permute` as a `tenferro-tensor` view operation
-- `MakeContiguous` as the execution primitive that materializes a view when
-  needed
-
-This is especially important for `einsum`, where the intended lowering is:
-
-```text
-permute view -> MakeContiguous -> BatchedGemm
-```
-
-## Minimal Semiring Core
-
-`TensorSemiringCore<Alg>` is intentionally small:
-
-| Operation | Why it is in core |
-|-----------|-------------------|
-| `BatchedGemm` | fundamental contraction primitive |
-| `ReduceAdd` | semiring addition reduction needed by einsum lowering |
-| `Trace` | semiring-valid diagonal contraction |
-| `AntiTrace` | AD adjoint of trace |
-| `AntiDiag` | AD adjoint of diagonal extraction/embedding |
-| `MakeContiguous` | explicit view materialization boundary |
-
-Notably absent from core:
-
-- `Contract`
-- `ElementwiseBinary { Add, Mul }`
-- `ReduceMul`
-- `Maximum`, `Minimum`, `Div`, `Exp`, `Log`, and other ordered/analytic ops
-- linalg factorizations and solves
-
-Those belong in `TensorSemiringFastPath`, `TensorScalarPrims`,
-`TensorAnalyticPrims`, or `tenferro-linalg-prims`.
-
-## Fast Paths
-
-`TensorSemiringFastPath<Alg>` holds operations that are semiring-valid but
-optional:
-
-- `Contract`
-- `ElementwiseBinary { Add, Mul }`
-
-The public descriptor is generalized, but backend implementations are expected
-to re-specialize at `plan()` time so hot loops stay as efficient as the old
-specialized kernels.
-
-## Current Implementation Status
-
-`tenferro-prims` now exposes only the family-native protocol surface:
-
-- `TensorSemiringCore`
-- `TensorSemiringFastPath`
-- `TensorScalarPrims`
-- `TensorAnalyticPrims`
-
-Current state by family:
-
-- `TensorSemiringCore` and `TensorSemiringFastPath` are the sole semiring
-  execution contracts for CPU/CUDA/ROCm backends.
-- `TensorSemiringContextFor<Alg>` is the context-side bridge higher layers use
-  when they need semiring execution without naming a concrete backend type.
-- `TensorScalarPrims` has explicit CPU planning/execution for the phase-1
-  unary, binary, and reduction inventory, and explicit CUDA execution for the
-  real `f32`/`f64` inventory plus the supported complex subset on
-  `Complex32`/`Complex64`.
-- `TensorAnalyticPrims` has explicit CPU planning/execution for the phase-1
-  unary, binary, and reduction inventory, and explicit CUDA execution for the
-  real `f32`/`f64` inventory plus the supported complex subset on
-  `Complex32`/`Complex64`.
-- ROCm remains a truthful stub backend for scalar and analytic families in this
-  phase.
-
-The backend code is also split by concern instead of a single dispatcher file:
-
-- CPU keeps `mod.rs` for public backend/context types and shared tensor-view
-  helpers, `planning.rs` for semiring planning, `execution.rs` for family
-  dispatch, `batched_gemm.rs` and `contract.rs` for the heavier GEMM paths,
-  `reduction.rs` for reduce/trace kernels, `gemm_support.rs` for dtype-specific
-  GEMM helpers, and `scratch.rs` for BLAS scratch-pool reuse.
-- CUDA keeps `mod.rs` for backend/context types and runtime loading,
-  `planning.rs` for cuTENSOR descriptor/plan construction,
-  `execution.rs` for semiring dispatch, `scalar_family.rs` and
-  `analytic_family.rs` for family-specific planning/execution,
-  `diagonal.rs` for semiring diagonal kernels, `pointwise_ops.rs` for shared
-  pointwise helpers, `runtime.rs` for GPU-resident scratch/workspace helpers,
-  `custom/` for NVRTC-backed custom kernel compilation and caching,
-  `scalar_type.rs` for dtype mapping, and `wrappers.rs` for RAII handle
-  management.
-- Einsum keeps eager API entrypoints and AD rules in separate module trees so
-  new execution APIs do not accumulate AD-specific wiring in the same file.
-
-The public scalar and analytic vocabularies remain intentionally broader than
-the currently executed subset so later GPU and reduction work can land without
-descriptor churn.
-
-The legacy eager `Permute` primitive has been removed. Structural reordering now stays in
-`tenferro-tensor`, and prims only expose `MakeContiguous` as the explicit
-materialization boundary.
-
-## Relationship to Linalg
-
-`tenferro-prims` is not responsible for structured factorizations like QR, SVD,
-LU, Cholesky, or eigendecomposition. Those live in
-[linalg-prims.md](./linalg-prims.md).
-
-The split is intentional:
-
-- `tenferro-prims` owns semiring/scalar execution substrate
-- `tenferro-linalg-prims` owns backend-facing linalg kernel contracts
-- `tenferro-linalg` owns public APIs and composite lowering
-
-## Performance Invariants
-
-The redesign keeps three invariants:
-
-1. `einsum` keeps its existing lowering shape: structural views plus explicit
-   materialization and GEMM.
-2. Generalized descriptors must specialize during planning, not per element.
-3. Optional fast paths are never required for correctness and may be absent on
-   semiring-only or tropical backends.
+General eigendecomposition is a permanent CUDA limitation for cuSOLVER:
+`CubeclBackend::eig` returns `BackendFailure`, and callers must explicitly
+download to CPU if they want CPU `eig`.

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -26,7 +26,11 @@ assert_eq!(result.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 
 ## Trace and diagonal
 
-These match the usual einsum idioms from NumPy, PyTorch, and JAX.
+These match the usual repeated-label einsum idioms from NumPy, PyTorch, and JAX.
+When a label appears more than once in one input, tenferro first selects the
+diagonal for those axes. If that label is absent from the output, the diagonal
+is reduced. If a label appears more than once in the output, tenferro embeds the
+input on that diagonal.
 
 ```rust
 use tenferro::{einsum::einsum, CpuBackend, Engine, TracedTensor};
@@ -45,6 +49,27 @@ let diagonal_result = diagonal.eval(&mut engine).unwrap();
 
 assert_eq!(trace_result.as_slice::<f64>().unwrap(), &[15.0]);
 assert_eq!(diagonal_result.as_slice::<f64>().unwrap(), &[1.0, 5.0, 9.0]);
+```
+
+Higher-rank repeated labels use the same rule. For `"iij->ij"`, the first two
+axes are diagonalized and the trailing `j` axis is preserved.
+
+```rust
+use tenferro::{einsum::einsum, CpuBackend, Engine, TracedTensor};
+
+let x = TracedTensor::from_vec(
+    vec![2, 2, 3],
+    vec![
+        1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+    ],
+);
+
+let mut engine = Engine::new(CpuBackend::new());
+let mut y = einsum(&mut engine, &[&x], "iij->ij").unwrap();
+let result = y.eval(&mut engine).unwrap();
+
+assert_eq!(result.shape(), &[2, 3]);
+assert_eq!(result.as_slice::<f64>().unwrap(), &[1.0, 4.0, 5.0, 8.0, 9.0, 12.0]);
 ```
 
 ## Outer product
@@ -115,8 +140,7 @@ For N-ary einsum the mode propagates:
 The engine caches optimized contraction trees keyed by `(subscripts, input shapes)`, so the eval-time cost is amortized across repeated calls with the same shapes.
 
 ```rust
-use tenferro::{einsum::einsum, CpuBackend, Engine, Tensor, TracedTensor};
-use tenferro_tensor::DType;
+use tenferro::{einsum::einsum, CpuBackend, DType, Engine, Tensor, TracedTensor};
 
 // One symbolic-shape input + one concrete-shape input.
 let a = TracedTensor::input_symbolic_shape(DType::F64, 2);

--- a/docs/plans/2026-05-02-ad-rule-boundaries-design.md
+++ b/docs/plans/2026-05-02-ad-rule-boundaries-design.md
@@ -10,9 +10,12 @@ Primary:
 
 - #772: BUG: TriangularSolve/FullPivLuSolve transpose rule drops A-cotangent
 - #773: BUG: Pad missing transpose_rule, panics on VJP
-- #777: BUG: 7 linalg ops missing transpose_rule, panics on VJP
 - #783: AD: Slice/DynamicSlice/Concatenate/Reverse/Select/Clamp/Maximum/Minimum have no AD rules
 - #787: BUG: transpose_scatter panics on symbolic shapes
+
+Explicitly separate:
+
+- #777: BUG: 7 linalg ops missing transpose_rule, panics on VJP
 
 ## Goal
 
@@ -28,6 +31,8 @@ It does not cover:
 
 - primal CPU/GPU indexing implementation,
 - linalg numerical kernel changes,
+- new linalg AD rule implementation for ops that currently have no
+  `transpose_rule` (#777),
 - dtype promotion policy,
 - broad AD support for every missing op in one patch.
 
@@ -72,12 +77,11 @@ a normal unsupported-AD error or stop before adding a partial rule.
 
 ### Missing linalg transpose rules
 
-Do not implement all seven linalg transpose rules by default. Classify each op:
-
-- implement only rules with clear math and oracle coverage,
-- replace `todo!()` panics with explicit unsupported-rule errors where the
-  runtime can represent that cleanly,
-- otherwise leave a documented stop report.
+Do not implement #777 in this dispatch. New linalg AD rules for Cholesky, LU,
+FullPivLu, SVD, QR, Eigh, or Eig require a dedicated design and implementation
+plan, even when `third_party/tensor-ad-oracles` already contains oracle
+families. That future plan should classify each op separately and use
+oracle-backed coverage where available.
 
 ### Indexing and piecewise ops
 
@@ -105,6 +109,9 @@ Use a two-stage dispatch:
 
 Do not let DeepSeek grow this into a broad AD project. Correctness beats issue
 count here.
+
+The current AD dispatch may fix an existing linalg transpose implementation bug
+such as #772, but it must not add brand-new linalg transpose rules from #777.
 
 ## Testing
 
@@ -135,7 +142,8 @@ Implement the AD rule boundary dispatch from
 docs/plans/2026-05-02-ad-rule-boundaries-design.md.
 
 First reread REPOSITORY_RULES.md. Fix only AD transpose/linearize boundary
-issues where correctness and test coverage are available. Do not add a mainline
+issues where correctness and test coverage are available. Do not implement the
+new linalg transpose-rule set from #777 in this dispatch. Do not add a mainline
 AD rule without finite-difference or oracle coverage. Prefer explicit
 unsupported-rule errors over todo!/panic paths when a correct rule is out of
 scope. Stop and report any rule that needs new oracle families before it can be
@@ -150,6 +158,7 @@ supported.
 - No new AD rule lacks finite-difference or oracle coverage.
 - No `todo!()` is added on a reachable AD path.
 - Linalg rules match existing adjoint/conjugation conventions.
+- #777 remains separate unless a dedicated linalg AD design has been approved.
 
 ## Stop Conditions
 

--- a/docs/plans/2026-05-02-ad-rule-boundaries-design.md
+++ b/docs/plans/2026-05-02-ad-rule-boundaries-design.md
@@ -1,0 +1,160 @@
+# AD Rule Boundaries Dispatch Design
+
+**Date:** 2026-05-02
+
+**Status:** Proposed dispatch spec
+
+## Issues
+
+Primary:
+
+- #772: BUG: TriangularSolve/FullPivLuSolve transpose rule drops A-cotangent
+- #773: BUG: Pad missing transpose_rule, panics on VJP
+- #777: BUG: 7 linalg ops missing transpose_rule, panics on VJP
+- #783: AD: Slice/DynamicSlice/Concatenate/Reverse/Select/Clamp/Maximum/Minimum have no AD rules
+- #787: BUG: transpose_scatter panics on symbolic shapes
+
+## Goal
+
+Make AD behavior explicit and correct at transpose-rule boundaries. Add rules
+only when the repository oracle and finite-difference requirements can be met.
+
+## Scope
+
+This dispatch covers graph-level AD rules in `tenferro-ops/src/ad/` and any
+minimal facade tests needed to exercise them.
+
+It does not cover:
+
+- primal CPU/GPU indexing implementation,
+- linalg numerical kernel changes,
+- dtype promotion policy,
+- broad AD support for every missing op in one patch.
+
+## Repository Contract
+
+Before touching these files, reread `REPOSITORY_RULES.md`.
+
+The source of truth is:
+
+- `PrimitiveOp::linearize`,
+- `PrimitiveOp::transpose_rule`.
+
+Every new or changed rule must have a corresponding finite-difference
+integration test. For linalg rules, prefer oracle families with both Torch
+reference data and finite-difference checks when available.
+
+Do not add or keep a mainline AD rule without the required oracle coverage.
+
+## Acceptance Specification
+
+### TriangularSolve and FullPivLuSolve
+
+If `active_mask[0]` is true, the transpose rule must produce the A-cotangent
+instead of silently returning `None`.
+
+Expected mathematical direction:
+
+- for `A @ X = B`, A-cotangent is proportional to `-ct @ X^H` or the equivalent
+  orientation used by the existing dot conventions,
+- for side/right variants, use the corresponding transposed orientation.
+
+The implementation must respect existing adjoint, transpose, and conjugation
+conventions in `tenferro-ops`.
+
+### Pad
+
+`Pad` transpose should crop/slice the cotangent back to the input region when
+the padding configuration is statically representable by existing ops.
+
+If dynamic or negative padding semantics cannot be represented correctly, return
+a normal unsupported-AD error or stop before adding a partial rule.
+
+### Missing linalg transpose rules
+
+Do not implement all seven linalg transpose rules by default. Classify each op:
+
+- implement only rules with clear math and oracle coverage,
+- replace `todo!()` panics with explicit unsupported-rule errors where the
+  runtime can represent that cleanly,
+- otherwise leave a documented stop report.
+
+### Indexing and piecewise ops
+
+For Slice, DynamicSlice, Concatenate, Reverse, Select, Clamp, Maximum, and
+Minimum:
+
+- implement simple structural transpose rules only when correctness is clear and
+  tests can cover them,
+- do not implement non-smooth derivative rules for Maximum/Minimum/Clamp without
+  a documented subgradient policy and tests.
+
+### Symbolic shapes
+
+`transpose_scatter` must not panic on symbolic shape dimensions. If inverse
+slice sizes require concrete values, return a structured unsupported-shape error
+or defer the rule for symbolic cases.
+
+## Design
+
+Use a two-stage dispatch:
+
+1. eliminate silent wrong gradients and runtime panics where an explicit error
+   path exists,
+2. add a small number of correct transpose rules with tests and oracle coverage.
+
+Do not let DeepSeek grow this into a broad AD project. Correctness beats issue
+count here.
+
+## Testing
+
+Required tests:
+
+- finite-difference coverage for every changed transpose rule,
+- a regression showing active A in triangular solve no longer drops cotangent if
+  implemented,
+- a Pad VJP test if Pad transpose is implemented,
+- a symbolic scatter case that no longer panics, or a test for the explicit
+  unsupported error.
+
+Run at least:
+
+```bash
+cargo test -p tenferro-ops ad
+cargo test -p tenferro ad
+cargo fmt --all --check
+```
+
+If oracle replay is touched, run the relevant oracle replay command documented
+near the changed tests.
+
+## Dispatch Prompt
+
+```text
+Implement the AD rule boundary dispatch from
+docs/plans/2026-05-02-ad-rule-boundaries-design.md.
+
+First reread REPOSITORY_RULES.md. Fix only AD transpose/linearize boundary
+issues where correctness and test coverage are available. Do not add a mainline
+AD rule without finite-difference or oracle coverage. Prefer explicit
+unsupported-rule errors over todo!/panic paths when a correct rule is out of
+scope. Stop and report any rule that needs new oracle families before it can be
+supported.
+```
+
+## Review Checklist
+
+- `REPOSITORY_RULES.md` was followed for every AD rule.
+- No silent `None` cotangent remains for an active differentiable input in a
+  changed rule.
+- No new AD rule lacks finite-difference or oracle coverage.
+- No `todo!()` is added on a reachable AD path.
+- Linalg rules match existing adjoint/conjugation conventions.
+
+## Stop Conditions
+
+Stop and report if:
+
+- a rule requires new oracle data that does not exist,
+- a mathematically correct transpose cannot be expressed with existing ops,
+- replacing `todo!()` with `Err` requires changing core AD trait signatures.

--- a/docs/plans/2026-05-02-ad-structural-boundary-plan.md
+++ b/docs/plans/2026-05-02-ad-structural-boundary-plan.md
@@ -1,0 +1,125 @@
+# AD Structural Boundary Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add correct first-order AD boundary rules for simple structural ops that currently panic during VJP/JVP, without expanding linalg AD scope.
+
+**Architecture:** Keep `PrimitiveOp::linearize` and `PrimitiveOp::transpose_rule` as the source of truth. Implement only Slice, Pad, and Reverse structural rules because they are linear maps with static configurations and can be checked by finite differences in the `tenferro` facade tests. Leave TriangularSolve/FullPivLuSolve A-cotangents and broader linalg transpose rules to a dedicated linalg AD plan, matching the current batch boundary.
+
+**Tech Stack:** Rust, `tenferro-ops` AD modules, `tenferro` integration AD tests, finite-difference checks.
+
+---
+
+## Scope For This Step
+
+Implement:
+
+- `StdTensorOp::Slice` forward linearization and transpose rule,
+- `StdTensorOp::Pad` transpose rule for statically representable padding/cropping,
+- `StdTensorOp::Reverse` forward linearization and transpose rule,
+- finite-difference integration tests for every new transpose/linearize rule.
+
+Defer:
+
+- TriangularSolve/FullPivLuSolve A-cotangents, because this is linalg AD and should get a dedicated oracle-backed design,
+- DynamicSlice/Concatenate/Select/Clamp/Maximum/Minimum AD rules,
+- symbolic-shape Scatter transpose redesign, because the current trait cannot return structured unsupported-shape errors.
+
+## Task 1: Add Failing Integration Tests
+
+**Files:**
+
+- Modify: `tenferro/tests/ad.rs`
+
+**Steps:**
+
+1. Add fragment builders for weighted `Slice`, `Pad`, and `Reverse` reductions.
+2. Add tests:
+   - `grad_slice_weighted_sum_matches_finite_diff`
+   - `grad_pad_weighted_sum_matches_finite_diff`
+   - `grad_reverse_weighted_sum_matches_finite_diff`
+3. Each test computes `grad_from_fragment_with_inputs(...)` and compares every input element with `finite_diff_scalar(...)`.
+4. Run:
+
+```bash
+cargo test -p tenferro --test ad -- grad_slice_weighted_sum_matches_finite_diff
+cargo test -p tenferro --test ad -- grad_pad_weighted_sum_matches_finite_diff
+cargo test -p tenferro --test ad -- grad_reverse_weighted_sum_matches_finite_diff
+```
+
+Expected: fail because `Slice`/`Reverse` linearize or `Pad` transpose are not implemented.
+
+## Task 2: Add Focused `tenferro-ops` Rule Tests
+
+**Files:**
+
+- Modify: `tenferro-ops/src/tests/std_tensor_op_tests.rs`
+
+**Steps:**
+
+1. Add structural unit assertions that:
+   - `Slice` linearize emits `StdTensorOp::Slice`,
+   - `Slice` transpose emits `StdTensorOp::Pad`,
+   - `Pad` transpose emits `StdTensorOp::Slice` and optionally `StdTensorOp::Pad`,
+   - `Reverse` linearize and transpose emit `StdTensorOp::Reverse`.
+2. Seed concrete input shape metadata for transpose tests that need original extents.
+3. Run:
+
+```bash
+cargo test -p tenferro-ops --lib -- structural_special_cases
+```
+
+Expected: fail until implementation is added.
+
+## Task 3: Implement Structural Rules
+
+**Files:**
+
+- Modify: `tenferro-ops/src/ad/mod.rs`
+- Modify: `tenferro-ops/src/ad/structural.rs`
+
+**Steps:**
+
+1. Add `linearize_slice(builder, tangent_in, config)` and dispatch `StdTensorOp::Slice`.
+2. Add `transpose_slice(emitter, cotangent_out, inputs, config, ctx)`:
+   - require concrete input extents,
+   - emit `StdTensorOp::Pad` with `edge_padding_low = starts`, `interior_padding = strides - 1`, and high padding to restore the original input extent.
+3. Add `transpose_pad(emitter, cotangent_out, inputs, config, ctx)`:
+   - require concrete input extents and non-negative interior padding,
+   - emit a `StdTensorOp::Slice` over the cotangent using the inverse padded positions,
+   - emit a trailing zero-interior `StdTensorOp::Pad` only when forward negative edge padding cropped input elements.
+4. Add `linearize_reverse(...)` and `transpose_reverse(...)`; both emit the same reverse op.
+5. Keep all new panics explicit and specific for unsupported symbolic extents or invalid static configurations.
+
+## Task 4: Verify Focused Tests
+
+**Commands:**
+
+```bash
+cargo test -p tenferro-ops --lib -- structural_special_cases
+cargo test -p tenferro --test ad -- grad_slice_weighted_sum_matches_finite_diff
+cargo test -p tenferro --test ad -- grad_pad_weighted_sum_matches_finite_diff
+cargo test -p tenferro --test ad -- grad_reverse_weighted_sum_matches_finite_diff
+```
+
+Expected: all pass.
+
+## Task 5: Broader Verification And Commit
+
+**Commands:**
+
+```bash
+cargo test -p tenferro-ops ad
+cargo test -p tenferro --test ad
+cargo fmt --all --check
+cargo check -p tenferro-ops
+cargo check -p tenferro
+git diff --check
+```
+
+Commit:
+
+```bash
+git add docs/plans/2026-05-02-ad-structural-boundary-plan.md tenferro-ops/src tenferro/tests/ad.rs
+git commit -m "fix: add structural ad boundary rules"
+```

--- a/docs/plans/2026-05-02-cpu-indexing-validation-design.md
+++ b/docs/plans/2026-05-02-cpu-indexing-validation-design.md
@@ -1,0 +1,172 @@
+# CPU Indexing Validation Dispatch Design
+
+**Date:** 2026-05-02
+
+**Status:** Proposed dispatch spec
+
+## Issues
+
+Primary:
+
+- #763: CPU reverse panics on I64 tensor, GPU accepts it
+- #766: BUG: CPU reverse panics on I64 tensor, GPU accepts it
+- #767: BUG: dispatch_tensor! / dispatch_binary! macros panic on I64 instead of returning Result
+- #769: BUG: CPU gather/scatter/dynamic_slice use assert! for config validation instead of Result
+- #779: BUG: index_tensor silently truncates float indices to int
+- #788: BUG: typed_reverse uses assert! for axis bounds instead of Result
+- #789: BUG: slice()/pad() public wrappers use .expect() and panic on error
+
+Related if the same files are already being edited:
+
+- #804: BUG: index_tensor panics on complex index tensors instead of returning error
+- #814: BUG: assert!/panic! validation in CPU indexing/linalg/BLAS helpers
+
+## Goal
+
+Make CPU indexing helpers return normal `Result` errors for invalid user input
+and unsupported index dtypes instead of panicking or silently coercing values.
+
+The primary user-visible contract is:
+
+- valid I64 reverse works on CPU, matching the CubeCL backend behavior,
+- invalid indexing configurations return `Err`, not `panic!`,
+- lossy or unsupported index dtype conversions return `Err`, not silent
+  truncation or process panic.
+
+## Scope
+
+This dispatch is limited to CPU indexing behavior in
+`tenferro-tensor/src/cpu/indexing.rs` and the smallest supporting changes
+needed in tensor dispatch helpers.
+
+It covers:
+
+- `reverse` / `typed_reverse`,
+- `gather`,
+- `scatter`,
+- `dynamic_slice`,
+- public CPU convenience wrappers for `slice` and `pad`,
+- index tensor conversion and validation.
+
+It does not cover:
+
+- GPU indexing performance (#765, #771),
+- GPU I64 reduction policy (#764),
+- broad `catch_backend_panic` redesign (#802),
+- AD rules for indexing ops (#783, #787),
+- dtype promotion semantics outside indexing (#811).
+
+## Acceptance Specification
+
+### I64 reverse
+
+CPU reverse must support `Tensor::I64` when the input tensor is otherwise valid.
+The implementation should mirror the explicit dtype dispatch style already used
+by CPU slice, pad, and concatenate helpers.
+
+### Error behavior
+
+The following cases must return a repository error variant through `Result`:
+
+- reverse axis out of bounds,
+- invalid gather/scatter/dynamic_slice rank or config lengths,
+- dynamic slice window sizes that exceed operand rank or bounds,
+- complex index tensors,
+- float index tensors containing non-finite values,
+- float index tensors containing fractional values,
+- float index tensors outside the exact integer range that can be represented
+  by `i64`.
+
+The implementation must not rely on `CpuBackend::catch_backend_panic` as the
+normal error path.
+
+### Public wrappers
+
+If public convenience wrappers cannot return `Result` without an API change,
+prefer one of these outcomes:
+
+1. replace them with `try_*`-style public functions and update internal callers,
+2. make non-Result wrappers private if no public contract depends on them,
+3. stop and report the required API change before editing broadly.
+
+Do not keep `.expect(...)` on user-controlled inputs.
+
+### Dispatch macros
+
+Do not mechanically put `Err(...)` inside macros whose expansion type is
+currently `Tensor`. If macro behavior cannot be made Result-aware cleanly,
+replace the indexing call sites with explicit dtype matches.
+
+## Design
+
+Use one small validation layer near each operation boundary. Each typed indexing
+helper should receive already validated config where practical, but validation
+may stay local when it depends on typed shape information.
+
+Preferred shape:
+
+1. top-level operation validates operation-level config and dtype support,
+2. dtype dispatch calls a typed helper,
+3. typed helper returns `Result<Tensor<T>>` or `Result<Tensor>`,
+4. unsupported dtype paths build a normal `Error` with operation context.
+
+For index tensors, introduce or reuse a helper that converts scalar index values
+losslessly into `i64`. The helper must reject complex values and reject floats
+that are not finite exact integers in `i64` range.
+
+## Testing
+
+Add focused regression tests in the owning crate. Keep tests outside production
+modules unless the module already has tiny local tests.
+
+Required cases:
+
+- CPU reverse on `Tensor::I64` returns reversed data,
+- CPU reverse with an out-of-bounds axis returns `Err`,
+- gather/scatter/dynamic_slice invalid config returns `Err`,
+- float index `1.5` returns `Err`,
+- large float index outside exact integer range returns `Err`,
+- complex index tensor returns `Err`,
+- public slice/pad error paths no longer panic.
+
+Run at least:
+
+```bash
+cargo test -p tenferro-tensor cpu::indexing
+cargo fmt --all --check
+```
+
+If the exact test filter is not available, run the narrowest tenferro-tensor
+test target that covers CPU indexing.
+
+## Dispatch Prompt
+
+```text
+Implement the CPU indexing validation dispatch from
+docs/plans/2026-05-02-cpu-indexing-validation-design.md.
+
+Focus only on the listed CPU indexing issues. Do not redesign GPU indexing,
+AD rules, dtype promotion, or catch_backend_panic. Replace panic/expect/assert
+paths for user-controlled indexing inputs with normal Result errors, support
+I64 reverse on CPU, and add focused regression tests. If a public non-Result
+wrapper forces a breaking API decision, stop and report the narrowest required
+change instead of broadening the patch.
+```
+
+## Review Checklist
+
+- No new `panic!`, `assert!`, `assert_eq!`, `.unwrap()`, or `.expect()` on
+  user-controlled indexing inputs.
+- I64 reverse has the same CPU/GPU support decision.
+- Float index conversion is explicit and lossless.
+- Tests cover both successful I64 reverse and invalid-input errors.
+- The patch does not touch unrelated GPU, AD, or linalg code.
+
+## Stop Conditions
+
+Stop and report if:
+
+- making slice/pad wrappers non-panicking requires a public API break wider than
+  CPU indexing,
+- existing tests encode panic behavior as a public guarantee,
+- fixing dispatch macros would require changing non-indexing call sites.

--- a/docs/plans/2026-05-02-cpu-indexing-validation-plan.md
+++ b/docs/plans/2026-05-02-cpu-indexing-validation-plan.md
@@ -1,0 +1,535 @@
+# CPU Indexing Validation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make CPU indexing return explicit `Result` errors for invalid inputs
+and support I64 data tensors for CPU reverse.
+
+**Architecture:** Convert CPU indexing entry points from panic-prone helpers to
+`Result<Tensor>` helpers, keep dtype dispatch explicit at the indexing boundary,
+and validate index tensors before typed execution. Backend and exec-session
+callers should use the Result-returning helpers directly instead of relying on
+`catch_backend_panic`.
+
+**Tech Stack:** Rust, `tenferro-tensor`, column-major `TypedTensor`, existing
+`crate::Error` variants, existing `src/tests/cpu_tests.rs` test module.
+
+**Execution Model:** Codex dispatches this plan to
+`opencode run -m deepseek/deepseek-v4-pro`. The implementation must stay within
+this plan and the companion spec
+`docs/plans/2026-05-02-cpu-indexing-validation-design.md`.
+
+---
+
+### Task 1: Add CPU Indexing Regression Tests
+
+**Files:**
+
+- Modify: `tenferro-tensor/src/tests/cpu_tests.rs`
+
+**Step 1: Add regression tests near the existing indexing tests**
+
+Add tests with these names and behaviors:
+
+```rust
+#[test]
+fn test_reverse_accepts_i64_data_tensor() {
+    let input = Tensor::from_vec(vec![3], vec![1_i64, 2, 3]);
+    let mut backend = CpuBackend::new();
+
+    let out = backend.reverse(&input, &[0]).unwrap();
+
+    assert_eq!(out.dtype(), DType::I64);
+    assert_eq!(out.shape(), &[3]);
+    assert_eq!(out.as_slice::<i64>(), Some([3, 2, 1].as_slice()));
+}
+
+#[test]
+fn test_reverse_axis_out_of_bounds_returns_error() {
+    let input = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
+    let mut backend = CpuBackend::new();
+
+    let err = backend.reverse(&input, &[1]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        crate::Error::AxisOutOfBounds {
+            op: "reverse",
+            axis: 1,
+            rank: 1,
+        }
+    ));
+}
+
+#[test]
+fn test_gather_rejects_fractional_float_indices() {
+    let operand = Tensor::F64(TypedTensor::from_vec(
+        vec![5],
+        vec![10.0, 20.0, 30.0, 40.0, 50.0],
+    ));
+    let start_indices = Tensor::F64(TypedTensor::from_vec(vec![1, 1], vec![1.5]));
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .gather(&operand, &start_indices, &simple_gather_config())
+        .unwrap_err();
+
+    assert!(matches!(err, crate::Error::InvalidConfig { op: "index_tensor", .. }));
+}
+
+#[test]
+fn test_gather_rejects_complex_indices() {
+    let operand = Tensor::F64(TypedTensor::from_vec(
+        vec![5],
+        vec![10.0, 20.0, 30.0, 40.0, 50.0],
+    ));
+    let start_indices = Tensor::C64(TypedTensor::from_vec(
+        vec![1, 1],
+        vec![Complex64::new(1.0, 0.0)],
+    ));
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .gather(&operand, &start_indices, &simple_gather_config())
+        .unwrap_err();
+
+    assert!(matches!(err, crate::Error::InvalidConfig { op: "index_tensor", .. }));
+}
+
+#[test]
+fn test_dynamic_slice_rejects_oversized_window() {
+    let input = Tensor::F64(TypedTensor::from_vec(
+        vec![2],
+        vec![1.0, 2.0],
+    ));
+    let starts = Tensor::from_vec(vec![1], vec![0_i64]);
+    let mut backend = CpuBackend::new();
+
+    let err = backend.dynamic_slice(&input, &starts, &[3]).unwrap_err();
+
+    assert!(matches!(err, crate::Error::InvalidConfig { op: "dynamic_slice", .. }));
+}
+```
+
+If `Complex64` is not already imported at the top of `cpu_tests.rs`, add it to
+the existing imports.
+
+**Step 2: Run tests to verify current failures**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor test_reverse_accepts_i64_data_tensor
+cargo test -p tenferro-tensor test_gather_rejects_fractional_float_indices
+cargo test -p tenferro-tensor test_gather_rejects_complex_indices
+cargo test -p tenferro-tensor test_dynamic_slice_rejects_oversized_window
+```
+
+Expected: at least the I64 reverse test fails or errors today, and the error
+tests expose panic-catcher or wrong-error behavior.
+
+**Step 3: Commit after the implementation passes**
+
+Do not commit failing tests alone unless the user explicitly asks for a TDD
+checkpoint commit. These tests should be committed together with the
+implementation task that makes them pass.
+
+### Task 2: Convert CPU Indexing Entry Points To Result
+
+**Files:**
+
+- Modify: `tenferro-tensor/src/cpu/indexing.rs:57-142`
+- Modify: `tenferro-tensor/src/cpu/backend.rs:358-411`
+- Modify: `tenferro-tensor/src/cpu/exec_session.rs:208-245`
+- Check: `tenferro-tensor/src/cpu/mod.rs:23`
+
+**Step 1: Change public CPU indexing helper signatures**
+
+Change these entry points to return `crate::Result<Tensor>`:
+
+```rust
+pub fn gather(
+    operand: &Tensor,
+    start_indices: &Tensor,
+    config: &GatherConfig,
+) -> crate::Result<Tensor>;
+
+pub fn scatter(
+    operand: &Tensor,
+    scatter_indices: &Tensor,
+    updates: &Tensor,
+    config: &ScatterConfig,
+) -> crate::Result<Tensor>;
+
+pub fn slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor>;
+
+pub fn dynamic_slice(
+    input: &Tensor,
+    starts: &Tensor,
+    slice_sizes: &[usize],
+) -> crate::Result<Tensor>;
+
+pub fn pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
+
+pub fn reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+```
+
+Keep `try_slice` and `try_pad` during the transition if existing call sites use
+them, but make `slice` and `pad` delegate without `.expect(...)`:
+
+```rust
+pub fn slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> {
+    try_slice(input, config)
+}
+
+pub fn pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
+    try_pad(input, config)
+}
+```
+
+**Step 2: Replace macro dispatch in indexing entry points**
+
+Do not use `dispatch_tensor!` or `dispatch_binary!` from indexing. Use explicit
+matches so unsupported I64 data tensors return errors except for reverse:
+
+```rust
+pub fn reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => typed_reverse(t, axes).map(Tensor::F32),
+        Tensor::F64(t) => typed_reverse(t, axes).map(Tensor::F64),
+        Tensor::I64(t) => typed_reverse(t, axes).map(Tensor::I64),
+        Tensor::C32(t) => typed_reverse(t, axes).map(Tensor::C32),
+        Tensor::C64(t) => typed_reverse(t, axes).map(Tensor::C64),
+    }
+}
+```
+
+For `gather` and `dynamic_slice`, reject `Tensor::I64` data operands with:
+
+```rust
+Err(crate::Error::BackendFailure {
+    op: "gather",
+    message: "I64 data tensors are not supported by this operation".into(),
+})
+```
+
+Use `op: "dynamic_slice"` for dynamic slice. For `scatter`, return
+`DTypeMismatch` when operand and updates dtypes differ, and return
+`BackendFailure { op: "scatter", .. }` when both are I64.
+
+**Step 3: Update backend callers**
+
+In `tenferro-tensor/src/cpu/backend.rs`, replace panic-catching wrappers for
+these operations with direct calls:
+
+```rust
+self.install(|| indexing::gather(operand, start_indices, config))
+self.install(|| indexing::scatter(operand, scatter_indices, updates, config))
+self.install(|| indexing::dynamic_slice(input, starts, slice_sizes))
+self.install(|| indexing::reverse(input, axes))
+```
+
+Do the same in `tenferro-tensor/src/cpu/exec_session.rs`.
+
+**Step 4: Run a compile check**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor test_reverse_accepts_i64_data_tensor
+```
+
+Expected: compilation reaches the implementation. Fix all call sites that still
+expect non-Result `gather`, `scatter`, `slice`, `dynamic_slice`, `pad`, or
+`reverse`.
+
+### Task 3: Add Lossless Index Tensor Conversion
+
+**Files:**
+
+- Modify: `tenferro-tensor/src/cpu/indexing.rs:368-383`
+
+**Step 1: Replace `index_tensor` with `try_index_tensor`**
+
+Change:
+
+```rust
+fn index_tensor(tensor: &Tensor) -> IndexTensor
+```
+
+to:
+
+```rust
+fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor>
+```
+
+Implement lossless conversion:
+
+```rust
+const F32_MAX_EXACT_INT: f32 = 16_777_216.0; // 2^24
+const F64_MAX_EXACT_INT: f64 = 9_007_199_254_740_992.0; // 2^53
+
+fn f32_index_to_i64(value: f32) -> crate::Result<i64> {
+    if !value.is_finite() || value.fract() != 0.0 || value.abs() > F32_MAX_EXACT_INT {
+        return Err(crate::Error::InvalidConfig {
+            op: "index_tensor",
+            message: format!("index value {value} is not an exactly representable i64"),
+        });
+    }
+    Ok(value as i64)
+}
+
+fn f64_index_to_i64(value: f64) -> crate::Result<i64> {
+    if !value.is_finite() || value.fract() != 0.0 || value.abs() > F64_MAX_EXACT_INT {
+        return Err(crate::Error::InvalidConfig {
+            op: "index_tensor",
+            message: format!("index value {value} is not an exactly representable i64"),
+        });
+    }
+    Ok(value as i64)
+}
+```
+
+For complex index tensors, return:
+
+```rust
+Err(crate::Error::InvalidConfig {
+    op: "index_tensor",
+    message: "complex index tensors are not supported".into(),
+})
+```
+
+**Step 2: Use the Result in entry points**
+
+Use:
+
+```rust
+let start_indices = try_index_tensor(start_indices)?;
+let scatter_indices = try_index_tensor(scatter_indices)?;
+let starts = try_index_tensor(starts)?;
+```
+
+**Step 3: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor test_gather_accepts_i64_indices
+cargo test -p tenferro-tensor test_gather_rejects_fractional_float_indices
+cargo test -p tenferro-tensor test_gather_rejects_complex_indices
+```
+
+Expected: all pass.
+
+### Task 4: Convert Typed Indexing Validation From Assertions To Result
+
+**Files:**
+
+- Modify: `tenferro-tensor/src/cpu/indexing.rs:386-689`
+
+**Step 1: Add Result-returning validation helpers**
+
+Replace panic-prone helpers with Result-returning forms:
+
+```rust
+fn try_index_vector_size(
+    op: &'static str,
+    shape: &[usize],
+    index_vector_dim: usize,
+) -> crate::Result<usize> {
+    if index_vector_dim > shape.len() {
+        return Err(crate::Error::AxisOutOfBounds {
+            op,
+            axis: index_vector_dim,
+            rank: shape.len(),
+        });
+    }
+    Ok(if index_vector_dim == shape.len() {
+        1
+    } else {
+        shape[index_vector_dim]
+    })
+}
+
+fn try_index_batch_shape(
+    op: &'static str,
+    shape: &[usize],
+    index_vector_dim: usize,
+) -> crate::Result<Vec<usize>> {
+    if index_vector_dim > shape.len() {
+        return Err(crate::Error::AxisOutOfBounds {
+            op,
+            axis: index_vector_dim,
+            rank: shape.len(),
+        });
+    }
+    if index_vector_dim == shape.len() {
+        return Ok(shape.to_vec());
+    }
+    Ok(shape
+        .iter()
+        .enumerate()
+        .filter_map(|(axis, &dim)| (axis != index_vector_dim).then_some(dim))
+        .collect())
+}
+
+fn clamp_window_start(
+    op: &'static str,
+    start: i64,
+    dim_size: usize,
+    window_size: usize,
+) -> crate::Result<usize> {
+    if window_size > dim_size {
+        return Err(crate::Error::InvalidConfig {
+            op,
+            message: format!("window size {window_size} exceeds dimension size {dim_size}"),
+        });
+    }
+    let max_start = dim_size.saturating_sub(window_size) as i64;
+    Ok(start.clamp(0, max_start) as usize)
+}
+```
+
+Keep helper names if preferred, but all user-controlled invalid cases must
+return `Err`.
+
+**Step 2: Change typed helpers to return Result**
+
+Change signatures:
+
+```rust
+fn typed_reverse<T: Copy + Clone>(
+    input: &TypedTensor<T>,
+    axes: &[usize],
+) -> crate::Result<TypedTensor<T>>;
+
+fn typed_gather<T: Copy + Clone + Zero>(
+    operand: &TypedTensor<T>,
+    start_indices: &IndexTensor,
+    config: &GatherConfig,
+) -> crate::Result<TypedTensor<T>>;
+
+fn typed_scatter<T>(
+    operand: &TypedTensor<T>,
+    scatter_indices: &IndexTensor,
+    updates: &TypedTensor<T>,
+    config: &ScatterConfig,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: Copy + Clone + Zero + Add<Output = T>;
+
+fn typed_dynamic_slice<T: Copy + Clone + Zero>(
+    input: &TypedTensor<T>,
+    starts: &IndexTensor,
+    slice_sizes: &[usize],
+) -> crate::Result<TypedTensor<T>>;
+```
+
+Replace every `assert!` and `assert_eq!` in these helpers with
+`RankMismatch`, `AxisOutOfBounds`, or `InvalidConfig` as appropriate.
+
+**Step 3: Protect internal index component access**
+
+`index_component` currently asserts for implicit index-vector shape. Convert it
+to `crate::Result<i64>` and propagate `?` through gather/scatter loops.
+
+**Step 4: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor test_reverse_axis_out_of_bounds_returns_error
+cargo test -p tenferro-tensor test_dynamic_slice_rejects_oversized_window
+cargo test -p tenferro-tensor test_backend_gather_scatter_dynamic_slice_dispatch
+```
+
+Expected: all pass.
+
+### Task 5: Update Existing Tests For Result Helpers
+
+**Files:**
+
+- Modify: `tenferro-tensor/src/tests/cpu_tests.rs`
+
+**Step 1: Update direct helper call sites**
+
+Existing direct calls to `gather`, `scatter`, `dynamic_slice`, and `pad` in
+`cpu_tests.rs` now return `Result<Tensor>`. Add `.unwrap()` only in tests where
+success is expected:
+
+```rust
+let out = gather(&operand, &start_indices, &simple_gather_config()).unwrap();
+let out = scatter(&operand, &scatter_indices, &updates, &config).unwrap();
+let out = dynamic_slice(&input, &starts, &[2, 2]).unwrap();
+let out = pad(&input, &config).unwrap();
+```
+
+Do not add unwraps in production code.
+
+**Step 2: Run the CPU test slice**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor cpu_tests
+```
+
+Expected: CPU tests compile and pass.
+
+### Task 6: Final Verification And Commit
+
+**Files:**
+
+- Review: `tenferro-tensor/src/cpu/indexing.rs`
+- Review: `tenferro-tensor/src/cpu/backend.rs`
+- Review: `tenferro-tensor/src/cpu/exec_session.rs`
+- Review: `tenferro-tensor/src/tests/cpu_tests.rs`
+
+**Step 1: Search for remaining panic-prone indexing paths**
+
+Run:
+
+```bash
+rg -n "panic!|assert!|assert_eq!|expect\\(|unwrap\\(" tenferro-tensor/src/cpu/indexing.rs
+```
+
+Expected: no `panic!`, `.expect(...)`, `.unwrap(...)`, or user-controlled
+`assert!`/`assert_eq!` remains in CPU indexing. A non-user-controlled internal
+assert requires a comment explaining why it is unreachable.
+
+**Step 2: Run focused verification**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor test_reverse_accepts_i64_data_tensor
+cargo test -p tenferro-tensor test_reverse_axis_out_of_bounds_returns_error
+cargo test -p tenferro-tensor test_gather_rejects_fractional_float_indices
+cargo test -p tenferro-tensor test_gather_rejects_complex_indices
+cargo test -p tenferro-tensor test_dynamic_slice_rejects_oversized_window
+cargo test -p tenferro-tensor cpu_tests
+cargo fmt --all --check
+```
+
+Expected: all pass.
+
+**Step 3: Commit**
+
+Run:
+
+```bash
+git add tenferro-tensor/src/cpu/indexing.rs \
+  tenferro-tensor/src/cpu/backend.rs \
+  tenferro-tensor/src/cpu/exec_session.rs \
+  tenferro-tensor/src/tests/cpu_tests.rs
+git commit -m "fix: return errors from cpu indexing validation"
+```
+
+**Step 4: Report**
+
+Report:
+
+- issues addressed,
+- files changed,
+- focused tests run,
+- any deferred parts of #767, #804, or #814.

--- a/docs/plans/2026-05-02-deferred-gpu-safety-large-issues-design.md
+++ b/docs/plans/2026-05-02-deferred-gpu-safety-large-issues-design.md
@@ -1,0 +1,145 @@
+# Deferred GPU, Safety, And Large Issues Dispatch Design
+
+**Date:** 2026-05-02
+
+**Status:** Proposed triage spec
+
+## Issues
+
+Large implementation or design issues:
+
+- #212: perf(tropical-ad): optimized argmax forward path
+- #602: Design: compute-device inference primary, runtime override secondary
+- #629 and #797: add F32/C32 CPU linalg support
+- #701: CPU elementwise fusion via closure composition
+- #745: global metadata registry is an unbounded memory leak
+- #755: shared execution handle for EagerTensor and plain Tensor ops
+- #760: provider-inject runtime path after cblas/lapack dual ABI support
+- #774: cpu-faer + cpu-blas both enabled causes eig compile error
+
+GPU and CubeCL issues:
+
+- #724 and #791: complex CubeCL math/fusion support
+- #728: GPU delegation benchmark matrix
+- #764: inconsistent I64 reduce_sum/reduce_prod CPU vs GPU
+- #765: GPU i64 index conversion roundtrip
+- #770: GPU LU decomposition roundtrip
+- #771: GPU scatter kernel is single-threaded
+- #793: GPU convert_float_to_complex_raw sets resident_device to None
+- #796: GEMM zero-alloc waste before GPU upload
+- #809: no I64 GPU tests
+- #810: no complex GPU fusion tests
+- #817: CudaDataType lacks explicit repr
+- #819: CubeCL real-conj clone path does not verify device residency
+
+Low-level safety and performance issues:
+
+- #782: buffer_pool set_len leaves uninitialized memory tail
+- #806: analytic ops use zero-initialized output instead of uninit
+- #812: consolidated minor audit issues
+- #813: missing/weak safety contracts around unsafe blocks
+- #815: integer overflow risks in tril/triu and GEMM planning
+- #816: unnecessary clone before reduction on contiguous inputs
+
+Infrastructure:
+
+- #586: use self-host runner
+
+## Goal
+
+Keep the first single PR bounded. These issues need either design review, GPU
+hardware, external dependency readiness, broad API changes, or performance
+measurement. They should not be silently mixed into the first implementation
+passes.
+
+## Dispatch Policy
+
+This document is not an instruction to implement all listed issues in one pass.
+It is the triage boundary for issues that should be deferred or split into
+dedicated future PRs unless the user explicitly reprioritizes them.
+
+## Classification
+
+### Requires design approval before implementation
+
+- #602 compute-device/runtime selection,
+- #745 global metadata registry ownership,
+- #755 shared execution handle,
+- #701 CPU fusion,
+- #212 tropical argmax primitive,
+- #782 buffer-pool initialization contract if runtime checking or MaybeUninit
+  migration is considered.
+
+### Requires external dependency or upstream readiness
+
+- #724 / #791 CubeCL complex math in fork,
+- #760 provider-inject ABI path,
+- #629 / #797 if faer API support or trait coverage is incomplete.
+- #774 if it is invalidated by the repository's exactly-one-CPU-backend
+  compile-time contract rather than a supported feature combination.
+
+### Requires GPU hardware or benchmark data
+
+- #728 GPU delegation benchmark,
+- #764 / #765 / #770 / #771 / #793 / #796 / #809 / #810 / #819.
+
+### Small but safety-sensitive follow-ups
+
+- #806 uninitialized analytic outputs,
+- #813 unsafe contracts,
+- #815 integer overflow,
+- #816 reduction clone,
+- #817 C ABI representation.
+
+These may become their own dispatches after the first five specs are complete.
+
+## Acceptance Specification
+
+For the first single PR:
+
+- do not implement deferred issues unless explicitly pulled into scope,
+- mention deferred issues in the PR body if related files were touched,
+- avoid partial fixes that make future dedicated work harder,
+- prefer opening or updating issue comments over speculative code changes.
+
+For a future dispatch from this document:
+
+1. select one subsection only,
+2. write a dedicated design doc for that subsection,
+3. define required hardware, benchmark, or oracle prerequisites,
+4. then dispatch implementation.
+
+## Testing Expectations
+
+No tests are required for this triage document itself.
+
+Any future dispatch must define its own verification. For GPU issues, the spec
+must state whether local non-GPU tests are sufficient or whether CUDA hardware
+is required before claiming completion.
+
+## Dispatch Prompt
+
+```text
+Do not implement this document as one patch. Use
+docs/plans/2026-05-02-deferred-gpu-safety-large-issues-design.md as the triage
+boundary for issues intentionally excluded from the first single PR.
+
+If asked to work on one listed subsection, first write a dedicated design doc
+for that subsection, including hardware, benchmark, API, and safety
+prerequisites.
+```
+
+## Review Checklist
+
+- Deferred issues are not accidentally mixed into unrelated dispatches.
+- Any touched deferred area has an explicit reason in the PR summary.
+- GPU completion claims are not made without GPU verification.
+- Design issues are not implemented from issue text alone.
+
+## Stop Conditions
+
+Stop and report if:
+
+- a first-pass dispatch starts requiring GPU hardware,
+- a first-pass fix requires redesigning public execution context APIs,
+- external provider or CubeCL changes are needed before tenferro can proceed.

--- a/docs/plans/2026-05-02-deferred-gpu-safety-large-issues-design.md
+++ b/docs/plans/2026-05-02-deferred-gpu-safety-large-issues-design.md
@@ -86,6 +86,9 @@ dedicated future PRs unless the user explicitly reprioritizes them.
   math support. Do not attempt a tenferro-side implementation in this batch.
   Once that PR lands, the tenferro follow-up should be limited to a fork rev
   bump plus focused complex GPU fusion/runtime coverage.
+- Keep tenferro depending on the `shinaoka/cubecl` fork. Do not migrate these
+  dependencies back to upstream CubeCL as part of this batch or the follow-up
+  complex-support rev bump.
 
 ### Requires GPU hardware
 
@@ -113,6 +116,7 @@ For the first single PR:
 
 - do not implement deferred issues unless explicitly pulled into scope,
 - do not implement #724 / #791 until the CubeCL PR lands,
+- do not replace the `shinaoka/cubecl` fork dependency with upstream CubeCL,
 - do not implement #728 or any GPU benchmark harness in this batch,
 - mention deferred issues in the PR body if related files were touched,
 - avoid partial fixes that make future dedicated work harder,

--- a/docs/plans/2026-05-02-deferred-gpu-safety-large-issues-design.md
+++ b/docs/plans/2026-05-02-deferred-gpu-safety-large-issues-design.md
@@ -19,8 +19,6 @@ Large implementation or design issues:
 
 GPU and CubeCL issues:
 
-- #724 and #791: complex CubeCL math/fusion support
-- #728: GPU delegation benchmark matrix
 - #764: inconsistent I64 reduce_sum/reduce_prod CPU vs GPU
 - #765: GPU i64 index conversion roundtrip
 - #770: GPU LU decomposition roundtrip
@@ -44,6 +42,11 @@ Low-level safety and performance issues:
 Infrastructure:
 
 - #586: use self-host runner
+
+Explicitly excluded from this batch:
+
+- #724 and #791: complex CubeCL math/fusion support
+- #728: GPU delegation benchmark matrix
 
 ## Goal
 
@@ -72,16 +75,27 @@ dedicated future PRs unless the user explicitly reprioritizes them.
 
 ### Requires external dependency or upstream readiness
 
-- #724 / #791 CubeCL complex math in fork,
 - #760 provider-inject ABI path,
 - #629 / #797 if faer API support or trait coverage is incomplete.
 - #774 if it is invalidated by the repository's exactly-one-CPU-backend
   compile-time contract rather than a supported feature combination.
 
-### Requires GPU hardware or benchmark data
+### Waiting on CubeCL PR
 
-- #728 GPU delegation benchmark,
+- #724 / #791 are blocked on the in-flight CubeCL repository PR for complex
+  math support. Do not attempt a tenferro-side implementation in this batch.
+  Once that PR lands, the tenferro follow-up should be limited to a fork rev
+  bump plus focused complex GPU fusion/runtime coverage.
+
+### Requires GPU hardware
+
 - #764 / #765 / #770 / #771 / #793 / #796 / #809 / #810 / #819.
+
+### Excluded benchmark work
+
+- #728 is out of scope for this batch. Do not create benchmark harnesses, run
+  performance comparisons, or adjust dispatch strategy based on benchmark goals
+  in the first single PR.
 
 ### Small but safety-sensitive follow-ups
 
@@ -98,6 +112,8 @@ These may become their own dispatches after the first five specs are complete.
 For the first single PR:
 
 - do not implement deferred issues unless explicitly pulled into scope,
+- do not implement #724 / #791 until the CubeCL PR lands,
+- do not implement #728 or any GPU benchmark harness in this batch,
 - mention deferred issues in the PR body if related files were touched,
 - avoid partial fixes that make future dedicated work harder,
 - prefer opening or updating issue comments over speculative code changes.

--- a/docs/plans/2026-05-02-docs-einsum-cleanup-design.md
+++ b/docs/plans/2026-05-02-docs-einsum-cleanup-design.md
@@ -1,0 +1,151 @@
+# Docs And Einsum Cleanup Dispatch Design
+
+**Date:** 2026-05-02
+
+**Status:** Proposed dispatch spec
+
+## Issues
+
+Primary:
+
+- #742: docs: realign GPU design docs with cubecl reality
+- #746: Cleanup: vestigial ShapeGuardContext / global_metadata APIs
+- #748: Document einsum repeated-label semantics
+
+Related if the same files are already being edited:
+
+- #798: BUG: multiple .unwrap() panics in einsum builder label lookups
+- #799: BUG: debug_assert in contraction_cost compiles away in release
+- #800: DESIGN: Subscripts::parse silently strips parentheses
+- #801: BUG: NestedEinsum::parse_group sorts intermediate output labels
+- #808: BUG: error type erasure in einsum planning
+- #792: BUG: DimExpr::Sub can underflow usize
+- #820: DOC: Stale OutFloat doc reference and minor test quality issues
+
+## Goal
+
+Bring docs and small cleanup surfaces back in line with current implementation
+without changing historical plan records or starting a broad einsum parser
+redesign.
+
+## Scope
+
+This dispatch covers:
+
+- `docs/design/gpu-backend-design.md`,
+- `docs/design/einsum.md`,
+- rustdoc or guide text for repeated-label einsum semantics,
+- vestigial metadata APIs after lazy lookup if cleanup stays narrow,
+- small einsum safety fixes only when directly adjacent to docs/tests being
+  updated.
+
+It does not cover:
+
+- changing files under `docs/plans/` other than this dispatch spec,
+- implementing new GPU functionality,
+- redesigning NestedEinsum parsing,
+- eliminating the global metadata leak (#745),
+- broad error-type migration for einsum planning.
+
+## Acceptance Specification
+
+### GPU design docs
+
+Forward-looking GPU design docs must describe the CubeCL-based implementation:
+
+- `tenferro-tensor/src/cubecl/` is the active GPU backend under the `cubecl`
+  feature,
+- CUDA execution flows through CubeCL/CubeCL-CUDA and supporting CUDA libraries,
+- ROCm remains a stub unless explicitly implemented later,
+- deleted `CudaBackend` direct-backend architecture must not be presented as the
+  current target.
+
+Historical references are acceptable only when clearly marked as historical.
+
+### Repeated-label einsum docs
+
+User-facing docs and rustdoc should state:
+
+- repeated labels in one input select a diagonal,
+- repeated labels omitted from output are reduced after diagonal extraction,
+- repeated labels in the output perform diagonal embedding,
+- public einsum APIs accept repeated labels,
+- strict binary/GEMM lowering may decline these patterns as a fast path and fall
+  back to the general path.
+
+Examples should include:
+
+- `ii->`,
+- `ii->i`,
+- `i->ii`,
+- one higher-rank example such as `iij->ij` or `iii->i`.
+
+### Metadata cleanup
+
+If `snapshot_global_metadata` is unused outside tests, remove or demote it to a
+test-only helper. `refresh_global_metadata` should either become a documented
+no-op or be removed if all callers can be updated safely.
+
+This dispatch must not attempt to solve the unbounded registry leak.
+
+### Eager einsum safety
+
+If editing einsum docs reveals nearby `unwrap()` or `debug_assert` failures in
+current non-historical code, fix only the narrow cases with obvious `Result`
+propagation. Parser-order design issues should be documented for a later
+dispatch unless tests already define the intended behavior.
+
+## Design
+
+Separate user-facing docs from internal design pointers:
+
+- user docs use `tenferro::{...}` imports only,
+- internal design docs may point to implementation files,
+- historical `docs/plans/` files remain unchanged.
+
+For cleanup, prefer deletion of vestigial APIs over compatibility shims unless
+there is a current public caller.
+
+## Testing
+
+Required checks:
+
+```bash
+cargo test -p tenferro-einsum
+cargo test -p tenferro --doc
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+cargo fmt --all --check
+```
+
+If only Markdown files changed and no rustdoc examples changed, explain which
+code tests were skipped and why.
+
+## Dispatch Prompt
+
+```text
+Implement the docs and einsum cleanup dispatch from
+docs/plans/2026-05-02-docs-einsum-cleanup-design.md.
+
+Update current design docs and user-facing repeated-label einsum docs. Do not
+edit historical docs/plans records. Keep metadata cleanup narrow and do not
+solve the global metadata leak. Fix only adjacent obvious einsum unwrap/assert
+issues if tests and local error propagation are straightforward; otherwise
+document them for a later dispatch.
+```
+
+## Review Checklist
+
+- `CudaBackend` is not described as the current GPU backend target.
+- Repeated-label semantics are explicit, not only implicit in examples.
+- User-facing docs import from `tenferro`, not internal crates.
+- `docs/plans/` historical records are not rewritten.
+- Metadata cleanup does not change the leak design problem.
+
+## Stop Conditions
+
+Stop and report if:
+
+- docs accuracy requires resolving an implementation ambiguity,
+- metadata API removal breaks public or downstream callers,
+- NestedEinsum parser fixes require a broader design decision.

--- a/docs/plans/2026-05-02-docs-einsum-cleanup-plan.md
+++ b/docs/plans/2026-05-02-docs-einsum-cleanup-plan.md
@@ -1,0 +1,151 @@
+# Docs And Einsum Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Bring current GPU and einsum documentation in line with the implemented CubeCL backend and repeated-label einsum behavior, while fixing the adjacent contraction-cost release-mode fallback.
+
+**Architecture:** Documentation changes are limited to current design/user-facing docs and rustdoc; historical `docs/plans/` records remain unchanged. Code changes stay inside the `tenferro-einsum` planner utility path, converting a debug-only invariant into checked `Result` propagation.
+
+**Tech Stack:** Rust, `tenferro-einsum`, `tenferro-tensor` CubeCL backend, Markdown docs, cargo test/doc tooling.
+
+---
+
+### Task 1: Planner Missing-Label Regression
+
+**Files:**
+- Modify: `tenferro-einsum/src/util.rs`
+- Modify: `tenferro-einsum/src/planning/tree.rs`
+- Modify: `tenferro-einsum/src/planning/tree/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add a unit test in `tenferro-einsum/src/planning/tree/tests.rs` that calls the self-greedy planner with a `needed` output label absent from `size_dict`, and asserts `Error::InvalidArgument` rather than silently treating the label size as `1`.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p tenferro-einsum --lib -- self_greedy_pair_optimizer_rejects_missing_needed_label
+```
+
+Expected: FAIL because `optimize_self_greedy_pairs` currently returns a `Vec` and `contraction_cost` uses a debug-only assertion plus `unwrap_or(1)`.
+
+**Step 3: Implement checked propagation**
+
+Change `contraction_cost` to return `Result<usize>` and produce `Error::InvalidArgument` when an output/intermediate label lacks a known size. Change `optimize_self_greedy_pairs` to return `Result<Vec<(usize, usize)>>` and propagate the error from `optimize_with_options`.
+
+**Step 4: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p tenferro-einsum --lib -- self_greedy_pair_optimizer
+cargo test -p tenferro-einsum --lib -- optimize_with_options
+```
+
+Expected: PASS.
+
+### Task 2: Repeated-Label Einsum Coverage
+
+**Files:**
+- Modify: `tenferro-einsum/src/tests/eager_tests.rs`
+- Modify: `tenferro-einsum/src/lib.rs`
+- Modify: `tenferro-einsum/src/syntax/subscripts.rs`
+- Modify: `docs/guides/einsum.md`
+- Modify: `docs/design/einsum.md`
+
+**Step 1: Add higher-rank eager test**
+
+Add an eager regression for `iij->ij` using a small deterministic tensor, asserting diagonal extraction across the first two axes while preserving the remaining axis.
+
+**Step 2: Run test to verify current behavior**
+
+Run:
+
+```bash
+cargo test -p tenferro-einsum --lib -- eager_einsum_handles_higher_rank_repeated_labels
+```
+
+Expected: PASS if the implementation already supports the behavior; keep it as documentation-backed coverage.
+
+**Step 3: Update rustdoc and guide text**
+
+Document that repeated labels in one input select diagonals, repeated labels absent from output are reduced after diagonal extraction, and repeated output labels embed diagonals. Include examples for `ii->`, `ii->i`, `i->ii`, and `iij->ij`. User-facing guide examples must import from `tenferro`, not internal crates.
+
+**Step 4: Run relevant checks**
+
+Run:
+
+```bash
+cargo test -p tenferro-einsum --lib -- eager_einsum_handles_higher_rank_repeated_labels
+cargo test -p tenferro --doc
+```
+
+Expected: PASS.
+
+### Task 3: Current GPU Design Documentation
+
+**Files:**
+- Modify: `docs/design/gpu-backend-design.md`
+- Modify: `docs/design/einsum.md`
+
+**Step 1: Replace stale direct-backend design claims**
+
+Rewrite `docs/design/gpu-backend-design.md` around the current `CubeclBackend` implementation in `tenferro-tensor/src/cubecl/`, the `cubecl` feature, explicit upload/download policy, CUDA-only status, and lazy runtime loading of cuTENSOR/cuSOLVER/cuBLAS. Clearly state that ROCm is a stub and GPU benchmarking is out of scope for this batch.
+
+**Step 2: Align einsum design status**
+
+Update `docs/design/einsum.md` to describe the current traced/eager surfaces, repeated-label semantics, strict binary lowering fallback for repeated labels, and CubeCL status without presenting deleted `CudaBackend`/`RocmBackend` architecture as current.
+
+**Step 3: Search for stale current claims**
+
+Run:
+
+```bash
+rg -n "CudaBackend|RocmBackend|tenferro-prims|tenferro_prims|tenferro_tensor|tenferro_einsum" docs/design/gpu-backend-design.md docs/design/einsum.md docs/guides/einsum.md
+```
+
+Expected: no stale current-backend claims and no internal-crate imports in user-facing guide snippets.
+
+### Task 4: Verification And Commit
+
+**Files:**
+- All files modified above
+
+**Step 1: Format/check diffs**
+
+Run:
+
+```bash
+cargo fmt --all --check
+git diff --check
+```
+
+Expected: PASS.
+
+**Step 2: Run focused code/docs checks**
+
+Run:
+
+```bash
+cargo test -p tenferro-einsum
+cargo test -p tenferro --doc
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+```
+
+Expected: PASS. If a full docs command is too slow or fails from pre-existing warnings outside the touched scope, record the exact failure and run the narrower command that covers the touched files.
+
+**Step 3: Commit**
+
+Run:
+
+```bash
+git add docs/plans/2026-05-02-docs-einsum-cleanup-plan.md \
+  docs/design/gpu-backend-design.md docs/design/einsum.md docs/guides/einsum.md \
+  tenferro-einsum/src/lib.rs tenferro-einsum/src/syntax/subscripts.rs \
+  tenferro-einsum/src/util.rs tenferro-einsum/src/planning/tree.rs \
+  tenferro-einsum/src/planning/tree/tests.rs tenferro-einsum/src/tests/eager_tests.rs
+git commit -m "docs: align gpu and repeated-label einsum docs"
+```

--- a/docs/plans/2026-05-02-faer-linalg-safety-design.md
+++ b/docs/plans/2026-05-02-faer-linalg-safety-design.md
@@ -1,0 +1,137 @@
+# Faer Linalg Safety Dispatch Design
+
+**Date:** 2026-05-02
+
+**Status:** Proposed dispatch spec
+
+## Issues
+
+Primary:
+
+- #768: BUG: debug_assert_eq! used before transmute, UB in release builds
+- #781: BUG: SVD/EIGH/eig decomposition failure panics via unwrap_or_else
+
+Related if the same files are already being edited:
+
+- #803: BUG: faer_gemm beta-scaling loop has no guard against zero stride
+- #805: BUG: check_singular_diagonal panics on rank<2 tensors
+- #807: BUG: batched linalg helpers use assert!/assert_eq! for validation
+- #814: BUG: assert!/panic! validation in CPU indexing/linalg/BLAS helpers
+
+## Goal
+
+Remove release-mode undefined-behavior risk and library panics from faer-backed
+linalg paths by converting invariant checks and decomposition failures into
+explicit contracts or `Result` errors.
+
+## Scope
+
+This dispatch covers faer-backed CPU linalg and tightly adjacent helpers in
+`tenferro-tensor`.
+
+It does not cover:
+
+- adding F32/C32 linalg support (#629, #797),
+- GPU linalg performance (#770),
+- provider-inject ABI work (#760),
+- adding new AD rules for linalg (#772, #777),
+- changing the one-CPU-backend feature contract.
+
+## Acceptance Specification
+
+### Complex slice reinterpretation
+
+The conversion helpers that reinterpret `num_complex::Complex64` slices as faer
+complex slices must not rely only on `debug_assert_eq!` before unsafe pointer
+reinterpretation.
+
+Acceptable outcomes:
+
+- use always-on assertions for layout invariants that are compile-time facts in
+  supported builds, or
+- mark the helpers `unsafe` and document exact safety requirements, while
+  ensuring every call site satisfies them.
+
+The preferred outcome is always-on layout validation with a short comment
+explaining why the representation is expected to match.
+
+### Decomposition failure
+
+SVD, EIGH, and eig paths must return `Err` on decomposition failure instead of
+panicking through `unwrap_or_else`.
+
+The error should preserve operation context. Use existing error variants where
+possible rather than introducing a new public error type.
+
+### Validation panics
+
+If nearby linalg validation currently uses `assert!` on user-controlled shapes
+or ranks, convert only the narrow cases listed above or directly touched by the
+same call path. Do not broaden into a full linalg validation refactor.
+
+## Design
+
+Keep the faer implementation structure intact. This dispatch should be a safety
+and error-propagation patch, not a linalg architecture change.
+
+For decomposition calls:
+
+1. replace panic adapters with `map_err(...)` or equivalent,
+2. return through the existing `Result` path,
+3. update callers only as needed to propagate `Result`.
+
+For unsafe slice conversions:
+
+1. keep the helper small,
+2. make the invariant check visible in release builds or documented as an
+   unsafe contract,
+3. avoid duplicating conversion logic across f64 and complex paths.
+
+## Testing
+
+Required tests:
+
+- a failure-mode test for at least one faer decomposition path that used to
+  panic and now returns `Err`,
+- a rank or shape validation test if any related validation panic is changed,
+- existing linalg success tests must still pass.
+
+Run at least:
+
+```bash
+cargo test -p tenferro-tensor linalg
+cargo fmt --all --check
+```
+
+If focused filters are too coarse, run the relevant tenferro-tensor linalg test
+target or the crate tests.
+
+## Dispatch Prompt
+
+```text
+Implement the faer linalg safety dispatch from
+docs/plans/2026-05-02-faer-linalg-safety-design.md.
+
+Limit the patch to faer-backed CPU linalg safety and error propagation. Remove
+release-only debug assertions before unsafe reinterpretation, return Err instead
+of panicking on SVD/EIGH/eig decomposition failures, and add focused regression
+tests. Do not add F32/C32 linalg, provider-inject support, GPU linalg work, or
+new linalg AD rules.
+```
+
+## Review Checklist
+
+- No decomposition failure path uses `panic!` or `unwrap_or_else(|_| panic!)`.
+- Unsafe slice reinterpretation has an always-enforced invariant or documented
+  unsafe contract.
+- Error messages name the failing operation.
+- Tests cover an error path, not only success paths.
+- The patch does not change linalg public semantics beyond panic-to-error.
+
+## Stop Conditions
+
+Stop and report if:
+
+- faer APIs do not expose recoverable failure information for a target op,
+- converting a panic to `Err` requires changing public trait signatures,
+- a layout invariant cannot be justified for all supported platforms.

--- a/docs/plans/2026-05-02-faer-linalg-safety-plan.md
+++ b/docs/plans/2026-05-02-faer-linalg-safety-plan.md
@@ -1,0 +1,94 @@
+# Faer Linalg Safety Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Convert faer-backed SVD/EIGH/eig decomposition failures from panic paths into `Result` errors and make complex slice reinterpretation invariants release-visible.
+
+**Architecture:** Keep the existing faer linalg module layout. Add result-returning batched helpers only for multi-output operations that can fail (`svd`, `eigh`, `eig`) so successful operations such as `qr`, `lu`, and `full_piv_lu` do not churn. Flatten the new internal `Result` at `CpuBackend` and `CpuExecSession` boundaries.
+
+**Tech Stack:** Rust, `tenferro-tensor`, faer CPU backend, module-local CPU tests.
+
+---
+
+## Scope For This Step
+
+Implement:
+
+- release-visible layout checks in `complex64_to_faer_slice` and `complex64_to_faer_slice_mut`,
+- `crate::Result` propagation for faer `svd`, `eigh`, and `eig`,
+- focused tests that call faer linalg internals and assert invalid decomposition inputs return `Err`.
+
+Defer:
+
+- broad linalg validation refactors for all `assert!` call paths,
+- LAPACK backend panic conversion,
+- full batched helper assertion cleanup outside the failing decomposition paths.
+
+## Task 1: Add Failing Tests
+
+**Files:**
+
+- Modify: `tenferro-tensor/src/tests/cpu_tests.rs`
+
+**Steps:**
+
+1. Add `#[cfg(feature = "cpu-faer")]` tests that call `crate::cpu::linalg::faer_linalg::{svd, eigh, eig}` directly with a NaN-containing matrix.
+2. Assert each call returns `Err` and the error text contains the operation name.
+3. Run the focused tests and verify they fail to compile or fail because the current helpers return `Vec` and panic internally.
+
+## Task 2: Result-Returning Faer Decompositions
+
+**Files:**
+
+- Modify: `tenferro-tensor/src/cpu/linalg/faer_linalg.rs`
+
+**Steps:**
+
+1. Change `FaerLinalg::svd_2d` and `FaerLinalg::eigh_2d` to return `crate::Result<Vec<TypedTensor<Self>>>`.
+2. Add `batched_multi_result` and `batched_multi_convert_result` alongside existing helpers.
+3. Change public faer `svd` and `eigh` helpers to return `crate::Result<Vec<TypedTensor<T>>>`.
+4. Change `eig_real_2d`, `eig_complex_2d`, and faer `eig` to return `crate::Result`.
+5. Replace each faer decomposition `unwrap_or_else(|_| panic!(...))` with `map_err` returning `crate::Error::BackendFailure { op, message }`.
+
+## Task 3: Boundary Flattening
+
+**Files:**
+
+- Modify: `tenferro-tensor/src/cpu/backend.rs`
+- Modify: `tenferro-tensor/src/cpu/exec_session.rs`
+
+**Steps:**
+
+1. In faer `CpuBackend::svd`, `CpuBackend::eigh`, and `CpuBackend::eig`, flatten `catch_backend_panic(...).and_then(|r| r)`.
+2. Add a faer-only `linalg_multi_result!` macro for `CpuExecSession::svd` and `CpuExecSession::eigh`.
+3. Flatten faer `CpuExecSession::eig` similarly.
+4. Keep cpu-blas branches unchanged.
+
+## Task 4: Complex Layout Checks
+
+**Files:**
+
+- Modify: `tenferro-tensor/src/cpu/linalg/faer_linalg.rs`
+
+**Steps:**
+
+1. Replace `debug_assert_eq!` layout checks before complex slice reinterpretation with always-on `assert_eq!`.
+2. Add one short safety comment before the unsafe conversion explaining that size and alignment are checked in release builds.
+
+## Task 5: Verify And Commit
+
+**Commands:**
+
+```bash
+cargo test -p tenferro-tensor --lib -- faer
+cargo test -p tenferro-tensor --lib -- linalg
+cargo fmt --all --check
+cargo check -p tenferro-tensor
+```
+
+Commit:
+
+```bash
+git add docs/plans/2026-05-02-faer-linalg-safety-plan.md tenferro-tensor/src
+git commit -m "fix: return faer linalg decomposition errors"
+```

--- a/docs/plans/2026-05-02-primitive-dtype-shape-design.md
+++ b/docs/plans/2026-05-02-primitive-dtype-shape-design.md
@@ -1,0 +1,162 @@
+# Primitive DType And Shape Semantics Dispatch Design
+
+**Date:** 2026-05-02
+
+**Status:** Proposed dispatch spec
+
+## Issues
+
+Primary:
+
+- #775: BUG: DynamicTruncate shape inference returns pre-truncation shape
+- #776: BUG: Add/Mul shape inference returns LHS shape instead of broadcast shape
+- #778: BUG: scalar_size_value rejects I64 for DynamicTruncate
+- #780: BUG: convert() silently overflows on narrowing casts
+- #784: BUG: eps parameter ignored in Svd/Eigh execution path
+- #785: BUG: eig_output_dtype maps I64 to I64
+- #786: BUG: scale_real truncates for I64 instead of rounding
+
+Related follow-up candidates:
+
+- #790: PERF: CPU elementwise add/mul limited to scalar broadcasting
+- #794: BUG: elementwise div lacks real-to-complex scalar promotion
+- #811: DESIGN: No dtype promotion anywhere, apply_binary uses lhs.dtype
+- #818: BUG: convert and embed_diagonal API inconsistencies
+
+## Goal
+
+Align compile-time metadata and small runtime scalar/dtype decisions with the
+actual tensor semantics, without attempting a full dtype-promotion redesign.
+
+## Scope
+
+This dispatch covers:
+
+- shape inference for `DynamicTruncate` and scalar/NumPy-style binary
+  broadcasting metadata,
+- I64 scalar size inputs for `DynamicTruncate`,
+- `svd_with_eps` and `eigh_with_eps` execution plumbing,
+- output dtype selection for eig,
+- I64 `scale_real` rounding behavior,
+- CPU convert semantics only if the API can be adjusted narrowly.
+
+It does not cover:
+
+- full dtype promotion policy (#811),
+- full NumPy broadcasting implementation for CPU kernels (#790),
+- real-to-complex binary promotion (#794),
+- broad structural API redesign (#818),
+- AD rule changes.
+
+## Acceptance Specification
+
+### Shape inference
+
+Shape inference must report the same output rank and dimensions that runtime
+execution will produce for:
+
+- `DynamicTruncate`,
+- binary add/mul with scalar operands,
+- binary add/mul with compatible non-scalar broadcast shapes.
+
+If runtime add/mul does not yet support full NumPy broadcasting, shape inference
+must not claim support beyond what execution can perform. In that case, stop
+and report the runtime/metadata mismatch rather than encoding optimistic
+metadata.
+
+### DynamicTruncate scalar sizes
+
+`DynamicTruncate` size inputs may be I64 scalar tensors. Float scalar inputs may
+keep the existing rounding policy if that is current public behavior.
+
+Invalid scalar size tensors must return `Err`, not panic.
+
+### Linalg eps parameters
+
+`svd_with_eps` and `eigh_with_eps` must pass their `eps` value through execution
+or the public API must stop accepting an unused value. The preferred outcome is
+to plumb `eps` through the traced execution path and keep eager behavior
+explicit.
+
+### DType decisions
+
+`eig_output_dtype` must not report I64 outputs for integer inputs. Since current
+backends reject I64 eig, acceptable outcomes are:
+
+- return a complex output dtype for real integer metadata, or
+- reject I64 eig metadata construction before execution.
+
+`scale_real` on I64 must use the same explicit rounding policy used elsewhere
+for scalar size conversion, or reject non-integer scale factors if rounding is
+not mathematically meaningful.
+
+### Convert semantics
+
+Do not silently convert lossy narrowing casts if the conversion API can return
+`Result` without broad churn. If changing `convert` from `Tensor` to
+`Result<Tensor>` requires a wide public API migration, document that migration
+and stop before making a partial inconsistent change.
+
+## Design
+
+Prefer small semantic helpers over ad hoc fixes:
+
+- a shared broadcast-shape helper for shape inference,
+- a scalar-size extraction helper that accepts I64 and validates scalar shape,
+- a single dtype-output helper for eig-like operations,
+- one documented rounding policy for real-to-I64 scalar conversion.
+
+Any helper added here should live near the existing owner of the semantic
+decision. Do not leak internal tensor crate details into the `tenferro` facade
+to solve metadata issues.
+
+## Testing
+
+Required tests:
+
+- shape inference for `f32[3,1] + f32[1,4]` if runtime supports that case, or a
+  test proving unsupported broadcasting is rejected consistently,
+- `DynamicTruncate` with I64 scalar size,
+- `DynamicTruncate` metadata reflects the truncated dimension,
+- `svd_with_eps` or `eigh_with_eps` dispatch observes the configured `eps` or
+  rejects unused `eps`,
+- `eig_output_dtype` no longer maps I64 to I64,
+- I64 `scale_real` follows the documented rounding/rejection rule.
+
+Run at least:
+
+```bash
+cargo test -p tenferro shape
+cargo test -p tenferro linalg
+cargo fmt --all --check
+```
+
+## Dispatch Prompt
+
+```text
+Implement the primitive dtype and shape semantics dispatch from
+docs/plans/2026-05-02-primitive-dtype-shape-design.md.
+
+Fix only the listed metadata, scalar extraction, eps plumbing, eig dtype, and
+I64 scale semantics. Do not implement a full dtype-promotion system, full CPU
+NumPy broadcasting, or broad convert API redesign unless the existing signatures
+already support it locally. Stop and report if a correct fix requires a wide
+public API migration.
+```
+
+## Review Checklist
+
+- Shape inference and runtime behavior agree.
+- I64 scalar sizes are accepted only for scalar size tensors.
+- No accepted public parameter is silently ignored.
+- No new lossy cast is added.
+- Any deferred convert or promotion work is explicitly called out.
+
+## Stop Conditions
+
+Stop and report if:
+
+- fixing broadcast metadata correctly requires implementing runtime broadcast
+  kernels first,
+- `eps` cannot be plumbed without backend trait changes,
+- `convert` requires a workspace-wide signature migration.

--- a/docs/plans/2026-05-02-primitive-dtype-shape-plan.md
+++ b/docs/plans/2026-05-02-primitive-dtype-shape-plan.md
@@ -18,12 +18,13 @@ Implement:
 - `DynamicTruncate` rejects non-scalar size tensors with `Err`, not indexing the first element.
 - `scale_real` and linalg scalar helpers round real-to-I64 constants instead of truncating.
 - `eig` metadata maps I64 input to C64, not I64.
-- Add/Mul shape inference stops returning the LHS shape for unsupported non-scalar broadcast shapes.
+- Add/Mul shape inference returns NumPy-style broadcast metadata instead of the LHS shape.
+- CPU I64 Add/Mul is enabled through the existing generic elementwise kernels so I64 `scale_real` can execute.
 
 Defer:
 
 - #775 exact `DynamicTruncate` compiled shape inference. `DimExpr` currently represents dimension expressions only, not scalar tensor values, so the truncated axis cannot be expressed without a scalar-value shape expression or constant propagation.
-- #776 full non-scalar Add/Mul raw-op broadcasting. Public traced Add/Mul already inserts `BroadcastInDim`; raw CPU and CubeCL Add/Mul only support equal shapes plus scalar CPU cases.
+- #776 raw backend parity for non-scalar Add/Mul broadcast. Public traced Add/Mul already inserts `BroadcastInDim`; this step fixes metadata and CPU I64 execution only.
 - #780 conversion overflow/narrowing semantics. This needs a coherent cross-backend conversion policy and test migration.
 - #784 SVD/Eigh `eps` in primal execution. `eps` is currently consumed by AD linearization; plumbing it into primal backend execution requires changing `TensorBackend::svd/eigh`.
 
@@ -75,7 +76,7 @@ Defer:
 
 1. Change `infer_output_dtype(StdTensorOp::Eig { input_dtype: DType::I64 })` to return `DType::C64`.
 2. Change `eig_output_dtype(DType::I64)` to return `DType::C64`.
-3. Replace `same_or_scalar_broadcast_shape` with a helper that returns equal shape or scalar-broadcast shape and panics for unsupported non-scalar broadcast metadata instead of silently returning LHS.
+3. Replace `same_or_scalar_broadcast_shape` with a NumPy-style broadcast shape helper instead of silently returning LHS.
 
 ## Task 4: Verify And Commit
 

--- a/docs/plans/2026-05-02-primitive-dtype-shape-plan.md
+++ b/docs/plans/2026-05-02-primitive-dtype-shape-plan.md
@@ -1,0 +1,98 @@
+# Primitive DType And Shape Semantics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the narrow primitive dtype and scalar-size bugs that can be corrected without a backend trait or shape-expression redesign.
+
+**Architecture:** Keep semantic decisions in the `tenferro` facade layer, because the affected behavior is traced metadata and host-side scalar extraction. Add one shared crate-private scalar helper module so traced scaling, eager DynamicTruncate, and compiled DynamicTruncate use the same rounding and scalar validation policy. Do not expand raw backend Add/Mul broadcasting or conversion semantics in this step.
+
+**Tech Stack:** Rust, `tenferro` traced/eager execution, `tenferro_tensor` CPU backend tests, cargo test.
+
+---
+
+## Scope For This Step
+
+Implement:
+
+- `DynamicTruncate` accepts scalar I64 sizes in eager and compiled execution.
+- `DynamicTruncate` rejects non-scalar size tensors with `Err`, not indexing the first element.
+- `scale_real` and linalg scalar helpers round real-to-I64 constants instead of truncating.
+- `eig` metadata maps I64 input to C64, not I64.
+- Add/Mul shape inference stops returning the LHS shape for unsupported non-scalar broadcast shapes.
+
+Defer:
+
+- #775 exact `DynamicTruncate` compiled shape inference. `DimExpr` currently represents dimension expressions only, not scalar tensor values, so the truncated axis cannot be expressed without a scalar-value shape expression or constant propagation.
+- #776 full non-scalar Add/Mul raw-op broadcasting. Public traced Add/Mul already inserts `BroadcastInDim`; raw CPU and CubeCL Add/Mul only support equal shapes plus scalar CPU cases.
+- #780 conversion overflow/narrowing semantics. This needs a coherent cross-backend conversion policy and test migration.
+- #784 SVD/Eigh `eps` in primal execution. `eps` is currently consumed by AD linearization; plumbing it into primal backend execution requires changing `TensorBackend::svd/eigh`.
+
+## Task 1: Add Failing Tests For Narrow Fixes
+
+**Files:**
+
+- Modify: `tenferro/tests/dynamic_truncate.rs`
+- Modify: `tenferro/tests/eager_exec.rs`
+- Modify: `tenferro/tests/primitive_ops.rs`
+- Modify: `tenferro/tests/dtype_propagation.rs`
+- Modify: `tenferro/tests/shape_inference.rs`
+
+**Steps:**
+
+1. Add a public traced `DynamicTruncate` test with an I64 scalar size.
+2. Add eager execution tests for I64 scalar size and vector-size rejection.
+3. Add an I64 `scale_real(2.7)` test expecting multiplication by `3`.
+4. Add dtype inference tests showing I64 `Eig` metadata returns C64 and traced `eig` on I64 has C64 output metadata.
+5. Add shape inference tests asserting Add/Mul reject non-scalar broadcast metadata until raw runtime support exists.
+6. Run the focused tests and verify failures.
+
+## Task 2: Shared Scalar Semantics
+
+**Files:**
+
+- Create: `tenferro/src/scalar_semantics.rs`
+- Modify: `tenferro/src/lib.rs`
+- Modify: `tenferro/src/exec.rs`
+- Modify: `tenferro/src/eager_exec.rs`
+- Modify: `tenferro/src/traced.rs`
+- Modify: `tenferro/src/linalg_api.rs`
+
+**Steps:**
+
+1. Add `round_real_to_i64(value: f64) -> i64` using the DynamicTruncate policy: finite values round to nearest integer, non-finite values become `0`.
+2. Add `dynamic_truncate_size(size_tensor: &Tensor, axis_extent: usize) -> Result<usize>` that accepts F64, F32, and I64 scalar tensors only, then rounds and clamps to `[0, axis_extent]`.
+3. Replace duplicated DynamicTruncate scalar extraction in eager and compiled execution with the helper.
+4. Replace real-to-I64 casts in `TracedTensor::scale_real` and `linalg_api::scalar_real` with `round_real_to_i64`.
+
+## Task 3: Metadata Fixes
+
+**Files:**
+
+- Modify: `tenferro/src/shape_infer.rs`
+- Modify: `tenferro/src/linalg_api.rs`
+
+**Steps:**
+
+1. Change `infer_output_dtype(StdTensorOp::Eig { input_dtype: DType::I64 })` to return `DType::C64`.
+2. Change `eig_output_dtype(DType::I64)` to return `DType::C64`.
+3. Replace `same_or_scalar_broadcast_shape` with a helper that returns equal shape or scalar-broadcast shape and panics for unsupported non-scalar broadcast metadata instead of silently returning LHS.
+
+## Task 4: Verify And Commit
+
+**Commands:**
+
+```bash
+cargo test -p tenferro dynamic_truncate
+cargo test -p tenferro primitive_ops
+cargo test -p tenferro dtype_propagation
+cargo test -p tenferro shape_inference
+cargo fmt --all --check
+cargo check -p tenferro
+```
+
+Commit:
+
+```bash
+git add docs/plans/2026-05-02-primitive-dtype-shape-plan.md tenferro/src tenferro/tests
+git commit -m "fix: align primitive dtype and scalar semantics"
+```

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -6,6 +6,8 @@
 //! - **Parenthesized notation**: `"ij,(jk,kl)->il"` respects user-specified
 //!   contraction order via [`NestedEinsum`]
 //! - **Integer label notation**: using `u32` labels
+//! - **Repeated labels**: `"ii->i"` extracts diagonals, `"ii->"` traces, and
+//!   `"i->ii"` embeds a vector on a diagonal
 //! - **N-ary contraction**: Automatic or manual optimization of pairwise
 //!   contraction order via [`ContractionTree`]
 //! - **v2 builder**: [`build_einsum_fragment`] lowers einsum into a compute
@@ -13,26 +15,26 @@
 //!
 //! # Examples
 //!
-//! ```ignore
-//! use computegraph::fragment::FragmentBuilder;
-//! use computegraph::types::ValRef;
-//! use tenferro_ops::input_key::TensorInputKey;
-//! use tenferro_ops::std_tensor_op::StdTensorOp;
-//! use tenferro_einsum::{ContractionTree, Subscripts, build_einsum_fragment};
+//! ```
+//! use tenferro_einsum::{ContractionTree, Subscripts};
 //!
 //! let subs = Subscripts::parse("ij,jk->ik").unwrap();
 //! let tree = ContractionTree::optimize(&subs, &[&[2, 3], &[3, 4]]).unwrap();
+//! assert_eq!(tree.step_count(), 1);
+//! ```
 //!
-//! let mut builder = FragmentBuilder::<StdTensorOp>::new();
-//! let a = builder.add_input(TensorInputKey::User { id: 0 });
-//! let b = builder.add_input(TensorInputKey::User { id: 1 });
+//! ```
+//! use tenferro_einsum::Subscripts;
 //!
-//! let result = build_einsum_fragment(
-//!     &mut builder,
-//!     &tree,
-//!     &[ValRef::Local(a), ValRef::Local(b)],
-//!     &[vec![2, 3], vec![3, 4]],
-//! );
+//! let trace = Subscripts::parse("ii->").unwrap();
+//! let diagonal = Subscripts::parse("ii->i").unwrap();
+//! let embedded = Subscripts::parse("i->ii").unwrap();
+//! let higher_rank = Subscripts::parse("iij->ij").unwrap();
+//!
+//! assert!(trace.output.is_empty());
+//! assert_eq!(diagonal.output, vec![b'i' as u32]);
+//! assert_eq!(embedded.output, vec![b'i' as u32, b'i' as u32]);
+//! assert_eq!(higher_rank.inputs[0], vec![b'i' as u32, b'i' as u32, b'j' as u32]);
 //! ```
 
 pub mod builder;

--- a/tenferro-einsum/src/planning/tree.rs
+++ b/tenferro-einsum/src/planning/tree.rs
@@ -132,7 +132,7 @@ impl ContractionTree {
             if let Some(omeco_pairs) = optimize_omeco_pairs(subscripts, &size_dict, options)? {
                 omeco_pairs
             } else {
-                optimize_self_greedy_pairs(subscripts, &size_dict)
+                optimize_self_greedy_pairs(subscripts, &size_dict)?
             };
         Self::from_pairs(subscripts, shapes, &pairs)
     }
@@ -364,7 +364,7 @@ fn nested_to_pairs(
 fn optimize_self_greedy_pairs(
     subscripts: &Subscripts,
     size_dict: &HashMap<u32, usize>,
-) -> Vec<(usize, usize)> {
+) -> Result<Vec<(usize, usize)>> {
     let n_inputs = subscripts.inputs.len();
     let mut available: Vec<usize> = (0..n_inputs).collect();
     let mut operand_subs: Vec<Vec<u32>> = subscripts.inputs.clone();
@@ -387,7 +387,7 @@ fn optimize_self_greedy_pairs(
                     }
                 }
                 let cost =
-                    contraction_cost(&operand_subs[li], &operand_subs[lj], &needed, size_dict);
+                    contraction_cost(&operand_subs[li], &operand_subs[lj], &needed, size_dict)?;
                 if cost < best_cost {
                     best_cost = cost;
                     best_i = i;
@@ -415,7 +415,7 @@ fn optimize_self_greedy_pairs(
         available.push(new_idx);
     }
 
-    pairs
+    Ok(pairs)
 }
 
 #[cfg(test)]

--- a/tenferro-einsum/src/planning/tree/tests.rs
+++ b/tenferro-einsum/src/planning/tree/tests.rs
@@ -139,11 +139,23 @@ fn self_greedy_pair_optimizer_returns_valid_sequence() {
     let shapes = [&[2, 3][..], &[3, 5][..], &[5, 7][..]];
     let size_dict = crate::util::build_size_dict(&subs, &shapes, None).unwrap();
 
-    let pairs = optimize_self_greedy_pairs(&subs, &size_dict);
+    let pairs = optimize_self_greedy_pairs(&subs, &size_dict).unwrap();
 
     assert_eq!(pairs.len(), 2);
     assert_eq!(pairs[0], (0, 1));
     assert_eq!(pairs[1], (2, 3));
+}
+
+#[test]
+fn self_greedy_pair_optimizer_rejects_missing_needed_label() {
+    let subs = Subscripts::new(&[&[0, 1], &[1, 4], &[4, 2]], &[0, 2]);
+    let size_dict: HashMap<u32, usize> = [(0, 2), (1, 3), (2, 5)].into_iter().collect();
+
+    let err = optimize_self_greedy_pairs(&subs, &size_dict).unwrap_err();
+
+    assert!(
+        matches!(err, Error::InvalidArgument(message) if message.contains("unknown size for label 4"))
+    );
 }
 
 #[test]
@@ -248,7 +260,7 @@ fn self_greedy_with_four_operands_chooses_cheapest_pairs() {
         .iter()
         .cloned()
         .collect();
-    let pairs = optimize_self_greedy_pairs(&subs, &size_dict);
+    let pairs = optimize_self_greedy_pairs(&subs, &size_dict).unwrap();
     assert_eq!(pairs.len(), 3);
     let mut live: Vec<usize> = (0..4).collect();
     let mut next = 4;

--- a/tenferro-einsum/src/syntax/subscripts.rs
+++ b/tenferro-einsum/src/syntax/subscripts.rs
@@ -5,8 +5,10 @@ use crate::syntax::notation::{char_to_label, split_and_validate_notation};
 /// Einsum subscripts using integer labels (omeinsum-rs compatible).
 ///
 /// Each dimension is represented by a `u32` label. Labels shared across
-/// multiple input tensors are contracted (summed over). Labels present
-/// only in the output are free indices.
+/// multiple input tensors are contracted (summed over). Repeated labels within
+/// one input select a diagonal before any reduction; if the repeated label is
+/// absent from the output, the diagonal is reduced. Repeated labels in the
+/// output embed the input on a diagonal.
 ///
 /// # Examples
 ///
@@ -19,12 +21,26 @@ use crate::syntax::notation::{char_to_label, split_and_validate_notation};
 /// assert_eq!(subs.output, vec![0, 2]);
 /// ```
 ///
-/// ```ignore
+/// ```
 /// use tenferro_einsum::Subscripts;
 ///
 /// // Parse from string notation
 /// let subs = Subscripts::parse("ij,jk->ik").unwrap();
 /// assert_eq!(subs.inputs.len(), 2);
+/// ```
+///
+/// ```
+/// use tenferro_einsum::Subscripts;
+///
+/// let trace = Subscripts::parse("ii->").unwrap();
+/// let diagonal = Subscripts::parse("ii->i").unwrap();
+/// let embed = Subscripts::parse("i->ii").unwrap();
+/// let higher_rank = Subscripts::parse("iij->ij").unwrap();
+///
+/// assert!(trace.output.is_empty());
+/// assert_eq!(diagonal.output, vec![b'i' as u32]);
+/// assert_eq!(embed.output, vec![b'i' as u32, b'i' as u32]);
+/// assert_eq!(higher_rank.inputs[0], vec![b'i' as u32, b'i' as u32, b'j' as u32]);
 /// ```
 #[derive(Debug, Clone)]
 pub struct Subscripts {
@@ -63,7 +79,10 @@ impl Subscripts {
     /// # Examples
     ///
     /// - `"ij,jk->ik"` — matrix multiplication
+    /// - `"ii->"` — diagonal extraction followed by reduction (trace)
     /// - `"ii->i"` — diagonal extraction
+    /// - `"i->ii"` — diagonal embedding
+    /// - `"iij->ij"` — higher-rank diagonal extraction
     /// - `"ijk->"` — full contraction (scalar result)
     /// - `"ij,(jk,kl)->il"` — contract B and C first, then with A
     ///

--- a/tenferro-einsum/src/tests/eager_tests.rs
+++ b/tenferro-einsum/src/tests/eager_tests.rs
@@ -58,6 +58,25 @@ fn eager_einsum_handles_outer_products_and_diagonal_patterns() {
 }
 
 #[test]
+fn eager_einsum_handles_higher_rank_repeated_labels() {
+    let mut ctx = CpuBackend::new();
+    let tensor = Tensor::from_vec(
+        vec![2, 2, 3],
+        vec![
+            1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ],
+    );
+
+    let diagonal = eager_einsum(&mut ctx, &[&tensor], "iij->ij").unwrap();
+
+    assert_eq!(diagonal.shape(), &[2, 3]);
+    assert_eq!(
+        diagonal.as_slice::<f64>(),
+        Some([1.0, 4.0, 5.0, 8.0, 9.0, 12.0].as_slice())
+    );
+}
+
+#[test]
 fn eager_einsum_rejects_empty_inputs_and_operand_count_mismatch() {
     let mut ctx = CpuBackend::new();
     let tensor = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);

--- a/tenferro-einsum/src/util.rs
+++ b/tenferro-einsum/src/util.rs
@@ -115,17 +115,16 @@ pub(crate) fn contraction_cost(
     subs_b: &[u32],
     needed: &HashSet<u32>,
     size_dict: &HashMap<u32, usize>,
-) -> usize {
+) -> Result<usize> {
     let out_subs = intermediate_subs(subs_a, subs_b, needed);
-    out_subs
-        .iter()
-        .map(|l| {
-            debug_assert!(
-                size_dict.contains_key(l),
-                "contraction_cost: label {l} missing from size_dict"
-            );
-            size_dict.get(l).copied().unwrap_or(1)
-        })
-        .product::<usize>()
-        .max(1)
+    let mut cost = 1usize;
+    for label in out_subs {
+        let size = size_dict.get(&label).copied().ok_or_else(|| {
+            Error::InvalidArgument(format!(
+                "unknown size for label {label} in contraction cost"
+            ))
+        })?;
+        cost = cost.saturating_mul(size);
+    }
+    Ok(cost.max(1))
 }

--- a/tenferro-ops/src/ad/context.rs
+++ b/tenferro-ops/src/ad/context.rs
@@ -185,6 +185,11 @@ impl ShapeGuardContext {
         &self.metadata_of(val).shape
     }
 
+    #[doc(hidden)]
+    pub fn try_shape_of(&mut self, val: &ValRef<StdTensorOp>) -> Option<&[SymDim]> {
+        self.try_metadata_of(val).map(|meta| meta.shape.as_slice())
+    }
+
     /// Return the dtype metadata for a value reference.
     ///
     /// # Examples
@@ -213,6 +218,17 @@ impl ShapeGuardContext {
         self.metadata
             .get(&key)
             .unwrap_or_else(|| panic!("ShapeGuardContext: missing TensorMeta for {:?}", key))
+    }
+
+    #[doc(hidden)]
+    pub fn try_metadata_of(&mut self, val: &ValRef<StdTensorOp>) -> Option<&TensorMeta> {
+        let key = self.resolve_key(val).clone();
+        if !self.metadata.contains_key(&key) && self.use_global_registry {
+            if let Some(meta) = lookup_global_metadata(&key) {
+                self.metadata.insert(key.clone(), meta);
+            }
+        }
+        self.metadata.get(&key)
     }
 
     #[doc(hidden)]

--- a/tenferro-ops/src/ad/dynamic.rs
+++ b/tenferro-ops/src/ad/dynamic.rs
@@ -1,17 +1,41 @@
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
+use tenferro_tensor::SliceConfig;
 
+use crate::ad::context::ShapeGuardContext;
 use crate::std_tensor_op::StdTensorOp;
 
 pub fn linearize_dynamic_truncate(
     builder: &mut FragmentBuilder<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
+    primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     axis: usize,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValId>> {
     match tangent_in[0] {
         Some(dx) => {
+            // Checkpointed dynamic truncation records the concrete runtime
+            // output extent. Preserve that narrower tangent shape when it is
+            // available so later checkpointed steps compile against the alias
+            // shape instead of the pre-truncation static upper bound.
+            if let Some(limits) = static_truncated_shape(primal_in, primal_out, axis, ctx) {
+                let rank = limits.len();
+                let out = builder.add_op(
+                    StdTensorOp::Slice(SliceConfig {
+                        starts: vec![0; rank],
+                        limits,
+                        strides: vec![1; rank],
+                    }),
+                    vec![ValRef::Local(dx)],
+                    OpMode::Linear {
+                        active_mask: vec![true],
+                    },
+                );
+                return vec![Some(out[0])];
+            }
+
             let out = builder.add_op(
                 StdTensorOp::DynamicTruncate { axis },
                 vec![ValRef::Local(dx), ValRef::External(primal_in[1].clone())],
@@ -71,26 +95,95 @@ pub fn transpose_pad_to_match(
     emitter: &mut impl OpEmitter<StdTensorOp>,
     cotangent_out: &[Option<LocalValId>],
     inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
     axis: usize,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValId>> {
-    match cotangent_out[0] {
-        Some(ct) => {
-            let size = emitter.add_op(
-                StdTensorOp::ShapeOf { axis },
-                vec![inputs[0].clone()],
-                OpMode::Linear {
-                    active_mask: vec![false],
-                },
-            );
-            let out = emitter.add_op(
-                StdTensorOp::DynamicTruncate { axis },
-                vec![ValRef::Local(ct), ValRef::Local(size[0])],
-                OpMode::Linear {
-                    active_mask: vec![true, false],
-                },
-            );
-            vec![Some(out[0]), None]
-        }
-        None => vec![None, None],
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None, None];
+    };
+    if !first_input_active(mode) {
+        return vec![None, None];
     }
+
+    // For concrete input metadata the adjoint is just a prefix slice back to
+    // the original input shape. This keeps the transposed graph statically
+    // shape-exact across checkpoint aliases.
+    if let Some(input_shape) = ctx.try_shape_of(&inputs[0]) {
+        assert!(
+            axis < input_shape.len(),
+            "transpose_pad_to_match: axis {axis} out of bounds for rank {}",
+            input_shape.len()
+        );
+        if let Some(limits) = input_shape
+            .iter()
+            .map(|dim| dim.constant_value())
+            .collect::<Option<Vec<_>>>()
+        {
+            let rank = limits.len();
+            let out = emitter.add_op(
+                StdTensorOp::Slice(SliceConfig {
+                    starts: vec![0; rank],
+                    limits,
+                    strides: vec![1; rank],
+                }),
+                vec![ValRef::Local(ct)],
+                OpMode::Linear {
+                    active_mask: vec![true],
+                },
+            );
+            return vec![Some(out[0]), None];
+        }
+    }
+
+    let size = emitter.add_op(
+        StdTensorOp::ShapeOf { axis },
+        vec![inputs[0].clone()],
+        OpMode::Linear {
+            active_mask: vec![false],
+        },
+    );
+    let out = emitter.add_op(
+        StdTensorOp::DynamicTruncate { axis },
+        vec![ValRef::Local(ct), ValRef::Local(size[0])],
+        OpMode::Linear {
+            active_mask: vec![true, false],
+        },
+    );
+    vec![Some(out[0]), None]
+}
+
+fn first_input_active(mode: &OpMode) -> bool {
+    matches!(
+        mode,
+        OpMode::Linear { active_mask } if active_mask.first().copied().unwrap_or(false)
+    )
+}
+
+fn static_truncated_shape(
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    primal_out: &[GlobalValKey<StdTensorOp>],
+    axis: usize,
+    ctx: &mut ShapeGuardContext,
+) -> Option<Vec<usize>> {
+    let input_shape = ctx
+        .try_shape_of(&ValRef::External(primal_in[0].clone()))?
+        .to_vec();
+    let output_shape = ctx
+        .try_shape_of(&ValRef::External(primal_out[0].clone()))?
+        .to_vec();
+    if axis >= input_shape.len() || input_shape.len() != output_shape.len() {
+        return None;
+    }
+
+    let input_extent = input_shape[axis].constant_value()?;
+    let output_extent = output_shape[axis].constant_value()?;
+    if output_extent >= input_extent {
+        return None;
+    }
+
+    output_shape
+        .iter()
+        .map(|dim| dim.constant_value())
+        .collect::<Option<Vec<_>>>()
 }

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -101,7 +101,9 @@ pub fn linearize(
         }
         StdTensorOp::Tril { k } => structural::linearize_tril(builder, tangent_in, *k),
         StdTensorOp::Triu { k } => structural::linearize_triu(builder, tangent_in, *k),
+        StdTensorOp::Slice(config) => structural::linearize_slice(builder, tangent_in, config),
         StdTensorOp::Pad(config) => structural::linearize_pad(builder, tangent_in, config),
+        StdTensorOp::Reverse { axes } => structural::linearize_reverse(builder, tangent_in, axes),
 
         // Diagonal family.
         StdTensorOp::ExtractDiag { axis_a, axis_b } => {
@@ -256,6 +258,15 @@ pub fn transpose_rule(
         }
         StdTensorOp::Tril { k } => structural::transpose_tril(emitter, cotangent_out, *k),
         StdTensorOp::Triu { k } => structural::transpose_triu(emitter, cotangent_out, *k),
+        StdTensorOp::Slice(config) => {
+            structural::transpose_slice(emitter, cotangent_out, inputs, mode, config, ctx)
+        }
+        StdTensorOp::Pad(config) => {
+            structural::transpose_pad(emitter, cotangent_out, inputs, mode, config, ctx)
+        }
+        StdTensorOp::Reverse { axes } => {
+            structural::transpose_reverse(emitter, cotangent_out, mode, axes)
+        }
 
         // Diagonal family.
         StdTensorOp::ExtractDiag { axis_a, axis_b } => {

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -122,9 +122,9 @@ pub fn linearize(
         }
 
         // Dynamic family.
-        StdTensorOp::DynamicTruncate { axis } => {
-            dynamic::linearize_dynamic_truncate(builder, primal_in, tangent_in, *axis)
-        }
+        StdTensorOp::DynamicTruncate { axis } => dynamic::linearize_dynamic_truncate(
+            builder, primal_in, primal_out, tangent_in, *axis, ctx,
+        ),
         StdTensorOp::PadToMatch { axis } => {
             dynamic::linearize_pad_to_match(builder, primal_in, tangent_in, *axis)
         }
@@ -289,7 +289,7 @@ pub fn transpose_rule(
             dynamic::transpose_dynamic_truncate(emitter, cotangent_out, inputs, *axis)
         }
         StdTensorOp::PadToMatch { axis } => {
-            dynamic::transpose_pad_to_match(emitter, cotangent_out, inputs, *axis)
+            dynamic::transpose_pad_to_match(emitter, cotangent_out, inputs, mode, *axis, ctx)
         }
         StdTensorOp::ShapeOf { .. } => vec![None],
 

--- a/tenferro-ops/src/ad/structural.rs
+++ b/tenferro-ops/src/ad/structural.rs
@@ -1,11 +1,12 @@
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
-use tenferro_tensor::PadConfig;
+use tenferro_tensor::{PadConfig, SliceConfig};
 
 use crate::ad::context::ShapeGuardContext;
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
+use crate::sym_dim::SymDim;
 
 pub fn linearize_transpose(
     builder: &mut FragmentBuilder<StdTensorOp>,
@@ -155,6 +156,26 @@ pub fn linearize_triu(
     }
 }
 
+pub fn linearize_slice(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    tangent_in: &[Option<LocalValId>],
+    config: &SliceConfig,
+) -> Vec<Option<LocalValId>> {
+    match tangent_in[0] {
+        Some(dx) => {
+            let out = builder.add_op(
+                StdTensorOp::Slice(config.clone()),
+                vec![ValRef::Local(dx)],
+                OpMode::Linear {
+                    active_mask: vec![true],
+                },
+            );
+            vec![Some(out[0])]
+        }
+        None => vec![None],
+    }
+}
+
 pub fn linearize_pad(
     builder: &mut FragmentBuilder<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
@@ -164,6 +185,28 @@ pub fn linearize_pad(
         Some(dx) => {
             let out = builder.add_op(
                 StdTensorOp::Pad(config.clone()),
+                vec![ValRef::Local(dx)],
+                OpMode::Linear {
+                    active_mask: vec![true],
+                },
+            );
+            vec![Some(out[0])]
+        }
+        None => vec![None],
+    }
+}
+
+pub fn linearize_reverse(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    tangent_in: &[Option<LocalValId>],
+    axes: &[usize],
+) -> Vec<Option<LocalValId>> {
+    match tangent_in[0] {
+        Some(dx) => {
+            let out = builder.add_op(
+                StdTensorOp::Reverse {
+                    axes: axes.to_vec(),
+                },
                 vec![ValRef::Local(dx)],
                 OpMode::Linear {
                     active_mask: vec![true],
@@ -345,4 +388,273 @@ pub fn transpose_triu(
         }
         None => vec![None],
     }
+}
+
+pub fn transpose_slice(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+    config: &SliceConfig,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None];
+    };
+    if !first_input_active(mode) {
+        return vec![None];
+    }
+
+    let input_shape = ctx.shape_of(&inputs[0]);
+    let rank = input_shape.len();
+    assert_eq!(
+        config.starts.len(),
+        rank,
+        "transpose_slice: starts rank mismatch"
+    );
+    assert_eq!(
+        config.limits.len(),
+        rank,
+        "transpose_slice: limits rank mismatch"
+    );
+    assert_eq!(
+        config.strides.len(),
+        rank,
+        "transpose_slice: strides rank mismatch"
+    );
+
+    let mut edge_padding_low = Vec::with_capacity(rank);
+    let mut edge_padding_high = Vec::with_capacity(rank);
+    let mut interior_padding = Vec::with_capacity(rank);
+
+    for axis in 0..rank {
+        let input_extent = static_dim(input_shape, axis, "transpose_slice");
+        let start = config.starts[axis];
+        let limit = config.limits[axis];
+        let stride = config.strides[axis];
+        assert!(
+            stride > 0,
+            "transpose_slice: stride must be positive on axis {axis}"
+        );
+        assert!(
+            start <= limit && limit <= input_extent,
+            "transpose_slice: invalid start/limit on axis {axis}"
+        );
+
+        let selected_len = if limit == start {
+            0
+        } else {
+            (limit - start + stride - 1) / stride
+        };
+        let covered = if selected_len == 0 {
+            0
+        } else {
+            (selected_len - 1) * stride + 1
+        };
+        let high = input_extent - start - covered;
+
+        edge_padding_low.push(usize_to_i64(start, "transpose_slice"));
+        edge_padding_high.push(usize_to_i64(high, "transpose_slice"));
+        interior_padding.push(usize_to_i64(stride - 1, "transpose_slice"));
+    }
+
+    let out = emitter.add_op(
+        StdTensorOp::Pad(PadConfig {
+            edge_padding_low,
+            edge_padding_high,
+            interior_padding,
+        }),
+        vec![ValRef::Local(ct)],
+        OpMode::Linear {
+            active_mask: vec![true],
+        },
+    );
+    vec![Some(out[0])]
+}
+
+pub fn transpose_pad(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+    config: &PadConfig,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None];
+    };
+    if !first_input_active(mode) {
+        return vec![None];
+    }
+
+    let input_shape = ctx.shape_of(&inputs[0]);
+    let rank = input_shape.len();
+    assert_eq!(
+        config.edge_padding_low.len(),
+        rank,
+        "transpose_pad: edge_padding_low rank mismatch"
+    );
+    assert_eq!(
+        config.edge_padding_high.len(),
+        rank,
+        "transpose_pad: edge_padding_high rank mismatch"
+    );
+    assert_eq!(
+        config.interior_padding.len(),
+        rank,
+        "transpose_pad: interior_padding rank mismatch"
+    );
+
+    let mut starts = Vec::with_capacity(rank);
+    let mut limits = Vec::with_capacity(rank);
+    let mut strides = Vec::with_capacity(rank);
+    let mut edge_padding_low = Vec::with_capacity(rank);
+    let mut edge_padding_high = Vec::with_capacity(rank);
+
+    for axis in 0..rank {
+        let input_extent = static_dim(input_shape, axis, "transpose_pad");
+        let input_extent_i = input_extent as i128;
+        let low = i128::from(config.edge_padding_low[axis]);
+        let high = i128::from(config.edge_padding_high[axis]);
+        let interior = i128::from(config.interior_padding[axis]);
+        assert!(
+            interior >= 0,
+            "transpose_pad: interior padding must be non-negative on axis {axis}"
+        );
+        let stride = interior + 1;
+        let base = if input_extent == 0 {
+            0
+        } else {
+            (input_extent_i - 1) * stride + 1
+        };
+        let output_extent = low + high + base;
+        assert!(
+            output_extent >= 0,
+            "transpose_pad: negative output extent on axis {axis}"
+        );
+
+        let first_kept = if low < 0 {
+            ceil_div_i128(-low, stride)
+        } else {
+            0
+        };
+        let first_dropped_after = ceil_div_i128(output_extent - low, stride);
+        let j_start = clamp_i128(first_kept, 0, input_extent_i);
+        let mut j_end = clamp_i128(first_dropped_after, 0, input_extent_i);
+        if j_end < j_start {
+            j_end = j_start;
+        }
+
+        let (slice_start, slice_limit) = if j_end > j_start {
+            let start = low + j_start * stride;
+            let limit = low + (j_end - 1) * stride + 1;
+            (start, limit)
+        } else {
+            let empty = clamp_i128(low + j_start * stride, 0, output_extent);
+            (empty, empty)
+        };
+        assert!(
+            0 <= slice_start && slice_start <= slice_limit && slice_limit <= output_extent,
+            "transpose_pad: invalid inverse slice on axis {axis}"
+        );
+
+        starts.push(i128_to_usize(slice_start, "transpose_pad"));
+        limits.push(i128_to_usize(slice_limit, "transpose_pad"));
+        strides.push(i128_to_usize(stride, "transpose_pad"));
+        edge_padding_low.push(i128_to_i64(j_start, "transpose_pad"));
+        edge_padding_high.push(i128_to_i64(input_extent_i - j_end, "transpose_pad"));
+    }
+
+    let sliced = emitter.add_op(
+        StdTensorOp::Slice(SliceConfig {
+            starts,
+            limits,
+            strides,
+        }),
+        vec![ValRef::Local(ct)],
+        OpMode::Linear {
+            active_mask: vec![true],
+        },
+    )[0];
+
+    if edge_padding_low.iter().all(|&pad| pad == 0) && edge_padding_high.iter().all(|&pad| pad == 0)
+    {
+        return vec![Some(sliced)];
+    }
+
+    let out = emitter.add_op(
+        StdTensorOp::Pad(PadConfig {
+            edge_padding_low,
+            edge_padding_high,
+            interior_padding: vec![0; rank],
+        }),
+        vec![ValRef::Local(sliced)],
+        OpMode::Linear {
+            active_mask: vec![true],
+        },
+    );
+    vec![Some(out[0])]
+}
+
+pub fn transpose_reverse(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    mode: &OpMode,
+    axes: &[usize],
+) -> Vec<Option<LocalValId>> {
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None];
+    };
+    if !first_input_active(mode) {
+        return vec![None];
+    }
+
+    let out = emitter.add_op(
+        StdTensorOp::Reverse {
+            axes: axes.to_vec(),
+        },
+        vec![ValRef::Local(ct)],
+        OpMode::Linear {
+            active_mask: vec![true],
+        },
+    );
+    vec![Some(out[0])]
+}
+
+fn first_input_active(mode: &OpMode) -> bool {
+    matches!(
+        mode,
+        OpMode::Linear { active_mask } if active_mask.first().copied().unwrap_or(false)
+    )
+}
+
+fn static_dim(shape: &[SymDim], axis: usize, op: &str) -> usize {
+    shape[axis]
+        .constant_value()
+        .unwrap_or_else(|| panic!("{op}: symbolic input dim {axis} is unsupported"))
+}
+
+fn ceil_div_i128(numer: i128, denom: i128) -> i128 {
+    assert!(denom > 0, "ceil_div_i128: denominator must be positive");
+    if numer >= 0 {
+        (numer + denom - 1) / denom
+    } else {
+        numer / denom
+    }
+}
+
+fn clamp_i128(value: i128, min: i128, max: i128) -> i128 {
+    value.max(min).min(max)
+}
+
+fn usize_to_i64(value: usize, op: &str) -> i64 {
+    i64::try_from(value).unwrap_or_else(|_| panic!("{op}: usize value does not fit in i64"))
+}
+
+fn i128_to_usize(value: i128, op: &str) -> usize {
+    usize::try_from(value).unwrap_or_else(|_| panic!("{op}: i128 value does not fit in usize"))
+}
+
+fn i128_to_i64(value: i128, op: &str) -> i64 {
+    i64::try_from(value).unwrap_or_else(|_| panic!("{op}: i128 value does not fit in i64"))
 }

--- a/tenferro-ops/src/sym_dim.rs
+++ b/tenferro-ops/src/sym_dim.rs
@@ -71,10 +71,7 @@ impl SymDim {
 
     #[doc(hidden)]
     pub fn constant_value(&self) -> Option<usize> {
-        match &self.0 {
-            RawSymDim::Const(value) => Some(*value),
-            _ => None,
-        }
+        raw_constant_value(&self.0)
     }
 
     #[doc(hidden)]
@@ -150,6 +147,26 @@ fn collect_tensor_ids(raw: &RawSymDim, ids: &mut Vec<u64>) {
             collect_tensor_ids(lhs, ids);
             collect_tensor_ids(rhs, ids);
         }
+    }
+}
+
+fn raw_constant_value(raw: &RawSymDim) -> Option<usize> {
+    match raw {
+        RawSymDim::Const(value) => Some(*value),
+        RawSymDim::TensorAxis { .. } => None,
+        RawSymDim::Add(lhs, rhs) => raw_constant_value(lhs)?.checked_add(raw_constant_value(rhs)?),
+        RawSymDim::Sub(lhs, rhs) => raw_constant_value(lhs)?.checked_sub(raw_constant_value(rhs)?),
+        RawSymDim::Mul(lhs, rhs) => raw_constant_value(lhs)?.checked_mul(raw_constant_value(rhs)?),
+        RawSymDim::FloorDiv(lhs, rhs) => {
+            let rhs = raw_constant_value(rhs)?;
+            if rhs == 0 {
+                None
+            } else {
+                Some(raw_constant_value(lhs)? / rhs)
+            }
+        }
+        RawSymDim::Min(lhs, rhs) => Some(raw_constant_value(lhs)?.min(raw_constant_value(rhs)?)),
+        RawSymDim::Max(lhs, rhs) => Some(raw_constant_value(lhs)?.max(raw_constant_value(rhs)?)),
     }
 }
 

--- a/tenferro-ops/src/tests/mod.rs
+++ b/tenferro-ops/src/tests/mod.rs
@@ -2,3 +2,4 @@ mod dim_expr_tests;
 mod ext_op_tests;
 mod input_key_tests;
 mod std_tensor_op_tests;
+mod sym_dim_tests;

--- a/tenferro-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-ops/src/tests/std_tensor_op_tests.rs
@@ -650,6 +650,73 @@ fn test_std_tensor_op_nary_einsum_transpose_emits_conjugates_and_vjp_term() {
 }
 
 #[test]
+fn test_std_tensor_op_pad_to_match_transpose_uses_static_slice_for_concrete_shape() {
+    let (result, _, fragment) = run_transpose_case_with_input_shapes(
+        StdTensorOp::PadToMatch { axis: 0 },
+        2,
+        &[true, false],
+        true,
+        &[&[2], &[3]],
+    );
+
+    assert!(result[0].is_some());
+    assert_eq!(result[1], None);
+    assert_eq!(fragment.ops().len(), 1);
+    assert_eq!(
+        fragment.ops()[0].op,
+        StdTensorOp::Slice(tenferro_tensor::SliceConfig {
+            starts: vec![0],
+            limits: vec![2],
+            strides: vec![1],
+        })
+    );
+}
+
+#[test]
+fn test_std_tensor_op_dynamic_truncate_linearize_uses_static_slice_for_narrowed_metadata() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ad_ctx = ShapeGuardContext::default();
+    let primal_in = add_input_keys(&mut builder, 960, 2);
+    let primal_out = add_input_keys(&mut builder, 970, 1);
+    let tangent = builder.add_input(tensor_input_key(980));
+
+    ad_ctx.insert_metadata(
+        primal_in[0].clone(),
+        TensorMeta {
+            dtype: DType::F64,
+            shape: vec![SymDim::from(3usize)],
+        },
+    );
+    ad_ctx.insert_metadata(
+        primal_out[0].clone(),
+        TensorMeta {
+            dtype: DType::F64,
+            shape: vec![SymDim::from(2usize)],
+        },
+    );
+
+    let result = StdTensorOp::DynamicTruncate { axis: 0 }.linearize(
+        &mut builder,
+        &primal_in,
+        &primal_out,
+        &[Some(tangent), None],
+        &mut ad_ctx,
+    );
+    let fragment = builder.build();
+
+    assert!(result[0].is_some());
+    assert_eq!(fragment.ops().len(), 1);
+    assert_eq!(
+        fragment.ops()[0].op,
+        StdTensorOp::Slice(tenferro_tensor::SliceConfig {
+            starts: vec![0],
+            limits: vec![2],
+            strides: vec![1],
+        })
+    );
+}
+
+#[test]
 fn test_std_tensor_op_constant_constructors_encode_expected_bytes() {
     assert_eq!(
         StdTensorOp::constant_f64(1.25),

--- a/tenferro-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-ops/src/tests/std_tensor_op_tests.rs
@@ -1030,6 +1030,82 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
     assert!(triu_result[0].is_some());
     assert_eq!(triu_fragment.ops()[0].op, StdTensorOp::Triu { k: 2 });
 
+    let slice = StdTensorOp::Slice(tenferro_tensor::SliceConfig {
+        starts: vec![1],
+        limits: vec![5],
+        strides: vec![2],
+    });
+    let (slice_result, slice_fragment) = run_linearize_case(slice.clone(), 0, 0, &[true]);
+    assert!(slice_result[0].is_some());
+    assert_eq!(slice_fragment.ops()[0].op, slice.clone());
+
+    let (transpose_slice_result, _, transpose_slice_fragment) =
+        run_transpose_case_with_input_shapes(slice, 1, &[true], true, &[&[5]]);
+    assert!(transpose_slice_result[0].is_some());
+    assert_eq!(transpose_slice_fragment.ops().len(), 1);
+    assert_eq!(
+        transpose_slice_fragment.ops()[0].op,
+        StdTensorOp::Pad(PadConfig {
+            edge_padding_low: vec![1],
+            edge_padding_high: vec![1],
+            interior_padding: vec![1],
+        })
+    );
+
+    let pad = StdTensorOp::Pad(PadConfig {
+        edge_padding_low: vec![1],
+        edge_padding_high: vec![2],
+        interior_padding: vec![1],
+    });
+    let (transpose_pad_result, _, transpose_pad_fragment) =
+        run_transpose_case_with_input_shapes(pad, 1, &[true], true, &[&[3]]);
+    assert!(transpose_pad_result[0].is_some());
+    assert_eq!(transpose_pad_fragment.ops().len(), 1);
+    assert_eq!(
+        transpose_pad_fragment.ops()[0].op,
+        StdTensorOp::Slice(tenferro_tensor::SliceConfig {
+            starts: vec![1],
+            limits: vec![6],
+            strides: vec![2],
+        })
+    );
+
+    let cropped_pad = StdTensorOp::Pad(PadConfig {
+        edge_padding_low: vec![-1],
+        edge_padding_high: vec![0],
+        interior_padding: vec![0],
+    });
+    let (cropped_pad_result, _, cropped_pad_fragment) =
+        run_transpose_case_with_input_shapes(cropped_pad, 1, &[true], true, &[&[4]]);
+    assert!(cropped_pad_result[0].is_some());
+    assert_eq!(cropped_pad_fragment.ops().len(), 2);
+    assert_eq!(
+        cropped_pad_fragment.ops()[0].op,
+        StdTensorOp::Slice(tenferro_tensor::SliceConfig {
+            starts: vec![0],
+            limits: vec![3],
+            strides: vec![1],
+        })
+    );
+    assert_eq!(
+        cropped_pad_fragment.ops()[1].op,
+        StdTensorOp::Pad(PadConfig {
+            edge_padding_low: vec![1],
+            edge_padding_high: vec![0],
+            interior_padding: vec![0],
+        })
+    );
+
+    let reverse = StdTensorOp::Reverse { axes: vec![0, 2] };
+    let (reverse_result, reverse_fragment) = run_linearize_case(reverse.clone(), 0, 0, &[true]);
+    assert!(reverse_result[0].is_some());
+    assert_eq!(reverse_fragment.ops()[0].op, reverse.clone());
+
+    let (transpose_reverse_result, _, transpose_reverse_fragment) =
+        run_transpose_case(reverse.clone(), 1, &[true], true);
+    assert!(transpose_reverse_result[0].is_some());
+    assert_eq!(transpose_reverse_fragment.ops()[0].op, reverse);
+
     let (transpose_tril_result, _, transpose_tril_fragment) =
         run_transpose_case(StdTensorOp::Tril { k: 0 }, 1, &[true], true);
     assert!(transpose_tril_result[0].is_some());

--- a/tenferro-ops/src/tests/sym_dim_tests.rs
+++ b/tenferro-ops/src/tests/sym_dim_tests.rs
@@ -1,0 +1,15 @@
+use crate::SymDim;
+
+#[test]
+fn constant_value_evaluates_constant_expressions() {
+    let expr = (SymDim::from(2usize).max(3usize) * SymDim::from(4usize)) / 2usize;
+
+    assert_eq!(expr.constant_value(), Some(6));
+}
+
+#[test]
+fn constant_value_returns_none_for_symbolic_expressions() {
+    let expr = SymDim::tensor_axis(7, 0).max(3usize);
+
+    assert_eq!(expr.constant_value(), None);
+}

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -361,11 +361,7 @@ impl TensorBackend for CpuBackend {
         start_indices: &Tensor,
         config: &GatherConfig,
     ) -> crate::Result<Tensor> {
-        self.install(|| {
-            catch_backend_panic("gather", || {
-                indexing::gather(operand, start_indices, config)
-            })
-        })
+        self.install(|| indexing::gather(operand, start_indices, config))
     }
 
     fn scatter(
@@ -375,11 +371,7 @@ impl TensorBackend for CpuBackend {
         updates: &Tensor,
         config: &ScatterConfig,
     ) -> crate::Result<Tensor> {
-        self.install(|| {
-            catch_backend_panic("scatter", || {
-                indexing::scatter(operand, scatter_indices, updates, config)
-            })
-        })
+        self.install(|| indexing::scatter(operand, scatter_indices, updates, config))
     }
 
     fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> {
@@ -392,11 +384,7 @@ impl TensorBackend for CpuBackend {
         starts: &Tensor,
         slice_sizes: &[usize],
     ) -> crate::Result<Tensor> {
-        self.install(|| {
-            catch_backend_panic("dynamic_slice", || {
-                indexing::dynamic_slice(input, starts, slice_sizes)
-            })
-        })
+        self.install(|| indexing::dynamic_slice(input, starts, slice_sizes))
     }
 
     fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
@@ -408,7 +396,7 @@ impl TensorBackend for CpuBackend {
     }
 
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        self.install(|| catch_backend_panic("reverse", || indexing::reverse(input, axes)))
+        self.install(|| indexing::reverse(input, axes))
     }
 
     fn cholesky(&mut self, input: &Tensor) -> crate::Result<Tensor> {

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -642,12 +642,9 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => catch_backend_panic("svd", || {
-                linalg::svd(ctx.as_ref(), buffers, t)
-                    .into_iter()
-                    .map(Tensor::F64)
-                    .collect()
-            }),
+            Tensor::F64(t) => catch_backend_panic("svd", || linalg::svd(ctx.as_ref(), buffers, t))
+                .and_then(|r| r)
+                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => catch_backend_panic("svd", || {
                 linalg::svd(buffers, t)
@@ -663,12 +660,9 @@ impl TensorBackend for CpuBackend {
                     .collect()
             }),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => catch_backend_panic("svd", || {
-                linalg::svd(ctx.as_ref(), buffers, t)
-                    .into_iter()
-                    .map(Tensor::C64)
-                    .collect()
-            }),
+            Tensor::C64(t) => catch_backend_panic("svd", || linalg::svd(ctx.as_ref(), buffers, t))
+                .and_then(|r| r)
+                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             _ => Err(unsupported_dtype("svd", input.dtype())),
         })
     }
@@ -714,12 +708,11 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => catch_backend_panic("eigh", || {
-                linalg::eigh(ctx.as_ref(), buffers, t)
-                    .into_iter()
-                    .map(Tensor::F64)
-                    .collect()
-            }),
+            Tensor::F64(t) => {
+                catch_backend_panic("eigh", || linalg::eigh(ctx.as_ref(), buffers, t))
+                    .and_then(|r| r)
+                    .map(|outputs| outputs.into_iter().map(Tensor::F64).collect())
+            }
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => catch_backend_panic("eigh", || {
                 linalg::eigh(buffers, t)
@@ -735,12 +728,11 @@ impl TensorBackend for CpuBackend {
                     .collect()
             }),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => catch_backend_panic("eigh", || {
-                linalg::eigh(ctx.as_ref(), buffers, t)
-                    .into_iter()
-                    .map(Tensor::C64)
-                    .collect()
-            }),
+            Tensor::C64(t) => {
+                catch_backend_panic("eigh", || linalg::eigh(ctx.as_ref(), buffers, t))
+                    .and_then(|r| r)
+                    .map(|outputs| outputs.into_iter().map(Tensor::C64).collect())
+            }
             _ => Err(unsupported_dtype("eigh", input.dtype())),
         })
     }
@@ -752,16 +744,15 @@ impl TensorBackend for CpuBackend {
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| {
-            catch_backend_panic("eig", || {
-                #[cfg(feature = "cpu-faer")]
-                {
-                    linalg::eig(ctx.as_ref(), buffers, input)
-                }
-                #[cfg(feature = "cpu-blas")]
-                {
-                    linalg::eig(buffers, input)
-                }
-            })
+            #[cfg(feature = "cpu-faer")]
+            {
+                catch_backend_panic("eig", || linalg::eig(ctx.as_ref(), buffers, input))
+                    .and_then(|r| r)
+            }
+            #[cfg(feature = "cpu-blas")]
+            {
+                catch_backend_panic("eig", || linalg::eig(buffers, input))
+            }
         })
     }
 

--- a/tenferro-tensor/src/cpu/elementwise.rs
+++ b/tenferro-tensor/src/cpu/elementwise.rs
@@ -164,6 +164,7 @@ pub fn add(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
     match (lhs, rhs) {
         (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_add(a, b)?)),
         (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_add(a, b)?)),
+        (Tensor::I64(a), Tensor::I64(b)) => Ok(Tensor::I64(typed_add(a, b)?)),
         (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_add(a, b)?)),
         (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_add(a, b)?)),
         (Tensor::F32(a), Tensor::C32(b)) if a.shape.is_empty() => {
@@ -194,6 +195,7 @@ pub fn mul(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
     match (lhs, rhs) {
         (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_mul(a, b)?)),
         (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_mul(a, b)?)),
+        (Tensor::I64(a), Tensor::I64(b)) => Ok(Tensor::I64(typed_mul(a, b)?)),
         (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_mul(a, b)?)),
         (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_mul(a, b)?)),
         (Tensor::F32(a), Tensor::C32(b)) if a.shape.is_empty() => {

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -205,44 +205,16 @@ impl TensorExec for CpuExecSession<'_> {
     }
 
     // Indexing
-    fn gather(
-        &mut self,
-        operand: &Tensor,
-        start_indices: &Tensor,
-        config: &GatherConfig,
-    ) -> crate::Result<Tensor> {
-        catch_backend_panic("gather", || {
-            indexing::gather(operand, start_indices, config)
-        })
-    }
-    fn scatter(
-        &mut self,
-        operand: &Tensor,
-        indices: &Tensor,
-        updates: &Tensor,
-        config: &ScatterConfig,
-    ) -> crate::Result<Tensor> {
-        catch_backend_panic("scatter", || {
-            indexing::scatter(operand, indices, updates, config)
-        })
-    }
+    delegate!(gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) => indexing::gather(operand, start_indices, config));
+    delegate!(scatter(operand: &Tensor, indices: &Tensor, updates: &Tensor, config: &ScatterConfig) => indexing::scatter(operand, indices, updates, config));
     delegate!(slice(input: &Tensor, config: &SliceConfig) => indexing::try_slice(input, config));
-    fn dynamic_slice(
-        &mut self,
-        input: &Tensor,
-        starts: &Tensor,
-        slice_sizes: &[usize],
-    ) -> crate::Result<Tensor> {
-        catch_backend_panic("dynamic_slice", || {
-            indexing::dynamic_slice(input, starts, slice_sizes)
-        })
-    }
+    delegate!(dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) => indexing::dynamic_slice(input, starts, slice_sizes));
     delegate!(pad(input: &Tensor, config: &PadConfig) => indexing::try_pad(input, config));
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
         indexing::try_concatenate(inputs, axis)
     }
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        catch_backend_panic("reverse", || indexing::reverse(input, axes))
+        indexing::reverse(input, axes)
     }
 
     // Linalg — macro-generated dtype dispatch

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -89,6 +89,28 @@ macro_rules! linalg_multi {
     };
 }
 
+/// Unary linalg returning Vec<Tensor> and internal Result — faer path.
+#[cfg(feature = "cpu-faer")]
+macro_rules! linalg_multi_result {
+    ($name:ident) => {
+        fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+            match input {
+                Tensor::F64(t) => catch_backend_panic(stringify!($name), || {
+                    linalg::$name(self.ctx, self.buffers, t)
+                })
+                .and_then(|r| r)
+                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                Tensor::C64(t) => catch_backend_panic(stringify!($name), || {
+                    linalg::$name(self.ctx, self.buffers, t)
+                })
+                .and_then(|r| r)
+                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+                _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
+            }
+        }
+    };
+}
+
 /// Unary linalg returning Vec<Tensor> — blas path.
 #[cfg(feature = "cpu-blas")]
 macro_rules! linalg_multi {
@@ -221,24 +243,29 @@ impl TensorExec for CpuExecSession<'_> {
     linalg_single!(cholesky);
     linalg_multi!(lu);
     linalg_multi!(full_piv_lu);
+    #[cfg(feature = "cpu-faer")]
+    linalg_multi_result!(svd);
+    #[cfg(feature = "cpu-blas")]
     linalg_multi!(svd);
     linalg_multi!(qr);
+    #[cfg(feature = "cpu-faer")]
+    linalg_multi_result!(eigh);
+    #[cfg(feature = "cpu-blas")]
     linalg_multi!(eigh);
 
     fn eig(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         if !matches!(input, Tensor::F64(_) | Tensor::C64(_)) {
             return Err(unsupported_dtype("eig", input.dtype()));
         }
-        catch_backend_panic("eig", || {
-            #[cfg(feature = "cpu-faer")]
-            {
-                linalg::eig(self.ctx, self.buffers, input)
-            }
-            #[cfg(feature = "cpu-blas")]
-            {
-                linalg::eig(self.buffers, input)
-            }
-        })
+        #[cfg(feature = "cpu-faer")]
+        {
+            catch_backend_panic("eig", || linalg::eig(self.ctx, self.buffers, input))
+                .and_then(|r| r)
+        }
+        #[cfg(feature = "cpu-blas")]
+        {
+            catch_backend_panic("eig", || linalg::eig(self.buffers, input))
+        }
     }
 
     fn triangular_solve(

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -539,6 +539,7 @@ fn try_index_batch_shape(
 }
 
 fn index_component(
+    op: &'static str,
     indices: &IndexTensor,
     batch_idx: &[usize],
     index_vector_dim: usize,
@@ -547,7 +548,7 @@ fn index_component(
     if index_vector_dim == indices.shape.len() {
         if component != 0 {
             return Err(crate::Error::InvalidConfig {
-                op: "gather",
+                op,
                 message: "implicit index_vector_dim only supports scalar index vectors".into(),
             });
         }
@@ -594,12 +595,36 @@ fn typed_gather<T: Copy + Clone + Zero>(
     start_indices: &IndexTensor,
     config: &GatherConfig,
 ) -> crate::Result<TypedTensor<T>> {
-    if config.slice_sizes.len() != operand.shape.len() {
+    let rank = operand.shape.len();
+    if config.slice_sizes.len() != rank {
         return Err(crate::Error::RankMismatch {
             op: "gather",
-            expected: operand.shape.len(),
+            expected: rank,
             actual: config.slice_sizes.len(),
         });
+    }
+
+    for &dim in &config.collapsed_slice_dims {
+        if dim >= rank {
+            return Err(crate::Error::AxisOutOfBounds {
+                op: "gather",
+                axis: dim,
+                rank,
+            });
+        }
+    }
+    {
+        let mut seen = vec![false; rank];
+        for &dim in &config.collapsed_slice_dims {
+            if seen[dim] {
+                return Err(crate::Error::DuplicateAxis {
+                    op: "gather",
+                    axis: dim,
+                    role: "collapsed_slice_dims",
+                });
+            }
+            seen[dim] = true;
+        }
     }
 
     let index_size =
@@ -614,8 +639,30 @@ fn typed_gather<T: Copy + Clone + Zero>(
             ),
         });
     }
+    for &operand_dim in &config.start_index_map {
+        if operand_dim >= rank {
+            return Err(crate::Error::AxisOutOfBounds {
+                op: "gather",
+                axis: operand_dim,
+                rank,
+            });
+        }
+    }
+    {
+        let mut seen = vec![false; rank];
+        for &operand_dim in &config.start_index_map {
+            if seen[operand_dim] {
+                return Err(crate::Error::DuplicateAxis {
+                    op: "gather",
+                    axis: operand_dim,
+                    role: "start_index_map",
+                });
+            }
+            seen[operand_dim] = true;
+        }
+    }
 
-    let window_dims = operand_window_dims(operand.shape.len(), &config.collapsed_slice_dims);
+    let window_dims = operand_window_dims(rank, &config.collapsed_slice_dims);
     if config.offset_dims.len() != window_dims.len() {
         return Err(crate::Error::InvalidConfig {
             op: "gather",
@@ -630,12 +677,35 @@ fn typed_gather<T: Copy + Clone + Zero>(
     let batch_shape =
         try_index_batch_shape("gather", &start_indices.shape, config.index_vector_dim)?;
     let out_rank = batch_shape.len() + config.offset_dims.len();
-    let mut out_shape = vec![0usize; out_rank];
+    for &out_axis in &config.offset_dims {
+        if out_axis >= out_rank {
+            return Err(crate::Error::AxisOutOfBounds {
+                op: "gather",
+                axis: out_axis,
+                rank: out_rank,
+            });
+        }
+    }
+    {
+        let mut seen = vec![false; out_rank];
+        for &out_axis in &config.offset_dims {
+            if seen[out_axis] {
+                return Err(crate::Error::DuplicateAxis {
+                    op: "gather",
+                    axis: out_axis,
+                    role: "offset_dims",
+                });
+            }
+            seen[out_axis] = true;
+        }
+    }
+
     let mut out_axis_to_operand_dim = vec![None; out_rank];
     for (offset_axis, &out_axis) in config.offset_dims.iter().enumerate() {
         out_axis_to_operand_dim[out_axis] = Some(window_dims[offset_axis]);
     }
 
+    let mut out_shape = vec![0usize; out_rank];
     let mut batch_axis = 0usize;
     for out_axis in 0..out_rank {
         if let Some(operand_dim) = out_axis_to_operand_dim[out_axis] {
@@ -646,11 +716,21 @@ fn typed_gather<T: Copy + Clone + Zero>(
         }
     }
 
+    for (component, &operand_dim) in config.start_index_map.iter().enumerate() {
+        let _ = clamp_window_start(
+            "gather",
+            0,
+            operand.shape[operand_dim],
+            config.slice_sizes[operand_dim],
+        )?;
+        let _ = component;
+    }
+
     let mut out = typed_tensor_uninit(out_shape.clone());
     let mut out_idx = vec![0usize; out_rank];
     let mut batch_idx = vec![0usize; batch_shape.len()];
-    let mut operand_idx = vec![0usize; operand.shape.len()];
-    let mut window_offsets = vec![0usize; operand.shape.len()];
+    let mut operand_idx = vec![0usize; rank];
+    let mut window_offsets = vec![0usize; rank];
 
     for flat in 0..out.n_elements() {
         flat_to_multi(flat, &out_shape, &mut out_idx);
@@ -669,6 +749,7 @@ fn typed_gather<T: Copy + Clone + Zero>(
         operand_idx.fill(0);
         for (component, &operand_dim) in config.start_index_map.iter().enumerate() {
             let start = index_component(
+                "gather",
                 start_indices,
                 &batch_idx,
                 config.index_vector_dim,
@@ -701,6 +782,30 @@ fn typed_scatter<T>(
 where
     T: Copy + Clone + Zero + Add<Output = T>,
 {
+    let op_rank = operand.shape.len();
+    for &dim in &config.inserted_window_dims {
+        if dim >= op_rank {
+            return Err(crate::Error::AxisOutOfBounds {
+                op: "scatter",
+                axis: dim,
+                rank: op_rank,
+            });
+        }
+    }
+    {
+        let mut seen = vec![false; op_rank];
+        for &dim in &config.inserted_window_dims {
+            if seen[dim] {
+                return Err(crate::Error::DuplicateAxis {
+                    op: "scatter",
+                    axis: dim,
+                    role: "inserted_window_dims",
+                });
+            }
+            seen[dim] = true;
+        }
+    }
+
     let index_size =
         try_index_vector_size("scatter", &scatter_indices.shape, config.index_vector_dim)?;
     if index_size != config.scatter_dims_to_operand_dims.len() {
@@ -713,10 +818,32 @@ where
             ),
         });
     }
+    for &operand_dim in &config.scatter_dims_to_operand_dims {
+        if operand_dim >= op_rank {
+            return Err(crate::Error::AxisOutOfBounds {
+                op: "scatter",
+                axis: operand_dim,
+                rank: op_rank,
+            });
+        }
+    }
+    {
+        let mut seen = vec![false; op_rank];
+        for &operand_dim in &config.scatter_dims_to_operand_dims {
+            if seen[operand_dim] {
+                return Err(crate::Error::DuplicateAxis {
+                    op: "scatter",
+                    axis: operand_dim,
+                    role: "scatter_dims_to_operand_dims",
+                });
+            }
+            seen[operand_dim] = true;
+        }
+    }
 
     let batch_shape =
         try_index_batch_shape("scatter", &scatter_indices.shape, config.index_vector_dim)?;
-    let window_dims = operand_window_dims(operand.shape.len(), &config.inserted_window_dims);
+    let window_dims = operand_window_dims(op_rank, &config.inserted_window_dims);
     if config.update_window_dims.len() != window_dims.len() {
         return Err(crate::Error::InvalidConfig {
             op: "scatter",
@@ -729,22 +856,77 @@ where
     }
 
     let update_rank = updates.shape.len();
-    let mut is_update_window_dim = vec![false; update_rank];
-    for &axis in &config.update_window_dims {
-        is_update_window_dim[axis] = true;
-    }
-    if update_rank - config.update_window_dims.len() != batch_shape.len() {
+    let expected_batch_rank = update_rank
+        .checked_sub(config.update_window_dims.len())
+        .ok_or_else(|| crate::Error::InvalidConfig {
+            op: "scatter",
+            message: format!(
+                "update_window_dims length {} exceeds update rank {}",
+                config.update_window_dims.len(),
+                update_rank
+            ),
+        })?;
+    if expected_batch_rank != batch_shape.len() {
         return Err(crate::Error::InvalidConfig {
             op: "scatter",
             message: format!(
                 "updates batch rank {} does not match index batch shape length {}",
-                update_rank - config.update_window_dims.len(),
+                expected_batch_rank,
                 batch_shape.len()
             ),
         });
     }
 
-    let mut window_shape = vec![1usize; operand.shape.len()];
+    for &axis in &config.update_window_dims {
+        if axis >= update_rank {
+            return Err(crate::Error::AxisOutOfBounds {
+                op: "scatter",
+                axis,
+                rank: update_rank,
+            });
+        }
+    }
+    {
+        let mut seen = vec![false; update_rank];
+        for &axis in &config.update_window_dims {
+            if seen[axis] {
+                return Err(crate::Error::DuplicateAxis {
+                    op: "scatter",
+                    axis,
+                    role: "update_window_dims",
+                });
+            }
+            seen[axis] = true;
+        }
+    }
+
+    let mut is_update_window_dim = vec![false; update_rank];
+    for &axis in &config.update_window_dims {
+        is_update_window_dim[axis] = true;
+    }
+
+    {
+        let mut batch_axis = 0usize;
+        for axis in 0..update_rank {
+            if !is_update_window_dim[axis] {
+                if updates.shape[axis] != batch_shape[batch_axis] {
+                    return Err(crate::Error::InvalidConfig {
+                        op: "scatter",
+                        message: format!(
+                            "updates batch dim {} extent {} does not match index batch dim {} extent {}",
+                            axis,
+                            updates.shape[axis],
+                            batch_axis,
+                            batch_shape[batch_axis]
+                        ),
+                    });
+                }
+                batch_axis += 1;
+            }
+        }
+    }
+
+    let mut window_shape = vec![1usize; op_rank];
     let mut window_shape_updates = vec![0usize; config.update_window_dims.len()];
     for (pos, &update_axis) in config.update_window_dims.iter().enumerate() {
         let dim = updates.shape[update_axis];
@@ -758,9 +940,9 @@ where
 
     let mut batch_idx = vec![0usize; batch_shape.len()];
     let mut window_idx = vec![0usize; window_shape_updates.len()];
-    let mut update_idx = vec![0usize; updates.shape.len()];
-    let mut operand_base = vec![0usize; operand.shape.len()];
-    let mut operand_idx = vec![0usize; operand.shape.len()];
+    let mut update_idx = vec![0usize; update_rank];
+    let mut operand_base = vec![0usize; op_rank];
+    let mut operand_idx = vec![0usize; op_rank];
 
     for batch_flat in 0..batch_elems {
         if !batch_shape.is_empty() {
@@ -771,6 +953,7 @@ where
         operand_base.fill(0);
         for (component, &operand_dim) in config.scatter_dims_to_operand_dims.iter().enumerate() {
             let start = index_component(
+                "scatter",
                 scatter_indices,
                 &batch_idx,
                 config.index_vector_dim,
@@ -786,7 +969,7 @@ where
             continue;
         }
 
-        for axis in 0..operand.shape.len() {
+        for axis in 0..op_rank {
             if operand_base[axis] + window_shape[axis] > operand.shape[axis] {
                 window_fits = false;
                 break;
@@ -803,7 +986,7 @@ where
 
             let mut batch_axis = 0usize;
             let mut window_axis = 0usize;
-            for axis in 0..updates.shape.len() {
+            for axis in 0..update_rank {
                 if is_update_window_dim[axis] {
                     update_idx[axis] = window_idx[window_axis];
                     window_axis += 1;

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -3,7 +3,7 @@ use std::ops::Add;
 use num_traits::Zero;
 
 use crate::config::{GatherConfig, PadConfig, ScatterConfig, SliceConfig};
-use crate::types::{dispatch_binary, dispatch_tensor, flat_to_multi, Tensor, TypedTensor};
+use crate::types::{flat_to_multi, Tensor, TypedTensor};
 
 trait TensorAsTyped<T> {
     fn as_typed(&self) -> Option<&TypedTensor<T>>;
@@ -54,9 +54,22 @@ impl TensorAsTyped<num_complex::Complex<f64>> for Tensor {
     }
 }
 
-pub fn gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> Tensor {
-    let start_indices = index_tensor(start_indices);
-    dispatch_tensor!(operand, t => typed_gather(t, &start_indices, config))
+pub fn gather(
+    operand: &Tensor,
+    start_indices: &Tensor,
+    config: &GatherConfig,
+) -> crate::Result<Tensor> {
+    let start_indices = try_index_tensor(start_indices)?;
+    match operand {
+        Tensor::F32(t) => typed_gather(t, &start_indices, config).map(Tensor::F32),
+        Tensor::F64(t) => typed_gather(t, &start_indices, config).map(Tensor::F64),
+        Tensor::C32(t) => typed_gather(t, &start_indices, config).map(Tensor::C32),
+        Tensor::C64(t) => typed_gather(t, &start_indices, config).map(Tensor::C64),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "gather",
+            message: "I64 data tensors are not supported by this operation".into(),
+        }),
+    }
 }
 
 pub fn scatter(
@@ -64,18 +77,35 @@ pub fn scatter(
     scatter_indices: &Tensor,
     updates: &Tensor,
     config: &ScatterConfig,
-) -> Tensor {
-    let scatter_indices = index_tensor(scatter_indices);
-    dispatch_binary!(operand, updates, |op, upd| typed_scatter(
-        op,
-        &scatter_indices,
-        upd,
-        config
-    ))
+) -> crate::Result<Tensor> {
+    let scatter_indices = try_index_tensor(scatter_indices)?;
+    match (operand, updates) {
+        (Tensor::F32(op), Tensor::F32(upd)) => {
+            typed_scatter(op, &scatter_indices, upd, config).map(Tensor::F32)
+        }
+        (Tensor::F64(op), Tensor::F64(upd)) => {
+            typed_scatter(op, &scatter_indices, upd, config).map(Tensor::F64)
+        }
+        (Tensor::C32(op), Tensor::C32(upd)) => {
+            typed_scatter(op, &scatter_indices, upd, config).map(Tensor::C32)
+        }
+        (Tensor::C64(op), Tensor::C64(upd)) => {
+            typed_scatter(op, &scatter_indices, upd, config).map(Tensor::C64)
+        }
+        (Tensor::I64(_), Tensor::I64(_)) => Err(crate::Error::BackendFailure {
+            op: "scatter",
+            message: "I64 data tensors are not supported by this operation".into(),
+        }),
+        _ => Err(crate::Error::DTypeMismatch {
+            op: "scatter",
+            lhs: operand.dtype(),
+            rhs: updates.dtype(),
+        }),
+    }
 }
 
-pub fn slice(input: &Tensor, config: &SliceConfig) -> Tensor {
-    try_slice(input, config).expect("slice")
+pub fn slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> {
+    try_slice(input, config)
 }
 
 pub fn try_slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> {
@@ -88,13 +118,26 @@ pub fn try_slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> 
     }
 }
 
-pub fn dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> Tensor {
-    let starts = index_tensor(starts);
-    dispatch_tensor!(input, t => typed_dynamic_slice(t, &starts, slice_sizes))
+pub fn dynamic_slice(
+    input: &Tensor,
+    starts: &Tensor,
+    slice_sizes: &[usize],
+) -> crate::Result<Tensor> {
+    let starts = try_index_tensor(starts)?;
+    match input {
+        Tensor::F32(t) => typed_dynamic_slice(t, &starts, slice_sizes).map(Tensor::F32),
+        Tensor::F64(t) => typed_dynamic_slice(t, &starts, slice_sizes).map(Tensor::F64),
+        Tensor::C32(t) => typed_dynamic_slice(t, &starts, slice_sizes).map(Tensor::C32),
+        Tensor::C64(t) => typed_dynamic_slice(t, &starts, slice_sizes).map(Tensor::C64),
+        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+            op: "dynamic_slice",
+            message: "I64 data tensors are not supported by this operation".into(),
+        }),
+    }
 }
 
-pub fn pad(input: &Tensor, config: &PadConfig) -> Tensor {
-    try_pad(input, config).expect("pad")
+pub fn pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
+    try_pad(input, config)
 }
 
 pub fn try_pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
@@ -138,8 +181,14 @@ pub fn try_concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>
     }
 }
 
-pub fn reverse(input: &Tensor, axes: &[usize]) -> Tensor {
-    dispatch_tensor!(input, tensor => typed_reverse(tensor, axes))
+pub fn reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(t) => typed_reverse(t, axes).map(Tensor::F32),
+        Tensor::F64(t) => typed_reverse(t, axes).map(Tensor::F64),
+        Tensor::I64(t) => typed_reverse(t, axes).map(Tensor::I64),
+        Tensor::C32(t) => typed_reverse(t, axes).map(Tensor::C32),
+        Tensor::C64(t) => typed_reverse(t, axes).map(Tensor::C64),
+    }
 }
 
 #[allow(clippy::uninit_vec)]
@@ -332,11 +381,20 @@ fn typed_concatenate<T: Copy + Clone>(
     Ok(TypedTensor::from_vec(out_shape, out_data))
 }
 
-fn typed_reverse<T: Copy + Clone>(input: &TypedTensor<T>, axes: &[usize]) -> TypedTensor<T> {
+fn typed_reverse<T: Copy + Clone>(
+    input: &TypedTensor<T>,
+    axes: &[usize],
+) -> crate::Result<TypedTensor<T>> {
     let rank = input.shape.len();
     let mut reverse_axis = vec![false; rank];
     for &axis in axes {
-        assert!(axis < rank, "reverse: axis out of bounds");
+        if axis >= rank {
+            return Err(crate::Error::AxisOutOfBounds {
+                op: "reverse",
+                axis,
+                rank,
+            });
+        }
         reverse_axis[axis] = true;
     }
 
@@ -357,7 +415,7 @@ fn typed_reverse<T: Copy + Clone>(input: &TypedTensor<T>, axes: &[usize]) -> Typ
         out_data.push(*input.get(&in_idx));
     }
 
-    TypedTensor::from_vec(input.shape.clone(), out_data)
+    Ok(TypedTensor::from_vec(input.shape.clone(), out_data))
 }
 
 struct IndexTensor {
@@ -365,21 +423,63 @@ struct IndexTensor {
     values: Vec<i64>,
 }
 
-fn index_tensor(tensor: &Tensor) -> IndexTensor {
+/// Maximum exact integer representable by f32 (2^24).
+const F32_MAX_EXACT_INT: f32 = 16_777_216.0;
+/// Maximum exact integer representable by f64 (2^53).
+const F64_MAX_EXACT_INT: f64 = 9_007_199_254_740_992.0;
+
+fn f32_index_to_i64(value: f32) -> crate::Result<i64> {
+    if !value.is_finite() || value.fract() != 0.0 || value.abs() > F32_MAX_EXACT_INT {
+        return Err(crate::Error::InvalidConfig {
+            op: "index_tensor",
+            message: format!("index value {value} is not an exactly representable i64"),
+        });
+    }
+    Ok(value as i64)
+}
+
+fn f64_index_to_i64(value: f64) -> crate::Result<i64> {
+    if !value.is_finite() || value.fract() != 0.0 || value.abs() > F64_MAX_EXACT_INT {
+        return Err(crate::Error::InvalidConfig {
+            op: "index_tensor",
+            message: format!("index value {value} is not an exactly representable i64"),
+        });
+    }
+    Ok(value as i64)
+}
+
+fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor> {
     match tensor {
-        Tensor::I64(t) => IndexTensor {
+        Tensor::I64(t) => Ok(IndexTensor {
             shape: t.shape.clone(),
             values: t.host_data().to_vec(),
-        },
-        Tensor::F32(t) => IndexTensor {
-            shape: t.shape.clone(),
-            values: t.host_data().iter().map(|&value| value as i64).collect(),
-        },
-        Tensor::F64(t) => IndexTensor {
-            shape: t.shape.clone(),
-            values: t.host_data().iter().map(|&value| value as i64).collect(),
-        },
-        Tensor::C32(_) | Tensor::C64(_) => panic!("complex index tensors are not supported"),
+        }),
+        Tensor::F32(t) => {
+            let values: crate::Result<Vec<i64>> = t
+                .host_data()
+                .iter()
+                .map(|&value| f32_index_to_i64(value))
+                .collect();
+            Ok(IndexTensor {
+                shape: t.shape.clone(),
+                values: values?,
+            })
+        }
+        Tensor::F64(t) => {
+            let values: crate::Result<Vec<i64>> = t
+                .host_data()
+                .iter()
+                .map(|&value| f64_index_to_i64(value))
+                .collect();
+            Ok(IndexTensor {
+                shape: t.shape.clone(),
+                values: values?,
+            })
+        }
+        Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::InvalidConfig {
+            op: "index_tensor",
+            message: "complex index tensors are not supported".into(),
+        }),
     }
 }
 
@@ -397,23 +497,45 @@ fn product(shape: &[usize]) -> usize {
     shape.iter().product()
 }
 
-fn index_vector_size(shape: &[usize], index_vector_dim: usize) -> usize {
-    if index_vector_dim == shape.len() {
+fn try_index_vector_size(
+    op: &'static str,
+    shape: &[usize],
+    index_vector_dim: usize,
+) -> crate::Result<usize> {
+    if index_vector_dim > shape.len() {
+        return Err(crate::Error::AxisOutOfBounds {
+            op,
+            axis: index_vector_dim,
+            rank: shape.len(),
+        });
+    }
+    Ok(if index_vector_dim == shape.len() {
         1
     } else {
         shape[index_vector_dim]
-    }
+    })
 }
 
-fn index_batch_shape(shape: &[usize], index_vector_dim: usize) -> Vec<usize> {
-    if index_vector_dim == shape.len() {
-        return shape.to_vec();
+fn try_index_batch_shape(
+    op: &'static str,
+    shape: &[usize],
+    index_vector_dim: usize,
+) -> crate::Result<Vec<usize>> {
+    if index_vector_dim > shape.len() {
+        return Err(crate::Error::AxisOutOfBounds {
+            op,
+            axis: index_vector_dim,
+            rank: shape.len(),
+        });
     }
-    shape
+    if index_vector_dim == shape.len() {
+        return Ok(shape.to_vec());
+    }
+    Ok(shape
         .iter()
         .enumerate()
         .filter_map(|(axis, &dim)| (axis != index_vector_dim).then_some(dim))
-        .collect()
+        .collect())
 }
 
 fn index_component(
@@ -421,13 +543,15 @@ fn index_component(
     batch_idx: &[usize],
     index_vector_dim: usize,
     component: usize,
-) -> i64 {
+) -> crate::Result<i64> {
     if index_vector_dim == indices.shape.len() {
-        assert_eq!(
-            component, 0,
-            "implicit index_vector_dim only supports scalar index vectors"
-        );
-        return indices.values[linear_offset(&indices.shape, batch_idx)];
+        if component != 0 {
+            return Err(crate::Error::InvalidConfig {
+                op: "gather",
+                message: "implicit index_vector_dim only supports scalar index vectors".into(),
+            });
+        }
+        return Ok(indices.values[linear_offset(&indices.shape, batch_idx)]);
     }
 
     let mut full_idx = vec![0usize; indices.shape.len()];
@@ -440,16 +564,23 @@ fn index_component(
             batch_axis += 1;
         }
     }
-    indices.values[linear_offset(&indices.shape, &full_idx)]
+    Ok(indices.values[linear_offset(&indices.shape, &full_idx)])
 }
 
-fn clamp_window_start(start: i64, dim_size: usize, window_size: usize) -> usize {
-    assert!(
-        window_size <= dim_size,
-        "window size {window_size} exceeds dimension size {dim_size}"
-    );
+fn clamp_window_start(
+    op: &'static str,
+    start: i64,
+    dim_size: usize,
+    window_size: usize,
+) -> crate::Result<usize> {
+    if window_size > dim_size {
+        return Err(crate::Error::InvalidConfig {
+            op,
+            message: format!("window size {window_size} exceeds dimension size {dim_size}"),
+        });
+    }
     let max_start = dim_size.saturating_sub(window_size) as i64;
-    start.clamp(0, max_start) as usize
+    Ok(start.clamp(0, max_start) as usize)
 }
 
 fn operand_window_dims(rank: usize, collapsed_or_inserted: &[usize]) -> Vec<usize> {
@@ -462,28 +593,42 @@ fn typed_gather<T: Copy + Clone + Zero>(
     operand: &TypedTensor<T>,
     start_indices: &IndexTensor,
     config: &GatherConfig,
-) -> TypedTensor<T> {
-    assert_eq!(
-        config.slice_sizes.len(),
-        operand.shape.len(),
-        "gather: slice_sizes rank mismatch"
-    );
+) -> crate::Result<TypedTensor<T>> {
+    if config.slice_sizes.len() != operand.shape.len() {
+        return Err(crate::Error::RankMismatch {
+            op: "gather",
+            expected: operand.shape.len(),
+            actual: config.slice_sizes.len(),
+        });
+    }
 
-    let index_size = index_vector_size(&start_indices.shape, config.index_vector_dim);
-    assert_eq!(
-        index_size,
-        config.start_index_map.len(),
-        "gather: start_index_map length mismatch"
-    );
+    let index_size =
+        try_index_vector_size("gather", &start_indices.shape, config.index_vector_dim)?;
+    if index_size != config.start_index_map.len() {
+        return Err(crate::Error::InvalidConfig {
+            op: "gather",
+            message: format!(
+                "start_index_map length {} does not match index vector size {}",
+                config.start_index_map.len(),
+                index_size
+            ),
+        });
+    }
 
     let window_dims = operand_window_dims(operand.shape.len(), &config.collapsed_slice_dims);
-    assert_eq!(
-        config.offset_dims.len(),
-        window_dims.len(),
-        "gather: offset_dims length mismatch"
-    );
+    if config.offset_dims.len() != window_dims.len() {
+        return Err(crate::Error::InvalidConfig {
+            op: "gather",
+            message: format!(
+                "offset_dims length {} does not match window dims count {}",
+                config.offset_dims.len(),
+                window_dims.len()
+            ),
+        });
+    }
 
-    let batch_shape = index_batch_shape(&start_indices.shape, config.index_vector_dim);
+    let batch_shape =
+        try_index_batch_shape("gather", &start_indices.shape, config.index_vector_dim)?;
     let out_rank = batch_shape.len() + config.offset_dims.len();
     let mut out_shape = vec![0usize; out_rank];
     let mut out_axis_to_operand_dim = vec![None; out_rank];
@@ -528,12 +673,13 @@ fn typed_gather<T: Copy + Clone + Zero>(
                 &batch_idx,
                 config.index_vector_dim,
                 component,
-            );
+            )?;
             operand_idx[operand_dim] = clamp_window_start(
+                "gather",
                 start,
                 operand.shape[operand_dim],
                 config.slice_sizes[operand_dim],
-            );
+            )?;
         }
 
         for axis in 0..operand_idx.len() {
@@ -543,7 +689,7 @@ fn typed_gather<T: Copy + Clone + Zero>(
         *out.get_mut(&out_idx) = *operand.get(&operand_idx);
     }
 
-    out
+    Ok(out)
 }
 
 fn typed_scatter<T>(
@@ -551,35 +697,52 @@ fn typed_scatter<T>(
     scatter_indices: &IndexTensor,
     updates: &TypedTensor<T>,
     config: &ScatterConfig,
-) -> TypedTensor<T>
+) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Zero + Add<Output = T>,
 {
-    let index_size = index_vector_size(&scatter_indices.shape, config.index_vector_dim);
-    assert_eq!(
-        index_size,
-        config.scatter_dims_to_operand_dims.len(),
-        "scatter: scatter_dims_to_operand_dims length mismatch"
-    );
+    let index_size =
+        try_index_vector_size("scatter", &scatter_indices.shape, config.index_vector_dim)?;
+    if index_size != config.scatter_dims_to_operand_dims.len() {
+        return Err(crate::Error::InvalidConfig {
+            op: "scatter",
+            message: format!(
+                "scatter_dims_to_operand_dims length {} does not match index vector size {}",
+                config.scatter_dims_to_operand_dims.len(),
+                index_size
+            ),
+        });
+    }
 
-    let batch_shape = index_batch_shape(&scatter_indices.shape, config.index_vector_dim);
+    let batch_shape =
+        try_index_batch_shape("scatter", &scatter_indices.shape, config.index_vector_dim)?;
     let window_dims = operand_window_dims(operand.shape.len(), &config.inserted_window_dims);
-    assert_eq!(
-        config.update_window_dims.len(),
-        window_dims.len(),
-        "scatter: update_window_dims length mismatch"
-    );
+    if config.update_window_dims.len() != window_dims.len() {
+        return Err(crate::Error::InvalidConfig {
+            op: "scatter",
+            message: format!(
+                "update_window_dims length {} does not match window dims count {}",
+                config.update_window_dims.len(),
+                window_dims.len()
+            ),
+        });
+    }
 
     let update_rank = updates.shape.len();
     let mut is_update_window_dim = vec![false; update_rank];
     for &axis in &config.update_window_dims {
         is_update_window_dim[axis] = true;
     }
-    assert_eq!(
-        update_rank - config.update_window_dims.len(),
-        batch_shape.len(),
-        "scatter: updates batch rank mismatch"
-    );
+    if update_rank - config.update_window_dims.len() != batch_shape.len() {
+        return Err(crate::Error::InvalidConfig {
+            op: "scatter",
+            message: format!(
+                "updates batch rank {} does not match index batch shape length {}",
+                update_rank - config.update_window_dims.len(),
+                batch_shape.len()
+            ),
+        });
+    }
 
     let mut window_shape = vec![1usize; operand.shape.len()];
     let mut window_shape_updates = vec![0usize; config.update_window_dims.len()];
@@ -591,9 +754,6 @@ where
 
     let batch_elems = product(&batch_shape).max(1);
     let window_elems = product(&window_shape_updates).max(1);
-    // StableHLO add-scatter: start from a copy of `operand` and accumulate
-    // `updates` additively at the scattered positions. Non-scattered slots
-    // retain the original operand values.
     let mut out = operand.clone();
 
     let mut batch_idx = vec![0usize; batch_shape.len()];
@@ -615,7 +775,7 @@ where
                 &batch_idx,
                 config.index_vector_dim,
                 component,
-            );
+            )?;
             if start < 0 {
                 window_fits = false;
                 break;
@@ -664,34 +824,46 @@ where
         }
     }
 
-    out
+    Ok(out)
 }
 
 fn typed_dynamic_slice<T: Copy + Clone + Zero>(
     input: &TypedTensor<T>,
     starts: &IndexTensor,
     slice_sizes: &[usize],
-) -> TypedTensor<T> {
-    assert_eq!(
-        slice_sizes.len(),
-        input.shape.len(),
-        "dynamic_slice: slice_sizes rank mismatch"
-    );
-    assert_eq!(
-        starts.shape.len(),
-        1,
-        "dynamic_slice: starts must be a rank-1 tensor"
-    );
-    assert_eq!(
-        starts.values.len(),
-        input.shape.len(),
-        "dynamic_slice: starts length must match input rank"
-    );
+) -> crate::Result<TypedTensor<T>> {
+    if slice_sizes.len() != input.shape.len() {
+        return Err(crate::Error::RankMismatch {
+            op: "dynamic_slice",
+            expected: input.shape.len(),
+            actual: slice_sizes.len(),
+        });
+    }
+    if starts.shape.len() != 1 {
+        return Err(crate::Error::InvalidConfig {
+            op: "dynamic_slice",
+            message: "starts must be a rank-1 tensor".into(),
+        });
+    }
+    if starts.values.len() != input.shape.len() {
+        return Err(crate::Error::InvalidConfig {
+            op: "dynamic_slice",
+            message: format!(
+                "starts length {} must match input rank {}",
+                starts.values.len(),
+                input.shape.len()
+            ),
+        });
+    }
 
     let mut clamped_starts = vec![0usize; input.shape.len()];
     for axis in 0..input.shape.len() {
-        clamped_starts[axis] =
-            clamp_window_start(starts.values[axis], input.shape[axis], slice_sizes[axis]);
+        clamped_starts[axis] = clamp_window_start(
+            "dynamic_slice",
+            starts.values[axis],
+            input.shape[axis],
+            slice_sizes[axis],
+        )?;
     }
 
     let out_shape = slice_sizes.to_vec();
@@ -707,7 +879,7 @@ fn typed_dynamic_slice<T: Copy + Clone + Zero>(
         *out.get_mut(&out_idx) = *input.get(&input_idx);
     }
 
-    out
+    Ok(out)
 }
 
 fn typed_pad<T: Copy + Clone + Zero>(

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -366,7 +366,10 @@ fn typed_concatenate<T: Copy + Clone>(
         let input_pos = segment_ends
             .iter()
             .position(|&end| concat_idx < end)
-            .expect("concatenate: output index must map to an input");
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "concatenate",
+                message: "output index must map to an input".to_string(),
+            })?;
         let axis_base = if input_pos == 0 {
             0
         } else {

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -47,7 +47,7 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>>;
+    ) -> crate::Result<Vec<TypedTensor<Self>>>;
     fn qr_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -57,7 +57,7 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>>;
+    ) -> crate::Result<Vec<TypedTensor<Self>>>;
 }
 
 fn matrix_dims<T>(input: &TypedTensor<T>, op: &str) -> (usize, usize) {
@@ -107,29 +107,40 @@ fn vec_from_diag<T: Copy + PoolScalar>(buffers: &mut BufferPool, diag: DiagRef<'
 }
 
 fn complex64_to_faer_slice(data: &[Complex64]) -> &[faer::c64] {
-    debug_assert_eq!(
+    assert_eq!(
         std::mem::size_of::<Complex64>(),
         std::mem::size_of::<faer::c64>()
     );
-    debug_assert_eq!(
+    assert_eq!(
         std::mem::align_of::<Complex64>(),
         std::mem::align_of::<faer::c64>()
     );
 
+    // SAFETY: size and alignment are checked above in release builds, and
+    // both types represent one complex f64 scalar in supported builds.
     unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<faer::c64>(), data.len()) }
 }
 
 fn complex64_to_faer_slice_mut(data: &mut [Complex64]) -> &mut [faer::c64] {
-    debug_assert_eq!(
+    assert_eq!(
         std::mem::size_of::<Complex64>(),
         std::mem::size_of::<faer::c64>()
     );
-    debug_assert_eq!(
+    assert_eq!(
         std::mem::align_of::<Complex64>(),
         std::mem::align_of::<faer::c64>()
     );
 
+    // SAFETY: size and alignment are checked above in release builds, and
+    // both types represent one complex f64 scalar in supported builds.
     unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr().cast::<faer::c64>(), data.len()) }
+}
+
+fn decomposition_failed(op: &'static str) -> crate::Error {
+    crate::Error::BackendFailure {
+        op,
+        message: "decomposition failed".into(),
+    }
 }
 
 fn complex_vec_from_real_diag(
@@ -414,16 +425,90 @@ where
         .collect()
 }
 
-fn batched_multi_convert<InT, OutT, F>(
+fn batched_multi_result<T, F>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+    core_rank: usize,
+    op: F,
+) -> crate::Result<Vec<TypedTensor<T>>>
+where
+    T: Clone + PoolScalar,
+    F: Fn(&mut BufferPool, &TypedTensor<T>) -> crate::Result<Vec<TypedTensor<T>>>,
+{
+    let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, "batched_multi");
+    if batch_shape.is_empty() {
+        return op(buffers, input);
+    }
+
+    let slice_size: usize = core_shape.iter().product();
+    let batch_count: usize = batch_shape.iter().product();
+    assert!(
+        batch_count > 0,
+        "batched_multi: zero-sized batch dims are unsupported"
+    );
+
+    let mut out_shapes: Vec<Vec<usize>> = Vec::new();
+    let mut out_data: Vec<Vec<T>> = Vec::new();
+
+    for batch_idx in 0..batch_count {
+        let start = batch_idx * slice_size;
+        let end = start + slice_size;
+        let batch_input = tensor_from_vec_with_template(
+            core_shape.to_vec(),
+            input.host_data()[start..end].to_vec(),
+            input,
+        );
+        let batch_outputs = op(buffers, &batch_input)?;
+
+        if out_shapes.is_empty() {
+            out_shapes = batch_outputs
+                .iter()
+                .map(|tensor| tensor.shape.clone())
+                .collect();
+            let mut pooled_outputs = Vec::with_capacity(batch_outputs.len());
+            for tensor in &batch_outputs {
+                pooled_outputs
+                    .push(buffers.acquire_with_capacity::<T>(tensor.n_elements() * batch_count));
+            }
+            out_data = pooled_outputs;
+        } else {
+            assert_eq!(
+                batch_outputs.len(),
+                out_shapes.len(),
+                "batched_multi: output count mismatch across batches"
+            );
+        }
+
+        for (idx, batch_output) in batch_outputs.iter().enumerate() {
+            assert_eq!(
+                batch_output.shape.as_slice(),
+                out_shapes[idx].as_slice(),
+                "batched_multi: output core shape mismatch across batches"
+            );
+            out_data[idx].extend_from_slice(batch_output.host_data());
+        }
+    }
+
+    Ok(out_shapes
+        .into_iter()
+        .zip(out_data)
+        .map(|(mut out_shape, out_data)| {
+            out_shape.extend_from_slice(batch_shape);
+            tensor_from_vec_with_template(out_shape, out_data, input)
+        })
+        .collect())
+}
+
+fn batched_multi_convert_result<InT, OutT, F>(
     buffers: &mut BufferPool,
     input: &TypedTensor<InT>,
     core_rank: usize,
     op: F,
-) -> Vec<TypedTensor<OutT>>
+) -> crate::Result<Vec<TypedTensor<OutT>>>
 where
     InT: Clone,
     OutT: Clone + PoolScalar,
-    F: Fn(&mut BufferPool, &TypedTensor<InT>) -> Vec<TypedTensor<OutT>>,
+    F: Fn(&mut BufferPool, &TypedTensor<InT>) -> crate::Result<Vec<TypedTensor<OutT>>>,
 {
     let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, "batched_multi");
     if batch_shape.is_empty() {
@@ -448,7 +533,7 @@ where
             input.host_data()[start..end].to_vec(),
             input,
         );
-        let batch_outputs = op(buffers, &batch_input);
+        let batch_outputs = op(buffers, &batch_input)?;
 
         if out_shapes.is_empty() {
             out_shapes = batch_outputs
@@ -479,14 +564,14 @@ where
         }
     }
 
-    out_shapes
+    Ok(out_shapes
         .into_iter()
         .zip(out_data)
         .map(|(mut out_shape, out_data)| {
             out_shape.extend_from_slice(batch_shape);
             tensor_from_vec_with_template(out_shape, out_data, input)
         })
-        .collect()
+        .collect())
 }
 
 fn batched_binary<T, F>(
@@ -1029,7 +1114,7 @@ impl FaerLinalg for f64 {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>> {
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "svd");
         let k = m.min(n);
         let mat = MatRef::from_column_major_slice(input.host_data(), m, n);
@@ -1054,7 +1139,7 @@ impl FaerLinalg for f64 {
             stack,
             Default::default(),
         )
-        .unwrap_or_else(|_| panic!("svd: decomposition failed"));
+        .map_err(|_| decomposition_failed("svd"))?;
 
         let u = tensor_from_vec_with_template(
             vec![m, k],
@@ -1070,7 +1155,7 @@ impl FaerLinalg for f64 {
         }
         let vt = tensor_from_vec_with_template(vec![k, n], vt_data, input);
 
-        vec![u, s, vt]
+        Ok(vec![u, s, vt])
     }
 
     fn qr_2d(
@@ -1138,7 +1223,7 @@ impl FaerLinalg for f64 {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>> {
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
         let n = square_matrix_dim(input, "eigh");
         let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
         let mut values = Diag::zeros(n);
@@ -1158,7 +1243,7 @@ impl FaerLinalg for f64 {
             stack,
             Default::default(),
         )
-        .unwrap_or_else(|_| panic!("eigh: decomposition failed"));
+        .map_err(|_| decomposition_failed("eigh"))?;
 
         let values =
             tensor_from_vec_with_template(vec![n], vec_from_diag(buffers, values.as_ref()), input);
@@ -1168,7 +1253,7 @@ impl FaerLinalg for f64 {
             input,
         );
 
-        vec![values, vectors]
+        Ok(vec![values, vectors])
     }
 }
 
@@ -1578,7 +1663,7 @@ impl FaerLinalg for Complex64 {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>> {
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "svd");
         let k = m.min(n);
         let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), m, n);
@@ -1603,7 +1688,7 @@ impl FaerLinalg for Complex64 {
             stack,
             Default::default(),
         )
-        .unwrap_or_else(|_| panic!("svd: decomposition failed"));
+        .map_err(|_| decomposition_failed("svd"))?;
 
         let u = tensor_from_vec_with_template(
             vec![m, k],
@@ -1623,7 +1708,7 @@ impl FaerLinalg for Complex64 {
         }
         let vt = tensor_from_vec_with_template(vec![k, n], vt_data, input);
 
-        vec![u, s, vt]
+        Ok(vec![u, s, vt])
     }
 
     fn qr_2d(
@@ -1691,7 +1776,7 @@ impl FaerLinalg for Complex64 {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>> {
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
         let n = square_matrix_dim(input, "eigh");
         let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), n, n);
         let mut values = Diag::zeros(n);
@@ -1711,7 +1796,7 @@ impl FaerLinalg for Complex64 {
             stack,
             Default::default(),
         )
-        .unwrap_or_else(|_| panic!("eigh: decomposition failed"));
+        .map_err(|_| decomposition_failed("eigh"))?;
 
         let values = tensor_from_vec_with_template(
             vec![n],
@@ -1724,7 +1809,7 @@ impl FaerLinalg for Complex64 {
             input,
         );
 
-        vec![values, vectors]
+        Ok(vec![values, vectors])
     }
 }
 
@@ -1884,13 +1969,13 @@ pub(crate) fn svd<T: FaerLinalg>(
     ctx: &CpuContext,
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
+) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
         let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "svd");
         let m = matrix_shape[0];
         let n = matrix_shape[1];
         let k = m.min(n);
-        return vec![
+        return Ok(vec![
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
@@ -1906,9 +1991,9 @@ pub(crate) fn svd<T: FaerLinalg>(
                 Vec::new(),
                 input,
             ),
-        ];
+        ]);
     }
-    batched_multi(buffers, input, 2, |buffers, batch| {
+    batched_multi_result(buffers, input, 2, |buffers, batch| {
         T::svd_2d(ctx, buffers, batch)
     })
 }
@@ -1945,11 +2030,11 @@ pub(crate) fn eigh<T: FaerLinalg>(
     ctx: &CpuContext,
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
+) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
         let n = input.shape[0];
         let batch_shape = &input.shape[2..];
-        return vec![
+        return Ok(vec![
             tensor_from_vec_with_template(
                 vector_with_batch_shape(n, batch_shape),
                 Vec::new(),
@@ -1960,9 +2045,9 @@ pub(crate) fn eigh<T: FaerLinalg>(
                 Vec::new(),
                 input,
             ),
-        ];
+        ]);
     }
-    batched_multi(buffers, input, 2, |buffers, batch| {
+    batched_multi_result(buffers, input, 2, |buffers, batch| {
         T::eigh_2d(ctx, buffers, batch)
     })
 }
@@ -1971,7 +2056,7 @@ fn eig_real_2d(
     ctx: &CpuContext,
     buffers: &mut BufferPool,
     input: &TypedTensor<f64>,
-) -> Vec<TypedTensor<Complex64>> {
+) -> crate::Result<Vec<TypedTensor<Complex64>>> {
     let n = square_matrix_dim(input, "eig");
     let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
     let mut u_real = Mat::zeros(n, n);
@@ -1995,21 +2080,21 @@ fn eig_real_2d(
         stack,
         Default::default(),
     )
-    .unwrap_or_else(|_| panic!("eig: decomposition failed"));
+    .map_err(|_| decomposition_failed("eig"))?;
     let (u, s) =
         real_eig_to_complex_outputs(buffers, u_real.as_ref(), s_re.as_ref(), s_im.as_ref());
 
-    vec![
+    Ok(vec![
         tensor_from_vec_with_template(vec![n], s, input),
         tensor_from_vec_with_template(vec![n, n], u, input),
-    ]
+    ])
 }
 
 fn eig_complex_2d(
     ctx: &CpuContext,
     buffers: &mut BufferPool,
     input: &TypedTensor<Complex64>,
-) -> Vec<TypedTensor<Complex64>> {
+) -> crate::Result<Vec<TypedTensor<Complex64>>> {
     let n = square_matrix_dim(input, "eig");
     let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), n, n);
     let mut u = Mat::zeros(n, n);
@@ -2031,19 +2116,23 @@ fn eig_complex_2d(
         stack,
         Default::default(),
     )
-    .unwrap_or_else(|_| panic!("eig: decomposition failed"));
+    .map_err(|_| decomposition_failed("eig"))?;
 
-    vec![
+    Ok(vec![
         tensor_from_vec_with_template(vec![n], complex_vec_from_diag(buffers, s.as_ref()), input),
         tensor_from_vec_with_template(vec![n, n], complex_vec_from_mat(buffers, u.as_ref()), input),
-    ]
+    ])
 }
 
-pub(crate) fn eig(ctx: &CpuContext, buffers: &mut BufferPool, input: &Tensor) -> Vec<Tensor> {
+pub(crate) fn eig(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &Tensor,
+) -> crate::Result<Vec<Tensor>> {
     if has_zero_dim(input.shape()) {
         let n = input.shape()[0];
         let batch_shape = &input.shape()[2..];
-        return vec![
+        return Ok(vec![
             Tensor::C64(TypedTensor::from_vec(
                 vector_with_batch_shape(n, batch_shape),
                 Vec::new(),
@@ -2052,22 +2141,26 @@ pub(crate) fn eig(ctx: &CpuContext, buffers: &mut BufferPool, input: &Tensor) ->
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
             )),
-        ];
+        ]);
     }
 
     match input {
-        Tensor::F64(t) => batched_multi_convert(buffers, t, 2, |buffers, batch| {
-            eig_real_2d(ctx, buffers, batch)
-        })
-        .into_iter()
-        .map(Tensor::C64)
-        .collect(),
-        Tensor::C64(t) => batched_multi_convert(buffers, t, 2, |buffers, batch| {
-            eig_complex_2d(ctx, buffers, batch)
-        })
-        .into_iter()
-        .map(Tensor::C64)
-        .collect(),
+        Tensor::F64(t) => Ok(
+            batched_multi_convert_result(buffers, t, 2, |buffers, batch| {
+                eig_real_2d(ctx, buffers, batch)
+            })?
+            .into_iter()
+            .map(Tensor::C64)
+            .collect(),
+        ),
+        Tensor::C64(t) => Ok(
+            batched_multi_convert_result(buffers, t, 2, |buffers, batch| {
+                eig_complex_2d(ctx, buffers, batch)
+            })?
+            .into_iter()
+            .map(Tensor::C64)
+            .collect(),
+        ),
         _ => todo!("eig: unsupported dtype"),
     }
 }

--- a/tenferro-tensor/src/tests/cpu_indexing_coverage_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_indexing_coverage_tests.rs
@@ -1,0 +1,656 @@
+use num_complex::{Complex32, Complex64};
+
+use crate::backend::TensorBackend;
+use crate::config::{DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig};
+use crate::cpu::{dynamic_slice, gather, pad, scatter, CpuBackend};
+use crate::types::{Tensor, TypedTensor};
+
+fn simple_gather_config() -> GatherConfig {
+    GatherConfig {
+        offset_dims: vec![],
+        collapsed_slice_dims: vec![0],
+        start_index_map: vec![0],
+        index_vector_dim: 1,
+        slice_sizes: vec![1],
+    }
+}
+
+fn valid_gather_2d_config() -> GatherConfig {
+    GatherConfig {
+        offset_dims: vec![1],
+        collapsed_slice_dims: vec![0],
+        start_index_map: vec![0],
+        index_vector_dim: 1,
+        slice_sizes: vec![1, 2],
+    }
+}
+
+fn diagonal_scatter_config() -> ScatterConfig {
+    ScatterConfig {
+        update_window_dims: vec![],
+        inserted_window_dims: vec![0, 1],
+        scatter_dims_to_operand_dims: vec![0, 1],
+        index_vector_dim: 1,
+    }
+}
+
+fn expect_invalid_config(result: crate::Result<Tensor>, op: &'static str) {
+    assert!(matches!(
+        result,
+        Err(crate::Error::InvalidConfig { op: actual, .. }) if actual == op
+    ));
+}
+
+fn expect_rank_mismatch(result: crate::Result<Tensor>, op: &'static str) {
+    assert!(matches!(
+        result,
+        Err(crate::Error::RankMismatch { op: actual, .. }) if actual == op
+    ));
+}
+
+fn expect_axis_oob(result: crate::Result<Tensor>, op: &'static str) {
+    assert!(matches!(
+        result,
+        Err(crate::Error::AxisOutOfBounds { op: actual, .. }) if actual == op
+    ));
+}
+
+fn expect_duplicate_axis(result: crate::Result<Tensor>, op: &'static str) {
+    assert!(matches!(
+        result,
+        Err(crate::Error::DuplicateAxis { op: actual, .. }) if actual == op
+    ));
+}
+
+#[test]
+fn cpu_indexing_dispatch_covers_supported_dtypes() {
+    let indices = Tensor::from_vec(vec![2], vec![0_i64, 2]);
+
+    let f32_operand = Tensor::F32(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
+    assert_eq!(
+        gather(&f32_operand, &indices, &simple_gather_config())
+            .unwrap()
+            .shape(),
+        &[2]
+    );
+
+    let c32_operand = Tensor::C32(TypedTensor::from_vec(
+        vec![3],
+        vec![
+            Complex32::new(1.0, 0.0),
+            Complex32::new(2.0, 1.0),
+            Complex32::new(3.0, 2.0),
+        ],
+    ));
+    assert_eq!(
+        gather(&c32_operand, &indices, &simple_gather_config())
+            .unwrap()
+            .shape(),
+        &[2]
+    );
+
+    let c64_operand = Tensor::C64(TypedTensor::from_vec(
+        vec![3],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 1.0),
+            Complex64::new(3.0, 2.0),
+        ],
+    ));
+    assert_eq!(
+        gather(&c64_operand, &indices, &simple_gather_config())
+            .unwrap()
+            .shape(),
+        &[2]
+    );
+
+    let i64_operand = Tensor::from_vec(vec![3], vec![1_i64, 2, 3]);
+    assert!(matches!(
+        gather(&i64_operand, &indices, &simple_gather_config()),
+        Err(crate::Error::BackendFailure { op: "gather", .. })
+    ));
+
+    let scatter_indices = Tensor::from_vec(vec![2, 2], vec![0_i64, 1, 0, 1]);
+
+    let f32_updates = Tensor::F32(TypedTensor::from_vec(vec![2], vec![5.0, 6.0]));
+    assert_eq!(
+        scatter(
+            &Tensor::F32(TypedTensor::zeros(vec![2, 2])),
+            &scatter_indices,
+            &f32_updates,
+            &diagonal_scatter_config(),
+        )
+        .unwrap()
+        .shape(),
+        &[2, 2]
+    );
+
+    let c32_updates = Tensor::C32(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex32::new(5.0, 1.0), Complex32::new(6.0, 2.0)],
+    ));
+    assert_eq!(
+        scatter(
+            &Tensor::C32(TypedTensor::zeros(vec![2, 2])),
+            &scatter_indices,
+            &c32_updates,
+            &diagonal_scatter_config(),
+        )
+        .unwrap()
+        .shape(),
+        &[2, 2]
+    );
+
+    let c64_updates = Tensor::C64(TypedTensor::from_vec(
+        vec![2],
+        vec![Complex64::new(5.0, 1.0), Complex64::new(6.0, 2.0)],
+    ));
+    assert_eq!(
+        scatter(
+            &Tensor::C64(TypedTensor::zeros(vec![2, 2])),
+            &scatter_indices,
+            &c64_updates,
+            &diagonal_scatter_config(),
+        )
+        .unwrap()
+        .shape(),
+        &[2, 2]
+    );
+
+    assert!(matches!(
+        scatter(
+            &Tensor::from_vec(vec![2, 2], vec![0_i64; 4]),
+            &scatter_indices,
+            &Tensor::from_vec(vec![2], vec![1_i64, 2]),
+            &diagonal_scatter_config(),
+        ),
+        Err(crate::Error::BackendFailure { op: "scatter", .. })
+    ));
+    assert!(matches!(
+        scatter(
+            &Tensor::F32(TypedTensor::zeros(vec![2, 2])),
+            &scatter_indices,
+            &Tensor::F64(TypedTensor::zeros(vec![2])),
+            &diagonal_scatter_config(),
+        ),
+        Err(crate::Error::DTypeMismatch { op: "scatter", .. })
+    ));
+
+    let slice_cfg = SliceConfig {
+        starts: vec![0],
+        limits: vec![2],
+        strides: vec![1],
+    };
+    assert_eq!(
+        crate::cpu::indexing::slice(&f32_operand, &slice_cfg)
+            .unwrap()
+            .shape(),
+        &[2]
+    );
+    assert_eq!(
+        crate::cpu::indexing::slice(&i64_operand, &slice_cfg)
+            .unwrap()
+            .shape(),
+        &[2]
+    );
+    assert_eq!(
+        crate::cpu::indexing::slice(&c32_operand, &slice_cfg)
+            .unwrap()
+            .shape(),
+        &[2]
+    );
+    assert_eq!(
+        crate::cpu::indexing::slice(&c64_operand, &slice_cfg)
+            .unwrap()
+            .shape(),
+        &[2]
+    );
+
+    let starts = Tensor::from_vec(vec![1], vec![1_i64]);
+    assert_eq!(
+        dynamic_slice(&f32_operand, &starts, &[2]).unwrap().shape(),
+        &[2]
+    );
+    assert_eq!(
+        dynamic_slice(&c32_operand, &starts, &[2]).unwrap().shape(),
+        &[2]
+    );
+    assert_eq!(
+        dynamic_slice(&c64_operand, &starts, &[2]).unwrap().shape(),
+        &[2]
+    );
+    assert!(matches!(
+        dynamic_slice(&i64_operand, &starts, &[2]),
+        Err(crate::Error::BackendFailure {
+            op: "dynamic_slice",
+            ..
+        })
+    ));
+
+    let pad_cfg = PadConfig {
+        edge_padding_low: vec![1],
+        edge_padding_high: vec![1],
+        interior_padding: vec![0],
+    };
+    assert_eq!(pad(&f32_operand, &pad_cfg).unwrap().shape(), &[5]);
+    assert_eq!(pad(&i64_operand, &pad_cfg).unwrap().shape(), &[5]);
+    assert_eq!(pad(&c32_operand, &pad_cfg).unwrap().shape(), &[5]);
+    assert_eq!(pad(&c64_operand, &pad_cfg).unwrap().shape(), &[5]);
+
+    let mut backend = CpuBackend::new();
+    assert_eq!(
+        backend
+            .concatenate(&[&f32_operand, &f32_operand], 0)
+            .unwrap()
+            .shape(),
+        &[6]
+    );
+    assert_eq!(
+        backend
+            .concatenate(&[&i64_operand, &i64_operand], 0)
+            .unwrap()
+            .shape(),
+        &[6]
+    );
+    assert_eq!(
+        backend
+            .concatenate(&[&c32_operand, &c32_operand], 0)
+            .unwrap()
+            .shape(),
+        &[6]
+    );
+    assert_eq!(
+        backend
+            .concatenate(&[&c64_operand, &c64_operand], 0)
+            .unwrap()
+            .shape(),
+        &[6]
+    );
+
+    assert_eq!(backend.reverse(&f32_operand, &[0]).unwrap().shape(), &[3]);
+    assert_eq!(backend.reverse(&c32_operand, &[0]).unwrap().shape(), &[3]);
+    assert_eq!(backend.reverse(&c64_operand, &[0]).unwrap().shape(), &[3]);
+}
+
+#[test]
+fn cpu_indexing_validation_covers_error_branches() {
+    let mut backend = CpuBackend::new();
+    let input = Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.0, 2.0]));
+
+    expect_rank_mismatch(
+        backend.slice(
+            &input,
+            &SliceConfig {
+                starts: vec![0],
+                limits: vec![2, 2],
+                strides: vec![1],
+            },
+        ),
+        "slice",
+    );
+    expect_rank_mismatch(
+        backend.slice(
+            &input,
+            &SliceConfig {
+                starts: vec![0],
+                limits: vec![2],
+                strides: vec![1, 1],
+            },
+        ),
+        "slice",
+    );
+    expect_invalid_config(
+        backend.slice(
+            &input,
+            &SliceConfig {
+                starts: vec![2],
+                limits: vec![1],
+                strides: vec![1],
+            },
+        ),
+        "slice",
+    );
+    expect_axis_oob(
+        backend.slice(
+            &input,
+            &SliceConfig {
+                starts: vec![0],
+                limits: vec![3],
+                strides: vec![1],
+            },
+        ),
+        "slice",
+    );
+    expect_invalid_config(
+        backend.slice(
+            &input,
+            &SliceConfig {
+                starts: vec![0],
+                limits: vec![2],
+                strides: vec![0],
+            },
+        ),
+        "slice",
+    );
+
+    let matrix = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
+    expect_rank_mismatch(
+        backend.dynamic_slice(&matrix, &Tensor::from_vec(vec![2], vec![0_i64, 0]), &[1]),
+        "dynamic_slice",
+    );
+    expect_invalid_config(
+        backend.dynamic_slice(&matrix, &Tensor::from_vec(vec![1, 1], vec![0_i64]), &[1, 1]),
+        "dynamic_slice",
+    );
+    expect_invalid_config(
+        backend.dynamic_slice(&matrix, &Tensor::from_vec(vec![1], vec![0_i64]), &[1, 1]),
+        "dynamic_slice",
+    );
+
+    expect_rank_mismatch(
+        backend.pad(
+            &input,
+            &PadConfig {
+                edge_padding_low: vec![0, 0],
+                edge_padding_high: vec![0],
+                interior_padding: vec![0],
+            },
+        ),
+        "pad",
+    );
+    expect_rank_mismatch(
+        backend.pad(
+            &input,
+            &PadConfig {
+                edge_padding_low: vec![0],
+                edge_padding_high: vec![0],
+                interior_padding: vec![0, 0],
+            },
+        ),
+        "pad",
+    );
+    expect_invalid_config(
+        backend.pad(
+            &input,
+            &PadConfig {
+                edge_padding_low: vec![0],
+                edge_padding_high: vec![0],
+                interior_padding: vec![-1],
+            },
+        ),
+        "pad",
+    );
+    expect_invalid_config(
+        backend.pad(
+            &input,
+            &PadConfig {
+                edge_padding_low: vec![-3],
+                edge_padding_high: vec![0],
+                interior_padding: vec![0],
+            },
+        ),
+        "pad",
+    );
+
+    let operand_2d = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
+    let idx = Tensor::from_vec(vec![1, 1], vec![0_i64]);
+    let idx2 = Tensor::from_vec(vec![1, 2], vec![0_i64, 0]);
+
+    expect_invalid_config(
+        gather(
+            &operand_2d,
+            &Tensor::F32(TypedTensor::from_vec(vec![1, 1], vec![0.5])),
+            &valid_gather_2d_config(),
+        ),
+        "index_tensor",
+    );
+    expect_invalid_config(
+        gather(
+            &operand_2d,
+            &Tensor::F32(TypedTensor::from_vec(vec![1, 1], vec![16_777_218.0])),
+            &valid_gather_2d_config(),
+        ),
+        "index_tensor",
+    );
+    expect_invalid_config(
+        gather(
+            &operand_2d,
+            &Tensor::F64(TypedTensor::from_vec(
+                vec![1, 1],
+                vec![9_007_199_254_740_994.0],
+            )),
+            &valid_gather_2d_config(),
+        ),
+        "index_tensor",
+    );
+
+    let mut gather_cfg = valid_gather_2d_config();
+    gather_cfg.slice_sizes = vec![1];
+    expect_rank_mismatch(gather(&operand_2d, &idx, &gather_cfg), "gather");
+
+    let mut gather_cfg = valid_gather_2d_config();
+    gather_cfg.collapsed_slice_dims = vec![2];
+    expect_axis_oob(gather(&operand_2d, &idx, &gather_cfg), "gather");
+
+    let mut gather_cfg = valid_gather_2d_config();
+    gather_cfg.collapsed_slice_dims = vec![0, 0];
+    expect_duplicate_axis(gather(&operand_2d, &idx, &gather_cfg), "gather");
+
+    let mut gather_cfg = valid_gather_2d_config();
+    gather_cfg.start_index_map = vec![0, 1];
+    expect_invalid_config(gather(&operand_2d, &idx, &gather_cfg), "gather");
+
+    let mut gather_cfg = valid_gather_2d_config();
+    gather_cfg.start_index_map = vec![2];
+    expect_axis_oob(gather(&operand_2d, &idx, &gather_cfg), "gather");
+
+    let mut gather_cfg = valid_gather_2d_config();
+    gather_cfg.start_index_map = vec![0, 0];
+    expect_duplicate_axis(gather(&operand_2d, &idx2, &gather_cfg), "gather");
+
+    let mut gather_cfg = valid_gather_2d_config();
+    gather_cfg.offset_dims = vec![];
+    expect_invalid_config(gather(&operand_2d, &idx, &gather_cfg), "gather");
+
+    let mut gather_cfg = valid_gather_2d_config();
+    gather_cfg.offset_dims = vec![2];
+    expect_axis_oob(gather(&operand_2d, &idx, &gather_cfg), "gather");
+
+    let gather_cfg = GatherConfig {
+        offset_dims: vec![0, 0],
+        collapsed_slice_dims: vec![],
+        start_index_map: vec![0],
+        index_vector_dim: 1,
+        slice_sizes: vec![1, 1],
+    };
+    expect_duplicate_axis(gather(&operand_2d, &idx, &gather_cfg), "gather");
+
+    let updates = Tensor::F64(TypedTensor::from_vec(vec![1], vec![5.0]));
+    let mut scatter_cfg = diagonal_scatter_config();
+    scatter_cfg.inserted_window_dims = vec![2];
+    expect_axis_oob(
+        scatter(&operand_2d, &idx2, &updates, &scatter_cfg),
+        "scatter",
+    );
+
+    let mut scatter_cfg = diagonal_scatter_config();
+    scatter_cfg.inserted_window_dims = vec![0, 0];
+    expect_duplicate_axis(
+        scatter(&operand_2d, &idx2, &updates, &scatter_cfg),
+        "scatter",
+    );
+
+    let mut scatter_cfg = diagonal_scatter_config();
+    scatter_cfg.scatter_dims_to_operand_dims = vec![0];
+    expect_invalid_config(
+        scatter(&operand_2d, &idx2, &updates, &scatter_cfg),
+        "scatter",
+    );
+
+    let mut scatter_cfg = diagonal_scatter_config();
+    scatter_cfg.scatter_dims_to_operand_dims = vec![0, 2];
+    expect_axis_oob(
+        scatter(&operand_2d, &idx2, &updates, &scatter_cfg),
+        "scatter",
+    );
+
+    let mut scatter_cfg = diagonal_scatter_config();
+    scatter_cfg.scatter_dims_to_operand_dims = vec![0, 0];
+    expect_duplicate_axis(
+        scatter(&operand_2d, &idx2, &updates, &scatter_cfg),
+        "scatter",
+    );
+
+    let scatter_cfg = ScatterConfig {
+        update_window_dims: vec![],
+        inserted_window_dims: vec![0],
+        scatter_dims_to_operand_dims: vec![0, 1],
+        index_vector_dim: 1,
+    };
+    expect_invalid_config(
+        scatter(&operand_2d, &idx2, &updates, &scatter_cfg),
+        "scatter",
+    );
+
+    let scatter_cfg = ScatterConfig {
+        update_window_dims: vec![0, 1],
+        inserted_window_dims: vec![],
+        scatter_dims_to_operand_dims: vec![0, 1],
+        index_vector_dim: 1,
+    };
+    expect_invalid_config(
+        scatter(&operand_2d, &idx2, &updates, &scatter_cfg),
+        "scatter",
+    );
+
+    let scatter_cfg = diagonal_scatter_config();
+    let bad_batch_updates = Tensor::F64(TypedTensor::from_vec(vec![1, 1], vec![5.0]));
+    expect_invalid_config(
+        scatter(&operand_2d, &idx2, &bad_batch_updates, &scatter_cfg),
+        "scatter",
+    );
+
+    let scatter_cfg = ScatterConfig {
+        update_window_dims: vec![2],
+        inserted_window_dims: vec![0],
+        scatter_dims_to_operand_dims: vec![0, 1],
+        index_vector_dim: 1,
+    };
+    let updates_2d = Tensor::F64(TypedTensor::from_vec(vec![1, 1], vec![5.0]));
+    expect_axis_oob(
+        scatter(&operand_2d, &idx2, &updates_2d, &scatter_cfg),
+        "scatter",
+    );
+
+    let scatter_cfg = ScatterConfig {
+        update_window_dims: vec![0, 0],
+        inserted_window_dims: vec![],
+        scatter_dims_to_operand_dims: vec![0, 1],
+        index_vector_dim: 1,
+    };
+    let updates_3d = Tensor::F64(TypedTensor::from_vec(vec![1, 1, 1], vec![5.0]));
+    expect_duplicate_axis(
+        scatter(&operand_2d, &idx2, &updates_3d, &scatter_cfg),
+        "scatter",
+    );
+
+    let scatter_cfg = diagonal_scatter_config();
+    let mismatched_updates = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
+    expect_invalid_config(
+        scatter(&operand_2d, &idx2, &mismatched_updates, &scatter_cfg),
+        "scatter",
+    );
+}
+
+#[test]
+fn cpu_exec_session_covers_complex_linalg_and_error_dispatch() {
+    let mut backend = CpuBackend::new();
+    backend.with_exec_session(|exec| {
+        let eye = Tensor::C64(TypedTensor::from_vec(
+            vec![2, 2],
+            vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(1.0, 0.0),
+            ],
+        ));
+        let rhs = Tensor::C64(TypedTensor::from_vec(
+            vec![2, 1],
+            vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+        ));
+
+        assert_eq!(exec.cholesky(&eye).unwrap().shape(), &[2, 2]);
+        assert_eq!(exec.lu(&eye).unwrap().len(), 4);
+        assert_eq!(exec.full_piv_lu(&eye).unwrap().len(), 5);
+        assert_eq!(
+            exec.full_piv_lu_solve(&eye, &rhs, false).unwrap().shape(),
+            &[2, 1]
+        );
+        assert_eq!(
+            exec.triangular_solve(&eye, &rhs, true, true, false, false)
+                .unwrap()
+                .shape(),
+            &[2, 1]
+        );
+        assert_eq!(exec.svd(&eye).unwrap().len(), 3);
+        assert_eq!(exec.qr(&eye).unwrap().len(), 2);
+        assert_eq!(exec.eigh(&eye).unwrap().len(), 2);
+        assert_eq!(exec.eig(&eye).unwrap().len(), 2);
+
+        let f32_vec = Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.0, 2.0]));
+        assert!(matches!(
+            exec.eig(&f32_vec),
+            Err(crate::Error::BackendFailure { op: "eig", .. })
+        ));
+        assert!(matches!(
+            exec.triangular_solve(&f32_vec, &f32_vec, true, true, false, false),
+            Err(crate::Error::BackendFailure {
+                op: "triangular_solve",
+                ..
+            })
+        ));
+        assert!(matches!(
+            exec.full_piv_lu_solve(&f32_vec, &f32_vec, false),
+            Err(crate::Error::BackendFailure {
+                op: "full_piv_lu_solve",
+                ..
+            })
+        ));
+
+        let f64_vec = Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.0, 2.0]));
+        assert!(matches!(
+            exec.triangular_solve(&f64_vec, &f32_vec, true, true, false, false),
+            Err(crate::Error::DTypeMismatch {
+                op: "triangular_solve",
+                ..
+            })
+        ));
+        assert!(matches!(
+            exec.full_piv_lu_solve(&f64_vec, &f32_vec, false),
+            Err(crate::Error::DTypeMismatch {
+                op: "full_piv_lu_solve",
+                ..
+            })
+        ));
+
+        let dot_cfg = DotGeneralConfig {
+            lhs_contracting_dims: vec![0],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        };
+        assert!(matches!(
+            exec.dot_general(&f64_vec, &f32_vec, &dot_cfg),
+            Err(crate::Error::DTypeMismatch {
+                op: "dot_general",
+                ..
+            })
+        ));
+
+        exec.reclaim_buffer(Tensor::F32(TypedTensor::zeros(vec![1])));
+        exec.reclaim_buffer(Tensor::F64(TypedTensor::zeros(vec![1])));
+        exec.reclaim_buffer(Tensor::C32(TypedTensor::zeros(vec![1])));
+        exec.reclaim_buffer(Tensor::C64(TypedTensor::zeros(vec![1])));
+    });
+}

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -5,10 +5,14 @@ use std::{ffi::OsString, sync::MutexGuard};
 use num_complex::{Complex32, Complex64};
 
 use crate::backend::TensorBackend;
+#[cfg(feature = "cpu-faer")]
+use crate::buffer_pool::BufferPool;
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
 use crate::cpu::backend;
+#[cfg(feature = "cpu-faer")]
+use crate::cpu::linalg::faer_linalg;
 use crate::cpu::{
     abs, add, broadcast_in_dim, clamp, compare, conj, div, dynamic_slice, embed_diagonal,
     extract_diagonal, gather, maximum, minimum, mul, neg, pad, reduce_max, reduce_min, reduce_prod,
@@ -3304,6 +3308,33 @@ fn test_svd_unsupported_dtype_returns_error() {
     ));
     let mut backend = CpuBackend::new();
     assert!(backend.svd(&input).is_err());
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn test_faer_svd_decomposition_failure_returns_error() {
+    let ctx = CpuContext::with_threads(1);
+    let mut buffers = BufferPool::new();
+    let input = TypedTensor::from_vec(vec![2, 2], vec![f64::NAN, 0.0, 0.0, 1.0]);
+
+    let err = faer_linalg::svd(&ctx, &mut buffers, &input).unwrap_err();
+
+    assert!(err.to_string().contains("svd"), "unexpected error: {err}");
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn test_faer_eig_decomposition_failure_returns_error() {
+    let ctx = CpuContext::with_threads(1);
+    let mut buffers = BufferPool::new();
+    let input = Tensor::F64(TypedTensor::from_vec(
+        vec![2, 2],
+        vec![f64::NAN, 0.0, 0.0, 1.0],
+    ));
+
+    let err = faer_linalg::eig(&ctx, &mut buffers, &input).unwrap_err();
+
+    assert!(err.to_string().contains("eig"), "unexpected error: {err}");
 }
 
 #[test]

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -675,6 +675,99 @@ fn test_reverse_axis_zero() {
 }
 
 #[test]
+fn test_reverse_accepts_i64_data_tensor() {
+    let input = Tensor::from_vec(vec![3], vec![1_i64, 2, 3]);
+    let mut backend = CpuBackend::new();
+
+    let out = backend.reverse(&input, &[0]).unwrap();
+
+    assert_eq!(out.dtype(), DType::I64);
+    assert_eq!(out.shape(), &[3]);
+    assert_eq!(out.as_slice::<i64>(), Some([3, 2, 1].as_slice()));
+}
+
+#[test]
+fn test_reverse_axis_out_of_bounds_returns_error() {
+    let input = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
+    let mut backend = CpuBackend::new();
+
+    let err = backend.reverse(&input, &[1]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        crate::Error::AxisOutOfBounds {
+            op: "reverse",
+            axis: 1,
+            rank: 1,
+        }
+    ));
+}
+
+#[test]
+fn test_gather_rejects_fractional_float_indices() {
+    let operand = Tensor::F64(TypedTensor::from_vec(
+        vec![5],
+        vec![10.0, 20.0, 30.0, 40.0, 50.0],
+    ));
+    let start_indices = Tensor::F64(TypedTensor::from_vec(vec![1, 1], vec![1.5]));
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .gather(&operand, &start_indices, &simple_gather_config())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        crate::Error::InvalidConfig {
+            op: "index_tensor",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn test_gather_rejects_complex_indices() {
+    let operand = Tensor::F64(TypedTensor::from_vec(
+        vec![5],
+        vec![10.0, 20.0, 30.0, 40.0, 50.0],
+    ));
+    let start_indices = Tensor::C64(TypedTensor::from_vec(
+        vec![1, 1],
+        vec![Complex64::new(1.0, 0.0)],
+    ));
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .gather(&operand, &start_indices, &simple_gather_config())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        crate::Error::InvalidConfig {
+            op: "index_tensor",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn test_dynamic_slice_rejects_oversized_window() {
+    let input = Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.0, 2.0]));
+    let starts = Tensor::from_vec(vec![1], vec![0_i64]);
+    let mut backend = CpuBackend::new();
+
+    let err = backend.dynamic_slice(&input, &starts, &[3]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        crate::Error::InvalidConfig {
+            op: "dynamic_slice",
+            ..
+        }
+    ));
+}
+
+#[test]
 fn test_concatenate_axis_zero() {
     let lhs = Tensor::F64(TypedTensor::from_vec(
         vec![2, 3],
@@ -2314,7 +2407,7 @@ fn test_gather_1d_indices() {
     ));
     let start_indices = Tensor::from_vec(vec![3, 1], vec![0_i64, 2, 4]);
 
-    let out = gather(&operand, &start_indices, &simple_gather_config());
+    let out = gather(&operand, &start_indices, &simple_gather_config()).unwrap();
 
     assert_eq!(out.shape(), &[3]);
     assert_eq!(get_f64(&out, &[0]), 10.0);
@@ -2330,7 +2423,7 @@ fn test_gather_accepts_i64_indices() {
     ));
     let start_indices = Tensor::from_vec(vec![3, 1], vec![0_i64, 2, 4]);
 
-    let out = gather(&operand, &start_indices, &simple_gather_config());
+    let out = gather(&operand, &start_indices, &simple_gather_config()).unwrap();
 
     assert_eq!(start_indices.dtype(), DType::I64);
     assert_eq!(start_indices.as_slice::<i64>(), Some([0, 2, 4].as_slice()));
@@ -2355,7 +2448,7 @@ fn test_gather_with_implicit_index_vector_dim() {
         slice_sizes: vec![1],
     };
 
-    let out = gather(&operand, &start_indices, &config);
+    let out = gather(&operand, &start_indices, &config).unwrap();
     assert_eq!(out.shape(), &[3]);
     assert_eq!(get_f64(&out, &[0]), 50.0);
     assert_eq!(get_f64(&out, &[1]), 20.0);
@@ -2373,7 +2466,8 @@ fn test_scatter_accepts_i64_indices() {
         &scatter_indices,
         &updates,
         &diagonal_scatter_config(),
-    );
+    )
+    .unwrap();
 
     assert_eq!(scatter_indices.dtype(), DType::I64);
     assert_eq!(out.shape(), &[3, 3]);
@@ -2393,7 +2487,8 @@ fn test_scatter_to_diagonal() {
         &scatter_indices,
         &updates,
         &diagonal_scatter_config(),
-    );
+    )
+    .unwrap();
 
     assert_eq!(out.shape(), &[3, 3]);
     assert_eq!(get_f64(&out, &[0, 0]), 5.0);
@@ -2415,7 +2510,7 @@ fn test_scatter_skips_negative_and_out_of_bounds_windows() {
         index_vector_dim: 1,
     };
 
-    let out = scatter(&operand, &scatter_indices, &updates, &config);
+    let out = scatter(&operand, &scatter_indices, &updates, &config).unwrap();
     assert_eq!(out.shape(), &[4]);
     assert_eq!(get_f64(&out, &[0]), 0.0);
     assert_eq!(get_f64(&out, &[1]), 0.0);
@@ -2435,7 +2530,7 @@ fn test_pad_adds_zero_edges() {
         interior_padding: vec![0, 0],
     };
 
-    let out = pad(&input, &config);
+    let out = pad(&input, &config).unwrap();
 
     assert_eq!(out.shape(), &[4, 5]);
     assert_eq!(get_f64(&out, &[1, 1]), 1.0);
@@ -2455,7 +2550,7 @@ fn test_pad_with_interior_spacing() {
         interior_padding: vec![1],
     };
 
-    let out = pad(&input, &config);
+    let out = pad(&input, &config).unwrap();
     assert_eq!(out.shape(), &[5]);
     assert_eq!(get_f64(&out, &[0]), 0.0);
     assert_eq!(get_f64(&out, &[1]), 1.0);
@@ -2474,7 +2569,7 @@ fn test_dynamic_slice_clamps_starts() {
     ));
     let starts = Tensor::from_vec(vec![2], vec![2_i64, 3]);
 
-    let out = dynamic_slice(&input, &starts, &[2, 2]);
+    let out = dynamic_slice(&input, &starts, &[2, 2]).unwrap();
 
     assert_eq!(out.shape(), &[2, 2]);
     assert_eq!(get_f64(&out, &[0, 0]), 11.0);
@@ -2493,7 +2588,7 @@ fn test_dynamic_slice_accepts_i64_starts() {
     ));
     let starts = Tensor::from_vec(vec![2], vec![2_i64, 3]);
 
-    let out = dynamic_slice(&input, &starts, &[2, 2]);
+    let out = dynamic_slice(&input, &starts, &[2, 2]).unwrap();
 
     assert_eq!(starts.dtype(), DType::I64);
     assert_eq!(out.shape(), &[2, 2]);

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -768,6 +768,144 @@ fn test_dynamic_slice_rejects_oversized_window() {
 }
 
 #[test]
+fn test_large_float_index_outside_exact_integer_range_returns_error() {
+    let operand = Tensor::F64(TypedTensor::from_vec(
+        vec![5],
+        vec![10.0, 20.0, 30.0, 40.0, 50.0],
+    ));
+    let start_indices = Tensor::F64(TypedTensor::from_vec(
+        vec![1, 1],
+        vec![9_007_199_254_740_995.0f64],
+    ));
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .gather(&operand, &start_indices, &simple_gather_config())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        crate::Error::InvalidConfig {
+            op: "index_tensor",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn test_invalid_slice_config_returns_error() {
+    let input = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .slice(
+            &input,
+            &SliceConfig {
+                starts: vec![0, 0, 0],
+                limits: vec![2, 2],
+                strides: vec![1, 1],
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::RankMismatch { op: "slice", .. }
+    ));
+}
+
+#[test]
+fn test_invalid_pad_config_returns_error() {
+    let input = Tensor::F64(TypedTensor::from_vec(vec![2], vec![1.0, 2.0]));
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .pad(
+            &input,
+            &PadConfig {
+                edge_padding_low: vec![0],
+                edge_padding_high: vec![0, 0],
+                interior_padding: vec![0],
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(err, crate::Error::RankMismatch { op: "pad", .. }));
+}
+
+#[test]
+fn test_gather_rejects_malformed_offset_dims() {
+    let operand = Tensor::F64(TypedTensor::from_vec(
+        vec![3, 2],
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+    let start_indices = Tensor::from_vec(vec![3, 1], vec![0_i64, 1, 2]);
+    let mut backend = CpuBackend::new();
+    let config = GatherConfig {
+        offset_dims: vec![2],
+        collapsed_slice_dims: vec![0],
+        start_index_map: vec![0],
+        index_vector_dim: 1,
+        slice_sizes: vec![1, 2],
+    };
+
+    let err = backend
+        .gather(&operand, &start_indices, &config)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::AxisOutOfBounds { op: "gather", .. }
+    ));
+}
+
+#[test]
+fn test_scatter_rejects_update_window_dim_out_of_bounds() {
+    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3, 3]));
+    let scatter_indices = Tensor::from_vec(vec![3, 2], vec![0_i64, 0, 1, 1, 2, 2]);
+    let updates = Tensor::F64(TypedTensor::from_vec(vec![3, 3, 3], vec![0.0; 27]));
+    let mut backend = CpuBackend::new();
+    let config = ScatterConfig {
+        update_window_dims: vec![0, 3],
+        inserted_window_dims: vec![0],
+        scatter_dims_to_operand_dims: vec![1, 2],
+        index_vector_dim: 1,
+    };
+
+    let err = backend
+        .scatter(&operand, &scatter_indices, &updates, &config)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::AxisOutOfBounds {
+            op: "scatter",
+            axis: 3,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn test_scatter_rejects_too_many_update_window_dims() {
+    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3, 3]));
+    let scatter_indices = Tensor::from_vec(vec![3, 2], vec![0_i64, 0, 1, 1, 2, 2]);
+    let updates = Tensor::F64(TypedTensor::from_vec(vec![3], vec![0.0; 3]));
+    let mut backend = CpuBackend::new();
+    let config = ScatterConfig {
+        update_window_dims: vec![0, 1],
+        inserted_window_dims: vec![0],
+        scatter_dims_to_operand_dims: vec![1, 2],
+        index_vector_dim: 1,
+    };
+
+    let err = backend
+        .scatter(&operand, &scatter_indices, &updates, &config)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::InvalidConfig { op: "scatter", ref message }
+        if message.contains("exceeds update rank")
+    ));
+}
+
+#[test]
 fn test_concatenate_axis_zero() {
     let lhs = Tensor::F64(TypedTensor::from_vec(
         vec![2, 3],

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -44,6 +44,13 @@ fn get_c32(t: &Tensor, idx: &[usize]) -> Complex32 {
     }
 }
 
+fn get_i64(t: &Tensor, idx: &[usize]) -> i64 {
+    match t {
+        Tensor::I64(inner) => *inner.get(idx),
+        _ => panic!("expected I64 tensor"),
+    }
+}
+
 fn assert_f64_close(actual: f64, expected: f64) {
     assert!(
         (actual - expected).abs() < 1.0e-12,
@@ -459,6 +466,24 @@ fn test_add_mul() {
     assert_eq!(get_f64(&prod, &[1, 0]), 40.0);
     assert_eq!(get_f64(&prod, &[0, 1]), 90.0);
     assert_eq!(get_f64(&prod, &[1, 1]), 160.0);
+}
+
+#[test]
+fn test_add_mul_i64() {
+    let a = Tensor::I64(TypedTensor::from_vec(vec![2, 2], vec![1, 2, 3, 4]));
+    let b = Tensor::I64(TypedTensor::from_vec(vec![2, 2], vec![10, 20, 30, 40]));
+    let sum = add(&a, &b).unwrap();
+    let prod = mul(&a, &b).unwrap();
+
+    assert_eq!(get_i64(&sum, &[0, 0]), 11);
+    assert_eq!(get_i64(&sum, &[1, 0]), 22);
+    assert_eq!(get_i64(&sum, &[0, 1]), 33);
+    assert_eq!(get_i64(&sum, &[1, 1]), 44);
+
+    assert_eq!(get_i64(&prod, &[0, 0]), 10);
+    assert_eq!(get_i64(&prod, &[1, 0]), 40);
+    assert_eq!(get_i64(&prod, &[0, 1]), 90);
+    assert_eq!(get_i64(&prod, &[1, 1]), 160);
 }
 
 #[test]

--- a/tenferro-tensor/src/tests/mod.rs
+++ b/tenferro-tensor/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod config_tests;
+mod cpu_indexing_coverage_tests;
 mod cpu_stub_tests;
 mod cpu_tests;
 mod eager_api_tests;

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -744,36 +744,6 @@ impl ConjElem for Complex<f64> {
     }
 }
 
-macro_rules! dispatch_tensor {
-    ($self:expr, $inner:ident => $body:expr) => {
-        match $self {
-            Tensor::F32($inner) => Tensor::F32($body),
-            Tensor::F64($inner) => Tensor::F64($body),
-            Tensor::I64(_) => panic!("I64 data tensors are not supported by this operation"),
-            Tensor::C32($inner) => Tensor::C32($body),
-            Tensor::C64($inner) => Tensor::C64($body),
-        }
-    };
-}
-
-macro_rules! dispatch_binary {
-    ($lhs:expr, $rhs:expr, |$a:ident, $b:ident| $body:expr) => {
-        match ($lhs, $rhs) {
-            (Tensor::F32($a), Tensor::F32($b)) => Tensor::F32($body),
-            (Tensor::F64($a), Tensor::F64($b)) => Tensor::F64($body),
-            (Tensor::I64(_), Tensor::I64(_)) => {
-                panic!("I64 data tensors are not supported by this operation")
-            }
-            (Tensor::C32($a), Tensor::C32($b)) => Tensor::C32($body),
-            (Tensor::C64($a), Tensor::C64($b)) => Tensor::C64($body),
-            _ => panic!("dtype mismatch in binary op"),
-        }
-    };
-}
-
-pub(crate) use dispatch_binary;
-pub(crate) use dispatch_tensor;
-
 impl Tensor {
     /// Create a tensor from a shape and flat data.
     ///

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -5,6 +5,7 @@ use tenferro_tensor::validate::validate_nonsingular_u;
 use tenferro_tensor::{DType, PadConfig, SliceConfig, Tensor, TensorBackend, TypedTensor};
 
 use crate::error::{Error, Result};
+use crate::scalar_semantics::dynamic_truncate_size;
 
 /// Execute a single [`StdTensorOp`] on concrete tensors.
 ///
@@ -149,21 +150,7 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
                 }
                 let size_tensor = inputs[1];
                 let axis_extent = input.shape()[*axis];
-                let size_f64 = match size_tensor {
-                    Tensor::F64(inner) => inner.host_data()[0],
-                    Tensor::F32(inner) => inner.host_data()[0] as f64,
-                    _ => {
-                        return Err(Error::Internal(
-                            "DynamicTruncate size must be an f32 or f64 scalar".into(),
-                        ))
-                    }
-                };
-                let rounded_size = if size_f64.is_finite() {
-                    size_f64.round()
-                } else {
-                    0.0
-                };
-                let size = rounded_size.max(0.0).min(axis_extent as f64) as usize;
+                let size = dynamic_truncate_size(size_tensor, axis_extent)?;
                 let rank = input.shape().len();
                 let mut limits = input.shape().to_vec();
                 limits[*axis] = size;

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -20,6 +20,8 @@ use tenferro_tensor::{
     Tensor, TensorBackend, TensorExec, TypedTensor,
 };
 
+use crate::scalar_semantics::dynamic_truncate_size;
+
 #[derive(Clone, Debug)]
 pub enum ExecOp {
     Transpose {
@@ -462,13 +464,7 @@ pub(crate) fn execute_host_instruction<B: TensorBackend>(
             }
             let size_tensor = backend.download_to_host(get(slots, &inst.input_slots, 1)?)?;
             let axis_extent = input.shape()[*axis];
-            let size_f64 = scalar_size_value(&size_tensor)?;
-            let rounded_size = if size_f64.is_finite() {
-                size_f64.round()
-            } else {
-                0.0
-            };
-            let size = rounded_size.max(0.0).min(axis_extent as f64) as usize;
+            let size = dynamic_truncate_size(&size_tensor, axis_extent)?;
             let rank = input.shape().len();
             let mut limits = input.shape().to_vec();
             limits[*axis] = size;
@@ -840,16 +836,6 @@ fn exact_bytes<const N: usize>(dtype: DType, bytes: &[u8]) -> [u8; N] {
     let mut out = [0u8; N];
     out.copy_from_slice(bytes);
     out
-}
-
-fn scalar_size_value(size_tensor: &Tensor) -> Result<f64> {
-    match size_tensor {
-        Tensor::F64(inner) => Ok(inner.host_data()[0]),
-        Tensor::F32(inner) => Ok(inner.host_data()[0] as f64),
-        _ => Err(Error::Internal(
-            "DynamicTruncate size must be an f32 or f64 scalar".into(),
-        )),
-    }
 }
 
 pub(crate) fn reclaim_last_use_inputs_exec(

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -33,6 +33,7 @@ pub mod exec;
 pub mod extension;
 mod linalg_api;
 mod metadata;
+mod scalar_semantics;
 pub mod segment;
 pub mod shape_infer;
 pub mod sym_dim;

--- a/tenferro/src/linalg_api.rs
+++ b/tenferro/src/linalg_api.rs
@@ -2,6 +2,7 @@ use num_complex::{Complex32, Complex64};
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{CompareDir, DType, DotGeneralConfig};
 
+use crate::scalar_semantics::round_real_to_i64;
 use crate::sym_dim::SymDim;
 use crate::traced::{
     apply_binary, apply_multi_output, apply_nullary, apply_unary, concrete_shape, TracedTensor,
@@ -607,7 +608,7 @@ fn eig_output_dtype(dtype: DType) -> DType {
     match dtype {
         DType::F64 | DType::C64 => DType::C64,
         DType::F32 | DType::C32 => DType::C32,
-        DType::I64 => DType::I64,
+        DType::I64 => DType::C64,
     }
 }
 
@@ -626,7 +627,7 @@ fn scalar_real(dtype: DType, value: f64) -> TracedTensor {
             Some(vec![]),
         ),
         DType::I64 => apply_nullary(
-            StdTensorOp::constant_i64(value as i64),
+            StdTensorOp::constant_i64(round_real_to_i64(value)),
             0,
             DType::I64,
             Some(vec![]),

--- a/tenferro/src/scalar_semantics.rs
+++ b/tenferro/src/scalar_semantics.rs
@@ -1,0 +1,39 @@
+use tenferro_tensor::Tensor;
+
+use crate::error::{Error, Result};
+
+pub(crate) fn round_real_to_i64(value: f64) -> i64 {
+    if value.is_finite() {
+        value.round() as i64
+    } else {
+        0
+    }
+}
+
+pub(crate) fn dynamic_truncate_size(size_tensor: &Tensor, axis_extent: usize) -> Result<usize> {
+    let value = scalar_size_value(size_tensor)?;
+    let rounded = if value.is_finite() {
+        value.round()
+    } else {
+        0.0
+    };
+    Ok(rounded.max(0.0).min(axis_extent as f64) as usize)
+}
+
+fn scalar_size_value(size_tensor: &Tensor) -> Result<f64> {
+    if !size_tensor.shape().is_empty() {
+        return Err(Error::Internal(format!(
+            "DynamicTruncate size must be an f32, f64, or i64 scalar, got shape {:?}",
+            size_tensor.shape()
+        )));
+    }
+
+    match size_tensor {
+        Tensor::F64(inner) => Ok(inner.host_data()[0]),
+        Tensor::F32(inner) => Ok(inner.host_data()[0] as f64),
+        Tensor::I64(inner) => Ok(inner.host_data()[0] as f64),
+        _ => Err(Error::Internal(
+            "DynamicTruncate size must be an f32, f64, or i64 scalar".into(),
+        )),
+    }
+}

--- a/tenferro/src/shape_infer.rs
+++ b/tenferro/src/shape_infer.rs
@@ -26,7 +26,7 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         StdTensorOp::Eig { input_dtype, .. } => match input_dtype {
             DType::F32 | DType::C32 => DType::C32,
             DType::F64 | DType::C64 => DType::C64,
-            DType::I64 => DType::I64,
+            DType::I64 => DType::C64,
         },
         StdTensorOp::Extension(ext) => extension_first_output_dtype(ext.as_ref(), input_dtypes),
         StdTensorOp::Add
@@ -323,15 +323,35 @@ fn reduced_shape(input_shape: &[DimExpr], axes: &[usize]) -> Vec<DimExpr> {
 }
 
 fn same_or_scalar_broadcast_shape(lhs_shape: &[DimExpr], rhs_shape: &[DimExpr]) -> Vec<DimExpr> {
-    if lhs_shape.is_empty() {
-        rhs_shape.to_vec()
-    } else if rhs_shape.is_empty() {
-        lhs_shape.to_vec()
+    let rank = lhs_shape.len().max(rhs_shape.len());
+    let mut out = Vec::with_capacity(rank);
+    for axis in 0..rank {
+        let lhs_dim = broadcast_aligned_dim(lhs_shape, rank, axis);
+        let rhs_dim = broadcast_aligned_dim(rhs_shape, rank, axis);
+        out.push(broadcast_dim(lhs_dim, rhs_dim));
+    }
+    out
+}
+
+fn broadcast_aligned_dim(shape: &[DimExpr], output_rank: usize, output_axis: usize) -> DimExpr {
+    if output_axis < output_rank - shape.len() {
+        DimExpr::Const(1)
     } else {
-        // Dynamic shape ops such as DynamicTruncate can only be inferred
-        // approximately here, so for non-scalar inputs we preserve the
-        // historical "follow lhs" behavior.
-        lhs_shape.to_vec()
+        shape[output_axis - (output_rank - shape.len())].clone()
+    }
+}
+
+fn broadcast_dim(lhs: DimExpr, rhs: DimExpr) -> DimExpr {
+    if lhs == rhs {
+        return lhs;
+    }
+    match (&lhs, &rhs) {
+        (DimExpr::Const(1), _) => rhs,
+        (_, DimExpr::Const(1)) => lhs,
+        (DimExpr::Const(lhs_value), DimExpr::Const(rhs_value)) => {
+            panic!("incompatible Add/Mul broadcast dimensions: {lhs_value} and {rhs_value}")
+        }
+        _ => dim_max(lhs, rhs),
     }
 }
 

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -25,6 +25,7 @@ use crate::metadata::{
     concrete_tensor_meta, register_fragment_metadata, register_value_metadata, registered_meta,
     symbolic_input_meta, tensor_meta_from_tensor,
 };
+use crate::scalar_semantics::round_real_to_i64;
 
 static NEXT_INPUT_ID: AtomicU64 = AtomicU64::new(0);
 static NEXT_DIFF_PASS_ID: AtomicU64 = AtomicU64::new(0);
@@ -1079,7 +1080,7 @@ impl TracedTensor {
         let op = match self.dtype {
             DType::F64 => StdTensorOp::constant_f64(factor),
             DType::F32 => StdTensorOp::constant_f32(factor as f32),
-            DType::I64 => StdTensorOp::constant_i64(factor as i64),
+            DType::I64 => StdTensorOp::constant_i64(round_real_to_i64(factor)),
             DType::C64 => StdTensorOp::constant_c64(Complex64::new(factor, 0.0)),
             DType::C32 => StdTensorOp::constant_c32(Complex32::new(factor as f32, 0.0)),
         };

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -727,6 +727,7 @@ impl TracedTensor {
         let old_fragment = self.fragment.clone();
         let old_output_key = old_fragment.vals()[self.val].key.clone();
         let old_inputs = (*self.inputs_map).clone();
+        let concrete_meta = tensor_meta_from_tensor(data.as_ref());
 
         let new_key = next_input_key();
         let mut builder = FragmentBuilder::new();
@@ -735,8 +736,12 @@ impl TracedTensor {
         let new_fragment = Arc::new(builder.build());
         register_value_metadata(
             new_fragment.vals()[leaf_val].key.clone(),
-            tensor_meta_from_tensor(data.as_ref()),
+            concrete_meta.clone(),
         );
+        // Dynamic shape ops may have conservative static metadata on their
+        // graph output. A checkpoint has evaluated the concrete tensor, so AD
+        // alias resolution should see the runtime shape on both sides.
+        register_value_metadata(old_output_key.clone(), concrete_meta);
 
         let node = CheckpointNode {
             fragment: old_fragment,

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -23,7 +23,8 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, SymDim};
 use tenferro_tensor::cpu::CpuBackend;
 use tenferro_tensor::{
-    DType, DotGeneralConfig, GatherConfig, ScatterConfig, Tensor, TensorBackend, TypedTensor,
+    DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor,
+    TensorBackend, TypedTensor,
 };
 use tidu::{differentiate, transpose, LinearFragment};
 
@@ -3119,6 +3120,31 @@ fn build_scatter_reduce_sum_fragment(
     (Arc::new(builder.build()), loss_key)
 }
 
+fn build_weighted_unary_sum_fragment(
+    input_key: TensorInputKey,
+    weights_key: TensorInputKey,
+    op: StdTensorOp,
+    reduce_axes: Vec<usize>,
+) -> (Arc<Fragment<StdTensorOp>>, GlobalValKey<StdTensorOp>) {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let input = builder.add_input(input_key);
+    let weights = builder.add_input(weights_key);
+    let output = builder.add_op(op, vec![ValRef::Local(input)], OpMode::Primal)[0];
+    let weighted = builder.add_op(
+        StdTensorOp::Mul,
+        vec![ValRef::Local(output), ValRef::Local(weights)],
+        OpMode::Primal,
+    )[0];
+    let loss = builder.add_op(
+        StdTensorOp::ReduceSum { axes: reduce_axes },
+        vec![ValRef::Local(weighted)],
+        OpMode::Primal,
+    )[0];
+    let loss_key = builder.global_key(loss).clone();
+    builder.set_outputs(vec![loss]);
+    (Arc::new(builder.build()), loss_key)
+}
+
 #[test]
 fn grad_scatter_reduce_sum_wrt_updates_is_ones() {
     // `y = reduce_sum(scatter(operand, indices, updates, config))`. The
@@ -3158,4 +3184,89 @@ fn grad_scatter_reduce_sum_wrt_updates_is_ones() {
     // reduce_sum over the scatter output contributes a 1 to each updated
     // slot; the inverse Gather reads one value for each `indices` entry.
     assert_close_slice(get_f64_data(&grad), &[1.0, 1.0, 1.0]);
+}
+
+#[test]
+fn grad_slice_weighted_sum_matches_finite_diff() {
+    let input_key = tensor_input_key(62_000);
+    let weights_key = tensor_input_key(62_001);
+    let config = SliceConfig {
+        starts: vec![1],
+        limits: vec![5],
+        strides: vec![2],
+    };
+    let (fragment, loss_key) = build_weighted_unary_sum_fragment(
+        input_key.clone(),
+        weights_key.clone(),
+        StdTensorOp::Slice(config),
+        vec![0],
+    );
+
+    let input_data = vec![0.5_f64, -1.0, 2.5, 4.0, -3.0];
+    let weights_data = vec![1.25_f64, -0.75];
+    let inputs_map = HashMap::from([
+        (input_key.clone(), f64_tensor(vec![5], input_data.clone())),
+        (weights_key, f64_tensor(vec![2], weights_data.clone())),
+    ]);
+
+    let grad = grad_from_fragment_with_inputs(fragment, loss_key, input_key, inputs_map);
+    assert_grad_matches_finite_diff(get_f64_data(&grad), &input_data, |xs| {
+        xs[1] * weights_data[0] + xs[3] * weights_data[1]
+    });
+}
+
+#[test]
+fn grad_pad_weighted_sum_matches_finite_diff() {
+    let input_key = tensor_input_key(63_000);
+    let weights_key = tensor_input_key(63_001);
+    let config = PadConfig {
+        edge_padding_low: vec![1],
+        edge_padding_high: vec![2],
+        interior_padding: vec![1],
+    };
+    let (fragment, loss_key) = build_weighted_unary_sum_fragment(
+        input_key.clone(),
+        weights_key.clone(),
+        StdTensorOp::Pad(config),
+        vec![0],
+    );
+
+    let input_data = vec![2.0_f64, -1.5, 0.25];
+    let weights_data = vec![0.5_f64, 1.25, -0.5, 2.0, 0.75, -1.0, 3.0, -2.5];
+    let inputs_map = HashMap::from([
+        (input_key.clone(), f64_tensor(vec![3], input_data.clone())),
+        (weights_key, f64_tensor(vec![8], weights_data.clone())),
+    ]);
+
+    let grad = grad_from_fragment_with_inputs(fragment, loss_key, input_key, inputs_map);
+    assert_grad_matches_finite_diff(get_f64_data(&grad), &input_data, |xs| {
+        xs[0] * weights_data[1] + xs[1] * weights_data[3] + xs[2] * weights_data[5]
+    });
+}
+
+#[test]
+fn grad_reverse_weighted_sum_matches_finite_diff() {
+    let input_key = tensor_input_key(64_000);
+    let weights_key = tensor_input_key(64_001);
+    let (fragment, loss_key) = build_weighted_unary_sum_fragment(
+        input_key.clone(),
+        weights_key.clone(),
+        StdTensorOp::Reverse { axes: vec![0] },
+        vec![0],
+    );
+
+    let input_data = vec![1.0_f64, -2.0, 3.5, 0.25];
+    let weights_data = vec![0.5_f64, -1.0, 2.0, 1.5];
+    let inputs_map = HashMap::from([
+        (input_key.clone(), f64_tensor(vec![4], input_data.clone())),
+        (weights_key, f64_tensor(vec![4], weights_data.clone())),
+    ]);
+
+    let grad = grad_from_fragment_with_inputs(fragment, loss_key, input_key, inputs_map);
+    assert_grad_matches_finite_diff(get_f64_data(&grad), &input_data, |xs| {
+        xs[0] * weights_data[3]
+            + xs[1] * weights_data[2]
+            + xs[2] * weights_data[1]
+            + xs[3] * weights_data[0]
+    });
 }

--- a/tenferro/tests/dtype_propagation.rs
+++ b/tenferro/tests/dtype_propagation.rs
@@ -1,4 +1,5 @@
 use tenferro::shape_infer::infer_output_dtype;
+use tenferro::{eig, Tensor, TracedTensor, TypedTensor};
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{DType, DotGeneralConfig};
 
@@ -52,6 +53,23 @@ fn test_eig_f64_produces_c64() {
         input_dtype: DType::F64,
     };
     assert_eq!(infer_output_dtype(&op, &[DType::F64]), DType::C64);
+}
+
+#[test]
+fn test_eig_i64_produces_c64() {
+    let op = StdTensorOp::Eig {
+        input_dtype: DType::I64,
+    };
+    assert_eq!(infer_output_dtype(&op, &[DType::I64]), DType::C64);
+}
+
+#[test]
+fn test_traced_eig_i64_outputs_c64_metadata() {
+    let input = Tensor::I64(TypedTensor::from_vec(vec![2, 2], vec![1, 0, 0, 2]));
+    let x = TracedTensor::from_tensor_concrete_shape(input);
+    let (values, vectors) = eig(&x);
+    assert_eq!(values.dtype, DType::C64);
+    assert_eq!(vectors.dtype, DType::C64);
 }
 
 #[test]

--- a/tenferro/tests/dynamic_truncate.rs
+++ b/tenferro/tests/dynamic_truncate.rs
@@ -11,6 +11,10 @@ fn f64_scalar(value: f64) -> Tensor {
     Tensor::F64(TypedTensor::from_vec(vec![], vec![value]))
 }
 
+fn i64_scalar(value: i64) -> Tensor {
+    Tensor::I64(TypedTensor::from_vec(vec![], vec![value]))
+}
+
 fn get_f64_data(tensor: &Tensor) -> Vec<f64> {
     match tensor {
         Tensor::F64(inner) => inner.host_data().to_vec(),
@@ -56,6 +60,18 @@ fn dynamic_truncate_clamps_oversize() {
     let mut result = x.dynamic_truncate(&size, 0);
     let data = get_f64_data(result.eval(&mut engine).unwrap());
     assert_eq!(data, vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn dynamic_truncate_accepts_i64_size() {
+    let mut engine = Engine::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]));
+    let size = TracedTensor::from_tensor_concrete_shape(i64_scalar(2));
+
+    let mut result = x.dynamic_truncate(&size, 0);
+    let out = result.eval(&mut engine).unwrap();
+    assert_eq!(out.shape(), &[2]);
+    assert_eq!(get_f64_data(out), vec![1.0, 2.0]);
 }
 
 #[test]

--- a/tenferro/tests/eager_exec.rs
+++ b/tenferro/tests/eager_exec.rs
@@ -18,6 +18,10 @@ fn scalar(v: f64) -> Tensor {
     f64t(vec![], vec![v])
 }
 
+fn i64_scalar(v: i64) -> Tensor {
+    Tensor::I64(TypedTensor::from_vec(vec![], vec![v]))
+}
+
 fn data(t: &Tensor) -> Vec<f64> {
     match t {
         Tensor::F64(inner) => inner.host_data().to_vec(),
@@ -81,6 +85,37 @@ fn dynamic_truncate_nan_gives_empty() {
     )
     .unwrap();
     assert_eq!(result[0].shape(), &[0]);
+}
+
+#[test]
+fn dynamic_truncate_accepts_i64_scalar_size() {
+    let mut b = CpuBackend::new();
+    let x = f64t(vec![4], vec![1.0, 2.0, 3.0, 4.0]);
+    let size = i64_scalar(2);
+    let result = exec_op_on_tensors(
+        &StdTensorOp::DynamicTruncate { axis: 0 },
+        &[&x, &size],
+        &mut b,
+    )
+    .unwrap();
+    assert_eq!(data(&result[0]), vec![1.0, 2.0]);
+}
+
+#[test]
+fn dynamic_truncate_rejects_non_scalar_size() {
+    let mut b = CpuBackend::new();
+    let x = f64t(vec![4], vec![1.0, 2.0, 3.0, 4.0]);
+    let size = f64t(vec![2], vec![1.0, 2.0]);
+    let err = exec_op_on_tensors(
+        &StdTensorOp::DynamicTruncate { axis: 0 },
+        &[&x, &size],
+        &mut b,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("scalar"),
+        "unexpected error: {err}"
+    );
 }
 
 // ── PadToMatch: no-op and padding ──

--- a/tenferro/tests/primitive_ops.rs
+++ b/tenferro/tests/primitive_ops.rs
@@ -8,10 +8,21 @@ fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec(shape, data))
 }
 
+fn i64_tensor(shape: Vec<usize>, data: Vec<i64>) -> Tensor {
+    Tensor::I64(TypedTensor::from_vec(shape, data))
+}
+
 fn get_f64_data(t: &Tensor) -> &[f64] {
     match t {
         Tensor::F64(inner) => inner.host_data(),
         _ => panic!("expected F64"),
+    }
+}
+
+fn get_i64_data(t: &Tensor) -> &[i64] {
+    match t {
+        Tensor::I64(inner) => inner.host_data(),
+        _ => panic!("expected I64"),
     }
 }
 
@@ -96,6 +107,15 @@ fn test_scale_real_operator_overload() {
     let mut engine = Engine::new(CpuBackend::new());
     let result = y.eval(&mut engine).unwrap();
     assert_eq!(get_f64_data(result), &[3.0, 6.0, 9.0]);
+}
+
+#[test]
+fn test_scale_real_i64_rounds_factor() {
+    let x = TracedTensor::from_tensor_concrete_shape(i64_tensor(vec![3], vec![1, 2, -3]));
+    let mut y = x.scale_real(2.7);
+    let mut engine = Engine::new(CpuBackend::new());
+    let result = y.eval(&mut engine).unwrap();
+    assert_eq!(get_i64_data(result), &[3, 6, -9]);
 }
 
 #[test]

--- a/tenferro/tests/shape_inference.rs
+++ b/tenferro/tests/shape_inference.rs
@@ -42,6 +42,22 @@ fn test_add_and_mul_preserve_tensor_shape_under_scalar_broadcast() {
 }
 
 #[test]
+fn test_add_infers_non_scalar_broadcast_shape() {
+    let lhs = vec![cst(3), cst(1)];
+    let rhs = vec![cst(1), cst(4)];
+    let out = infer_output_shapes(&StdTensorOp::Add, &[&lhs, &rhs]);
+    assert_eq!(out, vec![vec![cst(3), cst(4)]]);
+}
+
+#[test]
+fn test_mul_infers_non_scalar_broadcast_shape() {
+    let lhs = vec![cst(3), cst(1)];
+    let rhs = vec![cst(1), cst(4)];
+    let out = infer_output_shapes(&StdTensorOp::Mul, &[&lhs, &rhs]);
+    assert_eq!(out, vec![vec![cst(3), cst(4)]]);
+}
+
+#[test]
 fn test_transpose_applies_perm() {
     let op = StdTensorOp::Transpose { perm: vec![1, 0] };
     let input = vec![cst(3), cst(4)];


### PR DESCRIPTION
## Summary

This PR bundles the agreed issue batch into one draft PR:

- adds dispatch specs/plans for the CPU indexing, primitive dtype/shape, faer linalg safety, AD boundary, deferred GPU, and docs/einsum workstreams
- replaces CPU indexing panics/assertions and lossy index conversion with explicit `Result` errors, including I64 reverse support and complex/float index validation
- aligns primitive scalar/dtype behavior for I64 dynamic truncate sizes, scalar semantics, eig output dtype, and related shape metadata paths
- converts faer linalg decomposition failure paths into errors and hardens unsafe complex reinterpretation assumptions
- adds structural/indexing/linalg-ad boundary fixes and regression coverage, including checkpointed dynamic truncate shape preservation
- updates CubeCL/GPU design docs to match the current CubeCL backend implementation, while leaving CubeCL complex support and GPU benchmarks out of scope
- documents einsum repeated-label semantics and hardens planner cost/error paths

## Issue Notes

Primary issue families covered here include CPU indexing validation/reverse, primitive dtype/shape metadata, faer linalg safety, AD boundary rules, GPU design-doc drift, repeated-label einsum documentation, and einsum planner panic/error handling.

Explicitly out of scope from this PR: new linalg AD rule implementation (#777), CubeCL complex support while upstream CubeCL support is pending (#724/#791), GPU benchmark work (#728), and broader GPU/runtime drift items reserved for later work.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Note: auto-merge/squash is intentionally not enabled for this PR per coordination.