### PR TITLE
Fix small defensive shape edge cases

### DIFF
--- a/tenferro-einsum/src/syntax/nested.rs
+++ b/tenferro-einsum/src/syntax/nested.rs
@@ -116,16 +116,16 @@ impl NestedEinsum {
 
                 // Compute what this sub-group needs to output:
                 // labels in this group that appear in outer_needed or in sibling items
-                let group_labels = Self::collect_labels(inner)?;
+                let group_labels = Self::collect_labels_in_order(inner)?;
                 let sibling_labels = Self::collect_sibling_labels(&items, idx)?;
                 let mut needed: HashSet<u32> = HashSet::new();
-                for &label in &group_labels {
+                let mut sub_output = Vec::new();
+                for label in group_labels {
                     if outer_needed.contains(&label) || sibling_labels.contains(&label) {
                         needed.insert(label);
+                        sub_output.push(label);
                     }
                 }
-                let mut sub_output: Vec<u32> = needed.iter().copied().collect();
-                sub_output.sort();
 
                 let child = Self::parse_group(inner, &needed, &sub_output, leaf_counter)?;
                 child_subscript_inputs.push(sub_output);
@@ -196,6 +196,25 @@ impl NestedEinsum {
         Ok(labels)
     }
 
+    /// Collect unique labels in first-appearance order, ignoring
+    /// parentheses and commas.
+    fn collect_labels_in_order(s: &str) -> Result<Vec<u32>> {
+        let mut seen = HashSet::new();
+        let mut labels = Vec::new();
+        for c in s.chars() {
+            match c {
+                '(' | ')' | ',' => continue,
+                _ => {
+                    let label = char_to_label(c)?;
+                    if seen.insert(label) {
+                        labels.push(label);
+                    }
+                }
+            }
+        }
+        Ok(labels)
+    }
+
     /// Collect all labels from sibling items (all items except the one at `current_idx`).
     fn collect_sibling_labels(items: &[&str], current_idx: usize) -> Result<HashSet<u32>> {
         let mut labels = HashSet::new();
@@ -210,3 +229,6 @@ impl NestedEinsum {
         Ok(labels)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/tenferro-einsum/src/syntax/nested/tests.rs
+++ b/tenferro-einsum/src/syntax/nested/tests.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+fn labels(s: &str) -> Vec<u32> {
+    s.bytes().map(u32::from).collect()
+}
+
+#[test]
+fn parse_group_preserves_intermediate_output_label_order() {
+    let nested = NestedEinsum::parse("(ca,ab),cd->bd").unwrap();
+
+    let NestedEinsum::Node {
+        subscripts,
+        children,
+    } = nested
+    else {
+        panic!("expected root node");
+    };
+
+    assert_eq!(subscripts.inputs[0], labels("cb"));
+
+    let NestedEinsum::Node {
+        subscripts: inner_subscripts,
+        ..
+    } = &children[0]
+    else {
+        panic!("expected grouped child node");
+    };
+
+    assert_eq!(inner_subscripts.output, labels("cb"));
+}

--- a/tenferro-ops/src/dim_expr.rs
+++ b/tenferro-ops/src/dim_expr.rs
@@ -47,8 +47,8 @@ impl DimExpr {
     /// # Panics
     ///
     /// Panics if an `InputDim` node references an `input_idx` that is
-    /// out of bounds for `input_shapes`, or an `axis` that is out of
-    /// bounds for the corresponding shape slice.
+    /// out of bounds for `input_shapes`, an `axis` that is out of bounds
+    /// for the corresponding shape slice, or a subtraction would underflow.
     ///
     /// # Examples
     ///
@@ -69,7 +69,13 @@ impl DimExpr {
             Self::Const(v) => *v,
             Self::InputDim { input_idx, axis } => input_shapes[*input_idx][*axis],
             Self::Add(a, b) => a.eval(input_shapes) + b.eval(input_shapes),
-            Self::Sub(a, b) => a.eval(input_shapes) - b.eval(input_shapes),
+            Self::Sub(a, b) => {
+                let lhs = a.eval(input_shapes);
+                let rhs = b.eval(input_shapes);
+                lhs.checked_sub(rhs).unwrap_or_else(|| {
+                    panic!("DimExpr::Sub underflow: left operand {lhs} is smaller than {rhs}")
+                })
+            }
             Self::Mul(a, b) => a.eval(input_shapes) * b.eval(input_shapes),
             Self::FloorDiv(a, b) => a.eval(input_shapes) / b.eval(input_shapes),
             Self::Min(a, b) => a.eval(input_shapes).min(b.eval(input_shapes)),

--- a/tenferro-ops/src/tests/dim_expr_tests.rs
+++ b/tenferro-ops/src/tests/dim_expr_tests.rs
@@ -35,6 +35,13 @@ fn test_arithmetic() {
 }
 
 #[test]
+#[should_panic(expected = "DimExpr::Sub underflow")]
+fn test_sub_underflow_panics_instead_of_wrapping() {
+    let expr = DimExpr::sub(DimExpr::Const(2), DimExpr::Const(5));
+    let _ = expr.eval(&[]);
+}
+
+#[test]
 fn test_min_max() {
     let shapes: &[&[usize]] = &[&[3, 7]];
     let e_min = DimExpr::min(

--- a/tenferro-tensor/src/validate/mod.rs
+++ b/tenferro-tensor/src/validate/mod.rs
@@ -57,7 +57,8 @@ impl_diag_singularity_complex!(Complex64, Complex32);
 ///
 /// Iterates over all batch slices and inspects the diagonal entries
 /// `data[i + i * rows]` for `i` in `0..min(rows, cols)`. Returns
-/// [`Error::BackendFailure`] with `op: "solve"` on the first offending entry.
+/// [`Error::BackendFailure`] with `op: "solve"` on the first offending entry,
+/// or [`Error::RankMismatch`] when `t` has rank less than two.
 ///
 /// # Examples
 ///
@@ -71,6 +72,13 @@ impl_diag_singularity_complex!(Complex64, Complex32);
 pub fn check_singular_diagonal<T: DiagSingularity + Copy + std::fmt::Debug>(
     t: &TypedTensor<T>,
 ) -> Result<()> {
+    if t.shape.len() < 2 {
+        return Err(Error::RankMismatch {
+            op: "solve",
+            expected: 2,
+            actual: t.shape.len(),
+        });
+    }
     let rows = t.shape[0];
     let cols = t.shape[1];
     let n = rows.min(cols);

--- a/tenferro-tensor/src/validate/tests.rs
+++ b/tenferro-tensor/src/validate/tests.rs
@@ -344,6 +344,27 @@ complex_singular_tests!(c32_tests, Complex32, f32);
 complex_singular_tests!(c64_tests, Complex64, f64);
 
 #[test]
+fn rank_less_than_two_returns_error_instead_of_panicking() {
+    for shape in [Vec::new(), vec![3]] {
+        let data = if shape.is_empty() {
+            vec![1.0]
+        } else {
+            vec![1.0, 2.0, 3.0]
+        };
+        let t = TypedTensor::<f64>::from_vec(shape.clone(), data);
+        let err = check_singular_diagonal(&t).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::RankMismatch {
+                op: "solve",
+                expected: 2,
+                actual
+            } if actual == shape.len()
+        ));
+    }
+}
+
+#[test]
 fn f64_batched_error_includes_batch_index_and_position() {
     let t =
         TypedTensor::<f64>::from_vec(vec![2, 2, 2], vec![1.0, 0.0, 0.0, 2.0, 3.0, 0.0, 0.0, 0.0]);


### PR DESCRIPTION
## Summary

Fixes #805.
Fixes #792.
Fixes #801.

- Return `Error::RankMismatch` instead of panicking when singular-diagonal validation is called on rank < 2 tensors.
- Use checked subtraction in `DimExpr::Sub` so release builds panic with a diagnostic instead of wrapping on underflow.
- Preserve first-appearance label order for nested einsum intermediate outputs instead of sorting labels from a `HashSet`.

## Verification

Already run locally before PR gate:

- `cargo fmt --all --check`
- `cargo test -p tenferro-ops --lib`
- `cargo test -p tenferro-tensor --lib`
- `cargo test -p tenferro-einsum --lib`
- `cargo test -p tenferro-ops --release test_sub_underflow_panics_instead_of_wrapping`

The repository `scripts/create-pr.sh` gate also runs formatting, workspace release tests, workspace doctests, coverage, rustdoc, docs-site checks, push, auto-merge setup, and PR check monitoring.

## Documentation

Reviewed `README.md`, `AGENTS.md`, `REPOSITORY_RULES.md`, vendored agent rules, and affected public rustdoc for consistency.

Generated with [Codex](https://openai.com/codex)
