### PR TITLE
Align primitive div and convert behavior

### DIFF
--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -261,7 +261,7 @@ impl TensorBackend for CpuBackend {
     }
 
     fn convert(&mut self, input: &Tensor, to: crate::DType) -> crate::Result<Tensor> {
-        Ok(self.install(|| structural::convert(input, to)))
+        self.install(|| structural::convert(input, to))
     }
 
     fn extract_diagonal(

--- a/tenferro-tensor/src/cpu/elementwise.rs
+++ b/tenferro-tensor/src/cpu/elementwise.rs
@@ -228,6 +228,22 @@ pub fn div(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_div(a, b)?)),
         (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_div(a, b)?)),
         (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_div(a, b)?)),
+        (Tensor::F32(a), Tensor::C32(b)) if a.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            Ok(Tensor::C32(typed_div(&scalar, b)?))
+        }
+        (Tensor::C32(a), Tensor::F32(b)) if b.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            Ok(Tensor::C32(typed_div(a, &scalar)?))
+        }
+        (Tensor::F64(a), Tensor::C64(b)) if a.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(a.host_data()[0]);
+            Ok(Tensor::C64(typed_div(&scalar, b)?))
+        }
+        (Tensor::C64(a), Tensor::F64(b)) if b.shape.is_empty() => {
+            let scalar = complex_scalar_tensor(b.host_data()[0]);
+            Ok(Tensor::C64(typed_div(a, &scalar)?))
+        }
         _ => Err(crate::Error::DTypeMismatch {
             op: "div",
             lhs: lhs.dtype(),
@@ -433,23 +449,38 @@ pub fn typed_div<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> crate::Result
 where
     T: Copy + Clone + Zero + Div<Output = T>,
 {
-    if lhs.shape != rhs.shape {
-        return Err(crate::Error::ShapeMismatch {
+    if lhs.shape == rhs.shape {
+        // SAFETY: zip_map2_into overwrites every output element.
+        let mut out = unsafe { typed_array_uninit(&lhs.shape) };
+        zip_map2_into(
+            &mut out.view_mut(),
+            &typed_view(lhs),
+            &typed_view(rhs),
+            |x, y| x / y,
+        )
+        .map_err(|err| backend_failure("div", err))?;
+        Ok(tensor_from_array(out))
+    } else if lhs.shape.is_empty() {
+        let scalar = lhs.host_data()[0];
+        // SAFETY: map_into overwrites every output element.
+        let mut out = unsafe { typed_array_uninit(&rhs.shape) };
+        map_into(&mut out.view_mut(), &typed_view(rhs), |x| scalar / x)
+            .map_err(|err| backend_failure("div", err))?;
+        Ok(tensor_from_array(out))
+    } else if rhs.shape.is_empty() {
+        let scalar = rhs.host_data()[0];
+        // SAFETY: map_into overwrites every output element.
+        let mut out = unsafe { typed_array_uninit(&lhs.shape) };
+        map_into(&mut out.view_mut(), &typed_view(lhs), |x| x / scalar)
+            .map_err(|err| backend_failure("div", err))?;
+        Ok(tensor_from_array(out))
+    } else {
+        Err(crate::Error::ShapeMismatch {
             op: "div",
             lhs: lhs.shape.clone(),
             rhs: rhs.shape.clone(),
-        });
+        })
     }
-    // SAFETY: zip_map2_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit(&lhs.shape) };
-    zip_map2_into(
-        &mut out.view_mut(),
-        &typed_view(lhs),
-        &typed_view(rhs),
-        |x, y| x / y,
-    )
-    .map_err(|err| backend_failure("div", err))?;
-    Ok(tensor_from_array(out))
 }
 
 pub fn typed_neg<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -166,7 +166,7 @@ impl TensorExec for CpuExecSession<'_> {
     delegate!(transpose(input: &Tensor, perm: &[usize]) => structural::transpose(input, perm));
     delegate!(reshape(input: &Tensor, shape: &[usize]) => structural::reshape(input, shape));
     delegate!(broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) => structural::broadcast_in_dim(input, shape, dims));
-    delegate!(convert(input: &Tensor, to: crate::DType) => Ok(structural::convert(input, to)));
+    delegate!(convert(input: &Tensor, to: crate::DType) => structural::convert(input, to));
     delegate!(extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) => structural::extract_diagonal(input, axis_a, axis_b));
     delegate!(embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) => structural::embed_diagonal(input, axis_a, axis_b));
     delegate!(tril(input: &Tensor, k: i64) => structural::tril(input, k));

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -117,8 +117,8 @@ pub fn broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> crat
     }
 }
 
-pub fn convert(input: &Tensor, to: DType) -> Tensor {
-    match (input, to) {
+pub fn convert(input: &Tensor, to: DType) -> crate::Result<Tensor> {
+    let converted = match (input, to) {
         (Tensor::F32(t), DType::F32) => Tensor::F32(t.clone()),
         (Tensor::F32(t), DType::F64) => Tensor::F64(typed_convert(t, |x| x as f64)),
         (Tensor::F32(t), DType::I64) => Tensor::I64(typed_convert(t, |x| x as i64)),
@@ -156,7 +156,8 @@ pub fn convert(input: &Tensor, to: DType) -> Tensor {
             Complex32::new(z.re as f32, z.im as f32)
         })),
         (Tensor::C64(t), DType::C64) => Tensor::C64(t.clone()),
-    }
+    };
+    Ok(converted)
 }
 
 pub fn extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor> {

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -1602,6 +1602,14 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
     let mul_c32 = mul(&scalar_f32, &rhs_c32).unwrap();
     assert_eq!(get_c32(&mul_c32, &[1]), Complex32::new(0.0, 4.0));
 
+    let scalar_div_c32 = div(&scalar_f32, &rhs_c32).unwrap();
+    assert_eq!(get_c32(&scalar_div_c32, &[0]), Complex32::new(2.0, 0.0));
+    assert_eq!(get_c32(&scalar_div_c32, &[1]), Complex32::new(0.0, -1.0));
+
+    let c32_div_scalar = div(&rhs_c32, &scalar_f32).unwrap();
+    assert_eq!(get_c32(&c32_div_scalar, &[0]), Complex32::new(0.5, 0.0));
+    assert_eq!(get_c32(&c32_div_scalar, &[1]), Complex32::new(0.0, 1.0));
+
     assert!(matches!(
         div(
             &lhs_f32,
@@ -1695,6 +1703,14 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     assert_c64_close(get_c64(&mul_left_scalar, &[1]), Complex64::new(0.0, 4.0));
     let mul_right_scalar = mul(&lhs_c64, &scalar_f64).unwrap();
     assert_c64_close(get_c64(&mul_right_scalar, &[0]), Complex64::new(6.0, 8.0));
+
+    let div_left_scalar = div(&scalar_f64, &rhs_c64).unwrap();
+    assert_c64_close(get_c64(&div_left_scalar, &[0]), Complex64::new(2.0, 0.0));
+    assert_c64_close(get_c64(&div_left_scalar, &[1]), Complex64::new(0.0, -1.0));
+
+    let div_right_scalar = div(&lhs_c64, &scalar_f64).unwrap();
+    assert_c64_close(get_c64(&div_right_scalar, &[0]), Complex64::new(1.5, 2.0));
+    assert_c64_close(get_c64(&div_right_scalar, &[1]), Complex64::new(0.5, 0.0));
 
     let div_c64 = div(
         &lhs_c64,
@@ -2799,6 +2815,18 @@ fn test_slice_concatenate_and_reverse_edge_cases() {
     assert_eq!(reversed.shape(), &[4, 3]);
     assert_eq!(get_f64(&reversed, &[0, 0]), 12.0);
     assert_eq!(get_f64(&reversed, &[3, 2]), 1.0);
+}
+
+#[test]
+fn test_structural_convert_helper_returns_result() {
+    let input = Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.25_f32, -2.5_f32]));
+
+    let output = crate::cpu::structural::convert(&input, DType::F64).unwrap();
+
+    assert_eq!(output.shape(), &[2]);
+    assert_eq!(output.dtype(), DType::F64);
+    assert_eq!(get_f64(&output, &[0]), 1.25);
+    assert_eq!(get_f64(&output, &[1]), -2.5);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add CPU `div` support for rank-0 real scalar promotion with complex tensors, matching `add` and `mul` on both lhs/rhs sides.
- Extend typed CPU division to handle rank-0 scalar broadcasting so the promoted complex scalar paths execute correctly.
- Make the CPU structural `convert` helper return `Result<Tensor>` and delegate that typed error contract directly through backend/session paths.

Fixes #794.
Refs #818.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p tenferro-tensor --lib`
- `cargo test -p tenferro-tensor --features cubecl --lib test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths`
- `scripts/create-pr.sh` full gate

## Documentation

- Reviewed `README.md`, `AGENTS.md`, `REPOSITORY_RULES.md`, shared `ai/vendor/template-rs/*` rules, and `.claude/commands/createpr.md` for this primitive behavior change.
- No user-facing docs changes were needed; this aligns existing primitive behavior rather than adding a new public API.

Generated with [Codex](https://openai.com/codex)
