### PR TITLE
Preserve einsum parser and planning errors

### DIFF
--- a/docs/design/einsum-cpu-porting-notes.md
+++ b/docs/design/einsum-cpu-porting-notes.md
@@ -279,19 +279,15 @@ implement accordingly when moving out of POC phase. Cache key policy details are
 
 **Status**: Decided
 
-**Decision**: The einsum parser must support a parenthesized contraction-order
-notation (e.g., `"((ij,jk),kl)->il"`) in addition to the flat notation.
-`Subscripts::parse()` returns `Subscripts` + `Option<ContractionTree>`. When
-a parenthesized tree is present, `ContractionTree` is populated directly from
-the notation; otherwise the optimizer (`omeco`) generates the tree.
+**Decision**: Parenthesized contraction-order notation is handled by
+`NestedEinsum::parse`; the flat `Subscripts::parse` API rejects parentheses so
+it does not silently discard user-specified contraction order.
 
-**Next action**: Update `tenferro-einsum/src/parse.rs` (or equivalent)
-to handle parenthesized input. The POC `Subscripts::parse()` stub signature
-must be updated to return or accept an `Option<ContractionTree>` companion.
-
-**Success condition**: Round-trip test passes: `parse("((ij,jk),kl)->il")`
-produces a `ContractionTree` that encodes the `(ij,jk)` contraction before
-`kl`; flat notation `"ij,jk,kl->il"` falls back to optimizer.
+**Success condition**: `NestedEinsum::parse("((ij,jk),kl)->il")` preserves the
+tree that encodes the `(ij,jk)` contraction before `kl`; flat notation
+`"ij,jk,kl->il"` falls back to the optimizer, and
+`Subscripts::parse("((ij,jk),kl)->il")` returns an error that points callers to
+the nested parser.
 
 ---
 

--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -72,10 +72,9 @@ entrypoints rather than depending on binary lowering internals.
 
 ## Subscripts And Repeated Labels
 
-`Subscripts::parse` accepts NumPy/PyTorch-style labels. Parentheses are
-validated and stripped by `Subscripts::parse`; use `NestedEinsum::parse` or pass
-parenthesized notation through the higher-level traced facade when contraction
-order must be preserved.
+`Subscripts::parse` accepts flat NumPy/PyTorch-style labels and rejects
+parenthesized contraction-order notation. Use `NestedEinsum::parse` when
+contraction order must be preserved.
 
 Repeated-label semantics follow the usual einsum rules:
 

--- a/tenferro-einsum/src/planning/plan.rs
+++ b/tenferro-einsum/src/planning/plan.rs
@@ -5,6 +5,7 @@ pub(crate) use crate::planning::strict_binary::{
     compile_strict_binary_lowering_step_plan, StrictBinaryLoweringPlan,
 };
 use crate::planning::tree::ContractionTree;
+use tenferro_device::Result as DeviceResult;
 
 /// Pre-computed information for reducing axes unique to one operand.
 #[derive(Debug, PartialEq, Eq)]
@@ -215,7 +216,7 @@ pub(crate) fn compute_diag_plan_for_labels(
     }
 }
 
-pub(crate) fn compute_diag_plan(subs: &[u32]) -> Result<Option<DiagPlan>, String> {
+pub(crate) fn compute_diag_plan(subs: &[u32]) -> Option<DiagPlan> {
     let mut repeated_labels = HashSet::new();
     let mut label_positions: HashMap<u32, Vec<usize>> = HashMap::new();
     for (i, &label) in subs.iter().enumerate() {
@@ -229,7 +230,7 @@ pub(crate) fn compute_diag_plan(subs: &[u32]) -> Result<Option<DiagPlan>, String
             repeated_labels.insert(label);
         }
     }
-    Ok(compute_diag_plan_for_labels(subs, &repeated_labels))
+    compute_diag_plan_for_labels(subs, &repeated_labels)
 }
 
 pub(crate) fn compile_pairwise_step_plan(
@@ -237,10 +238,10 @@ pub(crate) fn compile_pairwise_step_plan(
     subs_b: &[u32],
     subs_c: &[u32],
     size_dict: &HashMap<u32, usize>,
-) -> std::result::Result<StepPlan, String> {
+) -> DeviceResult<StepPlan> {
     // 1. Diagonal extraction for repeated labels
-    let diag_a = compute_diag_plan(subs_a)?;
-    let diag_b = compute_diag_plan(subs_b)?;
+    let diag_a = compute_diag_plan(subs_a);
+    let diag_b = compute_diag_plan(subs_b);
 
     let eff_subs_a = diag_a
         .as_ref()
@@ -318,8 +319,8 @@ pub(crate) fn compile_pairwise_step_plan(
         .collect();
 
     let needs_final_permute = canonical_modes.as_slice() != subs_c;
-    let strict_binary = compile_strict_binary_lowering_step_plan(subs_a, subs_b, subs_c, size_dict)
-        .map_err(|e| e.to_string())?;
+    let strict_binary =
+        compile_strict_binary_lowering_step_plan(subs_a, subs_b, subs_c, size_dict)?;
 
     Ok(StepPlan {
         diag_a,
@@ -355,9 +356,7 @@ pub(crate) fn compile_pairwise_step_plan(
 ///   1. Diagonal extraction (if repeated labels in operand)
 ///   2. Pre-reduction (if unique-only axes)
 ///   3. GEMM (always, after steps 1-2 make all labels unique)
-pub(crate) fn compile_step_plans(
-    tree: &ContractionTree,
-) -> std::result::Result<Vec<StepPlan>, String> {
+pub(crate) fn compile_step_plans(tree: &ContractionTree) -> DeviceResult<Vec<StepPlan>> {
     let n_inputs = tree.subscripts.inputs.len();
     let size_dict = &tree.size_dict;
 

--- a/tenferro-einsum/src/planning/plan_tests.rs
+++ b/tenferro-einsum/src/planning/plan_tests.rs
@@ -80,3 +80,16 @@ fn pairwise_step_plan_embeds_strict_binary_lowering_when_available() {
         .expect("dense binary matmul step should cache strict lowering");
     assert_eq!(strict.output_perm, vec![1, 0]);
 }
+
+#[test]
+fn pairwise_step_plan_preserves_strict_lowering_error_type() {
+    let size_dict = [(0, 2), (1, 3)].into_iter().collect();
+
+    let err = compile_pairwise_step_plan(&[0], &[1], &[2], &size_dict).unwrap_err();
+
+    assert!(matches!(
+        err,
+        tenferro_device::Error::InvalidArgument(message)
+            if message.contains("unknown size")
+    ));
+}

--- a/tenferro-einsum/src/planning/tree.rs
+++ b/tenferro-einsum/src/planning/tree.rs
@@ -236,7 +236,7 @@ impl ContractionTree {
             operand_subs,
             step_plans: Vec::new(),
         };
-        tree.step_plans = compile_step_plans(&tree).map_err(Error::InvalidArgument)?;
+        tree.step_plans = compile_step_plans(&tree)?;
         Ok(tree)
     }
 

--- a/tenferro-einsum/src/syntax/subscripts.rs
+++ b/tenferro-einsum/src/syntax/subscripts.rs
@@ -1,4 +1,4 @@
-use tenferro_device::Result;
+use tenferro_device::{Error, Result};
 
 use crate::syntax::notation::{char_to_label, split_and_validate_notation};
 
@@ -71,10 +71,9 @@ impl Subscripts {
     /// Input tensors are separated by commas, and `->` separates inputs
     /// from the output.
     ///
-    /// Parentheses in the notation are accepted but stripped during parsing.
-    /// To respect parenthesized contraction order, use [`crate::NestedEinsum::parse`]
-    /// or pass the parenthesized string to the higher-level
-    /// `tenferro::einsum::einsum_with` helper.
+    /// Parentheses are rejected by this flat parser. Use
+    /// [`crate::NestedEinsum::parse`] when notation specifies a parenthesized
+    /// contraction order.
     ///
     /// # Examples
     ///
@@ -84,23 +83,25 @@ impl Subscripts {
     /// - `"i->ii"` — diagonal embedding
     /// - `"iij->ij"` — higher-rank diagonal extraction
     /// - `"ijk->"` — full contraction (scalar result)
-    /// - `"ij,(jk,kl)->il"` — contract B and C first, then with A
-    ///
     /// # Errors
     ///
-    /// Returns an error if the notation is malformed.
+    /// Returns an error if the notation is malformed or contains
+    /// parenthesized contraction order.
     pub fn parse(notation: &str) -> Result<Self> {
         let (inputs_str, output_str) = split_and_validate_notation(notation)?;
+        if inputs_str.contains(['(', ')']) {
+            return Err(Error::InvalidArgument(
+                "Subscripts::parse does not accept parentheses; use NestedEinsum::parse to preserve parenthesized contraction order"
+                    .into(),
+            ));
+        }
 
         let output: Vec<u32> = output_str
             .chars()
             .map(char_to_label)
             .collect::<Result<_>>()?;
 
-        // Parentheses already validated by split_and_validate_notation() above.
-        // Strip parentheses and parse input labels
-        let clean_inputs = inputs_str.replace(['(', ')'], "");
-        let inputs: Vec<Vec<u32>> = clean_inputs
+        let inputs: Vec<Vec<u32>> = inputs_str
             .split(',')
             .map(|s| s.chars().map(char_to_label).collect::<Result<_>>())
             .collect::<Result<_>>()?;
@@ -108,3 +109,6 @@ impl Subscripts {
         Ok(Self { inputs, output })
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/tenferro-einsum/src/syntax/subscripts/tests.rs
+++ b/tenferro-einsum/src/syntax/subscripts/tests.rs
@@ -1,0 +1,15 @@
+use tenferro_device::Error;
+
+use super::Subscripts;
+
+#[test]
+fn parse_rejects_parenthesized_order_without_discarding_it() {
+    let err = Subscripts::parse("ij,(jk,kl)->il").unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::InvalidArgument(message)
+            if message.contains("parentheses")
+                && message.contains("NestedEinsum::parse")
+    ));
+}


### PR DESCRIPTION
## Summary

- reject parenthesized contraction-order notation in the flat `Subscripts::parse` API and point callers to `NestedEinsum::parse`
- preserve typed `tenferro_device::Error` values from strict binary einsum lowering instead of converting them through `String`
- update einsum design notes and add regression coverage for both issue paths

Fixes #800.
Fixes #808.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p tenferro-einsum --lib`
- `cargo test -p tenferro-einsum --doc`
- `cargo test -p tenferro --test einsum`

Generated with [Codex](https://openai.com/codex)
