### PR TITLE
Batch CPU, einsum, AD, and CubeCL issue fixes

### DIFF
--- a/tenferro-einsum/src/builder.rs
+++ b/tenferro-einsum/src/builder.rs
@@ -39,6 +39,7 @@ use std::collections::{HashMap, HashSet};
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{OpMode, ValRef};
 
+use tenferro_device::{Error, Result};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::DotGeneralConfig;
@@ -54,6 +55,40 @@ struct LabeledVal {
 
 fn label_size_map(labels: &[u32], shape: &[usize]) -> Vec<(u32, usize)> {
     labels.iter().copied().zip(shape.iter().copied()).collect()
+}
+
+fn builder_invalid_argument(message: impl Into<String>) -> Error {
+    Error::InvalidArgument(format!("einsum builder: {}", message.into()))
+}
+
+fn find_label_axis(labels: &[u32], label: u32) -> Result<usize> {
+    labels
+        .iter()
+        .position(|candidate| *candidate == label)
+        .ok_or_else(|| builder_invalid_argument(format!("missing label {label} in {labels:?}")))
+}
+
+fn find_label_size(label: u32, label_sizes: &[&[(u32, usize)]]) -> Result<usize> {
+    for sizes in label_sizes {
+        for &(candidate, size) in *sizes {
+            if candidate == label {
+                return Ok(size);
+            }
+        }
+    }
+    Err(builder_invalid_argument(format!(
+        "missing size for label {label}"
+    )))
+}
+
+fn labeled_operand<'a>(
+    operands: &'a [LabeledVal],
+    index: usize,
+    role: &'static str,
+) -> Result<&'a LabeledVal> {
+    operands
+        .get(index)
+        .ok_or_else(|| builder_invalid_argument(format!("missing {role} operand at index {index}")))
 }
 
 fn reduce_val(
@@ -108,7 +143,7 @@ fn embed_repeated(
     builder: &mut FragmentBuilder<StdTensorOp>,
     lv: &LabeledVal,
     output_labels: &[u32],
-) -> LabeledVal {
+) -> Result<LabeledVal> {
     // Count how many times each label appears in output vs current labels.
     let mut result = lv.clone();
     for &label in output_labels {
@@ -117,11 +152,7 @@ fn embed_repeated(
         if output_count > current_count {
             // Need to embed: find the existing axis with this label and
             // insert a duplicate axis after it.
-            let axis_a = result
-                .labels
-                .iter()
-                .position(|&l| l == label)
-                .expect("label must exist in current tensor for embedding");
+            let axis_a = find_label_axis(&result.labels, label)?;
             // Insert the new axis right after axis_a.
             let axis_b = axis_a + 1;
             let n = result.shape[axis_a];
@@ -143,7 +174,7 @@ fn embed_repeated(
             return embed_repeated(builder, &result, output_labels);
         }
     }
-    result
+    Ok(result)
 }
 
 fn diagonalize_repeated(builder: &mut FragmentBuilder<StdTensorOp>, lv: &LabeledVal) -> LabeledVal {
@@ -182,7 +213,7 @@ fn binary_contract(
     rhs: &LabeledVal,
     survive_labels: &[u32],
     reorder_result: bool,
-) -> LabeledVal {
+) -> Result<LabeledVal> {
     let survive_set: HashSet<u32> = survive_labels.iter().copied().collect();
     let rhs_label_set: HashSet<u32> = rhs.labels.iter().copied().collect();
     let lhs_label_set: HashSet<u32> = lhs.labels.iter().copied().collect();
@@ -238,38 +269,28 @@ fn binary_contract(
     let lhs_sizes: Vec<(u32, usize)> = label_size_map(&lhs.labels, &lhs.shape);
     let rhs_sizes: Vec<(u32, usize)> = label_size_map(&rhs.labels, &rhs.shape);
 
-    let label_to_size = |l: u32| -> usize {
-        for &(label, size) in &lhs_sizes {
-            if label == l {
-                return size;
-            }
-        }
-        for &(label, size) in &rhs_sizes {
-            if label == l {
-                return size;
-            }
-        }
-        panic!("label {} not found in any operand", l);
+    let label_to_size = |label: u32| -> Result<usize> {
+        find_label_size(label, &[lhs_sizes.as_slice(), rhs_sizes.as_slice()])
     };
 
     let result = if !contracting_labels.is_empty() {
         // Use DotGeneral
         let lhs_contracting_dims: Vec<usize> = contracting_labels
             .iter()
-            .map(|l| lhs.labels.iter().position(|x| x == l).unwrap())
-            .collect();
+            .map(|l| find_label_axis(&lhs.labels, *l))
+            .collect::<Result<_>>()?;
         let rhs_contracting_dims: Vec<usize> = contracting_labels
             .iter()
-            .map(|l| rhs.labels.iter().position(|x| x == l).unwrap())
-            .collect();
+            .map(|l| find_label_axis(&rhs.labels, *l))
+            .collect::<Result<_>>()?;
         let lhs_batch_dims: Vec<usize> = batch_labels
             .iter()
-            .map(|l| lhs.labels.iter().position(|x| x == l).unwrap())
-            .collect();
+            .map(|l| find_label_axis(&lhs.labels, *l))
+            .collect::<Result<_>>()?;
         let rhs_batch_dims: Vec<usize> = batch_labels
             .iter()
-            .map(|l| rhs.labels.iter().position(|x| x == l).unwrap())
-            .collect();
+            .map(|l| find_label_axis(&rhs.labels, *l))
+            .collect::<Result<_>>()?;
 
         let config = DotGeneralConfig {
             lhs_contracting_dims,
@@ -285,7 +306,10 @@ fn binary_contract(
             .chain(batch_labels.iter())
             .copied()
             .collect();
-        let result_shape: Vec<usize> = result_labels.iter().map(|&l| label_to_size(l)).collect();
+        let result_shape: Vec<usize> = result_labels
+            .iter()
+            .map(|&l| label_to_size(l))
+            .collect::<Result<_>>()?;
 
         let outputs = builder.add_op(
             StdTensorOp::DotGeneral { config },
@@ -308,17 +332,17 @@ fn binary_contract(
             &lhs_free_labels,
             &rhs_free_labels,
             &label_to_size,
-        )
+        )?
     };
 
     if !reorder_result {
-        return result;
+        return Ok(result);
     }
 
     // Reorder to match the caller-visible order if needed.
     let current_labels = &result.labels;
     if current_labels.is_empty() {
-        return result;
+        return Ok(result);
     }
 
     // Filter survivor labels to those present in result (to handle final reduction later)
@@ -330,17 +354,17 @@ fn binary_contract(
         .collect();
 
     if current_labels.len() == target_labels.len() && *current_labels == target_labels {
-        return result;
+        return Ok(result);
     }
 
     // Build permutation
     let perm: Vec<usize> = target_labels
         .iter()
-        .map(|l| current_labels.iter().position(|x| x == l).unwrap())
-        .collect();
+        .map(|l| find_label_axis(current_labels, *l))
+        .collect::<Result<_>>()?;
 
     if perm.iter().enumerate().all(|(i, &p)| i == p) {
-        return result;
+        return Ok(result);
     }
 
     let new_shape: Vec<usize> = perm.iter().map(|&p| result.shape[p]).collect();
@@ -350,11 +374,11 @@ fn binary_contract(
         OpMode::Primal,
     );
 
-    LabeledVal {
+    Ok(LabeledVal {
         val: ValRef::Local(outputs[0]),
         labels: target_labels,
         shape: new_shape,
-    }
+    })
 }
 
 fn outer_product(
@@ -364,15 +388,18 @@ fn outer_product(
     batch_labels: &[u32],
     lhs_free_labels: &[u32],
     rhs_free_labels: &[u32],
-    label_to_size: &dyn Fn(u32) -> usize,
-) -> LabeledVal {
+    label_to_size: &dyn Fn(u32) -> Result<usize>,
+) -> Result<LabeledVal> {
     let combined_labels: Vec<u32> = lhs_free_labels
         .iter()
         .chain(rhs_free_labels.iter())
         .chain(batch_labels.iter())
         .copied()
         .collect();
-    let combined_shape: Vec<usize> = combined_labels.iter().map(|&l| label_to_size(l)).collect();
+    let combined_shape: Vec<usize> = combined_labels
+        .iter()
+        .map(|&l| label_to_size(l))
+        .collect::<Result<_>>()?;
 
     if lhs.labels == rhs.labels {
         // Same labels: just Mul
@@ -381,24 +408,24 @@ fn outer_product(
             vec![lhs.val.clone(), rhs.val.clone()],
             OpMode::Primal,
         );
-        return LabeledVal {
+        return Ok(LabeledVal {
             val: ValRef::Local(outputs[0]),
             labels: lhs.labels.clone(),
             shape: lhs.shape.clone(),
-        };
+        });
     }
 
     // Broadcast both to combined shape, then Mul
     let lhs_dims: Vec<usize> = lhs
         .labels
         .iter()
-        .map(|l| combined_labels.iter().position(|x| x == l).unwrap())
-        .collect();
+        .map(|l| find_label_axis(&combined_labels, *l))
+        .collect::<Result<_>>()?;
     let rhs_dims: Vec<usize> = rhs
         .labels
         .iter()
-        .map(|l| combined_labels.iter().position(|x| x == l).unwrap())
-        .collect();
+        .map(|l| find_label_axis(&combined_labels, *l))
+        .collect::<Result<_>>()?;
 
     let lhs_bc = builder.add_op(
         StdTensorOp::BroadcastInDim {
@@ -421,31 +448,64 @@ fn outer_product(
         vec![ValRef::Local(lhs_bc[0]), ValRef::Local(rhs_bc[0])],
         OpMode::Primal,
     );
-    LabeledVal {
+    Ok(LabeledVal {
         val: ValRef::Local(outputs[0]),
         labels: combined_labels,
         shape: combined_shape,
-    }
+    })
 }
 
+/// Lower a planned einsum contraction tree into a compute graph fragment.
+///
+/// # Errors
+///
+/// Returns an error if the supplied tree, input values, or input shapes are
+/// internally inconsistent.
+///
+/// # Examples
+///
+/// ```
+/// use computegraph::fragment::FragmentBuilder;
+/// use computegraph::types::ValRef;
+/// use tenferro_einsum::{build_einsum_fragment, ContractionTree, Subscripts};
+/// use tenferro_ops::input_key::TensorInputKey;
+/// use tenferro_ops::std_tensor_op::StdTensorOp;
+///
+/// let subs = Subscripts::parse("ij,jk->ik").unwrap();
+/// let shapes: [&[usize]; 2] = [&[2, 3], &[3, 4]];
+/// let tree = ContractionTree::optimize(&subs, &shapes).unwrap();
+/// let mut builder = FragmentBuilder::<StdTensorOp>::new();
+/// let a = builder.add_input(TensorInputKey::User { id: 0 });
+/// let b = builder.add_input(TensorInputKey::User { id: 1 });
+/// let out = build_einsum_fragment(
+///     &mut builder,
+///     &tree,
+///     &[ValRef::Local(a), ValRef::Local(b)],
+///     &[vec![2, 3], vec![3, 4]],
+/// )
+/// .unwrap();
+/// ```
 pub fn build_einsum_fragment(
     builder: &mut FragmentBuilder<StdTensorOp>,
     tree: &ContractionTree,
     input_vals: &[ValRef<StdTensorOp>],
     input_shapes: &[Vec<usize>],
-) -> ValRef<StdTensorOp> {
+) -> Result<ValRef<StdTensorOp>> {
     let subscripts = &tree.subscripts;
     let n_inputs = subscripts.inputs.len();
-    assert_eq!(
-        n_inputs,
-        input_vals.len(),
-        "number of subscripts inputs must match number of input values"
-    );
-    assert_eq!(
-        input_vals.len(),
-        input_shapes.len(),
-        "number of input values must match number of input shapes"
-    );
+    if n_inputs != input_vals.len() {
+        return Err(builder_invalid_argument(format!(
+            "number of subscripts inputs ({n_inputs}) must match number of input values ({})",
+            input_vals.len()
+        )));
+    }
+    if input_vals.len() != input_shapes.len() {
+        return Err(builder_invalid_argument(format!(
+            "number of input values ({}) must match number of input shapes ({})",
+            input_vals.len(),
+            input_shapes.len()
+        )));
+    }
 
     let output_labels = &subscripts.output;
 
@@ -454,18 +514,20 @@ pub fn build_einsum_fragment(
         .zip(subscripts.inputs.iter())
         .zip(input_shapes.iter())
         .map(|((val, labels), shape)| {
-            assert_eq!(
-                labels.len(),
-                shape.len(),
-                "labels length must match shape rank"
-            );
-            LabeledVal {
+            if labels.len() != shape.len() {
+                return Err(builder_invalid_argument(format!(
+                    "labels length ({}) must match shape rank ({})",
+                    labels.len(),
+                    shape.len()
+                )));
+            }
+            Ok(LabeledVal {
                 val: val.clone(),
                 labels: labels.clone(),
                 shape: shape.clone(),
-            }
+            })
         })
-        .collect();
+        .collect::<Result<_>>()?;
 
     // Diagonalize repeated indices in each input
     for lv in &mut labeled {
@@ -485,49 +547,55 @@ pub fn build_einsum_fragment(
         let result = reduce_val(builder, lv, &reduce_labels);
 
         // Embed diagonal axes if output needs higher multiplicity
-        let result = embed_repeated(builder, &result, output_labels);
+        let result = embed_repeated(builder, &result, output_labels)?;
 
         // Reorder if needed
         if result.labels == *output_labels {
-            return result.val;
+            return Ok(result.val);
         }
         let perm: Vec<usize> = output_labels
             .iter()
-            .map(|l| result.labels.iter().position(|x| x == l).unwrap())
-            .collect();
+            .map(|l| find_label_axis(&result.labels, *l))
+            .collect::<Result<_>>()?;
         if perm.iter().enumerate().all(|(i, &p)| i == p) {
-            return result.val;
+            return Ok(result.val);
         }
         let outputs = builder.add_op(
             StdTensorOp::Transpose { perm },
             vec![result.val],
             OpMode::Primal,
         );
-        return ValRef::Local(outputs[0]);
+        return Ok(ValRef::Local(outputs[0]));
     }
 
     // N >= 2: use contraction tree from v1
     // Operand indices: 0..n_inputs are originals, n_inputs+step_idx are intermediates
     for step_idx in 0..tree.step_count() {
-        let (left, right) = tree.step_pair(step_idx).unwrap();
+        let (left, right) = tree.step_pair(step_idx).ok_or_else(|| {
+            builder_invalid_argument(format!("missing contraction pair for step {step_idx}"))
+        })?;
         // Use the step's intermediate output subscripts so that labels needed
         // by later contractions are preserved (not pre-reduced away).
-        let (_, _, step_out_labels) = tree.step_subscripts(step_idx).unwrap();
+        let (_, _, step_out_labels) = tree.step_subscripts(step_idx).ok_or_else(|| {
+            builder_invalid_argument(format!(
+                "missing contraction subscripts for step {step_idx}"
+            ))
+        })?;
         let is_last = step_idx + 1 == tree.step_count();
         let result = binary_contract(
             builder,
-            &labeled[left],
-            &labeled[right],
+            labeled_operand(&labeled, left, "left")?,
+            labeled_operand(&labeled, right, "right")?,
             step_out_labels,
             is_last,
-        );
+        )?;
         // Push intermediate as new entry in labeled
         labeled.push(result);
     }
 
     // The final result is the last intermediate: labeled[n_inputs + step_count - 1]
     let final_idx = n_inputs + tree.step_count() - 1;
-    let result = &labeled[final_idx];
+    let result = labeled_operand(&labeled, final_idx, "final result")?;
 
     // Final reduction if result has labels not in output
     let output_set: HashSet<u32> = output_labels.iter().copied().collect();
@@ -541,24 +609,24 @@ pub fn build_einsum_fragment(
 
     // Final reorder if needed
     if result.labels == *output_labels {
-        return result.val;
+        return Ok(result.val);
     }
 
     if result.labels.is_empty() && output_labels.is_empty() {
-        return result.val;
+        return Ok(result.val);
     }
 
     let perm: Vec<usize> = output_labels
         .iter()
-        .map(|l| result.labels.iter().position(|x| x == l).unwrap())
-        .collect();
+        .map(|l| find_label_axis(&result.labels, *l))
+        .collect::<Result<_>>()?;
     if perm.iter().enumerate().all(|(i, &p)| i == p) {
-        return result.val;
+        return Ok(result.val);
     }
     let outputs = builder.add_op(
         StdTensorOp::Transpose { perm },
         vec![result.val.clone()],
         OpMode::Primal,
     );
-    ValRef::Local(outputs[0])
+    Ok(ValRef::Local(outputs[0]))
 }

--- a/tenferro-einsum/src/tests/builder_tests.rs
+++ b/tenferro-einsum/src/tests/builder_tests.rs
@@ -17,6 +17,30 @@ fn make_tree(notation: &str, shapes: &[&[usize]]) -> ContractionTree {
     ContractionTree::optimize(&subscripts, shapes).expect("optimize failed")
 }
 
+fn unwrap_local(result: tenferro_device::Result<ValRef<StdTensorOp>>) -> usize {
+    match result.expect("builder should succeed") {
+        ValRef::Local(id) => id,
+        ValRef::External(_) => panic!("expected local"),
+    }
+}
+
+#[test]
+fn builder_reports_missing_output_label_instead_of_panicking() {
+    let mut tree = make_tree("i->i", &[&[3]]);
+    tree.subscripts.output = vec![b'j' as u32];
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let a = builder.add_input(input_key(0));
+
+    let err =
+        build_einsum_fragment(&mut builder, &tree, &[ValRef::Local(a)], &[vec![3]]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        tenferro_device::Error::InvalidArgument(message)
+            if message.contains("missing") && message.contains("label")
+    ));
+}
+
 #[test]
 fn fragment_matmul_ij_jk_ik() {
     let tree = make_tree("ij,jk->ik", &[&[2, 3], &[3, 4]]);
@@ -31,10 +55,7 @@ fn fragment_matmul_ij_jk_ik() {
         &[vec![2, 3], vec![3, 4]],
     );
 
-    builder.set_outputs(vec![match &result {
-        ValRef::Local(id) => *id,
-        _ => panic!("expected local"),
-    }]);
+    builder.set_outputs(vec![unwrap_local(result)]);
     let fragment = builder.build();
     assert!(!fragment.ops().is_empty());
 }
@@ -47,10 +68,7 @@ fn fragment_row_sum_ij_i() {
 
     let result = build_einsum_fragment(&mut builder, &tree, &[ValRef::Local(a)], &[vec![3, 4]]);
 
-    builder.set_outputs(vec![match &result {
-        ValRef::Local(id) => *id,
-        _ => panic!("expected local"),
-    }]);
+    builder.set_outputs(vec![unwrap_local(result)]);
     let fragment = builder.build();
     // Should have a reduce_sum op
     assert!(!fragment.ops().is_empty());
@@ -70,10 +88,7 @@ fn fragment_outer_product_i_j_ij() {
         &[vec![3], vec![4]],
     );
 
-    builder.set_outputs(vec![match &result {
-        ValRef::Local(id) => *id,
-        _ => panic!("expected local"),
-    }]);
+    builder.set_outputs(vec![unwrap_local(result)]);
     let fragment = builder.build();
     assert!(!fragment.ops().is_empty());
 }
@@ -92,10 +107,7 @@ fn fragment_inner_product_i_i() {
         &[vec![3], vec![3]],
     );
 
-    builder.set_outputs(vec![match &result {
-        ValRef::Local(id) => *id,
-        _ => panic!("expected local"),
-    }]);
+    builder.set_outputs(vec![unwrap_local(result)]);
     let fragment = builder.build();
     assert!(!fragment.ops().is_empty());
 }
@@ -114,10 +126,7 @@ fn fragment_hadamard_ij_ij_ij() {
         &[vec![3, 4], vec![3, 4]],
     );
 
-    builder.set_outputs(vec![match &result {
-        ValRef::Local(id) => *id,
-        _ => panic!("expected local"),
-    }]);
+    builder.set_outputs(vec![unwrap_local(result)]);
     let fragment = builder.build();
     assert!(!fragment.ops().is_empty());
 }
@@ -140,10 +149,7 @@ fn fragment_batched_chain_avoids_intermediate_transpose() {
         &[vec![2, 3, 4], vec![2, 4, 5], vec![2, 5, 6]],
     );
 
-    builder.set_outputs(vec![match &result {
-        ValRef::Local(id) => *id,
-        _ => panic!("expected local"),
-    }]);
+    builder.set_outputs(vec![unwrap_local(result)]);
     let fragment = builder.build();
     let transpose_count = fragment
         .ops()
@@ -186,10 +192,7 @@ fn test_diagonalize_repeated() {
 
     let result = build_einsum_fragment(&mut builder, &tree, &[ValRef::Local(a)], &[vec![3, 3]]);
 
-    builder.set_outputs(vec![match &result {
-        ValRef::Local(id) => *id,
-        _ => panic!("expected local"),
-    }]);
+    builder.set_outputs(vec![unwrap_local(result)]);
     let fragment = builder.build();
     let ops: Vec<_> = fragment.ops().iter().map(|n| &n.op).collect();
     // Should contain exactly one ExtractDiag
@@ -218,10 +221,7 @@ fn test_trace_fragment() {
 
     let result = build_einsum_fragment(&mut builder, &tree, &[ValRef::Local(a)], &[vec![3, 3]]);
 
-    builder.set_outputs(vec![match &result {
-        ValRef::Local(id) => *id,
-        _ => panic!("expected local"),
-    }]);
+    builder.set_outputs(vec![unwrap_local(result)]);
     let fragment = builder.build();
     let ops: Vec<_> = fragment.ops().iter().map(|n| &n.op).collect();
     // Should contain ExtractDiag followed by ReduceSum

--- a/tenferro-ops/src/ad/context.rs
+++ b/tenferro-ops/src/ad/context.rs
@@ -8,7 +8,7 @@
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Mutex, OnceLock};
 
 use computegraph::fragment::Fragment;
 use computegraph::types::{GlobalValKey, ValRef};
@@ -23,32 +23,18 @@ type MetadataMap = HashMap<GlobalValKey<StdTensorOp>, TensorMeta>;
 /// Global metadata registry.
 ///
 /// Stored as `Mutex<MetadataMap>` directly: writes insert in place (O(1)),
-/// reads lock briefly. `ShapeGuardContext::metadata_of` reaches into the
-/// registry lazily via [`lookup_global_metadata`] and caches the result
-/// into the context's local map — no up-front full-map snapshot.
+/// and reads lock briefly for targeted key lookups. `ShapeGuardContext::metadata_of`
+/// reaches into the registry lazily via [`lookup_global_metadata`] and caches the
+/// result into the context's local map.
 ///
 /// Earlier designs either cloned the whole map up-front into each AD
-/// `ShapeGuardContext` (quadratic across the monotonically growing
-/// registry) or kept the map in an `Arc` and cloned on every write (also
-/// quadratic, since every traced op triggers at least one
-/// `register_value_metadata` write). Both variants dominated
-/// oracle_replay runtime.
+/// `ShapeGuardContext` or kept the map in an `Arc` and cloned on every write.
+/// Both variants were quadratic across the monotonically growing registry and
+/// dominated oracle_replay runtime.
 static GLOBAL_METADATA: OnceLock<Mutex<MetadataMap>> = OnceLock::new();
 
 fn global_metadata_registry() -> &'static Mutex<MetadataMap> {
     GLOBAL_METADATA.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-fn global_metadata_snapshot() -> Arc<MetadataMap> {
-    let guard = global_metadata_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    Arc::new(guard.clone())
-}
-
-#[doc(hidden)]
-pub fn snapshot_global_metadata() -> Arc<MetadataMap> {
-    global_metadata_snapshot()
 }
 
 /// Per-value tensor metadata used by AD rules.
@@ -140,8 +126,12 @@ impl ShapeGuardContext {
     }
 
     #[doc(hidden)]
+    /// Keep global-registry lookup enabled after a pass boundary.
+    ///
+    /// This is intentionally a no-op for cached entries: global metadata is
+    /// already read lazily on cache misses, and clearing the local cache would
+    /// also discard metadata inserted directly into this context.
     pub fn refresh_global_metadata(&mut self) {
-        self.metadata.clear();
         self.use_global_registry = true;
     }
 
@@ -284,9 +274,7 @@ pub fn register_global_metadata(key: GlobalValKey<StdTensorOp>, meta: TensorMeta
 
 /// Look up a single metadata entry from the global registry.
 ///
-/// Locks the registry briefly for a single `HashMap::get` + clone. Prefer
-/// this over [`snapshot_global_metadata`] for any callsite that only needs
-/// a handful of keys.
+/// Locks the registry briefly for a single `HashMap::get` + clone.
 ///
 /// # Examples
 ///

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -1,9 +1,7 @@
-use strided_kernel::{col_major_strides, StridedArray, StridedView};
-
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use crate::{Buffer, Tensor, TypedTensor};
+use crate::Tensor;
 
 /// Canonical elementwise fusion plan shared between segmented execution and backends.
 #[doc(hidden)]
@@ -48,29 +46,6 @@ pub enum ElementwiseFusionOp {
     Pow,
     Expm1,
     Log1p,
-}
-
-pub(crate) fn typed_view<T: Copy>(tensor: &TypedTensor<T>) -> StridedView<'_, T> {
-    match &tensor.buffer {
-        Buffer::Host(data) => {
-            let strides = col_major_strides(&tensor.shape);
-            StridedView::new(data, &tensor.shape, &strides, 0).expect("contiguous host tensor")
-        }
-        Buffer::Backend(_) => todo!("typed_view for backend buffers"),
-        #[cfg(feature = "cubecl")]
-        Buffer::Cubecl(_) => panic!("GPU tensor (Buffer::Cubecl) passed to CPU backend. Use cubecl::download_tensor() to transfer to CPU first."),
-    }
-}
-
-pub(crate) fn typed_array<T: Clone>(shape: &[usize], fill: T) -> StridedArray<T> {
-    let total: usize = shape.iter().product();
-    let strides = col_major_strides(shape);
-    StridedArray::from_parts(vec![fill; total], shape, &strides, 0)
-        .expect("column-major output array")
-}
-
-pub(crate) fn tensor_from_array<T: Clone>(array: StridedArray<T>) -> TypedTensor<T> {
-    TypedTensor::from_vec(array.dims().to_vec(), array.into_data())
 }
 
 /// Execution session surface for dense tensor backends.

--- a/tenferro-tensor/src/cpu/analytic.rs
+++ b/tenferro-tensor/src/cpu/analytic.rs
@@ -2,7 +2,7 @@ use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 use strided_kernel::{map_into, zip_map2_into};
 
-use crate::backend::{tensor_from_array, typed_array, typed_view};
+use super::{tensor_from_array, typed_array_uninit, typed_view};
 use crate::types::{Tensor, TypedTensor};
 
 trait UnaryAnalyticElem: Copy + Clone + One + Zero {
@@ -148,7 +148,7 @@ macro_rules! define_unary_analytic_op {
         where
             T: UnaryAnalyticElem,
         {
-            let mut out = typed_array(&input.shape, T::zero());
+            let mut out = unsafe { typed_array_uninit(&input.shape) };
             map_into(&mut out.view_mut(), &typed_view(input), |x| x.$elem_fn())
                 .map_err(|err| backend_failure(stringify!($typed_fn), err))?;
             Ok(tensor_from_array(out))
@@ -191,7 +191,7 @@ where
             rhs: rhs.shape.clone(),
         });
     }
-    let mut out = typed_array(&lhs.shape, T::zero());
+    let mut out = unsafe { typed_array_uninit(&lhs.shape) };
     zip_map2_into(
         &mut out.view_mut(),
         &typed_view(lhs),

--- a/tenferro-tensor/src/cpu/context.rs
+++ b/tenferro-tensor/src/cpu/context.rs
@@ -26,9 +26,13 @@ fn shared_pools() -> &'static Mutex<HashMap<usize, Arc<rayon::ThreadPool>>> {
 }
 
 pub(crate) fn get_or_create_pool(num_threads: usize) -> Arc<rayon::ThreadPool> {
-    let mut pools = shared_pools()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut pools = match shared_pools().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            eprintln!("tenferro-tensor: CPU thread-pool cache mutex was poisoned; recovering");
+            poisoned.into_inner()
+        }
+    };
     if let Some(pool) = pools.get(&num_threads) {
         return Arc::clone(pool);
     }

--- a/tenferro-tensor/src/cpu/gemm/blas_gemm.rs
+++ b/tenferro-tensor/src/cpu/gemm/blas_gemm.rs
@@ -16,6 +16,15 @@ pub(crate) trait BlasGemm: Sized {
     );
 
     #[allow(clippy::too_many_arguments)]
+    /// Run GEMM against raw strided matrix pointers.
+    ///
+    /// # Safety
+    ///
+    /// The caller must pass valid, non-null pointers to matrices whose logical
+    /// `m x k`, `k x n`, and `m x n` elements are addressable through the given
+    /// strides for the duration of the BLAS call. `c_ptr` must be uniquely
+    /// writable for the output elements and must not alias input elements in a
+    /// way forbidden by the linked BLAS implementation.
     unsafe fn strided_gemm(
         alpha: Self,
         a_ptr: *const Self,
@@ -111,6 +120,9 @@ macro_rules! impl_real_blas_gemm {
                 let m_i32 = dim_to_i32("m", m);
                 let n_i32 = dim_to_i32("n", n);
                 let k_i32 = dim_to_i32("k", k);
+                // SAFETY: the slices provide valid contiguous column-major
+                // storage for the BLAS read/write regions implied by m, n,
+                // and k, and dimensions were checked to fit BLAS i32 args.
                 unsafe {
                     $gemm(
                         CBLAS_LAYOUT::CblasColMajor,
@@ -154,6 +166,9 @@ macro_rules! impl_real_blas_gemm {
                 let (trans_b, ldb) = infer_b_layout(k, n, b_rs, b_cs);
                 let ldc = infer_c_layout(m, c_rs, c_cs);
 
+                // SAFETY: `strided_gemm`'s caller guarantees the raw pointers
+                // are valid for the strided matrix regions. Layout inference
+                // above checked the unit-stride axis and BLAS leading dims.
                 $gemm(
                     CBLAS_LAYOUT::CblasColMajor,
                     trans_a,
@@ -193,6 +208,9 @@ macro_rules! impl_complex_blas_gemm {
                 let k_i32 = dim_to_i32("k", k);
                 let alpha_ri = [alpha.re, alpha.im];
                 let beta_ri = [beta.re, beta.im];
+                // SAFETY: the slices provide valid contiguous column-major
+                // storage for the BLAS read/write regions implied by m, n,
+                // and k, and dimensions were checked to fit BLAS i32 args.
                 unsafe {
                     $gemm(
                         CBLAS_LAYOUT::CblasColMajor,
@@ -238,6 +256,9 @@ macro_rules! impl_complex_blas_gemm {
                 let alpha_ri = [alpha.re, alpha.im];
                 let beta_ri = [beta.re, beta.im];
 
+                // SAFETY: `strided_gemm`'s caller guarantees the raw pointers
+                // are valid for the strided matrix regions. Layout inference
+                // above checked the unit-stride axis and BLAS leading dims.
                 $gemm(
                     CBLAS_LAYOUT::CblasColMajor,
                     trans_a,

--- a/tenferro-tensor/src/cpu/gemm/faer_gemm.rs
+++ b/tenferro-tensor/src/cpu/gemm/faer_gemm.rs
@@ -44,6 +44,12 @@ macro_rules! impl_faer_gemm {
                 c_cs: isize,
             ) {
                 use faer::{Accum, MatMut, MatRef};
+                let a_rs = super::normalize_singleton_stride(a_rs, m, k);
+                let a_cs = super::normalize_singleton_stride(a_cs, k, m);
+                let b_rs = super::normalize_singleton_stride(b_rs, k, n);
+                let b_cs = super::normalize_singleton_stride(b_cs, n, k);
+                let c_rs = super::normalize_singleton_stride(c_rs, m, 1);
+                let c_cs = super::normalize_singleton_stride(c_cs, n, m);
                 let a_mat = MatRef::<$ty>::from_raw_parts(a_ptr, m, k, a_rs, a_cs);
                 let b_mat = MatRef::<$ty>::from_raw_parts(b_ptr, k, n, b_rs, b_cs);
                 let zero = <$ty as num_traits::Zero>::zero();

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -568,7 +568,6 @@ where
     })
 }
 
-#[cfg(feature = "cpu-blas")]
 fn normalize_singleton_stride(stride: isize, extent: usize, fallback: usize) -> isize {
     if extent == 1 {
         let fallback = fallback.max(1) as isize;

--- a/tenferro-tensor/src/cpu/gemm/tests.rs
+++ b/tenferro-tensor/src/cpu/gemm/tests.rs
@@ -117,3 +117,10 @@ fn faer_strided_gemm_accumulates_with_unit_beta_without_prescaling() {
 
     assert_eq!(c, [11.0, 22.0, 33.0, 44.0]);
 }
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn faer_singleton_strides_are_normalized_before_raw_gemm() {
+    assert_eq!(super::normalize_singleton_stride(0, 1, 4), 4);
+    assert_eq!(super::normalize_singleton_stride(0, 3, 4), 0);
+}

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -93,6 +93,9 @@ impl LapackFullPivLu for f64 {
         jpiv: &mut [i32],
         info: &mut i32,
     ) {
+        // SAFETY: `data` stores an `lda x n` LAPACK column-major matrix,
+        // pivot arrays have length at least `n`, and all pointers are valid
+        // for the duration of the FFI call.
         unsafe {
             dgetc2_ffi(
                 &n,
@@ -114,6 +117,9 @@ impl LapackFullPivLu for f64 {
         jpiv: &[i32],
         scale: &mut f64,
     ) {
+        // SAFETY: `data` stores the factorized `lda x n` matrix, `rhs` has
+        // length at least `n`, pivot arrays have length at least `n`, and
+        // LAPACK only writes through `rhs` and `scale`.
         unsafe {
             dgesc2_ffi(
                 &n,
@@ -153,6 +159,9 @@ impl LapackFullPivLu for Complex64 {
         jpiv: &mut [i32],
         info: &mut i32,
     ) {
+        // SAFETY: `data` stores an `lda x n` LAPACK column-major matrix,
+        // pivot arrays have length at least `n`, and all pointers are valid
+        // for the duration of the FFI call.
         unsafe {
             zgetc2_ffi(
                 &n,
@@ -174,6 +183,9 @@ impl LapackFullPivLu for Complex64 {
         jpiv: &[i32],
         scale: &mut f64,
     ) {
+        // SAFETY: `data` stores the factorized `lda x n` matrix, `rhs` has
+        // length at least `n`, pivot arrays have length at least `n`, and
+        // LAPACK only writes through `rhs` and `scale`.
         unsafe {
             zgesc2_ffi(
                 &n,

--- a/tenferro-tensor/src/cpu/reduction.rs
+++ b/tenferro-tensor/src/cpu/reduction.rs
@@ -1,8 +1,9 @@
 use std::ops::{Add, Mul};
 
 use num_traits::{Float, One, Zero};
-use strided_kernel::{col_major_strides, reduce_axis, StridedArray};
+use strided_kernel::reduce_axis;
 
+use super::typed_view;
 use crate::types::{Tensor, TypedTensor};
 
 fn backend_failure(op: &'static str, err: impl ToString) -> crate::Error {
@@ -106,14 +107,17 @@ where
         .map(|(_, &dim)| dim)
         .collect();
 
-    let strides = col_major_strides(&input.shape);
-    let mut current =
-        StridedArray::from_parts(input.host_data().to_vec(), &input.shape, &strides, 0)
-            .map_err(|err| backend_failure(label, err))?;
-
     let mut sorted_axes = axes.to_vec();
     sorted_axes.sort_unstable_by(|a, b| b.cmp(a));
-    for axis in sorted_axes {
+    let Some((&first_axis, remaining_axes)) = sorted_axes.split_first() else {
+        return Ok(input.clone());
+    };
+
+    let input_view = typed_view(input);
+    let mut current = reduce_axis(&input_view, first_axis, map_fn, reduce_fn, init)
+        .map_err(|err| backend_failure(label, err))?;
+
+    for &axis in remaining_axes {
         current = reduce_axis(&current.view(), axis, map_fn, reduce_fn, init)
             .map_err(|err| backend_failure(label, err))?;
     }

--- a/tenferro-tensor/src/cubecl/gemm.rs
+++ b/tenferro-tensor/src/cubecl/gemm.rs
@@ -179,7 +179,7 @@ where
     let rhs_ptr = typed_device_ptr(backend.runtime(), rhs)?;
     let output_ptr = typed_device_ptr(backend.runtime(), &output)?;
 
-    let accumulator = zero_alloc::<T>(backend.runtime(), &layout.output_shape);
+    let accumulator = alloc_output::<T>(backend.runtime(), &layout.output_shape);
     let accumulator_ptr = typed_device_ptr(backend.runtime(), &accumulator)?;
 
     let alpha = T::one();

--- a/tenferro-tensor/src/cubecl/linalg.rs
+++ b/tenferro-tensor/src/cubecl/linalg.rs
@@ -1191,10 +1191,25 @@ fn as_i32(value: usize, op: &'static str, label: &'static str) -> crate::Result<
     })
 }
 
+/// Offset a mutable device pointer by `offset` typed elements.
+///
+/// # Safety
+///
+/// `base` must point to a device allocation containing at least `offset`
+/// additional `T` elements, and the resulting pointer must remain within the
+/// same allocation. The caller is responsible for ensuring any later FFI call
+/// observes CUDA aliasing and mutability requirements.
 unsafe fn batch_ptr<T>(base: *mut c_void, offset: usize) -> *mut c_void {
     base.cast::<T>().add(offset).cast()
 }
 
+/// Offset an immutable device pointer by `offset` typed elements.
+///
+/// # Safety
+///
+/// `base` must point to a device allocation containing at least `offset`
+/// additional `T` elements, and the resulting pointer must remain within the
+/// same allocation for the lifetime required by the receiving CUDA library.
 unsafe fn batch_const_ptr<T>(base: *const c_void, offset: usize) -> *const c_void {
     base.cast::<T>().add(offset).cast()
 }

--- a/tenferro-tensor/src/cubecl/tests/fusion_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/fusion_tests.rs
@@ -3,7 +3,10 @@ use crate::backend::ElementwiseFusionPlan;
 use crate::config::CompareDir;
 use crate::{ElementwiseFusionInst, ElementwiseFusionOp, TensorBackend};
 
-use super::{assert_tensor_close, cpu_backend, download, gpu_backend, tensor_f64, upload};
+use super::{
+    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c32, tensor_c64, tensor_f64,
+    upload,
+};
 
 /// Build a plan for: out = (a + b) * a
 fn add_mul_plan() -> ElementwiseFusionPlan {
@@ -46,6 +49,123 @@ fn test_fused_add_mul_matches_cpu() {
     assert_eq!(result.len(), 1);
     let actual = download(&gpu, &result[0]);
     assert_tensor_close(&actual, &expected, 1e-12);
+}
+
+fn complex_add_conj_mul_plan(dtype: crate::DType) -> ElementwiseFusionPlan {
+    ElementwiseFusionPlan {
+        dtype,
+        n_inputs: 2,
+        outputs: vec![4],
+        ops: vec![
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Add,
+                inputs: vec![0, 1],
+            },
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Conj,
+                inputs: vec![2],
+            },
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Multiply,
+                inputs: vec![3, 0],
+            },
+        ],
+    }
+}
+
+#[test]
+#[ignore]
+fn test_fused_complex_c64_add_conj_mul_matches_cpu() {
+    let a = tensor_c64(
+        vec![3],
+        vec![
+            num_complex::Complex64::new(1.0, 2.0),
+            num_complex::Complex64::new(-3.0, 0.5),
+            num_complex::Complex64::new(0.25, -1.0),
+        ],
+    );
+    let b = tensor_c64(
+        vec![3],
+        vec![
+            num_complex::Complex64::new(0.5, -1.0),
+            num_complex::Complex64::new(2.0, 3.0),
+            num_complex::Complex64::new(-4.0, 0.75),
+        ],
+    );
+
+    let mut cpu = cpu_backend();
+    let sum = cpu.add(&a, &b).unwrap();
+    let conj = cpu.conj(&sum).unwrap();
+    let expected = cpu.mul(&conj, &a).unwrap();
+
+    let mut gpu = gpu_backend();
+    let gpu_a = upload(&gpu, &a);
+    let gpu_b = upload(&gpu, &b);
+
+    let plan = complex_add_conj_mul_plan(crate::DType::C64);
+    let result = gpu
+        .execute_elementwise_fusion(&[&gpu_a, &gpu_b], &plan)
+        .unwrap()
+        .expect("fusion should succeed for c64 add+conj+mul");
+    assert_eq!(result.len(), 1);
+    let actual = download(&gpu, &result[0]);
+    assert_tensor_close(&actual, &expected, 1e-12);
+}
+
+fn complex_div_neg_plan(dtype: crate::DType) -> ElementwiseFusionPlan {
+    ElementwiseFusionPlan {
+        dtype,
+        n_inputs: 2,
+        outputs: vec![3],
+        ops: vec![
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Divide,
+                inputs: vec![0, 1],
+            },
+            ElementwiseFusionInst {
+                op: ElementwiseFusionOp::Negate,
+                inputs: vec![2],
+            },
+        ],
+    }
+}
+
+#[test]
+#[ignore]
+fn test_fused_complex_c32_div_neg_matches_cpu() {
+    let a = tensor_c32(
+        vec![3],
+        vec![
+            num_complex::Complex32::new(1.0, 2.0),
+            num_complex::Complex32::new(-3.0, 0.5),
+            num_complex::Complex32::new(0.25, -1.0),
+        ],
+    );
+    let b = tensor_c32(
+        vec![3],
+        vec![
+            num_complex::Complex32::new(0.5, -1.0),
+            num_complex::Complex32::new(2.0, 3.0),
+            num_complex::Complex32::new(-4.0, 0.75),
+        ],
+    );
+
+    let mut cpu = cpu_backend();
+    let div = cpu.div(&a, &b).unwrap();
+    let expected = cpu.neg(&div).unwrap();
+
+    let mut gpu = gpu_backend();
+    let gpu_a = upload(&gpu, &a);
+    let gpu_b = upload(&gpu, &b);
+
+    let plan = complex_div_neg_plan(crate::DType::C32);
+    let result = gpu
+        .execute_elementwise_fusion(&[&gpu_a, &gpu_b], &plan)
+        .unwrap()
+        .expect("fusion should succeed for c32 div+neg");
+    assert_eq!(result.len(), 1);
+    let actual = download(&gpu, &result[0]);
+    assert_tensor_close(&actual, &expected, 1e-5);
 }
 
 /// Build a plan for: out = neg(a + b)

--- a/tenferro-tensor/src/cubecl/tests/mod.rs
+++ b/tenferro-tensor/src/cubecl/tests/mod.rs
@@ -75,6 +75,11 @@ fn assert_tensor_close(actual: &Tensor, expected: &Tensor, tol: f64) {
                 );
             }
         }
+        (Tensor::I64(_), Tensor::I64(_)) => {
+            let actual = actual.as_slice::<i64>().unwrap();
+            let expected = expected.as_slice::<i64>().unwrap();
+            assert_eq!(actual, expected);
+        }
         (Tensor::C32(_), Tensor::C32(_)) => {
             let actual = actual.as_slice::<Complex32>().unwrap();
             let expected = expected.as_slice::<Complex32>().unwrap();

--- a/tenferro-tensor/src/cubecl/tests/runtime_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/runtime_tests.rs
@@ -54,6 +54,21 @@ gpu_test!(test_upload_download_f64, {
     );
 });
 
+gpu_test!(test_upload_download_i64, {
+    let rt = CubeclRuntime::new(0).unwrap();
+    let host = Tensor::from_vec(vec![2, 3], vec![1_i64, -2, 3, -4, 5, -6]);
+    let gpu = upload_tensor(&rt, &host).unwrap();
+
+    assert_eq!(gpu.dtype(), crate::DType::I64);
+
+    let back = download_tensor(&rt, &gpu).unwrap();
+    assert_eq!(back.shape(), host.shape());
+    assert_eq!(
+        back.as_slice::<i64>().unwrap(),
+        host.as_slice::<i64>().unwrap()
+    );
+});
+
 gpu_test!(test_upload_download_c64, {
     use num_complex::Complex64;
 
@@ -142,6 +157,14 @@ gpu_test!(test_full_round_trip_all_dtypes, {
     assert_eq!(
         back.as_slice::<f32>().unwrap(),
         t.as_slice::<f32>().unwrap()
+    );
+
+    let t = Tensor::from_vec(vec![3], vec![1_i64, -2, 3]);
+    let gpu = upload_tensor(&rt, &t).unwrap();
+    let back = download_tensor(&rt, &gpu).unwrap();
+    assert_eq!(
+        back.as_slice::<i64>().unwrap(),
+        t.as_slice::<i64>().unwrap()
     );
 
     let t = Tensor::from_vec(

--- a/tenferro-tensor/src/cubecl/tests/structural_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/structural_tests.rs
@@ -3,7 +3,8 @@ use crate::DType;
 use crate::TensorBackend;
 
 use super::{
-    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c64, tensor_f64, upload,
+    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c64, tensor_f64, tensor_i64,
+    upload,
 };
 
 #[test]
@@ -68,6 +69,58 @@ fn test_cubecl_structural_ops_match_cpu() {
     let gpu_out = gpu.triu(&gpu_matrix, -1).unwrap();
     let actual = download(&gpu, &gpu_out);
     assert_tensor_close(&actual, &expected, 1e-12);
+}
+
+#[test]
+#[ignore]
+fn test_cubecl_i64_structural_ops_match_cpu() {
+    let input = tensor_i64(vec![2, 3], vec![1, -2, 3, -4, 5, -6]);
+    let scalar = tensor_i64(vec![], vec![7]);
+    let vector = tensor_i64(vec![3], vec![10, -20, 30]);
+    let matrix = tensor_i64(vec![3, 3], vec![1, -2, 3, -4, 5, -6, 7, -8, 9]);
+
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+    let gpu_scalar = upload(&gpu, &scalar);
+    let gpu_vector = upload(&gpu, &vector);
+
+    let expected = cpu.transpose(&input, &[1, 0]).unwrap();
+    let gpu_out = gpu.transpose(&gpu_input, &[1, 0]).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.reshape(&input, &[3, 2]).unwrap();
+    let gpu_out = gpu.reshape(&gpu_input, &[3, 2]).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.broadcast_in_dim(&scalar, &[2, 3], &[]).unwrap();
+    let gpu_out = gpu.broadcast_in_dim(&gpu_scalar, &[2, 3], &[]).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.reverse(&input, &[1]).unwrap();
+    let gpu_out = gpu.reverse(&gpu_input, &[1]).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.concatenate(&[&input, &input], 1).unwrap();
+    let gpu_out = gpu.concatenate(&[&gpu_input, &gpu_input], 1).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let gpu_matrix = upload(&gpu, &matrix);
+    let expected = cpu.extract_diagonal(&matrix, 0, 1).unwrap();
+    let gpu_out = gpu.extract_diagonal(&gpu_matrix, 0, 1).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.embed_diagonal(&vector, 0, 1).unwrap();
+    let gpu_out = gpu.embed_diagonal(&gpu_vector, 0, 1).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.tril(&matrix, 0).unwrap();
+    let gpu_out = gpu.tril(&gpu_matrix, 0).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.triu(&matrix, -1).unwrap();
+    let gpu_out = gpu.triu(&gpu_matrix, -1).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
 }
 
 #[test]

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -12,31 +12,6 @@
 //! assert_eq!(c.shape(), &[2]);
 //! ```
 
-pub mod backend;
-pub mod buffer_pool;
-pub mod config;
-pub mod cpu;
-pub mod error;
-#[cfg(feature = "provider-inject")]
-pub mod inject;
-mod typed_linalg;
-pub mod types;
-pub mod validate;
-
-#[cfg(feature = "rocm")]
-pub mod rocm;
-
-#[cfg(feature = "cubecl")]
-pub mod cubecl;
-
-pub use backend::{
-    default_exec_session, ElementwiseFusionInst, ElementwiseFusionOp, ElementwiseFusionPlan,
-    TensorBackend, TensorExec,
-};
-pub use config::*;
-pub use error::*;
-pub use types::*;
-
 #[cfg(not(any(feature = "cpu-faer", feature = "cpu-blas")))]
 compile_error!("enable at least one CPU backend: cpu-faer or cpu-blas");
 
@@ -46,16 +21,125 @@ compile_error!("enable exactly one CPU backend: cpu-faer or cpu-blas");
 #[cfg(all(feature = "provider-inject", not(feature = "cpu-blas")))]
 compile_error!("provider-inject requires cpu-blas");
 
-#[cfg(feature = "provider-src")]
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub mod backend;
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub mod buffer_pool;
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub mod config;
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub mod cpu;
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub mod error;
+#[cfg(all(
+    feature = "provider-inject",
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub mod inject;
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+mod typed_linalg;
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub mod types;
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub mod validate;
+
+#[cfg(all(
+    feature = "rocm",
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub mod rocm;
+
+#[cfg(all(
+    feature = "cubecl",
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub mod cubecl;
+
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub use backend::{
+    default_exec_session, ElementwiseFusionInst, ElementwiseFusionOp, ElementwiseFusionPlan,
+    TensorBackend, TensorExec,
+};
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub use config::*;
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub use error::*;
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub use types::*;
+
+#[cfg(all(
+    feature = "provider-src",
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
 extern crate blas_src as _;
-#[cfg(feature = "provider-inject")]
+#[cfg(all(
+    feature = "provider-inject",
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
 extern crate cblas_inject as _;
-#[cfg(feature = "provider-src")]
+#[cfg(all(
+    feature = "provider-src",
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
 extern crate cblas_src as _;
-#[cfg(feature = "provider-inject")]
+#[cfg(all(
+    feature = "provider-inject",
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
 extern crate lapack_inject as _;
-#[cfg(feature = "provider-src")]
+#[cfg(all(
+    feature = "provider-src",
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
 extern crate lapack_src as _;
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
 mod tests;

--- a/tenferro/src/einsum.rs
+++ b/tenferro/src/einsum.rs
@@ -285,16 +285,11 @@ pub fn einsum_with<B: TensorBackend>(
                 engine.einsum_cache.put(cache_key, tree.clone());
                 tree
             };
-            Ok(build_traced_from_tree(
-                inputs,
-                &subs,
-                tree.as_ref(),
-                &shapes,
-            ))
+            build_traced_from_tree(inputs, &subs, tree.as_ref(), &shapes)
         }
         optimize => {
             let tree = resolve_strategy(optimize, &subs, &shape_refs)?;
-            Ok(build_traced_from_tree(inputs, &subs, &tree, &shapes))
+            build_traced_from_tree(inputs, &subs, &tree, &shapes)
         }
     }
 }
@@ -465,7 +460,7 @@ fn build_traced_from_tree(
     subscripts: &Subscripts,
     tree: &ContractionTree,
     shapes: &[Vec<usize>],
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     let out_shape = compute_einsum_output_shape(subscripts, shapes);
 
     let mut builder = FragmentBuilder::new();
@@ -478,7 +473,8 @@ fn build_traced_from_tree(
         input_vals.push(val_ref);
     }
 
-    let result_ref = build_einsum_fragment(&mut builder, tree, &input_vals, shapes);
+    let result_ref = build_einsum_fragment(&mut builder, tree, &input_vals, shapes)
+        .map_err(|err| Error::ContractionError(err.to_string()))?;
 
     match result_ref {
         ValRef::Local(result_local) => {
@@ -497,7 +493,7 @@ fn build_traced_from_tree(
                 CheckpointNode::merge_chains(acc, input.checkpoint_chain.clone())
             });
 
-            TracedTensor {
+            Ok(TracedTensor {
                 id: next_traced_id(),
                 rank: out_shape.len(),
                 dtype: inputs[0].dtype,
@@ -508,14 +504,14 @@ fn build_traced_from_tree(
                 inputs_map: Arc::new(merged),
                 extra_roots,
                 checkpoint_chain: merged_chain,
-            }
+            })
         }
         ValRef::External(_) => {
             // Identity pass-through: the einsum doesn't add any ops.
             // Find which input was returned and clone its TracedTensor.
             for (i, iv) in input_vals.iter().enumerate() {
                 if *iv == result_ref {
-                    return TracedTensor {
+                    return Ok(TracedTensor {
                         id: next_traced_id(),
                         rank: out_shape.len(),
                         dtype: inputs[i].dtype,
@@ -526,10 +522,12 @@ fn build_traced_from_tree(
                         inputs_map: inputs[i].inputs_map.clone(),
                         extra_roots: inputs[i].extra_roots.clone(),
                         checkpoint_chain: inputs[i].checkpoint_chain.clone(),
-                    };
+                    });
                 }
             }
-            panic!("build_einsum_fragment returned unrecognized external ref");
+            Err(Error::Internal(
+                "einsum builder returned an unrecognized external value".into(),
+            ))
         }
     }
 }

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -725,7 +725,8 @@ fn execute_nary_einsum<B: TensorBackend>(
         input_vals.push(ValRef::Local(local));
     }
 
-    let result_ref = build_einsum_fragment(&mut builder, &tree, &input_vals, &shapes);
+    let result_ref = build_einsum_fragment(&mut builder, &tree, &input_vals, &shapes)
+        .map_err(|err| Error::ContractionError(err.to_string()))?;
     let result_local = match result_ref {
         ValRef::Local(local) => local,
         ValRef::External(_) => {

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -15,7 +15,7 @@ use tenferro::exec::eval_exec_ir;
 use tenferro::shape_infer::{infer_output_dtype, infer_output_shapes};
 use tenferro::{matmul, Engine, TracedTensor};
 use tenferro_ops::ad::context::{
-    register_global_metadata_batch, snapshot_global_metadata, TensorMeta,
+    lookup_global_metadata, register_global_metadata_batch, TensorMeta,
 };
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
@@ -198,8 +198,7 @@ fn register_fragment_metadata_for_test(
     seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
 ) {
     let seeded: Vec<_> = seeded.into_iter().collect();
-    let mut known = (*snapshot_global_metadata()).clone();
-    known.extend(seeded.iter().cloned());
+    let mut known: HashMap<_, _> = seeded.iter().cloned().collect();
 
     let mut registrations = seeded;
     for op_node in fragment.ops() {
@@ -211,10 +210,16 @@ fn register_fragment_metadata_for_test(
                     ValRef::Local(local_id) => &fragment.vals()[*local_id].key,
                     ValRef::External(key) => key,
                 };
-                known
-                    .get(key)
-                    .cloned()
-                    .unwrap_or_else(|| panic!("test metadata registration missing input {:?}", key))
+                match known.get(key).cloned() {
+                    Some(meta) => meta,
+                    None => {
+                        let meta = lookup_global_metadata(key).unwrap_or_else(|| {
+                            panic!("test metadata registration missing input {:?}", key)
+                        });
+                        known.insert(key.clone(), meta.clone());
+                        meta
+                    }
+                }
             })
             .collect();
         let input_shape_exprs: Vec<Vec<DimExpr>> = input_metas


### PR DESCRIPTION
## Summary

- Harden CPU backend feature gating, faer GEMM singleton-stride handling, and einsum fragment-builder error propagation.
- Remove avoidable CPU/GPU allocation work, clarify unsafe contracts, and drop unused backend helper code that was hurting coverage.
- Clean up AD metadata refresh behavior and add CubeCL coverage for complex fusion plus i64 runtime/structural operations.

## Issues

Closes #774
Closes #803
Closes #798
Closes #806
Closes #816
Closes #746
Closes #813
Closes #796
Closes #810
Closes #809

Not closed:
- #775 remains open; I left the issue with the current limitation around runtime scalar-dependent DynamicTruncate extent metadata.
- #812 is an index/tracking issue, not directly closed by this batch.

## Verification

- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-tensor --features cubecl test_dot_general_matmul_f32 -- --ignored`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-tensor --features cubecl fused_complex -- --ignored`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-tensor --features cubecl i64 -- --ignored`

## Merge Note

Auto-merge is intentionally not enabled from this PR creation pass because this batch is intended for a non-squash merge.

Generated with [Codex](https://openai.com/codex)
