### PR TITLE
[codex] fix CPU batch validation and shape arithmetic

### DIFF
--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -456,7 +456,7 @@ impl TensorBackend for CpuBackend {
             .and_then(|result| result),
             #[cfg(feature = "cpu-blas")]
             (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
-                Tensor::F64(linalg::triangular_solve(
+                linalg::triangular_solve(
                     buffers,
                     a,
                     b,
@@ -464,11 +464,13 @@ impl TensorBackend for CpuBackend {
                     lower,
                     transpose_a,
                     unit_diagonal,
-                ))
-            }),
+                )
+                .map(Tensor::F64)
+            })
+            .and_then(|result| result),
             #[cfg(feature = "cpu-blas")]
             (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
-                Tensor::C64(linalg::triangular_solve(
+                linalg::triangular_solve(
                     buffers,
                     a,
                     b,
@@ -476,8 +478,10 @@ impl TensorBackend for CpuBackend {
                     lower,
                     transpose_a,
                     unit_diagonal,
-                ))
-            }),
+                )
+                .map(Tensor::C64)
+            })
+            .and_then(|result| result),
             #[cfg(feature = "cpu-faer")]
             (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
                 linalg::triangular_solve(

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -441,7 +441,7 @@ impl TensorBackend for CpuBackend {
         self.install_with_pool(|buffers| match (a, b) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
-                Tensor::F64(linalg::triangular_solve(
+                linalg::triangular_solve(
                     ctx.as_ref(),
                     buffers,
                     a,
@@ -450,8 +450,10 @@ impl TensorBackend for CpuBackend {
                     lower,
                     transpose_a,
                     unit_diagonal,
-                ))
-            }),
+                )
+                .map(Tensor::F64)
+            })
+            .and_then(|result| result),
             #[cfg(feature = "cpu-blas")]
             (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
                 Tensor::F64(linalg::triangular_solve(
@@ -478,7 +480,7 @@ impl TensorBackend for CpuBackend {
             }),
             #[cfg(feature = "cpu-faer")]
             (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
-                Tensor::C64(linalg::triangular_solve(
+                linalg::triangular_solve(
                     ctx.as_ref(),
                     buffers,
                     a,
@@ -487,8 +489,10 @@ impl TensorBackend for CpuBackend {
                     lower,
                     transpose_a,
                     unit_diagonal,
-                ))
-            }),
+                )
+                .map(Tensor::C64)
+            })
+            .and_then(|result| result),
             _ => {
                 if a.dtype() != b.dtype() {
                     Err(crate::Error::DTypeMismatch {
@@ -508,12 +512,9 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => catch_backend_panic("lu", || {
-                linalg::lu(ctx.as_ref(), buffers, t)
-                    .into_iter()
-                    .map(Tensor::F64)
-                    .collect()
-            }),
+            Tensor::F64(t) => catch_backend_panic("lu", || linalg::lu(ctx.as_ref(), buffers, t))
+                .and_then(|result| result)
+                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => catch_backend_panic("lu", || {
                 linalg::lu(buffers, t)
@@ -529,12 +530,9 @@ impl TensorBackend for CpuBackend {
                     .collect()
             }),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => catch_backend_panic("lu", || {
-                linalg::lu(ctx.as_ref(), buffers, t)
-                    .into_iter()
-                    .map(Tensor::C64)
-                    .collect()
-            }),
+            Tensor::C64(t) => catch_backend_panic("lu", || linalg::lu(ctx.as_ref(), buffers, t))
+                .and_then(|result| result)
+                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             _ => Err(unsupported_dtype("lu", input.dtype())),
         })
     }
@@ -546,10 +544,9 @@ impl TensorBackend for CpuBackend {
             #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => catch_backend_panic("full_piv_lu", || {
                 linalg::full_piv_lu(ctx.as_ref(), buffers, t)
-                    .into_iter()
-                    .map(Tensor::F64)
-                    .collect()
-            }),
+            })
+            .and_then(|result| result)
+            .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => catch_backend_panic("full_piv_lu", || {
                 linalg::full_piv_lu(buffers, t)
@@ -567,10 +564,9 @@ impl TensorBackend for CpuBackend {
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => catch_backend_panic("full_piv_lu", || {
                 linalg::full_piv_lu(ctx.as_ref(), buffers, t)
-                    .into_iter()
-                    .map(Tensor::C64)
-                    .collect()
-            }),
+            })
+            .and_then(|result| result)
+            .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             _ => Err(unsupported_dtype("full_piv_lu", input.dtype())),
         })
     }
@@ -672,12 +668,9 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => catch_backend_panic("qr", || {
-                linalg::qr(ctx.as_ref(), buffers, t)
-                    .into_iter()
-                    .map(Tensor::F64)
-                    .collect()
-            }),
+            Tensor::F64(t) => catch_backend_panic("qr", || linalg::qr(ctx.as_ref(), buffers, t))
+                .and_then(|result| result)
+                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => catch_backend_panic("qr", || {
                 linalg::qr(buffers, t)
@@ -693,12 +686,9 @@ impl TensorBackend for CpuBackend {
                     .collect()
             }),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => catch_backend_panic("qr", || {
-                linalg::qr(ctx.as_ref(), buffers, t)
-                    .into_iter()
-                    .map(Tensor::C64)
-                    .collect()
-            }),
+            Tensor::C64(t) => catch_backend_panic("qr", || linalg::qr(ctx.as_ref(), buffers, t))
+                .and_then(|result| result)
+                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             _ => Err(unsupported_dtype("qr", input.dtype())),
         })
     }

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -308,7 +308,7 @@ impl TensorExec for CpuExecSession<'_> {
             .and_then(|r| r),
             #[cfg(feature = "cpu-blas")]
             (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
-                Tensor::F64(linalg::triangular_solve(
+                linalg::triangular_solve(
                     self.buffers,
                     a,
                     b,
@@ -316,11 +316,13 @@ impl TensorExec for CpuExecSession<'_> {
                     lower,
                     transpose_a,
                     unit_diagonal,
-                ))
-            }),
+                )
+                .map(Tensor::F64)
+            })
+            .and_then(|r| r),
             #[cfg(feature = "cpu-blas")]
             (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
-                Tensor::C64(linalg::triangular_solve(
+                linalg::triangular_solve(
                     self.buffers,
                     a,
                     b,
@@ -328,8 +330,10 @@ impl TensorExec for CpuExecSession<'_> {
                     lower,
                     transpose_a,
                     unit_diagonal,
-                ))
-            }),
+                )
+                .map(Tensor::C64)
+            })
+            .and_then(|r| r),
             _ => {
                 if a.dtype() != b.dtype() {
                     Err(crate::Error::DTypeMismatch {

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -73,16 +73,14 @@ macro_rules! linalg_multi {
             match input {
                 Tensor::F64(t) => catch_backend_panic(stringify!($name), || {
                     linalg::$name(self.ctx, self.buffers, t)
-                        .into_iter()
-                        .map(Tensor::F64)
-                        .collect()
-                }),
+                })
+                .and_then(|r| r)
+                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
                 Tensor::C64(t) => catch_backend_panic(stringify!($name), || {
                     linalg::$name(self.ctx, self.buffers, t)
-                        .into_iter()
-                        .map(Tensor::C64)
-                        .collect()
-                }),
+                })
+                .and_then(|r| r)
+                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
             }
         }
@@ -280,7 +278,7 @@ impl TensorExec for CpuExecSession<'_> {
         match (a, b) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
-                Tensor::F64(linalg::triangular_solve(
+                linalg::triangular_solve(
                     self.ctx,
                     self.buffers,
                     a,
@@ -289,11 +287,13 @@ impl TensorExec for CpuExecSession<'_> {
                     lower,
                     transpose_a,
                     unit_diagonal,
-                ))
-            }),
+                )
+                .map(Tensor::F64)
+            })
+            .and_then(|r| r),
             #[cfg(feature = "cpu-faer")]
             (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
-                Tensor::C64(linalg::triangular_solve(
+                linalg::triangular_solve(
                     self.ctx,
                     self.buffers,
                     a,
@@ -302,8 +302,10 @@ impl TensorExec for CpuExecSession<'_> {
                     lower,
                     transpose_a,
                     unit_diagonal,
-                ))
-            }),
+                )
+                .map(Tensor::C64)
+            })
+            .and_then(|r| r),
             #[cfg(feature = "cpu-blas")]
             (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
                 Tensor::F64(linalg::triangular_solve(

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -154,11 +154,17 @@ fn validate_dot_general<T>(
     Ok(())
 }
 
+fn checked_product(dims: &[usize]) -> Option<usize> {
+    dims.iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+}
+
 fn try_fuse_dims(shapes: &[usize], strides: &[isize]) -> Option<(usize, isize)> {
     if shapes.is_empty() {
         return Some((1, 0));
     }
     if shapes.len() == 1 {
+        isize::try_from(shapes[0]).ok()?;
         return Some((shapes[0], strides[0]));
     }
     let mut dims: SmallVec<[(usize, isize); 8]> = shapes
@@ -173,9 +179,15 @@ fn try_fuse_dims(shapes: &[usize], strides: &[isize]) -> Option<(usize, isize)> 
         if stride != expected {
             return None;
         }
-        expected = stride.checked_mul(shape as isize)?;
+        let shape = isize::try_from(shape).ok()?;
+        expected = stride.checked_mul(shape)?;
     }
-    Some((shapes.iter().product(), base_stride))
+    Some((checked_product(shapes)?, base_stride))
+}
+
+fn checked_batch_offset(batch: usize, stride: isize) -> Option<isize> {
+    let batch = isize::try_from(batch).ok()?;
+    batch.checked_mul(stride)
 }
 
 fn stride_sort_order(strides: &[isize]) -> SmallVec<[usize; 8]> {
@@ -257,7 +269,7 @@ fn analyse_gemm<T>(
         .iter()
         .map(|&d| lhs.shape[d])
         .collect();
-    let batch_total: usize = batch_shapes.iter().product();
+    let batch_total = checked_product(&batch_shapes)?;
 
     let lhs_free_shapes: SmallVec<[usize; 8]> = lhs_free.iter().map(|&d| lhs.shape[d]).collect();
     let rhs_free_shapes: SmallVec<[usize; 8]> = rhs_free.iter().map(|&d| rhs.shape[d]).collect();
@@ -267,9 +279,9 @@ fn analyse_gemm<T>(
         .map(|&d| lhs.shape[d])
         .collect();
 
-    let m: usize = lhs_free_shapes.iter().product();
-    let n: usize = rhs_free_shapes.iter().product();
-    let k: usize = contract_shapes.iter().product();
+    let m = checked_product(&lhs_free_shapes)?;
+    let n = checked_product(&rhs_free_shapes)?;
+    let k = checked_product(&contract_shapes)?;
 
     let lhs_free_strides: SmallVec<[isize; 8]> = lhs_free.iter().map(|&d| lhs_strides[d]).collect();
     let rhs_free_strides: SmallVec<[isize; 8]> = rhs_free.iter().map(|&d| rhs_strides[d]).collect();
@@ -394,7 +406,7 @@ where
     T: FaerGemm + PoolScalar + Copy + Clone + Zero + One + PartialEq,
 {
     let dims = analyse_gemm(lhs, rhs, config)?;
-    let out_n: usize = dims.out_shape.iter().product();
+    let out_n = checked_product(&dims.out_shape)?;
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
         return Some(TypedTensor {
             buffer: Buffer::Host(vec![T::zero(); out_n]),
@@ -421,9 +433,9 @@ where
     let c_ptr = out_data.as_mut_ptr();
 
     for batch in 0..dims.batch_total {
-        let a_off = batch as isize * dims.a_bs;
-        let b_off = batch as isize * dims.b_bs;
-        let c_off = batch as isize * dims.c_bs;
+        let a_off = checked_batch_offset(batch, dims.a_bs)?;
+        let b_off = checked_batch_offset(batch, dims.b_bs)?;
+        let c_off = checked_batch_offset(batch, dims.c_bs)?;
         unsafe {
             T::strided_gemm(
                 ctx,
@@ -497,7 +509,7 @@ where
     T: BlasGemm + PoolScalar + Copy + Clone + Zero + One,
 {
     let dims = analyse_gemm(lhs, rhs, config)?;
-    let out_n: usize = dims.out_shape.iter().product();
+    let out_n = checked_product(&dims.out_shape)?;
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
         return Some(TypedTensor {
             buffer: Buffer::Host(vec![T::zero(); out_n]),
@@ -538,9 +550,9 @@ where
     let c_ptr = out.as_mut_ptr();
 
     for batch in 0..dims.batch_total {
-        let a_off = batch as isize * dims.a_bs;
-        let b_off = batch as isize * dims.b_bs;
-        let c_off = batch as isize * dims.c_bs;
+        let a_off = checked_batch_offset(batch, dims.a_bs)?;
+        let b_off = checked_batch_offset(batch, dims.b_bs)?;
+        let c_off = checked_batch_offset(batch, dims.c_bs)?;
         unsafe {
             T::strided_gemm(
                 T::one(),

--- a/tenferro-tensor/src/cpu/gemm/tests.rs
+++ b/tenferro-tensor/src/cpu/gemm/tests.rs
@@ -1,4 +1,4 @@
-use super::try_fuse_dims;
+use super::{checked_product, try_fuse_dims};
 
 #[cfg(feature = "cpu-blas")]
 use super::dot_general;
@@ -36,6 +36,26 @@ fn try_fuse_dims_single_dim() {
 #[test]
 fn try_fuse_dims_empty() {
     assert_eq!(try_fuse_dims(&[], &[]), Some((1, 0)));
+}
+
+#[test]
+fn try_fuse_dims_rejects_extent_that_does_not_fit_isize() {
+    let too_large = (isize::MAX as usize).saturating_add(1);
+
+    assert_eq!(try_fuse_dims(&[too_large], &[1]), None);
+}
+
+#[test]
+fn try_fuse_dims_rejects_fused_stride_overflow() {
+    assert_eq!(
+        try_fuse_dims(&[isize::MAX as usize, 2], &[1, isize::MAX]),
+        None
+    );
+}
+
+#[test]
+fn checked_product_rejects_product_overflow() {
+    assert_eq!(checked_product(&[usize::MAX, 2]), None);
 }
 
 #[cfg(feature = "cpu-blas")]

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -486,18 +486,40 @@ fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor> {
     }
 }
 
-fn linear_offset(shape: &[usize], indices: &[usize]) -> usize {
+fn checked_product(op: &'static str, role: &'static str, shape: &[usize]) -> crate::Result<usize> {
+    shape.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op,
+                message: format!("{role} element count overflows usize"),
+            })
+    })
+}
+
+fn linear_offset(op: &'static str, shape: &[usize], indices: &[usize]) -> crate::Result<usize> {
     let mut offset = 0usize;
     let mut stride = 1usize;
     for (axis, &index) in indices.iter().enumerate() {
-        offset += index * stride;
-        stride *= shape[axis];
+        let scaled = index
+            .checked_mul(stride)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op,
+                message: format!("linear index component overflows usize on axis {axis}"),
+            })?;
+        offset = offset
+            .checked_add(scaled)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op,
+                message: format!("linear offset overflows usize on axis {axis}"),
+            })?;
+        stride = stride
+            .checked_mul(shape[axis])
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op,
+                message: format!("linear stride overflows usize after axis {axis}"),
+            })?;
     }
-    offset
-}
-
-fn product(shape: &[usize]) -> usize {
-    shape.iter().product()
+    Ok(offset)
 }
 
 fn try_index_vector_size(
@@ -555,7 +577,7 @@ fn index_component(
                 message: "implicit index_vector_dim only supports scalar index vectors".into(),
             });
         }
-        return Ok(indices.values[linear_offset(&indices.shape, batch_idx)]);
+        return Ok(indices.values[linear_offset(op, &indices.shape, batch_idx)?]);
     }
 
     let mut full_idx = vec![0usize; indices.shape.len()];
@@ -568,7 +590,7 @@ fn index_component(
             batch_axis += 1;
         }
     }
-    Ok(indices.values[linear_offset(&indices.shape, &full_idx)])
+    Ok(indices.values[linear_offset(op, &indices.shape, &full_idx)?])
 }
 
 fn clamp_window_start(
@@ -937,8 +959,9 @@ where
         window_shape[window_dims[pos]] = dim;
     }
 
-    let batch_elems = product(&batch_shape).max(1);
-    let window_elems = product(&window_shape_updates).max(1);
+    let batch_elems = checked_product("scatter", "batch shape", &batch_shape)?.max(1);
+    let window_elems =
+        checked_product("scatter", "window update shape", &window_shape_updates)?.max(1);
     let mut out = operand.clone();
 
     let mut batch_idx = vec![0usize; batch_shape.len()];

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -4,6 +4,7 @@ use faer::{
     Conj, Mat, MatMut, MatRef,
 };
 use num_complex::Complex64;
+use std::ops::Range;
 
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::cpu::CpuContext;
@@ -20,12 +21,12 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>>;
+    ) -> crate::Result<Vec<TypedTensor<Self>>>;
     fn full_piv_lu_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>>;
+    ) -> crate::Result<Vec<TypedTensor<Self>>>;
     fn full_piv_lu_solve_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -42,7 +43,7 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-    ) -> TypedTensor<Self>;
+    ) -> crate::Result<TypedTensor<Self>>;
     fn svd_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -52,7 +53,7 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>>;
+    ) -> crate::Result<Vec<TypedTensor<Self>>>;
     fn eigh_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -60,15 +61,27 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
     ) -> crate::Result<Vec<TypedTensor<Self>>>;
 }
 
-fn matrix_dims<T>(input: &TypedTensor<T>, op: &str) -> (usize, usize) {
-    assert_eq!(input.shape.len(), 2, "{op}: expected a 2D matrix");
-    (input.shape[0], input.shape[1])
+fn matrix_dims<T>(input: &TypedTensor<T>, op: &'static str) -> crate::Result<(usize, usize)> {
+    if input.shape.len() != 2 {
+        return Err(crate::Error::RankMismatch {
+            op,
+            expected: 2,
+            actual: input.shape.len(),
+        });
+    }
+    Ok((input.shape[0], input.shape[1]))
 }
 
-fn square_matrix_dim<T>(input: &TypedTensor<T>, op: &str) -> usize {
-    let (rows, cols) = matrix_dims(input, op);
-    assert_eq!(rows, cols, "{op}: expected a square matrix");
-    rows
+fn square_matrix_dim<T>(input: &TypedTensor<T>, op: &'static str) -> crate::Result<usize> {
+    let (rows, cols) = matrix_dims(input, op)?;
+    if rows != cols {
+        return Err(crate::Error::ShapeMismatch {
+            op,
+            lhs: vec![rows],
+            rhs: vec![cols],
+        });
+    }
+    Ok(rows)
 }
 
 fn tensor_from_vec_with_template<T: Clone, U>(
@@ -141,6 +154,45 @@ fn decomposition_failed(op: &'static str) -> crate::Error {
         op,
         message: "decomposition failed".into(),
     }
+}
+
+fn invalid_config(op: &'static str, message: impl Into<String>) -> crate::Error {
+    crate::Error::InvalidConfig {
+        op,
+        message: message.into(),
+    }
+}
+
+fn checked_product(op: &'static str, role: &'static str, shape: &[usize]) -> crate::Result<usize> {
+    shape
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or_else(|| invalid_config(op, format!("{role} element count overflows usize")))
+}
+
+fn checked_repeated_len(
+    op: &'static str,
+    role: &'static str,
+    per_batch: usize,
+    batch_count: usize,
+) -> crate::Result<usize> {
+    per_batch
+        .checked_mul(batch_count)
+        .ok_or_else(|| invalid_config(op, format!("{role} repeated batch length overflows usize")))
+}
+
+fn checked_slice_range(
+    op: &'static str,
+    batch_idx: usize,
+    slice_size: usize,
+) -> crate::Result<Range<usize>> {
+    let start = batch_idx
+        .checked_mul(slice_size)
+        .ok_or_else(|| invalid_config(op, "batch slice start overflows usize"))?;
+    let end = start
+        .checked_add(slice_size)
+        .ok_or_else(|| invalid_config(op, "batch slice end overflows usize"))?;
+    Ok(start..end)
 }
 
 fn complex_vec_from_real_diag(
@@ -262,16 +314,27 @@ fn real_eig_to_complex_outputs(
     (u, s)
 }
 
+fn split_shape_core_and_batch<'a>(
+    shape: &'a [usize],
+    core_rank: usize,
+    op: &'static str,
+) -> crate::Result<(&'a [usize], &'a [usize])> {
+    if shape.len() < core_rank {
+        return Err(crate::Error::RankMismatch {
+            op,
+            expected: core_rank,
+            actual: shape.len(),
+        });
+    }
+    Ok(shape.split_at(core_rank))
+}
+
 fn split_core_and_batch<'a, T>(
     input: &'a TypedTensor<T>,
     core_rank: usize,
-    op: &str,
-) -> (&'a [usize], &'a [usize]) {
-    assert!(
-        input.shape.len() >= core_rank,
-        "{op}: expected rank >= {core_rank}"
-    );
-    input.shape.split_at(core_rank)
+    op: &'static str,
+) -> crate::Result<(&'a [usize], &'a [usize])> {
+    split_shape_core_and_batch(&input.shape, core_rank, op)
 }
 
 fn transpose_col_major_data<T: Copy + PoolScalar>(
@@ -290,6 +353,7 @@ fn transpose_col_major_data<T: Copy + PoolScalar>(
 }
 
 fn batched_single<T, F>(
+    op_name: &'static str,
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
     core_rank: usize,
@@ -299,133 +363,69 @@ where
     T: Clone + PoolScalar,
     F: Fn(&mut BufferPool, &TypedTensor<T>) -> crate::Result<TypedTensor<T>>,
 {
-    let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, "batched_single");
+    let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, op_name)?;
     if batch_shape.is_empty() {
         return op(buffers, input);
     }
 
-    let slice_size: usize = core_shape.iter().product();
-    let batch_count: usize = batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_single: zero-sized batch dims are unsupported"
-    );
+    let slice_size = checked_product(op_name, "core shape", core_shape)?;
+    let batch_count = checked_product(op_name, "batch shape", batch_shape)?;
+    if batch_count == 0 {
+        return Err(invalid_config(
+            op_name,
+            "zero-sized batch dims must be handled by the caller",
+        ));
+    }
 
     let mut out_core_shape: Option<Vec<usize>> = None;
     let mut out_data: Option<Vec<T>> = None;
 
     for batch_idx in 0..batch_count {
-        let start = batch_idx * slice_size;
-        let end = start + slice_size;
+        let range = checked_slice_range(op_name, batch_idx, slice_size)?;
         let batch_input = tensor_from_vec_with_template(
             core_shape.to_vec(),
-            input.host_data()[start..end].to_vec(),
+            input.host_data()[range].to_vec(),
             input,
         );
         let batch_output = op(buffers, &batch_input)?;
 
         if let Some(expected_shape) = &out_core_shape {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                expected_shape.as_slice(),
-                "batched_single: output core shape mismatch across batches"
-            );
+            if batch_output.shape.as_slice() != expected_shape.as_slice() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: op_name,
+                    lhs: batch_output.shape.clone(),
+                    rhs: expected_shape.clone(),
+                });
+            }
         } else {
-            out_data =
-                Some(buffers.acquire_with_capacity::<T>(batch_output.n_elements() * batch_count));
+            let output_elements =
+                checked_product(op_name, "output core shape", &batch_output.shape)?;
+            let capacity =
+                checked_repeated_len(op_name, "output buffer", output_elements, batch_count)?;
+            out_data = Some(buffers.acquire_with_capacity::<T>(capacity));
             out_core_shape = Some(batch_output.shape.clone());
         }
 
-        out_data
-            .as_mut()
-            .expect("batched_single: missing output buffer")
-            .extend_from_slice(batch_output.host_data());
-    }
-
-    let mut out_shape = out_core_shape.expect("batched_single: missing output shape");
-    out_shape.extend_from_slice(batch_shape);
-    Ok(tensor_from_vec_with_template(
-        out_shape,
-        out_data.expect("batched_single: missing output data"),
-        input,
-    ))
-}
-
-fn batched_multi<T, F>(
-    buffers: &mut BufferPool,
-    input: &TypedTensor<T>,
-    core_rank: usize,
-    op: F,
-) -> Vec<TypedTensor<T>>
-where
-    T: Clone + PoolScalar,
-    F: Fn(&mut BufferPool, &TypedTensor<T>) -> Vec<TypedTensor<T>>,
-{
-    let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, "batched_multi");
-    if batch_shape.is_empty() {
-        return op(buffers, input);
-    }
-
-    let slice_size: usize = core_shape.iter().product();
-    let batch_count: usize = batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_multi: zero-sized batch dims are unsupported"
-    );
-
-    let mut out_shapes: Vec<Vec<usize>> = Vec::new();
-    let mut out_data: Vec<Vec<T>> = Vec::new();
-
-    for batch_idx in 0..batch_count {
-        let start = batch_idx * slice_size;
-        let end = start + slice_size;
-        let batch_input = tensor_from_vec_with_template(
-            core_shape.to_vec(),
-            input.host_data()[start..end].to_vec(),
-            input,
-        );
-        let batch_outputs = op(buffers, &batch_input);
-
-        if out_shapes.is_empty() {
-            out_shapes = batch_outputs
-                .iter()
-                .map(|tensor| tensor.shape.clone())
-                .collect();
-            let mut pooled_outputs = Vec::with_capacity(batch_outputs.len());
-            for tensor in &batch_outputs {
-                pooled_outputs
-                    .push(buffers.acquire_with_capacity::<T>(tensor.n_elements() * batch_count));
+        match &mut out_data {
+            Some(data) => data.extend_from_slice(batch_output.host_data()),
+            None => {
+                return Err(invalid_config(
+                    op_name,
+                    "missing output buffer after first batch",
+                ));
             }
-            out_data = pooled_outputs;
-        } else {
-            assert_eq!(
-                batch_outputs.len(),
-                out_shapes.len(),
-                "batched_multi: output count mismatch across batches"
-            );
-        }
-
-        for (idx, batch_output) in batch_outputs.iter().enumerate() {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                out_shapes[idx].as_slice(),
-                "batched_multi: output core shape mismatch across batches"
-            );
-            out_data[idx].extend_from_slice(batch_output.host_data());
         }
     }
 
-    out_shapes
-        .into_iter()
-        .zip(out_data)
-        .map(|(mut out_shape, out_data)| {
-            out_shape.extend_from_slice(batch_shape);
-            tensor_from_vec_with_template(out_shape, out_data, input)
-        })
-        .collect()
+    let mut out_shape =
+        out_core_shape.ok_or_else(|| invalid_config(op_name, "missing output shape"))?;
+    out_shape.extend_from_slice(batch_shape);
+    let out_data = out_data.ok_or_else(|| invalid_config(op_name, "missing output data"))?;
+    Ok(tensor_from_vec_with_template(out_shape, out_data, input))
 }
 
 fn batched_multi_result<T, F>(
+    op_name: &'static str,
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
     core_rank: usize,
@@ -435,27 +435,28 @@ where
     T: Clone + PoolScalar,
     F: Fn(&mut BufferPool, &TypedTensor<T>) -> crate::Result<Vec<TypedTensor<T>>>,
 {
-    let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, "batched_multi");
+    let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, op_name)?;
     if batch_shape.is_empty() {
         return op(buffers, input);
     }
 
-    let slice_size: usize = core_shape.iter().product();
-    let batch_count: usize = batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_multi: zero-sized batch dims are unsupported"
-    );
+    let slice_size = checked_product(op_name, "core shape", core_shape)?;
+    let batch_count = checked_product(op_name, "batch shape", batch_shape)?;
+    if batch_count == 0 {
+        return Err(invalid_config(
+            op_name,
+            "zero-sized batch dims must be handled by the caller",
+        ));
+    }
 
     let mut out_shapes: Vec<Vec<usize>> = Vec::new();
     let mut out_data: Vec<Vec<T>> = Vec::new();
 
     for batch_idx in 0..batch_count {
-        let start = batch_idx * slice_size;
-        let end = start + slice_size;
+        let range = checked_slice_range(op_name, batch_idx, slice_size)?;
         let batch_input = tensor_from_vec_with_template(
             core_shape.to_vec(),
-            input.host_data()[start..end].to_vec(),
+            input.host_data()[range].to_vec(),
             input,
         );
         let batch_outputs = op(buffers, &batch_input)?;
@@ -467,24 +468,30 @@ where
                 .collect();
             let mut pooled_outputs = Vec::with_capacity(batch_outputs.len());
             for tensor in &batch_outputs {
-                pooled_outputs
-                    .push(buffers.acquire_with_capacity::<T>(tensor.n_elements() * batch_count));
+                let output_elements = checked_product(op_name, "output core shape", &tensor.shape)?;
+                let capacity =
+                    checked_repeated_len(op_name, "output buffer", output_elements, batch_count)?;
+                pooled_outputs.push(buffers.acquire_with_capacity::<T>(capacity));
             }
             out_data = pooled_outputs;
         } else {
-            assert_eq!(
-                batch_outputs.len(),
-                out_shapes.len(),
-                "batched_multi: output count mismatch across batches"
-            );
+            if batch_outputs.len() != out_shapes.len() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: op_name,
+                    lhs: vec![batch_outputs.len()],
+                    rhs: vec![out_shapes.len()],
+                });
+            }
         }
 
         for (idx, batch_output) in batch_outputs.iter().enumerate() {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                out_shapes[idx].as_slice(),
-                "batched_multi: output core shape mismatch across batches"
-            );
+            if batch_output.shape.as_slice() != out_shapes[idx].as_slice() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: op_name,
+                    lhs: batch_output.shape.clone(),
+                    rhs: out_shapes[idx].clone(),
+                });
+            }
             out_data[idx].extend_from_slice(batch_output.host_data());
         }
     }
@@ -500,6 +507,7 @@ where
 }
 
 fn batched_multi_convert_result<InT, OutT, F>(
+    op_name: &'static str,
     buffers: &mut BufferPool,
     input: &TypedTensor<InT>,
     core_rank: usize,
@@ -510,27 +518,28 @@ where
     OutT: Clone + PoolScalar,
     F: Fn(&mut BufferPool, &TypedTensor<InT>) -> crate::Result<Vec<TypedTensor<OutT>>>,
 {
-    let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, "batched_multi");
+    let (core_shape, batch_shape) = split_core_and_batch(input, core_rank, op_name)?;
     if batch_shape.is_empty() {
         return op(buffers, input);
     }
 
-    let slice_size: usize = core_shape.iter().product();
-    let batch_count: usize = batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_multi: zero-sized batch dims are unsupported"
-    );
+    let slice_size = checked_product(op_name, "core shape", core_shape)?;
+    let batch_count = checked_product(op_name, "batch shape", batch_shape)?;
+    if batch_count == 0 {
+        return Err(invalid_config(
+            op_name,
+            "zero-sized batch dims must be handled by the caller",
+        ));
+    }
 
     let mut out_shapes: Vec<Vec<usize>> = Vec::new();
     let mut out_data: Vec<Vec<OutT>> = Vec::new();
 
     for batch_idx in 0..batch_count {
-        let start = batch_idx * slice_size;
-        let end = start + slice_size;
+        let range = checked_slice_range(op_name, batch_idx, slice_size)?;
         let batch_input = tensor_from_vec_with_template(
             core_shape.to_vec(),
-            input.host_data()[start..end].to_vec(),
+            input.host_data()[range].to_vec(),
             input,
         );
         let batch_outputs = op(buffers, &batch_input)?;
@@ -542,24 +551,30 @@ where
                 .collect();
             let mut pooled_outputs = Vec::with_capacity(batch_outputs.len());
             for tensor in &batch_outputs {
-                pooled_outputs
-                    .push(buffers.acquire_with_capacity::<OutT>(tensor.n_elements() * batch_count));
+                let output_elements = checked_product(op_name, "output core shape", &tensor.shape)?;
+                let capacity =
+                    checked_repeated_len(op_name, "output buffer", output_elements, batch_count)?;
+                pooled_outputs.push(buffers.acquire_with_capacity::<OutT>(capacity));
             }
             out_data = pooled_outputs;
         } else {
-            assert_eq!(
-                batch_outputs.len(),
-                out_shapes.len(),
-                "batched_multi: output count mismatch across batches"
-            );
+            if batch_outputs.len() != out_shapes.len() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: op_name,
+                    lhs: vec![batch_outputs.len()],
+                    rhs: vec![out_shapes.len()],
+                });
+            }
         }
 
         for (idx, batch_output) in batch_outputs.iter().enumerate() {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                out_shapes[idx].as_slice(),
-                "batched_multi: output core shape mismatch across batches"
-            );
+            if batch_output.shape.as_slice() != out_shapes[idx].as_slice() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: op_name,
+                    lhs: batch_output.shape.clone(),
+                    rhs: out_shapes[idx].clone(),
+                });
+            }
             out_data[idx].extend_from_slice(batch_output.host_data());
         }
     }
@@ -574,86 +589,8 @@ where
         .collect())
 }
 
-fn batched_binary<T, F>(
-    buffers: &mut BufferPool,
-    a: &TypedTensor<T>,
-    b: &TypedTensor<T>,
-    core_rank_a: usize,
-    core_rank_b: usize,
-    op: F,
-) -> TypedTensor<T>
-where
-    T: Clone + PoolScalar,
-    F: Fn(&mut BufferPool, &TypedTensor<T>, &TypedTensor<T>) -> TypedTensor<T>,
-{
-    let (a_core_shape, a_batch_shape) = split_core_and_batch(a, core_rank_a, "batched_binary");
-    let (b_core_shape, b_batch_shape) = split_core_and_batch(b, core_rank_b, "batched_binary");
-    assert_eq!(
-        a_batch_shape, b_batch_shape,
-        "batched_binary: batch shape mismatch"
-    );
-
-    if a_batch_shape.is_empty() {
-        return op(buffers, a, b);
-    }
-
-    let a_slice_size: usize = a_core_shape.iter().product();
-    let b_slice_size: usize = b_core_shape.iter().product();
-    let batch_count: usize = a_batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_binary: zero-sized batch dims are unsupported"
-    );
-
-    let mut out_core_shape: Option<Vec<usize>> = None;
-    let mut out_data: Option<Vec<T>> = None;
-
-    for batch_idx in 0..batch_count {
-        let a_start = batch_idx * a_slice_size;
-        let a_end = a_start + a_slice_size;
-        let b_start = batch_idx * b_slice_size;
-        let b_end = b_start + b_slice_size;
-
-        let batch_a = tensor_from_vec_with_template(
-            a_core_shape.to_vec(),
-            a.host_data()[a_start..a_end].to_vec(),
-            a,
-        );
-        let batch_b = tensor_from_vec_with_template(
-            b_core_shape.to_vec(),
-            b.host_data()[b_start..b_end].to_vec(),
-            b,
-        );
-        let batch_output = op(buffers, &batch_a, &batch_b);
-
-        if let Some(expected_shape) = &out_core_shape {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                expected_shape.as_slice(),
-                "batched_binary: output core shape mismatch across batches"
-            );
-        } else {
-            out_data =
-                Some(buffers.acquire_with_capacity::<T>(batch_output.n_elements() * batch_count));
-            out_core_shape = Some(batch_output.shape.clone());
-        }
-
-        out_data
-            .as_mut()
-            .expect("batched_binary: missing output buffer")
-            .extend_from_slice(batch_output.host_data());
-    }
-
-    let mut out_shape = out_core_shape.expect("batched_binary: missing output shape");
-    out_shape.extend_from_slice(a_batch_shape);
-    tensor_from_vec_with_template(
-        out_shape,
-        out_data.expect("batched_binary: missing output data"),
-        b,
-    )
-}
-
 fn batched_binary_result<T, F>(
+    op_name: &'static str,
     buffers: &mut BufferPool,
     a: &TypedTensor<T>,
     b: &TypedTensor<T>,
@@ -665,75 +602,81 @@ where
     T: Clone + PoolScalar,
     F: Fn(&mut BufferPool, &TypedTensor<T>, &TypedTensor<T>) -> crate::Result<TypedTensor<T>>,
 {
-    let (a_core_shape, a_batch_shape) =
-        split_core_and_batch(a, core_rank_a, "batched_binary_result");
-    let (b_core_shape, b_batch_shape) =
-        split_core_and_batch(b, core_rank_b, "batched_binary_result");
-    assert_eq!(
-        a_batch_shape, b_batch_shape,
-        "batched_binary_result: batch shape mismatch"
-    );
+    let (a_core_shape, a_batch_shape) = split_core_and_batch(a, core_rank_a, op_name)?;
+    let (b_core_shape, b_batch_shape) = split_core_and_batch(b, core_rank_b, op_name)?;
+    if a_batch_shape != b_batch_shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: op_name,
+            lhs: a_batch_shape.to_vec(),
+            rhs: b_batch_shape.to_vec(),
+        });
+    }
 
     if a_batch_shape.is_empty() {
         return op(buffers, a, b);
     }
 
-    let a_slice_size: usize = a_core_shape.iter().product();
-    let b_slice_size: usize = b_core_shape.iter().product();
-    let batch_count: usize = a_batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_binary_result: zero-sized batch dims are unsupported"
-    );
+    let a_slice_size = checked_product(op_name, "lhs core shape", a_core_shape)?;
+    let b_slice_size = checked_product(op_name, "rhs core shape", b_core_shape)?;
+    let batch_count = checked_product(op_name, "batch shape", a_batch_shape)?;
+    if batch_count == 0 {
+        return Err(invalid_config(
+            op_name,
+            "zero-sized batch dims must be handled by the caller",
+        ));
+    }
 
     let mut out_core_shape: Option<Vec<usize>> = None;
     let mut out_data: Option<Vec<T>> = None;
 
     for batch_idx in 0..batch_count {
-        let a_start = batch_idx * a_slice_size;
-        let a_end = a_start + a_slice_size;
-        let b_start = batch_idx * b_slice_size;
-        let b_end = b_start + b_slice_size;
+        let a_range = checked_slice_range(op_name, batch_idx, a_slice_size)?;
+        let b_range = checked_slice_range(op_name, batch_idx, b_slice_size)?;
 
         let batch_a = tensor_from_vec_with_template(
             a_core_shape.to_vec(),
-            a.host_data()[a_start..a_end].to_vec(),
+            a.host_data()[a_range].to_vec(),
             a,
         );
         let batch_b = tensor_from_vec_with_template(
             b_core_shape.to_vec(),
-            b.host_data()[b_start..b_end].to_vec(),
+            b.host_data()[b_range].to_vec(),
             b,
         );
         let batch_output = op(buffers, &batch_a, &batch_b)?;
 
         if let Some(expected_shape) = &out_core_shape {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                expected_shape.as_slice(),
-                "batched_binary_result: output core shape mismatch across batches"
-            );
+            if batch_output.shape.as_slice() != expected_shape.as_slice() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: op_name,
+                    lhs: batch_output.shape.clone(),
+                    rhs: expected_shape.clone(),
+                });
+            }
         } else {
-            out_data =
-                Some(buffers.acquire_with_capacity::<T>(batch_output.n_elements() * batch_count));
+            let output_elements =
+                checked_product(op_name, "output core shape", &batch_output.shape)?;
+            let capacity =
+                checked_repeated_len(op_name, "output buffer", output_elements, batch_count)?;
+            out_data = Some(buffers.acquire_with_capacity::<T>(capacity));
             out_core_shape = Some(batch_output.shape.clone());
         }
 
         match &mut out_data {
             Some(data) => data.extend_from_slice(batch_output.host_data()),
-            None => panic!("batched_binary_result: missing output buffer"),
+            None => {
+                return Err(invalid_config(
+                    op_name,
+                    "missing output buffer after first batch",
+                ));
+            }
         }
     }
 
-    let mut out_shape = match out_core_shape {
-        Some(shape) => shape,
-        None => panic!("batched_binary_result: missing output shape"),
-    };
+    let mut out_shape =
+        out_core_shape.ok_or_else(|| invalid_config(op_name, "missing output shape"))?;
     out_shape.extend_from_slice(a_batch_shape);
-    let out_data = match out_data {
-        Some(data) => data,
-        None => panic!("batched_binary_result: missing output data"),
-    };
+    let out_data = out_data.ok_or_else(|| invalid_config(op_name, "missing output data"))?;
     Ok(tensor_from_vec_with_template(out_shape, out_data, b))
 }
 
@@ -747,7 +690,7 @@ impl FaerLinalg for f64 {
         _buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> crate::Result<TypedTensor<Self>> {
-        let n = square_matrix_dim(input, "cholesky");
+        let n = square_matrix_dim(input, "cholesky")?;
         let mut l = Mat::zeros(n, n);
         l.copy_from(MatRef::from_column_major_slice(input.host_data(), n, n));
         let mut mem = MemBuffer::new(
@@ -780,8 +723,8 @@ impl FaerLinalg for f64 {
         ctx: &CpuContext,
         _buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>> {
-        let (m, n) = matrix_dims(input, "lu");
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let (m, n) = matrix_dims(input, "lu")?;
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
         lu.copy_from(MatRef::from_column_major_slice(input.host_data(), m, n));
@@ -822,20 +765,20 @@ impl FaerLinalg for f64 {
         }
         let u_data = upper_triangle_vec_from_mat(lu.as_ref().get(..k, ..));
 
-        vec![
+        Ok(vec![
             tensor_from_vec_with_template(vec![m, m], p_data, input),
             tensor_from_vec_with_template(vec![m, k], l_data, input),
             tensor_from_vec_with_template(vec![k, n], u_data, input),
             tensor_from_vec_with_template(vec![], vec![parity], input),
-        ]
+        ])
     }
 
     fn full_piv_lu_2d(
         ctx: &CpuContext,
         _buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>> {
-        let n = square_matrix_dim(input, "full_piv_lu");
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let n = square_matrix_dim(input, "full_piv_lu")?;
         let mut lu = Mat::zeros(n, n);
         lu.copy_from(MatRef::from_column_major_slice(input.host_data(), n, n));
         let mut row_perm = vec![0usize; n];
@@ -874,13 +817,13 @@ impl FaerLinalg for f64 {
             -1.0
         };
 
-        vec![
+        Ok(vec![
             tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, 1.0), input),
             tensor_from_vec_with_template(vec![n, n], l_data, input),
             tensor_from_vec_with_template(vec![n, n], u_data, input),
             tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, 1.0), input),
             tensor_from_vec_with_template(vec![], vec![parity], input),
-        ]
+        ])
     }
 
     fn full_piv_lu_solve_2d(
@@ -890,9 +833,15 @@ impl FaerLinalg for f64 {
         b: &TypedTensor<Self>,
         transpose_a: bool,
     ) -> crate::Result<TypedTensor<Self>> {
-        let n = square_matrix_dim(a, "full_piv_lu_solve");
-        let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve");
-        assert_eq!(b_rows, n, "full_piv_lu_solve: rhs row count mismatch");
+        let n = square_matrix_dim(a, "full_piv_lu_solve")?;
+        let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve")?;
+        if b_rows != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "full_piv_lu_solve",
+                lhs: vec![n],
+                rhs: vec![b_rows],
+            });
+        }
 
         let mut lu = Mat::zeros(n, n);
         lu.copy_from(MatRef::from_column_major_slice(a.host_data(), n, n));
@@ -972,13 +921,19 @@ impl FaerLinalg for f64 {
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-    ) -> TypedTensor<Self> {
-        let n = square_matrix_dim(a, "triangular_solve");
-        let (b_rows, b_cols) = matrix_dims(b, "triangular_solve");
+    ) -> crate::Result<TypedTensor<Self>> {
+        let n = square_matrix_dim(a, "triangular_solve")?;
+        let (b_rows, b_cols) = matrix_dims(b, "triangular_solve")?;
         let a_mat = MatRef::from_column_major_slice(a.host_data(), n, n);
 
         if left_side {
-            assert_eq!(b_rows, n, "triangular_solve: rhs row count mismatch");
+            if b_rows != n {
+                return Err(crate::Error::ShapeMismatch {
+                    op: "triangular_solve",
+                    lhs: vec![n],
+                    rhs: vec![b_rows],
+                });
+            }
             let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
             rhs_data.extend_from_slice(b.host_data());
             let rhs = MatMut::from_column_major_slice_mut(&mut rhs_data, n, b_cols);
@@ -1040,9 +995,15 @@ impl FaerLinalg for f64 {
                     );
                 }
             }
-            tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b)
+            Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
         } else {
-            assert_eq!(b_cols, n, "triangular_solve: rhs column count mismatch");
+            if b_cols != n {
+                return Err(crate::Error::ShapeMismatch {
+                    op: "triangular_solve",
+                    lhs: vec![n],
+                    rhs: vec![b_cols],
+                });
+            }
             let nrhs = b_rows;
             let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data(), nrhs, n);
             let rhs = MatMut::from_column_major_slice_mut(&mut rhs_transposed, n, nrhs);
@@ -1106,7 +1067,7 @@ impl FaerLinalg for f64 {
             }
             let result = transpose_col_major_data(buffers, &rhs_transposed, n, nrhs);
             <Self as PoolScalar>::pool_release(buffers, rhs_transposed);
-            tensor_from_vec_with_template(vec![nrhs, n], result, b)
+            Ok(tensor_from_vec_with_template(vec![nrhs, n], result, b))
         }
     }
 
@@ -1115,7 +1076,7 @@ impl FaerLinalg for f64 {
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> crate::Result<Vec<TypedTensor<Self>>> {
-        let (m, n) = matrix_dims(input, "svd");
+        let (m, n) = matrix_dims(input, "svd")?;
         let k = m.min(n);
         let mat = MatRef::from_column_major_slice(input.host_data(), m, n);
         let mut u = Mat::zeros(m, k);
@@ -1162,8 +1123,8 @@ impl FaerLinalg for f64 {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>> {
-        let (m, n) = matrix_dims(input, "qr");
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let (m, n) = matrix_dims(input, "qr")?;
         let k = m.min(n);
         let mat = MatRef::from_column_major_slice(input.host_data(), m, n);
         let block_size =
@@ -1216,7 +1177,7 @@ impl FaerLinalg for f64 {
             input,
         );
 
-        vec![q, r]
+        Ok(vec![q, r])
     }
 
     fn eigh_2d(
@@ -1224,7 +1185,7 @@ impl FaerLinalg for f64 {
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> crate::Result<Vec<TypedTensor<Self>>> {
-        let n = square_matrix_dim(input, "eigh");
+        let n = square_matrix_dim(input, "eigh")?;
         let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
         let mut values = Diag::zeros(n);
         let mut vectors = Mat::zeros(n, n);
@@ -1267,7 +1228,7 @@ impl FaerLinalg for Complex64 {
         _buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> crate::Result<TypedTensor<Self>> {
-        let n = square_matrix_dim(input, "cholesky");
+        let n = square_matrix_dim(input, "cholesky")?;
         let mut l = Mat::zeros(n, n);
         l.copy_from(MatRef::from_column_major_slice(
             complex64_to_faer_slice(input.host_data()),
@@ -1304,8 +1265,8 @@ impl FaerLinalg for Complex64 {
         ctx: &CpuContext,
         _buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>> {
-        let (m, n) = matrix_dims(input, "lu");
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let (m, n) = matrix_dims(input, "lu")?;
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
         lu.copy_from(MatRef::from_column_major_slice(
@@ -1349,20 +1310,20 @@ impl FaerLinalg for Complex64 {
         }
         let u_data = complex_matrix_from_predicate(lu.as_ref(), k, n, |row, col| row <= col);
 
-        vec![
+        Ok(vec![
             tensor_from_vec_with_template(vec![m, m], p_data, input),
             tensor_from_vec_with_template(vec![m, k], l_data, input),
             tensor_from_vec_with_template(vec![k, n], u_data, input),
             tensor_from_vec_with_template(vec![], vec![parity], input),
-        ]
+        ])
     }
 
     fn full_piv_lu_2d(
         ctx: &CpuContext,
         _buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>> {
-        let n = square_matrix_dim(input, "full_piv_lu");
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let n = square_matrix_dim(input, "full_piv_lu")?;
         let mut lu = Mat::zeros(n, n);
         lu.copy_from(MatRef::from_column_major_slice(
             complex64_to_faer_slice(input.host_data()),
@@ -1406,13 +1367,13 @@ impl FaerLinalg for Complex64 {
             Complex64::new(-1.0, 0.0)
         };
 
-        vec![
+        Ok(vec![
             tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, one), input),
             tensor_from_vec_with_template(vec![n, n], l_data, input),
             tensor_from_vec_with_template(vec![n, n], u_data, input),
             tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, one), input),
             tensor_from_vec_with_template(vec![], vec![parity], input),
-        ]
+        ])
     }
 
     fn full_piv_lu_solve_2d(
@@ -1422,9 +1383,15 @@ impl FaerLinalg for Complex64 {
         b: &TypedTensor<Self>,
         transpose_a: bool,
     ) -> crate::Result<TypedTensor<Self>> {
-        let n = square_matrix_dim(a, "full_piv_lu_solve");
-        let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve");
-        assert_eq!(b_rows, n, "full_piv_lu_solve: rhs row count mismatch");
+        let n = square_matrix_dim(a, "full_piv_lu_solve")?;
+        let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve")?;
+        if b_rows != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "full_piv_lu_solve",
+                lhs: vec![n],
+                rhs: vec![b_rows],
+            });
+        }
 
         let mut lu = Mat::zeros(n, n);
         lu.copy_from(MatRef::from_column_major_slice(
@@ -1513,13 +1480,19 @@ impl FaerLinalg for Complex64 {
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-    ) -> TypedTensor<Self> {
-        let n = square_matrix_dim(a, "triangular_solve");
-        let (b_rows, b_cols) = matrix_dims(b, "triangular_solve");
+    ) -> crate::Result<TypedTensor<Self>> {
+        let n = square_matrix_dim(a, "triangular_solve")?;
+        let (b_rows, b_cols) = matrix_dims(b, "triangular_solve")?;
         let a_mat = MatRef::from_column_major_slice(complex64_to_faer_slice(a.host_data()), n, n);
 
         if left_side {
-            assert_eq!(b_rows, n, "triangular_solve: rhs row count mismatch");
+            if b_rows != n {
+                return Err(crate::Error::ShapeMismatch {
+                    op: "triangular_solve",
+                    lhs: vec![n],
+                    rhs: vec![b_rows],
+                });
+            }
             let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
             rhs_data.extend_from_slice(b.host_data());
             let rhs = MatMut::from_column_major_slice_mut(
@@ -1585,9 +1558,15 @@ impl FaerLinalg for Complex64 {
                     );
                 }
             }
-            tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b)
+            Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
         } else {
-            assert_eq!(b_cols, n, "triangular_solve: rhs column count mismatch");
+            if b_cols != n {
+                return Err(crate::Error::ShapeMismatch {
+                    op: "triangular_solve",
+                    lhs: vec![n],
+                    rhs: vec![b_cols],
+                });
+            }
             let nrhs = b_rows;
             let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data(), nrhs, n);
             let rhs = MatMut::from_column_major_slice_mut(
@@ -1655,7 +1634,7 @@ impl FaerLinalg for Complex64 {
             }
             let result = transpose_col_major_data(buffers, &rhs_transposed, n, nrhs);
             <Self as PoolScalar>::pool_release(buffers, rhs_transposed);
-            tensor_from_vec_with_template(vec![nrhs, n], result, b)
+            Ok(tensor_from_vec_with_template(vec![nrhs, n], result, b))
         }
     }
 
@@ -1664,7 +1643,7 @@ impl FaerLinalg for Complex64 {
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> crate::Result<Vec<TypedTensor<Self>>> {
-        let (m, n) = matrix_dims(input, "svd");
+        let (m, n) = matrix_dims(input, "svd")?;
         let k = m.min(n);
         let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), m, n);
         let mut u = Mat::zeros(m, k);
@@ -1715,8 +1694,8 @@ impl FaerLinalg for Complex64 {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
-    ) -> Vec<TypedTensor<Self>> {
-        let (m, n) = matrix_dims(input, "qr");
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let (m, n) = matrix_dims(input, "qr")?;
         let k = m.min(n);
         let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), m, n);
         let block_size =
@@ -1769,7 +1748,7 @@ impl FaerLinalg for Complex64 {
             input,
         );
 
-        vec![q, r]
+        Ok(vec![q, r])
     }
 
     fn eigh_2d(
@@ -1777,7 +1756,7 @@ impl FaerLinalg for Complex64 {
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> crate::Result<Vec<TypedTensor<Self>>> {
-        let n = square_matrix_dim(input, "eigh");
+        let n = square_matrix_dim(input, "eigh")?;
         let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), n, n);
         let mut values = Diag::zeros(n);
         let mut vectors = Mat::zeros(n, n);
@@ -1825,7 +1804,7 @@ pub(crate) fn cholesky<T: FaerLinalg>(
             input,
         ));
     }
-    batched_single(buffers, input, 2, |buffers, batch| {
+    batched_single("cholesky", buffers, input, 2, |buffers, batch| {
         T::cholesky_2d(ctx, buffers, batch)
     })
 }
@@ -1834,18 +1813,14 @@ pub(crate) fn lu<T: FaerLinalg>(
     ctx: &CpuContext,
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
+) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let m = input.shape[0];
-        let n = input.shape[1];
+        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "lu")?;
+        let m = matrix_shape[0];
+        let n = matrix_shape[1];
         let k = m.min(n);
-        let batch_shape = &input.shape[2..];
-        let parity_elements = if batch_shape.is_empty() {
-            1
-        } else {
-            batch_shape.iter().product()
-        };
-        return vec![
+        let parity_elements = checked_product("lu", "batch shape", batch_shape)?;
+        return Ok(vec![
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, m, batch_shape),
                 Vec::new(),
@@ -1866,9 +1841,9 @@ pub(crate) fn lu<T: FaerLinalg>(
                 vec![T::parity_one(); parity_elements],
                 input,
             ),
-        ];
+        ]);
     }
-    batched_multi(buffers, input, 2, |buffers, batch| {
+    batched_multi_result("lu", buffers, input, 2, |buffers, batch| {
         T::lu_2d(ctx, buffers, batch)
     })
 }
@@ -1877,16 +1852,19 @@ pub(crate) fn full_piv_lu<T: FaerLinalg>(
     ctx: &CpuContext,
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
+) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let n = input.shape[0];
-        let batch_shape = &input.shape[2..];
-        let parity_elements = if batch_shape.is_empty() {
-            1
-        } else {
-            batch_shape.iter().product()
-        };
-        return vec![
+        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "full_piv_lu")?;
+        let n = matrix_shape[0];
+        if matrix_shape[1] != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "full_piv_lu",
+                lhs: vec![n],
+                rhs: vec![matrix_shape[1]],
+            });
+        }
+        let parity_elements = checked_product("full_piv_lu", "batch shape", batch_shape)?;
+        return Ok(vec![
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
@@ -1912,9 +1890,9 @@ pub(crate) fn full_piv_lu<T: FaerLinalg>(
                 vec![T::parity_one(); parity_elements],
                 input,
             ),
-        ];
+        ]);
     }
-    batched_multi(buffers, input, 2, |buffers, batch| {
+    batched_multi_result("full_piv_lu", buffers, input, 2, |buffers, batch| {
         T::full_piv_lu_2d(ctx, buffers, batch)
     })
 }
@@ -1927,13 +1905,22 @@ pub(crate) fn full_piv_lu_solve<T: FaerLinalg>(
     transpose_a: bool,
 ) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
+        let (_, a_batch_shape) = split_core_and_batch(a, 2, "full_piv_lu_solve")?;
+        let (_, b_batch_shape) = split_core_and_batch(b, 2, "full_piv_lu_solve")?;
+        if a_batch_shape != b_batch_shape {
+            return Err(crate::Error::ShapeMismatch {
+                op: "full_piv_lu_solve",
+                lhs: a_batch_shape.to_vec(),
+                rhs: b_batch_shape.to_vec(),
+            });
+        }
         return Ok(tensor_from_vec_with_template(
             b.shape.clone(),
             Vec::new(),
             b,
         ));
     }
-    batched_binary_result(buffers, a, b, 2, 2, |buffers, a, b| {
+    batched_binary_result("full_piv_lu_solve", buffers, a, b, 2, 2, |buffers, a, b| {
         T::full_piv_lu_solve_2d(ctx, buffers, a, b, transpose_a)
     })
 }
@@ -1947,11 +1934,24 @@ pub(crate) fn triangular_solve<T: FaerLinalg>(
     lower: bool,
     transpose_a: bool,
     unit_diagonal: bool,
-) -> TypedTensor<T> {
+) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
-        return tensor_from_vec_with_template(b.shape.clone(), Vec::new(), b);
+        let (_, a_batch_shape) = split_core_and_batch(a, 2, "triangular_solve")?;
+        let (_, b_batch_shape) = split_core_and_batch(b, 2, "triangular_solve")?;
+        if a_batch_shape != b_batch_shape {
+            return Err(crate::Error::ShapeMismatch {
+                op: "triangular_solve",
+                lhs: a_batch_shape.to_vec(),
+                rhs: b_batch_shape.to_vec(),
+            });
+        }
+        return Ok(tensor_from_vec_with_template(
+            b.shape.clone(),
+            Vec::new(),
+            b,
+        ));
     }
-    batched_binary(buffers, a, b, 2, 2, |buffers, a, b| {
+    batched_binary_result("triangular_solve", buffers, a, b, 2, 2, |buffers, a, b| {
         T::triangular_solve_2d(
             ctx,
             buffers,
@@ -1971,7 +1971,7 @@ pub(crate) fn svd<T: FaerLinalg>(
     input: &TypedTensor<T>,
 ) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "svd");
+        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "svd")?;
         let m = matrix_shape[0];
         let n = matrix_shape[1];
         let k = m.min(n);
@@ -1993,7 +1993,7 @@ pub(crate) fn svd<T: FaerLinalg>(
             ),
         ]);
     }
-    batched_multi_result(buffers, input, 2, |buffers, batch| {
+    batched_multi_result("svd", buffers, input, 2, |buffers, batch| {
         T::svd_2d(ctx, buffers, batch)
     })
 }
@@ -2002,13 +2002,13 @@ pub(crate) fn qr<T: FaerLinalg>(
     ctx: &CpuContext,
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
+) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "qr");
+        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "qr")?;
         let m = matrix_shape[0];
         let n = matrix_shape[1];
         let k = m.min(n);
-        return vec![
+        return Ok(vec![
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
@@ -2019,9 +2019,9 @@ pub(crate) fn qr<T: FaerLinalg>(
                 Vec::new(),
                 input,
             ),
-        ];
+        ]);
     }
-    batched_multi(buffers, input, 2, |buffers, batch| {
+    batched_multi_result("qr", buffers, input, 2, |buffers, batch| {
         T::qr_2d(ctx, buffers, batch)
     })
 }
@@ -2032,8 +2032,15 @@ pub(crate) fn eigh<T: FaerLinalg>(
     input: &TypedTensor<T>,
 ) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let n = input.shape[0];
-        let batch_shape = &input.shape[2..];
+        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "eigh")?;
+        let n = matrix_shape[0];
+        if matrix_shape[1] != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "eigh",
+                lhs: vec![n],
+                rhs: vec![matrix_shape[1]],
+            });
+        }
         return Ok(vec![
             tensor_from_vec_with_template(
                 vector_with_batch_shape(n, batch_shape),
@@ -2047,7 +2054,7 @@ pub(crate) fn eigh<T: FaerLinalg>(
             ),
         ]);
     }
-    batched_multi_result(buffers, input, 2, |buffers, batch| {
+    batched_multi_result("eigh", buffers, input, 2, |buffers, batch| {
         T::eigh_2d(ctx, buffers, batch)
     })
 }
@@ -2057,7 +2064,7 @@ fn eig_real_2d(
     buffers: &mut BufferPool,
     input: &TypedTensor<f64>,
 ) -> crate::Result<Vec<TypedTensor<Complex64>>> {
-    let n = square_matrix_dim(input, "eig");
+    let n = square_matrix_dim(input, "eig")?;
     let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
     let mut u_real = Mat::zeros(n, n);
     let mut s_re = Diag::zeros(n);
@@ -2095,7 +2102,7 @@ fn eig_complex_2d(
     buffers: &mut BufferPool,
     input: &TypedTensor<Complex64>,
 ) -> crate::Result<Vec<TypedTensor<Complex64>>> {
-    let n = square_matrix_dim(input, "eig");
+    let n = square_matrix_dim(input, "eig")?;
     let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), n, n);
     let mut u = Mat::zeros(n, n);
     let mut s = Diag::zeros(n);
@@ -2130,8 +2137,15 @@ pub(crate) fn eig(
     input: &Tensor,
 ) -> crate::Result<Vec<Tensor>> {
     if has_zero_dim(input.shape()) {
-        let n = input.shape()[0];
-        let batch_shape = &input.shape()[2..];
+        let (matrix_shape, batch_shape) = split_shape_core_and_batch(input.shape(), 2, "eig")?;
+        let n = matrix_shape[0];
+        if matrix_shape[1] != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "eig",
+                lhs: vec![n],
+                rhs: vec![matrix_shape[1]],
+            });
+        }
         return Ok(vec![
             Tensor::C64(TypedTensor::from_vec(
                 vector_with_batch_shape(n, batch_shape),
@@ -2145,22 +2159,26 @@ pub(crate) fn eig(
     }
 
     match input {
-        Tensor::F64(t) => Ok(
-            batched_multi_convert_result(buffers, t, 2, |buffers, batch| {
-                eig_real_2d(ctx, buffers, batch)
-            })?
-            .into_iter()
-            .map(Tensor::C64)
-            .collect(),
-        ),
-        Tensor::C64(t) => Ok(
-            batched_multi_convert_result(buffers, t, 2, |buffers, batch| {
-                eig_complex_2d(ctx, buffers, batch)
-            })?
-            .into_iter()
-            .map(Tensor::C64)
-            .collect(),
-        ),
+        Tensor::F64(t) => {
+            Ok(
+                batched_multi_convert_result("eig", buffers, t, 2, |buffers, batch| {
+                    eig_real_2d(ctx, buffers, batch)
+                })?
+                .into_iter()
+                .map(Tensor::C64)
+                .collect(),
+            )
+        }
+        Tensor::C64(t) => {
+            Ok(
+                batched_multi_convert_result("eig", buffers, t, 2, |buffers, batch| {
+                    eig_complex_2d(ctx, buffers, batch)
+                })?
+                .into_iter()
+                .map(Tensor::C64)
+                .collect(),
+            )
+        }
         _ => todo!("eig: unsupported dtype"),
     }
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -4,9 +4,9 @@ use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
 
 use super::helpers::{
-    dim_i32, has_zero_dim, leading_upper_triangle_from_lapack, lower_triangle_from_lapack,
-    matrix_dims, matrix_with_batch_shape, panic_on_lapack_error, square_matrix_dim,
-    tensor_from_vec_with_template, transpose_col_major_data,
+    batched_binary_result, dim_i32, has_zero_dim, leading_upper_triangle_from_lapack,
+    lower_triangle_from_lapack, matrix_dims, matrix_with_batch_shape, panic_on_lapack_error,
+    square_matrix_dim, tensor_from_vec_with_template, transpose_col_major_data,
 };
 
 extern "C" {
@@ -331,90 +331,6 @@ fn solve_2d<T: LapackFullPivLu>(
     Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs, b))
 }
 
-fn batched_binary_result<T, F>(
-    buffers: &mut BufferPool,
-    a: &TypedTensor<T>,
-    b: &TypedTensor<T>,
-    op: F,
-) -> crate::Result<TypedTensor<T>>
-where
-    T: Clone,
-    F: Fn(&mut BufferPool, &TypedTensor<T>, &TypedTensor<T>) -> crate::Result<TypedTensor<T>>,
-{
-    let (a_core_shape, a_batch_shape) =
-        super::helpers::split_core_and_batch(a, 2, "batched_binary_result");
-    let (b_core_shape, b_batch_shape) =
-        super::helpers::split_core_and_batch(b, 2, "batched_binary_result");
-    assert_eq!(
-        a_batch_shape, b_batch_shape,
-        "batched_binary_result: batch shape mismatch"
-    );
-
-    if a_batch_shape.is_empty() {
-        return op(buffers, a, b);
-    }
-
-    let a_slice_size: usize = a_core_shape.iter().product();
-    let b_slice_size: usize = b_core_shape.iter().product();
-    let batch_count: usize = a_batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_binary_result: zero-sized batch dims are unsupported"
-    );
-
-    let mut out_core_shape: Option<Vec<usize>> = None;
-    let mut out_data: Option<Vec<T>> = None;
-
-    for batch_idx in 0..batch_count {
-        let a_start = batch_idx * a_slice_size;
-        let a_end = a_start + a_slice_size;
-        let b_start = batch_idx * b_slice_size;
-        let b_end = b_start + b_slice_size;
-
-        let batch_a = tensor_from_vec_with_template(
-            a_core_shape.to_vec(),
-            a.host_data()[a_start..a_end].to_vec(),
-            a,
-        );
-        let batch_b = tensor_from_vec_with_template(
-            b_core_shape.to_vec(),
-            b.host_data()[b_start..b_end].to_vec(),
-            b,
-        );
-        let batch_output = op(buffers, &batch_a, &batch_b)?;
-
-        if let Some(expected_shape) = &out_core_shape {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                expected_shape.as_slice(),
-                "batched_binary_result: output core shape mismatch across batches"
-            );
-        } else {
-            out_data = Some(Vec::with_capacity(batch_output.n_elements() * batch_count));
-            out_core_shape = Some(batch_output.shape.clone());
-        }
-
-        match &mut out_data {
-            Some(data) => data.extend_from_slice(batch_output.host_data()),
-            None => panic!("batched_binary_result: missing output buffer"),
-        }
-    }
-
-    let mut out_shape = match out_core_shape {
-        Some(shape) => shape,
-        None => panic!("batched_binary_result: missing output shape"),
-    };
-    out_shape.extend_from_slice(a_batch_shape);
-    Ok(tensor_from_vec_with_template(
-        out_shape,
-        match out_data {
-            Some(data) => data,
-            None => panic!("batched_binary_result: missing output data"),
-        },
-        b,
-    ))
-}
-
 pub(crate) fn full_piv_lu<T: LapackFullPivLu>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
@@ -471,7 +387,7 @@ pub(crate) fn full_piv_lu_solve<T: LapackFullPivLu>(
             b,
         ));
     }
-    batched_binary_result(buffers, a, b, |buffers, a, b| {
+    batched_binary_result("full_piv_lu_solve", buffers, a, b, |buffers, a, b| {
         solve_2d(buffers, a, b, transpose_a)
     })
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs
@@ -36,6 +36,21 @@ pub(crate) fn split_core_and_batch<'a, T>(
     input.shape.split_at(core_rank)
 }
 
+pub(crate) fn split_core_and_batch_result<'a, T>(
+    input: &'a TypedTensor<T>,
+    core_rank: usize,
+    op: &'static str,
+) -> crate::Result<(&'a [usize], &'a [usize])> {
+    if input.shape.len() < core_rank {
+        return Err(crate::Error::RankMismatch {
+            op,
+            expected: core_rank,
+            actual: input.shape.len(),
+        });
+    }
+    Ok(input.shape.split_at(core_rank))
+}
+
 pub(crate) fn has_zero_dim(shape: &[usize]) -> bool {
     shape.contains(&0)
 }
@@ -329,22 +344,26 @@ where
         .collect()
 }
 
-pub(crate) fn batched_binary<T, F>(
+pub(crate) fn batched_binary_result<T, F>(
+    op_name: &'static str,
     buffers: &mut BufferPool,
     a: &TypedTensor<T>,
     b: &TypedTensor<T>,
     op: F,
-) -> TypedTensor<T>
+) -> crate::Result<TypedTensor<T>>
 where
     T: Clone,
-    F: Fn(&mut BufferPool, &TypedTensor<T>, &TypedTensor<T>) -> TypedTensor<T>,
+    F: Fn(&mut BufferPool, &TypedTensor<T>, &TypedTensor<T>) -> crate::Result<TypedTensor<T>>,
 {
-    let (a_core_shape, a_batch_shape) = split_core_and_batch(a, 2, "batched_binary");
-    let (b_core_shape, b_batch_shape) = split_core_and_batch(b, 2, "batched_binary");
-    assert_eq!(
-        a_batch_shape, b_batch_shape,
-        "batched_binary: batch shape mismatch"
-    );
+    let (a_core_shape, a_batch_shape) = split_core_and_batch_result(a, 2, op_name)?;
+    let (b_core_shape, b_batch_shape) = split_core_and_batch_result(b, 2, op_name)?;
+    if a_batch_shape != b_batch_shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: op_name,
+            lhs: a_batch_shape.to_vec(),
+            rhs: b_batch_shape.to_vec(),
+        });
+    }
 
     if a_batch_shape.is_empty() {
         return op(buffers, a, b);
@@ -353,10 +372,12 @@ where
     let a_slice_size: usize = a_core_shape.iter().product();
     let b_slice_size: usize = b_core_shape.iter().product();
     let batch_count: usize = a_batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_binary: zero-sized batch dims are unsupported"
-    );
+    if batch_count == 0 {
+        return Err(crate::Error::InvalidConfig {
+            op: op_name,
+            message: "zero-sized batch dims must be handled by the caller".into(),
+        });
+    }
 
     let mut out_core_shape: Option<Vec<usize>> = None;
     let mut out_data: Option<Vec<T>> = None;
@@ -377,14 +398,16 @@ where
             b.host_data()[b_start..b_end].to_vec(),
             b,
         );
-        let batch_output = op(buffers, &batch_a, &batch_b);
+        let batch_output = op(buffers, &batch_a, &batch_b)?;
 
         if let Some(expected_shape) = &out_core_shape {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                expected_shape.as_slice(),
-                "batched_binary: output core shape mismatch across batches"
-            );
+            if batch_output.shape.as_slice() != expected_shape.as_slice() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: op_name,
+                    lhs: batch_output.shape.clone(),
+                    rhs: expected_shape.clone(),
+                });
+            }
         } else {
             out_data = Some(Vec::with_capacity(batch_output.n_elements() * batch_count));
             out_core_shape = Some(batch_output.shape.clone());
@@ -392,23 +415,25 @@ where
 
         match &mut out_data {
             Some(data) => data.extend_from_slice(batch_output.host_data()),
-            None => panic!("batched_binary: missing output buffer"),
+            None => {
+                return Err(crate::Error::InvalidConfig {
+                    op: op_name,
+                    message: "missing output buffer after first batch".into(),
+                });
+            }
         }
     }
 
-    let mut out_shape = match out_core_shape {
-        Some(shape) => shape,
-        None => panic!("batched_binary: missing output shape"),
-    };
+    let mut out_shape = out_core_shape.ok_or_else(|| crate::Error::InvalidConfig {
+        op: op_name,
+        message: "missing output shape".into(),
+    })?;
     out_shape.extend_from_slice(a_batch_shape);
-    tensor_from_vec_with_template(
-        out_shape,
-        match out_data {
-            Some(data) => data,
-            None => panic!("batched_binary: missing output data"),
-        },
-        b,
-    )
+    let out_data = out_data.ok_or_else(|| crate::Error::InvalidConfig {
+        op: op_name,
+        message: "missing output data".into(),
+    })?;
+    Ok(tensor_from_vec_with_template(out_shape, out_data, b))
 }
 
 pub(crate) fn zero_dim_eig_outputs(input: &Tensor) -> Vec<Tensor> {

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/triangular_solve.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/triangular_solve.rs
@@ -4,8 +4,8 @@ use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
 
 use super::helpers::{
-    batched_binary, dim_i32, has_zero_dim, matrix_dims, panic_on_lapack_error, square_matrix_dim,
-    tensor_from_vec_with_template, transpose_col_major_data,
+    batched_binary_result, dim_i32, has_zero_dim, matrix_dims, panic_on_lapack_error,
+    square_matrix_dim, tensor_from_vec_with_template, transpose_col_major_data,
 };
 
 pub(crate) trait LapackTriangularSolve: Clone + Copy {
@@ -67,10 +67,16 @@ fn solve_left<T: LapackTriangularSolve>(
     lower: bool,
     transpose_a: bool,
     unit_diagonal: bool,
-) -> TypedTensor<T> {
+) -> crate::Result<TypedTensor<T>> {
     let n = square_matrix_dim(a, "triangular_solve");
     let (b_rows, b_cols) = matrix_dims(b, "triangular_solve");
-    assert_eq!(b_rows, n, "triangular_solve: rhs row count mismatch");
+    if b_rows != n {
+        return Err(crate::Error::ShapeMismatch {
+            op: "triangular_solve",
+            lhs: vec![n],
+            rhs: vec![b_rows],
+        });
+    }
 
     let mut rhs = b.host_data().to_vec();
     let mut info = 0;
@@ -87,7 +93,7 @@ fn solve_left<T: LapackTriangularSolve>(
         &mut info,
     );
     panic_on_lapack_error("triangular_solve", "dtrtrs", info);
-    tensor_from_vec_with_template(vec![n, b_cols], rhs, b)
+    Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs, b))
 }
 
 fn solve_right<T: LapackTriangularSolve>(
@@ -96,10 +102,16 @@ fn solve_right<T: LapackTriangularSolve>(
     lower: bool,
     transpose_a: bool,
     unit_diagonal: bool,
-) -> TypedTensor<T> {
+) -> crate::Result<TypedTensor<T>> {
     let n = square_matrix_dim(a, "triangular_solve");
     let (b_rows, b_cols) = matrix_dims(b, "triangular_solve");
-    assert_eq!(b_cols, n, "triangular_solve: rhs column count mismatch");
+    if b_cols != n {
+        return Err(crate::Error::ShapeMismatch {
+            op: "triangular_solve",
+            lhs: vec![n],
+            rhs: vec![b_cols],
+        });
+    }
 
     let mut rhs_t = transpose_col_major_data(b.host_data(), b_rows, n);
     let mut info = 0;
@@ -117,7 +129,7 @@ fn solve_right<T: LapackTriangularSolve>(
     );
     panic_on_lapack_error("triangular_solve", "dtrtrs", info);
     let result = transpose_col_major_data(&rhs_t, n, b_rows);
-    tensor_from_vec_with_template(vec![b_rows, n], result, b)
+    Ok(tensor_from_vec_with_template(vec![b_rows, n], result, b))
 }
 
 fn triangular_solve_2d<T: LapackTriangularSolve>(
@@ -128,7 +140,7 @@ fn triangular_solve_2d<T: LapackTriangularSolve>(
     lower: bool,
     transpose_a: bool,
     unit_diagonal: bool,
-) -> TypedTensor<T> {
+) -> crate::Result<TypedTensor<T>> {
     if left_side {
         solve_left(a, b, lower, transpose_a, unit_diagonal)
     } else {
@@ -144,11 +156,15 @@ pub(crate) fn triangular_solve<T: LapackTriangularSolve>(
     lower: bool,
     transpose_a: bool,
     unit_diagonal: bool,
-) -> TypedTensor<T> {
+) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
-        return tensor_from_vec_with_template(b.shape.clone(), Vec::new(), b);
+        return Ok(tensor_from_vec_with_template(
+            b.shape.clone(),
+            Vec::new(),
+            b,
+        ));
     }
-    batched_binary(buffers, a, b, |buffers, a, b| {
+    batched_binary_result("triangular_solve", buffers, a, b, |buffers, a, b| {
         triangular_solve_2d(buffers, a, b, left_side, lower, transpose_a, unit_diagonal)
     })
 }

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -422,15 +422,16 @@ fn typed_triangular_mask<T: Copy + Zero + Clone>(
     for batch_idx in 0..batch_count {
         let base = batch_idx * block_size;
         for col in 0..cols {
-            let boundary = col as i64 - k;
+            let boundary = col as i128 - k as i128;
             for row in 0..rows {
+                let row = row as i128;
                 let keep = if upper {
-                    (row as i64) <= boundary
+                    row <= boundary
                 } else {
-                    (row as i64) >= boundary
+                    row >= boundary
                 };
                 if !keep {
-                    data[base + row + col * rows] = T::zero();
+                    data[base + row as usize + col * rows] = T::zero();
                 }
             }
         }

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -1203,6 +1203,47 @@ fn test_tril_triu_zero_sized_batch_return_empty_tensor() {
 }
 
 #[test]
+fn test_tril_triu_extreme_offsets_do_not_overflow() {
+    let t = Tensor::F64(TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
+
+    let lower_min = tril(&t, i64::MIN).unwrap();
+    assert_eq!(
+        match &lower_min {
+            Tensor::F64(inner) => inner.host_data(),
+            _ => panic!("expected f64 tensor"),
+        },
+        &[0.0, 0.0, 0.0, 0.0]
+    );
+
+    let upper_min = triu(&t, i64::MIN).unwrap();
+    assert_eq!(
+        match &upper_min {
+            Tensor::F64(inner) => inner.host_data(),
+            _ => panic!("expected f64 tensor"),
+        },
+        &[1.0, 2.0, 3.0, 4.0]
+    );
+
+    let lower_max = tril(&t, i64::MAX).unwrap();
+    assert_eq!(
+        match &lower_max {
+            Tensor::F64(inner) => inner.host_data(),
+            _ => panic!("expected f64 tensor"),
+        },
+        &[1.0, 2.0, 3.0, 4.0]
+    );
+
+    let upper_max = triu(&t, i64::MAX).unwrap();
+    assert_eq!(
+        match &upper_max {
+            Tensor::F64(inner) => inner.host_data(),
+            _ => panic!("expected f64 tensor"),
+        },
+        &[0.0, 0.0, 0.0, 0.0]
+    );
+}
+
+#[test]
 fn test_neg_and_conj() {
     let t = Tensor::F64(TypedTensor::from_vec(vec![2], vec![3.0, -7.0]));
     let n = neg(&t).unwrap();

--- a/tenferro-tensor/tests/runtime_error_tests.rs
+++ b/tenferro-tensor/tests/runtime_error_tests.rs
@@ -300,3 +300,51 @@ fn concatenate_accepts_valid_inputs() {
     let out = result.unwrap();
     assert_eq!(out.shape(), &[4, 2]);
 }
+
+#[test]
+fn triangular_solve_rejects_batch_mismatch_without_backend_panic() {
+    let mut backend = CpuBackend::new();
+    let a = f64_tensor(vec![2, 2, 2], vec![1.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0, 2.0]);
+    let b = f64_tensor(vec![2, 1, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        backend.triangular_solve(&a, &b, true, true, false, false)
+    }));
+
+    assert!(
+        result.is_ok(),
+        "triangular_solve should return Err on batch mismatch, not panic"
+    );
+    let err = result.unwrap().unwrap_err();
+    assert!(matches!(
+        err,
+        Error::ShapeMismatch {
+            op: "triangular_solve",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn full_piv_lu_solve_rejects_batch_mismatch_without_backend_panic() {
+    let mut backend = CpuBackend::new();
+    let a = f64_tensor(vec![2, 2, 2], vec![1.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0, 2.0]);
+    let b = f64_tensor(vec![2, 1, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        backend.full_piv_lu_solve(&a, &b, false)
+    }));
+
+    assert!(
+        result.is_ok(),
+        "full_piv_lu_solve should return Err on batch mismatch, not panic"
+    );
+    let err = result.unwrap().unwrap_err();
+    assert!(matches!(
+        err,
+        Error::ShapeMismatch {
+            op: "full_piv_lu_solve",
+            ..
+        }
+    ));
+}


### PR DESCRIPTION
## Summary

- Harden CPU GEMM shape/stride fusion and batch offsets against `usize`/`isize` overflow.
- Make `tril`/`triu` handle extreme diagonal offsets without integer overflow.
- Convert faer batched linalg validation failures for LU/QR/triangular solve/full-pivot LU solve into typed `Result` errors instead of backend panics.
- Add regression coverage for the overflow and batch mismatch cases.

Closes #815
Closes #807

## Verification

- `cargo fmt --all --check`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo test -p tenferro-tensor --release`

`scripts/create-pr.sh` ran the full required PR gate successfully before push; manual continuation was needed only because the local branch upstream initially pointed at `origin/main`, causing the script's bare `git push` step to fail.

Generated with [Codex](https://openai.com/codex)
