### PR TITLE
[codex] fix solve matrix cotangents

### DIFF
--- a/tenferro-ops/src/ad/linalg.rs
+++ b/tenferro-ops/src/ad/linalg.rs
@@ -874,6 +874,7 @@ pub fn transpose_triangular_solve(
     lower: bool,
     transpose_a: bool,
     unit_diagonal: bool,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None, None];
@@ -883,7 +884,7 @@ pub fn transpose_triangular_solve(
     };
 
     let mut result = vec![None, None];
-    if active_mask[1] {
+    if active_mask[0] || active_mask[1] {
         let conjugated_a =
             emitter.add_op(StdTensorOp::Conj, vec![inputs[0].clone()], OpMode::Primal)[0];
         let out = emitter.add_op(
@@ -898,7 +899,34 @@ pub fn transpose_triangular_solve(
                 active_mask: vec![false, true],
             },
         );
-        result[1] = Some(out[0]);
+        let rhs_cotangent = out[0];
+        if active_mask[0] {
+            let rank = ctx.shape_of(&inputs[0]).len();
+            let solution = emitter.add_op(
+                StdTensorOp::TriangularSolve {
+                    left_side,
+                    lower,
+                    transpose_a,
+                    unit_diagonal,
+                },
+                inputs.to_vec(),
+                OpMode::Primal,
+            )[0];
+            let matrix_cotangent = solve_matrix_cotangent(
+                emitter,
+                rhs_cotangent,
+                ValRef::Local(solution),
+                left_side,
+                transpose_a,
+                rank,
+            );
+            let matrix_cotangent =
+                project_triangular_operand_linear(emitter, matrix_cotangent, lower, unit_diagonal);
+            result[0] = Some(matrix_cotangent);
+        }
+        if active_mask[1] {
+            result[1] = Some(rhs_cotangent);
+        }
     }
 
     result
@@ -910,6 +938,7 @@ pub fn transpose_full_piv_lu_solve(
     inputs: &[ValRef<StdTensorOp>],
     mode: &OpMode,
     transpose_a: bool,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None, None];
@@ -919,7 +948,7 @@ pub fn transpose_full_piv_lu_solve(
     };
 
     let mut result = vec![None, None];
-    if active_mask[1] {
+    if active_mask[0] || active_mask[1] {
         let conjugated_a =
             emitter.add_op(StdTensorOp::Conj, vec![inputs[0].clone()], OpMode::Primal)[0];
         let out = emitter.add_op(
@@ -931,10 +960,63 @@ pub fn transpose_full_piv_lu_solve(
                 active_mask: vec![false, true],
             },
         );
-        result[1] = Some(out[0]);
+        let rhs_cotangent = out[0];
+        if active_mask[0] {
+            let rank = ctx.shape_of(&inputs[0]).len();
+            let solution = emitter.add_op(
+                StdTensorOp::FullPivLuSolve { transpose_a },
+                inputs.to_vec(),
+                OpMode::Primal,
+            )[0];
+            result[0] = Some(solve_matrix_cotangent(
+                emitter,
+                rhs_cotangent,
+                ValRef::Local(solution),
+                true,
+                transpose_a,
+                rank,
+            ));
+        }
+        if active_mask[1] {
+            result[1] = Some(rhs_cotangent);
+        }
     }
 
     result
+}
+
+fn solve_matrix_cotangent(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    rhs_cotangent: LocalValId,
+    solution: ValRef<StdTensorOp>,
+    left_side: bool,
+    transpose_a: bool,
+    rank: usize,
+) -> LocalValId {
+    let negative_rhs_cotangent = linear_neg(emitter, rhs_cotangent);
+    let solution_h = adjoint_matrix_fixed(emitter, solution, rank);
+    let op_matrix_cotangent = if left_side {
+        matmul_linear(
+            emitter,
+            ValRef::Local(negative_rhs_cotangent),
+            ValRef::Local(solution_h),
+            vec![true, false],
+            rank,
+        )
+    } else {
+        matmul_linear(
+            emitter,
+            ValRef::Local(solution_h),
+            ValRef::Local(negative_rhs_cotangent),
+            vec![false, true],
+            rank,
+        )
+    };
+    if transpose_a {
+        transpose_matrix_linear(emitter, op_matrix_cotangent, rank)
+    } else {
+        op_matrix_cotangent
+    }
 }
 
 fn solve_in_graph(
@@ -992,7 +1074,7 @@ fn fixed_binary(
 }
 
 fn linear_unary(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut impl OpEmitter<StdTensorOp>,
     op: StdTensorOp,
     input: LocalValId,
 ) -> LocalValId {
@@ -1109,7 +1191,7 @@ fn linear_add(
     linear_binary(builder, StdTensorOp::Add, lhs, rhs)
 }
 
-fn linear_neg(builder: &mut FragmentBuilder<StdTensorOp>, input: LocalValId) -> LocalValId {
+fn linear_neg(builder: &mut impl OpEmitter<StdTensorOp>, input: LocalValId) -> LocalValId {
     linear_unary(builder, StdTensorOp::Neg, input)
 }
 
@@ -1231,7 +1313,7 @@ fn transpose_matrix_fixed(
 }
 
 fn adjoint_matrix_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut impl OpEmitter<StdTensorOp>,
     input: ValRef<StdTensorOp>,
     rank: usize,
 ) -> LocalValId {
@@ -1273,7 +1355,7 @@ fn transpose_matrix_linear(
 }
 
 fn project_triangular_operand_linear(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut impl OpEmitter<StdTensorOp>,
     input: LocalValId,
     lower: bool,
     unit_diagonal: bool,
@@ -1329,7 +1411,7 @@ fn matmul_fixed(
 }
 
 fn matmul_linear(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut impl OpEmitter<StdTensorOp>,
     lhs: ValRef<StdTensorOp>,
     rhs: ValRef<StdTensorOp>,
     active_mask: Vec<bool>,

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -308,10 +308,16 @@ pub fn transpose_rule(
             *lower,
             *transpose_a,
             *unit_diagonal,
+            ctx,
         ),
-        StdTensorOp::FullPivLuSolve { transpose_a } => {
-            linalg::transpose_full_piv_lu_solve(emitter, cotangent_out, inputs, mode, *transpose_a)
-        }
+        StdTensorOp::FullPivLuSolve { transpose_a } => linalg::transpose_full_piv_lu_solve(
+            emitter,
+            cotangent_out,
+            inputs,
+            mode,
+            *transpose_a,
+            ctx,
+        ),
         StdTensorOp::ValidateNonsingular => vec![cotangent_out[0]],
 
         // Extension substrate.

--- a/tenferro-ops/src/ad/tests/linalg_tests.rs
+++ b/tenferro-ops/src/ad/tests/linalg_tests.rs
@@ -1,0 +1,89 @@
+//! Unit tests for linalg AD rules.
+
+use chainrules_core::PrimitiveOp;
+use computegraph::fragment::FragmentBuilder;
+use computegraph::types::{GlobalValKey, OpMode, ValRef};
+use tenferro_tensor::DType;
+
+use crate::ad::context::ShapeGuardContext;
+use crate::input_key::TensorInputKey;
+use crate::std_tensor_op::StdTensorOp;
+use crate::{SymDim, TensorMeta};
+
+fn tensor_input(id: u64) -> TensorInputKey {
+    TensorInputKey::User { id }
+}
+
+fn input_key(id: u64) -> GlobalValKey<StdTensorOp> {
+    GlobalValKey::Input(tensor_input(id))
+}
+
+fn meta(shape: &[usize]) -> TensorMeta {
+    TensorMeta {
+        dtype: DType::F64,
+        shape: shape.iter().copied().map(SymDim::from).collect(),
+    }
+}
+
+#[test]
+fn transpose_triangular_solve_returns_matrix_cotangent_when_matrix_is_active() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let cot = builder.add_input(tensor_input(1));
+    let a_key = input_key(2);
+    let b_key = input_key(3);
+    ctx.insert_metadata(a_key.clone(), meta(&[2, 2]));
+    ctx.insert_metadata(b_key.clone(), meta(&[2, 1]));
+    let inputs = vec![ValRef::External(a_key), ValRef::External(b_key)];
+    let op = StdTensorOp::TriangularSolve {
+        left_side: true,
+        lower: true,
+        transpose_a: false,
+        unit_diagonal: false,
+    };
+
+    let result = op.transpose_rule(
+        &mut builder,
+        &[Some(cot)],
+        &inputs,
+        &OpMode::Linear {
+            active_mask: vec![true, false],
+        },
+        &mut ctx,
+    );
+
+    assert!(
+        result[0].is_some(),
+        "active triangular matrix input must receive a cotangent"
+    );
+    assert_eq!(result[1], None, "inactive RHS cotangent must stay None");
+}
+
+#[test]
+fn transpose_full_piv_lu_solve_returns_matrix_cotangent_when_matrix_is_active() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let cot = builder.add_input(tensor_input(4));
+    let a_key = input_key(5);
+    let b_key = input_key(6);
+    ctx.insert_metadata(a_key.clone(), meta(&[2, 2]));
+    ctx.insert_metadata(b_key.clone(), meta(&[2, 1]));
+    let inputs = vec![ValRef::External(a_key), ValRef::External(b_key)];
+    let op = StdTensorOp::FullPivLuSolve { transpose_a: false };
+
+    let result = op.transpose_rule(
+        &mut builder,
+        &[Some(cot)],
+        &inputs,
+        &OpMode::Linear {
+            active_mask: vec![true, false],
+        },
+        &mut ctx,
+    );
+
+    assert!(
+        result[0].is_some(),
+        "active LU matrix input must receive a cotangent"
+    );
+    assert_eq!(result[1], None, "inactive RHS cotangent must stay None");
+}

--- a/tenferro-ops/src/ad/tests/mod.rs
+++ b/tenferro-ops/src/ad/tests/mod.rs
@@ -11,6 +11,7 @@ use crate::std_tensor_op::StdTensorOp;
 use crate::{SymDim, TensorMeta};
 
 mod indexing_tests;
+mod linalg_tests;
 
 fn tensor_input(id: u64) -> TensorInputKey {
     TensorInputKey::User { id }


### PR DESCRIPTION
## Summary
- Preserve A-cotangents for TriangularSolve and FullPivLuSolve transpose rules.
- Recompute the primal solve inside the transpose rule when needed and build the matrix cotangent from the adjoint RHS solve and primal solution.
- Add linalg AD rule unit coverage for active matrix inputs.

## Root Cause
`transpose_triangular_solve` and `transpose_full_piv_lu_solve` only populated the RHS cotangent path. When the matrix operand was active, the returned matrix cotangent stayed `None`, silently dropping the A-gradient for direct primitive transpose use.

## Issue
Closes #772

## Verification
- `cargo fmt --all --check`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo test --workspace --release`

Generated by Codex.