### PR TITLE
[codex] Add AD rules for dynamic indexing and linalg

### DIFF
--- a/docs/spec/backend-contract.md
+++ b/docs/spec/backend-contract.md
@@ -102,7 +102,7 @@ the ops are the real runtime contract:
   `ExtractDiag`, `EmbedDiag`, `Tril`, `Triu`
 - Reductions: `ReduceSum`, `ReduceProd`, `ReduceMax`, `ReduceMin`
 - Indexing / shape: `Gather`, `GatherDynamicSliceSizes`, `Scatter`, `Slice`,
-  `DynamicSlice`, `Pad`, `Concatenate`, `Reverse`, `ShapeOf`,
+  `DynamicSlice`, `DynamicUpdateSlice`, `Pad`, `Concatenate`, `Reverse`, `ShapeOf`,
   `DynamicTruncate`, `PadToMatch`
 - Contraction: `DotGeneral`, `NaryEinsum`
 - Linalg: `Cholesky`, `Svd`, `Qr`, `Lu`, `Eigh`, `Eig`,
@@ -179,7 +179,7 @@ Examples:
 - structural ops such as `Transpose`, `Reshape`, `BroadcastInDim`
 - reductions such as `ReduceSum`, `ReduceProd`, `ReduceMax`, `ReduceMin`
 - indexing ops such as `Gather`, `GatherDynamicSliceSizes`, `Scatter`, `Slice`,
-  `DynamicSlice`, `Pad`, `Concatenate`, `Reverse`
+  `DynamicSlice`, `DynamicUpdateSlice`, `Pad`, `Concatenate`, `Reverse`
 
 The helper that executes one such instruction is `execute_backend_op()`.
 

--- a/docs/spec/primitive-catalog.md
+++ b/docs/spec/primitive-catalog.md
@@ -376,6 +376,7 @@ indexing ops are standard-arithmetic only:
 |-----------|------------|-------|
 | `Slice` | Read a static rectangular subregion | Start/limit/stride known in the op |
 | `DynamicSlice` | Read a slice whose start index is data-dependent | Dynamic counterpart of `Slice` |
+| `DynamicUpdateSlice` | Write an update tensor into an operand at data-dependent start indices | Transpose counterpart of `DynamicSlice`; start indices are adjusted with StableHLO `dynamic_update_slice` semantics. |
 | `Pad` | Extend a tensor with edge/interior padding values | Needed for transpose of slicing-like ops |
 | `Concatenate` | Join tensors along one axis | Rank-preserving shape change |
 | `Reverse` | Reverse the order of elements along selected axes | Useful for convolutions and sequence models |

--- a/tenferro-einsum/tests/typed_eager.rs
+++ b/tenferro-einsum/tests/typed_eager.rs
@@ -58,6 +58,7 @@ impl TensorBackend for WrongDTypeBackend {
         scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> tenferro_tensor::Result<Tensor>;
         slice(input: &Tensor, config: &SliceConfig) -> tenferro_tensor::Result<Tensor>;
         dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+        dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> tenferro_tensor::Result<Tensor>;
         pad(input: &Tensor, config: &PadConfig) -> tenferro_tensor::Result<Tensor>;
         concatenate(inputs: &[&Tensor], axis: usize) -> tenferro_tensor::Result<Tensor>;
         reverse(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;

--- a/tenferro-ops/src/ad/elementwise.rs
+++ b/tenferro-ops/src/ad/elementwise.rs
@@ -1,6 +1,7 @@
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
+use tenferro_tensor::CompareDir;
 
 use crate::std_tensor_op::StdTensorOp;
 
@@ -48,6 +49,15 @@ fn emit_fixed_div(
     emit_fixed_binary(emitter, StdTensorOp::Div, lhs, rhs)
 }
 
+fn emit_fixed_compare(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    dir: CompareDir,
+    lhs: ValRef<StdTensorOp>,
+    rhs: ValRef<StdTensorOp>,
+) -> LocalValId {
+    emit_fixed_binary(emitter, StdTensorOp::Compare(dir), lhs, rhs)
+}
+
 fn emit_linear_mul_fixed(
     emitter: &mut impl OpEmitter<StdTensorOp>,
     fixed: ValRef<StdTensorOp>,
@@ -58,6 +68,21 @@ fn emit_linear_mul_fixed(
         vec![fixed, ValRef::Local(active)],
         OpMode::Linear {
             active_mask: vec![false, true],
+        },
+    )[0]
+}
+
+fn emit_linear_select(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    condition: ValRef<StdTensorOp>,
+    on_true: LocalValId,
+    on_false: LocalValId,
+) -> LocalValId {
+    emitter.add_op(
+        StdTensorOp::Select,
+        vec![condition, ValRef::Local(on_true), ValRef::Local(on_false)],
+        OpMode::Linear {
+            active_mask: vec![false, true, true],
         },
     )[0]
 }
@@ -82,10 +107,55 @@ fn emit_zero_from_active(
     )[0]
 }
 
+fn select_tangents(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    condition: ValRef<StdTensorOp>,
+    on_true: Option<LocalValId>,
+    on_false: Option<LocalValId>,
+) -> Option<LocalValId> {
+    match (on_true, on_false) {
+        (Some(t), Some(f)) => Some(emit_linear_select(emitter, condition, t, f)),
+        (Some(t), None) => {
+            let zero = emit_zero_from_active(emitter, t);
+            Some(emit_linear_select(emitter, condition, t, zero))
+        }
+        (None, Some(f)) => {
+            let zero = emit_zero_from_active(emitter, f);
+            Some(emit_linear_select(emitter, condition, zero, f))
+        }
+        (None, None) => None,
+    }
+}
+
+fn split_cotangent_by_mask(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    condition: ValRef<StdTensorOp>,
+    cotangent: LocalValId,
+    true_active: bool,
+    false_active: bool,
+) -> (Option<LocalValId>, Option<LocalValId>) {
+    if !true_active && !false_active {
+        return (None, None);
+    }
+
+    let zero = emit_zero_from_active(emitter, cotangent);
+    let true_ct =
+        true_active.then(|| emit_linear_select(emitter, condition.clone(), cotangent, zero));
+    let false_ct = false_active.then(|| emit_linear_select(emitter, condition, zero, cotangent));
+    (true_ct, false_ct)
+}
+
 fn unary_is_active(mode: &OpMode) -> bool {
     match mode {
         OpMode::Linear { active_mask } => active_mask[0],
         OpMode::Primal => false,
+    }
+}
+
+fn active_mask(mode: &OpMode, len: usize) -> Vec<bool> {
+    match mode {
+        OpMode::Linear { active_mask } => active_mask.clone(),
+        OpMode::Primal => vec![false; len],
     }
 }
 
@@ -167,6 +237,108 @@ pub fn linearize_sign(
     }
 }
 
+pub fn linearize_maximum(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+) -> Vec<Option<LocalValId>> {
+    if tangent_in[0].is_none() && tangent_in[1].is_none() {
+        return vec![None];
+    }
+
+    let mask = emit_fixed_compare(
+        builder,
+        CompareDir::Ge,
+        ValRef::External(primal_in[0].clone()),
+        ValRef::External(primal_in[1].clone()),
+    );
+    vec![select_tangents(
+        builder,
+        ValRef::Local(mask),
+        tangent_in[0],
+        tangent_in[1],
+    )]
+}
+
+pub fn linearize_minimum(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+) -> Vec<Option<LocalValId>> {
+    if tangent_in[0].is_none() && tangent_in[1].is_none() {
+        return vec![None];
+    }
+
+    let mask = emit_fixed_compare(
+        builder,
+        CompareDir::Le,
+        ValRef::External(primal_in[0].clone()),
+        ValRef::External(primal_in[1].clone()),
+    );
+    vec![select_tangents(
+        builder,
+        ValRef::Local(mask),
+        tangent_in[0],
+        tangent_in[1],
+    )]
+}
+
+pub fn linearize_select(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+) -> Vec<Option<LocalValId>> {
+    vec![select_tangents(
+        builder,
+        ValRef::External(primal_in[0].clone()),
+        tangent_in[1],
+        tangent_in[2],
+    )]
+}
+
+pub fn linearize_clamp(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+) -> Vec<Option<LocalValId>> {
+    if tangent_in.iter().all(Option::is_none) {
+        return vec![None];
+    }
+
+    let upper_mask = emit_fixed_compare(
+        builder,
+        CompareDir::Le,
+        ValRef::External(primal_in[0].clone()),
+        ValRef::External(primal_in[2].clone()),
+    );
+    let inner_tangent = select_tangents(
+        builder,
+        ValRef::Local(upper_mask),
+        tangent_in[0],
+        tangent_in[2],
+    );
+
+    let inner_primal = emit_fixed_binary(
+        builder,
+        StdTensorOp::Minimum,
+        ValRef::External(primal_in[0].clone()),
+        ValRef::External(primal_in[2].clone()),
+    );
+    let lower_mask = emit_fixed_compare(
+        builder,
+        CompareDir::Ge,
+        ValRef::External(primal_in[1].clone()),
+        ValRef::Local(inner_primal),
+    );
+
+    vec![select_tangents(
+        builder,
+        ValRef::Local(lower_mask),
+        tangent_in[1],
+        inner_tangent,
+    )]
+}
+
 pub fn transpose_div(
     emitter: &mut impl OpEmitter<StdTensorOp>,
     cotangent_out: &[Option<LocalValId>],
@@ -240,4 +412,135 @@ pub fn transpose_sign(
         Some(ct) => vec![Some(emit_zero_from_active(emitter, ct))],
         None => vec![None],
     }
+}
+
+pub fn transpose_maximum(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+) -> Vec<Option<LocalValId>> {
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None, None];
+    };
+    let active = active_mask(mode, 2);
+    if active.iter().all(|is_active| !is_active) {
+        return vec![None, None];
+    }
+    let mask = emit_fixed_compare(
+        emitter,
+        CompareDir::Ge,
+        inputs[0].clone(),
+        inputs[1].clone(),
+    );
+    let lhs_active = active.first().copied().unwrap_or(false);
+    let rhs_active = active.get(1).copied().unwrap_or(false);
+    let (lhs, rhs) =
+        split_cotangent_by_mask(emitter, ValRef::Local(mask), ct, lhs_active, rhs_active);
+    vec![lhs, rhs]
+}
+
+pub fn transpose_minimum(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+) -> Vec<Option<LocalValId>> {
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None, None];
+    };
+    let active = active_mask(mode, 2);
+    if active.iter().all(|is_active| !is_active) {
+        return vec![None, None];
+    }
+    let mask = emit_fixed_compare(
+        emitter,
+        CompareDir::Le,
+        inputs[0].clone(),
+        inputs[1].clone(),
+    );
+    let lhs_active = active.first().copied().unwrap_or(false);
+    let rhs_active = active.get(1).copied().unwrap_or(false);
+    let (lhs, rhs) =
+        split_cotangent_by_mask(emitter, ValRef::Local(mask), ct, lhs_active, rhs_active);
+    vec![lhs, rhs]
+}
+
+pub fn transpose_select(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+) -> Vec<Option<LocalValId>> {
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None, None, None];
+    };
+    let active = active_mask(mode, 3);
+    let true_active = active.get(1).copied().unwrap_or(false);
+    let false_active = active.get(2).copied().unwrap_or(false);
+    if !true_active && !false_active {
+        return vec![None, None, None];
+    }
+    let (on_true, on_false) =
+        split_cotangent_by_mask(emitter, inputs[0].clone(), ct, true_active, false_active);
+    vec![None, on_true, on_false]
+}
+
+pub fn transpose_clamp(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+) -> Vec<Option<LocalValId>> {
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None, None, None];
+    };
+    let active = active_mask(mode, 3);
+    if active.iter().all(|is_active| !is_active) {
+        return vec![None, None, None];
+    }
+    let input_active = active.first().copied().unwrap_or(false);
+    let lower_active = active.get(1).copied().unwrap_or(false);
+    let upper_active = active.get(2).copied().unwrap_or(false);
+
+    let inner_primal = emit_fixed_binary(
+        emitter,
+        StdTensorOp::Minimum,
+        inputs[0].clone(),
+        inputs[2].clone(),
+    );
+    let lower_mask = emit_fixed_compare(
+        emitter,
+        CompareDir::Ge,
+        inputs[1].clone(),
+        ValRef::Local(inner_primal),
+    );
+    let (lower_ct, inner_ct) = split_cotangent_by_mask(
+        emitter,
+        ValRef::Local(lower_mask),
+        ct,
+        lower_active,
+        input_active || upper_active,
+    );
+
+    let (input_ct, upper_ct) = match inner_ct {
+        Some(inner_ct) => {
+            let upper_mask = emit_fixed_compare(
+                emitter,
+                CompareDir::Le,
+                inputs[0].clone(),
+                inputs[2].clone(),
+            );
+            split_cotangent_by_mask(
+                emitter,
+                ValRef::Local(upper_mask),
+                inner_ct,
+                input_active,
+                upper_active,
+            )
+        }
+        None => (None, None),
+    };
+
+    vec![input_ct, lower_ct, upper_ct]
 }

--- a/tenferro-ops/src/ad/indexing.rs
+++ b/tenferro-ops/src/ad/indexing.rs
@@ -27,9 +27,10 @@
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
-use tenferro_tensor::{DType, GatherConfig, ScatterConfig};
+use tenferro_tensor::{GatherConfig, ScatterConfig};
 
 use crate::ad::context::ShapeGuardContext;
+use crate::ad::zeros::build_zero_like;
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
@@ -102,6 +103,75 @@ pub fn linearize_gather_dynamic_slice_sizes(
         }
         None => vec![None],
     }
+}
+
+/// Forward-mode AD rule for `DynamicSlice`.
+///
+/// The source tensor tangent flows through the same dynamic slice. Runtime
+/// start indices are integer-valued and non-differentiable.
+pub fn linearize_dynamic_slice(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    slice_sizes: &[usize],
+) -> Vec<Option<LocalValId>> {
+    match tangent_in[0] {
+        Some(d_operand) => {
+            let out = builder.add_op(
+                StdTensorOp::DynamicSlice {
+                    slice_sizes: slice_sizes.to_vec(),
+                },
+                vec![
+                    ValRef::Local(d_operand),
+                    ValRef::External(primal_in[1].clone()),
+                ],
+                OpMode::Linear {
+                    active_mask: vec![true, false],
+                },
+            );
+            vec![Some(out[0])]
+        }
+        None => vec![None],
+    }
+}
+
+/// Forward-mode AD rule for `DynamicUpdateSlice`.
+///
+/// The operand and update inputs are differentiable. Runtime start indices are
+/// integer-valued and non-differentiable.
+pub fn linearize_dynamic_update_slice(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    if tangent_in[0].is_none() && tangent_in[1].is_none() {
+        return vec![None];
+    }
+
+    let operand = ValRef::External(primal_in[0].clone());
+    let update = ValRef::External(primal_in[1].clone());
+    let d_operand = tangent_in[0].unwrap_or_else(|| {
+        let meta = ctx.metadata_of(&operand);
+        build_zero_like(builder, meta.dtype, operand, meta.shape.len())
+    });
+    let d_update = tangent_in[1].unwrap_or_else(|| {
+        let meta = ctx.metadata_of(&update);
+        build_zero_like(builder, meta.dtype, update, meta.shape.len())
+    });
+
+    let out = builder.add_op(
+        StdTensorOp::DynamicUpdateSlice,
+        vec![
+            ValRef::Local(d_operand),
+            ValRef::Local(d_update),
+            ValRef::External(primal_in[2].clone()),
+        ],
+        OpMode::Linear {
+            active_mask: vec![tangent_in[0].is_some(), tangent_in[1].is_some(), false],
+        },
+    );
+    vec![Some(out[0])]
 }
 
 /// Reverse-mode AD rule for `Gather(operand, start_indices, config)`.
@@ -220,6 +290,113 @@ pub fn transpose_gather_dynamic_slice_sizes(
     );
 
     result[0] = Some(out[0]);
+    result
+}
+
+/// Reverse-mode AD rule for `DynamicSlice`.
+///
+/// The transpose of `DynamicSlice(x, starts, sizes)` writes the cotangent back
+/// into a zero tensor shaped like `x` using the same start-adjustment semantics.
+pub fn transpose_dynamic_slice(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    let ct = match cotangent_out[0] {
+        Some(ct) => ct,
+        None => return vec![None, None],
+    };
+
+    let active_mask = match mode {
+        OpMode::Linear { active_mask } => active_mask,
+        OpMode::Primal => return vec![None, None],
+    };
+    if !active_mask.first().copied().unwrap_or(false) {
+        return vec![None, None];
+    }
+
+    let operand_meta = ctx.metadata_of(&inputs[0]);
+    let zero_operand = build_zero_like(
+        emitter,
+        operand_meta.dtype,
+        inputs[0].clone(),
+        operand_meta.shape.len(),
+    );
+    let out = emitter.add_op(
+        StdTensorOp::DynamicUpdateSlice,
+        vec![
+            ValRef::Local(zero_operand),
+            ValRef::Local(ct),
+            inputs[1].clone(),
+        ],
+        OpMode::Linear {
+            active_mask: vec![false, true, false],
+        },
+    );
+    vec![Some(out[0]), None]
+}
+
+/// Reverse-mode AD rule for `DynamicUpdateSlice`.
+///
+/// Operand cotangent keeps the output cotangent outside the update window and
+/// zeros the updated window. Update cotangent is the matching dynamic slice of
+/// the output cotangent.
+pub fn transpose_dynamic_update_slice(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    let ct = match cotangent_out[0] {
+        Some(ct) => ct,
+        None => return vec![None, None, None],
+    };
+
+    let active_mask = match mode {
+        OpMode::Linear { active_mask } => active_mask,
+        OpMode::Primal => return vec![None, None, None],
+    };
+
+    let mut result = vec![None, None, None];
+    if active_mask.first().copied().unwrap_or(false) {
+        let update_meta = ctx.metadata_of(&inputs[1]);
+        let zero_update = build_zero_like(
+            emitter,
+            update_meta.dtype,
+            inputs[1].clone(),
+            update_meta.shape.len(),
+        );
+        let operand_ct = emitter.add_op(
+            StdTensorOp::DynamicUpdateSlice,
+            vec![
+                ValRef::Local(ct),
+                ValRef::Local(zero_update),
+                inputs[2].clone(),
+            ],
+            OpMode::Linear {
+                active_mask: vec![true, false, false],
+            },
+        )[0];
+        result[0] = Some(operand_ct);
+    }
+
+    if active_mask.get(1).copied().unwrap_or(false) {
+        let update_shape = exact_usize_shape(ctx, &inputs[1], "DynamicUpdateSlice transpose");
+        let update_ct = emitter.add_op(
+            StdTensorOp::DynamicSlice {
+                slice_sizes: update_shape,
+            },
+            vec![ValRef::Local(ct), inputs[2].clone()],
+            OpMode::Linear {
+                active_mask: vec![true, false],
+            },
+        )[0];
+        result[1] = Some(update_ct);
+    }
+
     result
 }
 
@@ -461,63 +638,17 @@ fn compute_inverse_gather(
     }
 }
 
-/// Emit a zero tensor shaped like `anchor` (rank `anchor_rank`) with
-/// dtype `dtype`. Uses `StdTensorOp::Constant { bytes: zeros }` for the
-/// scalar, then `BroadcastInDim` reading axis sizes from `anchor`.
-///
-/// When `anchor_rank == 0` returns the scalar `Constant` directly.
-fn build_zero_like(
-    emitter: &mut impl OpEmitter<StdTensorOp>,
-    dtype: DType,
-    anchor: ValRef<StdTensorOp>,
-    anchor_rank: usize,
-) -> LocalValId {
-    let zero_scalar = emitter.add_op(
-        StdTensorOp::Constant {
-            dtype,
-            bytes: zero_bytes(dtype),
-        },
-        vec![],
-        OpMode::Primal,
-    )[0];
-    if anchor_rank == 0 {
-        return zero_scalar;
-    }
-    // `BroadcastInDim` evaluates `DimExpr::InputDim { input_idx, axis }`
-    // against its own inputs at execution time. Input 0 is the scalar
-    // `zero_scalar`; input 1 is the anchor, whose shape we match.
-    let shape: Vec<DimExpr> = (0..anchor_rank)
-        .map(|axis| DimExpr::InputDim { input_idx: 1, axis })
-        .collect();
-    let out = emitter.add_op(
-        StdTensorOp::BroadcastInDim {
-            shape,
-            dims: vec![],
-        },
-        vec![ValRef::Local(zero_scalar), anchor],
-        OpMode::Primal,
-    );
-    out[0]
-}
-
-/// Bytes for a zero value of the given dtype (little-endian, matching
-/// the repr `Constant { dtype, bytes }` expects).
-fn zero_bytes(dtype: DType) -> Vec<u8> {
-    match dtype {
-        DType::F32 => 0.0_f32.to_le_bytes().to_vec(),
-        DType::F64 => 0.0_f64.to_le_bytes().to_vec(),
-        DType::I64 => 0_i64.to_le_bytes().to_vec(),
-        DType::C32 => {
-            let mut bytes = Vec::with_capacity(8);
-            bytes.extend_from_slice(&0.0_f32.to_le_bytes());
-            bytes.extend_from_slice(&0.0_f32.to_le_bytes());
-            bytes
-        }
-        DType::C64 => {
-            let mut bytes = Vec::with_capacity(16);
-            bytes.extend_from_slice(&0.0_f64.to_le_bytes());
-            bytes.extend_from_slice(&0.0_f64.to_le_bytes());
-            bytes
-        }
-    }
+fn exact_usize_shape(
+    ctx: &mut ShapeGuardContext,
+    value: &ValRef<StdTensorOp>,
+    op_name: &'static str,
+) -> Vec<usize> {
+    ctx.exact_shape_of(value)
+        .unwrap_or_else(|| panic!("{op_name} requires exact update shape metadata"))
+        .into_iter()
+        .map(|dim| {
+            dim.constant_value()
+                .unwrap_or_else(|| panic!("{op_name} requires concrete update shape metadata"))
+        })
+        .collect()
 }

--- a/tenferro-ops/src/ad/linalg.rs
+++ b/tenferro-ops/src/ad/linalg.rs
@@ -147,6 +147,74 @@ pub fn linearize_lu(
     vec![None, Some(dl), Some(du), None]
 }
 
+pub fn linearize_full_piv_lu(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    primal_out: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    let Some(da) = tangent_in[0] else {
+        return vec![None, None, None, None, None];
+    };
+
+    let input_shape = primal_input_shape(ctx, primal_in);
+    let input_shape = input_shape.as_slice();
+    let (rows, cols, _batch_shape) = matrix_shape_parts(input_shape, "linearize_full_piv_lu");
+    let (rows_size, cols_size) = resolve_and_guard(rows, cols, ctx);
+    assert_eq!(
+        rows_size, cols_size,
+        "linearize_full_piv_lu: expected square matrix"
+    );
+
+    let rank = input_shape.len();
+    let p = ValRef::External(primal_out[0].clone());
+    let l = ValRef::External(primal_out[1].clone());
+    let u = ValRef::External(primal_out[2].clone());
+    let q = ValRef::External(primal_out[3].clone());
+    let q_t = transpose_matrix_fixed(builder, q, rank);
+
+    let pd_a = matmul_linear(builder, p, ValRef::Local(da), vec![false, true], rank);
+    let pd_a_qt = matmul_linear(
+        builder,
+        ValRef::Local(pd_a),
+        ValRef::Local(q_t),
+        vec![true, false],
+        rank,
+    );
+    let la = builder.add_op(
+        StdTensorOp::TriangularSolve {
+            left_side: true,
+            lower: true,
+            transpose_a: false,
+            unit_diagonal: true,
+        },
+        vec![l.clone(), ValRef::Local(pd_a_qt)],
+        OpMode::Linear {
+            active_mask: vec![false, true],
+        },
+    )[0];
+    let x = builder.add_op(
+        StdTensorOp::TriangularSolve {
+            left_side: false,
+            lower: false,
+            transpose_a: false,
+            unit_diagonal: false,
+        },
+        vec![u.clone(), ValRef::Local(la)],
+        OpMode::Linear {
+            active_mask: vec![false, true],
+        },
+    )[0];
+
+    let x_lower = linear_unary(builder, StdTensorOp::Tril { k: -1 }, x);
+    let x_upper = linear_unary(builder, StdTensorOp::Triu { k: 0 }, x);
+    let dl = matmul_linear(builder, l, ValRef::Local(x_lower), vec![false, true], rank);
+    let du = matmul_linear(builder, ValRef::Local(x_upper), u, vec![true, false], rank);
+
+    vec![None, Some(dl), Some(du), None, None]
+}
+
 pub fn linearize_eig(
     builder: &mut FragmentBuilder<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -9,16 +9,13 @@ mod indexing;
 mod linalg;
 mod semiring;
 mod structural;
+mod zeros;
 
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 
 use crate::std_tensor_op::StdTensorOp;
-
-fn todo_linearize(op: &StdTensorOp) -> ! {
-    todo!("linearize not implemented for {:?}", op)
-}
 
 fn todo_transpose_rule(op: &StdTensorOp) -> ! {
     todo!("transpose_rule not implemented for {:?}", op)
@@ -52,6 +49,10 @@ pub fn linearize(
         StdTensorOp::Div => elementwise::linearize_div(builder, primal_in, primal_out, tangent_in),
         StdTensorOp::Abs => elementwise::linearize_abs(builder, primal_in, tangent_in),
         StdTensorOp::Sign => elementwise::linearize_sign(builder, tangent_in),
+        StdTensorOp::Maximum => elementwise::linearize_maximum(builder, primal_in, tangent_in),
+        StdTensorOp::Minimum => elementwise::linearize_minimum(builder, primal_in, tangent_in),
+        StdTensorOp::Select => elementwise::linearize_select(builder, primal_in, tangent_in),
+        StdTensorOp::Clamp => elementwise::linearize_clamp(builder, primal_in, tangent_in),
         StdTensorOp::Constant { .. } => vec![None],
         StdTensorOp::Compare(_) => vec![None],
 
@@ -103,6 +104,9 @@ pub fn linearize(
         StdTensorOp::Triu { k } => structural::linearize_triu(builder, tangent_in, *k),
         StdTensorOp::Slice(config) => structural::linearize_slice(builder, tangent_in, config),
         StdTensorOp::Pad(config) => structural::linearize_pad(builder, tangent_in, config),
+        StdTensorOp::Concatenate { axis, n_inputs } => {
+            structural::linearize_concatenate(builder, primal_in, tangent_in, *axis, *n_inputs, ctx)
+        }
         StdTensorOp::Reverse { axes } => structural::linearize_reverse(builder, tangent_in, axes),
 
         // Diagonal family.
@@ -136,6 +140,12 @@ pub fn linearize(
         StdTensorOp::Scatter(config) => {
             indexing::linearize_scatter(builder, primal_in, tangent_in, config, ctx)
         }
+        StdTensorOp::DynamicSlice { slice_sizes } => {
+            indexing::linearize_dynamic_slice(builder, primal_in, tangent_in, slice_sizes)
+        }
+        StdTensorOp::DynamicUpdateSlice => {
+            indexing::linearize_dynamic_update_slice(builder, primal_in, tangent_in, ctx)
+        }
 
         // Dynamic family.
         StdTensorOp::DynamicTruncate { axis } => dynamic::linearize_dynamic_truncate(
@@ -148,7 +158,9 @@ pub fn linearize(
 
         // Linalg family.
         StdTensorOp::Lu => linalg::linearize_lu(builder, primal_in, primal_out, tangent_in, ctx),
-        StdTensorOp::FullPivLu => vec![None, None, None, None, None],
+        StdTensorOp::FullPivLu => {
+            linalg::linearize_full_piv_lu(builder, primal_in, primal_out, tangent_in, ctx)
+        }
         StdTensorOp::FullPivLuSolve { transpose_a } => linalg::linearize_full_piv_lu_solve(
             builder,
             primal_in,
@@ -197,8 +209,6 @@ pub fn linearize(
         StdTensorOp::Extension(ext) => {
             ext.linearize(builder, primal_in, primal_out, tangent_in, ctx)
         }
-
-        _ => todo_linearize(op),
     }
 }
 
@@ -227,6 +237,14 @@ pub fn transpose_rule(
         StdTensorOp::Div => elementwise::transpose_div(emitter, cotangent_out, inputs, mode),
         StdTensorOp::Abs => elementwise::transpose_abs(emitter, cotangent_out, inputs, mode),
         StdTensorOp::Sign => elementwise::transpose_sign(emitter, cotangent_out, mode),
+        StdTensorOp::Maximum => {
+            elementwise::transpose_maximum(emitter, cotangent_out, inputs, mode)
+        }
+        StdTensorOp::Minimum => {
+            elementwise::transpose_minimum(emitter, cotangent_out, inputs, mode)
+        }
+        StdTensorOp::Select => elementwise::transpose_select(emitter, cotangent_out, inputs, mode),
+        StdTensorOp::Clamp => elementwise::transpose_clamp(emitter, cotangent_out, inputs, mode),
         StdTensorOp::Constant { .. } => vec![],
         StdTensorOp::Compare(_) => vec![None, None],
 
@@ -280,6 +298,15 @@ pub fn transpose_rule(
         StdTensorOp::Pad(config) => {
             structural::transpose_pad(emitter, cotangent_out, inputs, mode, config, ctx)
         }
+        StdTensorOp::Concatenate { axis, n_inputs } => structural::transpose_concatenate(
+            emitter,
+            cotangent_out,
+            inputs,
+            mode,
+            *axis,
+            *n_inputs,
+            ctx,
+        ),
         StdTensorOp::Reverse { axes } => {
             structural::transpose_reverse(emitter, cotangent_out, mode, axes)
         }
@@ -315,6 +342,12 @@ pub fn transpose_rule(
         ),
         StdTensorOp::Scatter(config) => {
             indexing::transpose_scatter(emitter, cotangent_out, inputs, mode, config, ctx)
+        }
+        StdTensorOp::DynamicSlice { .. } => {
+            indexing::transpose_dynamic_slice(emitter, cotangent_out, inputs, mode, ctx)
+        }
+        StdTensorOp::DynamicUpdateSlice => {
+            indexing::transpose_dynamic_update_slice(emitter, cotangent_out, inputs, mode, ctx)
         }
 
         // Dynamic family.

--- a/tenferro-ops/src/ad/structural.rs
+++ b/tenferro-ops/src/ad/structural.rs
@@ -4,6 +4,7 @@ use computegraph::OpEmitter;
 use tenferro_tensor::{PadConfig, SliceConfig};
 
 use crate::ad::context::ShapeGuardContext;
+use crate::ad::zeros::build_zero_like;
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
@@ -194,6 +195,47 @@ pub fn linearize_pad(
         }
         None => vec![None],
     }
+}
+
+pub fn linearize_concatenate(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    axis: usize,
+    n_inputs: usize,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    if tangent_in.iter().all(Option::is_none) {
+        return vec![None];
+    }
+    if n_inputs == 1 {
+        return vec![tangent_in[0]];
+    }
+
+    let mut inputs = Vec::with_capacity(n_inputs);
+    let mut active_mask = Vec::with_capacity(n_inputs);
+    for input_index in 0..n_inputs {
+        match tangent_in[input_index] {
+            Some(tangent) => {
+                inputs.push(ValRef::Local(tangent));
+                active_mask.push(true);
+            }
+            None => {
+                let anchor = ValRef::External(primal_in[input_index].clone());
+                let meta = ctx.metadata_of(&anchor);
+                let zero = build_zero_like(builder, meta.dtype, anchor, meta.shape.len());
+                inputs.push(ValRef::Local(zero));
+                active_mask.push(false);
+            }
+        }
+    }
+
+    let out = builder.add_op(
+        StdTensorOp::Concatenate { axis, n_inputs },
+        inputs,
+        OpMode::Linear { active_mask },
+    );
+    vec![Some(out[0])]
 }
 
 pub fn linearize_reverse(
@@ -621,11 +663,76 @@ pub fn transpose_reverse(
     vec![Some(out[0])]
 }
 
+pub fn transpose_concatenate(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+    axis: usize,
+    n_inputs: usize,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None; n_inputs];
+    };
+    let active_mask = match mode {
+        OpMode::Linear { active_mask } => active_mask,
+        OpMode::Primal => return vec![None; n_inputs],
+    };
+
+    let mut result = vec![None; n_inputs];
+    let mut axis_offset = 0usize;
+    for input_index in 0..n_inputs {
+        let input_shape = ctx.shape_of(&inputs[input_index]);
+        let rank = input_shape.len();
+        assert!(
+            axis < rank,
+            "transpose_concatenate: axis {axis} out of bounds for rank {rank}"
+        );
+        let axis_extent = static_dim(input_shape, axis, "transpose_concatenate");
+        if active_mask.get(input_index).copied().unwrap_or(false) {
+            let starts = vec_with_axis(rank, axis, axis_offset, 0);
+            let limits = input_shape
+                .iter()
+                .enumerate()
+                .map(|(dim, _)| {
+                    if dim == axis {
+                        axis_offset + axis_extent
+                    } else {
+                        static_dim(input_shape, dim, "transpose_concatenate")
+                    }
+                })
+                .collect();
+            let out = emitter.add_op(
+                StdTensorOp::Slice(SliceConfig {
+                    starts,
+                    limits,
+                    strides: vec![1; rank],
+                }),
+                vec![ValRef::Local(ct)],
+                OpMode::Linear {
+                    active_mask: vec![true],
+                },
+            );
+            result[input_index] = Some(out[0]);
+        }
+        axis_offset += axis_extent;
+    }
+
+    result
+}
+
 fn first_input_active(mode: &OpMode) -> bool {
     matches!(
         mode,
         OpMode::Linear { active_mask } if active_mask.first().copied().unwrap_or(false)
     )
+}
+
+fn vec_with_axis(rank: usize, axis: usize, axis_value: usize, other_value: usize) -> Vec<usize> {
+    (0..rank)
+        .map(|dim| if dim == axis { axis_value } else { other_value })
+        .collect()
 }
 
 fn static_dim(shape: &[SymDim], axis: usize, op: &str) -> usize {

--- a/tenferro-ops/src/ad/tests/elementwise_tests.rs
+++ b/tenferro-ops/src/ad/tests/elementwise_tests.rs
@@ -1,0 +1,298 @@
+//! Unit tests for elementwise AD helper rules.
+
+use chainrules_core::PrimitiveOp;
+use computegraph::fragment::FragmentBuilder;
+use computegraph::types::{GlobalValKey, OpMode, ValRef};
+use tenferro_tensor::{CompareDir, DType};
+
+use crate::ad::context::ShapeGuardContext;
+use crate::input_key::TensorInputKey;
+use crate::std_tensor_op::StdTensorOp;
+
+fn tensor_input(id: u64) -> TensorInputKey {
+    TensorInputKey::User { id }
+}
+
+fn input_key(id: u64) -> GlobalValKey<StdTensorOp> {
+    GlobalValKey::Input(tensor_input(id))
+}
+
+#[test]
+fn zero_like_covers_scalar_and_broadcasted_dtype_paths() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let anchor = builder.add_input(tensor_input(1));
+
+    let dtype_cases = [
+        (DType::F32, 4),
+        (DType::F64, 8),
+        (DType::I64, 8),
+        (DType::C32, 8),
+        (DType::C64, 16),
+    ];
+    let mut scalar_zeros = Vec::new();
+    for (dtype, byte_len) in dtype_cases {
+        let zero =
+            super::super::zeros::build_zero_like(&mut builder, dtype, ValRef::Local(anchor), 0);
+        scalar_zeros.push((zero, dtype, byte_len));
+    }
+
+    let vector_zero =
+        super::super::zeros::build_zero_like(&mut builder, DType::F64, ValRef::Local(anchor), 2);
+    let fragment = builder.build();
+
+    for (zero, dtype, byte_len) in scalar_zeros {
+        let (op_id, _) = fragment.vals()[zero]
+            .producer
+            .expect("zero scalar must be produced by a constant op");
+        let op = &fragment.ops()[op_id];
+        match &op.op {
+            StdTensorOp::Constant { dtype: got, bytes } => {
+                assert_eq!(*got, dtype);
+                assert_eq!(bytes.len(), byte_len);
+                assert!(bytes.iter().all(|byte| *byte == 0));
+            }
+            other => panic!("expected constant zero, got {other:?}"),
+        }
+    }
+
+    let (broadcast, _) = fragment.vals()[vector_zero]
+        .producer
+        .expect("ranked zero must be produced by broadcast");
+    let op = &fragment.ops()[broadcast];
+    assert_eq!(
+        op.op,
+        StdTensorOp::BroadcastInDim {
+            shape: vec![
+                crate::dim_expr::DimExpr::InputDim {
+                    input_idx: 1,
+                    axis: 0
+                },
+                crate::dim_expr::DimExpr::InputDim {
+                    input_idx: 1,
+                    axis: 1
+                },
+            ],
+            dims: vec![],
+        }
+    );
+    assert_eq!(op.inputs[1], ValRef::Local(anchor));
+}
+
+#[test]
+fn linearize_elementwise_inactive_inputs_return_none_without_ops() {
+    let mut ctx = ShapeGuardContext::default();
+    let keys = vec![input_key(1), input_key(2), input_key(3)];
+
+    for op in [
+        StdTensorOp::Div,
+        StdTensorOp::Abs,
+        StdTensorOp::Sign,
+        StdTensorOp::Maximum,
+        StdTensorOp::Minimum,
+        StdTensorOp::Select,
+        StdTensorOp::Clamp,
+    ] {
+        let mut builder = FragmentBuilder::<StdTensorOp>::new();
+        let result = op.linearize(
+            &mut builder,
+            &keys,
+            &[input_key(4)],
+            &[None, None, None],
+            &mut ctx,
+        );
+        assert_eq!(result, vec![None], "{op:?}");
+        assert!(
+            builder.build().ops().is_empty(),
+            "inactive {op:?} should not emit linearized ops"
+        );
+    }
+}
+
+#[test]
+fn linearize_div_with_two_active_inputs_sums_both_terms() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let dx = builder.add_input(tensor_input(10));
+    let dy = builder.add_input(tensor_input(11));
+    let mut ctx = ShapeGuardContext::default();
+    let op = StdTensorOp::Div;
+
+    let result = op.linearize(
+        &mut builder,
+        &[input_key(12), input_key(13)],
+        &[input_key(14)],
+        &[Some(dx), Some(dy)],
+        &mut ctx,
+    );
+
+    assert!(result[0].is_some());
+    let fragment = builder.build();
+    assert_eq!(
+        fragment.ops().last().map(|op| &op.op),
+        Some(&StdTensorOp::Add)
+    );
+}
+
+#[test]
+fn linearize_extrema_and_select_emit_zero_fill_for_one_sided_tangents() {
+    let mut ctx = ShapeGuardContext::default();
+
+    let mut max_builder = FragmentBuilder::<StdTensorOp>::new();
+    let dx = max_builder.add_input(tensor_input(20));
+    let result = StdTensorOp::Maximum.linearize(
+        &mut max_builder,
+        &[input_key(21), input_key(22)],
+        &[],
+        &[Some(dx), None],
+        &mut ctx,
+    );
+    assert!(result[0].is_some());
+    let fragment = max_builder.build();
+    assert_eq!(fragment.ops()[0].op, StdTensorOp::Compare(CompareDir::Ge));
+    assert!(fragment.ops().iter().any(|op| op.op == StdTensorOp::Select));
+
+    let mut min_builder = FragmentBuilder::<StdTensorOp>::new();
+    let dy = min_builder.add_input(tensor_input(23));
+    let result = StdTensorOp::Minimum.linearize(
+        &mut min_builder,
+        &[input_key(24), input_key(25)],
+        &[],
+        &[None, Some(dy)],
+        &mut ctx,
+    );
+    assert!(result[0].is_some());
+    let fragment = min_builder.build();
+    assert_eq!(fragment.ops()[0].op, StdTensorOp::Compare(CompareDir::Le));
+    assert!(fragment.ops().iter().any(|op| op.op == StdTensorOp::Select));
+}
+
+#[test]
+fn linearize_clamp_builds_nested_selects_for_active_bounds() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let dx = builder.add_input(tensor_input(30));
+    let dlower = builder.add_input(tensor_input(31));
+    let dupper = builder.add_input(tensor_input(32));
+    let mut ctx = ShapeGuardContext::default();
+
+    let result = StdTensorOp::Clamp.linearize(
+        &mut builder,
+        &[input_key(33), input_key(34), input_key(35)],
+        &[],
+        &[Some(dx), Some(dlower), Some(dupper)],
+        &mut ctx,
+    );
+
+    assert!(result[0].is_some());
+    let fragment = builder.build();
+    assert!(
+        fragment
+            .ops()
+            .iter()
+            .filter(|op| op.op == StdTensorOp::Select)
+            .count()
+            >= 2
+    );
+}
+
+#[test]
+fn transpose_elementwise_handles_missing_or_inactive_cotangents() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let inputs = vec![
+        ValRef::External(input_key(40)),
+        ValRef::External(input_key(41)),
+    ];
+
+    assert_eq!(
+        StdTensorOp::Div.transpose_rule(&mut builder, &[None], &inputs, &OpMode::Primal, &mut ctx),
+        vec![None, None]
+    );
+    let abs_ct = builder.add_input(tensor_input(42));
+    assert_eq!(
+        StdTensorOp::Abs.transpose_rule(
+            &mut builder,
+            &[Some(abs_ct)],
+            &[inputs[0].clone()],
+            &OpMode::Primal,
+            &mut ctx,
+        ),
+        vec![None]
+    );
+    assert_eq!(
+        StdTensorOp::Maximum.transpose_rule(
+            &mut builder,
+            &[None],
+            &inputs,
+            &OpMode::Linear {
+                active_mask: vec![true, true],
+            },
+            &mut ctx,
+        ),
+        vec![None, None]
+    );
+}
+
+#[test]
+fn transpose_select_splits_cotangent_only_to_active_value_inputs() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let ct = builder.add_input(tensor_input(50));
+    let mut ctx = ShapeGuardContext::default();
+    let inputs = vec![
+        ValRef::External(input_key(51)),
+        ValRef::External(input_key(52)),
+        ValRef::External(input_key(53)),
+    ];
+
+    let result = StdTensorOp::Select.transpose_rule(
+        &mut builder,
+        &[Some(ct)],
+        &inputs,
+        &OpMode::Linear {
+            active_mask: vec![false, true, false],
+        },
+        &mut ctx,
+    );
+
+    assert_eq!(result[0], None);
+    assert!(result[1].is_some());
+    assert_eq!(result[2], None);
+    let fragment = builder.build();
+    assert!(fragment.ops().iter().any(|op| op.op == StdTensorOp::Select));
+}
+
+#[test]
+fn transpose_clamp_covers_lower_only_and_inner_paths() {
+    let mut ctx = ShapeGuardContext::default();
+    let inputs = vec![
+        ValRef::External(input_key(60)),
+        ValRef::External(input_key(61)),
+        ValRef::External(input_key(62)),
+    ];
+
+    let mut lower_builder = FragmentBuilder::<StdTensorOp>::new();
+    let lower_ct = lower_builder.add_input(tensor_input(63));
+    let result = StdTensorOp::Clamp.transpose_rule(
+        &mut lower_builder,
+        &[Some(lower_ct)],
+        &inputs,
+        &OpMode::Linear {
+            active_mask: vec![false, true, false],
+        },
+        &mut ctx,
+    );
+    assert_eq!(result[0], None);
+    assert!(result[1].is_some());
+    assert_eq!(result[2], None);
+
+    let mut full_builder = FragmentBuilder::<StdTensorOp>::new();
+    let full_ct = full_builder.add_input(tensor_input(64));
+    let result = StdTensorOp::Clamp.transpose_rule(
+        &mut full_builder,
+        &[Some(full_ct)],
+        &inputs,
+        &OpMode::Linear {
+            active_mask: vec![true, true, true],
+        },
+        &mut ctx,
+    );
+    assert!(result.iter().all(Option::is_some));
+}

--- a/tenferro-ops/src/ad/tests/indexing_tests.rs
+++ b/tenferro-ops/src/ad/tests/indexing_tests.rs
@@ -149,6 +149,203 @@ fn linearize_dynamic_gather_reuses_primal_indices_and_shape_sources() {
 }
 
 #[test]
+fn linearize_dynamic_slice_reuses_primal_starts() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let operand_key = input_key(105);
+    let starts_key = input_key(106);
+    let operand_tangent = builder.add_input(tensor_input(107));
+
+    let slice_sizes = vec![3];
+    let op = StdTensorOp::DynamicSlice {
+        slice_sizes: slice_sizes.clone(),
+    };
+    let primal_in = vec![operand_key, starts_key.clone()];
+    let tangent_in = [Some(operand_tangent), None];
+
+    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+
+    assert_eq!(result.len(), 1);
+    let tangent_out = result[0].expect("output tangent must be active");
+    let fragment = builder.build();
+
+    assert_eq!(fragment.ops().len(), 1);
+    let dynamic_slice = &fragment.ops()[0];
+    assert_eq!(dynamic_slice.op, StdTensorOp::DynamicSlice { slice_sizes });
+    assert_eq!(dynamic_slice.inputs[0], ValRef::Local(operand_tangent));
+    assert_eq!(dynamic_slice.inputs[1], ValRef::External(starts_key));
+    assert_eq!(
+        dynamic_slice.mode,
+        OpMode::Linear {
+            active_mask: vec![true, false],
+        }
+    );
+    assert!(dynamic_slice.outputs.contains(&tangent_out));
+}
+
+#[test]
+fn linearize_dynamic_slice_inactive_tangent_returns_none() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let operand_key = input_key(108);
+    let starts_key = input_key(109);
+
+    let op = StdTensorOp::DynamicSlice {
+        slice_sizes: vec![3],
+    };
+    let primal_in = vec![operand_key, starts_key];
+    let tangent_in: [Option<LocalValId>; 2] = [None, None];
+
+    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    assert_eq!(result, vec![None]);
+    assert!(builder.build().ops().is_empty());
+}
+
+#[test]
+fn linearize_dynamic_update_slice_reuses_primal_starts() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let operand_key = input_key(110);
+    let update_key = input_key(111);
+    let starts_key = input_key(112);
+    let operand_tangent = builder.add_input(tensor_input(113));
+    let update_tangent = builder.add_input(tensor_input(114));
+
+    let op = StdTensorOp::DynamicUpdateSlice;
+    let primal_in = vec![operand_key, update_key, starts_key.clone()];
+    let tangent_in = [Some(operand_tangent), Some(update_tangent), None];
+
+    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+
+    assert_eq!(result.len(), 1);
+    let tangent_out = result[0].expect("output tangent must be active");
+    let fragment = builder.build();
+
+    assert_eq!(fragment.ops().len(), 1);
+    let update_slice = &fragment.ops()[0];
+    assert_eq!(update_slice.op, StdTensorOp::DynamicUpdateSlice);
+    assert_eq!(update_slice.inputs[0], ValRef::Local(operand_tangent));
+    assert_eq!(update_slice.inputs[1], ValRef::Local(update_tangent));
+    assert_eq!(update_slice.inputs[2], ValRef::External(starts_key));
+    assert_eq!(
+        update_slice.mode,
+        OpMode::Linear {
+            active_mask: vec![true, true, false],
+        }
+    );
+    assert!(update_slice.outputs.contains(&tangent_out));
+}
+
+#[test]
+fn transpose_dynamic_slice_emits_dynamic_update_slice() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let cot = builder.add_input(tensor_input(115));
+    let operand_key = input_key(116);
+    let starts_key = input_key(117);
+    seed_metadata(
+        &mut ctx,
+        &[(operand_key.clone(), &[5]), (starts_key.clone(), &[1])],
+    );
+
+    let inputs = vec![
+        ValRef::External(operand_key.clone()),
+        ValRef::External(starts_key.clone()),
+    ];
+    let result = (StdTensorOp::DynamicSlice {
+        slice_sizes: vec![3],
+    })
+    .transpose_rule(
+        &mut builder,
+        &[Some(cot)],
+        &inputs,
+        &OpMode::Linear {
+            active_mask: vec![true, false],
+        },
+        &mut ctx,
+    );
+
+    assert!(result[0].is_some(), "operand cotangent must be active");
+    assert_eq!(result[1], None, "starts cotangent must stay None");
+
+    let fragment = builder.build();
+    let update_slice = fragment
+        .ops()
+        .iter()
+        .find(|op_node| matches!(op_node.op, StdTensorOp::DynamicUpdateSlice))
+        .expect("expected a DynamicUpdateSlice op");
+    assert!(matches!(update_slice.inputs[0], ValRef::Local(_)));
+    assert_ne!(update_slice.inputs[0], ValRef::External(operand_key));
+    assert_eq!(update_slice.inputs[1], ValRef::Local(cot));
+    assert_eq!(update_slice.inputs[2], ValRef::External(starts_key));
+    assert_eq!(
+        update_slice.mode,
+        OpMode::Linear {
+            active_mask: vec![false, true, false],
+        }
+    );
+}
+
+#[test]
+fn transpose_dynamic_update_slice_returns_operand_and_update_cotangents() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let cot = builder.add_input(tensor_input(118));
+    let operand_key = input_key(119);
+    let update_key = input_key(120);
+    let starts_key = input_key(121);
+    seed_metadata(
+        &mut ctx,
+        &[
+            (operand_key.clone(), &[5]),
+            (update_key.clone(), &[3]),
+            (starts_key.clone(), &[1]),
+        ],
+    );
+
+    let inputs = vec![
+        ValRef::External(operand_key),
+        ValRef::External(update_key),
+        ValRef::External(starts_key.clone()),
+    ];
+    let result = StdTensorOp::DynamicUpdateSlice.transpose_rule(
+        &mut builder,
+        &[Some(cot)],
+        &inputs,
+        &OpMode::Linear {
+            active_mask: vec![true, true, false],
+        },
+        &mut ctx,
+    );
+
+    assert!(result[0].is_some(), "operand cotangent must be active");
+    assert!(result[1].is_some(), "update cotangent must be active");
+    assert_eq!(result[2], None, "starts cotangent must stay None");
+
+    let fragment = builder.build();
+    assert!(
+        fragment
+            .ops()
+            .iter()
+            .any(|op_node| matches!(op_node.op, StdTensorOp::DynamicUpdateSlice)),
+        "operand cotangent should be masked by DynamicUpdateSlice"
+    );
+    let update_ct = fragment
+        .ops()
+        .iter()
+        .find(|op_node| matches!(op_node.op, StdTensorOp::DynamicSlice { .. }))
+        .expect("expected a DynamicSlice op for update cotangent");
+    assert_eq!(
+        update_ct.op,
+        StdTensorOp::DynamicSlice {
+            slice_sizes: vec![3],
+        }
+    );
+    assert_eq!(update_ct.inputs[0], ValRef::Local(cot));
+    assert_eq!(update_ct.inputs[1], ValRef::External(starts_key));
+}
+
+#[test]
 fn transpose_gather_emits_scatter_with_inverted_config() {
     let mut builder = FragmentBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();

--- a/tenferro-ops/src/ad/tests/mod.rs
+++ b/tenferro-ops/src/ad/tests/mod.rs
@@ -11,6 +11,7 @@ use crate::shape_extent::ShapeExtent;
 use crate::std_tensor_op::StdTensorOp;
 use crate::{SymDim, TensorMeta};
 
+mod elementwise_tests;
 mod indexing_tests;
 mod linalg_tests;
 

--- a/tenferro-ops/src/ad/zeros.rs
+++ b/tenferro-ops/src/ad/zeros.rs
@@ -1,0 +1,58 @@
+use computegraph::types::{LocalValId, OpMode, ValRef};
+use computegraph::OpEmitter;
+use tenferro_tensor::DType;
+
+use crate::dim_expr::DimExpr;
+use crate::std_tensor_op::StdTensorOp;
+
+pub(super) fn build_zero_like(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    dtype: DType,
+    anchor: ValRef<StdTensorOp>,
+    anchor_rank: usize,
+) -> LocalValId {
+    let zero_scalar = emitter.add_op(
+        StdTensorOp::Constant {
+            dtype,
+            bytes: zero_bytes(dtype),
+        },
+        vec![],
+        OpMode::Primal,
+    )[0];
+    if anchor_rank == 0 {
+        return zero_scalar;
+    }
+
+    let shape: Vec<DimExpr> = (0..anchor_rank)
+        .map(|axis| DimExpr::InputDim { input_idx: 1, axis })
+        .collect();
+    let out = emitter.add_op(
+        StdTensorOp::BroadcastInDim {
+            shape,
+            dims: vec![],
+        },
+        vec![ValRef::Local(zero_scalar), anchor],
+        OpMode::Primal,
+    );
+    out[0]
+}
+
+fn zero_bytes(dtype: DType) -> Vec<u8> {
+    match dtype {
+        DType::F32 => 0.0_f32.to_le_bytes().to_vec(),
+        DType::F64 => 0.0_f64.to_le_bytes().to_vec(),
+        DType::I64 => 0_i64.to_le_bytes().to_vec(),
+        DType::C32 => {
+            let mut bytes = Vec::with_capacity(8);
+            bytes.extend_from_slice(&0.0_f32.to_le_bytes());
+            bytes.extend_from_slice(&0.0_f32.to_le_bytes());
+            bytes
+        }
+        DType::C64 => {
+            let mut bytes = Vec::with_capacity(16);
+            bytes.extend_from_slice(&0.0_f64.to_le_bytes());
+            bytes.extend_from_slice(&0.0_f64.to_le_bytes());
+            bytes
+        }
+    }
+}

--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -98,6 +98,7 @@ pub enum StdTensorOp {
     DynamicSlice {
         slice_sizes: Vec<usize>,
     },
+    DynamicUpdateSlice,
     Pad(PadConfig),
     /// N-ary einsum kept as a single graph node.
     /// Contraction path is optimized at execution time from actual input shapes.
@@ -286,7 +287,8 @@ impl PartialEq for StdTensorOp {
             | (Self::Lu, Self::Lu)
             | (Self::FullPivLu, Self::FullPivLu)
             | (Self::Qr, Self::Qr)
-            | (Self::ValidateNonsingular, Self::ValidateNonsingular) => true,
+            | (Self::ValidateNonsingular, Self::ValidateNonsingular)
+            | (Self::DynamicUpdateSlice, Self::DynamicUpdateSlice) => true,
             (Self::DotGeneral { config: a }, Self::DotGeneral { config: b }) => a == b,
             (Self::Transpose { perm: a }, Self::Transpose { perm: b }) => a == b,
             (Self::Reshape { to_shape: a }, Self::Reshape { to_shape: b }) => a == b,
@@ -489,6 +491,7 @@ impl Hash for StdTensorOp {
             Self::Scatter(config) => config.hash(state),
             Self::Slice(config) => config.hash(state),
             Self::DynamicSlice { slice_sizes } => slice_sizes.hash(state),
+            Self::DynamicUpdateSlice => {}
             Self::Pad(config) => config.hash(state),
             Self::NaryEinsum { subscripts } => {
                 subscripts.hash(state);
@@ -577,7 +580,7 @@ impl GraphOp for StdTensorOp {
             | Self::ReduceMin { .. } => 1,
             Self::Div | Self::Maximum | Self::Minimum | Self::Pow | Self::DynamicSlice { .. } => 2,
             Self::Constant { .. } => 0,
-            Self::Scatter(_) => 3,
+            Self::Scatter(_) | Self::DynamicUpdateSlice => 3,
             Self::NaryEinsum { subscripts } => n_inputs_from_einsum_subscripts(subscripts),
             Self::Concatenate { n_inputs, .. } => *n_inputs,
             Self::Abs
@@ -646,6 +649,7 @@ impl GraphOp for StdTensorOp {
             | Self::Scatter(_)
             | Self::Slice(_)
             | Self::DynamicSlice { .. }
+            | Self::DynamicUpdateSlice
             | Self::Pad(_)
             | Self::NaryEinsum { .. }
             | Self::Reverse { .. }

--- a/tenferro-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-ops/src/tests/std_tensor_op_tests.rs
@@ -275,6 +275,7 @@ fn test_std_tensor_op_input_output_counts() {
         .n_inputs(),
         2
     );
+    assert_eq!(StdTensorOp::DynamicUpdateSlice.n_inputs(), 3);
     assert_eq!(
         StdTensorOp::NaryEinsum {
             subscripts: "ij,jk,kl->il".into(),
@@ -346,6 +347,7 @@ fn test_std_tensor_op_input_output_counts() {
         .n_outputs(),
         1
     );
+    assert_eq!(StdTensorOp::DynamicUpdateSlice.n_outputs(), 1);
     assert_eq!(
         StdTensorOp::Pad(PadConfig {
             edge_padding_low: vec![1],
@@ -546,6 +548,7 @@ fn test_std_tensor_op_hash_covers_remaining_variants() {
         StdTensorOp::DynamicSlice {
             slice_sizes: vec![1],
         },
+        StdTensorOp::DynamicUpdateSlice,
         StdTensorOp::Pad(PadConfig {
             edge_padding_low: vec![0],
             edge_padding_high: vec![0],
@@ -1328,22 +1331,14 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
 }
 
 #[test]
-#[should_panic(expected = "linearize not implemented for Maximum")]
-fn test_std_tensor_op_linearize_panics_for_unimplemented_variant() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
-    let mut ad_ctx = ShapeGuardContext::default();
-    let _ = StdTensorOp::Maximum.linearize(&mut builder, &[], &[], &[None, None], &mut ad_ctx);
-}
-
-#[test]
-#[should_panic(expected = "transpose_rule not implemented for Maximum")]
+#[should_panic(expected = "transpose_rule not implemented for FullPivLu")]
 fn test_std_tensor_op_transpose_rule_panics_for_unimplemented_variant() {
     let mut builder = FragmentBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
-    let _ = StdTensorOp::Maximum.transpose_rule(
+    let _ = StdTensorOp::FullPivLu.transpose_rule(
         &mut builder,
-        &[None],
-        &external_inputs(950, 2),
+        &[None, None, None, None, None],
+        &external_inputs(950, 1),
         &OpMode::Primal,
         &mut ad_ctx,
     );

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -153,6 +153,12 @@ pub trait TensorExec {
         starts: &Tensor,
         slice_sizes: &[usize],
     ) -> crate::Result<Tensor>;
+    fn dynamic_update_slice(
+        &mut self,
+        operand: &Tensor,
+        update: &Tensor,
+        starts: &Tensor,
+    ) -> crate::Result<Tensor>;
     fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
@@ -252,6 +258,7 @@ impl<B: TensorBackend + ?Sized> TensorExec for BackendExecAdapter<'_, B> {
         ) -> crate::Result<Tensor>;
         slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor>;
         dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> crate::Result<Tensor>;
+        dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> crate::Result<Tensor>;
         pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
         concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;
         reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
@@ -395,6 +402,12 @@ pub trait TensorBackend {
         input: &Tensor,
         starts: &Tensor,
         slice_sizes: &[usize],
+    ) -> crate::Result<Tensor>;
+    fn dynamic_update_slice(
+        &mut self,
+        operand: &Tensor,
+        update: &Tensor,
+        starts: &Tensor,
     ) -> crate::Result<Tensor>;
     fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -387,6 +387,15 @@ impl TensorBackend for CpuBackend {
         self.install(|| indexing::dynamic_slice(input, starts, slice_sizes))
     }
 
+    fn dynamic_update_slice(
+        &mut self,
+        operand: &Tensor,
+        update: &Tensor,
+        starts: &Tensor,
+    ) -> crate::Result<Tensor> {
+        self.install(|| indexing::dynamic_update_slice(operand, update, starts))
+    }
+
     fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
         self.install(|| indexing::try_pad(input, config))
     }

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -229,6 +229,7 @@ impl TensorExec for CpuExecSession<'_> {
     delegate!(scatter(operand: &Tensor, indices: &Tensor, updates: &Tensor, config: &ScatterConfig) => indexing::scatter(operand, indices, updates, config));
     delegate!(slice(input: &Tensor, config: &SliceConfig) => indexing::try_slice(input, config));
     delegate!(dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) => indexing::dynamic_slice(input, starts, slice_sizes));
+    delegate!(dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) => indexing::dynamic_update_slice(operand, update, starts));
     delegate!(pad(input: &Tensor, config: &PadConfig) => indexing::try_pad(input, config));
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
         indexing::try_concatenate(inputs, axis)

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -136,6 +136,53 @@ pub fn dynamic_slice(
     }
 }
 
+/// Return `operand` with `update` written at dynamic `starts`.
+///
+/// Starts are clamped so the whole update window fits inside the operand,
+/// matching `dynamic_slice` behavior.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{cpu, Tensor, TypedTensor};
+///
+/// let operand = Tensor::F64(TypedTensor::from_vec(vec![5], vec![0.0; 5]));
+/// let update = Tensor::F64(TypedTensor::from_vec(vec![2], vec![3.0, 4.0]));
+/// let starts = Tensor::I64(TypedTensor::from_vec(vec![1], vec![4]));
+///
+/// let out = cpu::dynamic_update_slice(&operand, &update, &starts).unwrap();
+/// assert_eq!(out.as_slice::<f64>().unwrap(), &[0.0, 0.0, 0.0, 3.0, 4.0]);
+/// ```
+pub fn dynamic_update_slice(
+    operand: &Tensor,
+    update: &Tensor,
+    starts: &Tensor,
+) -> crate::Result<Tensor> {
+    let starts = try_index_tensor(starts)?;
+    match (operand, update) {
+        (Tensor::F32(op), Tensor::F32(upd)) => {
+            typed_dynamic_update_slice(op, upd, &starts).map(Tensor::F32)
+        }
+        (Tensor::F64(op), Tensor::F64(upd)) => {
+            typed_dynamic_update_slice(op, upd, &starts).map(Tensor::F64)
+        }
+        (Tensor::I64(op), Tensor::I64(upd)) => {
+            typed_dynamic_update_slice(op, upd, &starts).map(Tensor::I64)
+        }
+        (Tensor::C32(op), Tensor::C32(upd)) => {
+            typed_dynamic_update_slice(op, upd, &starts).map(Tensor::C32)
+        }
+        (Tensor::C64(op), Tensor::C64(upd)) => {
+            typed_dynamic_update_slice(op, upd, &starts).map(Tensor::C64)
+        }
+        _ => Err(crate::Error::DTypeMismatch {
+            op: "dynamic_update_slice",
+            lhs: operand.dtype(),
+            rhs: update.dtype(),
+        }),
+    }
+}
+
 pub fn pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
     try_pad(input, config)
 }
@@ -1086,6 +1133,60 @@ fn typed_dynamic_slice<T: Copy + Clone + Zero>(
             input_idx[axis] = clamped_starts[axis] + out_idx[axis];
         }
         *out.get_mut(&out_idx) = *input.get(&input_idx);
+    }
+
+    Ok(out)
+}
+
+fn typed_dynamic_update_slice<T: Copy + Clone>(
+    operand: &TypedTensor<T>,
+    update: &TypedTensor<T>,
+    starts: &IndexTensor,
+) -> crate::Result<TypedTensor<T>> {
+    if update.shape.len() != operand.shape.len() {
+        return Err(crate::Error::RankMismatch {
+            op: "dynamic_update_slice",
+            expected: operand.shape.len(),
+            actual: update.shape.len(),
+        });
+    }
+    if starts.shape.len() != 1 {
+        return Err(crate::Error::InvalidConfig {
+            op: "dynamic_update_slice",
+            message: "starts must be a rank-1 tensor".into(),
+        });
+    }
+    if starts.values.len() != operand.shape.len() {
+        return Err(crate::Error::InvalidConfig {
+            op: "dynamic_update_slice",
+            message: format!(
+                "starts length {} must match operand rank {}",
+                starts.values.len(),
+                operand.shape.len()
+            ),
+        });
+    }
+
+    let mut clamped_starts = vec![0usize; operand.shape.len()];
+    for axis in 0..operand.shape.len() {
+        clamped_starts[axis] = clamp_window_start(
+            "dynamic_update_slice",
+            starts.values[axis],
+            operand.shape[axis],
+            update.shape[axis],
+        )?;
+    }
+
+    let mut out = operand.clone();
+    let mut update_idx = vec![0usize; update.shape.len()];
+    let mut operand_idx = vec![0usize; operand.shape.len()];
+
+    for flat in 0..update.n_elements() {
+        flat_to_multi(flat, &update.shape, &mut update_idx);
+        for axis in 0..update.shape.len() {
+            operand_idx[axis] = clamped_starts[axis] + update_idx[axis];
+        }
+        *out.get_mut(&operand_idx) = *update.get(&update_idx);
     }
 
     Ok(out)

--- a/tenferro-tensor/src/cpu/mod.rs
+++ b/tenferro-tensor/src/cpu/mod.rs
@@ -20,7 +20,7 @@ pub use context::CpuContext;
 pub use elementwise::{
     abs, add, clamp, compare, conj, div, maximum, minimum, mul, neg, select, sign,
 };
-pub use indexing::{dynamic_slice, gather, pad, scatter};
+pub use indexing::{dynamic_slice, dynamic_update_slice, gather, pad, scatter};
 pub use reduction::{reduce_max, reduce_min, reduce_prod, reduce_sum};
 pub use structural::{
     broadcast_in_dim, convert, embed_diagonal, extract_diagonal, reshape, transpose, tril, triu,

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -2689,6 +2689,18 @@ impl TensorBackend for CubeclBackend {
         }
     }
 
+    fn dynamic_update_slice(
+        &mut self,
+        _operand: &Tensor,
+        _update: &Tensor,
+        _starts: &Tensor,
+    ) -> crate::Result<Tensor> {
+        Err(crate::Error::BackendFailure {
+            op: "dynamic_update_slice",
+            message: "dynamic_update_slice is not implemented for the CubeCL backend".into(),
+        })
+    }
+
     fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
         match input {
             Tensor::F32(t) => self.pad_typed(t, config).map(Tensor::F32),

--- a/tenferro-tensor/src/rocm/mod.rs
+++ b/tenferro-tensor/src/rocm/mod.rs
@@ -184,6 +184,14 @@ macro_rules! impl_stub_backend {
             ) -> crate::Result<Tensor> {
                 todo!(concat!($label, " dynamic_slice"))
             }
+            fn dynamic_update_slice(
+                &mut self,
+                _operand: &Tensor,
+                _update: &Tensor,
+                _starts: &Tensor,
+            ) -> crate::Result<Tensor> {
+                todo!(concat!($label, " dynamic_update_slice"))
+            }
             fn pad(&mut self, _input: &Tensor, _config: &PadConfig) -> crate::Result<Tensor> {
                 todo!(concat!($label, " pad"))
             }

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -14,9 +14,10 @@ use crate::cpu::backend;
 #[cfg(feature = "cpu-faer")]
 use crate::cpu::linalg::faer_linalg;
 use crate::cpu::{
-    abs, add, broadcast_in_dim, clamp, compare, conj, div, dynamic_slice, embed_diagonal,
-    extract_diagonal, gather, maximum, minimum, mul, neg, pad, reduce_max, reduce_min, reduce_prod,
-    reduce_sum, reshape, scatter, select, sign, transpose, tril, triu, CpuBackend, CpuContext,
+    abs, add, broadcast_in_dim, clamp, compare, conj, div, dynamic_slice, dynamic_update_slice,
+    embed_diagonal, extract_diagonal, gather, maximum, minimum, mul, neg, pad, reduce_max,
+    reduce_min, reduce_prod, reduce_sum, reshape, scatter, select, sign, transpose, tril, triu,
+    CpuBackend, CpuContext,
 };
 use crate::types::{DType, Tensor, TypedTensor};
 
@@ -2820,6 +2821,21 @@ fn test_dynamic_slice_accepts_i64_starts() {
     assert_eq!(get_f64(&out, &[1, 0]), 12.0);
     assert_eq!(get_f64(&out, &[0, 1]), 15.0);
     assert_eq!(get_f64(&out, &[1, 1]), 16.0);
+}
+
+#[test]
+fn test_dynamic_update_slice_clamps_starts() {
+    let operand = Tensor::F64(TypedTensor::from_vec(
+        vec![5],
+        vec![10.0, 11.0, 12.0, 13.0, 14.0],
+    ));
+    let update = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
+    let starts = Tensor::from_vec(vec![1], vec![4_i64]);
+
+    let out = dynamic_update_slice(&operand, &update, &starts).unwrap();
+
+    assert_eq!(out.shape(), &[5]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[10.0, 11.0, 1.0, 2.0, 3.0]);
 }
 
 #[test]

--- a/tenferro/src/compiler/mod.rs
+++ b/tenferro/src/compiler/mod.rs
@@ -386,6 +386,7 @@ fn std_to_exec_op(op: &StdTensorOp) -> ExecOp {
         StdTensorOp::DynamicSlice { slice_sizes } => ExecOp::DynamicSlice {
             slice_sizes: slice_sizes.clone(),
         },
+        StdTensorOp::DynamicUpdateSlice => ExecOp::DynamicUpdateSlice,
         StdTensorOp::Pad(config) => ExecOp::Pad(config.clone()),
         StdTensorOp::Concatenate { axis, .. } => ExecOp::Concatenate { axis: *axis },
         StdTensorOp::Reverse { axes } => ExecOp::Reverse { axes: axes.clone() },

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -118,6 +118,9 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
             StdTensorOp::DynamicSlice { slice_sizes } => {
                 vec![exec.dynamic_slice(inputs[0], inputs[1], slice_sizes)?]
             }
+            StdTensorOp::DynamicUpdateSlice => {
+                vec![exec.dynamic_update_slice(inputs[0], inputs[1], inputs[2])?]
+            }
             StdTensorOp::Cholesky { .. } => vec![exec.cholesky(inputs[0])?],
             StdTensorOp::TriangularSolve {
                 left_side,

--- a/tenferro/src/eager_ops_elementwise.rs
+++ b/tenferro/src/eager_ops_elementwise.rs
@@ -266,4 +266,22 @@ impl<B: TensorBackend> EagerTensor<B> {
     pub fn select(condition: &Self, on_true: &Self, on_false: &Self) -> Result<Self> {
         condition.ternary_op(on_true, on_false, StdTensorOp::Select)
     }
+
+    /// Clamp values elementwise between lower and upper bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{EagerTensor, Tensor};
+    ///
+    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![-2.0_f64, 0.5, 5.0]));
+    /// let lower = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![-1.0_f64, 0.0, 1.0]));
+    /// let upper = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 4.0]));
+    /// let y = x.clamp(&lower, &upper).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[-1.0, 0.5, 4.0]);
+    /// ```
+    pub fn clamp(&self, lower: &Self, upper: &Self) -> Result<Self> {
+        self.ternary_op(lower, upper, StdTensorOp::Clamp)
+    }
 }

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -97,6 +97,7 @@ pub enum ExecOp {
     DynamicSlice {
         slice_sizes: Vec<usize>,
     },
+    DynamicUpdateSlice,
     Pad(PadConfig),
     Concatenate {
         axis: usize,
@@ -442,6 +443,11 @@ pub(crate) fn execute_backend_op(
             get(slots, &inst.input_slots, 0)?,
             get(slots, &inst.input_slots, 1)?,
             slice_sizes,
+        )?,
+        ExecOp::DynamicUpdateSlice => exec.dynamic_update_slice(
+            get(slots, &inst.input_slots, 0)?,
+            get(slots, &inst.input_slots, 1)?,
+            get(slots, &inst.input_slots, 2)?,
         )?,
         ExecOp::Pad(config) => exec.pad(get(slots, &inst.input_slots, 0)?, config)?,
         ExecOp::Concatenate { axis } => {

--- a/tenferro/src/shape_infer.rs
+++ b/tenferro/src/shape_infer.rs
@@ -67,6 +67,7 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         | StdTensorOp::Scatter(_)
         | StdTensorOp::Slice(_)
         | StdTensorOp::DynamicSlice { .. }
+        | StdTensorOp::DynamicUpdateSlice
         | StdTensorOp::Pad(_)
         | StdTensorOp::Concatenate { .. }
         | StdTensorOp::Reverse { .. }
@@ -187,6 +188,7 @@ pub fn infer_output_shapes(op: &StdTensorOp, input_shapes: &[&[DimExpr]]) -> Vec
         StdTensorOp::DynamicSlice { slice_sizes } => {
             vec![slice_sizes.iter().copied().map(DimExpr::Const).collect()]
         }
+        StdTensorOp::DynamicUpdateSlice => vec![require_input(op, input_shapes, 0).to_vec()],
         StdTensorOp::Pad(config) => vec![pad_shape(require_input(op, input_shapes, 0), config)],
         StdTensorOp::DotGeneral { config, .. } => vec![dot_general_shape(
             require_input(op, input_shapes, 0),

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -825,6 +825,39 @@ fn build_full_piv_lu_solve_sum_fragment() -> (
     (Arc::new(builder.build()), a_key, b_key, loss_key)
 }
 
+fn build_full_piv_lu_lu_sum_fragment() -> (
+    Arc<Fragment<StdTensorOp>>,
+    TensorInputKey,
+    GlobalValKey<StdTensorOp>,
+) {
+    let input_key = tensor_input_key(38_100);
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let a = builder.add_input(input_key.clone());
+    let lu = builder.add_op(
+        StdTensorOp::FullPivLu,
+        vec![ValRef::Local(a)],
+        OpMode::Primal,
+    );
+    let l_sum = builder.add_op(
+        StdTensorOp::ReduceSum { axes: vec![0, 1] },
+        vec![ValRef::Local(lu[1])],
+        OpMode::Primal,
+    )[0];
+    let u_sum = builder.add_op(
+        StdTensorOp::ReduceSum { axes: vec![0, 1] },
+        vec![ValRef::Local(lu[2])],
+        OpMode::Primal,
+    )[0];
+    let loss = builder.add_op(
+        StdTensorOp::Add,
+        vec![ValRef::Local(l_sum), ValRef::Local(u_sum)],
+        OpMode::Primal,
+    )[0];
+    let loss_key = builder.global_key(loss).clone();
+    builder.set_outputs(vec![loss]);
+    (Arc::new(builder.build()), input_key, loss_key)
+}
+
 fn build_solve_real_sum_fragment() -> (
     Arc<Fragment<StdTensorOp>>,
     TensorInputKey,
@@ -1289,6 +1322,13 @@ fn sum_full_piv_lu_solve(a: &[f64], b: &[f64]) -> f64 {
     let b_tensor = f64_tensor(vec![2, 1], b.to_vec());
     let out = TensorBackend::full_piv_lu_solve(&mut backend, &a_tensor, &b_tensor, false).unwrap();
     get_f64_data(&out).iter().sum()
+}
+
+fn sum_full_piv_lu_lu(data: &[f64]) -> f64 {
+    let mut backend = CpuBackend::new();
+    let input = f64_tensor(vec![2, 2], data.to_vec());
+    let outputs = TensorBackend::full_piv_lu(&mut backend, &input).unwrap();
+    get_f64_data(&outputs[1]).iter().sum::<f64>() + get_f64_data(&outputs[2]).iter().sum::<f64>()
 }
 
 fn sum_cholesky(data: &[f64]) -> f64 {
@@ -2652,6 +2692,42 @@ fn grad_full_piv_lu_solve_matches_finite_diff() {
 }
 
 #[test]
+fn jvp_full_piv_lu_lu_matches_finite_diff() {
+    let a_data = vec![0.2, 2.0, 1.0, 3.0];
+    let tangent_data = vec![0.5, -1.0, 1.5, -0.25];
+    let (fragment, input_key, loss_key) = build_full_piv_lu_lu_sum_fragment();
+
+    let mut inputs = HashMap::new();
+    inputs.insert(input_key.clone(), f64_tensor(vec![2, 2], a_data.clone()));
+    let tangent = jvp_from_fragment_with_inputs(
+        fragment,
+        loss_key,
+        input_key,
+        inputs,
+        f64_tensor(vec![2, 2], tangent_data.clone()),
+    );
+
+    assert_jvp_matches_finite_diff(get_f64_data(&tangent), &a_data, &tangent_data, |xs| {
+        vec![sum_full_piv_lu_lu(xs)]
+    });
+}
+
+#[test]
+fn grad_full_piv_lu_lu_matches_finite_diff() {
+    let a_data = vec![0.2, 2.0, 1.0, 3.0];
+    let (fragment, input_key, loss_key) = build_full_piv_lu_lu_sum_fragment();
+
+    let grad = grad_from_fragment(
+        fragment,
+        loss_key,
+        input_key,
+        f64_tensor(vec![2, 2], a_data.clone()),
+    );
+
+    assert_grad_matches_finite_diff(get_f64_data(&grad), &a_data, sum_full_piv_lu_lu);
+}
+
+#[test]
 fn grad_triangular_solve_rhs_matches_finite_diff() {
     let a_data = vec![2.0, -1.0, 0.0, 3.0];
     let b_data = vec![1.0, 4.0];
@@ -3148,6 +3224,47 @@ fn build_weighted_unary_sum_fragment(
     (Arc::new(builder.build()), loss_key)
 }
 
+fn build_dynamic_slice_fragment(
+    input_key: TensorInputKey,
+    starts_key: TensorInputKey,
+    slice_sizes: Vec<usize>,
+) -> (Arc<Fragment<StdTensorOp>>, GlobalValKey<StdTensorOp>) {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let input = builder.add_input(input_key);
+    let starts = builder.add_input(starts_key);
+    let output = builder.add_op(
+        StdTensorOp::DynamicSlice { slice_sizes },
+        vec![ValRef::Local(input), ValRef::Local(starts)],
+        OpMode::Primal,
+    )[0];
+    let output_key = builder.global_key(output).clone();
+    builder.set_outputs(vec![output]);
+    (Arc::new(builder.build()), output_key)
+}
+
+fn build_dynamic_update_slice_fragment(
+    operand_key: TensorInputKey,
+    update_key: TensorInputKey,
+    starts_key: TensorInputKey,
+) -> (Arc<Fragment<StdTensorOp>>, GlobalValKey<StdTensorOp>) {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let operand = builder.add_input(operand_key);
+    let update = builder.add_input(update_key);
+    let starts = builder.add_input(starts_key);
+    let output = builder.add_op(
+        StdTensorOp::DynamicUpdateSlice,
+        vec![
+            ValRef::Local(operand),
+            ValRef::Local(update),
+            ValRef::Local(starts),
+        ],
+        OpMode::Primal,
+    )[0];
+    let output_key = builder.global_key(output).clone();
+    builder.set_outputs(vec![output]);
+    (Arc::new(builder.build()), output_key)
+}
+
 #[test]
 fn grad_scatter_reduce_sum_wrt_updates_is_ones() {
     // `y = reduce_sum(scatter(operand, indices, updates, config))`. The
@@ -3187,6 +3304,164 @@ fn grad_scatter_reduce_sum_wrt_updates_is_ones() {
     // reduce_sum over the scatter output contributes a 1 to each updated
     // slot; the inverse Gather reads one value for each `indices` entry.
     assert_close_slice(get_f64_data(&grad), &[1.0, 1.0, 1.0]);
+}
+
+#[test]
+fn jvp_dynamic_slice_matches_finite_diff() {
+    let input_key = tensor_input_key(61_500);
+    let starts_key = tensor_input_key(61_501);
+    let (fragment, output_key) =
+        build_dynamic_slice_fragment(input_key.clone(), starts_key.clone(), vec![3]);
+
+    let input_data = vec![0.5_f64, -1.0, 2.5, 4.0, -3.0];
+    let starts_data = vec![1_i64];
+    let tangent_data = vec![1.25_f64, -0.75, 3.0, 2.5, -1.0];
+    let inputs_map = HashMap::from([
+        (input_key.clone(), f64_tensor(vec![5], input_data.clone())),
+        (starts_key, i64_tensor(vec![1], starts_data)),
+    ]);
+
+    let tangent = jvp_from_fragment_with_inputs(
+        fragment,
+        output_key,
+        input_key,
+        inputs_map,
+        f64_tensor(vec![5], tangent_data.clone()),
+    );
+
+    assert_jvp_matches_finite_diff(get_f64_data(&tangent), &input_data, &tangent_data, |xs| {
+        xs[1..4].to_vec()
+    });
+}
+
+#[test]
+fn grad_dynamic_slice_clamped_start_matches_finite_diff() {
+    let input_key = tensor_input_key(61_510);
+    let starts_key = tensor_input_key(61_511);
+    let (fragment, output_key) =
+        build_dynamic_slice_fragment(input_key.clone(), starts_key.clone(), vec![3]);
+
+    let input_data = vec![0.5_f64, -1.0, 2.5, 4.0, -3.0];
+    let starts_data = vec![4_i64];
+    let cotangent_data = vec![0.5_f64, -1.0, 2.0];
+    let inputs_map = HashMap::from([
+        (input_key.clone(), f64_tensor(vec![5], input_data.clone())),
+        (starts_key, i64_tensor(vec![1], starts_data)),
+    ]);
+
+    let grad = grad_from_fragment_with_inputs_and_cotangent(
+        fragment,
+        output_key,
+        input_key,
+        inputs_map,
+        f64_tensor(vec![3], cotangent_data.clone()),
+    );
+
+    let loss = |xs: &[f64]| {
+        xs[2..5]
+            .iter()
+            .zip(cotangent_data.iter())
+            .map(|(&value, &weight)| value * weight)
+            .sum()
+    };
+    let expected: Vec<f64> = (0..input_data.len())
+        .map(|idx| finite_diff_scalar(loss, &input_data, idx, 1.0e-6))
+        .collect();
+    assert_close_slice(get_f64_data(&grad), &expected);
+}
+
+#[test]
+fn jvp_dynamic_update_slice_update_matches_finite_diff() {
+    let operand_key = tensor_input_key(61_520);
+    let update_key = tensor_input_key(61_521);
+    let starts_key = tensor_input_key(61_522);
+    let (fragment, output_key) = build_dynamic_update_slice_fragment(
+        operand_key.clone(),
+        update_key.clone(),
+        starts_key.clone(),
+    );
+
+    let operand_data = vec![10.0_f64, 11.0, 12.0, 13.0, 14.0];
+    let update_data = vec![1.0_f64, 2.0, 3.0];
+    let starts_data = vec![4_i64];
+    let tangent_data = vec![0.5_f64, -1.0, 2.0];
+    let inputs_map = HashMap::from([
+        (operand_key, f64_tensor(vec![5], operand_data.clone())),
+        (update_key.clone(), f64_tensor(vec![3], update_data.clone())),
+        (starts_key, i64_tensor(vec![1], starts_data)),
+    ]);
+
+    let tangent = jvp_from_fragment_with_inputs(
+        fragment,
+        output_key,
+        update_key,
+        inputs_map,
+        f64_tensor(vec![3], tangent_data.clone()),
+    );
+
+    assert_jvp_matches_finite_diff(get_f64_data(&tangent), &update_data, &tangent_data, |upd| {
+        let mut out = operand_data.clone();
+        out[2..5].copy_from_slice(upd);
+        out
+    });
+}
+
+#[test]
+fn grad_dynamic_update_slice_matches_finite_diff() {
+    let operand_key = tensor_input_key(61_530);
+    let update_key = tensor_input_key(61_531);
+    let starts_key = tensor_input_key(61_532);
+    let (fragment, output_key) = build_dynamic_update_slice_fragment(
+        operand_key.clone(),
+        update_key.clone(),
+        starts_key.clone(),
+    );
+
+    let operand_data = vec![10.0_f64, 11.0, 12.0, 13.0, 14.0];
+    let update_data = vec![1.0_f64, 2.0, 3.0];
+    let starts_data = vec![4_i64];
+    let cotangent_data = vec![0.5_f64, -0.25, 1.0, 2.0, -1.5];
+    let inputs_map = HashMap::from([
+        (
+            operand_key.clone(),
+            f64_tensor(vec![5], operand_data.clone()),
+        ),
+        (update_key.clone(), f64_tensor(vec![3], update_data.clone())),
+        (starts_key, i64_tensor(vec![1], starts_data)),
+    ]);
+
+    let grad_operand = grad_from_fragment_with_inputs_and_cotangent(
+        fragment.clone(),
+        output_key.clone(),
+        operand_key,
+        inputs_map.clone(),
+        f64_tensor(vec![5], cotangent_data.clone()),
+    );
+    let grad_update = grad_from_fragment_with_inputs_and_cotangent(
+        fragment,
+        output_key,
+        update_key,
+        inputs_map,
+        f64_tensor(vec![5], cotangent_data.clone()),
+    );
+
+    let loss_with = |operand: &[f64], update: &[f64]| {
+        let mut out = operand.to_vec();
+        out[2..5].copy_from_slice(update);
+        out.iter()
+            .zip(cotangent_data.iter())
+            .map(|(&value, &weight)| value * weight)
+            .sum()
+    };
+    let expected_operand: Vec<f64> = (0..operand_data.len())
+        .map(|idx| finite_diff_scalar_lhs(loss_with, &operand_data, &update_data, idx, 1.0e-6))
+        .collect();
+    let expected_update: Vec<f64> = (0..update_data.len())
+        .map(|idx| finite_diff_scalar_rhs(loss_with, &operand_data, &update_data, idx, 1.0e-6))
+        .collect();
+
+    assert_close_slice(get_f64_data(&grad_operand), &expected_operand);
+    assert_close_slice(get_f64_data(&grad_update), &expected_update);
 }
 
 #[test]

--- a/tenferro/tests/ad_structural_primitives.rs
+++ b/tenferro/tests/ad_structural_primitives.rs
@@ -1,0 +1,275 @@
+use tenferro::{EagerTensor, Tensor};
+
+const FD_H: f64 = 1.0e-6;
+const TOL: f64 = 1.0e-5;
+
+fn f64_data(tensor: &Tensor) -> &[f64] {
+    tensor.as_slice::<f64>().unwrap()
+}
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).abs() <= TOL,
+            "index {index}: expected {expected}, got {actual}"
+        );
+    }
+}
+
+fn finite_diff_unary(f: impl Fn(&[f64]) -> f64, base: &[f64]) -> Vec<f64> {
+    (0..base.len())
+        .map(|index| {
+            let mut plus = base.to_vec();
+            let mut minus = base.to_vec();
+            plus[index] += FD_H;
+            minus[index] -= FD_H;
+            (f(&plus) - f(&minus)) / (2.0 * FD_H)
+        })
+        .collect()
+}
+
+fn weighted_sum(values: impl Iterator<Item = f64>, weights: &[f64]) -> f64 {
+    values
+        .zip(weights.iter())
+        .map(|(value, &weight)| value * weight)
+        .sum()
+}
+
+#[test]
+fn eager_maximum_and_minimum_gradients_match_finite_diff() {
+    let x_data = vec![3.0_f64, -2.0, 0.5, 4.0];
+    let y_data = vec![1.0_f64, 5.0, -1.0, 2.0];
+    let max_weights = vec![0.5_f64, -1.25, 2.0, -0.75];
+    let min_weights = vec![1.5_f64, -0.25, 0.75, 2.25];
+
+    let x = EagerTensor::requires_grad(Tensor::from_vec(vec![4], x_data.clone()));
+    let y = EagerTensor::requires_grad(Tensor::from_vec(vec![4], y_data.clone()));
+    let max_weights_tensor =
+        EagerTensor::from_tensor(Tensor::from_vec(vec![4], max_weights.clone()));
+    let min_weights_tensor =
+        EagerTensor::from_tensor(Tensor::from_vec(vec![4], min_weights.clone()));
+
+    let max_loss = x
+        .maximum(&y)
+        .unwrap()
+        .mul(&max_weights_tensor)
+        .unwrap()
+        .reduce_sum(&[0])
+        .unwrap();
+    let min_loss = x
+        .minimum(&y)
+        .unwrap()
+        .mul(&min_weights_tensor)
+        .unwrap()
+        .reduce_sum(&[0])
+        .unwrap();
+    let loss = &max_loss + &min_loss;
+    let _ = loss.backward().unwrap();
+
+    let grad_x = x.grad().unwrap();
+    let grad_y = y.grad().unwrap();
+
+    let loss_for_x = |xs: &[f64]| {
+        let max_part = weighted_sum(
+            xs.iter()
+                .zip(&y_data)
+                .map(|(&x, &y)| if x >= y { x } else { y }),
+            &max_weights,
+        );
+        let min_part = weighted_sum(
+            xs.iter()
+                .zip(&y_data)
+                .map(|(&x, &y)| if x <= y { x } else { y }),
+            &min_weights,
+        );
+        max_part + min_part
+    };
+    let loss_for_y = |ys: &[f64]| {
+        let max_part = weighted_sum(
+            x_data
+                .iter()
+                .zip(ys)
+                .map(|(&x, &y)| if x >= y { x } else { y }),
+            &max_weights,
+        );
+        let min_part = weighted_sum(
+            x_data
+                .iter()
+                .zip(ys)
+                .map(|(&x, &y)| if x <= y { x } else { y }),
+            &min_weights,
+        );
+        max_part + min_part
+    };
+
+    assert_close(f64_data(&grad_x), &finite_diff_unary(loss_for_x, &x_data));
+    assert_close(f64_data(&grad_y), &finite_diff_unary(loss_for_y, &y_data));
+}
+
+#[test]
+fn eager_select_gradients_match_finite_diff() {
+    let condition_data = vec![0.0_f64, -1.0, 2.0, 0.0];
+    let true_data = vec![10.0_f64, 20.0, 30.0, 40.0];
+    let false_data = vec![1.0_f64, 2.0, 3.0, 4.0];
+    let weights = vec![0.5_f64, -1.0, 2.0, 1.25];
+
+    let condition = EagerTensor::from_tensor(Tensor::from_vec(vec![4], condition_data.clone()));
+    let on_true = EagerTensor::requires_grad(Tensor::from_vec(vec![4], true_data.clone()));
+    let on_false = EagerTensor::requires_grad(Tensor::from_vec(vec![4], false_data.clone()));
+    let weights_tensor = EagerTensor::from_tensor(Tensor::from_vec(vec![4], weights.clone()));
+
+    let loss = EagerTensor::select(&condition, &on_true, &on_false)
+        .unwrap()
+        .mul(&weights_tensor)
+        .unwrap()
+        .reduce_sum(&[0])
+        .unwrap();
+    let _ = loss.backward().unwrap();
+
+    let loss_for_true = |values: &[f64]| {
+        weighted_sum(
+            condition_data
+                .iter()
+                .zip(values.iter())
+                .zip(false_data.iter())
+                .map(|((&cond, &t), &f)| if cond != 0.0 { t } else { f }),
+            &weights,
+        )
+    };
+    let loss_for_false = |values: &[f64]| {
+        weighted_sum(
+            condition_data
+                .iter()
+                .zip(true_data.iter())
+                .zip(values.iter())
+                .map(|((&cond, &t), &f)| if cond != 0.0 { t } else { f }),
+            &weights,
+        )
+    };
+
+    assert_close(
+        f64_data(on_true.grad().unwrap().as_ref()),
+        &finite_diff_unary(loss_for_true, &true_data),
+    );
+    assert_close(
+        f64_data(on_false.grad().unwrap().as_ref()),
+        &finite_diff_unary(loss_for_false, &false_data),
+    );
+}
+
+#[test]
+fn eager_clamp_gradients_match_finite_diff() {
+    let input_data = vec![-2.0_f64, 0.5, 5.0, 2.0];
+    let lower_data = vec![-1.0_f64, 0.0, 1.0, 0.0];
+    let upper_data = vec![1.0_f64, 2.0, 4.0, 3.0];
+    let weights = vec![0.5_f64, -1.25, 2.0, 0.75];
+
+    let input = EagerTensor::requires_grad(Tensor::from_vec(vec![4], input_data.clone()));
+    let lower = EagerTensor::requires_grad(Tensor::from_vec(vec![4], lower_data.clone()));
+    let upper = EagerTensor::requires_grad(Tensor::from_vec(vec![4], upper_data.clone()));
+    let weights_tensor = EagerTensor::from_tensor(Tensor::from_vec(vec![4], weights.clone()));
+
+    let loss = input
+        .clamp(&lower, &upper)
+        .unwrap()
+        .mul(&weights_tensor)
+        .unwrap()
+        .reduce_sum(&[0])
+        .unwrap();
+    let _ = loss.backward().unwrap();
+
+    let loss_with = |xs: &[f64], lows: &[f64], highs: &[f64]| {
+        weighted_sum(
+            xs.iter()
+                .zip(lows.iter())
+                .zip(highs.iter())
+                .map(|((&x, &lo), &hi)| lo.max(hi.min(x))),
+            &weights,
+        )
+    };
+
+    assert_close(
+        f64_data(input.grad().unwrap().as_ref()),
+        &finite_diff_unary(|xs| loss_with(xs, &lower_data, &upper_data), &input_data),
+    );
+    assert_close(
+        f64_data(lower.grad().unwrap().as_ref()),
+        &finite_diff_unary(
+            |lows| loss_with(&input_data, lows, &upper_data),
+            &lower_data,
+        ),
+    );
+    assert_close(
+        f64_data(upper.grad().unwrap().as_ref()),
+        &finite_diff_unary(
+            |highs| loss_with(&input_data, &lower_data, highs),
+            &upper_data,
+        ),
+    );
+}
+
+#[test]
+fn eager_concatenate_gradients_match_finite_diff() {
+    let left_data = vec![1.0_f64, 2.0];
+    let middle_data = vec![3.0_f64];
+    let right_data = vec![4.0_f64, 5.0, 6.0];
+    let weights = vec![0.5_f64, -1.0, 2.0, 1.5, -0.25, 0.75];
+
+    let left = EagerTensor::requires_grad(Tensor::from_vec(vec![2], left_data.clone()));
+    let middle = EagerTensor::requires_grad(Tensor::from_vec(vec![1], middle_data.clone()));
+    let right = EagerTensor::requires_grad(Tensor::from_vec(vec![3], right_data.clone()));
+    let weights_tensor = EagerTensor::from_tensor(Tensor::from_vec(vec![6], weights.clone()));
+
+    let concatenated = EagerTensor::concatenate(&[&left, &middle, &right], 0).unwrap();
+    let loss = concatenated
+        .mul(&weights_tensor)
+        .unwrap()
+        .reduce_sum(&[0])
+        .unwrap();
+    let _ = loss.backward().unwrap();
+
+    let loss_for_left = |values: &[f64]| {
+        weighted_sum(
+            values
+                .iter()
+                .chain(middle_data.iter())
+                .chain(right_data.iter())
+                .copied(),
+            &weights,
+        )
+    };
+    let loss_for_middle = |values: &[f64]| {
+        weighted_sum(
+            left_data
+                .iter()
+                .chain(values.iter())
+                .chain(right_data.iter())
+                .copied(),
+            &weights,
+        )
+    };
+    let loss_for_right = |values: &[f64]| {
+        weighted_sum(
+            left_data
+                .iter()
+                .chain(middle_data.iter())
+                .chain(values.iter())
+                .copied(),
+            &weights,
+        )
+    };
+
+    assert_close(
+        f64_data(left.grad().unwrap().as_ref()),
+        &finite_diff_unary(loss_for_left, &left_data),
+    );
+    assert_close(
+        f64_data(middle.grad().unwrap().as_ref()),
+        &finite_diff_unary(loss_for_middle, &middle_data),
+    );
+    assert_close(
+        f64_data(right.grad().unwrap().as_ref()),
+        &finite_diff_unary(loss_for_right, &right_data),
+    );
+}

--- a/tenferro/tests/exec_dispatch.rs
+++ b/tenferro/tests/exec_dispatch.rs
@@ -281,6 +281,14 @@ impl TensorBackend for FakeTensorBackend {
     ) -> tenferro_tensor::Result<Tensor> {
         self.result("dynamic_slice", 36.0)
     }
+    fn dynamic_update_slice(
+        &mut self,
+        _operand: &Tensor,
+        _update: &Tensor,
+        _starts: &Tensor,
+    ) -> tenferro_tensor::Result<Tensor> {
+        self.result("dynamic_update_slice", 36.5)
+    }
     fn pad(&mut self, _input: &Tensor, _config: &PadConfig) -> tenferro_tensor::Result<Tensor> {
         self.result("pad", 37.0)
     }
@@ -465,6 +473,7 @@ fn eval_exec_ir_dispatches_tensor_ops_to_backend_methods() {
             "dynamic_slice",
             36.0,
         ),
+        (ExecOp::DynamicUpdateSlice, 3, "dynamic_update_slice", 36.5),
         (ExecOp::Pad(pad_config()), 1, "pad", 37.0),
         (ExecOp::Concatenate { axis: 0 }, 2, "concatenate", 38.0),
         (ExecOp::Reverse { axes: vec![0] }, 1, "reverse", 39.0),


### PR DESCRIPTION
## Summary
- add `DynamicUpdateSlice` primitive wiring and CPU implementation so `DynamicSlice` VJP can be represented as `dynamic_update_slice(zeros_like(operand), cotangent, starts)`
- add missing AD rules for `DynamicSlice`/`DynamicUpdateSlice`, `Maximum`/`Minimum`/`Select`/`Clamp`, and `Concatenate`
- add `FullPivLu` linearization for differentiating L/U while treating permutation/parity outputs as nondifferentiable, matching the partial-pivot LU convention

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `git diff --check`

## Notes
- `FullPivLu` direct primitive `transpose_rule` remains intentionally unimplemented, like `Lu`; VJP is obtained by transposing the emitted linearized graph.
- Full pivoting LU remains unsupported on GPU backends. CubeCL returns `BackendFailure` for `full_piv_lu` and `full_piv_lu_solve`; this PR only adds AD semantics for supported evaluation paths.
- Oracle-side support is assumed from the companion PR discussed separately.

Generated with Codex.
