### PR TITLE
[codex] add AD support manifest

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -18,6 +18,12 @@
   are the semantic source of truth for AD rules.
 - These are graph-level rules that emit ops into a `FragmentBuilder`.
   `tidu::differentiate` calls `linearize`; `tidu::transpose` calls `transpose_rule`.
+- Reverse-mode support is not always a direct `transpose_rule` arm on the
+  primal op. Some ops are supported by first applying `linearize` and then
+  transposing the emitted linear primitive graph. Before filing or closing an
+  AD support issue, check the machine-readable AD support manifest in
+  `tenferro-ops/src/ad/support.rs`; `SupportedViaLinearize` means a missing
+  direct transpose arm is intentional.
 - Reference JAX's implementations (`jax/_src/lax/lax.py`, `jax/_src/lax/linalg.py`)
   when implementing new AD rules.
 

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -1,3 +1,12 @@
+//! Automatic differentiation rules for [`StdTensorOp`].
+//!
+//! `linearize` and `transpose_rule` are separate graph-level contracts. Most
+//! ops have a direct transpose rule, but some primal ops are reverse-mode
+//! supported by first linearizing them into primitive linear ops and then
+//! transposing that emitted linear graph. The machine-readable support
+//! manifest in `support` records which path each core op uses; audits must
+//! consult it before treating a missing direct transpose arm as unsupported AD.
+
 pub mod context;
 
 mod analytic;
@@ -9,6 +18,7 @@ mod indexing;
 mod linalg;
 mod semiring;
 mod structural;
+mod support;
 mod zeros;
 
 use computegraph::fragment::FragmentBuilder;
@@ -18,7 +28,15 @@ use computegraph::OpEmitter;
 use crate::std_tensor_op::StdTensorOp;
 
 fn todo_transpose_rule(op: &StdTensorOp) -> ! {
-    todo!("transpose_rule not implemented for {:?}", op)
+    match support::ad_rule_support(op) {
+        support::AdRuleSupport::SupportedViaLinearize => {
+            panic!(
+                "direct transpose_rule not implemented for {:?}; reverse-mode support is provided by linearize() and transposing the emitted linear primitive graph",
+                op
+            )
+        }
+        _ => todo!("transpose_rule not implemented for {:?}", op),
+    }
 }
 
 /// Forward-mode AD (JVP) for `StdTensorOp`: given the primal op and its

--- a/tenferro-ops/src/ad/support.rs
+++ b/tenferro-ops/src/ad/support.rs
@@ -1,0 +1,85 @@
+use crate::std_tensor_op::StdTensorOp;
+
+/// Describes how a core [`StdTensorOp`] participates in AD.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AdRuleSupport {
+    /// The op has direct `linearize` and `transpose_rule` coverage.
+    DirectTranspose,
+    /// Reverse-mode support is obtained by linearizing the primal op first.
+    ///
+    /// A direct `transpose_rule` arm is not expected for these primal ops.
+    SupportedViaLinearize,
+    /// The op has no differentiable tangent contribution by construction.
+    NoTangent,
+    /// The extension object owns its own AD support contract.
+    DelegatedToExtension,
+}
+
+/// Return the AD support strategy for a core tensor op.
+pub(crate) fn ad_rule_support(op: &StdTensorOp) -> AdRuleSupport {
+    match op {
+        StdTensorOp::Constant { .. } | StdTensorOp::Compare(_) | StdTensorOp::ShapeOf { .. } => {
+            AdRuleSupport::NoTangent
+        }
+
+        StdTensorOp::Cholesky
+        | StdTensorOp::Lu
+        | StdTensorOp::FullPivLu
+        | StdTensorOp::Svd { .. }
+        | StdTensorOp::Qr
+        | StdTensorOp::Eigh { .. }
+        | StdTensorOp::Eig { .. } => AdRuleSupport::SupportedViaLinearize,
+
+        StdTensorOp::Extension(_) => AdRuleSupport::DelegatedToExtension,
+
+        StdTensorOp::Add
+        | StdTensorOp::Mul
+        | StdTensorOp::Neg
+        | StdTensorOp::Conj
+        | StdTensorOp::DotGeneral { .. }
+        | StdTensorOp::Transpose { .. }
+        | StdTensorOp::Reshape { .. }
+        | StdTensorOp::BroadcastInDim { .. }
+        | StdTensorOp::Convert { .. }
+        | StdTensorOp::ReduceSum { .. }
+        | StdTensorOp::Div
+        | StdTensorOp::Abs
+        | StdTensorOp::Sign
+        | StdTensorOp::Maximum
+        | StdTensorOp::Minimum
+        | StdTensorOp::Select
+        | StdTensorOp::Clamp
+        | StdTensorOp::Exp
+        | StdTensorOp::Log
+        | StdTensorOp::Sin
+        | StdTensorOp::Cos
+        | StdTensorOp::Tanh
+        | StdTensorOp::Sqrt
+        | StdTensorOp::Rsqrt
+        | StdTensorOp::Pow
+        | StdTensorOp::Expm1
+        | StdTensorOp::Log1p
+        | StdTensorOp::ExtractDiag { .. }
+        | StdTensorOp::EmbedDiag { .. }
+        | StdTensorOp::Tril { .. }
+        | StdTensorOp::Triu { .. }
+        | StdTensorOp::Gather(_)
+        | StdTensorOp::GatherDynamicSliceSizes { .. }
+        | StdTensorOp::Scatter(_)
+        | StdTensorOp::Slice(_)
+        | StdTensorOp::DynamicSlice { .. }
+        | StdTensorOp::DynamicUpdateSlice
+        | StdTensorOp::Pad(_)
+        | StdTensorOp::NaryEinsum { .. }
+        | StdTensorOp::Concatenate { .. }
+        | StdTensorOp::Reverse { .. }
+        | StdTensorOp::DynamicTruncate { .. }
+        | StdTensorOp::PadToMatch { .. }
+        | StdTensorOp::ReduceProd { .. }
+        | StdTensorOp::ReduceMax { .. }
+        | StdTensorOp::ReduceMin { .. }
+        | StdTensorOp::FullPivLuSolve { .. }
+        | StdTensorOp::TriangularSolve { .. }
+        | StdTensorOp::ValidateNonsingular => AdRuleSupport::DirectTranspose,
+    }
+}

--- a/tenferro-ops/src/ad/tests/mod.rs
+++ b/tenferro-ops/src/ad/tests/mod.rs
@@ -14,6 +14,7 @@ use crate::{SymDim, TensorMeta};
 mod elementwise_tests;
 mod indexing_tests;
 mod linalg_tests;
+mod support_tests;
 
 fn tensor_input(id: u64) -> TensorInputKey {
     TensorInputKey::User { id }

--- a/tenferro-ops/src/ad/tests/support_tests.rs
+++ b/tenferro-ops/src/ad/tests/support_tests.rs
@@ -1,0 +1,71 @@
+use tenferro_tensor::{CompareDir, DType, DotGeneralConfig};
+
+use crate::ad::support::{ad_rule_support, AdRuleSupport};
+use crate::std_tensor_op::StdTensorOp;
+
+#[test]
+fn linalg_factorizations_are_marked_supported_via_linearize() {
+    let ops = [
+        StdTensorOp::Cholesky,
+        StdTensorOp::Lu,
+        StdTensorOp::FullPivLu,
+        StdTensorOp::Svd { eps: 1.0e-12 },
+        StdTensorOp::Qr,
+        StdTensorOp::Eigh { eps: 1.0e-12 },
+        StdTensorOp::Eig {
+            input_dtype: DType::F64,
+        },
+    ];
+
+    for op in ops {
+        assert_eq!(ad_rule_support(&op), AdRuleSupport::SupportedViaLinearize);
+    }
+}
+
+#[test]
+fn direct_transpose_ops_are_marked_direct() {
+    let ops = [
+        StdTensorOp::Add,
+        StdTensorOp::Maximum,
+        StdTensorOp::Slice(tenferro_tensor::SliceConfig {
+            starts: vec![0],
+            limits: vec![2],
+            strides: vec![1],
+        }),
+        StdTensorOp::DotGeneral {
+            config: DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        },
+        StdTensorOp::TriangularSolve {
+            left_side: true,
+            lower: true,
+            transpose_a: false,
+            unit_diagonal: false,
+        },
+        StdTensorOp::FullPivLuSolve { transpose_a: false },
+    ];
+
+    for op in ops {
+        assert_eq!(ad_rule_support(&op), AdRuleSupport::DirectTranspose);
+    }
+}
+
+#[test]
+fn no_tangent_ops_are_marked_explicitly() {
+    let ops = [
+        StdTensorOp::Constant {
+            dtype: DType::F64,
+            bytes: 1.0_f64.to_ne_bytes().to_vec(),
+        },
+        StdTensorOp::Compare(CompareDir::Lt),
+        StdTensorOp::ShapeOf { axis: 0 },
+    ];
+
+    for op in ops {
+        assert_eq!(ad_rule_support(&op), AdRuleSupport::NoTangent);
+    }
+}

--- a/tenferro-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-ops/src/tests/std_tensor_op_tests.rs
@@ -1331,7 +1331,9 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
 }
 
 #[test]
-#[should_panic(expected = "transpose_rule not implemented for FullPivLu")]
+#[should_panic(
+    expected = "direct transpose_rule not implemented for FullPivLu; reverse-mode support is provided by linearize()"
+)]
 fn test_std_tensor_op_transpose_rule_panics_for_unimplemented_variant() {
     let mut builder = FragmentBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();


### PR DESCRIPTION
## Summary

- add a machine-readable AD support manifest for `StdTensorOp`
- mark linalg factorization ops as reverse-mode supported via `linearize()` rather than direct primal `transpose_rule` arms
- document the audit rule in `REPOSITORY_RULES.md` and AD module docs
- update the existing unimplemented direct transpose panic so audits see the linearize support path

## Related Issues

- Related triage context: #777 and #783. Both were already resolved before this PR.
- Separate issue: #831 tracks CPU linalg `eps`/F32/C32 conformance and is outside this PR.

## Validation

- `cargo fmt --all --check`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`