### PR TITLE
Fix CPU error handling without panic catching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ the symbol is present.
 
 ### Documentation Requirements
 
-Every public type, trait, and function **must** include minimal but sufficient usage examples in its doc comments (`/// # Examples`). The examples should help a human quickly understand how to use the API. Use `ignore` attribute on examples that cannot run in docs. Crate-level docs (`//!`) should include typical end-to-end usage examples.
+Every public type, trait, and function **must** include minimal but sufficient usage examples in its doc comments (`/// # Examples`). The examples should help a human quickly understand how to use the API. Doc examples must compile and run as doctests; do not use `ignore` or `no_run`. Crate-level docs (`//!`) should include typical end-to-end usage examples.
 
 ## Project Overview
 
@@ -151,6 +151,7 @@ If `cargo fmt --all --check` fails, run `cargo fmt --all` to fix formatting auto
 
 Additionally, verify the following before pushing:
 
+- **Side review**: Re-read `REPOSITORY_RULES.md` and review the local diff against repository rules before creating a PR. Fix any findings, or explicitly document residual risks.
 - **Sample code verification**: All code examples in `README.md` and `docs/getting-started/` must compile and run correctly. Extract and test any changed examples.
 - **Design document updates**: When code changes affect architecture or specifications, update the corresponding documents in `docs/architecture/`, `docs/spec/`, or `docs/design/`. Stale documentation is worse than no documentation.
 

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use crate::backend::{TensorBackend, TensorExec};
@@ -17,7 +15,7 @@ use super::{analytic, elementwise, gemm, indexing, linalg, reduction, structural
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tenferro_tensor::cpu::CpuBackend;
 ///
 /// let backend = CpuBackend::new();
@@ -32,7 +30,7 @@ impl CpuBackend {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tensor::cpu::CpuBackend;
     ///
     /// let backend = CpuBackend::new();
@@ -45,10 +43,11 @@ impl CpuBackend {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tensor::cpu::CpuBackend;
     ///
-    /// let backend = CpuBackend::try_new().unwrap();
+    /// let backend = CpuBackend::try_new()
+    ///     .unwrap_or_else(|_| CpuBackend::with_threads(1));
     /// let _ = backend.num_threads();
     /// ```
     pub fn try_new() -> crate::Result<Self> {
@@ -59,7 +58,7 @@ impl CpuBackend {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use std::sync::Arc;
     /// use tenferro_tensor::cpu::{CpuBackend, CpuContext};
     ///
@@ -78,22 +77,50 @@ impl CpuBackend {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tensor::cpu::CpuBackend;
     ///
     /// let backend = CpuBackend::with_threads(2);
     /// assert_eq!(backend.num_threads(), 2);
     /// ```
     pub fn with_threads(num_threads: usize) -> Self {
-        assert!(num_threads >= 1, "thread count must be >= 1");
-        Self::from_context(Arc::new(CpuContext::with_threads(num_threads)))
+        match Self::try_with_threads(num_threads) {
+            Ok(backend) => backend,
+            Err(err) => panic!("{err}"),
+        }
+    }
+
+    /// Try to create a CPU backend with a custom thread count.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::cpu::CpuBackend;
+    ///
+    /// let backend = CpuBackend::try_with_threads(1).unwrap();
+    /// assert_eq!(backend.num_threads(), 1);
+    /// ```
+    pub fn try_with_threads(num_threads: usize) -> crate::Result<Self> {
+        CpuContext::try_with_threads(num_threads)
+            .map(|ctx| Self::from_context(Arc::new(ctx)))
+            .map_err(|err| match err {
+                crate::Error::InvalidConfig { message, .. } => crate::Error::InvalidConfig {
+                    op: "CpuBackend::try_with_threads",
+                    message,
+                },
+                crate::Error::BackendFailure { message, .. } => crate::Error::BackendFailure {
+                    op: "CpuBackend::try_with_threads",
+                    message,
+                },
+                err => err,
+            })
     }
 
     /// Return the number of threads in this backend's CPU context.
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tensor::cpu::CpuBackend;
     ///
     /// let backend = CpuBackend::with_threads(2);
@@ -107,7 +134,7 @@ impl CpuBackend {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tensor::cpu::CpuBackend;
     ///
     /// let backend = CpuBackend::new();
@@ -413,25 +440,13 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => {
-                catch_backend_panic("cholesky", || linalg::cholesky(ctx.as_ref(), buffers, t))
-                    .and_then(|result| result)
-                    .map(Tensor::F64)
-            }
+            Tensor::F64(t) => linalg::cholesky(ctx.as_ref(), buffers, t).map(Tensor::F64),
             #[cfg(feature = "cpu-blas")]
-            Tensor::F64(t) => catch_backend_panic("cholesky", || linalg::cholesky(buffers, t))
-                .and_then(|result| result)
-                .map(Tensor::F64),
+            Tensor::F64(t) => linalg::cholesky(buffers, t).map(Tensor::F64),
             #[cfg(feature = "cpu-blas")]
-            Tensor::C64(t) => catch_backend_panic("cholesky", || linalg::cholesky(buffers, t))
-                .and_then(|result| result)
-                .map(Tensor::C64),
+            Tensor::C64(t) => linalg::cholesky(buffers, t).map(Tensor::C64),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => {
-                catch_backend_panic("cholesky", || linalg::cholesky(ctx.as_ref(), buffers, t))
-                    .and_then(|result| result)
-                    .map(Tensor::C64)
-            }
+            Tensor::C64(t) => linalg::cholesky(ctx.as_ref(), buffers, t).map(Tensor::C64),
             _ => Err(unsupported_dtype("cholesky", input.dtype())),
         })
     }
@@ -449,63 +464,51 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match (a, b) {
             #[cfg(feature = "cpu-faer")]
-            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
-                linalg::triangular_solve(
-                    ctx.as_ref(),
-                    buffers,
-                    a,
-                    b,
-                    left_side,
-                    lower,
-                    transpose_a,
-                    unit_diagonal,
-                )
-                .map(Tensor::F64)
-            })
-            .and_then(|result| result),
+            (Tensor::F64(a), Tensor::F64(b)) => linalg::triangular_solve(
+                ctx.as_ref(),
+                buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::F64),
             #[cfg(feature = "cpu-blas")]
-            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
-                linalg::triangular_solve(
-                    buffers,
-                    a,
-                    b,
-                    left_side,
-                    lower,
-                    transpose_a,
-                    unit_diagonal,
-                )
-                .map(Tensor::F64)
-            })
-            .and_then(|result| result),
+            (Tensor::F64(a), Tensor::F64(b)) => linalg::triangular_solve(
+                buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::F64),
             #[cfg(feature = "cpu-blas")]
-            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
-                linalg::triangular_solve(
-                    buffers,
-                    a,
-                    b,
-                    left_side,
-                    lower,
-                    transpose_a,
-                    unit_diagonal,
-                )
-                .map(Tensor::C64)
-            })
-            .and_then(|result| result),
+            (Tensor::C64(a), Tensor::C64(b)) => linalg::triangular_solve(
+                buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::C64),
             #[cfg(feature = "cpu-faer")]
-            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
-                linalg::triangular_solve(
-                    ctx.as_ref(),
-                    buffers,
-                    a,
-                    b,
-                    left_side,
-                    lower,
-                    transpose_a,
-                    unit_diagonal,
-                )
-                .map(Tensor::C64)
-            })
-            .and_then(|result| result),
+            (Tensor::C64(a), Tensor::C64(b)) => linalg::triangular_solve(
+                ctx.as_ref(),
+                buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::C64),
             _ => {
                 if a.dtype() != b.dtype() {
                     Err(crate::Error::DTypeMismatch {
@@ -525,26 +528,18 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => catch_backend_panic("lu", || linalg::lu(ctx.as_ref(), buffers, t))
-                .and_then(|result| result)
+            Tensor::F64(t) => linalg::lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
-            Tensor::F64(t) => catch_backend_panic("lu", || {
-                linalg::lu(buffers, t)
-                    .into_iter()
-                    .map(Tensor::F64)
-                    .collect()
-            }),
+            Tensor::F64(t) => {
+                linalg::lu(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::F64).collect())
+            }
             #[cfg(feature = "cpu-blas")]
-            Tensor::C64(t) => catch_backend_panic("lu", || {
-                linalg::lu(buffers, t)
-                    .into_iter()
-                    .map(Tensor::C64)
-                    .collect()
-            }),
+            Tensor::C64(t) => {
+                linalg::lu(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::C64).collect())
+            }
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => catch_backend_panic("lu", || linalg::lu(ctx.as_ref(), buffers, t))
-                .and_then(|result| result)
+            Tensor::C64(t) => linalg::lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             _ => Err(unsupported_dtype("lu", input.dtype())),
         })
@@ -555,31 +550,17 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => catch_backend_panic("full_piv_lu", || {
-                linalg::full_piv_lu(ctx.as_ref(), buffers, t)
-            })
-            .and_then(|result| result)
-            .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+            Tensor::F64(t) => linalg::full_piv_lu(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
-            Tensor::F64(t) => catch_backend_panic("full_piv_lu", || {
-                linalg::full_piv_lu(buffers, t)
-                    .into_iter()
-                    .map(Tensor::F64)
-                    .collect()
-            }),
+            Tensor::F64(t) => linalg::full_piv_lu(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
-            Tensor::C64(t) => catch_backend_panic("full_piv_lu", || {
-                linalg::full_piv_lu(buffers, t)
-                    .into_iter()
-                    .map(Tensor::C64)
-                    .collect()
-            }),
+            Tensor::C64(t) => linalg::full_piv_lu(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => catch_backend_panic("full_piv_lu", || {
-                linalg::full_piv_lu(ctx.as_ref(), buffers, t)
-            })
-            .and_then(|result| result)
-            .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+            Tensor::C64(t) => linalg::full_piv_lu(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             _ => Err(unsupported_dtype("full_piv_lu", input.dtype())),
         })
     }
@@ -607,25 +588,21 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         let result = self.install_with_pool(|buffers| match (a, &rhs) {
             #[cfg(feature = "cpu-faer")]
-            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+            (Tensor::F64(a), Tensor::F64(b)) => {
                 linalg::full_piv_lu_solve(ctx.as_ref(), buffers, a, b, transpose_a).map(Tensor::F64)
-            })
-            .and_then(|result| result),
+            }
             #[cfg(feature = "cpu-blas")]
-            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+            (Tensor::F64(a), Tensor::F64(b)) => {
                 linalg::full_piv_lu_solve(buffers, a, b, transpose_a).map(Tensor::F64)
-            })
-            .and_then(|result| result),
+            }
             #[cfg(feature = "cpu-blas")]
-            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+            (Tensor::C64(a), Tensor::C64(b)) => {
                 linalg::full_piv_lu_solve(buffers, a, b, transpose_a).map(Tensor::C64)
-            })
-            .and_then(|result| result),
+            }
             #[cfg(feature = "cpu-faer")]
-            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+            (Tensor::C64(a), Tensor::C64(b)) => {
                 linalg::full_piv_lu_solve(ctx.as_ref(), buffers, a, b, transpose_a).map(Tensor::C64)
-            })
-            .and_then(|result| result),
+            }
             _ => {
                 if a.dtype() != rhs.dtype() {
                     Err(crate::Error::DTypeMismatch {
@@ -651,26 +628,16 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => catch_backend_panic("svd", || linalg::svd(ctx.as_ref(), buffers, t))
-                .and_then(|r| r)
+            Tensor::F64(t) => linalg::svd(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
-            Tensor::F64(t) => catch_backend_panic("svd", || {
-                linalg::svd(buffers, t)
-                    .into_iter()
-                    .map(Tensor::F64)
-                    .collect()
-            }),
+            Tensor::F64(t) => linalg::svd(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
-            Tensor::C64(t) => catch_backend_panic("svd", || {
-                linalg::svd(buffers, t)
-                    .into_iter()
-                    .map(Tensor::C64)
-                    .collect()
-            }),
+            Tensor::C64(t) => linalg::svd(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => catch_backend_panic("svd", || linalg::svd(ctx.as_ref(), buffers, t))
-                .and_then(|r| r)
+            Tensor::C64(t) => linalg::svd(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             _ => Err(unsupported_dtype("svd", input.dtype())),
         })
@@ -681,26 +648,18 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => catch_backend_panic("qr", || linalg::qr(ctx.as_ref(), buffers, t))
-                .and_then(|result| result)
+            Tensor::F64(t) => linalg::qr(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
-            Tensor::F64(t) => catch_backend_panic("qr", || {
-                linalg::qr(buffers, t)
-                    .into_iter()
-                    .map(Tensor::F64)
-                    .collect()
-            }),
+            Tensor::F64(t) => {
+                linalg::qr(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::F64).collect())
+            }
             #[cfg(feature = "cpu-blas")]
-            Tensor::C64(t) => catch_backend_panic("qr", || {
-                linalg::qr(buffers, t)
-                    .into_iter()
-                    .map(Tensor::C64)
-                    .collect()
-            }),
+            Tensor::C64(t) => {
+                linalg::qr(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::C64).collect())
+            }
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => catch_backend_panic("qr", || linalg::qr(ctx.as_ref(), buffers, t))
-                .and_then(|result| result)
+            Tensor::C64(t) => linalg::qr(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             _ => Err(unsupported_dtype("qr", input.dtype())),
         })
@@ -711,31 +670,17 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
-            Tensor::F64(t) => {
-                catch_backend_panic("eigh", || linalg::eigh(ctx.as_ref(), buffers, t))
-                    .and_then(|r| r)
-                    .map(|outputs| outputs.into_iter().map(Tensor::F64).collect())
-            }
+            Tensor::F64(t) => linalg::eigh(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
-            Tensor::F64(t) => catch_backend_panic("eigh", || {
-                linalg::eigh(buffers, t)
-                    .into_iter()
-                    .map(Tensor::F64)
-                    .collect()
-            }),
+            Tensor::F64(t) => linalg::eigh(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
-            Tensor::C64(t) => catch_backend_panic("eigh", || {
-                linalg::eigh(buffers, t)
-                    .into_iter()
-                    .map(Tensor::C64)
-                    .collect()
-            }),
+            Tensor::C64(t) => linalg::eigh(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             #[cfg(feature = "cpu-faer")]
-            Tensor::C64(t) => {
-                catch_backend_panic("eigh", || linalg::eigh(ctx.as_ref(), buffers, t))
-                    .and_then(|r| r)
-                    .map(|outputs| outputs.into_iter().map(Tensor::C64).collect())
-            }
+            Tensor::C64(t) => linalg::eigh(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
             _ => Err(unsupported_dtype("eigh", input.dtype())),
         })
     }
@@ -749,12 +694,11 @@ impl TensorBackend for CpuBackend {
         self.install_with_pool(|buffers| {
             #[cfg(feature = "cpu-faer")]
             {
-                catch_backend_panic("eig", || linalg::eig(ctx.as_ref(), buffers, input))
-                    .and_then(|r| r)
+                linalg::eig(ctx.as_ref(), buffers, input)
             }
             #[cfg(feature = "cpu-blas")]
             {
-                catch_backend_panic("eig", || linalg::eig(buffers, input))
+                linalg::eig(buffers, input)
             }
         })
     }
@@ -872,23 +816,6 @@ fn zeros_like_tensor(input: &Tensor) -> Tensor {
         Tensor::C32(t) => Tensor::C32(TypedTensor::zeros(t.shape.clone())),
         Tensor::C64(t) => Tensor::C64(TypedTensor::zeros(t.shape.clone())),
     }
-}
-
-fn panic_payload_message(payload: Box<dyn Any + Send>) -> String {
-    if let Some(message) = payload.downcast_ref::<&str>() {
-        (*message).to_string()
-    } else if let Some(message) = payload.downcast_ref::<String>() {
-        message.clone()
-    } else {
-        "backend panic".into()
-    }
-}
-
-pub(crate) fn catch_backend_panic<R>(op: &'static str, f: impl FnOnce() -> R) -> crate::Result<R> {
-    catch_unwind(AssertUnwindSafe(f)).map_err(|payload| crate::Error::BackendFailure {
-        op,
-        message: panic_payload_message(payload),
-    })
 }
 
 pub(crate) fn unsupported_dtype(op: &'static str, dtype: crate::DType) -> crate::Error {

--- a/tenferro-tensor/src/cpu/context.rs
+++ b/tenferro-tensor/src/cpu/context.rs
@@ -8,7 +8,7 @@ use crate::{Error, Result};
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tenferro_tensor::cpu::CpuContext;
 ///
 /// let ctx = CpuContext::with_threads(1);
@@ -25,7 +25,14 @@ fn shared_pools() -> &'static Mutex<HashMap<usize, Arc<rayon::ThreadPool>>> {
     POOLS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-pub(crate) fn get_or_create_pool(num_threads: usize) -> Arc<rayon::ThreadPool> {
+pub(crate) fn try_get_or_create_pool(num_threads: usize) -> Result<Arc<rayon::ThreadPool>> {
+    if num_threads == 0 {
+        return Err(Error::InvalidConfig {
+            op: "CpuContext::try_with_threads",
+            message: "thread count must be at least 1".into(),
+        });
+    }
+
     let mut pools = match shared_pools().lock() {
         Ok(guard) => guard,
         Err(poisoned) => {
@@ -34,17 +41,20 @@ pub(crate) fn get_or_create_pool(num_threads: usize) -> Arc<rayon::ThreadPool> {
         }
     };
     if let Some(pool) = pools.get(&num_threads) {
-        return Arc::clone(pool);
+        return Ok(Arc::clone(pool));
     }
 
     let pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
             .num_threads(num_threads)
             .build()
-            .unwrap_or_else(|e| panic!("failed to create rayon thread pool: {e}")),
+            .map_err(|err| Error::BackendFailure {
+                op: "CpuContext::try_with_threads",
+                message: format!("failed to create rayon thread pool: {err}"),
+            })?,
     );
     pools.insert(num_threads, Arc::clone(&pool));
-    pool
+    Ok(pool)
 }
 
 impl CpuContext {
@@ -53,7 +63,7 @@ impl CpuContext {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tensor::cpu::CpuContext;
     ///
     /// let ctx = CpuContext::from_env();
@@ -68,10 +78,11 @@ impl CpuContext {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tensor::cpu::CpuContext;
     ///
-    /// let ctx = CpuContext::try_from_env().unwrap();
+    /// let ctx = CpuContext::try_from_env()
+    ///     .unwrap_or_else(|_| CpuContext::with_threads(1));
     /// let _ = ctx.num_threads();
     /// ```
     pub fn try_from_env() -> Result<Self> {
@@ -81,16 +92,20 @@ impl CpuContext {
                     op: "CpuContext::try_from_env",
                     message: format!("invalid RAYON_NUM_THREADS value {value:?}: {err}"),
                 })?;
-                if num_threads == 0 {
-                    return Err(Error::InvalidConfig {
+                Self::try_with_threads(num_threads).map_err(|err| match err {
+                    Error::InvalidConfig { message, .. } => Error::InvalidConfig {
                         op: "CpuContext::try_from_env",
-                        message: "RAYON_NUM_THREADS must be at least 1".to_string(),
-                    });
-                }
-                Ok(Self::with_threads(num_threads))
+                        message: format!("invalid RAYON_NUM_THREADS value {value:?}: {message}"),
+                    },
+                    Error::BackendFailure { message, .. } => Error::BackendFailure {
+                        op: "CpuContext::try_from_env",
+                        message,
+                    },
+                    err => err,
+                })
             }
             Err(env::VarError::NotPresent) => {
-                Ok(Self::with_threads(super::affinity::available_parallelism()))
+                Self::try_with_threads(super::affinity::available_parallelism())
             }
             Err(err) => Err(Error::InvalidConfig {
                 op: "CpuContext::try_from_env",
@@ -103,24 +118,40 @@ impl CpuContext {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tensor::cpu::CpuContext;
     ///
     /// let ctx = CpuContext::with_threads(2);
     /// assert_eq!(ctx.num_threads(), 2);
     /// ```
     pub fn with_threads(num_threads: usize) -> Self {
-        assert!(num_threads >= 1, "thread count must be >= 1");
-        Self {
-            pool: get_or_create_pool(num_threads),
+        match Self::try_with_threads(num_threads) {
+            Ok(ctx) => ctx,
+            Err(err) => panic!("{err}"),
         }
+    }
+
+    /// Try to create a CPU context with a fixed rayon thread-pool size.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::cpu::CpuContext;
+    ///
+    /// let ctx = CpuContext::try_with_threads(1).unwrap();
+    /// assert_eq!(ctx.num_threads(), 1);
+    /// ```
+    pub fn try_with_threads(num_threads: usize) -> Result<Self> {
+        Ok(Self {
+            pool: try_get_or_create_pool(num_threads)?,
+        })
     }
 
     /// Return the number of threads in this context's owned rayon pool.
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tensor::cpu::CpuContext;
     ///
     /// let ctx = CpuContext::with_threads(2);
@@ -134,7 +165,7 @@ impl CpuContext {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tenferro_tensor::cpu::CpuContext;
     ///
     /// let ctx = CpuContext::with_threads(1);

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -5,7 +5,7 @@ use crate::config::{
 };
 use crate::Tensor;
 
-use super::backend::{catch_backend_panic, reclaim_typed, unsupported_dtype};
+use super::backend::{reclaim_typed, unsupported_dtype};
 use super::{analytic, elementwise, gemm, indexing, linalg, reduction, structural, CpuContext};
 
 pub(crate) struct CpuExecSession<'a> {
@@ -27,16 +27,8 @@ macro_rules! linalg_single {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Tensor> {
             match input {
-                Tensor::F64(t) => catch_backend_panic(stringify!($name), || {
-                    linalg::$name(self.ctx, self.buffers, t)
-                })
-                .and_then(|r| r)
-                .map(Tensor::F64),
-                Tensor::C64(t) => catch_backend_panic(stringify!($name), || {
-                    linalg::$name(self.ctx, self.buffers, t)
-                })
-                .and_then(|r| r)
-                .map(Tensor::C64),
+                Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::F64),
+                Tensor::C64(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::C64),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
             }
         }
@@ -49,16 +41,8 @@ macro_rules! linalg_single {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Tensor> {
             match input {
-                Tensor::F64(t) => {
-                    catch_backend_panic(stringify!($name), || linalg::$name(self.buffers, t))
-                        .and_then(|r| r)
-                        .map(Tensor::F64)
-                }
-                Tensor::C64(t) => {
-                    catch_backend_panic(stringify!($name), || linalg::$name(self.buffers, t))
-                        .and_then(|r| r)
-                        .map(Tensor::C64)
-                }
+                Tensor::F64(t) => linalg::$name(self.buffers, t).map(Tensor::F64),
+                Tensor::C64(t) => linalg::$name(self.buffers, t).map(Tensor::C64),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
             }
         }
@@ -71,16 +55,10 @@ macro_rules! linalg_multi {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
             match input {
-                Tensor::F64(t) => catch_backend_panic(stringify!($name), || {
-                    linalg::$name(self.ctx, self.buffers, t)
-                })
-                .and_then(|r| r)
-                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
-                Tensor::C64(t) => catch_backend_panic(stringify!($name), || {
-                    linalg::$name(self.ctx, self.buffers, t)
-                })
-                .and_then(|r| r)
-                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+                Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                Tensor::C64(t) => linalg::$name(self.ctx, self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
             }
         }
@@ -93,16 +71,10 @@ macro_rules! linalg_multi_result {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
             match input {
-                Tensor::F64(t) => catch_backend_panic(stringify!($name), || {
-                    linalg::$name(self.ctx, self.buffers, t)
-                })
-                .and_then(|r| r)
-                .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
-                Tensor::C64(t) => catch_backend_panic(stringify!($name), || {
-                    linalg::$name(self.ctx, self.buffers, t)
-                })
-                .and_then(|r| r)
-                .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+                Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                Tensor::C64(t) => linalg::$name(self.ctx, self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
             }
         }
@@ -115,18 +87,10 @@ macro_rules! linalg_multi {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
             match input {
-                Tensor::F64(t) => catch_backend_panic(stringify!($name), || {
-                    linalg::$name(self.buffers, t)
-                        .into_iter()
-                        .map(Tensor::F64)
-                        .collect()
-                }),
-                Tensor::C64(t) => catch_backend_panic(stringify!($name), || {
-                    linalg::$name(self.buffers, t)
-                        .into_iter()
-                        .map(Tensor::C64)
-                        .collect()
-                }),
+                Tensor::F64(t) => linalg::$name(self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                Tensor::C64(t) => linalg::$name(self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
             }
         }
@@ -258,12 +222,11 @@ impl TensorExec for CpuExecSession<'_> {
         }
         #[cfg(feature = "cpu-faer")]
         {
-            catch_backend_panic("eig", || linalg::eig(self.ctx, self.buffers, input))
-                .and_then(|r| r)
+            linalg::eig(self.ctx, self.buffers, input)
         }
         #[cfg(feature = "cpu-blas")]
         {
-            catch_backend_panic("eig", || linalg::eig(self.buffers, input))
+            linalg::eig(self.buffers, input)
         }
     }
 
@@ -278,63 +241,51 @@ impl TensorExec for CpuExecSession<'_> {
     ) -> crate::Result<Tensor> {
         match (a, b) {
             #[cfg(feature = "cpu-faer")]
-            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
-                linalg::triangular_solve(
-                    self.ctx,
-                    self.buffers,
-                    a,
-                    b,
-                    left_side,
-                    lower,
-                    transpose_a,
-                    unit_diagonal,
-                )
-                .map(Tensor::F64)
-            })
-            .and_then(|r| r),
+            (Tensor::F64(a), Tensor::F64(b)) => linalg::triangular_solve(
+                self.ctx,
+                self.buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::F64),
             #[cfg(feature = "cpu-faer")]
-            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
-                linalg::triangular_solve(
-                    self.ctx,
-                    self.buffers,
-                    a,
-                    b,
-                    left_side,
-                    lower,
-                    transpose_a,
-                    unit_diagonal,
-                )
-                .map(Tensor::C64)
-            })
-            .and_then(|r| r),
+            (Tensor::C64(a), Tensor::C64(b)) => linalg::triangular_solve(
+                self.ctx,
+                self.buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::C64),
             #[cfg(feature = "cpu-blas")]
-            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("triangular_solve", || {
-                linalg::triangular_solve(
-                    self.buffers,
-                    a,
-                    b,
-                    left_side,
-                    lower,
-                    transpose_a,
-                    unit_diagonal,
-                )
-                .map(Tensor::F64)
-            })
-            .and_then(|r| r),
+            (Tensor::F64(a), Tensor::F64(b)) => linalg::triangular_solve(
+                self.buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::F64),
             #[cfg(feature = "cpu-blas")]
-            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("triangular_solve", || {
-                linalg::triangular_solve(
-                    self.buffers,
-                    a,
-                    b,
-                    left_side,
-                    lower,
-                    transpose_a,
-                    unit_diagonal,
-                )
-                .map(Tensor::C64)
-            })
-            .and_then(|r| r),
+            (Tensor::C64(a), Tensor::C64(b)) => linalg::triangular_solve(
+                self.buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::C64),
             _ => {
                 if a.dtype() != b.dtype() {
                     Err(crate::Error::DTypeMismatch {
@@ -357,27 +308,23 @@ impl TensorExec for CpuExecSession<'_> {
     ) -> crate::Result<Tensor> {
         match (a, b) {
             #[cfg(feature = "cpu-faer")]
-            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+            (Tensor::F64(a), Tensor::F64(b)) => {
                 linalg::full_piv_lu_solve(self.ctx, self.buffers, a, b, transpose_a)
                     .map(Tensor::F64)
-            })
-            .and_then(|result| result),
+            }
             #[cfg(feature = "cpu-faer")]
-            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+            (Tensor::C64(a), Tensor::C64(b)) => {
                 linalg::full_piv_lu_solve(self.ctx, self.buffers, a, b, transpose_a)
                     .map(Tensor::C64)
-            })
-            .and_then(|result| result),
+            }
             #[cfg(feature = "cpu-blas")]
-            (Tensor::F64(a), Tensor::F64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+            (Tensor::F64(a), Tensor::F64(b)) => {
                 linalg::full_piv_lu_solve(self.buffers, a, b, transpose_a).map(Tensor::F64)
-            })
-            .and_then(|result| result),
+            }
             #[cfg(feature = "cpu-blas")]
-            (Tensor::C64(a), Tensor::C64(b)) => catch_backend_panic("full_piv_lu_solve", || {
+            (Tensor::C64(a), Tensor::C64(b)) => {
                 linalg::full_piv_lu_solve(self.buffers, a, b, transpose_a).map(Tensor::C64)
-            })
-            .and_then(|result| result),
+            }
             _ => {
                 if a.dtype() != b.dtype() {
                     Err(crate::Error::DTypeMismatch {

--- a/tenferro-tensor/src/cpu/gemm/blas_gemm.rs
+++ b/tenferro-tensor/src/cpu/gemm/blas_gemm.rs
@@ -1,6 +1,8 @@
 use cblas_sys::{CBLAS_LAYOUT, CBLAS_TRANSPOSE};
 use num_complex::{Complex32, Complex64};
 
+use crate::Error;
+
 pub(crate) trait BlasGemm: Sized {
     #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
@@ -13,7 +15,7 @@ pub(crate) trait BlasGemm: Sized {
         m: usize,
         n: usize,
         k: usize,
-    );
+    ) -> crate::Result<()>;
 
     #[allow(clippy::too_many_arguments)]
     /// Run GEMM against raw strided matrix pointers.
@@ -40,68 +42,110 @@ pub(crate) trait BlasGemm: Sized {
         c_ptr: *mut Self,
         c_rs: isize,
         c_cs: isize,
-    );
+    ) -> crate::Result<()>;
 }
 
-fn dim_to_i32(name: &str, value: usize) -> i32 {
+fn dim_to_i32(name: &'static str, value: usize) -> crate::Result<i32> {
+    i32::try_from(value).map_err(|_| Error::InvalidConfig {
+        op: "dot_general",
+        message: format!("{name}={value} exceeds BLAS i32 range"),
+    })
+}
+
+fn stride_to_i32(name: &'static str, value: isize) -> crate::Result<i32> {
     match i32::try_from(value) {
-        Ok(value) => value,
-        Err(_) => panic!("{name} too large for BLAS i32 dimensions"),
+        Ok(value) if value > 0 => Ok(value),
+        _ => Err(Error::InvalidConfig {
+            op: "dot_general",
+            message: format!("{name}={value} must be a positive BLAS stride"),
+        }),
     }
 }
 
-fn stride_to_i32(name: &str, value: isize) -> i32 {
-    match i32::try_from(value) {
-        Ok(value) if value > 0 => value,
-        _ => panic!("{name} must be a positive BLAS stride"),
-    }
-}
-
-fn infer_a_layout(m: usize, k: usize, a_rs: isize, a_cs: isize) -> (CBLAS_TRANSPOSE, i32) {
+fn infer_a_layout(
+    m: usize,
+    k: usize,
+    a_rs: isize,
+    a_cs: isize,
+) -> crate::Result<(CBLAS_TRANSPOSE, i32)> {
     if a_rs == 1 {
-        let lda = stride_to_i32("lda", a_cs);
-        assert!(
-            lda >= dim_to_i32("m", m),
-            "lda must be >= max(1, m) for NoTrans A"
-        );
-        (CBLAS_TRANSPOSE::CblasNoTrans, lda)
+        let lda = stride_to_i32("lda", a_cs)?;
+        let min_lda = dim_to_i32("m", m)?;
+        if lda < min_lda {
+            return Err(Error::InvalidConfig {
+                op: "dot_general",
+                message: format!("lda={lda} must be >= max(1, m)={min_lda} for NoTrans A"),
+            });
+        }
+        Ok((CBLAS_TRANSPOSE::CblasNoTrans, lda))
     } else if a_cs == 1 {
-        let lda = stride_to_i32("lda", a_rs);
-        assert!(
-            lda >= dim_to_i32("k", k),
-            "lda must be >= max(1, k) for Trans A"
-        );
-        (CBLAS_TRANSPOSE::CblasTrans, lda)
+        let lda = stride_to_i32("lda", a_rs)?;
+        let min_lda = dim_to_i32("k", k)?;
+        if lda < min_lda {
+            return Err(Error::InvalidConfig {
+                op: "dot_general",
+                message: format!("lda={lda} must be >= max(1, k)={min_lda} for Trans A"),
+            });
+        }
+        Ok((CBLAS_TRANSPOSE::CblasTrans, lda))
     } else {
-        panic!("BLAS requires unit stride on one axis of A");
+        Err(Error::InvalidConfig {
+            op: "dot_general",
+            message: "BLAS requires unit stride on one axis of A".into(),
+        })
     }
 }
 
-fn infer_b_layout(k: usize, n: usize, b_rs: isize, b_cs: isize) -> (CBLAS_TRANSPOSE, i32) {
+fn infer_b_layout(
+    k: usize,
+    n: usize,
+    b_rs: isize,
+    b_cs: isize,
+) -> crate::Result<(CBLAS_TRANSPOSE, i32)> {
     if b_rs == 1 {
-        let ldb = stride_to_i32("ldb", b_cs);
-        assert!(
-            ldb >= dim_to_i32("k", k),
-            "ldb must be >= max(1, k) for NoTrans B"
-        );
-        (CBLAS_TRANSPOSE::CblasNoTrans, ldb)
+        let ldb = stride_to_i32("ldb", b_cs)?;
+        let min_ldb = dim_to_i32("k", k)?;
+        if ldb < min_ldb {
+            return Err(Error::InvalidConfig {
+                op: "dot_general",
+                message: format!("ldb={ldb} must be >= max(1, k)={min_ldb} for NoTrans B"),
+            });
+        }
+        Ok((CBLAS_TRANSPOSE::CblasNoTrans, ldb))
     } else if b_cs == 1 {
-        let ldb = stride_to_i32("ldb", b_rs);
-        assert!(
-            ldb >= dim_to_i32("n", n),
-            "ldb must be >= max(1, n) for Trans B"
-        );
-        (CBLAS_TRANSPOSE::CblasTrans, ldb)
+        let ldb = stride_to_i32("ldb", b_rs)?;
+        let min_ldb = dim_to_i32("n", n)?;
+        if ldb < min_ldb {
+            return Err(Error::InvalidConfig {
+                op: "dot_general",
+                message: format!("ldb={ldb} must be >= max(1, n)={min_ldb} for Trans B"),
+            });
+        }
+        Ok((CBLAS_TRANSPOSE::CblasTrans, ldb))
     } else {
-        panic!("BLAS requires unit stride on one axis of B");
+        Err(Error::InvalidConfig {
+            op: "dot_general",
+            message: "BLAS requires unit stride on one axis of B".into(),
+        })
     }
 }
 
-fn infer_c_layout(m: usize, c_rs: isize, c_cs: isize) -> i32 {
-    assert!(c_rs == 1, "BLAS output requires unit row stride");
-    let ldc = stride_to_i32("ldc", c_cs);
-    assert!(ldc >= dim_to_i32("m", m), "ldc must be >= max(1, m)");
-    ldc
+fn infer_c_layout(m: usize, c_rs: isize, c_cs: isize) -> crate::Result<i32> {
+    if c_rs != 1 {
+        return Err(Error::InvalidConfig {
+            op: "dot_general",
+            message: format!("BLAS output requires unit row stride, got {c_rs}"),
+        });
+    }
+    let ldc = stride_to_i32("ldc", c_cs)?;
+    let min_ldc = dim_to_i32("m", m)?;
+    if ldc < min_ldc {
+        return Err(Error::InvalidConfig {
+            op: "dot_general",
+            message: format!("ldc={ldc} must be >= max(1, m)={min_ldc}"),
+        });
+    }
+    Ok(ldc)
 }
 
 macro_rules! impl_real_blas_gemm {
@@ -116,10 +160,10 @@ macro_rules! impl_real_blas_gemm {
                 m: usize,
                 n: usize,
                 k: usize,
-            ) {
-                let m_i32 = dim_to_i32("m", m);
-                let n_i32 = dim_to_i32("n", n);
-                let k_i32 = dim_to_i32("k", k);
+            ) -> crate::Result<()> {
+                let m_i32 = dim_to_i32("m", m)?;
+                let n_i32 = dim_to_i32("n", n)?;
+                let k_i32 = dim_to_i32("k", k)?;
                 // SAFETY: the slices provide valid contiguous column-major
                 // storage for the BLAS read/write regions implied by m, n,
                 // and k, and dimensions were checked to fit BLAS i32 args.
@@ -141,6 +185,7 @@ macro_rules! impl_real_blas_gemm {
                         m_i32,
                     );
                 }
+                Ok(())
             }
 
             unsafe fn strided_gemm(
@@ -158,13 +203,13 @@ macro_rules! impl_real_blas_gemm {
                 c_ptr: *mut Self,
                 c_rs: isize,
                 c_cs: isize,
-            ) {
-                let m_i32 = dim_to_i32("m", m);
-                let n_i32 = dim_to_i32("n", n);
-                let k_i32 = dim_to_i32("k", k);
-                let (trans_a, lda) = infer_a_layout(m, k, a_rs, a_cs);
-                let (trans_b, ldb) = infer_b_layout(k, n, b_rs, b_cs);
-                let ldc = infer_c_layout(m, c_rs, c_cs);
+            ) -> crate::Result<()> {
+                let m_i32 = dim_to_i32("m", m)?;
+                let n_i32 = dim_to_i32("n", n)?;
+                let k_i32 = dim_to_i32("k", k)?;
+                let (trans_a, lda) = infer_a_layout(m, k, a_rs, a_cs)?;
+                let (trans_b, ldb) = infer_b_layout(k, n, b_rs, b_cs)?;
+                let ldc = infer_c_layout(m, c_rs, c_cs)?;
 
                 // SAFETY: `strided_gemm`'s caller guarantees the raw pointers
                 // are valid for the strided matrix regions. Layout inference
@@ -185,6 +230,7 @@ macro_rules! impl_real_blas_gemm {
                     c_ptr,
                     ldc,
                 );
+                Ok(())
             }
         }
     };
@@ -202,10 +248,10 @@ macro_rules! impl_complex_blas_gemm {
                 m: usize,
                 n: usize,
                 k: usize,
-            ) {
-                let m_i32 = dim_to_i32("m", m);
-                let n_i32 = dim_to_i32("n", n);
-                let k_i32 = dim_to_i32("k", k);
+            ) -> crate::Result<()> {
+                let m_i32 = dim_to_i32("m", m)?;
+                let n_i32 = dim_to_i32("n", n)?;
+                let k_i32 = dim_to_i32("k", k)?;
                 let alpha_ri = [alpha.re, alpha.im];
                 let beta_ri = [beta.re, beta.im];
                 // SAFETY: the slices provide valid contiguous column-major
@@ -229,6 +275,7 @@ macro_rules! impl_complex_blas_gemm {
                         m_i32,
                     );
                 }
+                Ok(())
             }
 
             unsafe fn strided_gemm(
@@ -246,13 +293,13 @@ macro_rules! impl_complex_blas_gemm {
                 c_ptr: *mut Self,
                 c_rs: isize,
                 c_cs: isize,
-            ) {
-                let m_i32 = dim_to_i32("m", m);
-                let n_i32 = dim_to_i32("n", n);
-                let k_i32 = dim_to_i32("k", k);
-                let (trans_a, lda) = infer_a_layout(m, k, a_rs, a_cs);
-                let (trans_b, ldb) = infer_b_layout(k, n, b_rs, b_cs);
-                let ldc = infer_c_layout(m, c_rs, c_cs);
+            ) -> crate::Result<()> {
+                let m_i32 = dim_to_i32("m", m)?;
+                let n_i32 = dim_to_i32("n", n)?;
+                let k_i32 = dim_to_i32("k", k)?;
+                let (trans_a, lda) = infer_a_layout(m, k, a_rs, a_cs)?;
+                let (trans_b, ldb) = infer_b_layout(k, n, b_rs, b_cs)?;
+                let ldc = infer_c_layout(m, c_rs, c_cs)?;
                 let alpha_ri = [alpha.re, alpha.im];
                 let beta_ri = [beta.re, beta.im];
 
@@ -275,6 +322,7 @@ macro_rules! impl_complex_blas_gemm {
                     c_ptr as *mut _,
                     ldc,
                 );
+                Ok(())
             }
         }
     };

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -475,7 +475,7 @@ where
     T: BlasGemm + PoolScalar + Copy + Clone + Zero + One,
 {
     validate_dot_general(lhs, rhs, config)?;
-    if let Some(result) = typed_blas_gemm(buffers, lhs, rhs, config) {
+    if let Some(result) = typed_blas_gemm(buffers, lhs, rhs, config)? {
         return Ok(result);
     }
     let (lhs_perm, rhs_perm, new_config) =
@@ -490,7 +490,7 @@ where
     } else {
         std::borrow::Cow::Owned(typed_transpose(rhs, &rhs_perm)?)
     };
-    typed_blas_gemm(buffers, &lhs_canon, &rhs_canon, &new_config).ok_or_else(|| {
+    typed_blas_gemm(buffers, &lhs_canon, &rhs_canon, &new_config)?.ok_or_else(|| {
         Error::BackendFailure {
             op: "dot_general",
             message: "CPU GEMM requires host-backed canonical inputs".into(),
@@ -504,18 +504,24 @@ fn typed_blas_gemm<T>(
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     config: &DotGeneralConfig,
-) -> Option<TypedTensor<T>>
+) -> crate::Result<Option<TypedTensor<T>>>
 where
     T: BlasGemm + PoolScalar + Copy + Clone + Zero + One,
 {
-    let dims = analyse_gemm(lhs, rhs, config)?;
-    let out_n = checked_product(&dims.out_shape)?;
+    let dims = match analyse_gemm(lhs, rhs, config) {
+        Some(dims) => dims,
+        None => return Ok(None),
+    };
+    let out_n = checked_product(&dims.out_shape).ok_or_else(|| Error::BackendFailure {
+        op: "dot_general",
+        message: "output element count overflow".into(),
+    })?;
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
-        return Some(TypedTensor {
+        return Ok(Some(TypedTensor {
             buffer: Buffer::Host(vec![T::zero(); out_n]),
             shape: dims.out_shape.into_vec(),
             placement: lhs.placement.clone(),
-        });
+        }));
     }
 
     let a_rs = normalize_singleton_stride(dims.a_rs, dims.m, dims.k);
@@ -529,18 +535,18 @@ where
     let b_ok = b_rs == 1 || b_cs == 1;
     let c_ok = c_rs == 1;
     if !a_ok || !b_ok || !c_ok {
-        return None;
+        return Ok(None);
     }
 
     let a_data = match &lhs.buffer {
         Buffer::Host(v) => v.as_ptr(),
-        Buffer::Backend(_) => return None,
+        Buffer::Backend(_) => return Ok(None),
         #[cfg(feature = "cubecl")]
         Buffer::Cubecl(_) => panic!("GPU tensor (Buffer::Cubecl) passed to CPU backend. Use cubecl::download_tensor() to transfer to CPU first."),
     };
     let b_data = match &rhs.buffer {
         Buffer::Host(v) => v.as_ptr(),
-        Buffer::Backend(_) => return None,
+        Buffer::Backend(_) => return Ok(None),
         #[cfg(feature = "cubecl")]
         Buffer::Cubecl(_) => panic!("GPU tensor (Buffer::Cubecl) passed to CPU backend. Use cubecl::download_tensor() to transfer to CPU first."),
     };
@@ -550,9 +556,21 @@ where
     let c_ptr = out.as_mut_ptr();
 
     for batch in 0..dims.batch_total {
-        let a_off = checked_batch_offset(batch, dims.a_bs)?;
-        let b_off = checked_batch_offset(batch, dims.b_bs)?;
-        let c_off = checked_batch_offset(batch, dims.c_bs)?;
+        let a_off =
+            checked_batch_offset(batch, dims.a_bs).ok_or_else(|| Error::BackendFailure {
+                op: "dot_general",
+                message: "lhs batch offset overflow".into(),
+            })?;
+        let b_off =
+            checked_batch_offset(batch, dims.b_bs).ok_or_else(|| Error::BackendFailure {
+                op: "dot_general",
+                message: "rhs batch offset overflow".into(),
+            })?;
+        let c_off =
+            checked_batch_offset(batch, dims.c_bs).ok_or_else(|| Error::BackendFailure {
+                op: "dot_general",
+                message: "output batch offset overflow".into(),
+            })?;
         unsafe {
             T::strided_gemm(
                 T::one(),
@@ -569,15 +587,15 @@ where
                 c_ptr.offset(c_off),
                 c_rs,
                 c_cs,
-            );
+            )?;
         }
     }
 
-    Some(TypedTensor {
+    Ok(Some(TypedTensor {
         buffer: Buffer::Host(out),
         shape: dims.out_shape.into_vec(),
         placement: lhs.placement.clone(),
-    })
+    }))
 }
 
 fn normalize_singleton_stride(stride: isize, extent: usize, fallback: usize) -> isize {

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -337,6 +337,29 @@ fn split_core_and_batch<'a, T>(
     split_shape_core_and_batch(&input.shape, core_rank, op)
 }
 
+fn matrix_core_and_batch<'a, T>(
+    input: &'a TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<(usize, usize, &'a [usize])> {
+    let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, op)?;
+    Ok((matrix_shape[0], matrix_shape[1], batch_shape))
+}
+
+fn square_core_and_batch<'a, T>(
+    input: &'a TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<(usize, &'a [usize])> {
+    let (rows, cols, batch_shape) = matrix_core_and_batch(input, op)?;
+    if rows != cols {
+        return Err(crate::Error::ShapeMismatch {
+            op,
+            lhs: vec![rows],
+            rhs: vec![cols],
+        });
+    }
+    Ok((rows, batch_shape))
+}
+
 fn transpose_col_major_data<T: Copy + PoolScalar>(
     buffers: &mut BufferPool,
     data: &[T],
@@ -1798,8 +1821,9 @@ pub(crate) fn cholesky<T: FaerLinalg>(
     input: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&input.shape) {
+        let (n, batch_shape) = square_core_and_batch(input, "cholesky")?;
         return Ok(tensor_from_vec_with_template(
-            input.shape.clone(),
+            matrix_with_batch_shape(n, n, batch_shape),
             Vec::new(),
             input,
         ));
@@ -1815,9 +1839,7 @@ pub(crate) fn lu<T: FaerLinalg>(
     input: &TypedTensor<T>,
 ) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "lu")?;
-        let m = matrix_shape[0];
-        let n = matrix_shape[1];
+        let (m, n, batch_shape) = matrix_core_and_batch(input, "lu")?;
         let k = m.min(n);
         let parity_elements = checked_product("lu", "batch shape", batch_shape)?;
         return Ok(vec![
@@ -1854,15 +1876,7 @@ pub(crate) fn full_piv_lu<T: FaerLinalg>(
     input: &TypedTensor<T>,
 ) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "full_piv_lu")?;
-        let n = matrix_shape[0];
-        if matrix_shape[1] != n {
-            return Err(crate::Error::ShapeMismatch {
-                op: "full_piv_lu",
-                lhs: vec![n],
-                rhs: vec![matrix_shape[1]],
-            });
-        }
+        let (n, batch_shape) = square_core_and_batch(input, "full_piv_lu")?;
         let parity_elements = checked_product("full_piv_lu", "batch shape", batch_shape)?;
         return Ok(vec![
             tensor_from_vec_with_template(
@@ -1905,8 +1919,15 @@ pub(crate) fn full_piv_lu_solve<T: FaerLinalg>(
     transpose_a: bool,
 ) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
-        let (_, a_batch_shape) = split_core_and_batch(a, 2, "full_piv_lu_solve")?;
-        let (_, b_batch_shape) = split_core_and_batch(b, 2, "full_piv_lu_solve")?;
+        let (n, a_batch_shape) = square_core_and_batch(a, "full_piv_lu_solve")?;
+        let (b_rows, _, b_batch_shape) = matrix_core_and_batch(b, "full_piv_lu_solve")?;
+        if b_rows != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "full_piv_lu_solve",
+                lhs: vec![n],
+                rhs: vec![b_rows],
+            });
+        }
         if a_batch_shape != b_batch_shape {
             return Err(crate::Error::ShapeMismatch {
                 op: "full_piv_lu_solve",
@@ -1936,8 +1957,16 @@ pub(crate) fn triangular_solve<T: FaerLinalg>(
     unit_diagonal: bool,
 ) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
-        let (_, a_batch_shape) = split_core_and_batch(a, 2, "triangular_solve")?;
-        let (_, b_batch_shape) = split_core_and_batch(b, 2, "triangular_solve")?;
+        let (n, a_batch_shape) = square_core_and_batch(a, "triangular_solve")?;
+        let (b_rows, b_cols, b_batch_shape) = matrix_core_and_batch(b, "triangular_solve")?;
+        let rhs_core_dim = if left_side { b_rows } else { b_cols };
+        if rhs_core_dim != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "triangular_solve",
+                lhs: vec![n],
+                rhs: vec![rhs_core_dim],
+            });
+        }
         if a_batch_shape != b_batch_shape {
             return Err(crate::Error::ShapeMismatch {
                 op: "triangular_solve",
@@ -1971,9 +2000,7 @@ pub(crate) fn svd<T: FaerLinalg>(
     input: &TypedTensor<T>,
 ) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "svd")?;
-        let m = matrix_shape[0];
-        let n = matrix_shape[1];
+        let (m, n, batch_shape) = matrix_core_and_batch(input, "svd")?;
         let k = m.min(n);
         return Ok(vec![
             tensor_from_vec_with_template(
@@ -2004,9 +2031,7 @@ pub(crate) fn qr<T: FaerLinalg>(
     input: &TypedTensor<T>,
 ) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "qr")?;
-        let m = matrix_shape[0];
-        let n = matrix_shape[1];
+        let (m, n, batch_shape) = matrix_core_and_batch(input, "qr")?;
         let k = m.min(n);
         return Ok(vec![
             tensor_from_vec_with_template(
@@ -2032,15 +2057,7 @@ pub(crate) fn eigh<T: FaerLinalg>(
     input: &TypedTensor<T>,
 ) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "eigh")?;
-        let n = matrix_shape[0];
-        if matrix_shape[1] != n {
-            return Err(crate::Error::ShapeMismatch {
-                op: "eigh",
-                lhs: vec![n],
-                rhs: vec![matrix_shape[1]],
-            });
-        }
+        let (n, batch_shape) = square_core_and_batch(input, "eigh")?;
         return Ok(vec![
             tensor_from_vec_with_template(
                 vector_with_batch_shape(n, batch_shape),
@@ -2179,7 +2196,10 @@ pub(crate) fn eig(
                 .collect(),
             )
         }
-        _ => todo!("eig: unsupported dtype"),
+        _ => Err(crate::Error::BackendFailure {
+            op: "eig",
+            message: format!("unsupported dtype {:?}", input.dtype()),
+        }),
     }
 }
 

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/cholesky.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/cholesky.rs
@@ -4,8 +4,9 @@ use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
 
 use super::helpers::{
-    batched_single, dim_i32, has_zero_dim, lower_triangle_from_lapack, panic_on_lapack_error,
-    square_matrix_dim, tensor_from_vec_with_template,
+    batched_single, check_lapack_info, dim_i32, has_zero_dim, lower_triangle_from_lapack,
+    matrix_with_batch_shape, square_core_and_batch_result, square_matrix_dim,
+    tensor_from_vec_with_template,
 };
 
 pub(crate) trait LapackCholesky: Clone + Copy + Default {
@@ -32,8 +33,8 @@ fn cholesky_2d<T: LapackCholesky>(
     _buffers: &mut BufferPool,
     input: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>> {
-    let n = square_matrix_dim(input, "cholesky");
-    let n_i32 = dim_i32(n, "cholesky");
+    let n = square_matrix_dim(input, "cholesky")?;
+    let n_i32 = dim_i32(n, "cholesky")?;
     let mut factor = input.host_data().to_vec();
     let mut info = 0;
     T::potrf(b'L', n_i32, &mut factor, n_i32, &mut info);
@@ -43,7 +44,7 @@ fn cholesky_2d<T: LapackCholesky>(
             message: "matrix is not positive definite".into(),
         });
     }
-    panic_on_lapack_error("cholesky", "dpotrf", info);
+    check_lapack_info("cholesky", "dpotrf", info)?;
     Ok(tensor_from_vec_with_template(
         vec![n, n],
         lower_triangle_from_lapack(&factor, n, n),
@@ -56,11 +57,12 @@ pub(crate) fn cholesky<T: LapackCholesky>(
     input: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&input.shape) {
+        let (n, batch_shape) = square_core_and_batch_result(input, "cholesky")?;
         return Ok(tensor_from_vec_with_template(
-            input.shape.clone(),
+            matrix_with_batch_shape(n, n, batch_shape),
             Vec::new(),
             input,
         ));
     }
-    batched_single(buffers, input, cholesky_2d)
+    batched_single("cholesky", buffers, input, cholesky_2d)
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/eig.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/eig.rs
@@ -4,7 +4,7 @@ use crate::buffer_pool::BufferPool;
 use crate::{Tensor, TypedTensor};
 
 use super::helpers::{
-    batched_multi_convert, dim_i32, has_zero_dim, panic_on_lapack_error, square_matrix_dim,
+    batched_multi_convert, check_lapack_info, dim_i32, has_zero_dim, square_matrix_dim,
     tensor_from_vec_with_template, work_len, zero_dim_eig_outputs,
 };
 
@@ -39,9 +39,12 @@ fn real_eig_to_complex_outputs(
     (vectors, values)
 }
 
-fn eig_real_2d(_buffers: &mut BufferPool, input: &TypedTensor<f64>) -> Vec<TypedTensor<Complex64>> {
-    let n = square_matrix_dim(input, "eig");
-    let n_i32 = dim_i32(n, "eig");
+fn eig_real_2d(
+    _buffers: &mut BufferPool,
+    input: &TypedTensor<f64>,
+) -> crate::Result<Vec<TypedTensor<Complex64>>> {
+    let n = square_matrix_dim(input, "eig")?;
+    let n_i32 = dim_i32(n, "eig")?;
     let mut a = input.host_data().to_vec();
     let mut values_re = vec![0.0; n];
     let mut values_im = vec![0.0; n];
@@ -67,8 +70,8 @@ fn eig_real_2d(_buffers: &mut BufferPool, input: &TypedTensor<f64>) -> Vec<Typed
             &mut info,
         );
     }
-    panic_on_lapack_error("eig", "dgeev(work query)", info);
-    let lwork = work_len(query[0], "eig", "dgeev");
+    check_lapack_info("eig", "dgeev(work query)", info)?;
+    let lwork = work_len(query[0], "eig", "dgeev")?;
     let mut work = vec![0.0; lwork as usize];
     unsafe {
         lapack::dgeev(
@@ -88,21 +91,21 @@ fn eig_real_2d(_buffers: &mut BufferPool, input: &TypedTensor<f64>) -> Vec<Typed
             &mut info,
         );
     }
-    panic_on_lapack_error("eig", "dgeev", info);
+    check_lapack_info("eig", "dgeev", info)?;
     let (vectors, values) = real_eig_to_complex_outputs(&vectors_real, &values_re, &values_im, n);
 
-    vec![
+    Ok(vec![
         tensor_from_vec_with_template(vec![n], values, input),
         tensor_from_vec_with_template(vec![n, n], vectors, input),
-    ]
+    ])
 }
 
 fn eig_complex_2d(
     _buffers: &mut BufferPool,
     input: &TypedTensor<Complex64>,
-) -> Vec<TypedTensor<Complex64>> {
-    let n = square_matrix_dim(input, "eig");
-    let n_i32 = dim_i32(n, "eig");
+) -> crate::Result<Vec<TypedTensor<Complex64>>> {
+    let n = square_matrix_dim(input, "eig")?;
+    let n_i32 = dim_i32(n, "eig")?;
     let mut a = input.host_data().to_vec();
     let mut values = vec![Complex64::new(0.0, 0.0); n];
     let mut vl = vec![Complex64::new(0.0, 0.0); 1];
@@ -128,8 +131,8 @@ fn eig_complex_2d(
             &mut info,
         );
     }
-    panic_on_lapack_error("eig", "zgeev(work query)", info);
-    let lwork = work_len(query[0].re, "eig", "zgeev");
+    check_lapack_info("eig", "zgeev(work query)", info)?;
+    let lwork = work_len(query[0].re, "eig", "zgeev")?;
     let mut work = vec![Complex64::new(0.0, 0.0); lwork as usize];
     unsafe {
         lapack::zgeev(
@@ -149,28 +152,31 @@ fn eig_complex_2d(
             &mut info,
         );
     }
-    panic_on_lapack_error("eig", "zgeev", info);
+    check_lapack_info("eig", "zgeev", info)?;
 
-    vec![
+    Ok(vec![
         tensor_from_vec_with_template(vec![n], values, input),
         tensor_from_vec_with_template(vec![n, n], vectors, input),
-    ]
+    ])
 }
 
-pub(crate) fn eig(buffers: &mut BufferPool, input: &Tensor) -> Vec<Tensor> {
+pub(crate) fn eig(buffers: &mut BufferPool, input: &Tensor) -> crate::Result<Vec<Tensor>> {
     if has_zero_dim(input.shape()) {
         return zero_dim_eig_outputs(input);
     }
 
     match input {
-        Tensor::F64(t) => batched_multi_convert(buffers, t, eig_real_2d)
+        Tensor::F64(t) => Ok(batched_multi_convert("eig", buffers, t, eig_real_2d)?
             .into_iter()
             .map(Tensor::C64)
-            .collect(),
-        Tensor::C64(t) => batched_multi_convert(buffers, t, eig_complex_2d)
+            .collect()),
+        Tensor::C64(t) => Ok(batched_multi_convert("eig", buffers, t, eig_complex_2d)?
             .into_iter()
             .map(Tensor::C64)
-            .collect(),
-        _ => panic!("eig: unsupported dtype"),
+            .collect()),
+        _ => Err(crate::Error::BackendFailure {
+            op: "eig",
+            message: format!("unsupported dtype {:?}", input.dtype()),
+        }),
     }
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/eigh.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/eigh.rs
@@ -4,18 +4,25 @@ use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
 
 use super::helpers::{
-    batched_multi, dim_i32, has_zero_dim, matrix_with_batch_shape, panic_on_lapack_error,
-    square_matrix_dim, tensor_from_vec_with_template, vector_with_batch_shape, work_len,
+    batched_multi, check_lapack_info, dim_i32, has_zero_dim, matrix_with_batch_shape,
+    square_core_and_batch_result, square_matrix_dim, tensor_from_vec_with_template,
+    vector_with_batch_shape, work_len,
 };
 
 pub(crate) trait LapackEigh: Clone + Copy + Default {
-    fn eigh_2d(buffers: &mut BufferPool, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>>;
+    fn eigh_2d(
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> crate::Result<Vec<TypedTensor<Self>>>;
 }
 
 impl LapackEigh for f64 {
-    fn eigh_2d(_buffers: &mut BufferPool, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
-        let n = square_matrix_dim(input, "eigh");
-        let n_i32 = dim_i32(n, "eigh");
+    fn eigh_2d(
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let n = square_matrix_dim(input, "eigh")?;
+        let n_i32 = dim_i32(n, "eigh")?;
         let mut vectors = input.host_data().to_vec();
         let mut values = vec![0.0; n];
         let mut query = vec![0.0; 1];
@@ -33,8 +40,8 @@ impl LapackEigh for f64 {
                 &mut info,
             );
         }
-        panic_on_lapack_error("eigh", "dsyev(work query)", info);
-        let lwork = work_len(query[0], "eigh", "dsyev");
+        check_lapack_info("eigh", "dsyev(work query)", info)?;
+        let lwork = work_len(query[0], "eigh", "dsyev")?;
         let mut work = vec![0.0; lwork as usize];
         unsafe {
             lapack::dsyev(
@@ -49,19 +56,22 @@ impl LapackEigh for f64 {
                 &mut info,
             );
         }
-        panic_on_lapack_error("eigh", "dsyev", info);
+        check_lapack_info("eigh", "dsyev", info)?;
 
-        vec![
+        Ok(vec![
             tensor_from_vec_with_template(vec![n], values, input),
             tensor_from_vec_with_template(vec![n, n], vectors, input),
-        ]
+        ])
     }
 }
 
 impl LapackEigh for Complex64 {
-    fn eigh_2d(_buffers: &mut BufferPool, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
-        let n = square_matrix_dim(input, "eigh");
-        let n_i32 = dim_i32(n, "eigh");
+    fn eigh_2d(
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let n = square_matrix_dim(input, "eigh")?;
+        let n_i32 = dim_i32(n, "eigh")?;
         let mut vectors = input.host_data().to_vec();
         let mut values = vec![0.0; n];
         let mut query = vec![Complex64::new(0.0, 0.0); 1];
@@ -81,8 +91,8 @@ impl LapackEigh for Complex64 {
                 &mut info,
             );
         }
-        panic_on_lapack_error("eigh", "zheev(work query)", info);
-        let lwork = work_len(query[0].re, "eigh", "zheev");
+        check_lapack_info("eigh", "zheev(work query)", info)?;
+        let lwork = work_len(query[0].re, "eigh", "zheev")?;
         let mut work = vec![Complex64::new(0.0, 0.0); lwork as usize];
         unsafe {
             lapack::zheev(
@@ -98,9 +108,9 @@ impl LapackEigh for Complex64 {
                 &mut info,
             );
         }
-        panic_on_lapack_error("eigh", "zheev", info);
+        check_lapack_info("eigh", "zheev", info)?;
 
-        vec![
+        Ok(vec![
             tensor_from_vec_with_template(
                 vec![n],
                 values
@@ -110,22 +120,24 @@ impl LapackEigh for Complex64 {
                 input,
             ),
             tensor_from_vec_with_template(vec![n, n], vectors, input),
-        ]
+        ])
     }
 }
 
-fn eigh_2d<T: LapackEigh>(buffers: &mut BufferPool, input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+fn eigh_2d<T: LapackEigh>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> crate::Result<Vec<TypedTensor<T>>> {
     T::eigh_2d(buffers, input)
 }
 
 pub(crate) fn eigh<T: LapackEigh>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
+) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let n = input.shape[0];
-        let batch_shape = &input.shape[2..];
-        return vec![
+        let (n, batch_shape) = square_core_and_batch_result(input, "eigh")?;
+        return Ok(vec![
             tensor_from_vec_with_template(
                 vector_with_batch_shape(n, batch_shape),
                 Vec::new(),
@@ -136,7 +148,7 @@ pub(crate) fn eigh<T: LapackEigh>(
                 Vec::new(),
                 input,
             ),
-        ];
+        ]);
     }
-    batched_multi(buffers, input, eigh_2d)
+    batched_multi("eigh", buffers, input, eigh_2d)
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -4,9 +4,10 @@ use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
 
 use super::helpers::{
-    batched_binary_result, dim_i32, has_zero_dim, leading_upper_triangle_from_lapack,
-    lower_triangle_from_lapack, matrix_dims, matrix_with_batch_shape, panic_on_lapack_error,
-    square_matrix_dim, tensor_from_vec_with_template, transpose_col_major_data,
+    batch_element_count, batched_binary_result, check_lapack_info, dim_i32, has_zero_dim,
+    leading_upper_triangle_from_lapack, lower_triangle_from_lapack, matrix_core_and_batch_result,
+    matrix_dims, matrix_with_batch_shape, square_core_and_batch_result, square_matrix_dim,
+    tensor_from_vec_with_template, transpose_col_major_data,
 };
 
 extern "C" {
@@ -208,18 +209,23 @@ impl LapackFullPivLu for Complex64 {
     }
 }
 
-fn permutation_from_lapack_pivots(pivots: &[i32], op: &str) -> Vec<usize> {
+fn permutation_from_lapack_pivots(pivots: &[i32], op: &'static str) -> crate::Result<Vec<usize>> {
     let mut permutation: Vec<usize> = (0..pivots.len()).collect();
     for (idx, &pivot_one_based) in pivots.iter().enumerate() {
         let pivot = match usize::try_from(pivot_one_based - 1) {
             Ok(pivot) if pivot < pivots.len() => pivot,
-            _ => panic!("{op}: LAPACK getc2 returned invalid pivot index"),
+            _ => {
+                return Err(crate::Error::BackendFailure {
+                    op,
+                    message: "LAPACK getc2 returned invalid pivot index".into(),
+                });
+            }
         };
         if pivot != idx {
             permutation.swap(idx, pivot);
         }
     }
-    permutation
+    Ok(permutation)
 }
 
 fn permutation_matrix<T: LapackFullPivLu>(permutation: &[usize]) -> Vec<T> {
@@ -235,26 +241,26 @@ fn factor_getc2<T: LapackFullPivLu>(
     op: &'static str,
     data: &mut [T],
     n: usize,
-) -> (Vec<i32>, Vec<i32>, i32) {
-    let n_i32 = dim_i32(n, op);
+) -> crate::Result<(Vec<i32>, Vec<i32>, i32)> {
+    let n_i32 = dim_i32(n, op)?;
     let mut ipiv = vec![0_i32; n];
     let mut jpiv = vec![0_i32; n];
     let mut info = 0;
     T::getc2(n_i32, data, n_i32, &mut ipiv, &mut jpiv, &mut info);
-    panic_on_lapack_error(op, "getc2", info.min(0));
-    (ipiv, jpiv, info)
+    check_lapack_info(op, "getc2", info.min(0))?;
+    Ok((ipiv, jpiv, info))
 }
 
 fn full_piv_lu_2d<T: LapackFullPivLu>(
     _buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
-    let n = square_matrix_dim(input, "full_piv_lu");
+) -> crate::Result<Vec<TypedTensor<T>>> {
+    let n = square_matrix_dim(input, "full_piv_lu")?;
     let mut lu = input.host_data().to_vec();
-    let (ipiv, jpiv, _info) = factor_getc2("full_piv_lu", &mut lu, n);
+    let (ipiv, jpiv, _info) = factor_getc2("full_piv_lu", &mut lu, n)?;
 
-    let row_perm = permutation_from_lapack_pivots(&ipiv, "full_piv_lu");
-    let col_perm = permutation_from_lapack_pivots(&jpiv, "full_piv_lu");
+    let row_perm = permutation_from_lapack_pivots(&ipiv, "full_piv_lu")?;
+    let col_perm = permutation_from_lapack_pivots(&jpiv, "full_piv_lu")?;
     let p_data = permutation_matrix::<T>(&row_perm);
     let q_data = permutation_matrix::<T>(&col_perm);
     let mut l_data = lower_triangle_from_lapack(&lu, n, n);
@@ -278,13 +284,13 @@ fn full_piv_lu_2d<T: LapackFullPivLu>(
         T::negative_one()
     };
 
-    vec![
+    Ok(vec![
         tensor_from_vec_with_template(vec![n, n], p_data, input),
         tensor_from_vec_with_template(vec![n, n], l_data, input),
         tensor_from_vec_with_template(vec![n, n], u_data, input),
         tensor_from_vec_with_template(vec![n, n], q_data, input),
         tensor_from_vec_with_template(vec![], vec![parity], input),
-    ]
+    ])
 }
 
 fn solve_2d<T: LapackFullPivLu>(
@@ -293,16 +299,22 @@ fn solve_2d<T: LapackFullPivLu>(
     b: &TypedTensor<T>,
     transpose_a: bool,
 ) -> crate::Result<TypedTensor<T>> {
-    let n = square_matrix_dim(a, "full_piv_lu_solve");
-    let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve");
-    assert_eq!(b_rows, n, "full_piv_lu_solve: rhs row count mismatch");
+    let n = square_matrix_dim(a, "full_piv_lu_solve")?;
+    let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve")?;
+    if b_rows != n {
+        return Err(crate::Error::ShapeMismatch {
+            op: "full_piv_lu_solve",
+            lhs: vec![n],
+            rhs: vec![b_rows],
+        });
+    }
 
     let mut lu = if transpose_a {
         transpose_col_major_data(a.host_data(), n, n)
     } else {
         a.host_data().to_vec()
     };
-    let (ipiv, jpiv, info) = factor_getc2("full_piv_lu_solve", &mut lu, n);
+    let (ipiv, jpiv, info) = factor_getc2("full_piv_lu_solve", &mut lu, n)?;
     if info > 0 {
         return Err(crate::Error::BackendFailure {
             op: "full_piv_lu_solve",
@@ -311,7 +323,7 @@ fn solve_2d<T: LapackFullPivLu>(
     }
 
     let mut rhs = b.host_data().to_vec();
-    let n_i32 = dim_i32(n, "full_piv_lu_solve");
+    let n_i32 = dim_i32(n, "full_piv_lu_solve")?;
     for col in 0..b_cols {
         let start = col * n;
         let end = start + n;
@@ -334,16 +346,11 @@ fn solve_2d<T: LapackFullPivLu>(
 pub(crate) fn full_piv_lu<T: LapackFullPivLu>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
+) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let n = input.shape[0];
-        let batch_shape = &input.shape[2..];
-        let parity_elements = if batch_shape.is_empty() {
-            1
-        } else {
-            batch_shape.iter().product()
-        };
-        return vec![
+        let (n, batch_shape) = square_core_and_batch_result(input, "full_piv_lu")?;
+        let parity_elements = batch_element_count("full_piv_lu", batch_shape)?;
+        return Ok(vec![
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
@@ -369,9 +376,9 @@ pub(crate) fn full_piv_lu<T: LapackFullPivLu>(
                 vec![T::one(); parity_elements],
                 input,
             ),
-        ];
+        ]);
     }
-    super::helpers::batched_multi(buffers, input, full_piv_lu_2d)
+    super::helpers::batched_multi("full_piv_lu", buffers, input, full_piv_lu_2d)
 }
 
 pub(crate) fn full_piv_lu_solve<T: LapackFullPivLu>(
@@ -381,6 +388,22 @@ pub(crate) fn full_piv_lu_solve<T: LapackFullPivLu>(
     transpose_a: bool,
 ) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
+        let (n, a_batch_shape) = square_core_and_batch_result(a, "full_piv_lu_solve")?;
+        let (b_rows, _, b_batch_shape) = matrix_core_and_batch_result(b, "full_piv_lu_solve")?;
+        if b_rows != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "full_piv_lu_solve",
+                lhs: vec![n],
+                rhs: vec![b_rows],
+            });
+        }
+        if a_batch_shape != b_batch_shape {
+            return Err(crate::Error::ShapeMismatch {
+                op: "full_piv_lu_solve",
+                lhs: a_batch_shape.to_vec(),
+                rhs: b_batch_shape.to_vec(),
+            });
+        }
         return Ok(tensor_from_vec_with_template(
             b.shape.clone(),
             Vec::new(),

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs
@@ -1,15 +1,33 @@
 use crate::buffer_pool::BufferPool;
 use crate::{Tensor, TypedTensor};
 
-pub(crate) fn matrix_dims<T>(input: &TypedTensor<T>, op: &str) -> (usize, usize) {
-    assert_eq!(input.shape.len(), 2, "{op}: expected a 2D matrix");
-    (input.shape[0], input.shape[1])
+pub(crate) fn matrix_dims<T>(
+    input: &TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<(usize, usize)> {
+    if input.shape.len() != 2 {
+        return Err(crate::Error::RankMismatch {
+            op,
+            expected: 2,
+            actual: input.shape.len(),
+        });
+    }
+    Ok((input.shape[0], input.shape[1]))
 }
 
-pub(crate) fn square_matrix_dim<T>(input: &TypedTensor<T>, op: &str) -> usize {
-    let (rows, cols) = matrix_dims(input, op);
-    assert_eq!(rows, cols, "{op}: expected a square matrix");
-    rows
+pub(crate) fn square_matrix_dim<T>(
+    input: &TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<usize> {
+    let (rows, cols) = matrix_dims(input, op)?;
+    if rows != cols {
+        return Err(crate::Error::ShapeMismatch {
+            op,
+            lhs: vec![rows],
+            rhs: vec![cols],
+        });
+    }
+    Ok(rows)
 }
 
 pub(crate) fn tensor_from_vec_with_template<T: Clone, U>(
@@ -22,18 +40,6 @@ pub(crate) fn tensor_from_vec_with_template<T: Clone, U>(
         shape,
         placement: template.placement.clone(),
     }
-}
-
-pub(crate) fn split_core_and_batch<'a, T>(
-    input: &'a TypedTensor<T>,
-    core_rank: usize,
-    op: &str,
-) -> (&'a [usize], &'a [usize]) {
-    assert!(
-        input.shape.len() >= core_rank,
-        "{op}: expected rank >= {core_rank}"
-    );
-    input.shape.split_at(core_rank)
 }
 
 pub(crate) fn split_core_and_batch_result<'a, T>(
@@ -49,6 +55,42 @@ pub(crate) fn split_core_and_batch_result<'a, T>(
         });
     }
     Ok(input.shape.split_at(core_rank))
+}
+
+pub(crate) fn matrix_core_and_batch_result<'a, T>(
+    input: &'a TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<(usize, usize, &'a [usize])> {
+    let (matrix_shape, batch_shape) = split_core_and_batch_result(input, 2, op)?;
+    Ok((matrix_shape[0], matrix_shape[1], batch_shape))
+}
+
+pub(crate) fn square_core_and_batch_result<'a, T>(
+    input: &'a TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<(usize, &'a [usize])> {
+    let (rows, cols, batch_shape) = matrix_core_and_batch_result(input, op)?;
+    if rows != cols {
+        return Err(crate::Error::ShapeMismatch {
+            op,
+            lhs: vec![rows],
+            rhs: vec![cols],
+        });
+    }
+    Ok((rows, batch_shape))
+}
+
+pub(crate) fn batch_element_count(op: &'static str, batch_shape: &[usize]) -> crate::Result<usize> {
+    if batch_shape.is_empty() {
+        return Ok(1);
+    }
+    batch_shape.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op,
+                message: "batch element count overflow".into(),
+            })
+    })
 }
 
 pub(crate) fn has_zero_dim(shape: &[usize]) -> bool {
@@ -71,31 +113,41 @@ pub(crate) fn vector_with_batch_shape(len: usize, batch_shape: &[usize]) -> Vec<
     shape
 }
 
-pub(crate) fn dim_i32(value: usize, op: &str) -> i32 {
-    match i32::try_from(value) {
-        Ok(value) => value,
-        Err(_) => panic!("{op}: dimension exceeds LAPACK i32 range"),
-    }
+pub(crate) fn dim_i32(value: usize, op: &'static str) -> crate::Result<i32> {
+    i32::try_from(value).map_err(|_| crate::Error::InvalidConfig {
+        op,
+        message: format!("dimension {value} exceeds LAPACK i32 range"),
+    })
 }
 
-pub(crate) fn work_len(query: f64, op: &str, routine: &str) -> i32 {
-    assert!(
-        query.is_finite() && query >= 1.0,
-        "{op}: LAPACK {routine} returned invalid workspace size {query}"
-    );
+pub(crate) fn work_len(query: f64, op: &'static str, routine: &'static str) -> crate::Result<i32> {
+    if !(query.is_finite() && query >= 1.0) {
+        return Err(crate::Error::BackendFailure {
+            op,
+            message: format!("LAPACK {routine} returned invalid workspace size {query}"),
+        });
+    }
     dim_i32(query.ceil() as usize, op)
 }
 
-pub(crate) fn panic_on_lapack_error(op: &str, routine: &str, info: i32) {
+pub(crate) fn check_lapack_info(
+    op: &'static str,
+    routine: &'static str,
+    info: i32,
+) -> crate::Result<()> {
     if info < 0 {
-        panic!(
-            "{op}: LAPACK {routine} argument {} had an illegal value",
-            -info
-        );
+        return Err(crate::Error::InvalidConfig {
+            op,
+            message: format!("LAPACK {routine} argument {} had an illegal value", -info),
+        });
     }
     if info > 0 {
-        panic!("{op}: LAPACK {routine} failed with info {info}");
+        return Err(crate::Error::BackendFailure {
+            op,
+            message: format!("LAPACK {routine} failed with info {info}"),
+        });
     }
+    Ok(())
 }
 
 pub(crate) fn lower_triangle_from_lapack<T: Copy + Default>(
@@ -138,6 +190,7 @@ pub(crate) fn transpose_col_major_data<T: Copy>(data: &[T], rows: usize, cols: u
 }
 
 pub(crate) fn batched_single<T, F>(
+    op_name: &'static str,
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
     op: F,
@@ -146,17 +199,19 @@ where
     T: Clone,
     F: Fn(&mut BufferPool, &TypedTensor<T>) -> crate::Result<TypedTensor<T>>,
 {
-    let (core_shape, batch_shape) = split_core_and_batch(input, 2, "batched_single");
+    let (core_shape, batch_shape) = split_core_and_batch_result(input, 2, op_name)?;
     if batch_shape.is_empty() {
         return op(buffers, input);
     }
 
     let slice_size: usize = core_shape.iter().product();
     let batch_count: usize = batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_single: zero-sized batch dims are unsupported"
-    );
+    if batch_count == 0 {
+        return Err(crate::Error::InvalidConfig {
+            op: op_name,
+            message: "zero-sized batch dims must be handled by the caller".into(),
+        });
+    }
 
     let mut out_core_shape: Option<Vec<usize>> = None;
     let mut out_data: Option<Vec<T>> = None;
@@ -172,11 +227,13 @@ where
         let batch_output = op(buffers, &batch_input)?;
 
         if let Some(expected_shape) = &out_core_shape {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                expected_shape.as_slice(),
-                "batched_single: output core shape mismatch across batches"
-            );
+            if batch_output.shape.as_slice() != expected_shape.as_slice() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: op_name,
+                    lhs: batch_output.shape.clone(),
+                    rhs: expected_shape.clone(),
+                });
+            }
         } else {
             out_data = Some(Vec::with_capacity(batch_output.n_elements() * batch_count));
             out_core_shape = Some(batch_output.shape.clone());
@@ -184,45 +241,50 @@ where
 
         match &mut out_data {
             Some(data) => data.extend_from_slice(batch_output.host_data()),
-            None => panic!("batched_single: missing output buffer"),
+            None => {
+                return Err(crate::Error::InvalidConfig {
+                    op: op_name,
+                    message: "missing output buffer after first batch".into(),
+                });
+            }
         }
     }
 
-    let mut out_shape = match out_core_shape {
-        Some(shape) => shape,
-        None => panic!("batched_single: missing output shape"),
-    };
+    let mut out_shape = out_core_shape.ok_or_else(|| crate::Error::InvalidConfig {
+        op: op_name,
+        message: "missing output shape".into(),
+    })?;
     out_shape.extend_from_slice(batch_shape);
-    Ok(tensor_from_vec_with_template(
-        out_shape,
-        match out_data {
-            Some(data) => data,
-            None => panic!("batched_single: missing output data"),
-        },
-        input,
-    ))
+    let out_data = out_data.ok_or_else(|| crate::Error::InvalidConfig {
+        op: op_name,
+        message: "missing output data".into(),
+    })?;
+    Ok(tensor_from_vec_with_template(out_shape, out_data, input))
 }
 
 pub(crate) fn batched_multi<T, F>(
+    op_name: &'static str,
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
     op: F,
-) -> Vec<TypedTensor<T>>
+) -> crate::Result<Vec<TypedTensor<T>>>
 where
     T: Clone,
-    F: Fn(&mut BufferPool, &TypedTensor<T>) -> Vec<TypedTensor<T>>,
+    F: Fn(&mut BufferPool, &TypedTensor<T>) -> crate::Result<Vec<TypedTensor<T>>>,
 {
-    let (core_shape, batch_shape) = split_core_and_batch(input, 2, "batched_multi");
+    let (core_shape, batch_shape) = split_core_and_batch_result(input, 2, op_name)?;
     if batch_shape.is_empty() {
         return op(buffers, input);
     }
 
     let slice_size: usize = core_shape.iter().product();
     let batch_count: usize = batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_multi: zero-sized batch dims are unsupported"
-    );
+    if batch_count == 0 {
+        return Err(crate::Error::InvalidConfig {
+            op: op_name,
+            message: "zero-sized batch dims must be handled by the caller".into(),
+        });
+    }
 
     let mut out_shapes: Vec<Vec<usize>> = Vec::new();
     let mut out_data: Vec<Vec<T>> = Vec::new();
@@ -235,9 +297,15 @@ where
             input.host_data()[start..end].to_vec(),
             input,
         );
-        let batch_outputs = op(buffers, &batch_input);
+        let batch_outputs = op(buffers, &batch_input)?;
 
         if out_shapes.is_empty() {
+            if batch_outputs.is_empty() {
+                return Err(crate::Error::InvalidConfig {
+                    op: op_name,
+                    message: "missing outputs for first batch".into(),
+                });
+            }
             out_shapes = batch_outputs
                 .iter()
                 .map(|tensor| tensor.shape.clone())
@@ -247,52 +315,62 @@ where
                 .map(|tensor| Vec::with_capacity(tensor.n_elements() * batch_count))
                 .collect();
         } else {
-            assert_eq!(
-                batch_outputs.len(),
-                out_shapes.len(),
-                "batched_multi: output count mismatch across batches"
-            );
+            if batch_outputs.len() != out_shapes.len() {
+                return Err(crate::Error::InvalidConfig {
+                    op: op_name,
+                    message: format!(
+                        "output count mismatch across batches: got {}, expected {}",
+                        batch_outputs.len(),
+                        out_shapes.len()
+                    ),
+                });
+            }
         }
 
         for (idx, batch_output) in batch_outputs.iter().enumerate() {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                out_shapes[idx].as_slice(),
-                "batched_multi: output core shape mismatch across batches"
-            );
+            if batch_output.shape.as_slice() != out_shapes[idx].as_slice() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: op_name,
+                    lhs: batch_output.shape.clone(),
+                    rhs: out_shapes[idx].clone(),
+                });
+            }
             out_data[idx].extend_from_slice(batch_output.host_data());
         }
     }
 
-    out_shapes
+    Ok(out_shapes
         .into_iter()
         .zip(out_data)
         .map(|(mut out_shape, out_data)| {
             out_shape.extend_from_slice(batch_shape);
             tensor_from_vec_with_template(out_shape, out_data, input)
         })
-        .collect()
+        .collect())
 }
 
 pub(crate) fn batched_multi_convert<InT: Clone, OutT: Clone, F>(
+    op_name: &'static str,
     buffers: &mut BufferPool,
     input: &TypedTensor<InT>,
     op: F,
-) -> Vec<TypedTensor<OutT>>
+) -> crate::Result<Vec<TypedTensor<OutT>>>
 where
-    F: Fn(&mut BufferPool, &TypedTensor<InT>) -> Vec<TypedTensor<OutT>>,
+    F: Fn(&mut BufferPool, &TypedTensor<InT>) -> crate::Result<Vec<TypedTensor<OutT>>>,
 {
-    let (core_shape, batch_shape) = split_core_and_batch(input, 2, "batched_multi");
+    let (core_shape, batch_shape) = split_core_and_batch_result(input, 2, op_name)?;
     if batch_shape.is_empty() {
         return op(buffers, input);
     }
 
     let slice_size: usize = core_shape.iter().product();
     let batch_count: usize = batch_shape.iter().product();
-    assert!(
-        batch_count > 0,
-        "batched_multi: zero-sized batch dims are unsupported"
-    );
+    if batch_count == 0 {
+        return Err(crate::Error::InvalidConfig {
+            op: op_name,
+            message: "zero-sized batch dims must be handled by the caller".into(),
+        });
+    }
 
     let mut out_shapes: Vec<Vec<usize>> = Vec::new();
     let mut out_data: Vec<Vec<OutT>> = Vec::new();
@@ -305,9 +383,15 @@ where
             input.host_data()[start..end].to_vec(),
             input,
         );
-        let batch_outputs = op(buffers, &batch_input);
+        let batch_outputs = op(buffers, &batch_input)?;
 
         if out_shapes.is_empty() {
+            if batch_outputs.is_empty() {
+                return Err(crate::Error::InvalidConfig {
+                    op: op_name,
+                    message: "missing outputs for first batch".into(),
+                });
+            }
             out_shapes = batch_outputs
                 .iter()
                 .map(|tensor| tensor.shape.clone())
@@ -317,31 +401,38 @@ where
                 .map(|tensor| Vec::with_capacity(tensor.n_elements() * batch_count))
                 .collect();
         } else {
-            assert_eq!(
-                batch_outputs.len(),
-                out_shapes.len(),
-                "batched_multi: output count mismatch across batches"
-            );
+            if batch_outputs.len() != out_shapes.len() {
+                return Err(crate::Error::InvalidConfig {
+                    op: op_name,
+                    message: format!(
+                        "output count mismatch across batches: got {}, expected {}",
+                        batch_outputs.len(),
+                        out_shapes.len()
+                    ),
+                });
+            }
         }
 
         for (idx, batch_output) in batch_outputs.iter().enumerate() {
-            assert_eq!(
-                batch_output.shape.as_slice(),
-                out_shapes[idx].as_slice(),
-                "batched_multi: output core shape mismatch across batches"
-            );
+            if batch_output.shape.as_slice() != out_shapes[idx].as_slice() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: op_name,
+                    lhs: batch_output.shape.clone(),
+                    rhs: out_shapes[idx].clone(),
+                });
+            }
             out_data[idx].extend_from_slice(batch_output.host_data());
         }
     }
 
-    out_shapes
+    Ok(out_shapes
         .into_iter()
         .zip(out_data)
         .map(|(mut out_shape, out_data)| {
             out_shape.extend_from_slice(batch_shape);
             tensor_from_vec_with_template(out_shape, out_data, input)
         })
-        .collect()
+        .collect())
 }
 
 pub(crate) fn batched_binary_result<T, F>(
@@ -436,10 +527,25 @@ where
     Ok(tensor_from_vec_with_template(out_shape, out_data, b))
 }
 
-pub(crate) fn zero_dim_eig_outputs(input: &Tensor) -> Vec<Tensor> {
-    let n = input.shape()[0];
-    let batch_shape = &input.shape()[2..];
-    vec![
+pub(crate) fn zero_dim_eig_outputs(input: &Tensor) -> crate::Result<Vec<Tensor>> {
+    let shape = input.shape();
+    if shape.len() < 2 {
+        return Err(crate::Error::RankMismatch {
+            op: "eig",
+            expected: 2,
+            actual: shape.len(),
+        });
+    }
+    let n = shape[0];
+    if shape[1] != n {
+        return Err(crate::Error::ShapeMismatch {
+            op: "eig",
+            lhs: vec![n],
+            rhs: vec![shape[1]],
+        });
+    }
+    let batch_shape = &shape[2..];
+    Ok(vec![
         Tensor::C64(TypedTensor::from_vec(
             vector_with_batch_shape(n, batch_shape),
             Vec::new(),
@@ -448,5 +554,5 @@ pub(crate) fn zero_dim_eig_outputs(input: &Tensor) -> Vec<Tensor> {
             matrix_with_batch_shape(n, n, batch_shape),
             Vec::new(),
         )),
-    ]
+    ])
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/lu.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/lu.rs
@@ -4,8 +4,9 @@ use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
 
 use super::helpers::{
-    batched_multi, dim_i32, has_zero_dim, leading_upper_triangle_from_lapack, matrix_dims,
-    matrix_with_batch_shape, panic_on_lapack_error, tensor_from_vec_with_template,
+    batch_element_count, batched_multi, check_lapack_info, dim_i32, has_zero_dim,
+    leading_upper_triangle_from_lapack, matrix_core_and_batch_result, matrix_dims,
+    matrix_with_batch_shape, tensor_from_vec_with_template,
 };
 
 pub(crate) trait LapackLu: Clone + Copy + Default {
@@ -46,24 +47,38 @@ impl LapackLu for Complex64 {
     }
 }
 
-fn lu_2d<T: LapackLu>(_buffers: &mut BufferPool, input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
-    let (m, n) = matrix_dims(input, "lu");
+fn lu_2d<T: LapackLu>(
+    _buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> crate::Result<Vec<TypedTensor<T>>> {
+    let (m, n) = matrix_dims(input, "lu")?;
     let k = m.min(n);
-    let m_i32 = dim_i32(m, "lu");
-    let n_i32 = dim_i32(n, "lu");
+    let m_i32 = dim_i32(m, "lu")?;
+    let n_i32 = dim_i32(n, "lu")?;
     let mut lu = input.host_data().to_vec();
     let mut ipiv = vec![0_i32; k];
     let mut info = 0;
     T::getrf(m_i32, n_i32, &mut lu, m_i32, &mut ipiv, &mut info);
-    panic_on_lapack_error("lu", "dgetrf", info.min(0));
+    check_lapack_info("lu", "getrf", info.min(0))?;
 
     let mut permutation: Vec<usize> = (0..m).collect();
     let mut swap_count = 0usize;
     for (idx, &pivot_one_based) in ipiv.iter().enumerate() {
         let pivot = match usize::try_from(pivot_one_based - 1) {
             Ok(pivot) => pivot,
-            Err(_) => panic!("lu: LAPACK dgetrf returned invalid pivot index"),
+            Err(_) => {
+                return Err(crate::Error::BackendFailure {
+                    op: "lu",
+                    message: "LAPACK getrf returned invalid pivot index".into(),
+                });
+            }
         };
+        if pivot >= m {
+            return Err(crate::Error::BackendFailure {
+                op: "lu",
+                message: "LAPACK getrf returned out-of-bounds pivot index".into(),
+            });
+        }
         if pivot != idx {
             permutation.swap(idx, pivot);
             swap_count += 1;
@@ -89,29 +104,23 @@ fn lu_2d<T: LapackLu>(_buffers: &mut BufferPool, input: &TypedTensor<T>) -> Vec<
     }
     let u_data = leading_upper_triangle_from_lapack(&lu, m, k, n);
 
-    vec![
+    Ok(vec![
         tensor_from_vec_with_template(vec![m, m], p_data, input),
         tensor_from_vec_with_template(vec![m, k], l_data, input),
         tensor_from_vec_with_template(vec![k, n], u_data, input),
         tensor_from_vec_with_template(vec![], vec![parity], input),
-    ]
+    ])
 }
 
 pub(crate) fn lu<T: LapackLu>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
+) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let m = input.shape[0];
-        let n = input.shape[1];
+        let (m, n, batch_shape) = matrix_core_and_batch_result(input, "lu")?;
         let k = m.min(n);
-        let batch_shape = &input.shape[2..];
-        let parity_elements = if batch_shape.is_empty() {
-            1
-        } else {
-            batch_shape.iter().product()
-        };
-        return vec![
+        let parity_elements = batch_element_count("lu", batch_shape)?;
+        return Ok(vec![
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, m, batch_shape),
                 Vec::new(),
@@ -132,7 +141,7 @@ pub(crate) fn lu<T: LapackLu>(
                 vec![T::one(); parity_elements],
                 input,
             ),
-        ];
+        ]);
     }
-    batched_multi(buffers, input, lu_2d)
+    batched_multi("lu", buffers, input, lu_2d)
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/qr.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/qr.rs
@@ -4,22 +4,28 @@ use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
 
 use super::helpers::{
-    batched_multi, dim_i32, has_zero_dim, leading_upper_triangle_from_lapack, matrix_dims,
-    matrix_with_batch_shape, panic_on_lapack_error, split_core_and_batch,
+    batched_multi, check_lapack_info, dim_i32, has_zero_dim, leading_upper_triangle_from_lapack,
+    matrix_dims, matrix_with_batch_shape, split_core_and_batch_result,
     tensor_from_vec_with_template, work_len,
 };
 
 pub(crate) trait LapackQr: Clone + Copy + Default {
-    fn qr_2d(buffers: &mut BufferPool, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>>;
+    fn qr_2d(
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> crate::Result<Vec<TypedTensor<Self>>>;
 }
 
 impl LapackQr for f64 {
-    fn qr_2d(_buffers: &mut BufferPool, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
-        let (m, n) = matrix_dims(input, "qr");
+    fn qr_2d(
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let (m, n) = matrix_dims(input, "qr")?;
         let k = m.min(n);
-        let m_i32 = dim_i32(m, "qr");
-        let n_i32 = dim_i32(n, "qr");
-        let k_i32 = dim_i32(k, "qr");
+        let m_i32 = dim_i32(m, "qr")?;
+        let n_i32 = dim_i32(n, "qr")?;
+        let k_i32 = dim_i32(k, "qr")?;
 
         let mut qr = input.host_data().to_vec();
         let mut tau = vec![0.0; k];
@@ -30,15 +36,15 @@ impl LapackQr for f64 {
                 m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut query, -1, &mut info,
             );
         }
-        panic_on_lapack_error("qr", "dgeqrf(work query)", info);
-        let lwork = work_len(query[0], "qr", "dgeqrf");
+        check_lapack_info("qr", "dgeqrf(work query)", info)?;
+        let lwork = work_len(query[0], "qr", "dgeqrf")?;
         let mut work = vec![0.0; lwork as usize];
         unsafe {
             lapack::dgeqrf(
                 m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut work, lwork, &mut info,
             );
         }
-        panic_on_lapack_error("qr", "dgeqrf", info);
+        check_lapack_info("qr", "dgeqrf", info)?;
 
         let r = leading_upper_triangle_from_lapack(&qr, m, k, n);
         let mut q = Vec::with_capacity(m * k);
@@ -53,30 +59,33 @@ impl LapackQr for f64 {
                 m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut query, -1, &mut info,
             );
         }
-        panic_on_lapack_error("qr", "dorgqr(work query)", info);
-        let lwork = work_len(query[0], "qr", "dorgqr");
+        check_lapack_info("qr", "dorgqr(work query)", info)?;
+        let lwork = work_len(query[0], "qr", "dorgqr")?;
         let mut work = vec![0.0; lwork as usize];
         unsafe {
             lapack::dorgqr(
                 m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut work, lwork, &mut info,
             );
         }
-        panic_on_lapack_error("qr", "dorgqr", info);
+        check_lapack_info("qr", "dorgqr", info)?;
 
-        vec![
+        Ok(vec![
             tensor_from_vec_with_template(vec![m, k], q, input),
             tensor_from_vec_with_template(vec![k, n], r, input),
-        ]
+        ])
     }
 }
 
 impl LapackQr for Complex64 {
-    fn qr_2d(_buffers: &mut BufferPool, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
-        let (m, n) = matrix_dims(input, "qr");
+    fn qr_2d(
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let (m, n) = matrix_dims(input, "qr")?;
         let k = m.min(n);
-        let m_i32 = dim_i32(m, "qr");
-        let n_i32 = dim_i32(n, "qr");
-        let k_i32 = dim_i32(k, "qr");
+        let m_i32 = dim_i32(m, "qr")?;
+        let n_i32 = dim_i32(n, "qr")?;
+        let k_i32 = dim_i32(k, "qr")?;
 
         let mut qr = input.host_data().to_vec();
         let mut tau = vec![Complex64::new(0.0, 0.0); k];
@@ -87,15 +96,15 @@ impl LapackQr for Complex64 {
                 m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut query, -1, &mut info,
             );
         }
-        panic_on_lapack_error("qr", "zgeqrf(work query)", info);
-        let lwork = work_len(query[0].re, "qr", "zgeqrf");
+        check_lapack_info("qr", "zgeqrf(work query)", info)?;
+        let lwork = work_len(query[0].re, "qr", "zgeqrf")?;
         let mut work = vec![Complex64::new(0.0, 0.0); lwork as usize];
         unsafe {
             lapack::zgeqrf(
                 m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut work, lwork, &mut info,
             );
         }
-        panic_on_lapack_error("qr", "zgeqrf", info);
+        check_lapack_info("qr", "zgeqrf", info)?;
 
         let r = leading_upper_triangle_from_lapack(&qr, m, k, n);
         let mut q = Vec::with_capacity(m * k);
@@ -110,37 +119,40 @@ impl LapackQr for Complex64 {
                 m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut query, -1, &mut info,
             );
         }
-        panic_on_lapack_error("qr", "zungqr(work query)", info);
-        let lwork = work_len(query[0].re, "qr", "zungqr");
+        check_lapack_info("qr", "zungqr(work query)", info)?;
+        let lwork = work_len(query[0].re, "qr", "zungqr")?;
         let mut work = vec![Complex64::new(0.0, 0.0); lwork as usize];
         unsafe {
             lapack::zungqr(
                 m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut work, lwork, &mut info,
             );
         }
-        panic_on_lapack_error("qr", "zungqr", info);
+        check_lapack_info("qr", "zungqr", info)?;
 
-        vec![
+        Ok(vec![
             tensor_from_vec_with_template(vec![m, k], q, input),
             tensor_from_vec_with_template(vec![k, n], r, input),
-        ]
+        ])
     }
 }
 
-fn qr_2d<T: LapackQr>(buffers: &mut BufferPool, input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+fn qr_2d<T: LapackQr>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> crate::Result<Vec<TypedTensor<T>>> {
     T::qr_2d(buffers, input)
 }
 
 pub(crate) fn qr<T: LapackQr>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
+) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "qr");
+        let (matrix_shape, batch_shape) = split_core_and_batch_result(input, 2, "qr")?;
         let m = matrix_shape[0];
         let n = matrix_shape[1];
         let k = m.min(n);
-        return vec![
+        return Ok(vec![
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
@@ -151,7 +163,7 @@ pub(crate) fn qr<T: LapackQr>(
                 Vec::new(),
                 input,
             ),
-        ];
+        ]);
     }
-    batched_multi(buffers, input, qr_2d)
+    batched_multi("qr", buffers, input, qr_2d)
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/svd.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/svd.rs
@@ -4,22 +4,27 @@ use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
 
 use super::helpers::{
-    batched_multi, dim_i32, has_zero_dim, matrix_dims, matrix_with_batch_shape,
-    panic_on_lapack_error, split_core_and_batch, tensor_from_vec_with_template,
-    vector_with_batch_shape, work_len,
+    batched_multi, check_lapack_info, dim_i32, has_zero_dim, matrix_dims, matrix_with_batch_shape,
+    split_core_and_batch_result, tensor_from_vec_with_template, vector_with_batch_shape, work_len,
 };
 
 pub(crate) trait LapackSvd: Clone + Copy + Default {
-    fn svd_2d(buffers: &mut BufferPool, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>>;
+    fn svd_2d(
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> crate::Result<Vec<TypedTensor<Self>>>;
 }
 
 impl LapackSvd for f64 {
-    fn svd_2d(_buffers: &mut BufferPool, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
-        let (m, n) = matrix_dims(input, "svd");
+    fn svd_2d(
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let (m, n) = matrix_dims(input, "svd")?;
         let k = m.min(n);
-        let m_i32 = dim_i32(m, "svd");
-        let n_i32 = dim_i32(n, "svd");
-        let k_i32 = dim_i32(k, "svd");
+        let m_i32 = dim_i32(m, "svd")?;
+        let n_i32 = dim_i32(n, "svd")?;
+        let k_i32 = dim_i32(k, "svd")?;
 
         let mut a = input.host_data().to_vec();
         let mut s = vec![0.0; k];
@@ -33,8 +38,8 @@ impl LapackSvd for f64 {
                 &mut query, -1, &mut info,
             );
         }
-        panic_on_lapack_error("svd", "dgesvd(work query)", info);
-        let lwork = work_len(query[0], "svd", "dgesvd");
+        check_lapack_info("svd", "dgesvd(work query)", info)?;
+        let lwork = work_len(query[0], "svd", "dgesvd")?;
         let mut work = vec![0.0; lwork as usize];
         unsafe {
             lapack::dgesvd(
@@ -42,23 +47,26 @@ impl LapackSvd for f64 {
                 &mut work, lwork, &mut info,
             );
         }
-        panic_on_lapack_error("svd", "dgesvd", info);
+        check_lapack_info("svd", "dgesvd", info)?;
 
-        vec![
+        Ok(vec![
             tensor_from_vec_with_template(vec![m, k], u, input),
             tensor_from_vec_with_template(vec![k], s, input),
             tensor_from_vec_with_template(vec![k, n], vt, input),
-        ]
+        ])
     }
 }
 
 impl LapackSvd for Complex64 {
-    fn svd_2d(_buffers: &mut BufferPool, input: &TypedTensor<Self>) -> Vec<TypedTensor<Self>> {
-        let (m, n) = matrix_dims(input, "svd");
+    fn svd_2d(
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> crate::Result<Vec<TypedTensor<Self>>> {
+        let (m, n) = matrix_dims(input, "svd")?;
         let k = m.min(n);
-        let m_i32 = dim_i32(m, "svd");
-        let n_i32 = dim_i32(n, "svd");
-        let k_i32 = dim_i32(k, "svd");
+        let m_i32 = dim_i32(m, "svd")?;
+        let n_i32 = dim_i32(n, "svd")?;
+        let k_i32 = dim_i32(k, "svd")?;
 
         let mut a = input.host_data().to_vec();
         let mut s = vec![0.0; k];
@@ -73,8 +81,8 @@ impl LapackSvd for Complex64 {
                 &mut query, -1, &mut rwork, &mut info,
             );
         }
-        panic_on_lapack_error("svd", "zgesvd(work query)", info);
-        let lwork = work_len(query[0].re, "svd", "zgesvd");
+        check_lapack_info("svd", "zgesvd(work query)", info)?;
+        let lwork = work_len(query[0].re, "svd", "zgesvd")?;
         let mut work = vec![Complex64::new(0.0, 0.0); lwork as usize];
         unsafe {
             lapack::zgesvd(
@@ -82,9 +90,9 @@ impl LapackSvd for Complex64 {
                 &mut work, lwork, &mut rwork, &mut info,
             );
         }
-        panic_on_lapack_error("svd", "zgesvd", info);
+        check_lapack_info("svd", "zgesvd", info)?;
 
-        vec![
+        Ok(vec![
             tensor_from_vec_with_template(vec![m, k], u, input),
             tensor_from_vec_with_template(
                 vec![k],
@@ -94,24 +102,27 @@ impl LapackSvd for Complex64 {
                 input,
             ),
             tensor_from_vec_with_template(vec![k, n], vt, input),
-        ]
+        ])
     }
 }
 
-fn svd_2d<T: LapackSvd>(buffers: &mut BufferPool, input: &TypedTensor<T>) -> Vec<TypedTensor<T>> {
+fn svd_2d<T: LapackSvd>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> crate::Result<Vec<TypedTensor<T>>> {
     T::svd_2d(buffers, input)
 }
 
 pub(crate) fn svd<T: LapackSvd>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
-) -> Vec<TypedTensor<T>> {
+) -> crate::Result<Vec<TypedTensor<T>>> {
     if has_zero_dim(&input.shape) {
-        let (matrix_shape, batch_shape) = split_core_and_batch(input, 2, "svd");
+        let (matrix_shape, batch_shape) = split_core_and_batch_result(input, 2, "svd")?;
         let m = matrix_shape[0];
         let n = matrix_shape[1];
         let k = m.min(n);
-        return vec![
+        return Ok(vec![
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
@@ -127,7 +138,7 @@ pub(crate) fn svd<T: LapackSvd>(
                 Vec::new(),
                 input,
             ),
-        ];
+        ]);
     }
-    batched_multi(buffers, input, svd_2d)
+    batched_multi("svd", buffers, input, svd_2d)
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/triangular_solve.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/triangular_solve.rs
@@ -4,8 +4,9 @@ use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
 
 use super::helpers::{
-    batched_binary_result, dim_i32, has_zero_dim, matrix_dims, panic_on_lapack_error,
-    square_matrix_dim, tensor_from_vec_with_template, transpose_col_major_data,
+    batched_binary_result, check_lapack_info, dim_i32, has_zero_dim, matrix_core_and_batch_result,
+    matrix_dims, square_core_and_batch_result, square_matrix_dim, tensor_from_vec_with_template,
+    transpose_col_major_data,
 };
 
 pub(crate) trait LapackTriangularSolve: Clone + Copy {
@@ -68,8 +69,8 @@ fn solve_left<T: LapackTriangularSolve>(
     transpose_a: bool,
     unit_diagonal: bool,
 ) -> crate::Result<TypedTensor<T>> {
-    let n = square_matrix_dim(a, "triangular_solve");
-    let (b_rows, b_cols) = matrix_dims(b, "triangular_solve");
+    let n = square_matrix_dim(a, "triangular_solve")?;
+    let (b_rows, b_cols) = matrix_dims(b, "triangular_solve")?;
     if b_rows != n {
         return Err(crate::Error::ShapeMismatch {
             op: "triangular_solve",
@@ -84,15 +85,15 @@ fn solve_left<T: LapackTriangularSolve>(
         if lower { b'L' } else { b'U' },
         if transpose_a { b'T' } else { b'N' },
         if unit_diagonal { b'U' } else { b'N' },
-        dim_i32(n, "triangular_solve"),
-        dim_i32(b_cols, "triangular_solve"),
+        dim_i32(n, "triangular_solve")?,
+        dim_i32(b_cols, "triangular_solve")?,
         a.host_data(),
-        dim_i32(n, "triangular_solve"),
+        dim_i32(n, "triangular_solve")?,
         &mut rhs,
-        dim_i32(n, "triangular_solve"),
+        dim_i32(n, "triangular_solve")?,
         &mut info,
     );
-    panic_on_lapack_error("triangular_solve", "dtrtrs", info);
+    check_lapack_info("triangular_solve", "trtrs", info)?;
     Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs, b))
 }
 
@@ -103,8 +104,8 @@ fn solve_right<T: LapackTriangularSolve>(
     transpose_a: bool,
     unit_diagonal: bool,
 ) -> crate::Result<TypedTensor<T>> {
-    let n = square_matrix_dim(a, "triangular_solve");
-    let (b_rows, b_cols) = matrix_dims(b, "triangular_solve");
+    let n = square_matrix_dim(a, "triangular_solve")?;
+    let (b_rows, b_cols) = matrix_dims(b, "triangular_solve")?;
     if b_cols != n {
         return Err(crate::Error::ShapeMismatch {
             op: "triangular_solve",
@@ -119,15 +120,15 @@ fn solve_right<T: LapackTriangularSolve>(
         if lower { b'L' } else { b'U' },
         if transpose_a { b'N' } else { b'T' },
         if unit_diagonal { b'U' } else { b'N' },
-        dim_i32(n, "triangular_solve"),
-        dim_i32(b_rows, "triangular_solve"),
+        dim_i32(n, "triangular_solve")?,
+        dim_i32(b_rows, "triangular_solve")?,
         a.host_data(),
-        dim_i32(n, "triangular_solve"),
+        dim_i32(n, "triangular_solve")?,
         &mut rhs_t,
-        dim_i32(n, "triangular_solve"),
+        dim_i32(n, "triangular_solve")?,
         &mut info,
     );
-    panic_on_lapack_error("triangular_solve", "dtrtrs", info);
+    check_lapack_info("triangular_solve", "trtrs", info)?;
     let result = transpose_col_major_data(&rhs_t, n, b_rows);
     Ok(tensor_from_vec_with_template(vec![b_rows, n], result, b))
 }
@@ -158,6 +159,23 @@ pub(crate) fn triangular_solve<T: LapackTriangularSolve>(
     unit_diagonal: bool,
 ) -> crate::Result<TypedTensor<T>> {
     if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
+        let (n, a_batch_shape) = square_core_and_batch_result(a, "triangular_solve")?;
+        let (b_rows, b_cols, b_batch_shape) = matrix_core_and_batch_result(b, "triangular_solve")?;
+        let rhs_core_dim = if left_side { b_rows } else { b_cols };
+        if rhs_core_dim != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "triangular_solve",
+                lhs: vec![n],
+                rhs: vec![rhs_core_dim],
+            });
+        }
+        if a_batch_shape != b_batch_shape {
+            return Err(crate::Error::ShapeMismatch {
+                op: "triangular_solve",
+                lhs: a_batch_shape.to_vec(),
+                rhs: b_batch_shape.to_vec(),
+            });
+        }
         return Ok(tensor_from_vec_with_template(
             b.shape.clone(),
             Vec::new(),

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -10,7 +10,6 @@ use crate::buffer_pool::BufferPool;
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use crate::cpu::backend;
 #[cfg(feature = "cpu-faer")]
 use crate::cpu::linalg::faer_linalg;
 use crate::cpu::{
@@ -276,6 +275,24 @@ fn cpu_context_try_from_env_rejects_invalid_rayon_num_threads() {
     with_rayon_num_threads(Some("not-a-number"), || {
         assert!(CpuContext::try_from_env().is_err());
     });
+}
+
+#[test]
+fn cpu_context_try_from_env_rejects_zero_rayon_num_threads() {
+    with_rayon_num_threads(Some("0"), || {
+        let err = match CpuContext::try_from_env() {
+            Ok(_) => panic!("expected zero RAYON_NUM_THREADS to be rejected"),
+            Err(err) => err,
+        };
+        assert!(format!("{err}").contains("CpuContext::try_from_env"));
+        assert!(format!("{err}").contains("thread count must be at least 1"));
+    });
+}
+
+#[test]
+#[should_panic(expected = "thread count must be at least 1")]
+fn cpu_context_with_threads_zero_panics_for_compatibility() {
+    let _ctx = CpuContext::with_threads(0);
 }
 
 #[test]
@@ -3277,42 +3294,6 @@ fn test_reclaim_buffer_covers_all_dtypes() {
     ));
     backend.reclaim_buffer(c64_t);
     assert!(backend.buffer_pool_len() >= 3);
-}
-
-#[test]
-fn test_catch_backend_panic_extracts_string_and_str_messages() {
-    let result = backend::catch_backend_panic("test_op", || panic!("explicit string message"));
-    let err = result.unwrap_err();
-    match err {
-        crate::Error::BackendFailure { op, message } => {
-            assert_eq!(op, "test_op");
-            assert!(message.contains("explicit string message"));
-        }
-        other => panic!("expected BackendFailure, got {:?}", other),
-    }
-
-    let result = backend::catch_backend_panic("test_op2", || panic!("formatted {}", 42));
-    let err = result.unwrap_err();
-    match err {
-        crate::Error::BackendFailure { op, message } => {
-            assert_eq!(op, "test_op2");
-            assert!(message.contains("formatted 42"));
-        }
-        other => panic!("expected BackendFailure, got {:?}", other),
-    }
-}
-
-#[test]
-fn test_catch_backend_panic_handles_non_string_payload() {
-    let result = backend::catch_backend_panic("test_op3", || std::panic::panic_any(42usize));
-    let err = result.unwrap_err();
-    match err {
-        crate::Error::BackendFailure { op, message } => {
-            assert_eq!(op, "test_op3");
-            assert_eq!(message, "backend panic");
-        }
-        other => panic!("expected BackendFailure, got {:?}", other),
-    }
 }
 
 #[test]

--- a/tenferro-tensor/tests/runtime_error_tests.rs
+++ b/tenferro-tensor/tests/runtime_error_tests.rs
@@ -14,6 +14,60 @@ fn f32_tensor(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
 }
 
 #[test]
+fn cpu_linalg_dispatch_does_not_use_panic_catching_as_error_handling() {
+    let backend_dispatch = include_str!("../src/cpu/backend.rs");
+    let exec_session_dispatch = include_str!("../src/cpu/exec_session.rs");
+
+    assert!(
+        !backend_dispatch.contains("catch_backend_panic"),
+        "CpuBackend should return typed errors from linalg helpers instead of catching panics"
+    );
+    assert!(
+        !exec_session_dispatch.contains("catch_backend_panic"),
+        "CpuExecSession should return typed errors from linalg helpers instead of catching panics"
+    );
+    assert!(
+        !backend_dispatch.contains("catch_unwind"),
+        "CPU backend error handling should not depend on panic unwinding"
+    );
+}
+
+#[test]
+fn cpu_backend_try_with_threads_rejects_zero_without_panicking() {
+    let err = match CpuBackend::try_with_threads(0) {
+        Ok(_) => panic!("zero threads should be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        Error::InvalidConfig {
+            op: "CpuBackend::try_with_threads",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn cholesky_rejects_rank_less_than_two_even_when_zero_dim() {
+    let input = f64_tensor(vec![0], Vec::new());
+    let mut backend = CpuBackend::new();
+
+    let result = catch_unwind(AssertUnwindSafe(|| backend.cholesky(&input)));
+
+    assert!(result.is_ok(), "cholesky should return Err, not panic");
+    let err = result.unwrap().unwrap_err();
+    assert!(matches!(
+        err,
+        Error::RankMismatch {
+            op: "cholesky",
+            expected: 2,
+            actual: 1,
+        }
+    ));
+}
+
+#[test]
 fn dot_general_rejects_out_of_bounds_contracting_dim() {
     let lhs = f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
     let rhs = f64_tensor(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]);


### PR DESCRIPTION
## Summary
- Remove CPU linalg/backend panic catching and return typed `Error` values from validation and LAPACK/BLAS helper paths.
- Add fallible `CpuContext::try_with_threads` / `CpuBackend::try_with_threads` while preserving existing `with_threads` panic compatibility.
- Validate zero-sized linalg inputs before empty-output fast paths, and add regression tests for issue #802.
- Add PR checklist side review guidance and align touched CPU rustdoc examples with executable doctest rules.

Fixes #802

## Side Review
- Re-read `REPOSITORY_RULES.md` before PR creation.
- Checked the local diff for panic-catching, ignored doctests in touched files, formatting, and coverage regressions.
- No README or `docs/getting-started/` examples were changed; no architecture/design docs needed updates for this error-handling change.

## Verification
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo check -p tenferro-tensor --no-default-features --features cpu-blas`
