### PR TITLE
[codex] Clarify linalg eps contract

### DIFF
--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -140,10 +140,20 @@ pub enum StdTensorOp {
     FullPivLuSolve {
         transpose_a: bool,
     },
+    /// Singular value decomposition.
+    ///
+    /// `eps` regularizes the AD rule for repeated or nearly repeated singular
+    /// values and singular values near zero. It is not a primal decomposition
+    /// backend parameter.
     Svd {
         eps: f64,
     },
     Qr,
+    /// Hermitian eigenvalue decomposition.
+    ///
+    /// `eps` regularizes the eigenvector AD rule for repeated or nearly
+    /// repeated eigenvalues. It is not a primal decomposition backend
+    /// parameter.
     Eigh {
         eps: f64,
     },

--- a/tenferro/src/compiler/mod.rs
+++ b/tenferro/src/compiler/mod.rs
@@ -399,9 +399,9 @@ fn std_to_exec_op(op: &StdTensorOp) -> ExecOp {
         StdTensorOp::FullPivLuSolve { transpose_a } => ExecOp::FullPivLuSolve {
             transpose_a: *transpose_a,
         },
-        StdTensorOp::Svd { eps, .. } => ExecOp::Svd { eps: *eps },
+        StdTensorOp::Svd { .. } => ExecOp::Svd,
         StdTensorOp::Qr { .. } => ExecOp::Qr,
-        StdTensorOp::Eigh { eps, .. } => ExecOp::Eigh { eps: *eps },
+        StdTensorOp::Eigh { .. } => ExecOp::Eigh,
         StdTensorOp::Eig { .. } => ExecOp::Eig,
         StdTensorOp::TriangularSolve {
             left_side,

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -124,18 +124,19 @@ pub enum ExecOp {
         axes: Vec<usize>,
     },
     Cholesky,
-    Svd {
-        eps: f64,
-    },
+    /// Primal SVD execution. AD regularization eps stays on `StdTensorOp::Svd`
+    /// and is consumed before lowering into this execution IR.
+    Svd,
     Qr,
     Lu,
     FullPivLu,
     FullPivLuSolve {
         transpose_a: bool,
     },
-    Eigh {
-        eps: f64,
-    },
+    /// Primal Hermitian eigendecomposition execution. AD regularization eps
+    /// stays on `StdTensorOp::Eigh` and is consumed before lowering into this
+    /// execution IR.
+    Eigh,
     Eig,
     ValidateNonsingular,
     TriangularSolve {
@@ -230,12 +231,12 @@ pub(crate) fn is_ffi_instruction(inst: &ExecInstruction) -> bool {
         ExecOp::DotGeneral(_)
             | ExecOp::NaryEinsum { .. }
             | ExecOp::Cholesky
-            | ExecOp::Svd { .. }
+            | ExecOp::Svd
             | ExecOp::Qr
             | ExecOp::Lu
             | ExecOp::FullPivLu
             | ExecOp::FullPivLuSolve { .. }
-            | ExecOp::Eigh { .. }
+            | ExecOp::Eigh
             | ExecOp::Eig
             | ExecOp::TriangularSolve { .. }
             | ExecOp::Extension(_)
@@ -580,7 +581,7 @@ pub(crate) fn execute_ffi_instruction<B: TensorBackend>(
             let result = backend.cholesky(get(slots, &inst.input_slots, 0)?)?;
             slots[inst.output_slots[0]] = Some(result);
         }
-        ExecOp::Svd { .. } => {
+        ExecOp::Svd => {
             let results = backend.svd(get(slots, &inst.input_slots, 0)?)?;
             assign_multi_output(slots, inst, results, "svd")?;
         }
@@ -604,7 +605,7 @@ pub(crate) fn execute_ffi_instruction<B: TensorBackend>(
             )?;
             slots[inst.output_slots[0]] = Some(result);
         }
-        ExecOp::Eigh { .. } => {
+        ExecOp::Eigh => {
             let results = backend.eigh(get(slots, &inst.input_slots, 0)?)?;
             assign_multi_output(slots, inst, results, "eigh")?;
         }

--- a/tenferro/src/linalg_api.rs
+++ b/tenferro/src/linalg_api.rs
@@ -25,7 +25,11 @@ fn sym_shape(shape: &[usize]) -> Vec<SymDim> {
     shape.iter().copied().map(SymDim::from).collect()
 }
 
-/// Singular value decomposition with a default numerical epsilon.
+/// Singular value decomposition with the default AD regularization epsilon.
+///
+/// The epsilon is used by the SVD AD rule to regularize divisions by small
+/// singular-value gaps and small singular values. It does not change the
+/// primal backend decomposition.
 ///
 /// # Examples
 ///
@@ -36,7 +40,12 @@ pub fn svd(a: &TracedTensor) -> (TracedTensor, TracedTensor, TracedTensor) {
     svd_with_eps(a, 1e-12)
 }
 
-/// Singular value decomposition with an explicit numerical epsilon.
+/// Singular value decomposition with an explicit AD regularization epsilon.
+///
+/// The epsilon is used only when differentiating through the SVD. It
+/// regularizes eigenvector-like singular-vector terms for repeated or nearly
+/// repeated singular values and for singular values near zero; primal execution
+/// returns the backend SVD result without applying this epsilon.
 ///
 /// # Examples
 ///
@@ -106,7 +115,10 @@ pub fn qr(a: &TracedTensor) -> (TracedTensor, TracedTensor) {
     }
 }
 
-/// Hermitian eigenvalue decomposition with a default numerical epsilon.
+/// Hermitian eigenvalue decomposition with the default AD regularization epsilon.
+///
+/// The epsilon is used by the `eigh` AD rule to regularize divisions by small
+/// eigenvalue gaps. It does not change the primal backend decomposition.
 ///
 /// # Examples
 ///
@@ -117,7 +129,12 @@ pub fn eigh(a: &TracedTensor) -> (TracedTensor, TracedTensor) {
     eigh_with_eps(a, 1e-12)
 }
 
-/// Hermitian eigenvalue decomposition with an explicit numerical epsilon.
+/// Hermitian eigenvalue decomposition with an explicit AD regularization epsilon.
+///
+/// The epsilon is used only when differentiating through the eigenvectors of
+/// `eigh`. It regularizes terms involving small eigenvalue gaps; primal
+/// execution returns the backend eigendecomposition result without applying
+/// this epsilon.
 ///
 /// # Examples
 ///

--- a/tenferro/tests/compiler_wiring.rs
+++ b/tenferro/tests/compiler_wiring.rs
@@ -351,7 +351,7 @@ fn compile_std_to_exec_lowers_linalg_variants_directly() {
         &[dim_shape(&[3, 2]), dim_shape(&[2, 2])],
     );
 
-    assert!(matches!(exec.instructions[0].op, ExecOp::Svd { eps } if eps == 1.0e-8));
+    assert!(matches!(exec.instructions[0].op, ExecOp::Svd));
     assert_eq!(
         exec.instructions[0].output_shapes,
         vec![dim_shape(&[3, 2]), dim_shape(&[2]), dim_shape(&[2, 2])]
@@ -371,7 +371,7 @@ fn compile_std_to_exec_lowers_linalg_variants_directly() {
             Vec::new()
         ]
     );
-    assert!(matches!(exec.instructions[3].op, ExecOp::Eigh { eps } if eps == 1.0e-6));
+    assert!(matches!(exec.instructions[3].op, ExecOp::Eigh));
     assert_eq!(
         exec.instructions[3].output_shapes,
         vec![dim_shape(&[2]), dim_shape(&[2, 2])]

--- a/tenferro/tests/exec_dispatch.rs
+++ b/tenferro/tests/exec_dispatch.rs
@@ -732,7 +732,7 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
     backend.calls.clear();
 
     // SVD: 1 input, 2 outputs (fake returns 2)
-    let program = multi_output_program(ExecOp::Svd { eps: 1e-10 }, 1, 2);
+    let program = multi_output_program(ExecOp::Svd, 1, 2);
     let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)]).unwrap();
     assert_eq!(backend.calls, vec!["svd"]);
     assert_eq!(outputs.len(), 2);
@@ -752,7 +752,7 @@ fn eval_exec_ir_dispatches_multi_output_linalg_ops() {
     backend.calls.clear();
 
     // Eigh: 1 input, 2 outputs
-    let program = multi_output_program(ExecOp::Eigh { eps: 1e-10 }, 1, 2);
+    let program = multi_output_program(ExecOp::Eigh, 1, 2);
     let outputs = eval_exec_ir(&mut backend, &program, vec![scalar_tensor(1.0)]).unwrap();
     assert_eq!(backend.calls, vec!["eigh"]);
     assert_eq!(outputs.len(), 2);


### PR DESCRIPTION
## Summary
- Keep SVD/eigh `eps` on the public traced API and `StdTensorOp` as AD-rule regularization.
- Remove `eps` from `ExecOp::Svd` and `ExecOp::Eigh` so primal backend execution has no unused decomposition parameter.
- Document that SVD/eigh `eps` does not affect primal backend results.

## Tests
- `cargo fmt --all --check`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Related to #831. This addresses the eps-contract clarification; dtype parity work remains separate.

Generated with Codex.