### PR TITLE
Reject cross-context EagerTensor mixing, add explicit import APIs (#841)

### DIFF
--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -15,7 +15,7 @@ use tidu::{
 
 use crate::eager_emitter::EagerEmitter;
 use crate::eager_exec::exec_op_on_tensors;
-use crate::error::{Error, Result};
+use crate::error::{ContextId, Error, Result};
 use crate::metadata::{
     register_fragment_metadata, register_value_metadata, tensor_meta_from_tensor,
 };
@@ -68,19 +68,25 @@ impl<B: TensorBackend> EagerContext<B> {
         Arc::new(Self::new(backend))
     }
 
+    /// Return an opaque identifier for this context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// assert_ne!(ctx.id(), EagerContext::with_backend(CpuBackend::new()).id());
+    /// ```
+    pub fn id(&self) -> ContextId {
+        ContextId::from_ptr(self)
+    }
+
     pub(crate) fn register_grad_slot(&self, key: &GlobalValKey<StdTensorOp>, slot: &GradSlot) {
         self.grad_slots
             .lock()
             .unwrap()
             .insert(key.clone(), Arc::downgrade(slot));
-    }
-
-    pub(crate) fn absorb_from(&self, other: &Self) {
-        let other_slots = other.grad_slots.lock().unwrap();
-        let mut slots = self.grad_slots.lock().unwrap();
-        for (key, slot) in other_slots.iter() {
-            slots.entry(key.clone()).or_insert_with(|| slot.clone());
-        }
     }
 
     /// Clear all live gradient slots tracked by this context.
@@ -113,6 +119,50 @@ impl<B: TensorBackend> EagerContext<B> {
                 false
             }
         });
+    }
+
+    /// Import a concrete tensor into this context as an untracked constant.
+    ///
+    /// The returned tensor does not participate in gradient tracking.
+    /// Use this for fixed masks, quadrature weights, physical constants,
+    /// and other data that should not receive gradients.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let c = ctx.constant_from(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+    /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx);
+    /// let z = x.add(&c).unwrap();
+    ///
+    /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+    /// ```
+    pub fn constant_from(self: &Arc<Self>, tensor: Tensor) -> EagerTensor<B> {
+        EagerTensor::new_leaf(Arc::clone(self), tensor, false)
+    }
+
+    /// Import a concrete tensor into this context as a trainable variable.
+    ///
+    /// The returned tensor participates in gradient tracking; its gradient
+    /// slot is registered in this context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let p = ctx.variable_from(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+    /// let loss = p.exp().unwrap().reduce_sum(&[0]).unwrap();
+    /// let _ = loss.backward().unwrap();
+    ///
+    /// let grad = p.grad().unwrap();
+    /// assert_eq!(grad.shape(), &[2]);
+    /// ```
+    pub fn variable_from(self: &Arc<Self>, tensor: Tensor) -> EagerTensor<B> {
+        EagerTensor::new_leaf(Arc::clone(self), tensor, true)
     }
 
     fn store_grads(
@@ -214,7 +264,16 @@ impl<B: TensorBackend> std::ops::Neg for &EagerTensor<B> {
 }
 
 impl EagerTensor<CpuBackend> {
+    fn default_ctx() -> Arc<EagerContext<CpuBackend>> {
+        use std::sync::OnceLock;
+        static DEFAULT_CTX: OnceLock<Arc<EagerContext<CpuBackend>>> = OnceLock::new();
+        Arc::clone(DEFAULT_CTX.get_or_init(|| EagerContext::with_backend(CpuBackend::new())))
+    }
+
     /// Create an untracked eager tensor on the default CPU backend.
+    ///
+    /// All tensors created via this constructor share a single default context,
+    /// so they can participate in operations with each other.
     ///
     /// # Examples
     ///
@@ -226,10 +285,13 @@ impl EagerTensor<CpuBackend> {
     /// assert!(x.grad().is_none());
     /// ```
     pub fn from_tensor(tensor: Tensor) -> Self {
-        Self::from_tensor_in(tensor, EagerContext::with_backend(CpuBackend::new()))
+        Self::from_tensor_in(tensor, Self::default_ctx())
     }
 
     /// Create a tracked eager leaf on the default CPU backend.
+    ///
+    /// All tensors created via this constructor share a single default context,
+    /// so gradients can flow between them.
     ///
     /// # Examples
     ///
@@ -240,7 +302,7 @@ impl EagerTensor<CpuBackend> {
     /// assert!(x.grad().is_none());
     /// ```
     pub fn requires_grad(tensor: Tensor) -> Self {
-        Self::requires_grad_in(tensor, EagerContext::with_backend(CpuBackend::new()))
+        Self::requires_grad_in(tensor, Self::default_ctx())
     }
 }
 
@@ -338,6 +400,26 @@ impl<B: TensorBackend> EagerTensor<B> {
         Self::new_leaf(self.ctx.clone(), self.data.as_ref().clone(), false)
     }
 
+    /// Detach this tensor from its graph and re-register it in a different
+    /// context as an untracked leaf.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx_a = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a);
+    /// let d = x.detach_into(&ctx_b);
+    ///
+    /// assert!(!d.tracks_grad());
+    /// assert_eq!(d.ctx_id(), ctx_b.id());
+    /// ```
+    pub fn detach_into(&self, ctx: &Arc<EagerContext<B>>) -> Self {
+        Self::new_leaf(Arc::clone(ctx), self.data.as_ref().clone(), false)
+    }
+
     /// Borrow the concrete tensor value.
     ///
     /// # Examples
@@ -420,6 +502,39 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     pub fn tracks_grad(&self) -> bool {
         self.requires_grad
+    }
+
+    /// Return the opaque identifier of the context this tensor belongs to.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx.clone());
+    ///
+    /// assert_eq!(x.ctx_id(), ctx.id());
+    /// ```
+    pub fn ctx_id(&self) -> ContextId {
+        self.ctx.id()
+    }
+
+    /// Check whether two tensors belong to the same eager context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx.clone());
+    /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![2.0_f64]), ctx);
+    ///
+    /// assert!(x.same_context(&y));
+    /// ```
+    pub fn same_context(&self, other: &Self) -> bool {
+        self.ctx_id() == other.ctx_id()
     }
 
     /// Run reverse-mode AD from this scalar output.

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -555,8 +555,11 @@ impl<B: TensorBackend> EagerTensor<B> {
 
         let ctx = Arc::clone(&first.ctx);
         for tensor in tensors.iter().skip(1) {
-            if !Arc::ptr_eq(&ctx, &tensor.ctx) {
-                ctx.absorb_from(&tensor.ctx);
+            if !first.same_context(tensor) {
+                return Err(Error::ContextMismatch {
+                    lhs: first.ctx_id(),
+                    rhs: tensor.ctx_id(),
+                });
             }
         }
 

--- a/tenferro/src/error.rs
+++ b/tenferro/src/error.rs
@@ -82,9 +82,34 @@ pub enum Error {
     )]
     PlaceholderRankMismatch { expected: usize, actual: usize },
 
+    /// Operation attempted to mix tensors from different eager contexts.
+    #[error(
+        "tensors belong to different eager contexts ({lhs} vs {rhs}); \
+         use EagerTensor::detach_into or EagerContext::constant_from"
+    )]
+    ContextMismatch { lhs: ContextId, rhs: ContextId },
+
     /// An unexpected internal error.
     #[error("internal error: {0}")]
     Internal(String),
+}
+
+/// Opaque identifier for an [`EagerContext`], used in [`Error::ContextMismatch`].
+///
+/// [`EagerContext`]: crate::EagerContext
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ContextId(usize);
+
+impl ContextId {
+    pub(crate) fn from_ptr<T>(ptr: *const T) -> Self {
+        Self(ptr as usize)
+    }
+}
+
+impl std::fmt::Display for ContextId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ctx@{:x}", self.0)
+    }
 }
 
 /// Result type alias for tenferro operations.

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -41,6 +41,7 @@ pub mod traced;
 
 pub use eager::{EagerContext, EagerTensor};
 pub use engine::Engine;
+pub use error::ContextId;
 pub use linalg_api::{
     cholesky, convert, det, eig, eigh, eigh_with_eps, eigvals, eigvalsh, full_piv_lu,
     full_piv_lu_solve, inv, lu, norm, pinv, pinv_with_rtol, qr, slogdet, solve, svd, svd_with_eps,

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -569,3 +569,132 @@ fn eager_embed_diag_and_triu_primal() {
         TOL,
     );
 }
+
+// --- Context boundary tests ---
+
+#[test]
+fn context_id_is_unique() {
+    let ctx_a = EagerContext::with_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    assert_ne!(ctx_a.id(), ctx_b.id());
+}
+
+#[test]
+fn same_context_true_for_shared_ctx() {
+    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx.clone());
+    let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![2.0_f64]), ctx);
+    assert!(x.same_context(&y));
+    assert_eq!(x.ctx_id(), y.ctx_id());
+}
+
+#[test]
+fn same_context_false_for_different_ctx() {
+    let ctx_a = EagerContext::with_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx_a);
+    let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![2.0_f64]), ctx_b);
+    assert!(!x.same_context(&y));
+    assert_ne!(x.ctx_id(), y.ctx_id());
+}
+
+#[test]
+fn constant_from_creates_untracked_leaf() {
+    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let c = ctx.constant_from(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+    assert_eq!(c.ctx_id(), ctx.id());
+    assert!(!c.tracks_grad());
+    assert_eq!(f64_data(c.data()), &[1.0, 2.0]);
+}
+
+#[test]
+fn variable_from_creates_tracked_leaf() {
+    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let p = ctx.variable_from(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+    assert_eq!(p.ctx_id(), ctx.id());
+    assert!(p.tracks_grad());
+    // backward should work on a tracked variable
+    let loss = p.exp().unwrap().reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+    assert!(p.grad().is_some());
+}
+
+#[test]
+fn cross_context_add_rejected() {
+    let ctx_a = EagerContext::with_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a);
+    let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx_b);
+    let msg = match x.add(&y) {
+        Err(e) => e.to_string(),
+        Ok(_) => panic!("expected error"),
+    };
+    assert!(msg.contains("different eager contexts"), "got: {msg}");
+}
+
+#[test]
+fn cross_context_mul_rejected() {
+    let ctx_a = EagerContext::with_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a);
+    let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx_b);
+    let msg = match x.mul(&y) {
+        Err(e) => e.to_string(),
+        Ok(_) => panic!("expected error"),
+    };
+    assert!(msg.contains("different eager contexts"), "got: {msg}");
+}
+
+#[test]
+fn cross_context_tracked_tensors_rejected() {
+    let ctx_a = EagerContext::with_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a);
+    let y = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx_b);
+    let msg = match x.add(&y) {
+        Err(e) => e.to_string(),
+        Ok(_) => panic!("expected error"),
+    };
+    assert!(msg.contains("different eager contexts"), "got: {msg}");
+}
+
+#[test]
+fn constant_from_can_cross_context() {
+    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let x =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
+    // Import a fixed mask from a raw tensor into the same context
+    let c = ctx.constant_from(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]));
+    let z = x.add(&c).unwrap();
+    assert_eq!(f64_data(z.data()), &[4.0, 6.0]);
+}
+
+#[test]
+fn detach_into_different_context() {
+    let ctx_a = EagerContext::with_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a);
+    let d = x.detach_into(&ctx_b);
+    assert_eq!(d.ctx_id(), ctx_b.id());
+    assert!(!d.tracks_grad());
+    assert_eq!(f64_data(d.data()), &[1.0, 2.0]);
+    // Can operate with tensors from ctx_b now
+    let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx_b);
+    let z = d.add(&y).unwrap();
+    assert_eq!(f64_data(z.data()), &[4.0, 6.0]);
+}
+
+#[test]
+fn detach_into_still_accessible_in_original_context() {
+    let ctx_a = EagerContext::with_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let x =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a.clone());
+    let d = x.detach_into(&ctx_b);
+    // Original tensor still in ctx_a, should work fine
+    let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+    assert!(x.grad().is_some());
+    // d is in ctx_b, x is in ctx_a
+    assert_ne!(d.ctx_id(), x.ctx_id());
+}


### PR DESCRIPTION
## Summary

Prohibit implicit cross-context tensor mixing in `nary_op`. Previously, when tensors from different `EagerContext`s were combined in an operation, `absorb_from` silently merged their gradient slot registries without checking backend, allocator, or device compatibility. This made gradient provenance ambiguous and error-prone.

### Changes

1. **`ContextId`** — opaque identifier for `EagerContext`, exposed via `EagerContext::id()` and `EagerTensor::ctx_id()`
2. **`Error::ContextMismatch`** — returned when cross-context tensors are mixed in `nary_op`
3. **`EagerContext::constant_from(tensor)`** — import as untracked constant
4. **`EagerContext::variable_from(tensor)`** — import as trainable leaf
5. **`EagerTensor::detach_into(ctx)`** — detach and re-register in a different context
6. **`EagerTensor::same_context(other)`** — context identity check
7. **Removed `absorb_from`** — dead code after `nary_op` no longer uses it
8. **Shared default context** — `EagerTensor::from_tensor()` and `requires_grad()` now share a single static context so existing convenience-API usage works without explicit context management

### Safe cross-context patterns

```rust
// Import fixed data as constant
let c = ctx.constant_from(raw_tensor);

// Move tensor between contexts (detached)
let d = tensor.detach_into(&other_ctx);

// Explicit context check
assert!(x.same_context(&y));
```

### Rejected (error)

```rust
let z = x.add(&y_from_different_ctx)?; // Error::ContextMismatch
```

## Test plan
- [x] 39 context-boundary + existing eager tensor tests pass
- [x] All workspace tests pass (`cargo test -p tenferro`)
- [x] `cargo fmt --all` clean

Closes #841.
🤖 Generated with [Claude Code](https://claude.com/claude-code)