### PR TITLE
Remove global context and EagerTensor convenience constructors

### DIFF
--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -216,9 +216,10 @@ impl<B: TensorBackend> EagerContext<B> {
 /// # Examples
 ///
 /// ```
-/// use tenferro::{EagerTensor, Tensor};
+/// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 ///
-/// let x = EagerTensor::requires_grad(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+/// let ctx = EagerContext::with_backend(CpuBackend::new());
+/// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx);
 /// let loss = (&x * &x).reduce_sum(&[0]).unwrap();
 /// let _cotangents = loss.backward().unwrap();
 /// let loss = (&x * &x).reduce_sum(&[0]).unwrap();
@@ -260,49 +261,6 @@ impl<B: TensorBackend> std::ops::Neg for &EagerTensor<B> {
 
     fn neg(self) -> Self::Output {
         EagerTensor::neg(self).unwrap_or_else(|err| panic!("eager neg failed: {}", err))
-    }
-}
-
-impl EagerTensor<CpuBackend> {
-    fn default_ctx() -> Arc<EagerContext<CpuBackend>> {
-        use std::sync::OnceLock;
-        static DEFAULT_CTX: OnceLock<Arc<EagerContext<CpuBackend>>> = OnceLock::new();
-        Arc::clone(DEFAULT_CTX.get_or_init(|| EagerContext::with_backend(CpuBackend::new())))
-    }
-
-    /// Create an untracked eager tensor on the default CPU backend.
-    ///
-    /// All tensors created via this constructor share a single default context,
-    /// so they can participate in operations with each other.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro::{EagerTensor, Tensor};
-    ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
-    /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
-    /// assert!(x.grad().is_none());
-    /// ```
-    pub fn from_tensor(tensor: Tensor) -> Self {
-        Self::from_tensor_in(tensor, Self::default_ctx())
-    }
-
-    /// Create a tracked eager leaf on the default CPU backend.
-    ///
-    /// All tensors created via this constructor share a single default context,
-    /// so gradients can flow between them.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro::{EagerTensor, Tensor};
-    ///
-    /// let x = EagerTensor::requires_grad(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
-    /// assert!(x.grad().is_none());
-    /// ```
-    pub fn requires_grad(tensor: Tensor) -> Self {
-        Self::requires_grad_in(tensor, Self::default_ctx())
     }
 }
 
@@ -388,9 +346,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::requires_grad(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx);
     /// let y = x.detach();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
@@ -425,9 +384,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![3.0_f64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![3.0_f64]), ctx);
     /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[3.0]);
     /// ```
     pub fn data(&self) -> &Tensor {
@@ -442,9 +402,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::requires_grad(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx);
     /// let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
     ///
@@ -546,9 +507,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::requires_grad(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx);
     /// let loss = (&x + &x).reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
     /// let loss = (&x + &x).reduce_sum(&[0]).unwrap();

--- a/tenferro/src/eager_einsum.rs
+++ b/tenferro/src/eager_einsum.rs
@@ -7,7 +7,7 @@
 //!
 //! ```rust
 //! use tenferro::eager_einsum::{eager_einsum, eager_einsum_ad, eager_einsum_owned};
-//! use tenferro::{CpuBackend, EagerTensor, Tensor};
+//! use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 //!
 //! let mut backend = CpuBackend::new();
 //! let a = Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]);
@@ -20,8 +20,9 @@
 //!
 //! assert_eq!(owned_dot.as_slice::<f64>().unwrap(), &[32.0]);
 //!
-//! let x = EagerTensor::requires_grad(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
-//! let y = EagerTensor::requires_grad(Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]));
+//! let ctx = EagerContext::with_backend(CpuBackend::new());
+//! let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
+//! let y = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx);
 //! let loss = eager_einsum_ad(&[&x, &y], "i,i->").unwrap();
 //! let _ = loss.backward().unwrap();
 //!
@@ -43,16 +44,17 @@ pub use tenferro_einsum::{eager_einsum, eager_einsum_owned};
 ///
 /// ```
 /// use tenferro::eager_einsum::eager_einsum_ad;
-/// use tenferro::{EagerTensor, Tensor};
+/// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 ///
-/// let a = EagerTensor::from_tensor(Tensor::from_vec(
+/// let ctx = EagerContext::with_backend(CpuBackend::new());
+/// let a = EagerTensor::from_tensor_in(Tensor::from_vec(
 ///     vec![2, 3],
 ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-/// ));
-/// let b = EagerTensor::from_tensor(Tensor::from_vec(
+/// ), ctx.clone());
+/// let b = EagerTensor::from_tensor_in(Tensor::from_vec(
 ///     vec![3, 2],
 ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-/// ));
+/// ), ctx.clone());
 /// let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
 ///
 /// assert_eq!(c.data().shape(), &[2, 2]);

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -17,10 +17,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
-    /// let y = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
+    /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let z = x.add(&y).unwrap();
     ///
     /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[4.0, 6.0]);
@@ -34,10 +35,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
-    /// let y = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
+    /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let z = x.mul(&y).unwrap();
     ///
     /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[3.0, 8.0]);
@@ -51,9 +53,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, -2.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, -2.0]), ctx.clone());
     /// let y = x.neg().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[-1.0, 2.0]);
@@ -67,9 +70,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![0.0_f64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.exp().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0]);
@@ -83,9 +87,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.reduce_sum(&[0, 1]).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[10.0]);
@@ -101,10 +106,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{DotGeneralConfig, EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, DotGeneralConfig, EagerContext, EagerTensor, Tensor};
     ///
-    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]));
-    /// let b = EagerTensor::from_tensor(Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]), ctx.clone());
+    /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]), ctx.clone());
     /// let c = a.dot_general(&b, DotGeneralConfig {
     ///     lhs_contracting_dims: vec![1],
     ///     rhs_contracting_dims: vec![0],
@@ -123,12 +129,13 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(
     ///     vec![2, 3],
     ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    /// ));
+    /// ), ctx.clone());
     /// let y = x.transpose(&[1, 0]).unwrap();
     ///
     /// assert_eq!(y.data().shape(), &[3, 2]);
@@ -145,12 +152,13 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(
     ///     vec![2, 3],
     ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    /// ));
+    /// ), ctx.clone());
     /// let y = x.reshape(&[6]).unwrap();
     ///
     /// assert_eq!(y.data().shape(), &[6]);
@@ -167,9 +175,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, SliceConfig, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, SliceConfig, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x
     ///     .slice(SliceConfig {
     ///         starts: vec![1],
@@ -189,9 +198,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
     /// let y = x.broadcast_in_dim(&[3, 2], &[0]).unwrap();
     ///
     /// assert_eq!(y.data().shape(), &[3, 2]);
@@ -208,9 +218,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{DType, EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, DType, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, -2.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, -2.0]), ctx.clone());
     /// let y = x.convert(DType::C64).unwrap();
     ///
     /// assert_eq!(y.data().dtype(), DType::C64);
@@ -228,9 +239,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, PadConfig, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, PadConfig, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
     /// let y = x
     ///     .pad(PadConfig {
     ///         edge_padding_low: vec![1],
@@ -250,9 +262,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.reverse(&[0]).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[4.0, 3.0, 2.0, 1.0]);
@@ -268,13 +281,14 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, GatherConfig, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, GatherConfig, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(
     ///     vec![5],
     ///     vec![10.0_f64, 20.0, 30.0, 40.0, 50.0],
-    /// ));
-    /// let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![4_i64, 1, 0]));
+    /// ), ctx.clone());
+    /// let indices = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![4_i64, 1, 0]), ctx.clone());
     /// let y = x
     ///     .gather(
     ///         &indices,
@@ -299,11 +313,12 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, ScatterConfig, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, ScatterConfig, Tensor};
     ///
-    /// let operand = EagerTensor::from_tensor(Tensor::from_vec(vec![4], vec![0.0_f64, 0.0, 0.0, 0.0]));
-    /// let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![1_i64, 3]));
-    /// let updates = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![5.0_f64, 7.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let operand = EagerTensor::from_tensor_in(Tensor::from_vec(vec![4], vec![0.0_f64, 0.0, 0.0, 0.0]), ctx.clone());
+    /// let indices = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![1_i64, 3]), ctx.clone());
+    /// let updates = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![5.0_f64, 7.0]), ctx.clone());
     /// let result = operand
     ///     .scatter(
     ///         &indices,
@@ -328,10 +343,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]));
-    /// let starts = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![2_i64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]), ctx.clone());
+    /// let starts = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![2_i64]), ctx.clone());
     /// let y = x.dynamic_slice(&starts, &[2]).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
@@ -350,10 +366,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
-    /// let y = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
+    /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let z = EagerTensor::concatenate(&[&x, &y], 0).unwrap();
     ///
     /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
@@ -373,12 +390,13 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(
     ///     vec![3, 3],
     ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-    /// ));
+    /// ), ctx.clone());
     /// let y = x.extract_diag(0, 1).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 5.0, 9.0]);
@@ -392,9 +410,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
     /// let y = x.embed_diag(0, 1).unwrap();
     ///
     /// assert_eq!(y.data().shape(), &[3, 3]);
@@ -409,9 +428,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.tril(0).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 2.0, 0.0, 4.0]);
@@ -425,9 +445,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.triu(0).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 0.0, 3.0, 4.0]);
@@ -441,9 +462,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.reduce_prod(&[0, 1]).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[24.0]);
@@ -459,9 +481,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.reduce_max(&[0, 1]).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[4.0]);
@@ -477,9 +500,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.reduce_min(&[0, 1]).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0]);

--- a/tenferro/src/eager_ops_elementwise.rs
+++ b/tenferro/src/eager_ops_elementwise.rs
@@ -10,9 +10,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![-1.0_f64, 2.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![-1.0_f64, 2.0]), ctx.clone());
     /// let y = x.abs().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
@@ -26,9 +27,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, -2.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, -2.0]), ctx.clone());
     /// let y = x.conj().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, -2.0]);
@@ -42,9 +44,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![-2.0_f64, 3.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![-2.0_f64, 3.0]), ctx.clone());
     /// let y = x.sign().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[-1.0, 1.0]);
@@ -58,9 +61,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![1.0_f64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx.clone());
     /// let y = x.log().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0]);
@@ -74,9 +78,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![4.0_f64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![4.0_f64]), ctx.clone());
     /// let y = x.sqrt().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[2.0]);
@@ -90,9 +95,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![4.0_f64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![4.0_f64]), ctx.clone());
     /// let y = x.rsqrt().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.5]);
@@ -106,9 +112,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![0.0_f64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.sin().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0]);
@@ -122,9 +129,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![0.0_f64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.cos().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0]);
@@ -138,9 +146,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![0.0_f64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.tanh().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0]);
@@ -154,9 +163,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![0.0_f64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.expm1().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0]);
@@ -170,9 +180,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![1], vec![0.0_f64]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.log1p().unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[0.0]);
@@ -186,10 +197,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![8.0_f64, -6.0, 9.0]));
-    /// let y = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![2.0_f64, 3.0, 3.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![8.0_f64, -6.0, 9.0]), ctx.clone());
+    /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![2.0_f64, 3.0, 3.0]), ctx.clone());
     /// let z = x.div(&y).unwrap();
     ///
     /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[4.0, -2.0, 3.0]);
@@ -203,10 +215,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let base = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![2.0_f64, 3.0]));
-    /// let exp = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![3.0_f64, 2.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let base = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![2.0_f64, 3.0]), ctx.clone());
+    /// let exp = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 2.0]), ctx.clone());
     /// let y = base.pow(&exp).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[8.0, 9.0]);
@@ -220,10 +233,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 5.0]));
-    /// let y = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 5.0]), ctx.clone());
+    /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let z = x.maximum(&y).unwrap();
     ///
     /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[3.0, 5.0]);
@@ -237,10 +251,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 5.0]));
-    /// let y = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 5.0]), ctx.clone());
+    /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let z = x.minimum(&y).unwrap();
     ///
     /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[1.0, 4.0]);
@@ -254,11 +269,12 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let condition = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![0.0_f64, 1.0]));
-    /// let on_true = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![10.0_f64, 20.0]));
-    /// let on_false = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let condition = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![0.0_f64, 1.0]), ctx.clone());
+    /// let on_true = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![10.0_f64, 20.0]), ctx.clone());
+    /// let on_false = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
     /// let y = EagerTensor::select(&condition, &on_true, &on_false).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 20.0]);
@@ -272,11 +288,12 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let x = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![-2.0_f64, 0.5, 5.0]));
-    /// let lower = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![-1.0_f64, 0.0, 1.0]));
-    /// let upper = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 4.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![-2.0_f64, 0.5, 5.0]), ctx.clone());
+    /// let lower = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![-1.0_f64, 0.0, 1.0]), ctx.clone());
+    /// let upper = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 4.0]), ctx.clone());
     /// let y = x.clamp(&lower, &upper).unwrap();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[-1.0, 0.5, 4.0]);

--- a/tenferro/src/eager_ops_linalg.rs
+++ b/tenferro/src/eager_ops_linalg.rs
@@ -10,9 +10,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]), ctx.clone());
     /// let (u, s, vh) = a.svd().unwrap();
     ///
     /// assert_eq!(u.data().shape(), &[2, 2]);
@@ -41,9 +42,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]), ctx.clone());
     /// let (q, r) = a.qr().unwrap();
     ///
     /// assert_eq!(q.data().shape(), &[2, 2]);
@@ -64,9 +66,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]), ctx.clone());
     /// let (p, l, u, parity) = a.lu().unwrap();
     ///
     /// assert_eq!(p.data().shape(), &[2, 2]);
@@ -95,9 +98,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]), ctx.clone());
     /// let (p, l, u, q, parity) = a.full_piv_lu().unwrap();
     ///
     /// assert_eq!(p.data().shape(), &[2, 2]);
@@ -130,10 +134,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]));
-    /// let b = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![-1.0_f64, 5.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]), ctx.clone());
+    /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![-1.0_f64, 5.0]), ctx.clone());
     /// let x = a.full_piv_lu_solve(&b).unwrap();
     ///
     /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[4.0, -1.0]);
@@ -147,9 +152,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]), ctx.clone());
     /// let l = a.cholesky().unwrap();
     ///
     /// assert_eq!(l.data().shape(), &[2, 2]);
@@ -164,9 +170,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]), ctx.clone());
     /// let (values, vectors) = a.eigh().unwrap();
     ///
     /// assert_eq!(values.data().shape(), &[2]);
@@ -189,9 +196,10 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]), ctx.clone());
     /// let (values, vectors) = a.eig().unwrap();
     ///
     /// assert_eq!(values.data().shape(), &[2]);
@@ -215,10 +223,11 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// # Examples
     ///
     /// ```
-    /// use tenferro::{EagerTensor, Tensor};
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]));
-    /// let b = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![4.0_f64, 8.0]));
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]), ctx.clone());
+    /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![4.0_f64, 8.0]), ctx.clone());
     /// let x = a
     ///     .triangular_solve(&b, true, true, false, false)
     ///     .unwrap();

--- a/tenferro/tests/ad_structural_primitives.rs
+++ b/tenferro/tests/ad_structural_primitives.rs
@@ -1,4 +1,6 @@
-use tenferro::{EagerTensor, Tensor};
+use std::sync::Arc;
+
+use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 
 const FD_H: f64 = 1.0e-6;
 const TOL: f64 = 1.0e-5;
@@ -15,6 +17,10 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
             "index {index}: expected {expected}, got {actual}"
         );
     }
+}
+
+fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
+    EagerContext::with_backend(CpuBackend::new())
 }
 
 fn finite_diff_unary(f: impl Fn(&[f64]) -> f64, base: &[f64]) -> Vec<f64> {
@@ -38,17 +44,18 @@ fn weighted_sum(values: impl Iterator<Item = f64>, weights: &[f64]) -> f64 {
 
 #[test]
 fn eager_maximum_and_minimum_gradients_match_finite_diff() {
+    let ctx = test_ctx();
     let x_data = vec![3.0_f64, -2.0, 0.5, 4.0];
     let y_data = vec![1.0_f64, 5.0, -1.0, 2.0];
     let max_weights = vec![0.5_f64, -1.25, 2.0, -0.75];
     let min_weights = vec![1.5_f64, -0.25, 0.75, 2.25];
 
-    let x = EagerTensor::requires_grad(Tensor::from_vec(vec![4], x_data.clone()));
-    let y = EagerTensor::requires_grad(Tensor::from_vec(vec![4], y_data.clone()));
+    let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![4], x_data.clone()), ctx.clone());
+    let y = EagerTensor::requires_grad_in(Tensor::from_vec(vec![4], y_data.clone()), ctx.clone());
     let max_weights_tensor =
-        EagerTensor::from_tensor(Tensor::from_vec(vec![4], max_weights.clone()));
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![4], max_weights.clone()), ctx.clone());
     let min_weights_tensor =
-        EagerTensor::from_tensor(Tensor::from_vec(vec![4], min_weights.clone()));
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![4], min_weights.clone()), ctx.clone());
 
     let max_loss = x
         .maximum(&y)
@@ -109,15 +116,22 @@ fn eager_maximum_and_minimum_gradients_match_finite_diff() {
 
 #[test]
 fn eager_select_gradients_match_finite_diff() {
+    let ctx = test_ctx();
     let condition_data = vec![0.0_f64, -1.0, 2.0, 0.0];
     let true_data = vec![10.0_f64, 20.0, 30.0, 40.0];
     let false_data = vec![1.0_f64, 2.0, 3.0, 4.0];
     let weights = vec![0.5_f64, -1.0, 2.0, 1.25];
 
-    let condition = EagerTensor::from_tensor(Tensor::from_vec(vec![4], condition_data.clone()));
-    let on_true = EagerTensor::requires_grad(Tensor::from_vec(vec![4], true_data.clone()));
-    let on_false = EagerTensor::requires_grad(Tensor::from_vec(vec![4], false_data.clone()));
-    let weights_tensor = EagerTensor::from_tensor(Tensor::from_vec(vec![4], weights.clone()));
+    let condition = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![4], condition_data.clone()),
+        ctx.clone(),
+    );
+    let on_true =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![4], true_data.clone()), ctx.clone());
+    let on_false =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![4], false_data.clone()), ctx.clone());
+    let weights_tensor =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![4], weights.clone()), ctx.clone());
 
     let loss = EagerTensor::select(&condition, &on_true, &on_false)
         .unwrap()
@@ -160,15 +174,20 @@ fn eager_select_gradients_match_finite_diff() {
 
 #[test]
 fn eager_clamp_gradients_match_finite_diff() {
+    let ctx = test_ctx();
     let input_data = vec![-2.0_f64, 0.5, 5.0, 2.0];
     let lower_data = vec![-1.0_f64, 0.0, 1.0, 0.0];
     let upper_data = vec![1.0_f64, 2.0, 4.0, 3.0];
     let weights = vec![0.5_f64, -1.25, 2.0, 0.75];
 
-    let input = EagerTensor::requires_grad(Tensor::from_vec(vec![4], input_data.clone()));
-    let lower = EagerTensor::requires_grad(Tensor::from_vec(vec![4], lower_data.clone()));
-    let upper = EagerTensor::requires_grad(Tensor::from_vec(vec![4], upper_data.clone()));
-    let weights_tensor = EagerTensor::from_tensor(Tensor::from_vec(vec![4], weights.clone()));
+    let input =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![4], input_data.clone()), ctx.clone());
+    let lower =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![4], lower_data.clone()), ctx.clone());
+    let upper =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![4], upper_data.clone()), ctx.clone());
+    let weights_tensor =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![4], weights.clone()), ctx.clone());
 
     let loss = input
         .clamp(&lower, &upper)
@@ -211,15 +230,20 @@ fn eager_clamp_gradients_match_finite_diff() {
 
 #[test]
 fn eager_concatenate_gradients_match_finite_diff() {
+    let ctx = test_ctx();
     let left_data = vec![1.0_f64, 2.0];
     let middle_data = vec![3.0_f64];
     let right_data = vec![4.0_f64, 5.0, 6.0];
     let weights = vec![0.5_f64, -1.0, 2.0, 1.5, -0.25, 0.75];
 
-    let left = EagerTensor::requires_grad(Tensor::from_vec(vec![2], left_data.clone()));
-    let middle = EagerTensor::requires_grad(Tensor::from_vec(vec![1], middle_data.clone()));
-    let right = EagerTensor::requires_grad(Tensor::from_vec(vec![3], right_data.clone()));
-    let weights_tensor = EagerTensor::from_tensor(Tensor::from_vec(vec![6], weights.clone()));
+    let left =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], left_data.clone()), ctx.clone());
+    let middle =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![1], middle_data.clone()), ctx.clone());
+    let right =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], right_data.clone()), ctx.clone());
+    let weights_tensor =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![6], weights.clone()), ctx.clone());
 
     let concatenated = EagerTensor::concatenate(&[&left, &middle, &right], 0).unwrap();
     let loss = concatenated

--- a/tenferro/tests/eager_einsum_ad.rs
+++ b/tenferro/tests/eager_einsum_ad.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use tenferro::eager_einsum::eager_einsum_ad;
 use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 
@@ -5,16 +7,21 @@ fn f64_data(tensor: &Tensor) -> &[f64] {
     tensor.as_slice::<f64>().unwrap()
 }
 
+fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
+    EagerContext::with_backend(CpuBackend::new())
+}
+
 #[test]
 fn eager_einsum_ad_matmul_primal_matches_expected_values() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
-    let b = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![3, 2],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let ctx = test_ctx();
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
 
     let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
 
@@ -24,14 +31,15 @@ fn eager_einsum_ad_matmul_primal_matches_expected_values() {
 
 #[test]
 fn eager_einsum_ad_backward_populates_input_grads() {
-    let a = EagerTensor::requires_grad(Tensor::from_vec(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
-    let b = EagerTensor::requires_grad(Tensor::from_vec(
-        vec![3, 2],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let ctx = test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
+    let b = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
 
     let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
     let loss = c.reduce_sum(&[0, 1]).unwrap();
@@ -48,14 +56,15 @@ fn eager_einsum_ad_backward_populates_input_grads() {
 
 #[test]
 fn eager_einsum_ad_repeated_backward_accumulates_across_calls() {
-    let a = EagerTensor::requires_grad(Tensor::from_vec(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
-    let b = EagerTensor::requires_grad(Tensor::from_vec(
-        vec![3, 2],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let ctx = test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
+    let b = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
 
     let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
     let loss = c.reduce_sum(&[0, 1]).unwrap();

--- a/tenferro/tests/eager_linalg.rs
+++ b/tenferro/tests/eager_linalg.rs
@@ -1,5 +1,12 @@
 use num_complex::Complex64;
-use tenferro::{EagerTensor, Tensor};
+use std::sync::{Arc, OnceLock};
+use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+
+fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
+    static CTX: OnceLock<Arc<EagerContext<CpuBackend>>> = OnceLock::new();
+    CTX.get_or_init(|| EagerContext::with_backend(CpuBackend::new()))
+        .clone()
+}
 
 fn f64_data(tensor: &Tensor) -> &[f64] {
     tensor.as_slice::<f64>().unwrap()
@@ -11,7 +18,10 @@ fn c64_data(tensor: &Tensor) -> &[Complex64] {
 
 #[test]
 fn svd_returns_correct_shapes() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]),
+        test_ctx(),
+    );
     let (u, s, vt) = a.svd().unwrap();
 
     assert_eq!(u.data().shape(), &[2, 2]);
@@ -21,7 +31,10 @@ fn svd_returns_correct_shapes() {
 
 #[test]
 fn qr_returns_correct_shapes() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]),
+        test_ctx(),
+    );
     let (q, r) = a.qr().unwrap();
 
     assert_eq!(q.data().shape(), &[2, 2]);
@@ -30,7 +43,10 @@ fn qr_returns_correct_shapes() {
 
 #[test]
 fn qr_second_output_backward_records_selected_output_slot() {
-    let a = EagerTensor::requires_grad(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]));
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]),
+        test_ctx(),
+    );
     let (_q, r) = a.qr().unwrap();
     let loss = r.reduce_sum(&[0, 1]).unwrap();
 
@@ -42,7 +58,10 @@ fn qr_second_output_backward_records_selected_output_slot() {
 
 #[test]
 fn cholesky_of_identity() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]),
+        test_ctx(),
+    );
     let l = a.cholesky().unwrap();
 
     assert_eq!(l.data().shape(), &[2, 2]);
@@ -51,7 +70,10 @@ fn cholesky_of_identity() {
 
 #[test]
 fn svd_gradient_smoke() {
-    let a = EagerTensor::requires_grad(Tensor::from_vec(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 1.0]));
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 1.0]),
+        test_ctx(),
+    );
     let (_, s, _) = a.svd().unwrap();
     let loss = s.reduce_sum(&[0]).unwrap();
 
@@ -64,7 +86,10 @@ fn svd_gradient_smoke() {
 
 #[test]
 fn lu_returns_expected_factors_for_swap_matrix() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]),
+        test_ctx(),
+    );
     let (p, l, u, parity) = a.lu().unwrap();
 
     assert_eq!(p.data().shape(), &[2, 2]);
@@ -80,7 +105,10 @@ fn lu_returns_expected_factors_for_swap_matrix() {
 
 #[test]
 fn full_piv_lu_returns_expected_shapes() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]),
+        test_ctx(),
+    );
     let (p, l, u, q, parity) = a.full_piv_lu().unwrap();
 
     assert_eq!(p.data().shape(), &[2, 2]);
@@ -92,8 +120,14 @@ fn full_piv_lu_returns_expected_shapes() {
 
 #[test]
 fn full_piv_lu_solve_returns_expected_solution() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]));
-    let b = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![-1.0_f64, 5.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]),
+        test_ctx(),
+    );
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 1], vec![-1.0_f64, 5.0]),
+        test_ctx(),
+    );
     let x = a.full_piv_lu_solve(&b).unwrap();
 
     assert_eq!(x.data().shape(), &[2, 1]);
@@ -102,7 +136,10 @@ fn full_piv_lu_solve_returns_expected_solution() {
 
 #[test]
 fn eigh_returns_expected_values_for_diagonal_matrix() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]),
+        test_ctx(),
+    );
     let (values, vectors) = a.eigh().unwrap();
 
     assert_eq!(values.data().shape(), &[2]);
@@ -115,7 +152,10 @@ fn eigh_returns_expected_values_for_diagonal_matrix() {
 
 #[test]
 fn eig_returns_expected_complex_values_for_diagonal_matrix() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]),
+        test_ctx(),
+    );
     let (values, vectors) = a.eig().unwrap();
 
     assert_eq!(values.data().shape(), &[2]);
@@ -135,8 +175,12 @@ fn eig_returns_expected_complex_values_for_diagonal_matrix() {
 
 #[test]
 fn triangular_solve_returns_expected_solution() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]));
-    let b = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![4.0_f64, 8.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]),
+        test_ctx(),
+    );
+    let b =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![4.0_f64, 8.0]), test_ctx());
     let x = a.triangular_solve(&b, true, true, false, false).unwrap();
 
     assert_eq!(x.data().shape(), &[2, 1]);

--- a/tenferro/tests/eager_linalg_tests.rs
+++ b/tenferro/tests/eager_linalg_tests.rs
@@ -1,5 +1,14 @@
 use num_complex::Complex64;
-use tenferro::{DType, DotGeneralConfig, EagerTensor, ScatterConfig, Tensor};
+use std::sync::{Arc, OnceLock};
+use tenferro::{
+    CpuBackend, DType, DotGeneralConfig, EagerContext, EagerTensor, ScatterConfig, Tensor,
+};
+
+fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
+    static CTX: OnceLock<Arc<EagerContext<CpuBackend>>> = OnceLock::new();
+    CTX.get_or_init(|| EagerContext::with_backend(CpuBackend::new()))
+        .clone()
+}
 
 const LINALG_TOL: f64 = 1.0e-7;
 const ELEMENTWISE_TOL: f64 = 1.0e-8;
@@ -52,7 +61,10 @@ fn reduce_all(tensor: &EagerTensor) -> EagerTensor {
 
 #[test]
 fn eager_linalg_svd_reconstructs_input() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![3.0_f64, 0.5, 1.0, 2.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![3.0_f64, 0.5, 1.0, 2.0]),
+        test_ctx(),
+    );
     let (u, s, vh) = a.svd().unwrap();
 
     let sigma = s.embed_diag(0, 1).unwrap();
@@ -67,7 +79,10 @@ fn eager_linalg_svd_reconstructs_input() {
 
 #[test]
 fn eager_linalg_svd_backward_is_finite() {
-    let a = EagerTensor::requires_grad(Tensor::from_vec(vec![2, 2], vec![3.0_f64, 0.5, 1.0, 2.0]));
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![2, 2], vec![3.0_f64, 0.5, 1.0, 2.0]),
+        test_ctx(),
+    );
     let (_, s, _) = a.svd().unwrap();
     let loss = reduce_all(&s);
 
@@ -80,10 +95,10 @@ fn eager_linalg_svd_backward_is_finite() {
 
 #[test]
 fn eager_linalg_qr_reconstructs_input() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![3, 2],
-        vec![3.0_f64, 1.0, 2.0, 2.0, 0.0, 1.0],
-    ));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3, 2], vec![3.0_f64, 1.0, 2.0, 2.0, 0.0, 1.0]),
+        test_ctx(),
+    );
     let (q, r) = a.qr().unwrap();
 
     let reconstruction = matmul(&q, &r);
@@ -97,10 +112,10 @@ fn eager_linalg_qr_reconstructs_input() {
 
 #[test]
 fn eager_linalg_qr_backward_is_finite() {
-    let a = EagerTensor::requires_grad(Tensor::from_vec(
-        vec![3, 2],
-        vec![3.0_f64, 1.0, 2.0, 2.0, 0.0, 1.0],
-    ));
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![3, 2], vec![3.0_f64, 1.0, 2.0, 2.0, 0.0, 1.0]),
+        test_ctx(),
+    );
     let (_, r) = a.qr().unwrap();
     let loss = reduce_all(&r);
 
@@ -113,7 +128,10 @@ fn eager_linalg_qr_backward_is_finite() {
 
 #[test]
 fn eager_linalg_lu_reconstructs_permuted_input() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]),
+        test_ctx(),
+    );
     let (p, l, u, _) = a.lu().unwrap();
 
     let pa = matmul(&p, &a);
@@ -124,7 +142,10 @@ fn eager_linalg_lu_reconstructs_permuted_input() {
 
 #[test]
 fn eager_linalg_lu_backward_is_finite() {
-    let a = EagerTensor::requires_grad(Tensor::from_vec(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]));
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]),
+        test_ctx(),
+    );
     let (_, l, u, _) = a.lu().unwrap();
     let l_sum = reduce_all(&l);
     let u_sum = reduce_all(&u);
@@ -139,7 +160,10 @@ fn eager_linalg_lu_backward_is_finite() {
 
 #[test]
 fn eager_linalg_cholesky_reconstructs_input() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]),
+        test_ctx(),
+    );
     let l = a.cholesky().unwrap();
 
     let reconstruction = matmul(&l, &transpose(&l));
@@ -153,7 +177,10 @@ fn eager_linalg_cholesky_reconstructs_input() {
 
 #[test]
 fn eager_linalg_cholesky_backward_is_finite() {
-    let a = EagerTensor::requires_grad(Tensor::from_vec(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]));
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]),
+        test_ctx(),
+    );
     let l = a.cholesky().unwrap();
     let loss = reduce_all(&l);
 
@@ -166,7 +193,10 @@ fn eager_linalg_cholesky_backward_is_finite() {
 
 #[test]
 fn eager_linalg_eigh_reconstructs_input() {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]));
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]),
+        test_ctx(),
+    );
     let (values, vectors) = a.eigh().unwrap();
 
     let diagonal = values.embed_diag(0, 1).unwrap();
@@ -181,7 +211,10 @@ fn eager_linalg_eigh_reconstructs_input() {
 
 #[test]
 fn eager_linalg_eigh_backward_is_finite() {
-    let a = EagerTensor::requires_grad(Tensor::from_vec(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]));
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]),
+        test_ctx(),
+    );
     let (values, _) = a.eigh().unwrap();
     let loss = reduce_all(&values);
 
@@ -194,8 +227,14 @@ fn eager_linalg_eigh_backward_is_finite() {
 
 #[test]
 fn eager_elementwise_forward_surface_smoke() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![8.0_f64, -6.0, 9.0]));
-    let y = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![2.0_f64, 3.0, 3.0]));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![8.0_f64, -6.0, 9.0]),
+        test_ctx(),
+    );
+    let y = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![2.0_f64, 3.0, 3.0]),
+        test_ctx(),
+    );
     assert_close_slice(
         f64_data(x.div(&y).unwrap().data()),
         &[4.0, -2.0, 3.0],
@@ -222,10 +261,10 @@ fn eager_elementwise_forward_surface_smoke() {
         ELEMENTWISE_TOL,
     );
 
-    let positive = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![2],
-        vec![1.0_f64, std::f64::consts::E],
-    ));
+    let positive = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2], vec![1.0_f64, std::f64::consts::E]),
+        test_ctx(),
+    );
     assert_close_slice(
         f64_data(positive.log().unwrap().data()),
         &[0.0, 1.0],
@@ -247,10 +286,10 @@ fn eager_elementwise_forward_surface_smoke() {
         ELEMENTWISE_TOL,
     );
 
-    let angles = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![2],
-        vec![0.0_f64, std::f64::consts::FRAC_PI_2],
-    ));
+    let angles = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2], vec![0.0_f64, std::f64::consts::FRAC_PI_2]),
+        test_ctx(),
+    );
     assert_close_slice(
         f64_data(angles.sin().unwrap().data()),
         &[0.0, 1.0],
@@ -262,7 +301,8 @@ fn eager_elementwise_forward_surface_smoke() {
         ELEMENTWISE_TOL,
     );
 
-    let tanh_input = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![0.0_f64, 1.0]));
+    let tanh_input =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![0.0_f64, 1.0]), test_ctx());
     assert_close_slice(
         f64_data(tanh_input.tanh().unwrap().data()),
         &[0.0, 1.0_f64.tanh()],
@@ -274,17 +314,32 @@ fn eager_elementwise_forward_surface_smoke() {
         ELEMENTWISE_TOL,
     );
 
-    let pow_base = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![8.0_f64, 9.0, 4.0]));
-    let exponents = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![3.0_f64, 0.5, 2.0]));
+    let pow_base = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![8.0_f64, 9.0, 4.0]),
+        test_ctx(),
+    );
+    let exponents = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![3.0_f64, 0.5, 2.0]),
+        test_ctx(),
+    );
     assert_close_slice(
         f64_data(pow_base.pow(&exponents).unwrap().data()),
         &[512.0, 3.0, 16.0],
         ELEMENTWISE_TOL,
     );
 
-    let condition = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![0.0_f64, -1.0, 2.0]));
-    let on_true = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]));
-    let on_false = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let condition = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![0.0_f64, -1.0, 2.0]),
+        test_ctx(),
+    );
+    let on_true = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]),
+        test_ctx(),
+    );
+    let on_false = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        test_ctx(),
+    );
     assert_close_slice(
         f64_data(
             EagerTensor::select(&condition, &on_true, &on_false)
@@ -295,10 +350,13 @@ fn eager_elementwise_forward_surface_smoke() {
         ELEMENTWISE_TOL,
     );
 
-    let complex = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![2],
-        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
-    ));
+    let complex = EagerTensor::from_tensor_in(
+        Tensor::from_vec(
+            vec![2],
+            vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
+        ),
+        test_ctx(),
+    );
     assert_eq!(
         c64_data(complex.conj().unwrap().data()),
         &[Complex64::new(1.0, -2.0), Complex64::new(-3.0, -0.5)]
@@ -317,9 +375,14 @@ fn eager_elementwise_forward_surface_smoke() {
 
 #[test]
 fn eager_elementwise_scatter_forward_updates_operand() {
-    let operand = EagerTensor::from_tensor(Tensor::from_vec(vec![4], vec![0.0_f64, 0.0, 0.0, 0.0]));
-    let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 1], vec![1_i64, 3]));
-    let updates = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![5.0_f64, 4.0]));
+    let operand = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![4], vec![0.0_f64, 0.0, 0.0, 0.0]),
+        test_ctx(),
+    );
+    let indices =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![1_i64, 3]), test_ctx());
+    let updates =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![5.0_f64, 4.0]), test_ctx());
     let result = operand
         .scatter(
             &indices,

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, OnceLock};
+
 use num_complex::Complex64;
 use tenferro::{
     CpuBackend, DotGeneralConfig, EagerContext, EagerTensor, GatherConfig, PadConfig, SliceConfig,
@@ -72,8 +74,8 @@ fn matmul_config() -> DotGeneralConfig {
 }
 
 fn eager_matmul_sum(lhs: &[f64], rhs: &[f64]) -> f64 {
-    let a = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 3], lhs.to_vec()));
-    let b = EagerTensor::from_tensor(Tensor::from_vec(vec![3, 2], rhs.to_vec()));
+    let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 3], lhs.to_vec()), test_ctx());
+    let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3, 2], rhs.to_vec()), test_ctx());
     let loss = a
         .dot_general(&b, matmul_config())
         .unwrap()
@@ -82,10 +84,16 @@ fn eager_matmul_sum(lhs: &[f64], rhs: &[f64]) -> f64 {
     f64_data(loss.data())[0]
 }
 
+fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
+    static CTX: OnceLock<Arc<EagerContext<CpuBackend>>> = OnceLock::new();
+    CTX.get_or_init(|| EagerContext::with_backend(CpuBackend::new()))
+        .clone()
+}
+
 #[test]
 fn eager_x_squared_gradient_matches_finite_difference() {
     let x_data = vec![1.0, 2.0, 3.0];
-    let x = EagerTensor::requires_grad(Tensor::from_vec(vec![3], x_data.clone()));
+    let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], x_data.clone()), test_ctx());
     let loss = (&x * &x).reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
     let grad = x.grad().unwrap();
@@ -105,7 +113,10 @@ fn eager_x_squared_gradient_matches_finite_difference() {
 
 #[test]
 fn eager_repeated_backward_accumulates_across_calls() {
-    let x = EagerTensor::requires_grad(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        test_ctx(),
+    );
 
     let loss = (&x * &x).reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
@@ -121,8 +132,8 @@ fn eager_matmul_gradients_match_finite_difference() {
     let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let b_data = vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
 
-    let a = EagerTensor::requires_grad(Tensor::from_vec(vec![2, 3], a_data.clone()));
-    let b = EagerTensor::requires_grad(Tensor::from_vec(vec![3, 2], b_data.clone()));
+    let a = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2, 3], a_data.clone()), test_ctx());
+    let b = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3, 2], b_data.clone()), test_ctx());
     let loss = a
         .dot_general(&b, matmul_config())
         .unwrap()
@@ -148,7 +159,8 @@ fn eager_matmul_gradients_match_finite_difference() {
 
 #[test]
 fn eager_exp_gradient_matches_primal() {
-    let x = EagerTensor::requires_grad(Tensor::from_vec(vec![3], vec![0.0, 1.0, 2.0]));
+    let x =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![0.0, 1.0, 2.0]), test_ctx());
     let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
@@ -159,7 +171,8 @@ fn eager_exp_gradient_matches_primal() {
 
 #[test]
 fn eager_fan_out_accumulates_gradient() {
-    let x = EagerTensor::requires_grad(Tensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
+    let x =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]), test_ctx());
     let loss = (&x + &x).reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
@@ -271,7 +284,8 @@ fn eager_send_sync_contracts_compile() {
 
 #[test]
 fn eager_detach_cuts_one_gradient_path() {
-    let x = EagerTensor::requires_grad(Tensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
+    let x =
+        EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]), test_ctx());
     let detached = x.detach();
     let loss = (&detached * &x).reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
@@ -283,8 +297,8 @@ fn eager_detach_cuts_one_gradient_path() {
 
 #[test]
 fn eager_untracked_tensor_behaves_like_plain_tensor() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
-    let y = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![4.0, 5.0, 6.0]));
+    let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]), test_ctx());
+    let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![4.0, 5.0, 6.0]), test_ctx());
     let z = &x * &y;
 
     assert_close_slice(f64_data(z.data()), &[4.0, 10.0, 18.0], TOL);
@@ -295,10 +309,10 @@ fn eager_untracked_tensor_behaves_like_plain_tensor() {
 
 #[test]
 fn eager_structural_primal_ops_transpose_and_reshape() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        test_ctx(),
+    );
 
     let transposed = x.transpose(&[1, 0]).unwrap();
     assert_eq!(transposed.data().shape(), &[3, 2]);
@@ -319,8 +333,14 @@ fn eager_structural_primal_ops_transpose_and_reshape() {
 
 #[test]
 fn eager_elementwise_primal_ops_div_abs_and_sin() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![8.0_f64, -6.0, 9.0]));
-    let y = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![2.0_f64, 3.0, 3.0]));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![8.0_f64, -6.0, 9.0]),
+        test_ctx(),
+    );
+    let y = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![2.0_f64, 3.0, 3.0]),
+        test_ctx(),
+    );
 
     let div = x.div(&y).unwrap();
     assert_close_slice(f64_data(div.data()), &[4.0, -2.0, 3.0], TOL);
@@ -328,33 +348,41 @@ fn eager_elementwise_primal_ops_div_abs_and_sin() {
     let abs = x.abs().unwrap();
     assert_close_slice(f64_data(abs.data()), &[8.0, 6.0, 9.0], TOL);
 
-    let angles = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![2],
-        vec![0.0_f64, std::f64::consts::FRAC_PI_2],
-    ));
+    let angles = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2], vec![0.0_f64, std::f64::consts::FRAC_PI_2]),
+        test_ctx(),
+    );
     let sin = angles.sin().unwrap();
     assert_close_slice(f64_data(sin.data()), &[0.0, 1.0], TOL);
 }
 
 #[test]
 fn eager_diagonal_primal_ops_extract_diag_and_tril() {
-    let matrix = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![3, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-    ));
+    let matrix = EagerTensor::from_tensor_in(
+        Tensor::from_vec(
+            vec![3, 3],
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+        ),
+        test_ctx(),
+    );
     let diag = matrix.extract_diag(0, 1).unwrap();
     assert_close_slice(f64_data(diag.data()), &[1.0, 5.0, 9.0], TOL);
 
-    let lower =
-        EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]))
-            .tril(0)
-            .unwrap();
+    let lower = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+        test_ctx(),
+    )
+    .tril(0)
+    .unwrap();
     assert_close_slice(f64_data(lower.data()), &[1.0, 2.0, 0.0, 4.0], TOL);
 }
 
 #[test]
 fn eager_reduction_primal_ops_reduce_prod() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+        test_ctx(),
+    );
 
     let prod = x.reduce_prod(&[0, 1]).unwrap();
     assert_close_slice(f64_data(prod.data()), &[24.0], TOL);
@@ -368,12 +396,15 @@ fn eager_reduction_primal_ops_reduce_prod() {
 
 #[test]
 fn eager_slice_primal() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![4, 3],
-        vec![
-            1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
-        ],
-    ));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(
+            vec![4, 3],
+            vec![
+                1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+            ],
+        ),
+        test_ctx(),
+    );
 
     let y = x
         .slice(SliceConfig {
@@ -389,7 +420,10 @@ fn eager_slice_primal() {
 
 #[test]
 fn eager_broadcast_in_dim_primal() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        test_ctx(),
+    );
     let y = x.broadcast_in_dim(&[3, 2], &[0]).unwrap();
 
     assert_eq!(y.data().shape(), &[3, 2]);
@@ -398,7 +432,7 @@ fn eager_broadcast_in_dim_primal() {
 
 #[test]
 fn eager_pad_primal() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+    let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), test_ctx());
     let y = x
         .pad(PadConfig {
             edge_padding_low: vec![1],
@@ -413,7 +447,10 @@ fn eager_pad_primal() {
 
 #[test]
 fn eager_reverse_primal() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]),
+        test_ctx(),
+    );
     let y = x.reverse(&[0]).unwrap();
 
     assert_close_slice(f64_data(y.data()), &[4.0, 3.0, 2.0, 1.0], TOL);
@@ -421,8 +458,8 @@ fn eager_reverse_primal() {
 
 #[test]
 fn eager_concatenate_primal() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
-    let y = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]));
+    let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), test_ctx());
+    let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), test_ctx());
     let z = EagerTensor::concatenate(&[&x, &y], 0).unwrap();
 
     assert_eq!(z.data().shape(), &[4]);
@@ -431,11 +468,12 @@ fn eager_concatenate_primal() {
 
 #[test]
 fn eager_gather_primal() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![5],
-        vec![10.0_f64, 20.0, 30.0, 40.0, 50.0],
-    ));
-    let indices = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![4_i64, 1, 0]));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![5], vec![10.0_f64, 20.0, 30.0, 40.0, 50.0]),
+        test_ctx(),
+    );
+    let indices =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![4_i64, 1, 0]), test_ctx());
     let y = x
         .gather(
             &indices,
@@ -455,14 +493,17 @@ fn eager_gather_primal() {
 
 #[test]
 fn eager_dynamic_slice_primal() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![4, 4],
-        vec![
-            1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
-            16.0,
-        ],
-    ));
-    let starts = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![2_i64, 3]));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(
+            vec![4, 4],
+            vec![
+                1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
+                15.0, 16.0,
+            ],
+        ),
+        test_ctx(),
+    );
+    let starts = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![2_i64, 3]), test_ctx());
     let y = x.dynamic_slice(&starts, &[2, 2]).unwrap();
 
     assert_eq!(y.data().shape(), &[2, 2]);
@@ -471,10 +512,13 @@ fn eager_dynamic_slice_primal() {
 
 #[test]
 fn eager_conj_primal() {
-    let x = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![2],
-        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
-    ));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(
+            vec![2],
+            vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
+        ),
+        test_ctx(),
+    );
     let y = x.conj().unwrap();
 
     assert_eq!(
@@ -485,52 +529,67 @@ fn eager_conj_primal() {
 
 #[test]
 fn eager_analytic_primal_ops_sign_log_sqrt_rsqrt_cos_tanh_expm1_log1p() {
-    let sign_input = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![-2.0_f64, 0.0, 3.0]));
+    let sign_input = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![-2.0_f64, 0.0, 3.0]),
+        test_ctx(),
+    );
     let sign = sign_input.sign().unwrap();
     assert_close_slice(f64_data(sign.data()), &[-1.0, 0.0, 1.0], TOL);
 
-    let log_input = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![2],
-        vec![1.0_f64, std::f64::consts::E],
-    ));
+    let log_input = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2], vec![1.0_f64, std::f64::consts::E]),
+        test_ctx(),
+    );
     let log = log_input.log().unwrap();
     assert_close_slice(f64_data(log.data()), &[0.0, 1.0], TOL);
 
-    let sqrt_input = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 4.0]));
+    let sqrt_input =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 4.0]), test_ctx());
     let sqrt = sqrt_input.sqrt().unwrap();
     let rsqrt = sqrt_input.rsqrt().unwrap();
     assert_close_slice(f64_data(sqrt.data()), &[1.0, 2.0], TOL);
     assert_close_slice(f64_data(rsqrt.data()), &[1.0, 0.5], TOL);
 
-    let angles = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![2],
-        vec![0.0_f64, std::f64::consts::PI],
-    ));
+    let angles = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2], vec![0.0_f64, std::f64::consts::PI]),
+        test_ctx(),
+    );
     let cos = angles.cos().unwrap();
     assert_close_slice(f64_data(cos.data()), &[1.0, -1.0], TOL);
 
-    let tanh_input = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![0.0_f64, 1.0]));
+    let tanh_input =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![0.0_f64, 1.0]), test_ctx());
     let tanh = tanh_input.tanh().unwrap();
     assert_close_slice(f64_data(tanh.data()), &[0.0, 1.0_f64.tanh()], TOL);
 
-    let expm1_input = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![0.0_f64, 1.0]));
+    let expm1_input =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![0.0_f64, 1.0]), test_ctx());
     let expm1 = expm1_input.expm1().unwrap();
     assert_close_slice(f64_data(expm1.data()), &[0.0, 1.0_f64.exp_m1()], TOL);
 
-    let log1p_input = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![1.0_f64, 4.0]));
+    let log1p_input =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 4.0]), test_ctx());
     let log1p = log1p_input.log1p().unwrap();
     assert_close_slice(f64_data(log1p.data()), &[2.0_f64.ln(), 5.0_f64.ln()], TOL);
 }
 
 #[test]
 fn eager_pow_maximum_and_minimum_primal() {
-    let base = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![2.0_f64, 9.0]));
-    let exp = EagerTensor::from_tensor(Tensor::from_vec(vec![2], vec![3.0_f64, 0.5]));
+    let base =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![2.0_f64, 9.0]), test_ctx());
+    let exp =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 0.5]), test_ctx());
     let pow = base.pow(&exp).unwrap();
     assert_close_slice(f64_data(pow.data()), &[8.0, 3.0], TOL);
 
-    let x = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![8.0_f64, -2.0, 9.0]));
-    let y = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![2.0_f64, 5.0, 3.0]));
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![8.0_f64, -2.0, 9.0]),
+        test_ctx(),
+    );
+    let y = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![2.0_f64, 5.0, 3.0]),
+        test_ctx(),
+    );
     let maximum = x.maximum(&y).unwrap();
     let minimum = x.minimum(&y).unwrap();
     assert_close_slice(f64_data(maximum.data()), &[8.0, 5.0, 9.0], TOL);
@@ -539,9 +598,18 @@ fn eager_pow_maximum_and_minimum_primal() {
 
 #[test]
 fn eager_select_primal() {
-    let condition = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![0.0_f64, -1.0, 2.0]));
-    let on_true = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]));
-    let on_false = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let condition = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![0.0_f64, -1.0, 2.0]),
+        test_ctx(),
+    );
+    let on_true = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]),
+        test_ctx(),
+    );
+    let on_false = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        test_ctx(),
+    );
     let y = EagerTensor::select(&condition, &on_true, &on_false).unwrap();
 
     assert_close_slice(f64_data(y.data()), &[1.0, 20.0, 30.0], TOL);
@@ -549,7 +617,10 @@ fn eager_select_primal() {
 
 #[test]
 fn eager_embed_diag_and_triu_primal() {
-    let diagonal = EagerTensor::from_tensor(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let diagonal = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        test_ctx(),
+    );
     let embedded = diagonal.embed_diag(0, 1).unwrap();
     assert_eq!(embedded.data().shape(), &[3, 3]);
     assert_close_slice(
@@ -558,10 +629,13 @@ fn eager_embed_diag_and_triu_primal() {
         TOL,
     );
 
-    let matrix = EagerTensor::from_tensor(Tensor::from_vec(
-        vec![3, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-    ));
+    let matrix = EagerTensor::from_tensor_in(
+        Tensor::from_vec(
+            vec![3, 3],
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+        ),
+        test_ctx(),
+    );
     let upper = matrix.triu(0).unwrap();
     assert_close_slice(
         f64_data(upper.data()),


### PR DESCRIPTION
## Summary

Delete `EagerTensor::from_tensor()` and `EagerTensor::requires_grad()` — the
no-context convenience constructors that relied on a hidden static context.
Every `EagerTensor` is now explicitly associated with an `EagerContext`.

### Why

A static `OnceLock<Arc<EagerContext>>` was added in #842 to keep existing
tests working after cross-context mixing was banned.  That global state is
unnecessary: the real fix is to make context ownership explicit at every call
site.

### Changes

- Remove `EagerTensor::from_tensor(tensor)` → use `from_tensor_in(tensor, ctx)`
- Remove `EagerTensor::requires_grad(tensor)` → use `requires_grad_in(tensor, ctx)`
- Remove the static `OnceLock` default context
- Update all 106+ call sites in tests and doc examples
- Test files use a local `test_ctx()` helper

### Result: zero global state

```rust
// Before (hidden static context):
let x = EagerTensor::from_tensor(Tensor::from_vec(...));
let y = EagerTensor::requires_grad(Tensor::from_vec(...));

// After (explicit context):
let ctx = EagerContext::with_backend(CpuBackend::new());
let x = EagerTensor::from_tensor_in(Tensor::from_vec(...), ctx.clone());
let y = EagerTensor::requires_grad_in(Tensor::from_vec(...), ctx);
```

## Test plan
- [x] All 94 tenferro tests pass
- [x] `cargo fmt --all` clean
- [x] `cargo build --workspace` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)