### PR TITLE
Add F32/C32 CPU linalg backend parity

### DIFF
--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -440,6 +440,14 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
+            Tensor::F32(t) => linalg::cholesky(ctx.as_ref(), buffers, t).map(Tensor::F32),
+            #[cfg(feature = "cpu-blas")]
+            Tensor::F32(t) => linalg::cholesky(buffers, t).map(Tensor::F32),
+            #[cfg(feature = "cpu-blas")]
+            Tensor::C32(t) => linalg::cholesky(buffers, t).map(Tensor::C32),
+            #[cfg(feature = "cpu-faer")]
+            Tensor::C32(t) => linalg::cholesky(ctx.as_ref(), buffers, t).map(Tensor::C32),
+            #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => linalg::cholesky(ctx.as_ref(), buffers, t).map(Tensor::F64),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => linalg::cholesky(buffers, t).map(Tensor::F64),
@@ -464,6 +472,18 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match (a, b) {
             #[cfg(feature = "cpu-faer")]
+            (Tensor::F32(a), Tensor::F32(b)) => linalg::triangular_solve(
+                ctx.as_ref(),
+                buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::F32),
+            #[cfg(feature = "cpu-faer")]
             (Tensor::F64(a), Tensor::F64(b)) => linalg::triangular_solve(
                 ctx.as_ref(),
                 buffers,
@@ -476,6 +496,17 @@ impl TensorBackend for CpuBackend {
             )
             .map(Tensor::F64),
             #[cfg(feature = "cpu-blas")]
+            (Tensor::F32(a), Tensor::F32(b)) => linalg::triangular_solve(
+                buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::F32),
+            #[cfg(feature = "cpu-blas")]
             (Tensor::F64(a), Tensor::F64(b)) => linalg::triangular_solve(
                 buffers,
                 a,
@@ -487,6 +518,17 @@ impl TensorBackend for CpuBackend {
             )
             .map(Tensor::F64),
             #[cfg(feature = "cpu-blas")]
+            (Tensor::C32(a), Tensor::C32(b)) => linalg::triangular_solve(
+                buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::C32),
+            #[cfg(feature = "cpu-blas")]
             (Tensor::C64(a), Tensor::C64(b)) => linalg::triangular_solve(
                 buffers,
                 a,
@@ -497,6 +539,18 @@ impl TensorBackend for CpuBackend {
                 unit_diagonal,
             )
             .map(Tensor::C64),
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::C32(a), Tensor::C32(b)) => linalg::triangular_solve(
+                ctx.as_ref(),
+                buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::C32),
             #[cfg(feature = "cpu-faer")]
             (Tensor::C64(a), Tensor::C64(b)) => linalg::triangular_solve(
                 ctx.as_ref(),
@@ -528,16 +582,30 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
+            Tensor::F32(t) => linalg::lu(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
+            #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => linalg::lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+            #[cfg(feature = "cpu-blas")]
+            Tensor::F32(t) => {
+                linalg::lu(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::F32).collect())
+            }
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => {
                 linalg::lu(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::F64).collect())
             }
             #[cfg(feature = "cpu-blas")]
+            Tensor::C32(t) => {
+                linalg::lu(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::C32).collect())
+            }
+            #[cfg(feature = "cpu-blas")]
             Tensor::C64(t) => {
                 linalg::lu(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::C64).collect())
             }
+            #[cfg(feature = "cpu-faer")]
+            Tensor::C32(t) => linalg::lu(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => linalg::lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
@@ -550,14 +618,26 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
+            Tensor::F32(t) => linalg::full_piv_lu(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
+            #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => linalg::full_piv_lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+            #[cfg(feature = "cpu-blas")]
+            Tensor::F32(t) => linalg::full_piv_lu(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => linalg::full_piv_lu(buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
+            Tensor::C32(t) => linalg::full_piv_lu(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
+            #[cfg(feature = "cpu-blas")]
             Tensor::C64(t) => linalg::full_piv_lu(buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+            #[cfg(feature = "cpu-faer")]
+            Tensor::C32(t) => linalg::full_piv_lu(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => linalg::full_piv_lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
@@ -588,16 +668,32 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         let result = self.install_with_pool(|buffers| match (a, &rhs) {
             #[cfg(feature = "cpu-faer")]
+            (Tensor::F32(a), Tensor::F32(b)) => {
+                linalg::full_piv_lu_solve(ctx.as_ref(), buffers, a, b, transpose_a).map(Tensor::F32)
+            }
+            #[cfg(feature = "cpu-faer")]
             (Tensor::F64(a), Tensor::F64(b)) => {
                 linalg::full_piv_lu_solve(ctx.as_ref(), buffers, a, b, transpose_a).map(Tensor::F64)
+            }
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::F32(a), Tensor::F32(b)) => {
+                linalg::full_piv_lu_solve(buffers, a, b, transpose_a).map(Tensor::F32)
             }
             #[cfg(feature = "cpu-blas")]
             (Tensor::F64(a), Tensor::F64(b)) => {
                 linalg::full_piv_lu_solve(buffers, a, b, transpose_a).map(Tensor::F64)
             }
             #[cfg(feature = "cpu-blas")]
+            (Tensor::C32(a), Tensor::C32(b)) => {
+                linalg::full_piv_lu_solve(buffers, a, b, transpose_a).map(Tensor::C32)
+            }
+            #[cfg(feature = "cpu-blas")]
             (Tensor::C64(a), Tensor::C64(b)) => {
                 linalg::full_piv_lu_solve(buffers, a, b, transpose_a).map(Tensor::C64)
+            }
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::C32(a), Tensor::C32(b)) => {
+                linalg::full_piv_lu_solve(ctx.as_ref(), buffers, a, b, transpose_a).map(Tensor::C32)
             }
             #[cfg(feature = "cpu-faer")]
             (Tensor::C64(a), Tensor::C64(b)) => {
@@ -628,14 +724,26 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
+            Tensor::F32(t) => linalg::svd(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
+            #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => linalg::svd(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+            #[cfg(feature = "cpu-blas")]
+            Tensor::F32(t) => linalg::svd(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => linalg::svd(buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
+            Tensor::C32(t) => linalg::svd(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
+            #[cfg(feature = "cpu-blas")]
             Tensor::C64(t) => linalg::svd(buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+            #[cfg(feature = "cpu-faer")]
+            Tensor::C32(t) => linalg::svd(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => linalg::svd(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
@@ -648,16 +756,30 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
+            Tensor::F32(t) => linalg::qr(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
+            #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => linalg::qr(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+            #[cfg(feature = "cpu-blas")]
+            Tensor::F32(t) => {
+                linalg::qr(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::F32).collect())
+            }
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => {
                 linalg::qr(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::F64).collect())
             }
             #[cfg(feature = "cpu-blas")]
+            Tensor::C32(t) => {
+                linalg::qr(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::C32).collect())
+            }
+            #[cfg(feature = "cpu-blas")]
             Tensor::C64(t) => {
                 linalg::qr(buffers, t).map(|outputs| outputs.into_iter().map(Tensor::C64).collect())
             }
+            #[cfg(feature = "cpu-faer")]
+            Tensor::C32(t) => linalg::qr(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => linalg::qr(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
@@ -670,14 +792,26 @@ impl TensorBackend for CpuBackend {
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
+            Tensor::F32(t) => linalg::eigh(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
+            #[cfg(feature = "cpu-faer")]
             Tensor::F64(t) => linalg::eigh(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+            #[cfg(feature = "cpu-blas")]
+            Tensor::F32(t) => linalg::eigh(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
             #[cfg(feature = "cpu-blas")]
             Tensor::F64(t) => linalg::eigh(buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
             #[cfg(feature = "cpu-blas")]
+            Tensor::C32(t) => linalg::eigh(buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
+            #[cfg(feature = "cpu-blas")]
             Tensor::C64(t) => linalg::eigh(buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+            #[cfg(feature = "cpu-faer")]
+            Tensor::C32(t) => linalg::eigh(ctx.as_ref(), buffers, t)
+                .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
             #[cfg(feature = "cpu-faer")]
             Tensor::C64(t) => linalg::eigh(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
@@ -686,7 +820,10 @@ impl TensorBackend for CpuBackend {
     }
 
     fn eig(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        if !matches!(input, Tensor::F64(_) | Tensor::C64(_)) {
+        if !matches!(
+            input,
+            Tensor::F32(_) | Tensor::F64(_) | Tensor::C32(_) | Tensor::C64(_)
+        ) {
             return Err(unsupported_dtype("eig", input.dtype()));
         }
         #[cfg(feature = "cpu-faer")]

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -27,7 +27,9 @@ macro_rules! linalg_single {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Tensor> {
             match input {
+                Tensor::F32(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::F32),
                 Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::F64),
+                Tensor::C32(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::C32),
                 Tensor::C64(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::C64),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
             }
@@ -41,7 +43,9 @@ macro_rules! linalg_single {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Tensor> {
             match input {
+                Tensor::F32(t) => linalg::$name(self.buffers, t).map(Tensor::F32),
                 Tensor::F64(t) => linalg::$name(self.buffers, t).map(Tensor::F64),
+                Tensor::C32(t) => linalg::$name(self.buffers, t).map(Tensor::C32),
                 Tensor::C64(t) => linalg::$name(self.buffers, t).map(Tensor::C64),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
             }
@@ -55,8 +59,12 @@ macro_rules! linalg_multi {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
             match input {
+                Tensor::F32(t) => linalg::$name(self.ctx, self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                 Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                Tensor::C32(t) => linalg::$name(self.ctx, self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
                 Tensor::C64(t) => linalg::$name(self.ctx, self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
@@ -71,8 +79,12 @@ macro_rules! linalg_multi_result {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
             match input {
+                Tensor::F32(t) => linalg::$name(self.ctx, self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                 Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                Tensor::C32(t) => linalg::$name(self.ctx, self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
                 Tensor::C64(t) => linalg::$name(self.ctx, self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
@@ -87,8 +99,12 @@ macro_rules! linalg_multi {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
             match input {
+                Tensor::F32(t) => linalg::$name(self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                 Tensor::F64(t) => linalg::$name(self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                Tensor::C32(t) => linalg::$name(self.buffers, t)
+                    .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
                 Tensor::C64(t) => linalg::$name(self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
                 _ => Err(unsupported_dtype(stringify!($name), input.dtype())),
@@ -217,7 +233,10 @@ impl TensorExec for CpuExecSession<'_> {
     linalg_multi!(eigh);
 
     fn eig(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        if !matches!(input, Tensor::F64(_) | Tensor::C64(_)) {
+        if !matches!(
+            input,
+            Tensor::F32(_) | Tensor::F64(_) | Tensor::C32(_) | Tensor::C64(_)
+        ) {
             return Err(unsupported_dtype("eig", input.dtype()));
         }
         #[cfg(feature = "cpu-faer")]
@@ -241,6 +260,18 @@ impl TensorExec for CpuExecSession<'_> {
     ) -> crate::Result<Tensor> {
         match (a, b) {
             #[cfg(feature = "cpu-faer")]
+            (Tensor::F32(a), Tensor::F32(b)) => linalg::triangular_solve(
+                self.ctx,
+                self.buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::F32),
+            #[cfg(feature = "cpu-faer")]
             (Tensor::F64(a), Tensor::F64(b)) => linalg::triangular_solve(
                 self.ctx,
                 self.buffers,
@@ -252,6 +283,18 @@ impl TensorExec for CpuExecSession<'_> {
                 unit_diagonal,
             )
             .map(Tensor::F64),
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::C32(a), Tensor::C32(b)) => linalg::triangular_solve(
+                self.ctx,
+                self.buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::C32),
             #[cfg(feature = "cpu-faer")]
             (Tensor::C64(a), Tensor::C64(b)) => linalg::triangular_solve(
                 self.ctx,
@@ -265,6 +308,17 @@ impl TensorExec for CpuExecSession<'_> {
             )
             .map(Tensor::C64),
             #[cfg(feature = "cpu-blas")]
+            (Tensor::F32(a), Tensor::F32(b)) => linalg::triangular_solve(
+                self.buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::F32),
+            #[cfg(feature = "cpu-blas")]
             (Tensor::F64(a), Tensor::F64(b)) => linalg::triangular_solve(
                 self.buffers,
                 a,
@@ -275,6 +329,17 @@ impl TensorExec for CpuExecSession<'_> {
                 unit_diagonal,
             )
             .map(Tensor::F64),
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::C32(a), Tensor::C32(b)) => linalg::triangular_solve(
+                self.buffers,
+                a,
+                b,
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+            )
+            .map(Tensor::C32),
             #[cfg(feature = "cpu-blas")]
             (Tensor::C64(a), Tensor::C64(b)) => linalg::triangular_solve(
                 self.buffers,
@@ -308,9 +373,19 @@ impl TensorExec for CpuExecSession<'_> {
     ) -> crate::Result<Tensor> {
         match (a, b) {
             #[cfg(feature = "cpu-faer")]
+            (Tensor::F32(a), Tensor::F32(b)) => {
+                linalg::full_piv_lu_solve(self.ctx, self.buffers, a, b, transpose_a)
+                    .map(Tensor::F32)
+            }
+            #[cfg(feature = "cpu-faer")]
             (Tensor::F64(a), Tensor::F64(b)) => {
                 linalg::full_piv_lu_solve(self.ctx, self.buffers, a, b, transpose_a)
                     .map(Tensor::F64)
+            }
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::C32(a), Tensor::C32(b)) => {
+                linalg::full_piv_lu_solve(self.ctx, self.buffers, a, b, transpose_a)
+                    .map(Tensor::C32)
             }
             #[cfg(feature = "cpu-faer")]
             (Tensor::C64(a), Tensor::C64(b)) => {
@@ -318,8 +393,16 @@ impl TensorExec for CpuExecSession<'_> {
                     .map(Tensor::C64)
             }
             #[cfg(feature = "cpu-blas")]
+            (Tensor::F32(a), Tensor::F32(b)) => {
+                linalg::full_piv_lu_solve(self.buffers, a, b, transpose_a).map(Tensor::F32)
+            }
+            #[cfg(feature = "cpu-blas")]
             (Tensor::F64(a), Tensor::F64(b)) => {
                 linalg::full_piv_lu_solve(self.buffers, a, b, transpose_a).map(Tensor::F64)
+            }
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::C32(a), Tensor::C32(b)) => {
+                linalg::full_piv_lu_solve(self.buffers, a, b, transpose_a).map(Tensor::C32)
             }
             #[cfg(feature = "cpu-blas")]
             (Tensor::C64(a), Tensor::C64(b)) => {

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -3,7 +3,7 @@ use faer::{
     diag::{Diag, DiagRef},
     Conj, Mat, MatMut, MatRef,
 };
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 use std::ops::Range;
 
 use crate::buffer_pool::{BufferPool, PoolScalar};
@@ -119,35 +119,57 @@ fn vec_from_diag<T: Copy + PoolScalar>(buffers: &mut BufferPool, diag: DiagRef<'
     data
 }
 
-fn complex64_to_faer_slice(data: &[Complex64]) -> &[faer::c64] {
-    assert_eq!(
-        std::mem::size_of::<Complex64>(),
-        std::mem::size_of::<faer::c64>()
-    );
-    assert_eq!(
-        std::mem::align_of::<Complex64>(),
-        std::mem::align_of::<faer::c64>()
-    );
+macro_rules! impl_complex_faer_casts {
+    ($to_faer_slice:ident, $to_faer_slice_mut:ident, $complex:ty, $faer_complex:ty) => {
+        fn $to_faer_slice(data: &[$complex]) -> &[$faer_complex] {
+            assert_eq!(
+                std::mem::size_of::<$complex>(),
+                std::mem::size_of::<$faer_complex>()
+            );
+            assert_eq!(
+                std::mem::align_of::<$complex>(),
+                std::mem::align_of::<$faer_complex>()
+            );
 
-    // SAFETY: size and alignment are checked above in release builds, and
-    // both types represent one complex f64 scalar in supported builds.
-    unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<faer::c64>(), data.len()) }
+            // SAFETY: size and alignment are checked above in release builds,
+            // and both types represent one complex scalar over the same real type.
+            unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<$faer_complex>(), data.len()) }
+        }
+
+        fn $to_faer_slice_mut(data: &mut [$complex]) -> &mut [$faer_complex] {
+            assert_eq!(
+                std::mem::size_of::<$complex>(),
+                std::mem::size_of::<$faer_complex>()
+            );
+            assert_eq!(
+                std::mem::align_of::<$complex>(),
+                std::mem::align_of::<$faer_complex>()
+            );
+
+            // SAFETY: size and alignment are checked above in release builds,
+            // and both types represent one complex scalar over the same real type.
+            unsafe {
+                std::slice::from_raw_parts_mut(
+                    data.as_mut_ptr().cast::<$faer_complex>(),
+                    data.len(),
+                )
+            }
+        }
+    };
 }
 
-fn complex64_to_faer_slice_mut(data: &mut [Complex64]) -> &mut [faer::c64] {
-    assert_eq!(
-        std::mem::size_of::<Complex64>(),
-        std::mem::size_of::<faer::c64>()
-    );
-    assert_eq!(
-        std::mem::align_of::<Complex64>(),
-        std::mem::align_of::<faer::c64>()
-    );
-
-    // SAFETY: size and alignment are checked above in release builds, and
-    // both types represent one complex f64 scalar in supported builds.
-    unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr().cast::<faer::c64>(), data.len()) }
-}
+impl_complex_faer_casts!(
+    complex32_to_faer_slice,
+    complex32_to_faer_slice_mut,
+    Complex32,
+    faer::c32
+);
+impl_complex_faer_casts!(
+    complex64_to_faer_slice,
+    complex64_to_faer_slice_mut,
+    Complex64,
+    faer::c64
+);
 
 fn decomposition_failed(op: &'static str) -> crate::Error {
     crate::Error::BackendFailure {
@@ -195,37 +217,72 @@ fn checked_slice_range(
     Ok(start..end)
 }
 
-fn complex_vec_from_real_diag(
-    buffers: &mut BufferPool,
-    diag: DiagRef<'_, faer::c64>,
-) -> Vec<Complex64> {
-    let col = diag.column_vector();
-    let mut data = buffers.acquire_with_capacity::<Complex64>(col.nrows());
-    for i in 0..col.nrows() {
-        data.push(Complex64::new(col[i].re, 0.0));
-    }
-    data
-}
-
-fn complex_vec_from_diag(buffers: &mut BufferPool, diag: DiagRef<'_, faer::c64>) -> Vec<Complex64> {
-    let col = diag.column_vector();
-    let mut data = buffers.acquire_with_capacity::<Complex64>(col.nrows());
-    for i in 0..col.nrows() {
-        data.push(Complex64::new(col[i].re, col[i].im));
-    }
-    data
-}
-
-fn complex_vec_from_mat(buffers: &mut BufferPool, mat: MatRef<'_, faer::c64>) -> Vec<Complex64> {
-    let (rows, cols) = mat.shape();
-    let mut data = buffers.acquire_with_capacity::<Complex64>(rows * cols);
-    for j in 0..cols {
-        for i in 0..rows {
-            let value = mat[(i, j)];
-            data.push(Complex64::new(value.re, value.im));
+macro_rules! impl_complex_vec_helpers {
+    (
+        $vec_from_real_diag:ident,
+        $vec_from_diag:ident,
+        $vec_from_mat:ident,
+        $matrix_from_predicate:ident,
+        $complex:ty,
+        $faer_complex:ty
+    ) => {
+        fn $vec_from_real_diag(
+            buffers: &mut BufferPool,
+            diag: DiagRef<'_, $faer_complex>,
+        ) -> Vec<$complex> {
+            let col = diag.column_vector();
+            let mut data = buffers.acquire_with_capacity::<$complex>(col.nrows());
+            for i in 0..col.nrows() {
+                data.push(<$complex>::new(col[i].re, 0.0));
+            }
+            data
         }
-    }
-    data
+
+        fn $vec_from_diag(
+            buffers: &mut BufferPool,
+            diag: DiagRef<'_, $faer_complex>,
+        ) -> Vec<$complex> {
+            let col = diag.column_vector();
+            let mut data = buffers.acquire_with_capacity::<$complex>(col.nrows());
+            for i in 0..col.nrows() {
+                data.push(<$complex>::new(col[i].re, col[i].im));
+            }
+            data
+        }
+
+        fn $vec_from_mat(
+            buffers: &mut BufferPool,
+            mat: MatRef<'_, $faer_complex>,
+        ) -> Vec<$complex> {
+            let (rows, cols) = mat.shape();
+            let mut data = buffers.acquire_with_capacity::<$complex>(rows * cols);
+            for j in 0..cols {
+                for i in 0..rows {
+                    let value = mat[(i, j)];
+                    data.push(<$complex>::new(value.re, value.im));
+                }
+            }
+            data
+        }
+
+        fn $matrix_from_predicate(
+            mat: MatRef<'_, $faer_complex>,
+            rows: usize,
+            cols: usize,
+            predicate: impl Fn(usize, usize) -> bool,
+        ) -> Vec<$complex> {
+            let mut data = vec![<$complex>::new(0.0, 0.0); rows * cols];
+            for j in 0..cols {
+                for i in 0..rows {
+                    if predicate(i, j) {
+                        let value = mat[(i, j)];
+                        data[i + j * rows] = <$complex>::new(value.re, value.im);
+                    }
+                }
+            }
+            data
+        }
+    };
 }
 
 fn matrix_from_predicate<T: Copy + Default>(
@@ -264,55 +321,61 @@ fn permutation_matrix<T: Copy + Default>(perm: &[usize], one: T) -> Vec<T> {
     data
 }
 
-fn complex_matrix_from_predicate(
-    mat: MatRef<'_, faer::c64>,
-    rows: usize,
-    cols: usize,
-    predicate: impl Fn(usize, usize) -> bool,
-) -> Vec<Complex64> {
-    let mut data = vec![Complex64::new(0.0, 0.0); rows * cols];
-    for j in 0..cols {
-        for i in 0..rows {
-            if predicate(i, j) {
-                let value = mat[(i, j)];
-                data[i + j * rows] = Complex64::new(value.re, value.im);
+impl_complex_vec_helpers!(
+    complex32_vec_from_real_diag,
+    complex32_vec_from_diag,
+    complex32_vec_from_mat,
+    complex32_matrix_from_predicate,
+    Complex32,
+    faer::c32
+);
+impl_complex_vec_helpers!(
+    complex64_vec_from_real_diag,
+    complex64_vec_from_diag,
+    complex64_vec_from_mat,
+    complex64_matrix_from_predicate,
+    Complex64,
+    faer::c64
+);
+
+macro_rules! impl_real_eig_to_complex_outputs {
+    ($name:ident, $real:ty, $complex:ty) => {
+        fn $name(
+            buffers: &mut BufferPool,
+            u_real: MatRef<'_, $real>,
+            s_re: DiagRef<'_, $real>,
+            s_im: DiagRef<'_, $real>,
+        ) -> (Vec<$complex>, Vec<$complex>) {
+            let n = u_real.nrows();
+            // SAFETY: the loop below writes every element of `u` and `s` before any read.
+            let mut u = unsafe { <$complex as PoolScalar>::pool_acquire(buffers, n * n) };
+            // SAFETY: the loop below writes every element of `u` and `s` before any read.
+            let mut s = unsafe { <$complex as PoolScalar>::pool_acquire(buffers, n) };
+            let mut j = 0;
+            while j < n {
+                if s_im[j] == 0.0 {
+                    s[j] = <$complex>::new(s_re[j], 0.0);
+                    for i in 0..n {
+                        u[i + j * n] = <$complex>::new(u_real[(i, j)], 0.0);
+                    }
+                    j += 1;
+                } else {
+                    s[j] = <$complex>::new(s_re[j], s_im[j]);
+                    s[j + 1] = <$complex>::new(s_re[j], -s_im[j]);
+                    for i in 0..n {
+                        u[i + j * n] = <$complex>::new(u_real[(i, j)], u_real[(i, j + 1)]);
+                        u[i + (j + 1) * n] = <$complex>::new(u_real[(i, j)], -u_real[(i, j + 1)]);
+                    }
+                    j += 2;
+                }
             }
+            (u, s)
         }
-    }
-    data
+    };
 }
 
-fn real_eig_to_complex_outputs(
-    buffers: &mut BufferPool,
-    u_real: MatRef<'_, f64>,
-    s_re: DiagRef<'_, f64>,
-    s_im: DiagRef<'_, f64>,
-) -> (Vec<Complex64>, Vec<Complex64>) {
-    let n = u_real.nrows();
-    // SAFETY: the loop below writes every element of `u` and `s` before any read.
-    let mut u = unsafe { <Complex64 as PoolScalar>::pool_acquire(buffers, n * n) };
-    // SAFETY: the loop below writes every element of `u` and `s` before any read.
-    let mut s = unsafe { <Complex64 as PoolScalar>::pool_acquire(buffers, n) };
-    let mut j = 0;
-    while j < n {
-        if s_im[j] == 0.0 {
-            s[j] = Complex64::new(s_re[j], 0.0);
-            for i in 0..n {
-                u[i + j * n] = Complex64::new(u_real[(i, j)], 0.0);
-            }
-            j += 1;
-        } else {
-            s[j] = Complex64::new(s_re[j], s_im[j]);
-            s[j + 1] = Complex64::new(s_re[j], -s_im[j]);
-            for i in 0..n {
-                u[i + j * n] = Complex64::new(u_real[(i, j)], u_real[(i, j + 1)]);
-                u[i + (j + 1) * n] = Complex64::new(u_real[(i, j)], -u_real[(i, j + 1)]);
-            }
-            j += 2;
-        }
-    }
-    (u, s)
-}
+impl_real_eig_to_complex_outputs!(real32_eig_to_complex_outputs, f32, Complex32);
+impl_real_eig_to_complex_outputs!(real64_eig_to_complex_outputs, f64, Complex64);
 
 fn split_shape_core_and_batch<'a>(
     shape: &'a [usize],
@@ -703,7 +766,9 @@ where
     Ok(tensor_from_vec_with_template(out_shape, out_data, b))
 }
 
-impl FaerLinalg for f64 {
+macro_rules! impl_faer_linalg_for_real {
+    ($scalar:ty) => {
+        impl FaerLinalg for $scalar {
     fn parity_one() -> Self {
         1.0
     }
@@ -1239,11 +1304,27 @@ impl FaerLinalg for f64 {
 
         Ok(vec![values, vectors])
     }
+        }
+    };
 }
 
-impl FaerLinalg for Complex64 {
+impl_faer_linalg_for_real!(f32);
+impl_faer_linalg_for_real!(f64);
+
+macro_rules! impl_faer_linalg_for_complex {
+    (
+        $complex:ty,
+        $faer_complex:ty,
+        $to_faer_slice:ident,
+        $to_faer_slice_mut:ident,
+        $vec_from_real_diag:ident,
+        $vec_from_diag:ident,
+        $vec_from_mat:ident,
+        $matrix_from_predicate:ident
+    ) => {
+        impl FaerLinalg for $complex {
     fn parity_one() -> Self {
-        Complex64::new(1.0, 0.0)
+        <$complex>::new(1.0, 0.0)
     }
 
     fn cholesky_2d(
@@ -1254,12 +1335,12 @@ impl FaerLinalg for Complex64 {
         let n = square_matrix_dim(input, "cholesky")?;
         let mut l = Mat::zeros(n, n);
         l.copy_from(MatRef::from_column_major_slice(
-            complex64_to_faer_slice(input.host_data()),
+            $to_faer_slice(input.host_data()),
             n,
             n,
         ));
         let mut mem = MemBuffer::new(
-            faer::linalg::cholesky::llt::factor::cholesky_in_place_scratch::<faer::c64>(
+            faer::linalg::cholesky::llt::factor::cholesky_in_place_scratch::<$faer_complex>(
                 n,
                 ctx.faer_par(),
                 Default::default(),
@@ -1279,7 +1360,7 @@ impl FaerLinalg for Complex64 {
         })?;
         Ok(tensor_from_vec_with_template(
             vec![n, n],
-            complex_matrix_from_predicate(l.as_ref(), n, n, |row, col| row >= col),
+            $matrix_from_predicate(l.as_ref(), n, n, |row, col| row >= col),
             input,
         ))
     }
@@ -1293,14 +1374,14 @@ impl FaerLinalg for Complex64 {
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
         lu.copy_from(MatRef::from_column_major_slice(
-            complex64_to_faer_slice(input.host_data()),
+            $to_faer_slice(input.host_data()),
             m,
             n,
         ));
         let mut perm = vec![0usize; m];
         let mut perm_inv = vec![0usize; m];
         let mut mem = MemBuffer::new(
-            faer::linalg::lu::partial_pivoting::factor::lu_in_place_scratch::<usize, faer::c64>(
+            faer::linalg::lu::partial_pivoting::factor::lu_in_place_scratch::<usize, $faer_complex>(
                 m,
                 n,
                 ctx.faer_par(),
@@ -1318,20 +1399,20 @@ impl FaerLinalg for Complex64 {
         )
         .0;
 
-        let mut p_data = vec![Complex64::new(0.0, 0.0); m * m];
+        let mut p_data = vec![<$complex>::new(0.0, 0.0); m * m];
         for (row, &col) in perm.iter().enumerate() {
-            p_data[row + col * m] = Complex64::new(1.0, 0.0);
+            p_data[row + col * m] = <$complex>::new(1.0, 0.0);
         }
         let parity = if info.transposition_count % 2 == 0 {
-            Complex64::new(1.0, 0.0)
+            <$complex>::new(1.0, 0.0)
         } else {
-            Complex64::new(-1.0, 0.0)
+            <$complex>::new(-1.0, 0.0)
         };
-        let mut l_data = complex_matrix_from_predicate(lu.as_ref(), m, k, |row, col| row >= col);
+        let mut l_data = $matrix_from_predicate(lu.as_ref(), m, k, |row, col| row >= col);
         for i in 0..k {
-            l_data[i + i * m] = Complex64::new(1.0, 0.0);
+            l_data[i + i * m] = <$complex>::new(1.0, 0.0);
         }
-        let u_data = complex_matrix_from_predicate(lu.as_ref(), k, n, |row, col| row <= col);
+        let u_data = $matrix_from_predicate(lu.as_ref(), k, n, |row, col| row <= col);
 
         Ok(vec![
             tensor_from_vec_with_template(vec![m, m], p_data, input),
@@ -1349,7 +1430,7 @@ impl FaerLinalg for Complex64 {
         let n = square_matrix_dim(input, "full_piv_lu")?;
         let mut lu = Mat::zeros(n, n);
         lu.copy_from(MatRef::from_column_major_slice(
-            complex64_to_faer_slice(input.host_data()),
+            $to_faer_slice(input.host_data()),
             n,
             n,
         ));
@@ -1358,7 +1439,7 @@ impl FaerLinalg for Complex64 {
         let mut col_perm = vec![0usize; n];
         let mut col_perm_inv = vec![0usize; n];
         let mut mem = MemBuffer::new(
-            faer::linalg::lu::full_pivoting::factor::lu_in_place_scratch::<usize, faer::c64>(
+            faer::linalg::lu::full_pivoting::factor::lu_in_place_scratch::<usize, $faer_complex>(
                 n,
                 n,
                 ctx.faer_par(),
@@ -1378,16 +1459,16 @@ impl FaerLinalg for Complex64 {
         )
         .0;
 
-        let mut l_data = complex_matrix_from_predicate(lu.as_ref(), n, n, |row, col| row >= col);
+        let mut l_data = $matrix_from_predicate(lu.as_ref(), n, n, |row, col| row >= col);
         for i in 0..n {
-            l_data[i + i * n] = Complex64::new(1.0, 0.0);
+            l_data[i + i * n] = <$complex>::new(1.0, 0.0);
         }
-        let u_data = complex_matrix_from_predicate(lu.as_ref(), n, n, |row, col| row <= col);
-        let one = Complex64::new(1.0, 0.0);
+        let u_data = $matrix_from_predicate(lu.as_ref(), n, n, |row, col| row <= col);
+        let one = <$complex>::new(1.0, 0.0);
         let parity = if info.transposition_count % 2 == 0 {
             one
         } else {
-            Complex64::new(-1.0, 0.0)
+            <$complex>::new(-1.0, 0.0)
         };
 
         Ok(vec![
@@ -1418,7 +1499,7 @@ impl FaerLinalg for Complex64 {
 
         let mut lu = Mat::zeros(n, n);
         lu.copy_from(MatRef::from_column_major_slice(
-            complex64_to_faer_slice(a.host_data()),
+            $to_faer_slice(a.host_data()),
             n,
             n,
         ));
@@ -1427,7 +1508,7 @@ impl FaerLinalg for Complex64 {
         let mut col_perm = vec![0usize; n];
         let mut col_perm_inv = vec![0usize; n];
         let mut mem = MemBuffer::new(
-            faer::linalg::lu::full_pivoting::factor::lu_in_place_scratch::<usize, faer::c64>(
+            faer::linalg::lu::full_pivoting::factor::lu_in_place_scratch::<usize, $faer_complex>(
                 n,
                 n,
                 ctx.faer_par(),
@@ -1458,12 +1539,12 @@ impl FaerLinalg for Complex64 {
         let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
         rhs_data.extend_from_slice(b.host_data());
         let rhs = MatMut::from_column_major_slice_mut(
-            complex64_to_faer_slice_mut(&mut rhs_data),
+            $to_faer_slice_mut(&mut rhs_data),
             n,
             b_cols,
         );
         let mut mem = MemBuffer::new(
-            faer::linalg::lu::full_pivoting::solve::solve_in_place_scratch::<usize, faer::c64>(
+            faer::linalg::lu::full_pivoting::solve::solve_in_place_scratch::<usize, $faer_complex>(
                 n,
                 b_cols,
                 ctx.faer_par(),
@@ -1506,7 +1587,7 @@ impl FaerLinalg for Complex64 {
     ) -> crate::Result<TypedTensor<Self>> {
         let n = square_matrix_dim(a, "triangular_solve")?;
         let (b_rows, b_cols) = matrix_dims(b, "triangular_solve")?;
-        let a_mat = MatRef::from_column_major_slice(complex64_to_faer_slice(a.host_data()), n, n);
+        let a_mat = MatRef::from_column_major_slice($to_faer_slice(a.host_data()), n, n);
 
         if left_side {
             if b_rows != n {
@@ -1519,7 +1600,7 @@ impl FaerLinalg for Complex64 {
             let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
             rhs_data.extend_from_slice(b.host_data());
             let rhs = MatMut::from_column_major_slice_mut(
-                complex64_to_faer_slice_mut(&mut rhs_data),
+                $to_faer_slice_mut(&mut rhs_data),
                 n,
                 b_cols,
             );
@@ -1593,7 +1674,7 @@ impl FaerLinalg for Complex64 {
             let nrhs = b_rows;
             let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data(), nrhs, n);
             let rhs = MatMut::from_column_major_slice_mut(
-                complex64_to_faer_slice_mut(&mut rhs_transposed),
+                $to_faer_slice_mut(&mut rhs_transposed),
                 n,
                 nrhs,
             );
@@ -1668,11 +1749,11 @@ impl FaerLinalg for Complex64 {
     ) -> crate::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "svd")?;
         let k = m.min(n);
-        let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), m, n);
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), m, n);
         let mut u = Mat::zeros(m, k);
         let mut v = Mat::zeros(n, k);
         let mut s = Diag::zeros(k);
-        let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<faer::c64>(
+        let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<$faer_complex>(
             m,
             n,
             faer::linalg::svd::ComputeSvdVectors::Thin,
@@ -1694,12 +1775,12 @@ impl FaerLinalg for Complex64 {
 
         let u = tensor_from_vec_with_template(
             vec![m, k],
-            complex_vec_from_mat(buffers, u.as_ref()),
+            $vec_from_mat(buffers, u.as_ref()),
             input,
         );
         let s = tensor_from_vec_with_template(
             vec![k],
-            complex_vec_from_real_diag(buffers, s.as_ref()),
+            $vec_from_real_diag(buffers, s.as_ref()),
             input,
         );
         let mut vt_data = buffers.acquire_with_capacity::<Self>(k * n);
@@ -1720,14 +1801,14 @@ impl FaerLinalg for Complex64 {
     ) -> crate::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "qr")?;
         let k = m.min(n);
-        let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), m, n);
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), m, n);
         let block_size =
-            faer::linalg::qr::no_pivoting::factor::recommended_block_size::<faer::c64>(m, n);
+            faer::linalg::qr::no_pivoting::factor::recommended_block_size::<$faer_complex>(m, n);
         let mut qr = Mat::zeros(m, n);
         qr.copy_from(mat);
         let mut coeff = Mat::zeros(block_size, k);
         let mut mem = MemBuffer::new(
-            faer::linalg::qr::no_pivoting::factor::qr_in_place_scratch::<faer::c64>(
+            faer::linalg::qr::no_pivoting::factor::qr_in_place_scratch::<$faer_complex>(
                 m,
                 n,
                 block_size,
@@ -1745,7 +1826,7 @@ impl FaerLinalg for Complex64 {
         );
         let mut q = Mat::identity(m, k);
         let mut mem = MemBuffer::new(
-            faer::linalg::householder::apply_block_householder_sequence_on_the_left_in_place_scratch::<faer::c64>(
+            faer::linalg::householder::apply_block_householder_sequence_on_the_left_in_place_scratch::<$faer_complex>(
                 m,
                 block_size,
                 k,
@@ -1762,12 +1843,12 @@ impl FaerLinalg for Complex64 {
         );
         let q = tensor_from_vec_with_template(
             vec![m, k],
-            complex_vec_from_mat(buffers, q.as_ref()),
+            $vec_from_mat(buffers, q.as_ref()),
             input,
         );
         let r = tensor_from_vec_with_template(
             vec![k, n],
-            complex_matrix_from_predicate(qr.as_ref(), k, n, |row, col| row <= col),
+            $matrix_from_predicate(qr.as_ref(), k, n, |row, col| row <= col),
             input,
         );
 
@@ -1780,10 +1861,10 @@ impl FaerLinalg for Complex64 {
         input: &TypedTensor<Self>,
     ) -> crate::Result<Vec<TypedTensor<Self>>> {
         let n = square_matrix_dim(input, "eigh")?;
-        let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), n, n);
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), n, n);
         let mut values = Diag::zeros(n);
         let mut vectors = Mat::zeros(n, n);
-        let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<faer::c64>(
+        let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<$faer_complex>(
             n,
             faer::linalg::evd::ComputeEigenvectors::Yes,
             ctx.faer_par(),
@@ -1802,18 +1883,41 @@ impl FaerLinalg for Complex64 {
 
         let values = tensor_from_vec_with_template(
             vec![n],
-            complex_vec_from_real_diag(buffers, values.as_ref()),
+            $vec_from_real_diag(buffers, values.as_ref()),
             input,
         );
         let vectors = tensor_from_vec_with_template(
             vec![n, n],
-            complex_vec_from_mat(buffers, vectors.as_ref()),
+            $vec_from_mat(buffers, vectors.as_ref()),
             input,
         );
 
         Ok(vec![values, vectors])
     }
+        }
+    };
 }
+
+impl_faer_linalg_for_complex!(
+    Complex32,
+    faer::c32,
+    complex32_to_faer_slice,
+    complex32_to_faer_slice_mut,
+    complex32_vec_from_real_diag,
+    complex32_vec_from_diag,
+    complex32_vec_from_mat,
+    complex32_matrix_from_predicate
+);
+impl_faer_linalg_for_complex!(
+    Complex64,
+    faer::c64,
+    complex64_to_faer_slice,
+    complex64_to_faer_slice_mut,
+    complex64_vec_from_real_diag,
+    complex64_vec_from_diag,
+    complex64_vec_from_mat,
+    complex64_matrix_from_predicate
+);
 
 pub(crate) fn cholesky<T: FaerLinalg>(
     ctx: &CpuContext,
@@ -2076,77 +2180,119 @@ pub(crate) fn eigh<T: FaerLinalg>(
     })
 }
 
-fn eig_real_2d(
-    ctx: &CpuContext,
-    buffers: &mut BufferPool,
-    input: &TypedTensor<f64>,
-) -> crate::Result<Vec<TypedTensor<Complex64>>> {
-    let n = square_matrix_dim(input, "eig")?;
-    let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
-    let mut u_real = Mat::zeros(n, n);
-    let mut s_re = Diag::zeros(n);
-    let mut s_im = Diag::zeros(n);
-    let mut mem = MemBuffer::new(faer::linalg::evd::evd_scratch::<f64>(
-        n,
-        faer::linalg::evd::ComputeEigenvectors::No,
-        faer::linalg::evd::ComputeEigenvectors::Yes,
-        ctx.faer_par(),
-        Default::default(),
-    ));
-    let stack = MemStack::new(&mut mem);
-    faer::linalg::evd::evd_real(
-        mat,
-        s_re.as_mut(),
-        s_im.as_mut(),
-        None,
-        Some(u_real.as_mut()),
-        ctx.faer_par(),
-        stack,
-        Default::default(),
-    )
-    .map_err(|_| decomposition_failed("eig"))?;
-    let (u, s) =
-        real_eig_to_complex_outputs(buffers, u_real.as_ref(), s_re.as_ref(), s_im.as_ref());
+macro_rules! impl_eig_real_2d {
+    ($name:ident, $real:ty, $complex:ty, $real_eig_to_complex_outputs:ident) => {
+        fn $name(
+            ctx: &CpuContext,
+            buffers: &mut BufferPool,
+            input: &TypedTensor<$real>,
+        ) -> crate::Result<Vec<TypedTensor<$complex>>> {
+            let n = square_matrix_dim(input, "eig")?;
+            let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
+            let mut u_real = Mat::zeros(n, n);
+            let mut s_re = Diag::zeros(n);
+            let mut s_im = Diag::zeros(n);
+            let mut mem = MemBuffer::new(faer::linalg::evd::evd_scratch::<$real>(
+                n,
+                faer::linalg::evd::ComputeEigenvectors::No,
+                faer::linalg::evd::ComputeEigenvectors::Yes,
+                ctx.faer_par(),
+                Default::default(),
+            ));
+            let stack = MemStack::new(&mut mem);
+            faer::linalg::evd::evd_real(
+                mat,
+                s_re.as_mut(),
+                s_im.as_mut(),
+                None,
+                Some(u_real.as_mut()),
+                ctx.faer_par(),
+                stack,
+                Default::default(),
+            )
+            .map_err(|_| decomposition_failed("eig"))?;
+            let (u, s) = $real_eig_to_complex_outputs(
+                buffers,
+                u_real.as_ref(),
+                s_re.as_ref(),
+                s_im.as_ref(),
+            );
 
-    Ok(vec![
-        tensor_from_vec_with_template(vec![n], s, input),
-        tensor_from_vec_with_template(vec![n, n], u, input),
-    ])
+            Ok(vec![
+                tensor_from_vec_with_template(vec![n], s, input),
+                tensor_from_vec_with_template(vec![n, n], u, input),
+            ])
+        }
+    };
 }
 
-fn eig_complex_2d(
-    ctx: &CpuContext,
-    buffers: &mut BufferPool,
-    input: &TypedTensor<Complex64>,
-) -> crate::Result<Vec<TypedTensor<Complex64>>> {
-    let n = square_matrix_dim(input, "eig")?;
-    let mat = MatRef::from_column_major_slice(complex64_to_faer_slice(input.host_data()), n, n);
-    let mut u = Mat::zeros(n, n);
-    let mut s = Diag::zeros(n);
-    let mut mem = MemBuffer::new(faer::linalg::evd::evd_scratch::<faer::c64>(
-        n,
-        faer::linalg::evd::ComputeEigenvectors::No,
-        faer::linalg::evd::ComputeEigenvectors::Yes,
-        ctx.faer_par(),
-        Default::default(),
-    ));
-    let stack = MemStack::new(&mut mem);
-    faer::linalg::evd::evd_cplx(
-        mat,
-        s.as_mut(),
-        None,
-        Some(u.as_mut()),
-        ctx.faer_par(),
-        stack,
-        Default::default(),
-    )
-    .map_err(|_| decomposition_failed("eig"))?;
+macro_rules! impl_eig_complex_2d {
+    (
+        $name:ident,
+        $complex:ty,
+        $faer_complex:ty,
+        $to_faer_slice:ident,
+        $vec_from_diag:ident,
+        $vec_from_mat:ident
+    ) => {
+        fn $name(
+            ctx: &CpuContext,
+            buffers: &mut BufferPool,
+            input: &TypedTensor<$complex>,
+        ) -> crate::Result<Vec<TypedTensor<$complex>>> {
+            let n = square_matrix_dim(input, "eig")?;
+            let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), n, n);
+            let mut u = Mat::zeros(n, n);
+            let mut s = Diag::zeros(n);
+            let mut mem = MemBuffer::new(faer::linalg::evd::evd_scratch::<$faer_complex>(
+                n,
+                faer::linalg::evd::ComputeEigenvectors::No,
+                faer::linalg::evd::ComputeEigenvectors::Yes,
+                ctx.faer_par(),
+                Default::default(),
+            ));
+            let stack = MemStack::new(&mut mem);
+            faer::linalg::evd::evd_cplx(
+                mat,
+                s.as_mut(),
+                None,
+                Some(u.as_mut()),
+                ctx.faer_par(),
+                stack,
+                Default::default(),
+            )
+            .map_err(|_| decomposition_failed("eig"))?;
 
-    Ok(vec![
-        tensor_from_vec_with_template(vec![n], complex_vec_from_diag(buffers, s.as_ref()), input),
-        tensor_from_vec_with_template(vec![n, n], complex_vec_from_mat(buffers, u.as_ref()), input),
-    ])
+            Ok(vec![
+                tensor_from_vec_with_template(vec![n], $vec_from_diag(buffers, s.as_ref()), input),
+                tensor_from_vec_with_template(
+                    vec![n, n],
+                    $vec_from_mat(buffers, u.as_ref()),
+                    input,
+                ),
+            ])
+        }
+    };
 }
+
+impl_eig_real_2d!(eig_real32_2d, f32, Complex32, real32_eig_to_complex_outputs);
+impl_eig_real_2d!(eig_real64_2d, f64, Complex64, real64_eig_to_complex_outputs);
+impl_eig_complex_2d!(
+    eig_complex32_2d,
+    Complex32,
+    faer::c32,
+    complex32_to_faer_slice,
+    complex32_vec_from_diag,
+    complex32_vec_from_mat
+);
+impl_eig_complex_2d!(
+    eig_complex64_2d,
+    Complex64,
+    faer::c64,
+    complex64_to_faer_slice,
+    complex64_vec_from_diag,
+    complex64_vec_from_mat
+);
 
 pub(crate) fn eig(
     ctx: &CpuContext,
@@ -2163,33 +2309,59 @@ pub(crate) fn eig(
                 rhs: vec![matrix_shape[1]],
             });
         }
-        return Ok(vec![
-            Tensor::C64(TypedTensor::from_vec(
-                vector_with_batch_shape(n, batch_shape),
-                Vec::new(),
-            )),
-            Tensor::C64(TypedTensor::from_vec(
-                matrix_with_batch_shape(n, n, batch_shape),
-                Vec::new(),
-            )),
-        ]);
+        let value_shape = vector_with_batch_shape(n, batch_shape);
+        let vector_shape = matrix_with_batch_shape(n, n, batch_shape);
+        return match input {
+            Tensor::F32(_) | Tensor::C32(_) => Ok(vec![
+                Tensor::C32(TypedTensor::from_vec(value_shape, Vec::new())),
+                Tensor::C32(TypedTensor::from_vec(vector_shape, Vec::new())),
+            ]),
+            Tensor::F64(_) | Tensor::C64(_) => Ok(vec![
+                Tensor::C64(TypedTensor::from_vec(value_shape, Vec::new())),
+                Tensor::C64(TypedTensor::from_vec(vector_shape, Vec::new())),
+            ]),
+            _ => Err(crate::Error::BackendFailure {
+                op: "eig",
+                message: format!("unsupported dtype {:?}", input.dtype()),
+            }),
+        };
     }
 
     match input {
+        Tensor::F32(t) => {
+            Ok(
+                batched_multi_convert_result("eig", buffers, t, 2, |buffers, batch| {
+                    eig_real32_2d(ctx, buffers, batch)
+                })?
+                .into_iter()
+                .map(Tensor::C32)
+                .collect(),
+            )
+        }
         Tensor::F64(t) => {
             Ok(
                 batched_multi_convert_result("eig", buffers, t, 2, |buffers, batch| {
-                    eig_real_2d(ctx, buffers, batch)
+                    eig_real64_2d(ctx, buffers, batch)
                 })?
                 .into_iter()
                 .map(Tensor::C64)
                 .collect(),
             )
         }
+        Tensor::C32(t) => {
+            Ok(
+                batched_multi_convert_result("eig", buffers, t, 2, |buffers, batch| {
+                    eig_complex32_2d(ctx, buffers, batch)
+                })?
+                .into_iter()
+                .map(Tensor::C32)
+                .collect(),
+            )
+        }
         Tensor::C64(t) => {
             Ok(
                 batched_multi_convert_result("eig", buffers, t, 2, |buffers, batch| {
-                    eig_complex_2d(ctx, buffers, batch)
+                    eig_complex64_2d(ctx, buffers, batch)
                 })?
                 .into_iter()
                 .map(Tensor::C64)

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/cholesky.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/cholesky.rs
@@ -1,4 +1,4 @@
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 
 use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
@@ -17,6 +17,22 @@ impl LapackCholesky for f64 {
     fn potrf(uplo: u8, n: i32, factor: &mut [Self], lda: i32, info: &mut i32) {
         unsafe {
             lapack::dpotrf(uplo, n, factor, lda, info);
+        }
+    }
+}
+
+impl LapackCholesky for f32 {
+    fn potrf(uplo: u8, n: i32, factor: &mut [Self], lda: i32, info: &mut i32) {
+        unsafe {
+            lapack::spotrf(uplo, n, factor, lda, info);
+        }
+    }
+}
+
+impl LapackCholesky for Complex32 {
+    fn potrf(uplo: u8, n: i32, factor: &mut [Self], lda: i32, info: &mut i32) {
+        unsafe {
+            lapack::cpotrf(uplo, n, factor, lda, info);
         }
     }
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/eig.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/eig.rs
@@ -1,4 +1,4 @@
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 
 use crate::buffer_pool::BufferPool;
 use crate::{Tensor, TypedTensor};
@@ -8,157 +8,190 @@ use super::helpers::{
     tensor_from_vec_with_template, work_len, zero_dim_eig_outputs,
 };
 
-fn real_eig_to_complex_outputs(
-    u_real: &[f64],
-    s_re: &[f64],
-    s_im: &[f64],
-    n: usize,
-) -> (Vec<Complex64>, Vec<Complex64>) {
-    let mut vectors = vec![Complex64::new(0.0, 0.0); n * n];
-    let mut values = vec![Complex64::new(0.0, 0.0); n];
-    let mut col = 0;
-    while col < n {
-        if s_im[col] == 0.0 {
-            values[col] = Complex64::new(s_re[col], 0.0);
-            for row in 0..n {
-                vectors[row + col * n] = Complex64::new(u_real[row + col * n], 0.0);
+macro_rules! impl_real_eig_to_complex_outputs {
+    ($name:ident, $real:ty, $complex:ty) => {
+        fn $name(
+            u_real: &[$real],
+            s_re: &[$real],
+            s_im: &[$real],
+            n: usize,
+        ) -> (Vec<$complex>, Vec<$complex>) {
+            let mut vectors = vec![<$complex>::new(0.0, 0.0); n * n];
+            let mut values = vec![<$complex>::new(0.0, 0.0); n];
+            let mut col = 0;
+            while col < n {
+                if s_im[col] == 0.0 {
+                    values[col] = <$complex>::new(s_re[col], 0.0);
+                    for row in 0..n {
+                        vectors[row + col * n] = <$complex>::new(u_real[row + col * n], 0.0);
+                    }
+                    col += 1;
+                } else {
+                    values[col] = <$complex>::new(s_re[col], s_im[col]);
+                    values[col + 1] = <$complex>::new(s_re[col], -s_im[col]);
+                    for row in 0..n {
+                        vectors[row + col * n] =
+                            <$complex>::new(u_real[row + col * n], u_real[row + (col + 1) * n]);
+                        vectors[row + (col + 1) * n] =
+                            <$complex>::new(u_real[row + col * n], -u_real[row + (col + 1) * n]);
+                    }
+                    col += 2;
+                }
             }
-            col += 1;
-        } else {
-            values[col] = Complex64::new(s_re[col], s_im[col]);
-            values[col + 1] = Complex64::new(s_re[col], -s_im[col]);
-            for row in 0..n {
-                vectors[row + col * n] =
-                    Complex64::new(u_real[row + col * n], u_real[row + (col + 1) * n]);
-                vectors[row + (col + 1) * n] =
-                    Complex64::new(u_real[row + col * n], -u_real[row + (col + 1) * n]);
-            }
-            col += 2;
+            (vectors, values)
         }
-    }
-    (vectors, values)
+    };
 }
 
-fn eig_real_2d(
-    _buffers: &mut BufferPool,
-    input: &TypedTensor<f64>,
-) -> crate::Result<Vec<TypedTensor<Complex64>>> {
-    let n = square_matrix_dim(input, "eig")?;
-    let n_i32 = dim_i32(n, "eig")?;
-    let mut a = input.host_data().to_vec();
-    let mut values_re = vec![0.0; n];
-    let mut values_im = vec![0.0; n];
-    let mut vl = vec![0.0; 1];
-    let mut vectors_real = vec![0.0; n * n];
-    let mut query = vec![0.0; 1];
-    let mut info = 0;
-    unsafe {
-        lapack::dgeev(
-            b'N',
-            b'V',
-            n_i32,
-            &mut a,
-            n_i32,
-            &mut values_re,
-            &mut values_im,
-            &mut vl,
-            1,
-            &mut vectors_real,
-            n_i32,
-            &mut query,
-            -1,
-            &mut info,
-        );
-    }
-    check_lapack_info("eig", "dgeev(work query)", info)?;
-    let lwork = work_len(query[0], "eig", "dgeev")?;
-    let mut work = vec![0.0; lwork as usize];
-    unsafe {
-        lapack::dgeev(
-            b'N',
-            b'V',
-            n_i32,
-            &mut a,
-            n_i32,
-            &mut values_re,
-            &mut values_im,
-            &mut vl,
-            1,
-            &mut vectors_real,
-            n_i32,
-            &mut work,
-            lwork,
-            &mut info,
-        );
-    }
-    check_lapack_info("eig", "dgeev", info)?;
-    let (vectors, values) = real_eig_to_complex_outputs(&vectors_real, &values_re, &values_im, n);
+macro_rules! impl_eig_real_2d {
+    ($name:ident, $real:ty, $complex:ty, $geev:path, $routine:literal, $convert:ident) => {
+        fn $name(
+            _buffers: &mut BufferPool,
+            input: &TypedTensor<$real>,
+        ) -> crate::Result<Vec<TypedTensor<$complex>>> {
+            let n = square_matrix_dim(input, "eig")?;
+            let n_i32 = dim_i32(n, "eig")?;
+            let mut a = input.host_data().to_vec();
+            let mut values_re = vec![0.0 as $real; n];
+            let mut values_im = vec![0.0 as $real; n];
+            let mut vl = vec![0.0 as $real; 1];
+            let mut vectors_real = vec![0.0 as $real; n * n];
+            let mut query = vec![0.0 as $real; 1];
+            let mut info = 0;
+            unsafe {
+                $geev(
+                    b'N',
+                    b'V',
+                    n_i32,
+                    &mut a,
+                    n_i32,
+                    &mut values_re,
+                    &mut values_im,
+                    &mut vl,
+                    1,
+                    &mut vectors_real,
+                    n_i32,
+                    &mut query,
+                    -1,
+                    &mut info,
+                );
+            }
+            check_lapack_info("eig", concat!($routine, "(work query)"), info)?;
+            let lwork = work_len(query[0] as f64, "eig", $routine)?;
+            let mut work = vec![0.0 as $real; lwork as usize];
+            unsafe {
+                $geev(
+                    b'N',
+                    b'V',
+                    n_i32,
+                    &mut a,
+                    n_i32,
+                    &mut values_re,
+                    &mut values_im,
+                    &mut vl,
+                    1,
+                    &mut vectors_real,
+                    n_i32,
+                    &mut work,
+                    lwork,
+                    &mut info,
+                );
+            }
+            check_lapack_info("eig", $routine, info)?;
+            let (vectors, values) = $convert(&vectors_real, &values_re, &values_im, n);
 
-    Ok(vec![
-        tensor_from_vec_with_template(vec![n], values, input),
-        tensor_from_vec_with_template(vec![n, n], vectors, input),
-    ])
+            Ok(vec![
+                tensor_from_vec_with_template(vec![n], values, input),
+                tensor_from_vec_with_template(vec![n, n], vectors, input),
+            ])
+        }
+    };
 }
 
-fn eig_complex_2d(
-    _buffers: &mut BufferPool,
-    input: &TypedTensor<Complex64>,
-) -> crate::Result<Vec<TypedTensor<Complex64>>> {
-    let n = square_matrix_dim(input, "eig")?;
-    let n_i32 = dim_i32(n, "eig")?;
-    let mut a = input.host_data().to_vec();
-    let mut values = vec![Complex64::new(0.0, 0.0); n];
-    let mut vl = vec![Complex64::new(0.0, 0.0); 1];
-    let mut vectors = vec![Complex64::new(0.0, 0.0); n * n];
-    let mut query = vec![Complex64::new(0.0, 0.0); 1];
-    let mut rwork = vec![0.0; 2 * n.max(1)];
-    let mut info = 0;
-    unsafe {
-        lapack::zgeev(
-            b'N',
-            b'V',
-            n_i32,
-            &mut a,
-            n_i32,
-            &mut values,
-            &mut vl,
-            1,
-            &mut vectors,
-            n_i32,
-            &mut query,
-            -1,
-            &mut rwork,
-            &mut info,
-        );
-    }
-    check_lapack_info("eig", "zgeev(work query)", info)?;
-    let lwork = work_len(query[0].re, "eig", "zgeev")?;
-    let mut work = vec![Complex64::new(0.0, 0.0); lwork as usize];
-    unsafe {
-        lapack::zgeev(
-            b'N',
-            b'V',
-            n_i32,
-            &mut a,
-            n_i32,
-            &mut values,
-            &mut vl,
-            1,
-            &mut vectors,
-            n_i32,
-            &mut work,
-            lwork,
-            &mut rwork,
-            &mut info,
-        );
-    }
-    check_lapack_info("eig", "zgeev", info)?;
+macro_rules! impl_eig_complex_2d {
+    ($name:ident, $complex:ty, $real:ty, $geev:path, $routine:literal) => {
+        fn $name(
+            _buffers: &mut BufferPool,
+            input: &TypedTensor<$complex>,
+        ) -> crate::Result<Vec<TypedTensor<$complex>>> {
+            let n = square_matrix_dim(input, "eig")?;
+            let n_i32 = dim_i32(n, "eig")?;
+            let mut a = input.host_data().to_vec();
+            let mut values = vec![<$complex>::new(0.0, 0.0); n];
+            let mut vl = vec![<$complex>::new(0.0, 0.0); 1];
+            let mut vectors = vec![<$complex>::new(0.0, 0.0); n * n];
+            let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+            let mut rwork = vec![0.0 as $real; 2 * n.max(1)];
+            let mut info = 0;
+            unsafe {
+                $geev(
+                    b'N',
+                    b'V',
+                    n_i32,
+                    &mut a,
+                    n_i32,
+                    &mut values,
+                    &mut vl,
+                    1,
+                    &mut vectors,
+                    n_i32,
+                    &mut query,
+                    -1,
+                    &mut rwork,
+                    &mut info,
+                );
+            }
+            check_lapack_info("eig", concat!($routine, "(work query)"), info)?;
+            let lwork = work_len(query[0].re as f64, "eig", $routine)?;
+            let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+            unsafe {
+                $geev(
+                    b'N',
+                    b'V',
+                    n_i32,
+                    &mut a,
+                    n_i32,
+                    &mut values,
+                    &mut vl,
+                    1,
+                    &mut vectors,
+                    n_i32,
+                    &mut work,
+                    lwork,
+                    &mut rwork,
+                    &mut info,
+                );
+            }
+            check_lapack_info("eig", $routine, info)?;
 
-    Ok(vec![
-        tensor_from_vec_with_template(vec![n], values, input),
-        tensor_from_vec_with_template(vec![n, n], vectors, input),
-    ])
+            Ok(vec![
+                tensor_from_vec_with_template(vec![n], values, input),
+                tensor_from_vec_with_template(vec![n, n], vectors, input),
+            ])
+        }
+    };
 }
+
+impl_real_eig_to_complex_outputs!(real32_eig_to_complex_outputs, f32, Complex32);
+impl_real_eig_to_complex_outputs!(real64_eig_to_complex_outputs, f64, Complex64);
+impl_eig_real_2d!(
+    eig_real32_2d,
+    f32,
+    Complex32,
+    lapack::sgeev,
+    "sgeev",
+    real32_eig_to_complex_outputs
+);
+impl_eig_real_2d!(
+    eig_real64_2d,
+    f64,
+    Complex64,
+    lapack::dgeev,
+    "dgeev",
+    real64_eig_to_complex_outputs
+);
+impl_eig_complex_2d!(eig_complex32_2d, Complex32, f32, lapack::cgeev, "cgeev");
+impl_eig_complex_2d!(eig_complex64_2d, Complex64, f64, lapack::zgeev, "zgeev");
 
 pub(crate) fn eig(buffers: &mut BufferPool, input: &Tensor) -> crate::Result<Vec<Tensor>> {
     if has_zero_dim(input.shape()) {
@@ -166,11 +199,19 @@ pub(crate) fn eig(buffers: &mut BufferPool, input: &Tensor) -> crate::Result<Vec
     }
 
     match input {
-        Tensor::F64(t) => Ok(batched_multi_convert("eig", buffers, t, eig_real_2d)?
+        Tensor::F32(t) => Ok(batched_multi_convert("eig", buffers, t, eig_real32_2d)?
+            .into_iter()
+            .map(Tensor::C32)
+            .collect()),
+        Tensor::F64(t) => Ok(batched_multi_convert("eig", buffers, t, eig_real64_2d)?
             .into_iter()
             .map(Tensor::C64)
             .collect()),
-        Tensor::C64(t) => Ok(batched_multi_convert("eig", buffers, t, eig_complex_2d)?
+        Tensor::C32(t) => Ok(batched_multi_convert("eig", buffers, t, eig_complex32_2d)?
+            .into_iter()
+            .map(Tensor::C32)
+            .collect()),
+        Tensor::C64(t) => Ok(batched_multi_convert("eig", buffers, t, eig_complex64_2d)?
             .into_iter()
             .map(Tensor::C64)
             .collect()),

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/eigh.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/eigh.rs
@@ -1,4 +1,4 @@
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 
 use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
@@ -16,113 +16,126 @@ pub(crate) trait LapackEigh: Clone + Copy + Default {
     ) -> crate::Result<Vec<TypedTensor<Self>>>;
 }
 
-impl LapackEigh for f64 {
-    fn eigh_2d(
-        _buffers: &mut BufferPool,
-        input: &TypedTensor<Self>,
-    ) -> crate::Result<Vec<TypedTensor<Self>>> {
-        let n = square_matrix_dim(input, "eigh")?;
-        let n_i32 = dim_i32(n, "eigh")?;
-        let mut vectors = input.host_data().to_vec();
-        let mut values = vec![0.0; n];
-        let mut query = vec![0.0; 1];
-        let mut info = 0;
-        unsafe {
-            lapack::dsyev(
-                b'V',
-                b'L',
-                n_i32,
-                &mut vectors,
-                n_i32,
-                &mut values,
-                &mut query,
-                -1,
-                &mut info,
-            );
-        }
-        check_lapack_info("eigh", "dsyev(work query)", info)?;
-        let lwork = work_len(query[0], "eigh", "dsyev")?;
-        let mut work = vec![0.0; lwork as usize];
-        unsafe {
-            lapack::dsyev(
-                b'V',
-                b'L',
-                n_i32,
-                &mut vectors,
-                n_i32,
-                &mut values,
-                &mut work,
-                lwork,
-                &mut info,
-            );
-        }
-        check_lapack_info("eigh", "dsyev", info)?;
+macro_rules! impl_real_eigh {
+    ($scalar:ty, $syev:path, $routine:literal) => {
+        impl LapackEigh for $scalar {
+            fn eigh_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> crate::Result<Vec<TypedTensor<Self>>> {
+                let n = square_matrix_dim(input, "eigh")?;
+                let n_i32 = dim_i32(n, "eigh")?;
+                let mut vectors = input.host_data().to_vec();
+                let mut values = vec![0.0 as $scalar; n];
+                let mut query = vec![0.0 as $scalar; 1];
+                let mut info = 0;
+                unsafe {
+                    $syev(
+                        b'V',
+                        b'L',
+                        n_i32,
+                        &mut vectors,
+                        n_i32,
+                        &mut values,
+                        &mut query,
+                        -1,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("eigh", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0] as f64, "eigh", $routine)?;
+                let mut work = vec![0.0 as $scalar; lwork as usize];
+                unsafe {
+                    $syev(
+                        b'V',
+                        b'L',
+                        n_i32,
+                        &mut vectors,
+                        n_i32,
+                        &mut values,
+                        &mut work,
+                        lwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("eigh", $routine, info)?;
 
-        Ok(vec![
-            tensor_from_vec_with_template(vec![n], values, input),
-            tensor_from_vec_with_template(vec![n, n], vectors, input),
-        ])
-    }
+                Ok(vec![
+                    tensor_from_vec_with_template(vec![n], values, input),
+                    tensor_from_vec_with_template(vec![n, n], vectors, input),
+                ])
+            }
+        }
+    };
 }
 
-impl LapackEigh for Complex64 {
-    fn eigh_2d(
-        _buffers: &mut BufferPool,
-        input: &TypedTensor<Self>,
-    ) -> crate::Result<Vec<TypedTensor<Self>>> {
-        let n = square_matrix_dim(input, "eigh")?;
-        let n_i32 = dim_i32(n, "eigh")?;
-        let mut vectors = input.host_data().to_vec();
-        let mut values = vec![0.0; n];
-        let mut query = vec![Complex64::new(0.0, 0.0); 1];
-        let mut rwork = vec![0.0; (3 * n).saturating_sub(2).max(1)];
-        let mut info = 0;
-        unsafe {
-            lapack::zheev(
-                b'V',
-                b'L',
-                n_i32,
-                &mut vectors,
-                n_i32,
-                &mut values,
-                &mut query,
-                -1,
-                &mut rwork,
-                &mut info,
-            );
-        }
-        check_lapack_info("eigh", "zheev(work query)", info)?;
-        let lwork = work_len(query[0].re, "eigh", "zheev")?;
-        let mut work = vec![Complex64::new(0.0, 0.0); lwork as usize];
-        unsafe {
-            lapack::zheev(
-                b'V',
-                b'L',
-                n_i32,
-                &mut vectors,
-                n_i32,
-                &mut values,
-                &mut work,
-                lwork,
-                &mut rwork,
-                &mut info,
-            );
-        }
-        check_lapack_info("eigh", "zheev", info)?;
+macro_rules! impl_complex_eigh {
+    ($complex:ty, $real:ty, $heev:path, $routine:literal) => {
+        impl LapackEigh for $complex {
+            fn eigh_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> crate::Result<Vec<TypedTensor<Self>>> {
+                let n = square_matrix_dim(input, "eigh")?;
+                let n_i32 = dim_i32(n, "eigh")?;
+                let mut vectors = input.host_data().to_vec();
+                let mut values = vec![0.0 as $real; n];
+                let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                let mut rwork = vec![0.0 as $real; (3 * n).saturating_sub(2).max(1)];
+                let mut info = 0;
+                unsafe {
+                    $heev(
+                        b'V',
+                        b'L',
+                        n_i32,
+                        &mut vectors,
+                        n_i32,
+                        &mut values,
+                        &mut query,
+                        -1,
+                        &mut rwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("eigh", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0].re as f64, "eigh", $routine)?;
+                let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                unsafe {
+                    $heev(
+                        b'V',
+                        b'L',
+                        n_i32,
+                        &mut vectors,
+                        n_i32,
+                        &mut values,
+                        &mut work,
+                        lwork,
+                        &mut rwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("eigh", $routine, info)?;
 
-        Ok(vec![
-            tensor_from_vec_with_template(
-                vec![n],
-                values
-                    .into_iter()
-                    .map(|value| Complex64::new(value, 0.0))
-                    .collect(),
-                input,
-            ),
-            tensor_from_vec_with_template(vec![n, n], vectors, input),
-        ])
-    }
+                Ok(vec![
+                    tensor_from_vec_with_template(
+                        vec![n],
+                        values
+                            .into_iter()
+                            .map(|value| <$complex>::new(value, 0.0))
+                            .collect(),
+                        input,
+                    ),
+                    tensor_from_vec_with_template(vec![n, n], vectors, input),
+                ])
+            }
+        }
+    };
 }
+
+impl_real_eigh!(f32, lapack::ssyev, "ssyev");
+impl_real_eigh!(f64, lapack::dsyev, "dsyev");
+impl_complex_eigh!(Complex32, f32, lapack::cheev, "cheev");
+impl_complex_eigh!(Complex64, f64, lapack::zheev, "zheev");
 
 fn eigh_2d<T: LapackEigh>(
     buffers: &mut BufferPool,

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -1,4 +1,4 @@
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 
 use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
@@ -11,6 +11,27 @@ use super::helpers::{
 };
 
 extern "C" {
+    #[link_name = "sgetc2_"]
+    fn sgetc2_ffi(
+        n: *const i32,
+        a: *mut f32,
+        lda: *const i32,
+        ipiv: *mut i32,
+        jpiv: *mut i32,
+        info: *mut i32,
+    );
+
+    #[link_name = "sgesc2_"]
+    fn sgesc2_ffi(
+        n: *const i32,
+        a: *const f32,
+        lda: *const i32,
+        rhs: *mut f32,
+        ipiv: *const i32,
+        jpiv: *const i32,
+        scale: *mut f32,
+    );
+
     #[link_name = "dgetc2_"]
     fn dgetc2_ffi(
         n: *const i32,
@@ -30,6 +51,27 @@ extern "C" {
         ipiv: *const i32,
         jpiv: *const i32,
         scale: *mut f64,
+    );
+
+    #[link_name = "cgetc2_"]
+    fn cgetc2_ffi(
+        n: *const i32,
+        a: *mut Complex32,
+        lda: *const i32,
+        ipiv: *mut i32,
+        jpiv: *mut i32,
+        info: *mut i32,
+    );
+
+    #[link_name = "cgesc2_"]
+    fn cgesc2_ffi(
+        n: *const i32,
+        a: *const Complex32,
+        lda: *const i32,
+        rhs: *mut Complex32,
+        ipiv: *const i32,
+        jpiv: *const i32,
+        scale: *mut f32,
     );
 
     #[link_name = "zgetc2_"]
@@ -55,8 +97,11 @@ extern "C" {
 }
 
 pub(crate) trait LapackFullPivLu: Clone + Copy + Default {
+    type Scale: Copy;
+
     fn one() -> Self;
     fn negative_one() -> Self;
+    fn scale_one() -> Self::Scale;
     fn getc2(
         n: i32,
         data: &mut [Self],
@@ -72,18 +117,90 @@ pub(crate) trait LapackFullPivLu: Clone + Copy + Default {
         rhs: &mut [Self],
         ipiv: &[i32],
         jpiv: &[i32],
-        scale: &mut f64,
+        scale: &mut Self::Scale,
     );
-    fn apply_inverse_scale(rhs: &mut [Self], scale: f64);
+    fn apply_inverse_scale(rhs: &mut [Self], scale: Self::Scale);
 }
 
-impl LapackFullPivLu for f64 {
+impl LapackFullPivLu for f32 {
+    type Scale = f32;
+
     fn one() -> Self {
         1.0
     }
 
     fn negative_one() -> Self {
         -1.0
+    }
+
+    fn scale_one() -> Self::Scale {
+        1.0
+    }
+
+    fn getc2(
+        n: i32,
+        data: &mut [Self],
+        lda: i32,
+        ipiv: &mut [i32],
+        jpiv: &mut [i32],
+        info: &mut i32,
+    ) {
+        unsafe {
+            sgetc2_ffi(
+                &n,
+                data.as_mut_ptr(),
+                &lda,
+                ipiv.as_mut_ptr(),
+                jpiv.as_mut_ptr(),
+                info,
+            );
+        }
+    }
+
+    fn gesc2(
+        n: i32,
+        data: &[Self],
+        lda: i32,
+        rhs: &mut [Self],
+        ipiv: &[i32],
+        jpiv: &[i32],
+        scale: &mut Self::Scale,
+    ) {
+        unsafe {
+            sgesc2_ffi(
+                &n,
+                data.as_ptr(),
+                &lda,
+                rhs.as_mut_ptr(),
+                ipiv.as_ptr(),
+                jpiv.as_ptr(),
+                scale,
+            );
+        }
+    }
+
+    fn apply_inverse_scale(rhs: &mut [Self], scale: Self::Scale) {
+        if scale != 1.0 {
+            for value in rhs {
+                *value /= scale;
+            }
+        }
+    }
+}
+
+impl LapackFullPivLu for f64 {
+    type Scale = f64;
+
+    fn one() -> Self {
+        1.0
+    }
+
+    fn negative_one() -> Self {
+        -1.0
+    }
+
+    fn scale_one() -> Self::Scale {
+        1.0
     }
 
     fn getc2(
@@ -116,7 +233,7 @@ impl LapackFullPivLu for f64 {
         rhs: &mut [Self],
         ipiv: &[i32],
         jpiv: &[i32],
-        scale: &mut f64,
+        scale: &mut Self::Scale,
     ) {
         // SAFETY: `data` stores the factorized `lda x n` matrix, `rhs` has
         // length at least `n`, pivot arrays have length at least `n`, and
@@ -134,7 +251,73 @@ impl LapackFullPivLu for f64 {
         }
     }
 
-    fn apply_inverse_scale(rhs: &mut [Self], scale: f64) {
+    fn apply_inverse_scale(rhs: &mut [Self], scale: Self::Scale) {
+        if scale != 1.0 {
+            for value in rhs {
+                *value /= scale;
+            }
+        }
+    }
+}
+
+impl LapackFullPivLu for Complex32 {
+    type Scale = f32;
+
+    fn one() -> Self {
+        Complex32::new(1.0, 0.0)
+    }
+
+    fn negative_one() -> Self {
+        Complex32::new(-1.0, 0.0)
+    }
+
+    fn scale_one() -> Self::Scale {
+        1.0
+    }
+
+    fn getc2(
+        n: i32,
+        data: &mut [Self],
+        lda: i32,
+        ipiv: &mut [i32],
+        jpiv: &mut [i32],
+        info: &mut i32,
+    ) {
+        unsafe {
+            cgetc2_ffi(
+                &n,
+                data.as_mut_ptr(),
+                &lda,
+                ipiv.as_mut_ptr(),
+                jpiv.as_mut_ptr(),
+                info,
+            );
+        }
+    }
+
+    fn gesc2(
+        n: i32,
+        data: &[Self],
+        lda: i32,
+        rhs: &mut [Self],
+        ipiv: &[i32],
+        jpiv: &[i32],
+        scale: &mut Self::Scale,
+    ) {
+        unsafe {
+            cgesc2_ffi(
+                &n,
+                data.as_ptr(),
+                &lda,
+                rhs.as_mut_ptr(),
+                ipiv.as_ptr(),
+                jpiv.as_ptr(),
+                scale,
+            );
+        }
+    }
+
+    fn apply_inverse_scale(rhs: &mut [Self], scale: Self::Scale) {
         if scale != 1.0 {
             for value in rhs {
                 *value /= scale;
@@ -144,12 +327,18 @@ impl LapackFullPivLu for f64 {
 }
 
 impl LapackFullPivLu for Complex64 {
+    type Scale = f64;
+
     fn one() -> Self {
         Complex64::new(1.0, 0.0)
     }
 
     fn negative_one() -> Self {
         Complex64::new(-1.0, 0.0)
+    }
+
+    fn scale_one() -> Self::Scale {
+        1.0
     }
 
     fn getc2(
@@ -182,7 +371,7 @@ impl LapackFullPivLu for Complex64 {
         rhs: &mut [Self],
         ipiv: &[i32],
         jpiv: &[i32],
-        scale: &mut f64,
+        scale: &mut Self::Scale,
     ) {
         // SAFETY: `data` stores the factorized `lda x n` matrix, `rhs` has
         // length at least `n`, pivot arrays have length at least `n`, and
@@ -200,7 +389,7 @@ impl LapackFullPivLu for Complex64 {
         }
     }
 
-    fn apply_inverse_scale(rhs: &mut [Self], scale: f64) {
+    fn apply_inverse_scale(rhs: &mut [Self], scale: Self::Scale) {
         if scale != 1.0 {
             for value in rhs {
                 *value /= scale;
@@ -327,7 +516,7 @@ fn solve_2d<T: LapackFullPivLu>(
     for col in 0..b_cols {
         let start = col * n;
         let end = start + n;
-        let mut scale = 1.0;
+        let mut scale = T::scale_one();
         T::gesc2(
             n_i32,
             &lu,

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs
@@ -545,14 +545,20 @@ pub(crate) fn zero_dim_eig_outputs(input: &Tensor) -> crate::Result<Vec<Tensor>>
         });
     }
     let batch_shape = &shape[2..];
-    Ok(vec![
-        Tensor::C64(TypedTensor::from_vec(
-            vector_with_batch_shape(n, batch_shape),
-            Vec::new(),
-        )),
-        Tensor::C64(TypedTensor::from_vec(
-            matrix_with_batch_shape(n, n, batch_shape),
-            Vec::new(),
-        )),
-    ])
+    let value_shape = vector_with_batch_shape(n, batch_shape);
+    let vector_shape = matrix_with_batch_shape(n, n, batch_shape);
+    match input {
+        Tensor::F32(_) | Tensor::C32(_) => Ok(vec![
+            Tensor::C32(TypedTensor::from_vec(value_shape, Vec::new())),
+            Tensor::C32(TypedTensor::from_vec(vector_shape, Vec::new())),
+        ]),
+        Tensor::F64(_) | Tensor::C64(_) => Ok(vec![
+            Tensor::C64(TypedTensor::from_vec(value_shape, Vec::new())),
+            Tensor::C64(TypedTensor::from_vec(vector_shape, Vec::new())),
+        ]),
+        _ => Err(crate::Error::BackendFailure {
+            op: "eig",
+            message: format!("unsupported dtype {:?}", input.dtype()),
+        }),
+    }
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/lu.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/lu.rs
@@ -1,4 +1,4 @@
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 
 use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
@@ -27,6 +27,38 @@ impl LapackLu for f64 {
     fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
         unsafe {
             lapack::dgetrf(m, n, data, lda, ipiv, info);
+        }
+    }
+}
+
+impl LapackLu for f32 {
+    fn one() -> Self {
+        1.0
+    }
+
+    fn negative_one() -> Self {
+        -1.0
+    }
+
+    fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        unsafe {
+            lapack::sgetrf(m, n, data, lda, ipiv, info);
+        }
+    }
+}
+
+impl LapackLu for Complex32 {
+    fn one() -> Self {
+        Complex32::new(1.0, 0.0)
+    }
+
+    fn negative_one() -> Self {
+        Complex32::new(-1.0, 0.0)
+    }
+
+    fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        unsafe {
+            lapack::cgetrf(m, n, data, lda, ipiv, info);
         }
     }
 }

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/qr.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/qr.rs
@@ -1,4 +1,4 @@
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 
 use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
@@ -16,125 +16,150 @@ pub(crate) trait LapackQr: Clone + Copy + Default {
     ) -> crate::Result<Vec<TypedTensor<Self>>>;
 }
 
-impl LapackQr for f64 {
-    fn qr_2d(
-        _buffers: &mut BufferPool,
-        input: &TypedTensor<Self>,
-    ) -> crate::Result<Vec<TypedTensor<Self>>> {
-        let (m, n) = matrix_dims(input, "qr")?;
-        let k = m.min(n);
-        let m_i32 = dim_i32(m, "qr")?;
-        let n_i32 = dim_i32(n, "qr")?;
-        let k_i32 = dim_i32(k, "qr")?;
+macro_rules! impl_real_qr {
+    ($scalar:ty, $geqrf:path, $orgqr:path, $geqrf_name:literal, $orgqr_name:literal) => {
+        impl LapackQr for $scalar {
+            fn qr_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> crate::Result<Vec<TypedTensor<Self>>> {
+                let (m, n) = matrix_dims(input, "qr")?;
+                let k = m.min(n);
+                let m_i32 = dim_i32(m, "qr")?;
+                let n_i32 = dim_i32(n, "qr")?;
+                let k_i32 = dim_i32(k, "qr")?;
 
-        let mut qr = input.host_data().to_vec();
-        let mut tau = vec![0.0; k];
-        let mut query = vec![0.0; 1];
-        let mut info = 0;
-        unsafe {
-            lapack::dgeqrf(
-                m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut query, -1, &mut info,
-            );
-        }
-        check_lapack_info("qr", "dgeqrf(work query)", info)?;
-        let lwork = work_len(query[0], "qr", "dgeqrf")?;
-        let mut work = vec![0.0; lwork as usize];
-        unsafe {
-            lapack::dgeqrf(
-                m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut work, lwork, &mut info,
-            );
-        }
-        check_lapack_info("qr", "dgeqrf", info)?;
+                let mut qr = input.host_data().to_vec();
+                let mut tau = vec![0.0 as $scalar; k];
+                let mut query = vec![0.0 as $scalar; 1];
+                let mut info = 0;
+                unsafe {
+                    $geqrf(
+                        m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut query, -1, &mut info,
+                    );
+                }
+                check_lapack_info("qr", concat!($geqrf_name, "(work query)"), info)?;
+                let lwork = work_len(query[0] as f64, "qr", $geqrf_name)?;
+                let mut work = vec![0.0 as $scalar; lwork as usize];
+                unsafe {
+                    $geqrf(
+                        m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut work, lwork, &mut info,
+                    );
+                }
+                check_lapack_info("qr", $geqrf_name, info)?;
 
-        let r = leading_upper_triangle_from_lapack(&qr, m, k, n);
-        let mut q = Vec::with_capacity(m * k);
-        for col in 0..k {
-            let start = col * m;
-            q.extend_from_slice(&qr[start..start + m]);
-        }
+                let r = leading_upper_triangle_from_lapack(&qr, m, k, n);
+                let mut q = Vec::with_capacity(m * k);
+                for col in 0..k {
+                    let start = col * m;
+                    q.extend_from_slice(&qr[start..start + m]);
+                }
 
-        let mut query = vec![0.0; 1];
-        unsafe {
-            lapack::dorgqr(
-                m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut query, -1, &mut info,
-            );
-        }
-        check_lapack_info("qr", "dorgqr(work query)", info)?;
-        let lwork = work_len(query[0], "qr", "dorgqr")?;
-        let mut work = vec![0.0; lwork as usize];
-        unsafe {
-            lapack::dorgqr(
-                m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut work, lwork, &mut info,
-            );
-        }
-        check_lapack_info("qr", "dorgqr", info)?;
+                let mut query = vec![0.0 as $scalar; 1];
+                unsafe {
+                    $orgqr(
+                        m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut query, -1, &mut info,
+                    );
+                }
+                check_lapack_info("qr", concat!($orgqr_name, "(work query)"), info)?;
+                let lwork = work_len(query[0] as f64, "qr", $orgqr_name)?;
+                let mut work = vec![0.0 as $scalar; lwork as usize];
+                unsafe {
+                    $orgqr(
+                        m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut work, lwork, &mut info,
+                    );
+                }
+                check_lapack_info("qr", $orgqr_name, info)?;
 
-        Ok(vec![
-            tensor_from_vec_with_template(vec![m, k], q, input),
-            tensor_from_vec_with_template(vec![k, n], r, input),
-        ])
-    }
+                Ok(vec![
+                    tensor_from_vec_with_template(vec![m, k], q, input),
+                    tensor_from_vec_with_template(vec![k, n], r, input),
+                ])
+            }
+        }
+    };
 }
 
-impl LapackQr for Complex64 {
-    fn qr_2d(
-        _buffers: &mut BufferPool,
-        input: &TypedTensor<Self>,
-    ) -> crate::Result<Vec<TypedTensor<Self>>> {
-        let (m, n) = matrix_dims(input, "qr")?;
-        let k = m.min(n);
-        let m_i32 = dim_i32(m, "qr")?;
-        let n_i32 = dim_i32(n, "qr")?;
-        let k_i32 = dim_i32(k, "qr")?;
+macro_rules! impl_complex_qr {
+    ($complex:ty, $geqrf:path, $ungqr:path, $geqrf_name:literal, $ungqr_name:literal) => {
+        impl LapackQr for $complex {
+            fn qr_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> crate::Result<Vec<TypedTensor<Self>>> {
+                let (m, n) = matrix_dims(input, "qr")?;
+                let k = m.min(n);
+                let m_i32 = dim_i32(m, "qr")?;
+                let n_i32 = dim_i32(n, "qr")?;
+                let k_i32 = dim_i32(k, "qr")?;
 
-        let mut qr = input.host_data().to_vec();
-        let mut tau = vec![Complex64::new(0.0, 0.0); k];
-        let mut query = vec![Complex64::new(0.0, 0.0); 1];
-        let mut info = 0;
-        unsafe {
-            lapack::zgeqrf(
-                m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut query, -1, &mut info,
-            );
-        }
-        check_lapack_info("qr", "zgeqrf(work query)", info)?;
-        let lwork = work_len(query[0].re, "qr", "zgeqrf")?;
-        let mut work = vec![Complex64::new(0.0, 0.0); lwork as usize];
-        unsafe {
-            lapack::zgeqrf(
-                m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut work, lwork, &mut info,
-            );
-        }
-        check_lapack_info("qr", "zgeqrf", info)?;
+                let mut qr = input.host_data().to_vec();
+                let mut tau = vec![<$complex>::new(0.0, 0.0); k];
+                let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                let mut info = 0;
+                unsafe {
+                    $geqrf(
+                        m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut query, -1, &mut info,
+                    );
+                }
+                check_lapack_info("qr", concat!($geqrf_name, "(work query)"), info)?;
+                let lwork = work_len(query[0].re as f64, "qr", $geqrf_name)?;
+                let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                unsafe {
+                    $geqrf(
+                        m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut work, lwork, &mut info,
+                    );
+                }
+                check_lapack_info("qr", $geqrf_name, info)?;
 
-        let r = leading_upper_triangle_from_lapack(&qr, m, k, n);
-        let mut q = Vec::with_capacity(m * k);
-        for col in 0..k {
-            let start = col * m;
-            q.extend_from_slice(&qr[start..start + m]);
-        }
+                let r = leading_upper_triangle_from_lapack(&qr, m, k, n);
+                let mut q = Vec::with_capacity(m * k);
+                for col in 0..k {
+                    let start = col * m;
+                    q.extend_from_slice(&qr[start..start + m]);
+                }
 
-        let mut query = vec![Complex64::new(0.0, 0.0); 1];
-        unsafe {
-            lapack::zungqr(
-                m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut query, -1, &mut info,
-            );
-        }
-        check_lapack_info("qr", "zungqr(work query)", info)?;
-        let lwork = work_len(query[0].re, "qr", "zungqr")?;
-        let mut work = vec![Complex64::new(0.0, 0.0); lwork as usize];
-        unsafe {
-            lapack::zungqr(
-                m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut work, lwork, &mut info,
-            );
-        }
-        check_lapack_info("qr", "zungqr", info)?;
+                let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                unsafe {
+                    $ungqr(
+                        m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut query, -1, &mut info,
+                    );
+                }
+                check_lapack_info("qr", concat!($ungqr_name, "(work query)"), info)?;
+                let lwork = work_len(query[0].re as f64, "qr", $ungqr_name)?;
+                let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                unsafe {
+                    $ungqr(
+                        m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut work, lwork, &mut info,
+                    );
+                }
+                check_lapack_info("qr", $ungqr_name, info)?;
 
-        Ok(vec![
-            tensor_from_vec_with_template(vec![m, k], q, input),
-            tensor_from_vec_with_template(vec![k, n], r, input),
-        ])
-    }
+                Ok(vec![
+                    tensor_from_vec_with_template(vec![m, k], q, input),
+                    tensor_from_vec_with_template(vec![k, n], r, input),
+                ])
+            }
+        }
+    };
 }
+
+impl_real_qr!(f32, lapack::sgeqrf, lapack::sorgqr, "sgeqrf", "sorgqr");
+impl_real_qr!(f64, lapack::dgeqrf, lapack::dorgqr, "dgeqrf", "dorgqr");
+impl_complex_qr!(
+    Complex32,
+    lapack::cgeqrf,
+    lapack::cungqr,
+    "cgeqrf",
+    "cungqr"
+);
+impl_complex_qr!(
+    Complex64,
+    lapack::zgeqrf,
+    lapack::zungqr,
+    "zgeqrf",
+    "zungqr"
+);
 
 fn qr_2d<T: LapackQr>(
     buffers: &mut BufferPool,

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/svd.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/svd.rs
@@ -1,4 +1,4 @@
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 
 use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
@@ -15,96 +15,109 @@ pub(crate) trait LapackSvd: Clone + Copy + Default {
     ) -> crate::Result<Vec<TypedTensor<Self>>>;
 }
 
-impl LapackSvd for f64 {
-    fn svd_2d(
-        _buffers: &mut BufferPool,
-        input: &TypedTensor<Self>,
-    ) -> crate::Result<Vec<TypedTensor<Self>>> {
-        let (m, n) = matrix_dims(input, "svd")?;
-        let k = m.min(n);
-        let m_i32 = dim_i32(m, "svd")?;
-        let n_i32 = dim_i32(n, "svd")?;
-        let k_i32 = dim_i32(k, "svd")?;
+macro_rules! impl_real_svd {
+    ($scalar:ty, $gesvd:path, $routine:literal) => {
+        impl LapackSvd for $scalar {
+            fn svd_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> crate::Result<Vec<TypedTensor<Self>>> {
+                let (m, n) = matrix_dims(input, "svd")?;
+                let k = m.min(n);
+                let m_i32 = dim_i32(m, "svd")?;
+                let n_i32 = dim_i32(n, "svd")?;
+                let k_i32 = dim_i32(k, "svd")?;
 
-        let mut a = input.host_data().to_vec();
-        let mut s = vec![0.0; k];
-        let mut u = vec![0.0; m * k];
-        let mut vt = vec![0.0; k * n];
-        let mut query = vec![0.0; 1];
-        let mut info = 0;
-        unsafe {
-            lapack::dgesvd(
-                b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt, k_i32,
-                &mut query, -1, &mut info,
-            );
-        }
-        check_lapack_info("svd", "dgesvd(work query)", info)?;
-        let lwork = work_len(query[0], "svd", "dgesvd")?;
-        let mut work = vec![0.0; lwork as usize];
-        unsafe {
-            lapack::dgesvd(
-                b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt, k_i32,
-                &mut work, lwork, &mut info,
-            );
-        }
-        check_lapack_info("svd", "dgesvd", info)?;
+                let mut a = input.host_data().to_vec();
+                let mut s = vec![0.0 as $scalar; k];
+                let mut u = vec![0.0 as $scalar; m * k];
+                let mut vt = vec![0.0 as $scalar; k * n];
+                let mut query = vec![0.0 as $scalar; 1];
+                let mut info = 0;
+                unsafe {
+                    $gesvd(
+                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
+                        k_i32, &mut query, -1, &mut info,
+                    );
+                }
+                check_lapack_info("svd", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0] as f64, "svd", $routine)?;
+                let mut work = vec![0.0 as $scalar; lwork as usize];
+                unsafe {
+                    $gesvd(
+                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
+                        k_i32, &mut work, lwork, &mut info,
+                    );
+                }
+                check_lapack_info("svd", $routine, info)?;
 
-        Ok(vec![
-            tensor_from_vec_with_template(vec![m, k], u, input),
-            tensor_from_vec_with_template(vec![k], s, input),
-            tensor_from_vec_with_template(vec![k, n], vt, input),
-        ])
-    }
+                Ok(vec![
+                    tensor_from_vec_with_template(vec![m, k], u, input),
+                    tensor_from_vec_with_template(vec![k], s, input),
+                    tensor_from_vec_with_template(vec![k, n], vt, input),
+                ])
+            }
+        }
+    };
 }
 
-impl LapackSvd for Complex64 {
-    fn svd_2d(
-        _buffers: &mut BufferPool,
-        input: &TypedTensor<Self>,
-    ) -> crate::Result<Vec<TypedTensor<Self>>> {
-        let (m, n) = matrix_dims(input, "svd")?;
-        let k = m.min(n);
-        let m_i32 = dim_i32(m, "svd")?;
-        let n_i32 = dim_i32(n, "svd")?;
-        let k_i32 = dim_i32(k, "svd")?;
+macro_rules! impl_complex_svd {
+    ($complex:ty, $real:ty, $gesvd:path, $routine:literal) => {
+        impl LapackSvd for $complex {
+            fn svd_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> crate::Result<Vec<TypedTensor<Self>>> {
+                let (m, n) = matrix_dims(input, "svd")?;
+                let k = m.min(n);
+                let m_i32 = dim_i32(m, "svd")?;
+                let n_i32 = dim_i32(n, "svd")?;
+                let k_i32 = dim_i32(k, "svd")?;
 
-        let mut a = input.host_data().to_vec();
-        let mut s = vec![0.0; k];
-        let mut u = vec![Complex64::new(0.0, 0.0); m * k];
-        let mut vt = vec![Complex64::new(0.0, 0.0); k * n];
-        let mut query = vec![Complex64::new(0.0, 0.0); 1];
-        let mut rwork = vec![0.0; 5 * k.max(1)];
-        let mut info = 0;
-        unsafe {
-            lapack::zgesvd(
-                b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt, k_i32,
-                &mut query, -1, &mut rwork, &mut info,
-            );
-        }
-        check_lapack_info("svd", "zgesvd(work query)", info)?;
-        let lwork = work_len(query[0].re, "svd", "zgesvd")?;
-        let mut work = vec![Complex64::new(0.0, 0.0); lwork as usize];
-        unsafe {
-            lapack::zgesvd(
-                b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt, k_i32,
-                &mut work, lwork, &mut rwork, &mut info,
-            );
-        }
-        check_lapack_info("svd", "zgesvd", info)?;
+                let mut a = input.host_data().to_vec();
+                let mut s = vec![0.0 as $real; k];
+                let mut u = vec![<$complex>::new(0.0, 0.0); m * k];
+                let mut vt = vec![<$complex>::new(0.0, 0.0); k * n];
+                let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
+                let mut info = 0;
+                unsafe {
+                    $gesvd(
+                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
+                        k_i32, &mut query, -1, &mut rwork, &mut info,
+                    );
+                }
+                check_lapack_info("svd", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0].re as f64, "svd", $routine)?;
+                let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                unsafe {
+                    $gesvd(
+                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
+                        k_i32, &mut work, lwork, &mut rwork, &mut info,
+                    );
+                }
+                check_lapack_info("svd", $routine, info)?;
 
-        Ok(vec![
-            tensor_from_vec_with_template(vec![m, k], u, input),
-            tensor_from_vec_with_template(
-                vec![k],
-                s.into_iter()
-                    .map(|value| Complex64::new(value, 0.0))
-                    .collect(),
-                input,
-            ),
-            tensor_from_vec_with_template(vec![k, n], vt, input),
-        ])
-    }
+                Ok(vec![
+                    tensor_from_vec_with_template(vec![m, k], u, input),
+                    tensor_from_vec_with_template(
+                        vec![k],
+                        s.into_iter()
+                            .map(|value| <$complex>::new(value, 0.0))
+                            .collect(),
+                        input,
+                    ),
+                    tensor_from_vec_with_template(vec![k, n], vt, input),
+                ])
+            }
+        }
+    };
 }
+
+impl_real_svd!(f32, lapack::sgesvd, "sgesvd");
+impl_real_svd!(f64, lapack::dgesvd, "dgesvd");
+impl_complex_svd!(Complex32, f32, lapack::cgesvd, "cgesvd");
+impl_complex_svd!(Complex64, f64, lapack::zgesvd, "zgesvd");
 
 fn svd_2d<T: LapackSvd>(
     buffers: &mut BufferPool,

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/triangular_solve.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/triangular_solve.rs
@@ -1,4 +1,4 @@
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 
 use crate::buffer_pool::BufferPool;
 use crate::TypedTensor;
@@ -39,6 +39,44 @@ impl LapackTriangularSolve for f64 {
     ) {
         unsafe {
             lapack::dtrtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
+        }
+    }
+}
+
+impl LapackTriangularSolve for f32 {
+    fn trtrs(
+        uplo: u8,
+        trans: u8,
+        diag: u8,
+        n: i32,
+        nrhs: i32,
+        a: &[Self],
+        lda: i32,
+        b: &mut [Self],
+        ldb: i32,
+        info: &mut i32,
+    ) {
+        unsafe {
+            lapack::strtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
+        }
+    }
+}
+
+impl LapackTriangularSolve for Complex32 {
+    fn trtrs(
+        uplo: u8,
+        trans: u8,
+        diag: u8,
+        n: i32,
+        nrhs: i32,
+        a: &[Self],
+        lda: i32,
+        b: &mut [Self],
+        ldb: i32,
+        info: &mut i32,
+    ) {
+        unsafe {
+            lapack::ctrtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
         }
     }
 }

--- a/tenferro-tensor/src/inject.rs
+++ b/tenferro-tensor/src/inject.rs
@@ -31,7 +31,10 @@
 use std::ffi::c_void;
 
 use cblas_inject::{CgemmFnPtr, DgemmFnPtr, SgemmFnPtr, ZgemmFnPtr};
-use lapack_inject::{Dgesc2Lp64FnPtr, Dgetc2Lp64FnPtr, Zgesc2Lp64FnPtr, Zgetc2Lp64FnPtr};
+use lapack_inject::{
+    Cgesc2Lp64FnPtr, Cgetc2Lp64FnPtr, Dgesc2Lp64FnPtr, Dgetc2Lp64FnPtr, Sgesc2Lp64FnPtr,
+    Sgetc2Lp64FnPtr, Zgesc2Lp64FnPtr, Zgetc2Lp64FnPtr,
+};
 
 // --- Public types --------------------------------------------------------
 
@@ -147,44 +150,84 @@ impl BlasGemmProviderPtrSet {
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct LapackProviderPtrSet {
+    /// Fortran `sgesvd` raw function pointer.
+    pub sgesvd: Option<*const c_void>,
     /// Fortran `dgesvd` raw function pointer.
     pub dgesvd: Option<*const c_void>,
+    /// Fortran `cgesvd` raw function pointer.
+    pub cgesvd: Option<*const c_void>,
     /// Fortran `zgesvd` raw function pointer.
     pub zgesvd: Option<*const c_void>,
+    /// Fortran `sgeqrf` raw function pointer.
+    pub sgeqrf: Option<*const c_void>,
     /// Fortran `dgeqrf` raw function pointer.
     pub dgeqrf: Option<*const c_void>,
+    /// Fortran `cgeqrf` raw function pointer.
+    pub cgeqrf: Option<*const c_void>,
     /// Fortran `zgeqrf` raw function pointer.
     pub zgeqrf: Option<*const c_void>,
+    /// Fortran `sorgqr` raw function pointer.
+    pub sorgqr: Option<*const c_void>,
     /// Fortran `dorgqr` raw function pointer.
     pub dorgqr: Option<*const c_void>,
+    /// Fortran `cungqr` raw function pointer.
+    pub cungqr: Option<*const c_void>,
     /// Fortran `zungqr` raw function pointer.
     pub zungqr: Option<*const c_void>,
+    /// Fortran `strtrs` raw function pointer.
+    pub strtrs: Option<*const c_void>,
     /// Fortran `dtrtrs` raw function pointer.
     pub dtrtrs: Option<*const c_void>,
+    /// Fortran `ctrtrs` raw function pointer.
+    pub ctrtrs: Option<*const c_void>,
     /// Fortran `ztrtrs` raw function pointer.
     pub ztrtrs: Option<*const c_void>,
+    /// Fortran `spotrf` raw function pointer.
+    pub spotrf: Option<*const c_void>,
     /// Fortran `dpotrf` raw function pointer.
     pub dpotrf: Option<*const c_void>,
+    /// Fortran `cpotrf` raw function pointer.
+    pub cpotrf: Option<*const c_void>,
     /// Fortran `zpotrf` raw function pointer.
     pub zpotrf: Option<*const c_void>,
+    /// Fortran `sgetrf` raw function pointer.
+    pub sgetrf: Option<*const c_void>,
     /// Fortran `dgetrf` raw function pointer.
     pub dgetrf: Option<*const c_void>,
+    /// Fortran `cgetrf` raw function pointer.
+    pub cgetrf: Option<*const c_void>,
     /// Fortran `zgetrf` raw function pointer.
     pub zgetrf: Option<*const c_void>,
+    /// Fortran `ssyev` raw function pointer.
+    pub ssyev: Option<*const c_void>,
     /// Fortran `dsyev` raw function pointer.
     pub dsyev: Option<*const c_void>,
+    /// Fortran `cheev` raw function pointer.
+    pub cheev: Option<*const c_void>,
     /// Fortran `zheev` raw function pointer.
     pub zheev: Option<*const c_void>,
+    /// Fortran `sgeev` raw function pointer.
+    pub sgeev: Option<*const c_void>,
     /// Fortran `dgeev` raw function pointer.
     pub dgeev: Option<*const c_void>,
+    /// Fortran `cgeev` raw function pointer.
+    pub cgeev: Option<*const c_void>,
     /// Fortran `zgeev` raw function pointer.
     pub zgeev: Option<*const c_void>,
+    /// Fortran `sgetc2` raw function pointer.
+    pub sgetc2: Option<*const c_void>,
     /// Fortran `dgetc2` raw function pointer.
     pub dgetc2: Option<*const c_void>,
+    /// Fortran `sgesc2` raw function pointer.
+    pub sgesc2: Option<*const c_void>,
     /// Fortran `dgesc2` raw function pointer.
     pub dgesc2: Option<*const c_void>,
+    /// Fortran `cgetc2` raw function pointer.
+    pub cgetc2: Option<*const c_void>,
     /// Fortran `zgetc2` raw function pointer.
     pub zgetc2: Option<*const c_void>,
+    /// Fortran `cgesc2` raw function pointer.
+    pub cgesc2: Option<*const c_void>,
     /// Fortran `zgesc2` raw function pointer.
     pub zgesc2: Option<*const c_void>,
 }
@@ -202,25 +245,45 @@ impl LapackProviderPtrSet {
     /// ```
     pub const fn new() -> Self {
         Self {
+            sgesvd: None,
             dgesvd: None,
+            cgesvd: None,
             zgesvd: None,
+            sgeqrf: None,
             dgeqrf: None,
+            cgeqrf: None,
             zgeqrf: None,
+            sorgqr: None,
             dorgqr: None,
+            cungqr: None,
             zungqr: None,
+            strtrs: None,
             dtrtrs: None,
+            ctrtrs: None,
             ztrtrs: None,
+            spotrf: None,
             dpotrf: None,
+            cpotrf: None,
             zpotrf: None,
+            sgetrf: None,
             dgetrf: None,
+            cgetrf: None,
             zgetrf: None,
+            ssyev: None,
             dsyev: None,
+            cheev: None,
             zheev: None,
+            sgeev: None,
             dgeev: None,
+            cgeev: None,
             zgeev: None,
+            sgetc2: None,
             dgetc2: None,
+            sgesc2: None,
             dgesc2: None,
+            cgetc2: None,
             zgetc2: None,
+            cgesc2: None,
             zgesc2: None,
         }
     }
@@ -300,10 +363,18 @@ impl BlasGemmFnPtrSet {
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct LapackFullPivLuFnPtrSet {
+    /// Fortran `sgetc2` LP64 function pointer.
+    pub sgetc2: Option<Sgetc2Lp64FnPtr>,
+    /// Fortran `sgesc2` LP64 function pointer.
+    pub sgesc2: Option<Sgesc2Lp64FnPtr>,
     /// Fortran `dgetc2` LP64 function pointer.
     pub dgetc2: Option<Dgetc2Lp64FnPtr>,
     /// Fortran `dgesc2` LP64 function pointer.
     pub dgesc2: Option<Dgesc2Lp64FnPtr>,
+    /// Fortran `cgetc2` LP64 function pointer.
+    pub cgetc2: Option<Cgetc2Lp64FnPtr>,
+    /// Fortran `cgesc2` LP64 function pointer.
+    pub cgesc2: Option<Cgesc2Lp64FnPtr>,
     /// Fortran `zgetc2` LP64 function pointer.
     pub zgetc2: Option<Zgetc2Lp64FnPtr>,
     /// Fortran `zgesc2` LP64 function pointer.
@@ -323,8 +394,12 @@ impl LapackFullPivLuFnPtrSet {
     /// ```
     pub const fn new() -> Self {
         Self {
+            sgetc2: None,
+            sgesc2: None,
             dgetc2: None,
             dgesc2: None,
+            cgetc2: None,
+            cgesc2: None,
             zgetc2: None,
             zgesc2: None,
         }
@@ -430,11 +505,23 @@ pub unsafe fn register_blas_gemm_fn_ptrs(ptrs: BlasGemmFnPtrSet) {
 /// }
 /// ```
 pub unsafe fn register_lapack_full_piv_lu_fn_ptrs(ptrs: LapackFullPivLuFnPtrSet) {
+    if let Some(f) = ptrs.sgetc2 {
+        unsafe { lapack_inject::register_sgetc2_lp64(f) };
+    }
+    if let Some(f) = ptrs.sgesc2 {
+        unsafe { lapack_inject::register_sgesc2_lp64(f) };
+    }
     if let Some(f) = ptrs.dgetc2 {
         unsafe { lapack_inject::register_dgetc2_lp64(f) };
     }
     if let Some(f) = ptrs.dgesc2 {
         unsafe { lapack_inject::register_dgesc2_lp64(f) };
+    }
+    if let Some(f) = ptrs.cgetc2 {
+        unsafe { lapack_inject::register_cgetc2_lp64(f) };
+    }
+    if let Some(f) = ptrs.cgesc2 {
+        unsafe { lapack_inject::register_cgesc2_lp64(f) };
     }
     if let Some(f) = ptrs.zgetc2 {
         unsafe { lapack_inject::register_zgetc2_lp64(f) };
@@ -593,26 +680,7 @@ pub unsafe fn register_lapack_provider_ptrs(
     abi: ProviderAbi,
     ptrs: LapackProviderPtrSet,
 ) -> Result<(), ProviderRegistrationError> {
-    use lapack_inject::{
-        register_dgeev_ilp64, register_dgeev_lp64, register_dgeqrf_ilp64, register_dgeqrf_lp64,
-        register_dgesc2_ilp64, register_dgesc2_lp64, register_dgesvd_ilp64, register_dgesvd_lp64,
-        register_dgetc2_ilp64, register_dgetc2_lp64, register_dgetrf_ilp64, register_dgetrf_lp64,
-        register_dorgqr_ilp64, register_dorgqr_lp64, register_dpotrf_ilp64, register_dpotrf_lp64,
-        register_dsyev_ilp64, register_dsyev_lp64, register_dtrtrs_ilp64, register_dtrtrs_lp64,
-        register_zgeev_ilp64, register_zgeev_lp64, register_zgeqrf_ilp64, register_zgeqrf_lp64,
-        register_zgesc2_ilp64, register_zgesc2_lp64, register_zgesvd_ilp64, register_zgesvd_lp64,
-        register_zgetc2_ilp64, register_zgetc2_lp64, register_zgetrf_ilp64, register_zgetrf_lp64,
-        register_zheev_ilp64, register_zheev_lp64, register_zpotrf_ilp64, register_zpotrf_lp64,
-        register_ztrtrs_ilp64, register_ztrtrs_lp64, register_zungqr_ilp64, register_zungqr_lp64,
-        DgeevIlp64FnPtr, DgeevLp64FnPtr, DgeqrfIlp64FnPtr, DgeqrfLp64FnPtr, Dgesc2Ilp64FnPtr,
-        Dgesc2Lp64FnPtr, DgesvdIlp64FnPtr, DgesvdLp64FnPtr, Dgetc2Ilp64FnPtr, Dgetc2Lp64FnPtr,
-        DgetrfIlp64FnPtr, DgetrfLp64FnPtr, DorgqrIlp64FnPtr, DorgqrLp64FnPtr, DpotrfIlp64FnPtr,
-        DpotrfLp64FnPtr, DsyevIlp64FnPtr, DsyevLp64FnPtr, DtrtrsIlp64FnPtr, DtrtrsLp64FnPtr,
-        ZgeevIlp64FnPtr, ZgeevLp64FnPtr, ZgeqrfIlp64FnPtr, ZgeqrfLp64FnPtr, Zgesc2Ilp64FnPtr,
-        Zgesc2Lp64FnPtr, ZgesvdIlp64FnPtr, ZgesvdLp64FnPtr, Zgetc2Ilp64FnPtr, Zgetc2Lp64FnPtr,
-        ZgetrfIlp64FnPtr, ZgetrfLp64FnPtr, ZheevIlp64FnPtr, ZheevLp64FnPtr, ZpotrfIlp64FnPtr,
-        ZpotrfLp64FnPtr, ZtrtrsIlp64FnPtr, ZtrtrsLp64FnPtr, ZungqrIlp64FnPtr, ZungqrLp64FnPtr,
-    };
+    use lapack_inject::*;
 
     macro_rules! register_field {
         ($field:ident, $symbol:literal,
@@ -627,12 +695,28 @@ pub unsafe fn register_lapack_provider_ptrs(
     }
 
     register_field!(
+        sgesvd,
+        "sgesvd",
+        SgesvdLp64FnPtr,
+        SgesvdIlp64FnPtr,
+        register_sgesvd_lp64,
+        register_sgesvd_ilp64
+    );
+    register_field!(
         dgesvd,
         "dgesvd",
         DgesvdLp64FnPtr,
         DgesvdIlp64FnPtr,
         register_dgesvd_lp64,
         register_dgesvd_ilp64
+    );
+    register_field!(
+        cgesvd,
+        "cgesvd",
+        CgesvdLp64FnPtr,
+        CgesvdIlp64FnPtr,
+        register_cgesvd_lp64,
+        register_cgesvd_ilp64
     );
     register_field!(
         zgesvd,
@@ -643,12 +727,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_zgesvd_ilp64
     );
     register_field!(
+        sgeqrf,
+        "sgeqrf",
+        SgeqrfLp64FnPtr,
+        SgeqrfIlp64FnPtr,
+        register_sgeqrf_lp64,
+        register_sgeqrf_ilp64
+    );
+    register_field!(
         dgeqrf,
         "dgeqrf",
         DgeqrfLp64FnPtr,
         DgeqrfIlp64FnPtr,
         register_dgeqrf_lp64,
         register_dgeqrf_ilp64
+    );
+    register_field!(
+        cgeqrf,
+        "cgeqrf",
+        CgeqrfLp64FnPtr,
+        CgeqrfIlp64FnPtr,
+        register_cgeqrf_lp64,
+        register_cgeqrf_ilp64
     );
     register_field!(
         zgeqrf,
@@ -659,12 +759,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_zgeqrf_ilp64
     );
     register_field!(
+        sorgqr,
+        "sorgqr",
+        SorgqrLp64FnPtr,
+        SorgqrIlp64FnPtr,
+        register_sorgqr_lp64,
+        register_sorgqr_ilp64
+    );
+    register_field!(
         dorgqr,
         "dorgqr",
         DorgqrLp64FnPtr,
         DorgqrIlp64FnPtr,
         register_dorgqr_lp64,
         register_dorgqr_ilp64
+    );
+    register_field!(
+        cungqr,
+        "cungqr",
+        CungqrLp64FnPtr,
+        CungqrIlp64FnPtr,
+        register_cungqr_lp64,
+        register_cungqr_ilp64
     );
     register_field!(
         zungqr,
@@ -675,12 +791,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_zungqr_ilp64
     );
     register_field!(
+        strtrs,
+        "strtrs",
+        StrtrsLp64FnPtr,
+        StrtrsIlp64FnPtr,
+        register_strtrs_lp64,
+        register_strtrs_ilp64
+    );
+    register_field!(
         dtrtrs,
         "dtrtrs",
         DtrtrsLp64FnPtr,
         DtrtrsIlp64FnPtr,
         register_dtrtrs_lp64,
         register_dtrtrs_ilp64
+    );
+    register_field!(
+        ctrtrs,
+        "ctrtrs",
+        CtrtrsLp64FnPtr,
+        CtrtrsIlp64FnPtr,
+        register_ctrtrs_lp64,
+        register_ctrtrs_ilp64
     );
     register_field!(
         ztrtrs,
@@ -691,12 +823,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_ztrtrs_ilp64
     );
     register_field!(
+        spotrf,
+        "spotrf",
+        SpotrfLp64FnPtr,
+        SpotrfIlp64FnPtr,
+        register_spotrf_lp64,
+        register_spotrf_ilp64
+    );
+    register_field!(
         dpotrf,
         "dpotrf",
         DpotrfLp64FnPtr,
         DpotrfIlp64FnPtr,
         register_dpotrf_lp64,
         register_dpotrf_ilp64
+    );
+    register_field!(
+        cpotrf,
+        "cpotrf",
+        CpotrfLp64FnPtr,
+        CpotrfIlp64FnPtr,
+        register_cpotrf_lp64,
+        register_cpotrf_ilp64
     );
     register_field!(
         zpotrf,
@@ -707,12 +855,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_zpotrf_ilp64
     );
     register_field!(
+        sgetrf,
+        "sgetrf",
+        SgetrfLp64FnPtr,
+        SgetrfIlp64FnPtr,
+        register_sgetrf_lp64,
+        register_sgetrf_ilp64
+    );
+    register_field!(
         dgetrf,
         "dgetrf",
         DgetrfLp64FnPtr,
         DgetrfIlp64FnPtr,
         register_dgetrf_lp64,
         register_dgetrf_ilp64
+    );
+    register_field!(
+        cgetrf,
+        "cgetrf",
+        CgetrfLp64FnPtr,
+        CgetrfIlp64FnPtr,
+        register_cgetrf_lp64,
+        register_cgetrf_ilp64
     );
     register_field!(
         zgetrf,
@@ -723,12 +887,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_zgetrf_ilp64
     );
     register_field!(
+        ssyev,
+        "ssyev",
+        SsyevLp64FnPtr,
+        SsyevIlp64FnPtr,
+        register_ssyev_lp64,
+        register_ssyev_ilp64
+    );
+    register_field!(
         dsyev,
         "dsyev",
         DsyevLp64FnPtr,
         DsyevIlp64FnPtr,
         register_dsyev_lp64,
         register_dsyev_ilp64
+    );
+    register_field!(
+        cheev,
+        "cheev",
+        CheevLp64FnPtr,
+        CheevIlp64FnPtr,
+        register_cheev_lp64,
+        register_cheev_ilp64
     );
     register_field!(
         zheev,
@@ -739,12 +919,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_zheev_ilp64
     );
     register_field!(
+        sgeev,
+        "sgeev",
+        SgeevLp64FnPtr,
+        SgeevIlp64FnPtr,
+        register_sgeev_lp64,
+        register_sgeev_ilp64
+    );
+    register_field!(
         dgeev,
         "dgeev",
         DgeevLp64FnPtr,
         DgeevIlp64FnPtr,
         register_dgeev_lp64,
         register_dgeev_ilp64
+    );
+    register_field!(
+        cgeev,
+        "cgeev",
+        CgeevLp64FnPtr,
+        CgeevIlp64FnPtr,
+        register_cgeev_lp64,
+        register_cgeev_ilp64
     );
     register_field!(
         zgeev,
@@ -755,12 +951,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_zgeev_ilp64
     );
     register_field!(
+        sgetc2,
+        "sgetc2",
+        Sgetc2Lp64FnPtr,
+        Sgetc2Ilp64FnPtr,
+        register_sgetc2_lp64,
+        register_sgetc2_ilp64
+    );
+    register_field!(
         dgetc2,
         "dgetc2",
         Dgetc2Lp64FnPtr,
         Dgetc2Ilp64FnPtr,
         register_dgetc2_lp64,
         register_dgetc2_ilp64
+    );
+    register_field!(
+        sgesc2,
+        "sgesc2",
+        Sgesc2Lp64FnPtr,
+        Sgesc2Ilp64FnPtr,
+        register_sgesc2_lp64,
+        register_sgesc2_ilp64
     );
     register_field!(
         dgesc2,
@@ -771,12 +983,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_dgesc2_ilp64
     );
     register_field!(
+        cgetc2,
+        "cgetc2",
+        Cgetc2Lp64FnPtr,
+        Cgetc2Ilp64FnPtr,
+        register_cgetc2_lp64,
+        register_cgetc2_ilp64
+    );
+    register_field!(
         zgetc2,
         "zgetc2",
         Zgetc2Lp64FnPtr,
         Zgetc2Ilp64FnPtr,
         register_zgetc2_lp64,
         register_zgetc2_ilp64
+    );
+    register_field!(
+        cgesc2,
+        "cgesc2",
+        Cgesc2Lp64FnPtr,
+        Cgesc2Ilp64FnPtr,
+        register_cgesc2_lp64,
+        register_cgesc2_ilp64
     );
     register_field!(
         zgesc2,

--- a/tenferro-tensor/src/tests/cpu_indexing_coverage_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_indexing_coverage_tests.rs
@@ -599,19 +599,20 @@ fn cpu_exec_session_covers_complex_linalg_and_error_dispatch() {
         assert_eq!(exec.eig(&eye).unwrap().len(), 2);
 
         let f32_vec = Tensor::F32(TypedTensor::from_vec(vec![2], vec![1.0, 2.0]));
+        let i64_vec = Tensor::I64(TypedTensor::from_vec(vec![2], vec![1_i64, 2]));
         assert!(matches!(
-            exec.eig(&f32_vec),
+            exec.eig(&i64_vec),
             Err(crate::Error::BackendFailure { op: "eig", .. })
         ));
         assert!(matches!(
-            exec.triangular_solve(&f32_vec, &f32_vec, true, true, false, false),
+            exec.triangular_solve(&i64_vec, &i64_vec, true, true, false, false),
             Err(crate::Error::BackendFailure {
                 op: "triangular_solve",
                 ..
             })
         ));
         assert!(matches!(
-            exec.full_piv_lu_solve(&f32_vec, &f32_vec, false),
+            exec.full_piv_lu_solve(&i64_vec, &i64_vec, false),
             Err(crate::Error::BackendFailure {
                 op: "full_piv_lu_solve",
                 ..

--- a/tenferro-tensor/src/tests/cpu_linalg_dtype_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_linalg_dtype_tests.rs
@@ -1,0 +1,362 @@
+use num_complex::Complex32;
+
+use crate::backend::TensorBackend;
+use crate::cpu::CpuBackend;
+use crate::{Tensor, TypedTensor};
+
+fn col_major_index(rows: usize, row: usize, col: usize) -> usize {
+    row + col * rows
+}
+
+fn matmul_f32(lhs: &[f32], rhs: &[f32], m: usize, k: usize, n: usize) -> Vec<f32> {
+    let mut out = vec![0.0; m * n];
+    for j in 0..n {
+        for p in 0..k {
+            let rhs_pj = rhs[col_major_index(k, p, j)];
+            for i in 0..m {
+                out[col_major_index(m, i, j)] += lhs[col_major_index(m, i, p)] * rhs_pj;
+            }
+        }
+    }
+    out
+}
+
+fn matmul_c32(
+    lhs: &[Complex32],
+    rhs: &[Complex32],
+    m: usize,
+    k: usize,
+    n: usize,
+) -> Vec<Complex32> {
+    let mut out = vec![Complex32::new(0.0, 0.0); m * n];
+    for j in 0..n {
+        for p in 0..k {
+            let rhs_pj = rhs[col_major_index(k, p, j)];
+            for i in 0..m {
+                out[col_major_index(m, i, j)] += lhs[col_major_index(m, i, p)] * rhs_pj;
+            }
+        }
+    }
+    out
+}
+
+fn transpose_f32(mat: &[f32], rows: usize, cols: usize) -> Vec<f32> {
+    let mut out = vec![0.0; rows * cols];
+    for j in 0..cols {
+        for i in 0..rows {
+            out[col_major_index(cols, j, i)] = mat[col_major_index(rows, i, j)];
+        }
+    }
+    out
+}
+
+fn conjugate_transpose_c32(mat: &[Complex32], rows: usize, cols: usize) -> Vec<Complex32> {
+    let mut out = vec![Complex32::new(0.0, 0.0); rows * cols];
+    for j in 0..cols {
+        for i in 0..rows {
+            out[col_major_index(cols, j, i)] = mat[col_major_index(rows, i, j)].conj();
+        }
+    }
+    out
+}
+
+fn diag_f32(values: &[f32]) -> Vec<f32> {
+    let mut out = vec![0.0; values.len() * values.len()];
+    for (i, value) in values.iter().enumerate() {
+        out[col_major_index(values.len(), i, i)] = *value;
+    }
+    out
+}
+
+fn diag_c32(values: &[Complex32]) -> Vec<Complex32> {
+    let mut out = vec![Complex32::new(0.0, 0.0); values.len() * values.len()];
+    for (i, value) in values.iter().enumerate() {
+        out[col_major_index(values.len(), i, i)] = *value;
+    }
+    out
+}
+
+fn f32_data(tensor: &Tensor) -> &[f32] {
+    match tensor {
+        Tensor::F32(inner) => inner.host_data(),
+        other => panic!("expected F32 tensor, got {:?}", other.dtype()),
+    }
+}
+
+fn c32_data(tensor: &Tensor) -> &[Complex32] {
+    match tensor {
+        Tensor::C32(inner) => inner.host_data(),
+        other => panic!("expected C32 tensor, got {:?}", other.dtype()),
+    }
+}
+
+fn assert_f32_close(actual: f32, expected: f32, tol: f32) {
+    assert!(
+        (actual - expected).abs() <= tol,
+        "expected {expected}, got {actual}, tol={tol}"
+    );
+}
+
+fn assert_c32_close(actual: Complex32, expected: Complex32, tol: f32) {
+    assert_f32_close(actual.re, expected.re, tol);
+    assert_f32_close(actual.im, expected.im, tol);
+}
+
+fn assert_f32_slice_close(actual: &[f32], expected: &[f32], tol: f32) {
+    assert_eq!(actual.len(), expected.len());
+    for (actual, expected) in actual.iter().zip(expected.iter()) {
+        assert_f32_close(*actual, *expected, tol);
+    }
+}
+
+fn assert_c32_slice_close(actual: &[Complex32], expected: &[Complex32], tol: f32) {
+    assert_eq!(actual.len(), expected.len());
+    for (actual, expected) in actual.iter().zip(expected.iter()) {
+        assert_c32_close(*actual, *expected, tol);
+    }
+}
+
+#[test]
+fn cpu_linalg_accepts_f32_happy_paths() {
+    let mut backend = CpuBackend::new();
+    let tol = 5.0e-4;
+
+    let lower = vec![2.0, 0.5, 0.0, 1.5];
+    let spd = matmul_f32(&lower, &transpose_f32(&lower, 2, 2), 2, 2, 2);
+    let chol = backend
+        .cholesky(&Tensor::F32(TypedTensor::from_vec(vec![2, 2], spd.clone())))
+        .unwrap();
+    let chol_recon = matmul_f32(
+        f32_data(&chol),
+        &transpose_f32(f32_data(&chol), 2, 2),
+        2,
+        2,
+        2,
+    );
+    assert_f32_slice_close(&chol_recon, &spd, tol);
+
+    let rectangular = vec![1.0, 2.0, 3.0, 4.0, 0.5, -1.0];
+    let input = Tensor::F32(TypedTensor::from_vec(vec![3, 2], rectangular.clone()));
+    let qr = backend.qr(&input).unwrap();
+    assert_eq!(qr[0].shape(), &[3, 2]);
+    assert_eq!(qr[1].shape(), &[2, 2]);
+    assert_f32_slice_close(
+        &matmul_f32(f32_data(&qr[0]), f32_data(&qr[1]), 3, 2, 2),
+        &rectangular,
+        tol,
+    );
+
+    let svd = backend.svd(&input).unwrap();
+    assert_eq!(svd[0].shape(), &[3, 2]);
+    assert_eq!(svd[1].shape(), &[2]);
+    assert_eq!(svd[2].shape(), &[2, 2]);
+    assert_f32_slice_close(
+        &matmul_f32(
+            &matmul_f32(f32_data(&svd[0]), &diag_f32(f32_data(&svd[1])), 3, 2, 2),
+            f32_data(&svd[2]),
+            3,
+            2,
+            2,
+        ),
+        &rectangular,
+        1.0e-3,
+    );
+
+    let symmetric = vec![4.0, 1.0, 1.0, 3.0];
+    let eigh = backend
+        .eigh(&Tensor::F32(TypedTensor::from_vec(
+            vec![2, 2],
+            symmetric.clone(),
+        )))
+        .unwrap();
+    assert_f32_slice_close(
+        &matmul_f32(
+            &matmul_f32(f32_data(&eigh[1]), &diag_f32(f32_data(&eigh[0])), 2, 2, 2),
+            &transpose_f32(f32_data(&eigh[1]), 2, 2),
+            2,
+            2,
+            2,
+        ),
+        &symmetric,
+        tol,
+    );
+
+    let eig = backend
+        .eig(&Tensor::F32(TypedTensor::from_vec(
+            vec![2, 2],
+            vec![1.0, 0.0, 0.0, 3.0],
+        )))
+        .unwrap();
+    assert_eq!(eig[0].dtype(), crate::DType::C32);
+    assert_eq!(eig[1].dtype(), crate::DType::C32);
+
+    let a = Tensor::F32(TypedTensor::from_vec(vec![2, 2], vec![3.0, 1.0, 1.0, 2.0]));
+    let b = Tensor::F32(TypedTensor::from_vec(vec![2, 2], vec![5.0, 1.0, -2.0, 4.0]));
+    let x = backend.solve(&a, &b).unwrap();
+    assert_f32_slice_close(
+        &matmul_f32(f32_data(&a), f32_data(&x), 2, 2, 2),
+        f32_data(&b),
+        tol,
+    );
+
+    let triangular = Tensor::F32(TypedTensor::from_vec(vec![2, 2], vec![2.0, 1.0, 0.0, 3.0]));
+    let rhs = Tensor::F32(TypedTensor::from_vec(vec![2, 1], vec![5.0, 7.0]));
+    let y = backend
+        .triangular_solve(&triangular, &rhs, true, true, false, false)
+        .unwrap();
+    assert_f32_slice_close(
+        &matmul_f32(f32_data(&triangular), f32_data(&y), 2, 2, 1),
+        f32_data(&rhs),
+        tol,
+    );
+
+    let lu_input = Tensor::F32(TypedTensor::from_vec(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]));
+    let lu = backend.lu(&lu_input).unwrap();
+    assert_eq!(lu.len(), 4);
+    assert_eq!(lu[3].shape(), &[]);
+
+    let full = backend.full_piv_lu(&lu_input).unwrap();
+    assert_eq!(full.len(), 5);
+    let full_x = backend.full_piv_lu_solve(&lu_input, &rhs, false).unwrap();
+    assert_f32_slice_close(
+        &matmul_f32(f32_data(&lu_input), f32_data(&full_x), 2, 2, 1),
+        f32_data(&rhs),
+        tol,
+    );
+}
+
+#[test]
+fn cpu_linalg_accepts_c32_happy_paths() {
+    let mut backend = CpuBackend::new();
+    let tol = 1.0e-3;
+
+    let lower = vec![
+        Complex32::new(2.0, 0.0),
+        Complex32::new(0.5, -1.0),
+        Complex32::new(0.0, 0.0),
+        Complex32::new(1.5, 0.0),
+    ];
+    let spd = matmul_c32(&lower, &conjugate_transpose_c32(&lower, 2, 2), 2, 2, 2);
+    let chol = backend
+        .cholesky(&Tensor::C32(TypedTensor::from_vec(vec![2, 2], spd.clone())))
+        .unwrap();
+    assert_c32_slice_close(
+        &matmul_c32(
+            c32_data(&chol),
+            &conjugate_transpose_c32(c32_data(&chol), 2, 2),
+            2,
+            2,
+            2,
+        ),
+        &spd,
+        tol,
+    );
+
+    let rectangular = vec![
+        Complex32::new(1.0, 1.0),
+        Complex32::new(2.0, -0.5),
+        Complex32::new(-1.0, 2.0),
+        Complex32::new(0.5, -1.0),
+        Complex32::new(-0.25, 1.5),
+        Complex32::new(3.0, 0.75),
+    ];
+    let input = Tensor::C32(TypedTensor::from_vec(vec![3, 2], rectangular.clone()));
+    let qr = backend.qr(&input).unwrap();
+    assert_c32_slice_close(
+        &matmul_c32(c32_data(&qr[0]), c32_data(&qr[1]), 3, 2, 2),
+        &rectangular,
+        2.0e-3,
+    );
+
+    let svd = backend.svd(&input).unwrap();
+    assert_c32_slice_close(
+        &matmul_c32(
+            &matmul_c32(c32_data(&svd[0]), &diag_c32(c32_data(&svd[1])), 3, 2, 2),
+            c32_data(&svd[2]),
+            3,
+            2,
+            2,
+        ),
+        &rectangular,
+        2.0e-3,
+    );
+
+    let eigh = backend
+        .eigh(&Tensor::C32(TypedTensor::from_vec(vec![2, 2], spd.clone())))
+        .unwrap();
+    assert_c32_slice_close(
+        &matmul_c32(
+            &matmul_c32(c32_data(&eigh[1]), &diag_c32(c32_data(&eigh[0])), 2, 2, 2),
+            &conjugate_transpose_c32(c32_data(&eigh[1]), 2, 2),
+            2,
+            2,
+            2,
+        ),
+        &spd,
+        2.0e-3,
+    );
+
+    let eig_input = Tensor::C32(TypedTensor::from_vec(
+        vec![2, 2],
+        vec![
+            Complex32::new(0.0, 0.0),
+            Complex32::new(1.0, 0.0),
+            Complex32::new(-1.0, 0.0),
+            Complex32::new(0.0, 0.0),
+        ],
+    ));
+    let eig = backend.eig(&eig_input).unwrap();
+    assert_eq!(eig[0].dtype(), crate::DType::C32);
+    assert_eq!(eig[1].dtype(), crate::DType::C32);
+
+    let a = Tensor::C32(TypedTensor::from_vec(
+        vec![2, 2],
+        vec![
+            Complex32::new(3.0, 0.0),
+            Complex32::new(1.0, -1.0),
+            Complex32::new(1.0, 0.5),
+            Complex32::new(2.0, 0.0),
+        ],
+    ));
+    let b = Tensor::C32(TypedTensor::from_vec(
+        vec![2, 1],
+        vec![Complex32::new(5.0, 1.0), Complex32::new(1.0, -2.0)],
+    ));
+    let x = backend.solve(&a, &b).unwrap();
+    assert_c32_slice_close(
+        &matmul_c32(c32_data(&a), c32_data(&x), 2, 2, 1),
+        c32_data(&b),
+        2.0e-3,
+    );
+
+    let triangular = Tensor::C32(TypedTensor::from_vec(
+        vec![2, 2],
+        vec![
+            Complex32::new(2.0, 0.0),
+            Complex32::new(1.0, -0.5),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(3.0, 0.0),
+        ],
+    ));
+    let y = backend
+        .triangular_solve(&triangular, &b, true, true, false, false)
+        .unwrap();
+    assert_c32_slice_close(
+        &matmul_c32(c32_data(&triangular), c32_data(&y), 2, 2, 1),
+        c32_data(&b),
+        2.0e-3,
+    );
+
+    let lu = backend.lu(&a).unwrap();
+    assert_eq!(lu.len(), 4);
+    assert_eq!(lu[3].shape(), &[]);
+
+    let full = backend.full_piv_lu(&a).unwrap();
+    assert_eq!(full.len(), 5);
+    let full_x = backend.full_piv_lu_solve(&a, &b, false).unwrap();
+    assert_c32_slice_close(
+        &matmul_c32(c32_data(&a), c32_data(&full_x), 2, 2, 1),
+        c32_data(&b),
+        2.0e-3,
+    );
+}

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -3014,31 +3014,18 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
 #[test]
 fn test_backend_linalg_returns_errors_for_unsupported_dtypes() {
     let mut backend = CpuBackend::new();
-    let f32_matrix = Tensor::F32(TypedTensor::from_vec(
-        vec![2, 2],
-        vec![1.0_f32, 0.0, 0.0, 1.0],
-    ));
-    let f32_rhs = Tensor::F32(TypedTensor::from_vec(vec![2, 1], vec![1.0_f32, 2.0]));
-    let c32_matrix = Tensor::C32(TypedTensor::from_vec(
-        vec![2, 2],
-        vec![
-            Complex32::new(1.0, 0.0),
-            Complex32::new(0.0, 0.0),
-            Complex32::new(0.0, 0.0),
-            Complex32::new(1.0, 0.0),
-        ],
-    ));
+    let i64_matrix = Tensor::I64(TypedTensor::from_vec(vec![2, 2], vec![1_i64, 0, 0, 1]));
+    let i64_rhs = Tensor::I64(TypedTensor::from_vec(vec![2, 1], vec![1_i64, 2]));
 
-    assert!(backend.cholesky(&f32_matrix).is_err());
-    assert!(backend.svd(&f32_matrix).is_err());
-    assert!(backend.qr(&f32_matrix).is_err());
-    assert!(backend.eigh(&f32_matrix).is_err());
-    assert!(backend.eig(&f32_matrix).is_err());
-    assert!(backend.solve(&f32_matrix, &f32_rhs).is_err());
+    assert!(backend.cholesky(&i64_matrix).is_err());
+    assert!(backend.svd(&i64_matrix).is_err());
+    assert!(backend.qr(&i64_matrix).is_err());
+    assert!(backend.eigh(&i64_matrix).is_err());
+    assert!(backend.eig(&i64_matrix).is_err());
+    assert!(backend.solve(&i64_matrix, &i64_rhs).is_err());
     assert!(backend
-        .triangular_solve(&f32_matrix, &f32_rhs, true, true, false, false)
+        .triangular_solve(&i64_matrix, &i64_rhs, true, true, false, false)
         .is_err());
-    assert!(backend.cholesky(&c32_matrix).is_err());
 }
 
 #[test]
@@ -3247,13 +3234,10 @@ fn test_triangular_solve_dtype_mismatch_and_unsupported() {
         }
     ));
 
-    let a_f32 = Tensor::F32(TypedTensor::from_vec(
-        vec![2, 2],
-        vec![1.0f32, 0.0, 0.0, 1.0],
-    ));
-    let b_f32 = Tensor::F32(TypedTensor::from_vec(vec![2, 1], vec![1.0f32, 2.0]));
+    let a_i64 = Tensor::I64(TypedTensor::from_vec(vec![2, 2], vec![1_i64, 0, 0, 1]));
+    let b_i64 = Tensor::I64(TypedTensor::from_vec(vec![2, 1], vec![1_i64, 2]));
     let err = backend
-        .triangular_solve(&a_f32, &b_f32, true, true, false, false)
+        .triangular_solve(&a_i64, &b_i64, true, true, false, false)
         .unwrap_err();
     assert!(matches!(
         err,
@@ -3339,10 +3323,7 @@ fn test_solve_with_regular_matrix_rhs() {
 
 #[test]
 fn test_lu_unsupported_dtype_returns_error() {
-    let input = Tensor::F32(TypedTensor::from_vec(
-        vec![2, 2],
-        vec![1.0f32, 0.0, 0.0, 1.0],
-    ));
+    let input = Tensor::I64(TypedTensor::from_vec(vec![2, 2], vec![1_i64, 0, 0, 1]));
     let mut backend = CpuBackend::new();
     assert!(backend.lu(&input).is_err());
 }
@@ -3368,10 +3349,7 @@ fn test_lu_zero_sized_batch_outputs_empty_parity() {
 
 #[test]
 fn test_svd_unsupported_dtype_returns_error() {
-    let input = Tensor::F32(TypedTensor::from_vec(
-        vec![2, 2],
-        vec![1.0f32, 0.0, 0.0, 1.0],
-    ));
+    let input = Tensor::I64(TypedTensor::from_vec(vec![2, 2], vec![1_i64, 0, 0, 1]));
     let mut backend = CpuBackend::new();
     assert!(backend.svd(&input).is_err());
 }
@@ -3405,10 +3383,7 @@ fn test_faer_eig_decomposition_failure_returns_error() {
 
 #[test]
 fn test_qr_unsupported_dtype_returns_error() {
-    let input = Tensor::F32(TypedTensor::from_vec(
-        vec![2, 2],
-        vec![1.0f32, 0.0, 0.0, 1.0],
-    ));
+    let input = Tensor::I64(TypedTensor::from_vec(vec![2, 2], vec![1_i64, 0, 0, 1]));
     let mut backend = CpuBackend::new();
     assert!(backend.qr(&input).is_err());
 }

--- a/tenferro-tensor/src/tests/mod.rs
+++ b/tenferro-tensor/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod config_tests;
 mod cpu_indexing_coverage_tests;
+mod cpu_linalg_dtype_tests;
 mod cpu_stub_tests;
 mod cpu_tests;
 mod eager_api_tests;


### PR DESCRIPTION
## Summary
- Enable F32/C32 CPU linalg dispatch for faer and LAPACK-backed configurations.
- Add single-precision real/complex LAPACK wrappers, eig C32 output handling, and provider-inject pointer coverage.
- Add F32/C32 numerical parity tests and move unsupported dtype assertions to I64.

Closes #831.

## Test Plan
- cargo fmt --all --check
- cargo nextest run --workspace --release --no-fail-fast
- cargo test --doc --workspace --release
- cargo llvm-cov nextest --workspace --release --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py
- cargo check -p tenferro-tensor --no-default-features --features cpu-blas
- cargo check -p tenferro-tensor --no-default-features --features cpu-blas,provider-inject
- cargo test -p tenferro-tensor --test inject_tests --release --no-default-features --features cpu-blas,provider-inject
- cargo test -p tenferro-tensor --test inject_dual_abi_tests --release --no-default-features --features cpu-blas,provider-inject
- cargo test -p tenferro-tensor --no-default-features --features cpu-blas,src-openblas --lib --release cpu_linalg_dtype_tests -- --nocapture

Generated with Codex.