### PR TITLE
fix: scope tensor metadata registry entries

### DIFF
--- a/tenferro-ops/src/ad/context.rs
+++ b/tenferro-ops/src/ad/context.rs
@@ -21,6 +21,14 @@ use crate::sym_dim::SymDim;
 
 type MetadataMap = HashMap<GlobalValKey<StdTensorOp>, TensorMeta>;
 
+type GlobalMetadataMap = HashMap<GlobalValKey<StdTensorOp>, GlobalMetadataEntry>;
+
+#[derive(Clone, Debug)]
+struct GlobalMetadataEntry {
+    meta: TensorMeta,
+    scoped_refs: usize,
+}
+
 /// Global metadata registry.
 ///
 /// Stored as `Mutex<MetadataMap>` directly: writes insert in place (O(1)),
@@ -32,10 +40,26 @@ type MetadataMap = HashMap<GlobalValKey<StdTensorOp>, TensorMeta>;
 /// `ShapeGuardContext` or kept the map in an `Arc` and cloned on every write.
 /// Both variants were quadratic across the monotonically growing registry and
 /// dominated oracle_replay runtime.
-static GLOBAL_METADATA: OnceLock<Mutex<MetadataMap>> = OnceLock::new();
+static GLOBAL_METADATA: OnceLock<Mutex<GlobalMetadataMap>> = OnceLock::new();
 
-fn global_metadata_registry() -> &'static Mutex<MetadataMap> {
+fn global_metadata_registry() -> &'static Mutex<GlobalMetadataMap> {
     GLOBAL_METADATA.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Lifetime token for graph-scoped global metadata.
+///
+/// Dropping the last frontend owner of a traced graph drops this scope and
+/// releases the metadata keys that were registered for that graph fragment.
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct GlobalMetadataScope {
+    keys: Vec<GlobalValKey<StdTensorOp>>,
+}
+
+impl Drop for GlobalMetadataScope {
+    fn drop(&mut self) {
+        release_scoped_global_metadata(&self.keys);
+    }
 }
 
 /// Per-value tensor metadata used by AD rules.
@@ -450,14 +474,6 @@ impl ShapeGuardContext {
     }
 }
 
-#[doc(hidden)]
-pub fn register_global_metadata(key: GlobalValKey<StdTensorOp>, meta: TensorMeta) {
-    let mut guard = global_metadata_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    guard.insert(key, meta);
-}
-
 /// Look up a single metadata entry from the global registry.
 ///
 /// Locks the registry briefly for a single `HashMap::get` + clone.
@@ -478,18 +494,45 @@ pub fn lookup_global_metadata(key: &GlobalValKey<StdTensorOp>) -> Option<TensorM
     let guard = global_metadata_registry()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    guard.get(key).cloned()
+    guard.get(key).map(|entry| entry.meta.clone())
 }
 
 #[doc(hidden)]
-pub fn register_global_metadata_batch<I>(entries: I)
+pub fn register_scoped_global_metadata_batch<I>(entries: I) -> GlobalMetadataScope
 where
     I: IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
 {
     let mut guard = global_metadata_registry()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    guard.extend(entries);
+    let mut keys = Vec::new();
+    for (key, meta) in entries {
+        let entry = guard.entry(key.clone()).or_insert(GlobalMetadataEntry {
+            meta: meta.clone(),
+            scoped_refs: 0,
+        });
+        entry.meta = meta;
+        entry.scoped_refs += 1;
+        keys.push(key);
+    }
+    GlobalMetadataScope { keys }
+}
+
+fn release_scoped_global_metadata(keys: &[GlobalValKey<StdTensorOp>]) {
+    let mut guard = global_metadata_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for key in keys {
+        let should_remove = if let Some(entry) = guard.get_mut(key) {
+            entry.scoped_refs = entry.scoped_refs.saturating_sub(1);
+            entry.scoped_refs == 0
+        } else {
+            false
+        };
+        if should_remove {
+            guard.remove(key);
+        }
+    }
 }
 
 /// Resolve a [`DimExpr`] to a concrete `usize`.

--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -17,7 +17,9 @@ use crate::eager_emitter::EagerEmitter;
 use crate::eager_exec::exec_op_on_tensors;
 use crate::error::{ContextId, Error, Result};
 use crate::metadata::{
-    register_fragment_metadata, register_value_metadata, tensor_meta_from_tensor,
+    metadata_scopes_for_scope, push_metadata_scope, register_scoped_fragment_metadata,
+    register_scoped_metadata_batch, register_scoped_value_metadata, tensor_meta_from_tensor,
+    MetadataScope,
 };
 use crate::traced::next_input_key;
 
@@ -237,6 +239,7 @@ pub struct EagerTensor<B: TensorBackend = CpuBackend> {
     pub(crate) grad_node: Option<Arc<GradNode<StdTensorOp>>>,
     pub(crate) requires_grad: bool,
     grad_slot: GradSlot,
+    pub(crate) metadata_scopes: Vec<Arc<MetadataScope>>,
     pub(crate) ctx: Arc<EagerContext<B>>,
 }
 
@@ -299,7 +302,8 @@ impl<B: TensorBackend> EagerTensor<B> {
 
     pub(crate) fn new_leaf(ctx: Arc<EagerContext<B>>, tensor: Tensor, requires_grad: bool) -> Self {
         let key = eager_val_key();
-        register_value_metadata(key.clone(), tensor_meta_from_tensor(&tensor));
+        let metadata_scope =
+            register_scoped_value_metadata(key.clone(), tensor_meta_from_tensor(&tensor));
         let grad_slot = Arc::new(Mutex::new(None));
         if requires_grad {
             ctx.register_grad_slot(&key, &grad_slot);
@@ -311,6 +315,7 @@ impl<B: TensorBackend> EagerTensor<B> {
             grad_node: None,
             requires_grad,
             grad_slot,
+            metadata_scopes: metadata_scopes_for_scope(metadata_scope),
             ctx,
         }
     }
@@ -321,8 +326,8 @@ impl<B: TensorBackend> EagerTensor<B> {
         tensor: Tensor,
         requires_grad: bool,
         grad_node: Option<Arc<GradNode<StdTensorOp>>>,
+        metadata_scopes: Vec<Arc<MetadataScope>>,
     ) -> Self {
-        register_value_metadata(key.clone(), tensor_meta_from_tensor(&tensor));
         let grad_slot = Arc::new(Mutex::new(None));
         if requires_grad {
             ctx.register_grad_slot(&key, &grad_slot);
@@ -334,6 +339,7 @@ impl<B: TensorBackend> EagerTensor<B> {
             grad_node,
             requires_grad,
             grad_slot,
+            metadata_scopes,
             ctx,
         }
     }
@@ -530,6 +536,7 @@ impl<B: TensorBackend> EagerTensor<B> {
         let seed = Arc::new(one_like_tensor(self.data.as_ref(), &mut *backend));
         let mut callbacks = TenferroBackwardCallbacks {
             backend: &mut *backend,
+            metadata_scopes: self.metadata_scopes.clone(),
         };
         let mut ad_ctx = ShapeGuardContext::with_global_metadata();
         let cotangents = try_backward_dag(&sorted, &self.key, seed, &mut callbacks, &mut ad_ctx)?;
@@ -540,6 +547,7 @@ impl<B: TensorBackend> EagerTensor<B> {
 
 pub(crate) struct TenferroBackwardCallbacks<'a, B: TensorBackend> {
     backend: &'a mut B,
+    metadata_scopes: Vec<Arc<MetadataScope>>,
 }
 
 impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallbacks<'_, B> {
@@ -597,7 +605,7 @@ impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallba
             }
         }
 
-        register_fragment_metadata(
+        let metadata_scope = register_scoped_fragment_metadata(
             fragment,
             fragment.inputs().iter().map(|input_id| {
                 let key = fragment.vals()[*input_id].key.clone();
@@ -612,6 +620,7 @@ impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallba
                 (key, meta)
             }),
         );
+        push_metadata_scope(&mut self.metadata_scopes, Arc::new(metadata_scope));
 
         all_values
     }
@@ -700,28 +709,37 @@ pub(crate) fn eager_value<B: TensorBackend>(tensor: &EagerTensor<B>) -> EagerVal
     }
 }
 
+pub(crate) struct RecordedEagerOutputs {
+    pub(crate) traces: Vec<EagerOutput<StdTensorOp>>,
+    pub(crate) metadata_scope: Arc<MetadataScope>,
+}
+
 pub(crate) fn record_eager_outputs<B: TensorBackend>(
     op: &StdTensorOp,
     outputs: &[Arc<Tensor>],
     inputs: &[&EagerTensor<B>],
-) -> Vec<EagerOutput<StdTensorOp>> {
+) -> RecordedEagerOutputs {
     let input_values: Vec<_> = inputs.iter().map(|tensor| eager_value(*tensor)).collect();
     let mut key_source = EagerTensorKeySource;
     let traces = tidu::record_eager_op(&mut key_source, op.clone(), &input_values, outputs);
 
+    let mut registrations = Vec::new();
     for trace in &traces {
         if let Some(output) = outputs.get(trace.output_slot) {
-            register_value_metadata(trace.key.clone(), tensor_meta_from_tensor(output.as_ref()));
+            registrations.push((trace.key.clone(), tensor_meta_from_tensor(output.as_ref())));
         }
     }
 
     if let Some(node) = traces.iter().find_map(|trace| trace.node.as_ref()) {
         for (key, value) in node.saved_data() {
-            register_value_metadata(key.clone(), tensor_meta_from_tensor(value.as_ref()));
+            registrations.push((key.clone(), tensor_meta_from_tensor(value.as_ref())));
         }
     }
 
-    traces
+    RecordedEagerOutputs {
+        traces,
+        metadata_scope: Arc::new(register_scoped_metadata_batch(registrations)),
+    }
 }
 
 pub(crate) fn exec_single_output<B: TensorBackend>(

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -10,6 +10,7 @@ use tenferro_tensor::{
 use crate::eager::{exec_single_output, record_eager_outputs, EagerTensor};
 use crate::eager_exec::exec_op_on_tensors;
 use crate::error::{Error, Result};
+use crate::metadata::push_metadata_scope;
 
 impl<B: TensorBackend> EagerTensor<B> {
     /// Elementwise addition.
@@ -541,17 +542,22 @@ impl<B: TensorBackend> EagerTensor<B> {
         }
 
         let outputs: Vec<Arc<Tensor>> = outputs.into_iter().map(Arc::new).collect();
-        let traces = record_eager_outputs(&op, &outputs, &[self]);
-        if traces.len() != outputs.len() {
+        let recorded = record_eager_outputs(&op, &outputs, &[self]);
+        if recorded.traces.len() != outputs.len() {
             return Err(Error::Internal(format!(
                 "expected {} eager traces for {:?}, got {}",
                 outputs.len(),
                 op,
-                traces.len()
+                recorded.traces.len()
             )));
         }
+        let mut metadata_scopes = vec![Arc::clone(&recorded.metadata_scope)];
+        for scope in &self.metadata_scopes {
+            push_metadata_scope(&mut metadata_scopes, Arc::clone(scope));
+        }
 
-        Ok(traces
+        Ok(recorded
+            .traces
             .into_iter()
             .zip(outputs)
             .map(|(trace, output)| {
@@ -561,6 +567,7 @@ impl<B: TensorBackend> EagerTensor<B> {
                     output.as_ref().clone(),
                     trace.requires_grad,
                     trace.node,
+                    metadata_scopes.clone(),
                 )
             })
             .collect())
@@ -590,10 +597,16 @@ impl<B: TensorBackend> EagerTensor<B> {
         let inputs: Vec<&Tensor> = tensors.iter().map(|tensor| tensor.data.as_ref()).collect();
         let output = Arc::new(exec_single_output(&op, &inputs, &ctx)?);
         let outputs = vec![Arc::clone(&output)];
-        let mut traces = record_eager_outputs(&op, &outputs, tensors);
-        let trace = traces.pop().ok_or_else(|| {
+        let mut recorded = record_eager_outputs(&op, &outputs, tensors);
+        let trace = recorded.traces.pop().ok_or_else(|| {
             Error::Internal(format!("expected one eager trace for {:?}, got 0", op))
         })?;
+        let mut metadata_scopes = vec![Arc::clone(&recorded.metadata_scope)];
+        for tensor in tensors {
+            for scope in &tensor.metadata_scopes {
+                push_metadata_scope(&mut metadata_scopes, Arc::clone(scope));
+            }
+        }
 
         Ok(Self::new_result(
             ctx,
@@ -601,6 +614,7 @@ impl<B: TensorBackend> EagerTensor<B> {
             output.as_ref().clone(),
             trace.requires_grad,
             trace.node,
+            metadata_scopes,
         ))
     }
 }

--- a/tenferro/src/einsum.rs
+++ b/tenferro/src/einsum.rs
@@ -34,7 +34,9 @@ use tenferro_tensor::TensorBackend;
 use super::checkpoint::CheckpointNode;
 use super::engine::Engine;
 use super::error::{Error, Result};
-use super::metadata::register_fragment_metadata;
+use super::metadata::{
+    metadata_scopes_with_new, push_metadata_scope, register_scoped_fragment_metadata,
+};
 use super::sym_dim::SymDim;
 use super::traced::{concrete_shape, next_traced_id, try_concrete_shape, TracedTensor};
 
@@ -327,7 +329,13 @@ fn build_symbolic_nary_einsum(
     );
     builder.set_outputs(outputs.clone());
     let fragment = Arc::new(builder.build());
-    register_fragment_metadata(fragment.as_ref(), std::iter::empty());
+    let metadata_scope = register_scoped_fragment_metadata(fragment.as_ref(), std::iter::empty());
+    let mut metadata_scopes = metadata_scopes_with_new(metadata_scope, []);
+    for input in inputs {
+        for scope in &input.metadata_scopes {
+            push_metadata_scope(&mut metadata_scopes, Arc::clone(scope));
+        }
+    }
 
     TracedTensor {
         id: next_traced_id(),
@@ -340,6 +348,7 @@ fn build_symbolic_nary_einsum(
         inputs_map: Arc::new(merged),
         extra_roots,
         checkpoint_chain: None,
+        metadata_scopes,
     }
 }
 
@@ -480,13 +489,18 @@ fn build_traced_from_tree(
         ValRef::Local(result_local) => {
             builder.set_outputs(vec![result_local]);
             let fragment = Arc::new(builder.build());
-            register_fragment_metadata(fragment.as_ref(), std::iter::empty());
+            let metadata_scope =
+                register_scoped_fragment_metadata(fragment.as_ref(), std::iter::empty());
 
             let mut merged = HashMap::new();
             let mut extra_roots = Vec::new();
+            let mut metadata_scopes = metadata_scopes_with_new(metadata_scope, []);
             for input in inputs {
                 merged.extend(input.inputs_map.iter().map(|(k, v)| (k.clone(), v.clone())));
                 extra_roots.extend(input.extra_roots.iter().cloned());
+                for scope in &input.metadata_scopes {
+                    push_metadata_scope(&mut metadata_scopes, Arc::clone(scope));
+                }
             }
 
             let merged_chain = inputs.iter().fold(None, |acc, input| {
@@ -504,6 +518,7 @@ fn build_traced_from_tree(
                 inputs_map: Arc::new(merged),
                 extra_roots,
                 checkpoint_chain: merged_chain,
+                metadata_scopes,
             })
         }
         ValRef::External(_) => {
@@ -522,6 +537,7 @@ fn build_traced_from_tree(
                         inputs_map: inputs[i].inputs_map.clone(),
                         extra_roots: inputs[i].extra_roots.clone(),
                         checkpoint_chain: inputs[i].checkpoint_chain.clone(),
+                        metadata_scopes: inputs[i].metadata_scopes.clone(),
                     });
                 }
             }

--- a/tenferro/src/extension.rs
+++ b/tenferro/src/extension.rs
@@ -40,7 +40,7 @@ use crate::checkpoint::CheckpointNode;
 use crate::eager::{record_eager_outputs, EagerTensor};
 use crate::eager_exec::exec_op_on_tensors;
 use crate::error::{Error, Result};
-use crate::metadata::register_fragment_metadata;
+use crate::metadata::{push_metadata_scope, register_scoped_fragment_metadata};
 use crate::traced::{next_traced_id, TracedTensor};
 
 pub use tenferro_ops::ext_op::{
@@ -135,17 +135,24 @@ pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Vec<TracedTe
     let outputs = builder.add_op(carrier, op_inputs, OpMode::Primal);
     builder.set_outputs(outputs.clone());
     let fragment = Arc::new(builder.build());
-    register_fragment_metadata(fragment.as_ref(), std::iter::empty());
+    let metadata_scope = Arc::new(register_scoped_fragment_metadata(
+        fragment.as_ref(),
+        std::iter::empty(),
+    ));
 
     // Merge shared-state across all parent TracedTensors.
     let mut merged_map = HashMap::new();
     let mut extra_roots = Vec::new();
     let mut checkpoint_chain = None;
+    let mut metadata_scopes = vec![Arc::clone(&metadata_scope)];
     for input in inputs {
         merged_map.extend(input.inputs_map.iter().map(|(k, v)| (k.clone(), v.clone())));
         extra_roots.extend(input.extra_roots.iter().cloned());
         checkpoint_chain =
             CheckpointNode::merge_chains(checkpoint_chain, input.checkpoint_chain.clone());
+        for scope in &input.metadata_scopes {
+            push_metadata_scope(&mut metadata_scopes, Arc::clone(scope));
+        }
     }
     let merged_map = Arc::new(merged_map);
 
@@ -179,6 +186,7 @@ pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Vec<TracedTe
                 inputs_map: merged_map.clone(),
                 extra_roots: extra_roots.clone(),
                 checkpoint_chain: checkpoint_chain.clone(),
+                metadata_scopes: metadata_scopes.clone(),
             }
         })
         .collect()
@@ -234,17 +242,24 @@ pub fn apply_eager<B: TensorBackend>(
     }
 
     let outputs: Vec<Arc<Tensor>> = outputs.into_iter().map(Arc::new).collect();
-    let traces = record_eager_outputs(&op, &outputs, inputs);
-    if traces.len() != outputs.len() {
+    let recorded = record_eager_outputs(&op, &outputs, inputs);
+    if recorded.traces.len() != outputs.len() {
         return Err(Error::Internal(format!(
             "expected {} eager traces for {:?}, got {}",
             outputs.len(),
             op,
-            traces.len()
+            recorded.traces.len()
         )));
     }
+    let mut metadata_scopes = vec![Arc::clone(&recorded.metadata_scope)];
+    for input in inputs {
+        for scope in &input.metadata_scopes {
+            push_metadata_scope(&mut metadata_scopes, Arc::clone(scope));
+        }
+    }
 
-    Ok(traces
+    Ok(recorded
+        .traces
         .into_iter()
         .zip(outputs)
         .map(|(trace, output)| {
@@ -254,6 +269,7 @@ pub fn apply_eager<B: TensorBackend>(
                 output.as_ref().clone(),
                 trace.requires_grad,
                 trace.node,
+                metadata_scopes.clone(),
             )
         })
         .collect())

--- a/tenferro/src/metadata.rs
+++ b/tenferro/src/metadata.rs
@@ -1,9 +1,10 @@
 use computegraph::fragment::Fragment;
 use computegraph::types::{GlobalValKey, ValRef};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use tenferro_ops::ad::context::{
-    lookup_global_metadata, register_global_metadata, register_global_metadata_batch, TensorMeta,
+    lookup_global_metadata, register_scoped_global_metadata_batch, GlobalMetadataScope, TensorMeta,
 };
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -11,6 +12,8 @@ use tenferro_ops::sym_dim::SymDim;
 use tenferro_tensor::{DType, Tensor};
 
 use crate::shape_infer::{infer_extension_output_meta, infer_output_dtype, infer_output_extents};
+
+pub(crate) type MetadataScope = GlobalMetadataScope;
 
 pub(crate) fn tensor_meta(dtype: DType, shape: Vec<SymDim>) -> TensorMeta {
     TensorMeta::exact(dtype, shape)
@@ -33,8 +36,17 @@ pub(crate) fn tensor_meta_from_tensor(tensor: &Tensor) -> TensorMeta {
     concrete_tensor_meta(tensor.dtype(), tensor.shape())
 }
 
-pub(crate) fn register_value_metadata(key: GlobalValKey<StdTensorOp>, meta: TensorMeta) {
-    register_global_metadata(key, meta);
+pub(crate) fn register_scoped_value_metadata(
+    key: GlobalValKey<StdTensorOp>,
+    meta: TensorMeta,
+) -> MetadataScope {
+    register_scoped_global_metadata_batch([(key, meta)])
+}
+
+pub(crate) fn register_scoped_metadata_batch(
+    entries: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
+) -> MetadataScope {
+    register_scoped_global_metadata_batch(entries)
 }
 
 pub(crate) fn registered_meta(key: &GlobalValKey<StdTensorOp>) -> TensorMeta {
@@ -42,10 +54,56 @@ pub(crate) fn registered_meta(key: &GlobalValKey<StdTensorOp>) -> TensorMeta {
         .unwrap_or_else(|| panic!("metadata lookup: missing registered metadata for {:?}", key))
 }
 
-pub(crate) fn register_fragment_metadata(
+pub(crate) fn register_scoped_fragment_metadata(
     fragment: &Fragment<StdTensorOp>,
     seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
+) -> MetadataScope {
+    register_scoped_global_metadata_batch(fragment_metadata_registrations(fragment, seeded))
+}
+
+pub(crate) fn metadata_scopes_with_new<'a>(
+    scope: MetadataScope,
+    inherited: impl IntoIterator<Item = &'a [Arc<MetadataScope>]>,
+) -> Vec<Arc<MetadataScope>> {
+    let scope = Arc::new(scope);
+    metadata_scopes_with_scope(scope, inherited)
+}
+
+pub(crate) fn metadata_scopes_for_scope(scope: MetadataScope) -> Vec<Arc<MetadataScope>> {
+    vec![Arc::new(scope)]
+}
+
+pub(crate) fn metadata_scopes_with_scope<'a>(
+    scope: Arc<MetadataScope>,
+    inherited: impl IntoIterator<Item = &'a [Arc<MetadataScope>]>,
+) -> Vec<Arc<MetadataScope>> {
+    let mut scopes = Vec::new();
+    push_metadata_scope(&mut scopes, scope);
+    extend_metadata_scopes(&mut scopes, inherited);
+    scopes
+}
+
+pub(crate) fn push_metadata_scope(scopes: &mut Vec<Arc<MetadataScope>>, scope: Arc<MetadataScope>) {
+    if scopes.iter().all(|existing| !Arc::ptr_eq(existing, &scope)) {
+        scopes.push(scope);
+    }
+}
+
+fn extend_metadata_scopes<'a>(
+    scopes: &mut Vec<Arc<MetadataScope>>,
+    inherited: impl IntoIterator<Item = &'a [Arc<MetadataScope>]>,
 ) {
+    for source in inherited {
+        for scope in source {
+            push_metadata_scope(scopes, Arc::clone(scope));
+        }
+    }
+}
+
+fn fragment_metadata_registrations(
+    fragment: &Fragment<StdTensorOp>,
+    seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
+) -> Vec<(GlobalValKey<StdTensorOp>, TensorMeta)> {
     let seeded: Vec<_> = seeded.into_iter().collect();
     // Start from just the seeded inputs. External keys not in `seeded` are
     // resolved on demand via a single-key lookup against the global
@@ -87,7 +145,7 @@ pub(crate) fn register_fragment_metadata(
         }
     }
 
-    register_global_metadata_batch(registrations);
+    registrations
 }
 
 fn infer_output_metas(op: &StdTensorOp, input_metas: &[TensorMeta]) -> Vec<TensorMeta> {

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -22,8 +22,10 @@ use super::error::{Error, Result};
 use super::sym_dim::SymDim;
 use crate::checkpoint::CheckpointNode;
 use crate::metadata::{
-    concrete_tensor_meta, register_fragment_metadata, register_value_metadata, registered_meta,
-    symbolic_input_meta, tensor_meta_from_tensor,
+    concrete_tensor_meta, metadata_scopes_for_scope, metadata_scopes_with_new,
+    metadata_scopes_with_scope, push_metadata_scope, register_scoped_fragment_metadata,
+    register_scoped_value_metadata, registered_meta, symbolic_input_meta, tensor_meta_from_tensor,
+    MetadataScope,
 };
 use crate::scalar_semantics::round_real_to_i64;
 
@@ -59,6 +61,7 @@ pub struct TracedTensor {
     pub(crate) inputs_map: Arc<HashMap<TensorInputKey, Arc<Tensor>>>,
     pub(crate) extra_roots: Vec<Arc<Fragment<StdTensorOp>>>,
     pub(crate) checkpoint_chain: Option<Arc<CheckpointNode>>,
+    pub(crate) metadata_scopes: Vec<Arc<MetadataScope>>,
 }
 
 /// Compute a broadcast output shape following NumPy rules.
@@ -271,7 +274,7 @@ impl TracedTensor {
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
         let fragment = Arc::new(builder.build());
-        register_value_metadata(
+        let metadata_scope = register_scoped_value_metadata(
             fragment.vals()[val].key.clone(),
             concrete_tensor_meta(dtype, &shape),
         );
@@ -290,6 +293,7 @@ impl TracedTensor {
             inputs_map: Arc::new(map),
             extra_roots: Vec::new(),
             checkpoint_chain: None,
+            metadata_scopes: metadata_scopes_for_scope(metadata_scope),
         }
     }
 
@@ -326,7 +330,7 @@ impl TracedTensor {
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
         let fragment = Arc::new(builder.build());
-        register_value_metadata(
+        let metadata_scope = register_scoped_value_metadata(
             fragment.vals()[val].key.clone(),
             symbolic_input_meta(dtype, id, rank),
         );
@@ -345,6 +349,7 @@ impl TracedTensor {
             inputs_map: Arc::new(map),
             extra_roots: Vec::new(),
             checkpoint_chain: None,
+            metadata_scopes: metadata_scopes_for_scope(metadata_scope),
         }
     }
 
@@ -374,7 +379,7 @@ impl TracedTensor {
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
         let fragment = Arc::new(builder.build());
-        register_value_metadata(
+        let metadata_scope = register_scoped_value_metadata(
             fragment.vals()[val].key.clone(),
             concrete_tensor_meta(dtype, &shape),
         );
@@ -390,6 +395,7 @@ impl TracedTensor {
             inputs_map: Arc::new(HashMap::new()),
             extra_roots: Vec::new(),
             checkpoint_chain: None,
+            metadata_scopes: metadata_scopes_for_scope(metadata_scope),
         }
     }
 
@@ -420,7 +426,7 @@ impl TracedTensor {
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
         let fragment = Arc::new(builder.build());
-        register_value_metadata(
+        let metadata_scope = register_scoped_value_metadata(
             fragment.vals()[val].key.clone(),
             symbolic_input_meta(dtype, id, rank),
         );
@@ -436,6 +442,7 @@ impl TracedTensor {
             inputs_map: Arc::new(HashMap::new()),
             extra_roots: Vec::new(),
             checkpoint_chain: None,
+            metadata_scopes: metadata_scopes_for_scope(metadata_scope),
         }
     }
 
@@ -739,14 +746,15 @@ impl TracedTensor {
         let leaf_val = builder.add_input(new_key.clone());
         builder.set_outputs(vec![leaf_val]);
         let new_fragment = Arc::new(builder.build());
-        register_value_metadata(
+        let new_metadata_scope = register_scoped_value_metadata(
             new_fragment.vals()[leaf_val].key.clone(),
             concrete_meta.clone(),
         );
         // Dynamic shape ops may have conservative static metadata on their
         // graph output. A checkpoint has evaluated the concrete tensor, so AD
         // alias resolution should see the runtime shape on both sides.
-        register_value_metadata(old_output_key.clone(), concrete_meta);
+        let old_output_metadata_scope =
+            register_scoped_value_metadata(old_output_key.clone(), concrete_meta);
 
         let node = CheckpointNode {
             fragment: old_fragment,
@@ -761,6 +769,11 @@ impl TracedTensor {
         self.extra_roots.clear();
         self.shape_hint = concrete_shape_hint;
         self.checkpoint_chain = Some(Arc::new(node));
+        push_metadata_scope(&mut self.metadata_scopes, Arc::new(new_metadata_scope));
+        push_metadata_scope(
+            &mut self.metadata_scopes,
+            Arc::new(old_output_metadata_scope),
+        );
 
         let mut merged = HashMap::new();
         if let Some(chain) = &self.checkpoint_chain {
@@ -821,7 +834,7 @@ impl TracedTensor {
             return Ok(None);
         };
         let tangent_input_key = linear_input_key(&linear.fragment, linear.tangent_inputs[0].1);
-        register_fragment_metadata(
+        let metadata_scope = register_scoped_fragment_metadata(
             &linear.fragment,
             vec![(
                 GlobalValKey::Input(tangent_input_key.clone()),
@@ -862,6 +875,14 @@ impl TracedTensor {
             inputs_map: Arc::new(inputs_map),
             extra_roots,
             checkpoint_chain: self.checkpoint_chain.clone(),
+            metadata_scopes: metadata_scopes_with_new(
+                metadata_scope,
+                [
+                    self.metadata_scopes.as_slice(),
+                    wrt.metadata_scopes.as_slice(),
+                    tangent.metadata_scopes.as_slice(),
+                ],
+            ),
         }))
     }
 
@@ -911,7 +932,7 @@ impl TracedTensor {
             return Ok(None);
         }
         let linear_seed_key = linear_input_key(&linear.fragment, linear.tangent_inputs[0].1);
-        register_fragment_metadata(
+        let linear_metadata_scope = register_scoped_fragment_metadata(
             &linear.fragment,
             vec![(
                 GlobalValKey::Input(linear_seed_key),
@@ -927,7 +948,7 @@ impl TracedTensor {
         let transposed = try_transpose(&linear, &mut ad_ctx)?;
         let cotangent_input_key =
             linear_input_key(&transposed.fragment, transposed.tangent_inputs[0].1);
-        register_fragment_metadata(
+        let transposed_metadata_scope = register_scoped_fragment_metadata(
             &transposed.fragment,
             vec![(
                 GlobalValKey::Input(cotangent_input_key.clone()),
@@ -997,6 +1018,18 @@ impl TracedTensor {
             inputs_map: Arc::new(inputs_map),
             extra_roots,
             checkpoint_chain: self.checkpoint_chain.clone(),
+            metadata_scopes: {
+                let mut scopes = metadata_scopes_with_new(
+                    linear_metadata_scope,
+                    [
+                        self.metadata_scopes.as_slice(),
+                        wrt.metadata_scopes.as_slice(),
+                        cotangent.metadata_scopes.as_slice(),
+                    ],
+                );
+                push_metadata_scope(&mut scopes, Arc::new(transposed_metadata_scope));
+                scopes
+            },
         }))
     }
 
@@ -1922,7 +1955,7 @@ pub(crate) fn apply_unary_with_dtype(
     let outputs = builder.add_op(op, vec![input_ref], OpMode::Primal);
     builder.set_outputs(outputs.clone());
     let fragment = Arc::new(builder.build());
-    register_fragment_metadata(fragment.as_ref(), std::iter::empty());
+    let metadata_scope = register_scoped_fragment_metadata(fragment.as_ref(), std::iter::empty());
 
     TracedTensor {
         id: next_traced_id(),
@@ -1935,6 +1968,10 @@ pub(crate) fn apply_unary_with_dtype(
         inputs_map: input.inputs_map.clone(),
         extra_roots: input.extra_roots.clone(),
         checkpoint_chain: input.checkpoint_chain.clone(),
+        metadata_scopes: metadata_scopes_with_new(
+            metadata_scope,
+            [input.metadata_scopes.as_slice()],
+        ),
     }
 }
 
@@ -1968,7 +2005,7 @@ pub(crate) fn apply_unary_with_shape_refs(
     let outputs = builder.add_op(op, op_inputs, OpMode::Primal);
     builder.set_outputs(outputs.clone());
     let fragment = Arc::new(builder.build());
-    register_fragment_metadata(fragment.as_ref(), std::iter::empty());
+    let metadata_scope = register_scoped_fragment_metadata(fragment.as_ref(), std::iter::empty());
 
     let mut merged = (*input.inputs_map).clone();
     for t in shape_refs {
@@ -1997,6 +2034,16 @@ pub(crate) fn apply_unary_with_shape_refs(
         inputs_map: Arc::new(merged),
         extra_roots,
         checkpoint_chain,
+        metadata_scopes: {
+            let mut scopes =
+                metadata_scopes_with_new(metadata_scope, [input.metadata_scopes.as_slice()]);
+            for t in shape_refs {
+                for scope in &t.metadata_scopes {
+                    push_metadata_scope(&mut scopes, Arc::clone(scope));
+                }
+            }
+            scopes
+        },
     }
 }
 
@@ -2010,7 +2057,7 @@ pub(crate) fn apply_nullary(
     let outputs = builder.add_op(op, vec![], OpMode::Primal);
     builder.set_outputs(outputs.clone());
     let fragment = Arc::new(builder.build());
-    register_fragment_metadata(fragment.as_ref(), std::iter::empty());
+    let metadata_scope = register_scoped_fragment_metadata(fragment.as_ref(), std::iter::empty());
 
     TracedTensor {
         id: next_traced_id(),
@@ -2023,6 +2070,7 @@ pub(crate) fn apply_nullary(
         inputs_map: Arc::new(HashMap::new()),
         extra_roots: Vec::new(),
         checkpoint_chain: None,
+        metadata_scopes: metadata_scopes_for_scope(metadata_scope),
     }
 }
 
@@ -2056,7 +2104,7 @@ pub(crate) fn apply_binary(
     let outputs = builder.add_op(op, vec![lhs_ref, rhs_ref], OpMode::Primal);
     builder.set_outputs(outputs.clone());
     let fragment = Arc::new(builder.build());
-    register_fragment_metadata(fragment.as_ref(), std::iter::empty());
+    let metadata_scope = register_scoped_fragment_metadata(fragment.as_ref(), std::iter::empty());
 
     let mut merged = (*lhs.inputs_map).clone();
     merged.extend(rhs.inputs_map.iter().map(|(k, v)| (k.clone(), v.clone())));
@@ -2077,6 +2125,13 @@ pub(crate) fn apply_binary(
             lhs.checkpoint_chain.clone(),
             rhs.checkpoint_chain.clone(),
         ),
+        metadata_scopes: metadata_scopes_with_new(
+            metadata_scope,
+            [
+                lhs.metadata_scopes.as_slice(),
+                rhs.metadata_scopes.as_slice(),
+            ],
+        ),
     }
 }
 
@@ -2091,7 +2146,10 @@ pub(crate) fn apply_multi_output(
     let outputs = builder.add_op(op, vec![input_ref], OpMode::Primal);
     builder.set_outputs(outputs.clone());
     let fragment = Arc::new(builder.build());
-    register_fragment_metadata(fragment.as_ref(), std::iter::empty());
+    let metadata_scope = Arc::new(register_scoped_fragment_metadata(
+        fragment.as_ref(),
+        std::iter::empty(),
+    ));
     assert_eq!(
         outputs.len(),
         output_shapes.len(),
@@ -2112,6 +2170,10 @@ pub(crate) fn apply_multi_output(
             inputs_map: input.inputs_map.clone(),
             extra_roots: input.extra_roots.clone(),
             checkpoint_chain: input.checkpoint_chain.clone(),
+            metadata_scopes: metadata_scopes_with_scope(
+                Arc::clone(&metadata_scope),
+                [input.metadata_scopes.as_slice()],
+            ),
         })
         .collect()
 }

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -15,7 +15,7 @@ use tenferro::exec::eval_exec_ir;
 use tenferro::shape_infer::{infer_output_dtype, infer_output_extents};
 use tenferro::{matmul, Engine, TracedTensor};
 use tenferro_ops::ad::context::{
-    lookup_global_metadata, register_global_metadata_batch, TensorMeta,
+    lookup_global_metadata, register_scoped_global_metadata_batch, GlobalMetadataScope, TensorMeta,
 };
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
@@ -196,7 +196,7 @@ fn tensor_meta_from_tensor(tensor: &Tensor) -> TensorMeta {
 fn register_fragment_metadata_for_test(
     fragment: &Fragment<StdTensorOp>,
     seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
-) {
+) -> GlobalMetadataScope {
     let seeded: Vec<_> = seeded.into_iter().collect();
     let mut known: HashMap<_, _> = seeded.iter().cloned().collect();
 
@@ -252,7 +252,7 @@ fn register_fragment_metadata_for_test(
         }
     }
 
-    register_global_metadata_batch(registrations);
+    register_scoped_global_metadata_batch(registrations)
 }
 
 fn eval_tensor(mut traced: TracedTensor) -> Tensor {
@@ -988,7 +988,7 @@ fn grad_from_fragment_with_inputs_and_cotangent(
     mut inputs_map: HashMap<TensorInputKey, Tensor>,
     cotangent: Tensor,
 ) -> Tensor {
-    register_fragment_metadata_for_test(
+    let _primal_metadata_scope = register_fragment_metadata_for_test(
         fragment.as_ref(),
         inputs_map.iter().map(|(key, tensor)| {
             (
@@ -1007,7 +1007,7 @@ fn grad_from_fragment_with_inputs_and_cotangent(
         &mut ad_ctx,
         &HashMap::new(),
     );
-    register_fragment_metadata_for_test(
+    let _linear_metadata_scope = register_fragment_metadata_for_test(
         &linear.fragment,
         vec![(
             GlobalValKey::Input(input_key.tangent_of(0)),
@@ -1104,7 +1104,7 @@ fn jvp_from_fragment_with_inputs(
     mut inputs_map: HashMap<TensorInputKey, Tensor>,
     tangent: Tensor,
 ) -> Tensor {
-    register_fragment_metadata_for_test(
+    let _primal_metadata_scope = register_fragment_metadata_for_test(
         fragment.as_ref(),
         inputs_map.iter().map(|(key, tensor)| {
             (
@@ -1123,7 +1123,7 @@ fn jvp_from_fragment_with_inputs(
         &mut ad_ctx,
         &HashMap::new(),
     );
-    register_fragment_metadata_for_test(
+    let _linear_metadata_scope = register_fragment_metadata_for_test(
         &linear.fragment,
         vec![(
             GlobalValKey::Input(input_key.tangent_of(0)),
@@ -1200,7 +1200,7 @@ fn transpose_primal_unary_op_with_inputs(
         tangent_inputs: vec![(input_key, tangent_input)],
         tangent_outputs: vec![Some(output)],
     };
-    register_fragment_metadata_for_test(
+    let _linear_metadata_scope = register_fragment_metadata_for_test(
         &linear.fragment,
         vec![(
             GlobalValKey::Input(tangent_input_key.clone()),
@@ -3547,4 +3547,30 @@ fn grad_reverse_weighted_sum_matches_finite_diff() {
             + xs[2] * weights_data[1]
             + xs[3] * weights_data[0]
     });
+}
+
+#[test]
+fn dropped_traced_graph_releases_registered_metadata() {
+    let leaf_key;
+    let derived_key;
+    let y;
+
+    {
+        let x = TracedTensor::from_vec(vec![1], vec![2.0_f64]);
+        leaf_key = GlobalValKey::Input(x.input_key().expect("leaf input key"));
+
+        y = &x + &x;
+        derived_key = y.fragment.vals()[y.val].key.clone();
+
+        assert!(lookup_global_metadata(&leaf_key).is_some());
+        assert!(lookup_global_metadata(&derived_key).is_some());
+    }
+
+    assert!(lookup_global_metadata(&leaf_key).is_some());
+    assert!(lookup_global_metadata(&derived_key).is_some());
+
+    drop(y);
+
+    assert!(lookup_global_metadata(&leaf_key).is_none());
+    assert!(lookup_global_metadata(&derived_key).is_none());
 }


### PR DESCRIPTION
## Summary

- Replace the global tensor metadata registry entries with scope-owned registrations that unregister on drop.
- Thread metadata scopes through traced tensors, eager tensors, einsum, extension ops, checkpointing, JVP, and VJP so live graphs keep metadata alive without process-lifetime leaks.
- Remove the unscoped global metadata registration compatibility path.

Closes #745

## Verification

- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` (73/73 files passed)
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo test --workspace --release`
- `bash scripts/check-agent-assets.sh --quiet`
- `bash scripts/check-repo-settings.sh --quiet`

Generated with [Codex](https://openai.com/codex).
