### PR TITLE
Add owned contiguous memory order support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ cubecl = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96", fea
 cubecl-cuda = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96" }
 cubecl-runtime = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96" }
 tenferro-cubecl = { path = "tenferro-cubecl" }
-ndarray = "0.17.2"
 sha2 = "0.10"
 omeco = "0.2.4"
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "8306196" }

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -105,6 +105,12 @@ the logical layout; dense column-major strides are `[1, d_0, d_0 * d_1, ...]`.
 See [backend-contract.md](../spec/backend-contract.md#vii-layout-and-device-contract)
 for the runtime layout contract.
 
+Host tensors with `MemoryOrder::RowMajor` are supported at the GPU transfer
+boundary by canonicalizing their owned host buffer to dense column-major during
+`upload_tensor()` / `upload_host_tensor()`. Device tensors themselves remain
+column-major. This keeps existing CubeCL kernels correct, including raw linear
+buffer kernels that do not consume tensor stride metadata.
+
 CubeCL kernels that perform logical tensor indexing must receive tensor
 metadata through CubeCL tensor metadata. There is no hidden row-major fallback
 and no implicit global shape state.

--- a/docs/plans/2026-05-12-memory-order-implementation.md
+++ b/docs/plans/2026-05-12-memory-order-implementation.md
@@ -1,0 +1,190 @@
+# Owned Contiguous Memory Order Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add CPU owned-contiguous row/column memory-order metadata and zero-copy owned buffer import/export APIs without adding `ndarray` or strided-view support.
+
+**Architecture:** `MemoryOrder` lives only on concrete `TypedTensor<T>` values. `Tensor`, `EagerTensor`, graph metadata, and operation axis semantics remain structurally unchanged. CPU kernels either read using derived contiguous strides from `shape + order` or explicitly materialize row-major inputs to column-major for column-major-only paths.
+
+**Tech Stack:** Rust 2021, `tenferro-tensor`, `tenferro` facade re-exports, existing `strided-kernel` CPU helpers, Cargo tests and doctests.
+
+---
+
+### Task 1: Memory Order Metadata and Owned API
+
+**Files:**
+- Modify: `tenferro-tensor/src/types.rs`
+- Modify: `tenferro-tensor/src/tests/types_tests.rs`
+- Modify: `tenferro/src/lib.rs`
+
+**Step 1: Write failing tests**
+
+Add tests to `tenferro-tensor/src/tests/types_tests.rs`:
+
+```rust
+#[test]
+fn typed_tensor_explicit_memory_order_constructors_set_order() {
+    let col = TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let row = TypedTensor::from_vec_row_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+
+    assert_eq!(col.order(), MemoryOrder::ColMajor);
+    assert_eq!(row.order(), MemoryOrder::RowMajor);
+    assert_eq!(TypedTensor::from_vec(vec![1], vec![1.0_f64]).order(), MemoryOrder::ColMajor);
+}
+
+#[test]
+fn tensor_owned_export_is_zero_copy_only_for_matching_order() {
+    let data = vec![1.0_f64, 2.0, 3.0, 4.0];
+    let ptr = data.as_ptr();
+    let tensor = Tensor::from_vec_row_major(vec![2, 2], data);
+
+    let (shape, out) = tensor.try_into_vec_row_major::<f64>().unwrap();
+
+    assert_eq!(shape, vec![2, 2]);
+    assert_eq!(out.as_ptr(), ptr);
+
+    let mismatch = Tensor::from_vec_row_major(vec![2], vec![1.0_f64])
+        .try_into_vec_col_major::<f64>()
+        .unwrap_err();
+    assert!(mismatch.to_string().contains("memory order"));
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p tenferro-tensor types_tests -- typed_tensor_explicit_memory_order_constructors_set_order tensor_owned_export_is_zero_copy_only_for_matching_order`
+
+Expected: FAIL because `MemoryOrder`, row-major constructors, `order()`, and typed export methods are missing.
+
+**Step 3: Implement minimal API**
+
+In `types.rs`, add `MemoryOrder`, add `order: MemoryOrder` to `TypedTensor<T>`, set default order to `ColMajor`, add explicit row/col-major constructors, add `Tensor::from_vec_row_major`, `Tensor::from_vec_col_major`, `Tensor::from_vec_with_order`, and typed `try_into_vec_*` methods.
+
+Update `tenferro/src/lib.rs` to re-export `MemoryOrder`.
+
+**Step 4: Run tests to verify green**
+
+Run: `cargo test -p tenferro-tensor types_tests -- typed_tensor_explicit_memory_order_constructors_set_order tensor_owned_export_is_zero_copy_only_for_matching_order`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tenferro-tensor/src/types.rs tenferro-tensor/src/tests/types_tests.rs tenferro/src/lib.rs
+git commit -m "Add owned tensor memory order metadata"
+```
+
+### Task 2: Explicit Layout Conversion and CPU Read Semantics
+
+**Files:**
+- Modify: `tenferro-tensor/src/types.rs`
+- Modify: `tenferro-tensor/src/cpu/mod.rs`
+- Modify: `tenferro-tensor/src/cpu/structural.rs`
+- Modify: `tenferro-tensor/src/cpu/gemm/mod.rs`
+- Modify: `tenferro-tensor/src/tests/types_tests.rs`
+- Test: `tenferro-tensor/src/tests/cpu_tests.rs`
+
+**Step 1: Write failing tests**
+
+Add tests that prove `to_col_major`, `to_row_major`, `linear_offset`, elementwise CPU ops, and `dot_general` preserve logical semantics for row-major inputs.
+
+Use a 2x3 buffer where row-major and column-major logical indexing differ:
+
+```rust
+let row = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+assert_eq!(row.to_col_major().unwrap().as_slice::<f64>().unwrap(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p tenferro-tensor types_tests cpu_tests -- row_major`
+
+Expected: FAIL because conversion and CPU row-major read paths are not implemented.
+
+**Step 3: Implement minimal conversion and stride derivation**
+
+Add `row_major_strides`, `contiguous_strides`, and layout conversion helpers derived from `shape + order`. Make `TypedTensor::linear_offset`, `cpu::typed_view`, and `cpu::structural::host_view` use derived strides. Make GEMM analysis use derived strides for inputs while keeping outputs column-major.
+
+**Step 4: Run tests to verify green**
+
+Run: `cargo test -p tenferro-tensor types_tests cpu_tests -- row_major`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tenferro-tensor/src/types.rs tenferro-tensor/src/cpu/mod.rs tenferro-tensor/src/cpu/structural.rs tenferro-tensor/src/cpu/gemm/mod.rs tenferro-tensor/src/tests/types_tests.rs tenferro-tensor/src/tests/cpu_tests.rs
+git commit -m "Handle contiguous row-major CPU tensors"
+```
+
+### Task 3: Graph and Eager Boundary Coverage
+
+**Files:**
+- Test: `tenferro/tests/primitive_ops.rs`
+- Test: `tenferro/src/eager.rs` or existing eager integration tests
+- Modify only if required: `tenferro/src/metadata.rs`, `tenferro/src/traced.rs`
+
+**Step 1: Write failing tests**
+
+Add a traced `eval_with_inputs` test that binds a row-major `Tensor` and checks logical output. Add an eager test that imports a row-major tensor through `EagerTensor::from_tensor_in` and checks a simple operation. The tests should assert graph shape metadata remains logical and output tensors are usable.
+
+**Step 2: Run tests to verify status**
+
+Run: `cargo test -p tenferro row_major`
+
+Expected: PASS if lower layers are sufficient; otherwise FAIL with the specific boundary gap.
+
+**Step 3: Implement only boundary fixes required by the tests**
+
+Do not add layout to graph metadata. If failures appear, fix concrete tensor handling at import/evaluation boundaries without changing `TensorMeta`, `StdTensorOp`, or axis numbering.
+
+**Step 4: Run tests to verify green**
+
+Run: `cargo test -p tenferro row_major`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tenferro/tests tenferro/src
+git commit -m "Cover row-major tensors at graph boundaries"
+```
+
+### Task 4: Docs, Dependency Cleanup, and Verification
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: rustdoc comments in `tenferro-tensor/src/types.rs`
+- Modify if needed: `docs/plans/2026-05-12-owned-contiguous-memory-order-design.md`
+
+**Step 1: Remove unused ndarray workspace dependency**
+
+Delete `ndarray = "0.17.2"` from root `Cargo.toml` unless another workspace crate now uses it.
+
+**Step 2: Add rustdoc examples**
+
+Every new public enum and method gets a compiling `# Examples` block using only `Vec + shape`, not `ndarray`.
+
+**Step 3: Run targeted verification**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test -p tenferro-tensor types_tests cpu_tests -- row_major
+cargo test -p tenferro row_major
+cargo test --doc -p tenferro-tensor
+cargo test --doc -p tenferro
+```
+
+Expected: all commands exit 0.
+
+**Step 4: Commit**
+
+```bash
+git add Cargo.toml tenferro-tensor/src/types.rs docs/plans/2026-05-12-owned-contiguous-memory-order-design.md
+git commit -m "Document memory order API examples"
+```

--- a/docs/plans/2026-05-12-owned-contiguous-memory-order-design.md
+++ b/docs/plans/2026-05-12-owned-contiguous-memory-order-design.md
@@ -1,0 +1,125 @@
+# Owned Contiguous Memory Order Design
+
+## Scope
+
+tenferro remains a dense tensor library whose runtime tensors own contiguous
+storage. The first row-major interoperability step is limited to CPU host
+buffers passed by ownership transfer. It does not add borrowed tensor views,
+strided tensor views, offset metadata, GPU placement changes, or a direct
+`ndarray` dependency.
+
+The goal is to let callers move an owned row-major `Vec<T>` into tenferro
+without copying, and move an owned tenferro buffer back out when the requested
+memory order already matches the stored order.
+
+## Tensor Metadata
+
+Add a physical contiguous memory-order tag:
+
+```rust
+pub enum MemoryOrder {
+    ColMajor,
+    RowMajor,
+}
+```
+
+`TypedTensor<T>` gains only this field:
+
+```rust
+pub struct TypedTensor<T> {
+    pub buffer: Buffer<T>,
+    pub shape: Vec<usize>,
+    pub placement: Placement,
+    pub order: MemoryOrder,
+}
+```
+
+`shape` remains the logical tensor shape. Because tensors are contiguous, the
+logical strides can be derived from `shape` and `order` whenever a backend
+needs them. No `strides` or `offset` fields are added.
+
+`Tensor`, `EagerTensor`, and `EagerContext` do not need structural changes.
+`Tensor` continues to wrap dtype-specialized `TypedTensor<T>` values.
+`EagerTensor` continues to hold `Arc<Tensor>`, so memory order is available
+through its concrete data.
+
+## Constructors and Export
+
+Existing constructors keep their current column-major meaning:
+
+```rust
+TypedTensor::from_vec(shape, data)
+Tensor::from_vec(shape, data)
+```
+
+Add explicit owned constructors:
+
+```rust
+TypedTensor::from_vec_col_major(shape, data)
+TypedTensor::from_vec_row_major(shape, data)
+Tensor::from_vec_col_major(shape, data)
+Tensor::from_vec_row_major(shape, data)
+```
+
+Owned export should distinguish zero-copy extraction from layout conversion:
+
+```rust
+tensor.try_into_vec_col_major()
+tensor.try_into_vec_row_major()
+tensor.to_col_major()
+tensor.to_row_major()
+```
+
+The `try_into_vec_*` methods return the owned buffer without copying only when
+the stored order matches the requested order and the tensor owns host storage.
+If the order differs, they return an error. The `to_*` methods may allocate and
+reorder explicitly.
+
+## Computation Graph Boundary
+
+Graph semantics do not change. `TensorMeta` remains dtype plus logical shape,
+and graph operations continue to use logical axis numbering. Row-major input
+does not reverse graph axes.
+
+Concrete input tensors carry `MemoryOrder` at evaluation time:
+
+```rust
+TracedTensor::from_tensor_concrete_shape(tensor)
+TracedTensor::from_tensor_symbolic_shape(tensor)
+TracedTensor::eval_with_inputs(engine, bindings)
+Engine::eval_exec_ir(program, inputs)
+```
+
+Compilation, shape inference, AD rules, and operation descriptors remain based
+on logical shape and dtype. Backends decide how to handle physical memory order
+when executing concrete tensors. The minimal CPU implementation may materialize
+row-major inputs into column-major buffers at backend boundaries for operations
+that assume column-major layout.
+
+Backend outputs should initially stay column-major unless a specific operation
+has a deliberate reason to preserve or produce row-major output. Users who need
+row-major output call an explicit conversion or zero-copy export method.
+
+## ndarray Interop Without Dependency
+
+The core crate does not depend on `ndarray`. Users or a future adapter crate can
+bridge through owned contiguous buffers:
+
+```rust
+let shape = array.shape().to_vec();
+let (data, offset) = array.into_raw_vec_and_offset();
+assert_eq!(offset, Some(0));
+let tensor = Tensor::from_vec_row_major(shape, data)?;
+```
+
+Non-contiguous ndarray views are not zero-copy inputs for this design. They must
+be made contiguous before ownership transfer.
+
+## Non-Goals
+
+- No `ndarray` dependency in core crates.
+- No borrowed host tensor views.
+- No runtime `strides` or `offset` fields.
+- No GPU or multi-device changes.
+- No graph-level layout metadata.
+- No implicit layout conversion during zero-copy export.

--- a/docs/plans/2026-05-12-owned-contiguous-memory-order-design.md
+++ b/docs/plans/2026-05-12-owned-contiguous-memory-order-design.md
@@ -3,9 +3,9 @@
 ## Scope
 
 tenferro remains a dense tensor library whose runtime tensors own contiguous
-storage. The first row-major interoperability step is limited to CPU host
-buffers passed by ownership transfer. It does not add borrowed tensor views,
-strided tensor views, offset metadata, GPU placement changes, or a direct
+storage. The first row-major interoperability step is centered on host buffers
+passed by ownership transfer. It does not add borrowed tensor views, strided
+tensor views, offset metadata, device-side row-major storage, or a direct
 `ndarray` dependency.
 
 The goal is to let callers move an owned row-major `Vec<T>` into tenferro
@@ -94,7 +94,9 @@ Compilation, shape inference, AD rules, and operation descriptors remain based
 on logical shape and dtype. Backends decide how to handle physical memory order
 when executing concrete tensors. The minimal CPU implementation may materialize
 row-major inputs into column-major buffers at backend boundaries for operations
-that assume column-major layout.
+that assume column-major layout. GPU upload boundaries canonicalize row-major
+host tensors to column-major device tensors because CubeCL kernels assume dense
+column-major runtime tensors.
 
 Backend outputs should initially stay column-major unless a specific operation
 has a deliberate reason to preserve or produce row-major output. Users who need
@@ -120,6 +122,6 @@ be made contiguous before ownership transfer.
 - No `ndarray` dependency in core crates.
 - No borrowed host tensor views.
 - No runtime `strides` or `offset` fields.
-- No GPU or multi-device changes.
+- No row-major GPU storage or multi-device changes.
 - No graph-level layout metadata.
 - No implicit layout conversion during zero-copy export.

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -436,9 +436,10 @@ impl TensorBackend for CpuBackend {
     }
 
     fn cholesky(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.install_with_pool(|buffers| match &input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::cholesky(ctx.as_ref(), buffers, t).map(Tensor::F32),
             #[cfg(feature = "cpu-blas")]
@@ -468,9 +469,11 @@ impl TensorBackend for CpuBackend {
         transpose_a: bool,
         unit_diagonal: bool,
     ) -> crate::Result<Tensor> {
+        let a = a.to_col_major()?;
+        let b = b.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match (a, b) {
+        self.install_with_pool(|buffers| match (&a, &b) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F32(a), Tensor::F32(b)) => linalg::triangular_solve(
                 ctx.as_ref(),
@@ -578,9 +581,10 @@ impl TensorBackend for CpuBackend {
     }
 
     fn lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.install_with_pool(|buffers| match &input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -614,9 +618,10 @@ impl TensorBackend for CpuBackend {
     }
 
     fn full_piv_lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.install_with_pool(|buffers| match &input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::full_piv_lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -666,7 +671,9 @@ impl TensorBackend for CpuBackend {
 
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        let result = self.install_with_pool(|buffers| match (a, &rhs) {
+        let a = a.to_col_major()?;
+        let rhs = rhs.to_col_major()?;
+        let result = self.install_with_pool(|buffers| match (&a, &rhs) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F32(a), Tensor::F32(b)) => {
                 linalg::full_piv_lu_solve(ctx.as_ref(), buffers, a, b, transpose_a).map(Tensor::F32)
@@ -720,9 +727,10 @@ impl TensorBackend for CpuBackend {
     }
 
     fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.install_with_pool(|buffers| match &input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::svd(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -752,9 +760,10 @@ impl TensorBackend for CpuBackend {
     }
 
     fn qr(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.install_with_pool(|buffers| match &input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::qr(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -788,9 +797,10 @@ impl TensorBackend for CpuBackend {
     }
 
     fn eigh(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
+        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.install_with_pool(|buffers| match &input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::eigh(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -826,16 +836,17 @@ impl TensorBackend for CpuBackend {
         ) {
             return Err(unsupported_dtype("eig", input.dtype()));
         }
+        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| {
             #[cfg(feature = "cpu-faer")]
             {
-                linalg::eig(ctx.as_ref(), buffers, input)
+                linalg::eig(ctx.as_ref(), buffers, &input)
             }
             #[cfg(feature = "cpu-blas")]
             {
-                linalg::eig(buffers, input)
+                linalg::eig(buffers, &input)
             }
         })
     }

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -26,7 +26,8 @@ macro_rules! delegate {
 macro_rules! linalg_single {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-            match input {
+            let input = input.to_col_major()?;
+            match &input {
                 Tensor::F32(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::F32),
                 Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::F64),
                 Tensor::C32(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::C32),
@@ -42,7 +43,8 @@ macro_rules! linalg_single {
 macro_rules! linalg_single {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-            match input {
+            let input = input.to_col_major()?;
+            match &input {
                 Tensor::F32(t) => linalg::$name(self.buffers, t).map(Tensor::F32),
                 Tensor::F64(t) => linalg::$name(self.buffers, t).map(Tensor::F64),
                 Tensor::C32(t) => linalg::$name(self.buffers, t).map(Tensor::C32),
@@ -58,7 +60,8 @@ macro_rules! linalg_single {
 macro_rules! linalg_multi {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-            match input {
+            let input = input.to_col_major()?;
+            match &input {
                 Tensor::F32(t) => linalg::$name(self.ctx, self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                 Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t)
@@ -78,7 +81,8 @@ macro_rules! linalg_multi {
 macro_rules! linalg_multi_result {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-            match input {
+            let input = input.to_col_major()?;
+            match &input {
                 Tensor::F32(t) => linalg::$name(self.ctx, self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                 Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t)
@@ -98,7 +102,8 @@ macro_rules! linalg_multi_result {
 macro_rules! linalg_multi {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-            match input {
+            let input = input.to_col_major()?;
+            match &input {
                 Tensor::F32(t) => linalg::$name(self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                 Tensor::F64(t) => linalg::$name(self.buffers, t)
@@ -239,13 +244,14 @@ impl TensorExec for CpuExecSession<'_> {
         ) {
             return Err(unsupported_dtype("eig", input.dtype()));
         }
+        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         {
-            linalg::eig(self.ctx, self.buffers, input)
+            linalg::eig(self.ctx, self.buffers, &input)
         }
         #[cfg(feature = "cpu-blas")]
         {
-            linalg::eig(self.buffers, input)
+            linalg::eig(self.buffers, &input)
         }
     }
 
@@ -258,7 +264,9 @@ impl TensorExec for CpuExecSession<'_> {
         transpose_a: bool,
         unit_diagonal: bool,
     ) -> crate::Result<Tensor> {
-        match (a, b) {
+        let a = a.to_col_major()?;
+        let b = b.to_col_major()?;
+        match (&a, &b) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F32(a), Tensor::F32(b)) => linalg::triangular_solve(
                 self.ctx,
@@ -371,7 +379,9 @@ impl TensorExec for CpuExecSession<'_> {
         b: &Tensor,
         transpose_a: bool,
     ) -> crate::Result<Tensor> {
-        match (a, b) {
+        let a = a.to_col_major()?;
+        let b = b.to_col_major()?;
+        match (&a, &b) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F32(a), Tensor::F32(b)) => {
                 linalg::full_piv_lu_solve(self.ctx, self.buffers, a, b, transpose_a)

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -261,8 +261,12 @@ fn analyse_gemm<T>(
         .filter(|d| !config.rhs_contracting_dims.contains(d) && !config.rhs_batch_dims.contains(d))
         .collect();
 
-    let lhs_strides: SmallVec<[isize; 8]> = contiguous_strides(&lhs.shape, lhs.order).into_iter().collect();
-    let rhs_strides: SmallVec<[isize; 8]> = contiguous_strides(&rhs.shape, rhs.order).into_iter().collect();
+    let lhs_strides: SmallVec<[isize; 8]> = contiguous_strides(&lhs.shape, lhs.order)
+        .into_iter()
+        .collect();
+    let rhs_strides: SmallVec<[isize; 8]> = contiguous_strides(&rhs.shape, rhs.order)
+        .into_iter()
+        .collect();
 
     let batch_shapes: SmallVec<[usize; 8]> = config
         .lhs_batch_dims

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -412,6 +412,7 @@ where
             buffer: Buffer::Host(vec![T::zero(); out_n]),
             shape: dims.out_shape.into_vec(),
             placement: lhs.placement.clone(),
+            order: crate::MemoryOrder::ColMajor,
         });
     }
 
@@ -461,6 +462,7 @@ where
         buffer: Buffer::Host(out_data),
         shape: dims.out_shape.into_vec(),
         placement: lhs.placement.clone(),
+        order: crate::MemoryOrder::ColMajor,
     })
 }
 
@@ -521,6 +523,7 @@ where
             buffer: Buffer::Host(vec![T::zero(); out_n]),
             shape: dims.out_shape.into_vec(),
             placement: lhs.placement.clone(),
+            order: crate::MemoryOrder::ColMajor,
         }));
     }
 
@@ -595,6 +598,7 @@ where
         buffer: Buffer::Host(out),
         shape: dims.out_shape.into_vec(),
         placement: lhs.placement.clone(),
+        order: crate::MemoryOrder::ColMajor,
     }))
 }
 

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -4,7 +4,7 @@ use smallvec::SmallVec;
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::config::DotGeneralConfig;
 use crate::cpu::structural::typed_transpose;
-use crate::types::{col_major_strides, Buffer, TypedTensor};
+use crate::types::{col_major_strides, contiguous_strides, Buffer, TypedTensor};
 use crate::Error;
 
 #[cfg(feature = "cpu-blas")]
@@ -261,8 +261,8 @@ fn analyse_gemm<T>(
         .filter(|d| !config.rhs_contracting_dims.contains(d) && !config.rhs_batch_dims.contains(d))
         .collect();
 
-    let lhs_strides: SmallVec<[isize; 8]> = col_major_strides(&lhs.shape).into_iter().collect();
-    let rhs_strides: SmallVec<[isize; 8]> = col_major_strides(&rhs.shape).into_iter().collect();
+    let lhs_strides: SmallVec<[isize; 8]> = contiguous_strides(&lhs.shape, lhs.order).into_iter().collect();
+    let rhs_strides: SmallVec<[isize; 8]> = contiguous_strides(&rhs.shape, rhs.order).into_iter().collect();
 
     let batch_shapes: SmallVec<[usize; 8]> = config
         .lhs_batch_dims

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -500,11 +500,15 @@ fn f64_index_to_i64(value: f64) -> crate::Result<i64> {
 
 fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor> {
     match tensor {
-        Tensor::I64(t) => Ok(IndexTensor {
-            shape: t.shape.clone(),
-            values: t.host_data().to_vec(),
-        }),
+        Tensor::I64(t) => {
+            let t = t.to_col_major()?;
+            Ok(IndexTensor {
+                shape: t.shape.clone(),
+                values: t.host_data().to_vec(),
+            })
+        }
         Tensor::F32(t) => {
+            let t = t.to_col_major()?;
             let values: crate::Result<Vec<i64>> = t
                 .host_data()
                 .iter()
@@ -516,6 +520,7 @@ fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor> {
             })
         }
         Tensor::F64(t) => {
+            let t = t.to_col_major()?;
             let values: crate::Result<Vec<i64>> = t
                 .host_data()
                 .iter()

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -93,6 +93,7 @@ fn tensor_from_vec_with_template<T: Clone, U>(
         buffer: Buffer::Host(data),
         shape,
         placement: template.placement.clone(),
+        order: crate::MemoryOrder::ColMajor,
     }
 }
 

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs
@@ -39,6 +39,7 @@ pub(crate) fn tensor_from_vec_with_template<T: Clone, U>(
         buffer: crate::Buffer::Host(data),
         shape,
         placement: template.placement.clone(),
+        order: crate::MemoryOrder::ColMajor,
     }
 }
 

--- a/tenferro-tensor/src/cpu/mod.rs
+++ b/tenferro-tensor/src/cpu/mod.rs
@@ -29,7 +29,7 @@ pub use structural::{
 pub(crate) fn typed_view<T: Copy>(tensor: &TypedTensor<T>) -> StridedView<'_, T> {
     match &tensor.buffer {
         Buffer::Host(data) => {
-            let strides = col_major_strides(&tensor.shape);
+            let strides = crate::contiguous_strides(&tensor.shape, tensor.order);
             StridedView::new(data, &tensor.shape, &strides, 0).expect("contiguous host tensor")
         }
         Buffer::Backend(_) => todo!("typed_view for backend buffers"),

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -244,7 +244,7 @@ pub fn typed_broadcast_in_dim<T: Copy + Zero + Clone>(
     let mut seen = vec![false; shape.len()];
     let mut base_dims = vec![1usize; shape.len()];
     let mut base_strides = vec![0isize; shape.len()];
-    let source_strides = crate::col_major_strides(&tensor.shape);
+    let source_strides = crate::contiguous_strides(&tensor.shape, tensor.order);
     for (src_axis, &dst_axis) in dims.iter().enumerate() {
         validate_axis("broadcast_in_dim", dst_axis, shape.len())?;
         if seen[dst_axis] {

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -231,6 +231,7 @@ pub fn typed_reshape<T: Clone>(
         buffer: tensor.buffer.clone(),
         shape: shape.to_vec(),
         placement: tensor.placement.clone(),
+        order: tensor.order,
     })
 }
 

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -65,7 +65,7 @@ fn validate_permutation(op: &'static str, perm: &[usize], rank: usize) -> crate:
 fn host_view<T: Copy>(tensor: &TypedTensor<T>) -> crate::Result<StridedView<'_, T, Identity>> {
     match &tensor.buffer {
         crate::Buffer::Host(data) => {
-            let strides = crate::col_major_strides(&tensor.shape);
+            let strides = crate::contiguous_strides(&tensor.shape, tensor.order);
             StridedView::new(data, &tensor.shape, &strides, 0)
                 .map_err(|err| backend_failure("structural", err))
         }

--- a/tenferro-tensor/src/cubecl/dispatch.rs
+++ b/tenferro-tensor/src/cubecl/dispatch.rs
@@ -5,7 +5,7 @@ use cubecl_cuda::CudaRuntime;
 use crate::config::CompareDir;
 use crate::cubecl::CubeclRuntime;
 use crate::types::{
-    Buffer, ComputeDevice, CubeclBuffer, MemoryKind, Placement, Tensor, TypedTensor,
+    Buffer, ComputeDevice, CubeclBuffer, MemoryKind, MemoryOrder, Placement, Tensor, TypedTensor,
 };
 
 pub(crate) const DEFAULT_CUBE_DIM_X: u32 = 256;
@@ -76,6 +76,12 @@ pub(crate) fn typed_tensor_binding<T: CubeElement + Clone>(
                 "expected shape product {expected_len} elements, actual CubeclBuffer::len {}",
                 buffer.len
             ),
+        });
+    }
+    if tensor.order != MemoryOrder::ColMajor {
+        return Err(crate::Error::BackendFailure {
+            op,
+            message: "expected column-major GPU tensor; row-major host tensors must be canonicalized during upload".into(),
         });
     }
     let (shape, strides) = cubecl_shape_and_strides(&tensor.shape);

--- a/tenferro-tensor/src/cubecl/dispatch.rs
+++ b/tenferro-tensor/src/cubecl/dispatch.rs
@@ -141,6 +141,7 @@ pub(crate) fn typed_from_cubecl<T>(
                 ordinal: device_ordinal,
             }),
         },
+        order: crate::MemoryOrder::ColMajor,
     }
 }
 

--- a/tenferro-tensor/src/cubecl/linalg.rs
+++ b/tenferro-tensor/src/cubecl/linalg.rs
@@ -1013,6 +1013,7 @@ fn upload_host_tensor<T>(
 where
     T: CubeElement + Clone,
 {
+    let tensor = tensor.to_col_major()?;
     let (shape, data) = match tensor.buffer {
         crate::Buffer::Host(data) => (tensor.shape, data),
         crate::Buffer::Backend(_) | crate::Buffer::Cubecl(_) => {

--- a/tenferro-tensor/src/cubecl/memory.rs
+++ b/tenferro-tensor/src/cubecl/memory.rs
@@ -1,5 +1,7 @@
 //! Host-to-device and device-to-host transfers via CubeCL-managed allocations.
 
+use std::borrow::Cow;
+
 use cubecl::client::ComputeClient;
 use cubecl::prelude::CubeElement;
 use cubecl_cuda::CudaRuntime;
@@ -7,7 +9,7 @@ use num_complex::{Complex32, Complex64};
 
 use crate::cubecl::runtime::CubeclRuntime;
 use crate::types::{
-    Buffer, ComputeDevice, CubeclBuffer, MemoryKind, Placement, Tensor, TypedTensor,
+    Buffer, ComputeDevice, CubeclBuffer, MemoryKind, MemoryOrder, Placement, Tensor, TypedTensor,
 };
 
 /// Upload a host tensor into a CubeCL-managed GPU allocation.
@@ -83,8 +85,32 @@ fn upload_typed<T: CubeElement + Clone>(
     device_ordinal: usize,
     typed: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>> {
-    let host_data = match &typed.buffer {
+    let upload_source = canonical_host_tensor_for_upload(typed)?;
+    let host_data = match &upload_source.buffer {
         Buffer::Host(data) => data,
+        Buffer::Backend(_) | Buffer::Cubecl(_) => unreachable!("canonical upload source is host"),
+    };
+
+    let handle = client.create_from_slice(T::as_bytes(host_data));
+    Ok(TypedTensor {
+        buffer: Buffer::Cubecl(CubeclBuffer::new(handle, host_data.len())),
+        shape: upload_source.shape.clone(),
+        placement: Placement {
+            memory_kind: MemoryKind::Device,
+            resident_device: Some(ComputeDevice {
+                kind: "cuda".into(),
+                ordinal: device_ordinal,
+            }),
+        },
+        order: MemoryOrder::ColMajor,
+    })
+}
+
+pub(crate) fn canonical_host_tensor_for_upload<T: Clone>(
+    typed: &TypedTensor<T>,
+) -> crate::Result<Cow<'_, TypedTensor<T>>> {
+    match &typed.buffer {
+        Buffer::Host(_) => {}
         Buffer::Backend(_) => {
             return Err(crate::Error::BackendFailure {
                 op: "upload",
@@ -98,20 +124,11 @@ fn upload_typed<T: CubeElement + Clone>(
             });
         }
     };
-
-    let handle = client.create_from_slice(T::as_bytes(host_data));
-    Ok(TypedTensor {
-        buffer: Buffer::Cubecl(CubeclBuffer::new(handle, host_data.len())),
-        shape: typed.shape.clone(),
-        placement: Placement {
-            memory_kind: MemoryKind::Device,
-            resident_device: Some(ComputeDevice {
-                kind: "cuda".into(),
-                ordinal: device_ordinal,
-            }),
-        },
-        order: typed.order,
-    })
+    if typed.order == MemoryOrder::ColMajor {
+        Ok(Cow::Borrowed(typed))
+    } else {
+        typed.to_col_major().map(Cow::Owned)
+    }
 }
 
 fn download_typed<T: CubeElement + Clone>(

--- a/tenferro-tensor/src/cubecl/memory.rs
+++ b/tenferro-tensor/src/cubecl/memory.rs
@@ -110,6 +110,7 @@ fn upload_typed<T: CubeElement + Clone>(
                 ordinal: device_ordinal,
             }),
         },
+        order: typed.order,
     })
 }
 

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -2301,26 +2301,31 @@ impl TensorBackend for CubeclBackend {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
+                order: t.order,
             })),
             Tensor::F64(t) => Ok(Tensor::F64(TypedTensor {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
+                order: t.order,
             })),
             Tensor::I64(t) => Ok(Tensor::I64(TypedTensor {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
+                order: t.order,
             })),
             Tensor::C32(t) => Ok(Tensor::C32(TypedTensor {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
+                order: t.order,
             })),
             Tensor::C64(t) => Ok(Tensor::C64(TypedTensor {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
+                order: t.order,
             })),
         }
     }

--- a/tenferro-tensor/src/cubecl/tests/metadata_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/metadata_tests.rs
@@ -59,5 +59,6 @@ fn cubecl_tensor_with_len(shape: Vec<usize>, len: usize) -> TypedTensor<f32> {
                 ordinal: 0,
             }),
         },
+        order: crate::MemoryOrder::ColMajor,
     }
 }

--- a/tenferro-tensor/src/cubecl/tests/metadata_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/metadata_tests.rs
@@ -1,7 +1,8 @@
 use cubecl::stream_id::StreamId;
 
 use crate::cubecl::dispatch::{cubecl_shape_and_strides, typed_tensor_binding};
-use crate::{Buffer, ComputeDevice, CubeclBuffer, MemoryKind, Placement, TypedTensor};
+use crate::cubecl::memory::canonical_host_tensor_for_upload;
+use crate::{Buffer, ComputeDevice, CubeclBuffer, MemoryKind, MemoryOrder, Placement, TypedTensor};
 
 #[test]
 fn cubecl_metadata_uses_dense_column_major_strides() {
@@ -39,6 +40,48 @@ fn typed_tensor_binding_rejects_shape_product_overflow() {
             assert_eq!(op, "metadata_test");
             assert!(message.contains("shape product overflow"));
             assert!(message.contains("["));
+        }
+        other => panic!("expected BackendFailure, got {other:?}"),
+    }
+}
+
+#[test]
+fn typed_tensor_binding_rejects_row_major_gpu_tensor() {
+    let mut tensor = cubecl_tensor_with_len(vec![2, 3], 6);
+    tensor.order = MemoryOrder::RowMajor;
+
+    let err = typed_tensor_binding(&tensor, "metadata_test").unwrap_err();
+
+    match err {
+        crate::Error::BackendFailure { op, message } => {
+            assert_eq!(op, "metadata_test");
+            assert!(message.contains("column-major GPU tensor"));
+        }
+        other => panic!("expected BackendFailure, got {other:?}"),
+    }
+}
+
+#[test]
+fn upload_canonicalizes_row_major_host_tensor_to_col_major() {
+    let tensor =
+        TypedTensor::from_vec_row_major(vec![2, 3], vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let upload_source = canonical_host_tensor_for_upload(&tensor).unwrap();
+
+    assert_eq!(upload_source.order(), MemoryOrder::ColMajor);
+    assert_eq!(upload_source.host_data(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+}
+
+#[test]
+fn upload_canonicalization_rejects_non_host_tensors() {
+    let tensor = cubecl_tensor_with_len(vec![2], 2);
+
+    let err = canonical_host_tensor_for_upload(&tensor).unwrap_err();
+
+    match err {
+        crate::Error::BackendFailure { op, message } => {
+            assert_eq!(op, "upload");
+            assert!(message.contains("already backed by CubeCL"));
         }
         other => panic!("expected BackendFailure, got {other:?}"),
     }

--- a/tenferro-tensor/src/tests/cpu_linalg_dtype_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_linalg_dtype_tests.rs
@@ -213,7 +213,7 @@ fn cpu_linalg_accepts_f32_happy_paths() {
     let lu_input = Tensor::F32(TypedTensor::from_vec(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]));
     let lu = backend.lu(&lu_input).unwrap();
     assert_eq!(lu.len(), 4);
-    assert_eq!(lu[3].shape(), &[]);
+    assert_eq!(lu[3].shape(), &[] as &[usize]);
 
     let full = backend.full_piv_lu(&lu_input).unwrap();
     assert_eq!(full.len(), 5);
@@ -349,7 +349,7 @@ fn cpu_linalg_accepts_c32_happy_paths() {
 
     let lu = backend.lu(&a).unwrap();
     assert_eq!(lu.len(), 4);
-    assert_eq!(lu[3].shape(), &[]);
+    assert_eq!(lu[3].shape(), &[] as &[usize]);
 
     let full = backend.full_piv_lu(&a).unwrap();
     assert_eq!(full.len(), 5);

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -186,28 +186,87 @@ fn matrix_f64_from_tensor(t: &Tensor, rows: usize, cols: usize) -> Vec<f64> {
     out
 }
 
-#[test]
-fn row_major_inputs_preserve_logical_elementwise_semantics() {
-    let lhs = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let rhs = Tensor::from_vec_row_major(vec![2, 3], vec![10.0_f64, 20.0, 30.0, 40.0, 50.0, 60.0]);
+fn assert_same_f64_tensor(name: &str, actual: &Tensor, expected: &Tensor) {
+    assert_eq!(actual.shape(), expected.shape(), "{name}: shape mismatch");
+    let actual = actual.to_col_major().unwrap();
+    let expected = expected.to_col_major().unwrap();
+    assert_eq!(
+        actual.as_slice::<f64>().unwrap().len(),
+        expected.as_slice::<f64>().unwrap().len(),
+        "{name}: element count mismatch"
+    );
+    for (index, (&actual, &expected)) in actual
+        .as_slice::<f64>()
+        .unwrap()
+        .iter()
+        .zip(expected.as_slice::<f64>().unwrap())
+        .enumerate()
+    {
+        assert_f64_close_tol(actual, expected, 1.0e-10);
+        let _ = index;
+    }
+}
 
-    let out = add(&lhs, &rhs).unwrap();
+fn assert_row_major_unary_matches_col_major(
+    name: &str,
+    input: &Tensor,
+    op: impl Fn(&Tensor) -> crate::Result<Tensor>,
+) {
+    let expected = op(input).unwrap();
+    let row_input = input.to_row_major().unwrap();
+    let actual = op(&row_input).unwrap();
 
-    assert_eq!(out.shape(), &[2, 3]);
-    assert_f64_close(get_f64(&out, &[0, 2]), 33.0);
-    assert_f64_close(get_f64(&out, &[1, 0]), 44.0);
+    assert_same_f64_tensor(name, &actual, &expected);
+}
+
+fn assert_row_major_binary_matches_col_major(
+    name: &str,
+    lhs: &Tensor,
+    rhs: &Tensor,
+    op: impl Fn(&Tensor, &Tensor) -> crate::Result<Tensor>,
+) {
+    let expected = op(lhs, rhs).unwrap();
+    let row_lhs = lhs.to_row_major().unwrap();
+    let row_rhs = rhs.to_row_major().unwrap();
+    let actual = op(&row_lhs, &row_rhs).unwrap();
+
+    assert_same_f64_tensor(name, &actual, &expected);
 }
 
 #[test]
-fn row_major_inputs_preserve_logical_dot_general_semantics() {
-    let mut backend = CpuBackend::with_threads(1);
-    let lhs = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let rhs = Tensor::from_vec_row_major(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]);
+fn row_major_computation_matches_col_major_for_elementwise_and_structural_ops() {
+    let input = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let other = Tensor::from_vec(vec![2, 3], vec![10.0_f64, 40.0, 20.0, 50.0, 30.0, 60.0]);
 
-    let out = backend
-        .dot_general(
-            &lhs,
-            &rhs,
+    assert_row_major_binary_matches_col_major("add", &input, &other, add);
+    assert_row_major_binary_matches_col_major("mul", &input, &other, mul);
+    assert_row_major_unary_matches_col_major("neg", &input, neg);
+    assert_row_major_unary_matches_col_major("transpose", &input, |x| transpose(x, &[1, 0]));
+    assert_row_major_unary_matches_col_major("reduce_sum", &input, |x| reduce_sum(x, &[1]));
+    assert_row_major_unary_matches_col_major("broadcast_in_dim", &input, |x| {
+        broadcast_in_dim(x, &[2, 3, 2], &[0, 1])
+    });
+    assert_row_major_unary_matches_col_major("slice", &input, |x| {
+        crate::cpu::indexing::try_slice(
+            x,
+            &SliceConfig {
+                starts: vec![0, 1],
+                limits: vec![2, 3],
+                strides: vec![1, 1],
+            },
+        )
+    });
+}
+
+#[test]
+fn row_major_computation_matches_col_major_for_gemm_indexing_and_linalg_ops() {
+    let lhs = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let rhs = Tensor::from_vec(vec![3, 2], vec![7.0_f64, 9.0, 11.0, 8.0, 10.0, 12.0]);
+    assert_row_major_binary_matches_col_major("dot_general", &lhs, &rhs, |a, b| {
+        let mut backend = CpuBackend::with_threads(1);
+        backend.dot_general(
+            a,
+            b,
             &DotGeneralConfig {
                 lhs_contracting_dims: vec![1],
                 rhs_contracting_dims: vec![0],
@@ -215,33 +274,13 @@ fn row_major_inputs_preserve_logical_dot_general_semantics() {
                 rhs_batch_dims: vec![],
             },
         )
-        .unwrap();
+    });
 
-    assert_eq!(out.shape(), &[2, 2]);
-    assert_eq!(out.as_slice::<f64>().unwrap(), &[58.0, 139.0, 64.0, 154.0]);
-}
-
-#[test]
-fn row_major_input_preserves_logical_broadcast_semantics() {
-    let input = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-
-    let out = broadcast_in_dim(&input, &[2, 3, 2], &[0, 1]).unwrap();
-    let row_major = out.to_row_major().unwrap();
-
-    assert_eq!(out.shape(), &[2, 3, 2]);
-    assert_eq!(
-        row_major.as_slice::<f64>().unwrap(),
-        &[1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0, 5.0, 6.0, 6.0]
-    );
-}
-
-#[test]
-fn row_major_index_tensor_preserves_logical_gather_indices() {
     let operand = Tensor::from_vec(
         vec![3, 3],
         vec![1.0_f64, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0],
     );
-    let start_indices = Tensor::from_vec_row_major(vec![2, 2], vec![0_i64, 2, 1, 0]);
+    let start_indices = Tensor::from_vec(vec![2, 2], vec![0_i64, 1, 2, 0]);
     let config = GatherConfig {
         offset_dims: vec![],
         collapsed_slice_dims: vec![0, 1],
@@ -249,24 +288,16 @@ fn row_major_index_tensor_preserves_logical_gather_indices() {
         index_vector_dim: 1,
         slice_sizes: vec![1, 1],
     };
+    assert_row_major_binary_matches_col_major("gather", &operand, &start_indices, |x, indices| {
+        gather(x, indices, &config)
+    });
 
-    let out = gather(&operand, &start_indices, &config).unwrap();
-
-    assert_eq!(out.shape(), &[2]);
-    assert_eq!(out.as_slice::<f64>().unwrap(), &[3.0, 4.0]);
-}
-
-#[test]
-fn row_major_linalg_input_preserves_logical_solve_semantics() {
-    let mut backend = CpuBackend::with_threads(1);
-    let a = Tensor::from_vec_row_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let a = Tensor::from_vec(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
     let b = Tensor::from_vec(vec![2], vec![5.0_f64, 11.0]);
-
-    let out = backend.solve(&a, &b).unwrap();
-
-    assert_eq!(out.shape(), &[2]);
-    assert_f64_close_tol(get_f64(&out, &[0]), 1.0, 1.0e-10);
-    assert_f64_close_tol(get_f64(&out, &[1]), 2.0, 1.0e-10);
+    assert_row_major_binary_matches_col_major("solve", &a, &b, |a, b| {
+        let mut backend = CpuBackend::with_threads(1);
+        backend.solve(a, b)
+    });
 }
 
 fn batch_vector_f64_from_tensor(t: &Tensor, len: usize, batch_idx: usize) -> Vec<f64> {

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -186,6 +186,53 @@ fn matrix_f64_from_tensor(t: &Tensor, rows: usize, cols: usize) -> Vec<f64> {
     out
 }
 
+#[test]
+fn row_major_inputs_preserve_logical_elementwise_semantics() {
+    let lhs = Tensor::from_vec_row_major(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    );
+    let rhs = Tensor::from_vec_row_major(
+        vec![2, 3],
+        vec![10.0_f64, 20.0, 30.0, 40.0, 50.0, 60.0],
+    );
+
+    let out = add(&lhs, &rhs).unwrap();
+
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_f64_close(get_f64(&out, &[0, 2]), 33.0);
+    assert_f64_close(get_f64(&out, &[1, 0]), 44.0);
+}
+
+#[test]
+fn row_major_inputs_preserve_logical_dot_general_semantics() {
+    let mut backend = CpuBackend::with_threads(1);
+    let lhs = Tensor::from_vec_row_major(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    );
+    let rhs = Tensor::from_vec_row_major(
+        vec![3, 2],
+        vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0],
+    );
+
+    let out = backend
+        .dot_general(
+            &lhs,
+            &rhs,
+            &DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        )
+        .unwrap();
+
+    assert_eq!(out.shape(), &[2, 2]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[58.0, 139.0, 64.0, 154.0]);
+}
+
 fn batch_vector_f64_from_tensor(t: &Tensor, len: usize, batch_idx: usize) -> Vec<f64> {
     let mut out = vec![0.0; len];
     for i in 0..len {

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -188,14 +188,8 @@ fn matrix_f64_from_tensor(t: &Tensor, rows: usize, cols: usize) -> Vec<f64> {
 
 #[test]
 fn row_major_inputs_preserve_logical_elementwise_semantics() {
-    let lhs = Tensor::from_vec_row_major(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    );
-    let rhs = Tensor::from_vec_row_major(
-        vec![2, 3],
-        vec![10.0_f64, 20.0, 30.0, 40.0, 50.0, 60.0],
-    );
+    let lhs = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let rhs = Tensor::from_vec_row_major(vec![2, 3], vec![10.0_f64, 20.0, 30.0, 40.0, 50.0, 60.0]);
 
     let out = add(&lhs, &rhs).unwrap();
 
@@ -207,14 +201,8 @@ fn row_major_inputs_preserve_logical_elementwise_semantics() {
 #[test]
 fn row_major_inputs_preserve_logical_dot_general_semantics() {
     let mut backend = CpuBackend::with_threads(1);
-    let lhs = Tensor::from_vec_row_major(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    );
-    let rhs = Tensor::from_vec_row_major(
-        vec![3, 2],
-        vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0],
-    );
+    let lhs = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let rhs = Tensor::from_vec_row_major(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]);
 
     let out = backend
         .dot_general(
@@ -235,10 +223,7 @@ fn row_major_inputs_preserve_logical_dot_general_semantics() {
 
 #[test]
 fn row_major_input_preserves_logical_broadcast_semantics() {
-    let input = Tensor::from_vec_row_major(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    );
+    let input = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
     let out = broadcast_in_dim(&input, &[2, 3, 2], &[0, 1]).unwrap();
     let row_major = out.to_row_major().unwrap();

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -233,6 +233,57 @@ fn row_major_inputs_preserve_logical_dot_general_semantics() {
     assert_eq!(out.as_slice::<f64>().unwrap(), &[58.0, 139.0, 64.0, 154.0]);
 }
 
+#[test]
+fn row_major_input_preserves_logical_broadcast_semantics() {
+    let input = Tensor::from_vec_row_major(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    );
+
+    let out = broadcast_in_dim(&input, &[2, 3, 2], &[0, 1]).unwrap();
+    let row_major = out.to_row_major().unwrap();
+
+    assert_eq!(out.shape(), &[2, 3, 2]);
+    assert_eq!(
+        row_major.as_slice::<f64>().unwrap(),
+        &[1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0, 5.0, 6.0, 6.0]
+    );
+}
+
+#[test]
+fn row_major_index_tensor_preserves_logical_gather_indices() {
+    let operand = Tensor::from_vec(
+        vec![3, 3],
+        vec![1.0_f64, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0],
+    );
+    let start_indices = Tensor::from_vec_row_major(vec![2, 2], vec![0_i64, 2, 1, 0]);
+    let config = GatherConfig {
+        offset_dims: vec![],
+        collapsed_slice_dims: vec![0, 1],
+        start_index_map: vec![0, 1],
+        index_vector_dim: 1,
+        slice_sizes: vec![1, 1],
+    };
+
+    let out = gather(&operand, &start_indices, &config).unwrap();
+
+    assert_eq!(out.shape(), &[2]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[3.0, 4.0]);
+}
+
+#[test]
+fn row_major_linalg_input_preserves_logical_solve_semantics() {
+    let mut backend = CpuBackend::with_threads(1);
+    let a = Tensor::from_vec_row_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let b = Tensor::from_vec(vec![2], vec![5.0_f64, 11.0]);
+
+    let out = backend.solve(&a, &b).unwrap();
+
+    assert_eq!(out.shape(), &[2]);
+    assert_f64_close_tol(get_f64(&out, &[0]), 1.0, 1.0e-10);
+    assert_f64_close_tol(get_f64(&out, &[1]), 2.0, 1.0e-10);
+}
+
 fn batch_vector_f64_from_tensor(t: &Tensor, len: usize, batch_idx: usize) -> Vec<f64> {
     let mut out = vec![0.0; len];
     for i in 0..len {

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -85,10 +85,8 @@ fn tensor_owned_export_is_zero_copy_only_for_matching_order() {
 
 #[test]
 fn row_major_typed_tensor_uses_logical_indices() {
-    let tensor = TypedTensor::from_vec_row_major(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    );
+    let tensor =
+        TypedTensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
     assert_eq!(*tensor.get(&[0, 2]), 3.0);
     assert_eq!(*tensor.get(&[1, 0]), 4.0);
@@ -96,10 +94,7 @@ fn row_major_typed_tensor_uses_logical_indices() {
 
 #[test]
 fn row_major_to_col_major_reorders_owned_buffer() {
-    let tensor = Tensor::from_vec_row_major(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    );
+    let tensor = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
     let converted = tensor.to_col_major().unwrap();
 

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -4,7 +4,7 @@ use num_complex::{Complex32, Complex64};
 
 use crate::types::{
     col_major_strides, flat_to_multi, Buffer, BufferHandle, ComputeDevice, ConjElem, DType,
-    MemoryKind, Placement, Tensor, TensorScalar, TypedTensor,
+    MemoryKind, MemoryOrder, Placement, Tensor, TensorScalar, TypedTensor,
 };
 use crate::Error;
 
@@ -54,6 +54,36 @@ fn typed_tensor_rank_zero_access_and_mutation_work() {
 }
 
 #[test]
+fn typed_tensor_explicit_memory_order_constructors_set_order() {
+    let col = TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let row = TypedTensor::from_vec_row_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+
+    assert_eq!(col.order(), MemoryOrder::ColMajor);
+    assert_eq!(row.order(), MemoryOrder::RowMajor);
+    assert_eq!(
+        TypedTensor::from_vec(vec![1], vec![1.0_f64]).order(),
+        MemoryOrder::ColMajor
+    );
+}
+
+#[test]
+fn tensor_owned_export_is_zero_copy_only_for_matching_order() {
+    let data = vec![1.0_f64, 2.0, 3.0, 4.0];
+    let ptr = data.as_ptr();
+    let tensor = Tensor::from_vec_row_major(vec![2, 2], data);
+
+    let (shape, out) = tensor.try_into_vec_row_major::<f64>().unwrap();
+
+    assert_eq!(shape, vec![2, 2]);
+    assert_eq!(out.as_ptr(), ptr);
+
+    let mismatch = Tensor::from_vec_row_major(vec![1], vec![1.0_f64])
+        .try_into_vec_col_major::<f64>()
+        .unwrap_err();
+    assert!(mismatch.to_string().contains("memory order"));
+}
+
+#[test]
 fn typed_tensor_panics_cover_length_and_indexing_errors() {
     let mismatched = catch_unwind(|| TypedTensor::<f64>::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0]));
     assert!(mismatched.is_err());
@@ -79,6 +109,7 @@ fn backend_buffers_panic_when_host_access_is_requested() {
         buffer: Buffer::Backend(BufferHandle::<f64>::new(7)),
         shape: vec![1],
         placement: placement.clone(),
+        order: MemoryOrder::ColMajor,
     };
     assert_eq!(
         tensor.placement.resident_device.as_ref().unwrap().ordinal,
@@ -92,6 +123,7 @@ fn backend_buffers_panic_when_host_access_is_requested() {
         buffer: Buffer::Backend(BufferHandle::<f64>::new(8)),
         shape: vec![1],
         placement,
+        order: MemoryOrder::ColMajor,
     };
     let host_data_mut = catch_unwind(AssertUnwindSafe(|| {
         let _ = mutable_tensor.host_data_mut();

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -84,6 +84,33 @@ fn tensor_owned_export_is_zero_copy_only_for_matching_order() {
 }
 
 #[test]
+fn row_major_typed_tensor_uses_logical_indices() {
+    let tensor = TypedTensor::from_vec_row_major(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    );
+
+    assert_eq!(*tensor.get(&[0, 2]), 3.0);
+    assert_eq!(*tensor.get(&[1, 0]), 4.0);
+}
+
+#[test]
+fn row_major_to_col_major_reorders_owned_buffer() {
+    let tensor = Tensor::from_vec_row_major(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    );
+
+    let converted = tensor.to_col_major().unwrap();
+
+    assert_eq!(converted.order(), MemoryOrder::ColMajor);
+    assert_eq!(
+        converted.as_slice::<f64>().unwrap(),
+        &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
+    );
+}
+
+#[test]
 fn typed_tensor_panics_cover_length_and_indexing_errors() {
     let mismatched = catch_unwind(|| TypedTensor::<f64>::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0]));
     assert!(mismatched.is_err());

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -531,6 +531,90 @@ pub fn col_major_strides(shape: &[usize]) -> Vec<isize> {
     strides
 }
 
+/// Row-major strides derived from a shape.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::row_major_strides;
+///
+/// assert_eq!(row_major_strides(&[2, 3]), vec![3, 1]);
+/// ```
+pub fn row_major_strides(shape: &[usize]) -> Vec<isize> {
+    if shape.is_empty() {
+        return vec![];
+    }
+    let mut strides = vec![1isize; shape.len()];
+    for i in (0..shape.len() - 1).rev() {
+        strides[i] = strides[i + 1] * shape[i + 1] as isize;
+    }
+    strides
+}
+
+/// Contiguous strides derived from a shape and memory order.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{contiguous_strides, MemoryOrder};
+///
+/// assert_eq!(contiguous_strides(&[2, 3], MemoryOrder::ColMajor), vec![1, 2]);
+/// assert_eq!(contiguous_strides(&[2, 3], MemoryOrder::RowMajor), vec![3, 1]);
+/// ```
+pub fn contiguous_strides(shape: &[usize], order: MemoryOrder) -> Vec<isize> {
+    match order {
+        MemoryOrder::ColMajor => col_major_strides(shape),
+        MemoryOrder::RowMajor => row_major_strides(shape),
+    }
+}
+
+fn linear_offset_for_order(shape: &[usize], indices: &[usize], order: MemoryOrder) -> usize {
+    assert_eq!(indices.len(), shape.len());
+    let strides = contiguous_strides(shape, order);
+    let mut offset = 0usize;
+    for (axis, (&idx, &extent)) in indices.iter().zip(shape).enumerate() {
+        assert!(idx < extent, "index out of bounds");
+        offset += idx * strides[axis] as usize;
+    }
+    offset
+}
+
+fn flat_to_multi_for_order(flat: usize, shape: &[usize], order: MemoryOrder, out: &mut [usize]) {
+    assert_eq!(shape.len(), out.len());
+    if shape.is_empty() {
+        return;
+    }
+    let strides = contiguous_strides(shape, order);
+    let mut remaining = flat;
+    let mut axes: Vec<usize> = (0..shape.len()).collect();
+    axes.sort_by_key(|&axis| std::cmp::Reverse(strides[axis]));
+    for axis in axes {
+        let stride = strides[axis] as usize;
+        out[axis] = remaining / stride;
+        remaining %= stride;
+    }
+}
+
+fn reorder_contiguous<T: Clone>(
+    shape: &[usize],
+    data: &[T],
+    from: MemoryOrder,
+    to: MemoryOrder,
+) -> Vec<T> {
+    if from == to {
+        return data.to_vec();
+    }
+    let total: usize = shape.iter().product();
+    let mut out = Vec::with_capacity(total);
+    let mut idx = vec![0usize; shape.len()];
+    for dst_flat in 0..total {
+        flat_to_multi_for_order(dst_flat, shape, to, &mut idx);
+        let src = linear_offset_for_order(shape, &idx, from);
+        out.push(data[src].clone());
+    }
+    out
+}
+
 pub(crate) fn default_placement() -> Placement {
     Placement {
         memory_kind: MemoryKind::UnpinnedHost,
@@ -738,6 +822,76 @@ impl<T: Clone> TypedTensor<T> {
         self.try_into_vec_with_order(MemoryOrder::RowMajor)
     }
 
+    /// Return a tensor with the requested contiguous memory order.
+    ///
+    /// This clones the tensor when the order already matches and allocates a
+    /// reordered host buffer when conversion is required.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2], vec![1.0, 2.0]);
+    /// assert_eq!(t.to_order(MemoryOrder::ColMajor).unwrap().order(), MemoryOrder::ColMajor);
+    /// ```
+    pub fn to_order(&self, order: MemoryOrder) -> crate::Result<Self> {
+        if self.order == order {
+            return Ok(self.clone());
+        }
+        let data = match &self.buffer {
+            Buffer::Host(data) => reorder_contiguous(&self.shape, data, self.order, order),
+            Buffer::Backend(_) => {
+                return Err(crate::Error::BackendFailure {
+                    op: "to_order",
+                    message: "backend buffers cannot be reordered on host".into(),
+                })
+            }
+            #[cfg(feature = "cubecl")]
+            Buffer::Cubecl(_) => {
+                return Err(crate::Error::BackendFailure {
+                    op: "to_order",
+                    message: "GPU buffers cannot be reordered on host".into(),
+                })
+            }
+        };
+        Ok(Self {
+            buffer: Buffer::Host(data),
+            shape: self.shape.clone(),
+            placement: self.placement.clone(),
+            order,
+        })
+    }
+
+    /// Return a column-major tensor, allocating only when conversion is
+    /// required.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2], vec![1.0, 2.0]);
+    /// assert_eq!(t.to_col_major().unwrap().order(), MemoryOrder::ColMajor);
+    /// ```
+    pub fn to_col_major(&self) -> crate::Result<Self> {
+        self.to_order(MemoryOrder::ColMajor)
+    }
+
+    /// Return a row-major tensor, allocating only when conversion is required.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
+    /// assert_eq!(t.to_row_major().unwrap().order(), MemoryOrder::RowMajor);
+    /// ```
+    pub fn to_row_major(&self) -> crate::Result<Self> {
+        self.to_order(MemoryOrder::RowMajor)
+    }
+
     /// Number of elements in the tensor.
     ///
     /// # Examples
@@ -829,15 +983,7 @@ impl<T: Clone> TypedTensor<T> {
     /// assert_eq!(t.linear_offset(&[1, 2]), 5);
     /// ```
     pub fn linear_offset(&self, indices: &[usize]) -> usize {
-        assert_eq!(indices.len(), self.shape.len());
-        let mut offset = 0usize;
-        let mut stride = 1usize;
-        for (i, &idx) in indices.iter().enumerate() {
-            assert!(idx < self.shape[i], "index out of bounds");
-            offset += idx * stride;
-            stride *= self.shape[i];
-        }
-        offset
+        linear_offset_for_order(&self.shape, indices, self.order)
     }
 
     /// Borrow a single element by multi-index.
@@ -1101,6 +1247,55 @@ impl Tensor {
             rhs: actual,
         })?;
         typed.try_into_vec_with_order(order)
+    }
+
+    /// Return a tensor with the requested contiguous memory order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::from_vec_row_major(vec![2], vec![1.0_f64, 2.0]);
+    /// assert_eq!(t.to_col_major().unwrap().order(), MemoryOrder::ColMajor);
+    /// ```
+    pub fn to_order(&self, order: MemoryOrder) -> crate::Result<Self> {
+        match self {
+            Tensor::F32(t) => Ok(Tensor::F32(t.to_order(order)?)),
+            Tensor::F64(t) => Ok(Tensor::F64(t.to_order(order)?)),
+            Tensor::I64(t) => Ok(Tensor::I64(t.to_order(order)?)),
+            Tensor::C32(t) => Ok(Tensor::C32(t.to_order(order)?)),
+            Tensor::C64(t) => Ok(Tensor::C64(t.to_order(order)?)),
+        }
+    }
+
+    /// Return a column-major tensor, allocating only when conversion is
+    /// required.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::from_vec_row_major(vec![2], vec![1.0_f64, 2.0]);
+    /// assert_eq!(t.to_col_major().unwrap().order(), MemoryOrder::ColMajor);
+    /// ```
+    pub fn to_col_major(&self) -> crate::Result<Self> {
+        self.to_order(MemoryOrder::ColMajor)
+    }
+
+    /// Return a row-major tensor, allocating only when conversion is required.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    /// assert_eq!(t.to_row_major().unwrap().order(), MemoryOrder::RowMajor);
+    /// ```
+    pub fn to_row_major(&self) -> crate::Result<Self> {
+        self.to_order(MemoryOrder::RowMajor)
     }
 
     /// Singular value decomposition: `A = U diag(S) Vt`.

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -147,7 +147,7 @@ impl<T> CubeclBuffer<T> {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tenferro_tensor::TypedTensor;
 ///
 /// let t = TypedTensor::<f64>::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
@@ -158,6 +158,26 @@ pub struct TypedTensor<T> {
     pub buffer: Buffer<T>,
     pub shape: Vec<usize>,
     pub placement: Placement,
+    pub order: MemoryOrder,
+}
+
+/// Physical memory order for contiguous tensor storage.
+///
+/// The tensor shape is always logical. This tag records how logical indices
+/// are laid out in the owned contiguous buffer.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::MemoryOrder;
+///
+/// assert_eq!(MemoryOrder::ColMajor, MemoryOrder::ColMajor);
+/// assert_ne!(MemoryOrder::ColMajor, MemoryOrder::RowMajor);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MemoryOrder {
+    ColMajor,
+    RowMajor,
 }
 
 /// Runtime scalar dtype tag.
@@ -207,8 +227,14 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// ```
     fn dtype() -> DType;
 
-    /// Wrap typed data into a [`Tensor`] enum variant.
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor;
+    /// Wrap typed column-major data into a [`Tensor`] enum variant.
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Self::into_tensor_with_order(shape, data, MemoryOrder::ColMajor)
+    }
+
+    /// Wrap typed data with an explicit memory order into a [`Tensor`] enum
+    /// variant.
+    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor;
 
     /// Try to borrow the host data from a [`Tensor`].
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]>;
@@ -247,8 +273,8 @@ impl TensorScalar for f64 {
         DType::F64
     }
 
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::F64(TypedTensor::from_vec(shape, data))
+    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor {
+        Tensor::F64(TypedTensor::from_vec_with_order(shape, data, order))
     }
 
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -273,8 +299,8 @@ impl TensorScalar for f32 {
         DType::F32
     }
 
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::F32(TypedTensor::from_vec(shape, data))
+    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor {
+        Tensor::F32(TypedTensor::from_vec_with_order(shape, data, order))
     }
 
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -299,8 +325,8 @@ impl TensorScalar for i64 {
         DType::I64
     }
 
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::I64(TypedTensor::from_vec(shape, data))
+    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor {
+        Tensor::I64(TypedTensor::from_vec_with_order(shape, data, order))
     }
 
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -325,8 +351,8 @@ impl TensorScalar for Complex64 {
         DType::C64
     }
 
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::C64(TypedTensor::from_vec(shape, data))
+    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor {
+        Tensor::C64(TypedTensor::from_vec_with_order(shape, data, order))
     }
 
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -351,8 +377,8 @@ impl TensorScalar for Complex32 {
         DType::C32
     }
 
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::C32(TypedTensor::from_vec(shape, data))
+    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor {
+        Tensor::C32(TypedTensor::from_vec_with_order(shape, data, order))
     }
 
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -529,6 +555,7 @@ impl<T: Clone + Zero> TypedTensor<T> {
             buffer: Buffer::Host(vec![T::zero(); n]),
             shape,
             placement: default_placement(),
+            order: MemoryOrder::ColMajor,
         }
     }
 }
@@ -550,6 +577,7 @@ impl<T: Clone + One + Zero> TypedTensor<T> {
             buffer: Buffer::Host(vec![T::one(); n]),
             shape,
             placement: default_placement(),
+            order: MemoryOrder::ColMajor,
         }
     }
 }
@@ -566,6 +594,52 @@ impl<T: Clone> TypedTensor<T> {
     /// assert_eq!(t.get(&[1, 0]), &2.0);
     /// ```
     pub fn from_vec(shape: Vec<usize>, data: Vec<T>) -> Self {
+        Self::from_vec_col_major(shape, data)
+    }
+
+    /// Create a tensor from a contiguous column-major buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
+    /// assert_eq!(t.order(), MemoryOrder::ColMajor);
+    /// ```
+    pub fn from_vec_col_major(shape: Vec<usize>, data: Vec<T>) -> Self {
+        Self::from_vec_with_order(shape, data, MemoryOrder::ColMajor)
+    }
+
+    /// Create a tensor from a contiguous row-major buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2], vec![1.0, 2.0]);
+    /// assert_eq!(t.order(), MemoryOrder::RowMajor);
+    /// ```
+    pub fn from_vec_row_major(shape: Vec<usize>, data: Vec<T>) -> Self {
+        Self::from_vec_with_order(shape, data, MemoryOrder::RowMajor)
+    }
+
+    /// Create a tensor from a contiguous buffer with an explicit memory order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_with_order(
+    ///     vec![2],
+    ///     vec![1.0, 2.0],
+    ///     MemoryOrder::RowMajor,
+    /// );
+    /// assert_eq!(t.order(), MemoryOrder::RowMajor);
+    /// ```
+    pub fn from_vec_with_order(shape: Vec<usize>, data: Vec<T>, order: MemoryOrder) -> Self {
         let n: usize = shape.iter().product();
         assert_eq!(
             data.len(),
@@ -578,7 +652,90 @@ impl<T: Clone> TypedTensor<T> {
             buffer: Buffer::Host(data),
             shape,
             placement: default_placement(),
+            order,
         }
+    }
+
+    /// Return the physical memory order of this contiguous tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
+    ///
+    /// let t = TypedTensor::<f64>::from_vec(vec![1], vec![1.0]);
+    /// assert_eq!(t.order(), MemoryOrder::ColMajor);
+    /// ```
+    pub fn order(&self) -> MemoryOrder {
+        self.order
+    }
+
+    /// Consume this tensor and return its owned buffer if the memory order
+    /// matches `order`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2], vec![1.0, 2.0]);
+    /// let (shape, data) = t.try_into_vec_with_order(MemoryOrder::RowMajor).unwrap();
+    /// assert_eq!(shape, vec![2]);
+    /// assert_eq!(data, vec![1.0, 2.0]);
+    /// ```
+    pub fn try_into_vec_with_order(
+        self,
+        order: MemoryOrder,
+    ) -> crate::Result<(Vec<usize>, Vec<T>)> {
+        if self.order != order {
+            return Err(crate::Error::InvalidConfig {
+                op: "try_into_vec_with_order",
+                message: format!(
+                    "memory order mismatch: tensor is {:?}, requested {:?}",
+                    self.order, order
+                ),
+            });
+        }
+        match self.buffer {
+            Buffer::Host(data) => Ok((self.shape, data)),
+            Buffer::Backend(_) => Err(crate::Error::BackendFailure {
+                op: "try_into_vec_with_order",
+                message: "backend buffers cannot be exported as host Vec".into(),
+            }),
+            #[cfg(feature = "cubecl")]
+            Buffer::Cubecl(_) => Err(crate::Error::BackendFailure {
+                op: "try_into_vec_with_order",
+                message: "GPU buffers cannot be exported as host Vec".into(),
+            }),
+        }
+    }
+
+    /// Consume this tensor and return its owned column-major buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![3.0]);
+    /// assert_eq!(t.try_into_vec_col_major().unwrap().1, vec![3.0]);
+    /// ```
+    pub fn try_into_vec_col_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
+        self.try_into_vec_with_order(MemoryOrder::ColMajor)
+    }
+
+    /// Consume this tensor and return its owned row-major buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![1], vec![3.0]);
+    /// assert_eq!(t.try_into_vec_row_major().unwrap().1, vec![3.0]);
+    /// ```
+    pub fn try_into_vec_row_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
+        self.try_into_vec_with_order(MemoryOrder::RowMajor)
     }
 
     /// Number of elements in the tensor.
@@ -762,6 +919,52 @@ impl Tensor {
         T::into_tensor(shape, data)
     }
 
+    /// Create a tensor from a contiguous column-major buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    /// assert_eq!(t.order(), MemoryOrder::ColMajor);
+    /// ```
+    pub fn from_vec_col_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Self {
+        T::into_tensor_with_order(shape, data, MemoryOrder::ColMajor)
+    }
+
+    /// Create a tensor from a contiguous row-major buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::from_vec_row_major(vec![2], vec![1.0_f64, 2.0]);
+    /// assert_eq!(t.order(), MemoryOrder::RowMajor);
+    /// ```
+    pub fn from_vec_row_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Self {
+        T::into_tensor_with_order(shape, data, MemoryOrder::RowMajor)
+    }
+
+    /// Create a tensor from a contiguous buffer with an explicit memory order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::from_vec_with_order(vec![1], vec![4.0_f64], MemoryOrder::RowMajor);
+    /// assert_eq!(t.order(), MemoryOrder::RowMajor);
+    /// ```
+    pub fn from_vec_with_order<T: TensorScalar>(
+        shape: Vec<usize>,
+        data: Vec<T>,
+        order: MemoryOrder,
+    ) -> Self {
+        T::into_tensor_with_order(shape, data, order)
+    }
+
     /// Tensor shape.
     ///
     /// # Examples
@@ -802,6 +1005,26 @@ impl Tensor {
         }
     }
 
+    /// Physical memory order of the underlying contiguous buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::from_vec(vec![1], vec![1.0_f64]);
+    /// assert_eq!(t.order(), MemoryOrder::ColMajor);
+    /// ```
+    pub fn order(&self) -> MemoryOrder {
+        match self {
+            Tensor::F32(t) => t.order(),
+            Tensor::F64(t) => t.order(),
+            Tensor::I64(t) => t.order(),
+            Tensor::C32(t) => t.order(),
+            Tensor::C64(t) => t.order(),
+        }
+    }
+
     /// Try to borrow the host data as a typed slice.
     ///
     /// Returns `None` if the tensor dtype does not match `T`.
@@ -817,6 +1040,67 @@ impl Tensor {
     /// ```
     pub fn as_slice<T: TensorScalar>(&self) -> Option<&[T]> {
         T::try_as_slice(self)
+    }
+
+    /// Consume this tensor and return its owned column-major buffer when the
+    /// dtype and memory order match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]);
+    /// assert_eq!(t.try_into_vec_col_major::<f64>().unwrap().1, vec![2.0]);
+    /// ```
+    pub fn try_into_vec_col_major<T: TensorScalar>(
+        self,
+    ) -> crate::Result<(Vec<usize>, Vec<T>)> {
+        self.try_into_vec_with_order::<T>(MemoryOrder::ColMajor)
+    }
+
+    /// Consume this tensor and return its owned row-major buffer when the
+    /// dtype and memory order match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec_row_major(vec![1], vec![2.0_f64]);
+    /// assert_eq!(t.try_into_vec_row_major::<f64>().unwrap().1, vec![2.0]);
+    /// ```
+    pub fn try_into_vec_row_major<T: TensorScalar>(
+        self,
+    ) -> crate::Result<(Vec<usize>, Vec<T>)> {
+        self.try_into_vec_with_order::<T>(MemoryOrder::RowMajor)
+    }
+
+    /// Consume this tensor and return its owned buffer when dtype and memory
+    /// order match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{MemoryOrder, Tensor};
+    ///
+    /// let t = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]);
+    /// assert_eq!(
+    ///     t.try_into_vec_with_order::<f64>(MemoryOrder::ColMajor).unwrap().1,
+    ///     vec![2.0],
+    /// );
+    /// ```
+    pub fn try_into_vec_with_order<T: TensorScalar>(
+        self,
+        order: MemoryOrder,
+    ) -> crate::Result<(Vec<usize>, Vec<T>)> {
+        let actual = self.dtype();
+        let typed = T::try_into_typed(self).ok_or(crate::Error::DTypeMismatch {
+            op: "try_into_vec_with_order",
+            lhs: T::dtype(),
+            rhs: actual,
+        })?;
+        typed.try_into_vec_with_order(order)
     }
 
     /// Singular value decomposition: `A = U diag(S) Vt`.

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -1199,9 +1199,7 @@ impl Tensor {
     /// let t = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]);
     /// assert_eq!(t.try_into_vec_col_major::<f64>().unwrap().1, vec![2.0]);
     /// ```
-    pub fn try_into_vec_col_major<T: TensorScalar>(
-        self,
-    ) -> crate::Result<(Vec<usize>, Vec<T>)> {
+    pub fn try_into_vec_col_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
         self.try_into_vec_with_order::<T>(MemoryOrder::ColMajor)
     }
 
@@ -1216,9 +1214,7 @@ impl Tensor {
     /// let t = Tensor::from_vec_row_major(vec![1], vec![2.0_f64]);
     /// assert_eq!(t.try_into_vec_row_major::<f64>().unwrap().1, vec![2.0]);
     /// ```
-    pub fn try_into_vec_row_major<T: TensorScalar>(
-        self,
-    ) -> crate::Result<(Vec<usize>, Vec<T>)> {
+    pub fn try_into_vec_row_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
         self.try_into_vec_with_order::<T>(MemoryOrder::RowMajor)
     }
 

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -49,7 +49,7 @@ pub use linalg_api::{
 };
 pub use sym_dim::SymDim;
 pub use tenferro_tensor::cpu::CpuBackend;
-pub use tenferro_tensor::{DType, Tensor, TensorBackend, TensorScalar, TypedTensor};
+pub use tenferro_tensor::{DType, MemoryOrder, Tensor, TensorBackend, TensorScalar, TypedTensor};
 pub use traced::TracedTensor;
 
 /// Matrix multiplication helper for rank-2 traced tensors.

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -91,6 +91,25 @@ fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
 }
 
 #[test]
+fn row_major_eager_input_uses_logical_shape_and_values() {
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_row_major(
+            vec![2, 3],
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        ),
+        test_ctx(),
+    );
+    let y = &x + &x;
+    let row_major = y.data().to_row_major().expect("row-major conversion");
+
+    assert_eq!(y.data().shape(), &[2, 3]);
+    assert_eq!(
+        f64_data(&row_major),
+        &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]
+    );
+}
+
+#[test]
 fn eager_x_squared_gradient_matches_finite_difference() {
     let x_data = vec![1.0, 2.0, 3.0];
     let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], x_data.clone()), test_ctx());

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -93,20 +93,14 @@ fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
 #[test]
 fn row_major_eager_input_uses_logical_shape_and_values() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_row_major(
-            vec![2, 3],
-            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-        ),
+        Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
         test_ctx(),
     );
     let y = &x + &x;
     let row_major = y.data().to_row_major().expect("row-major conversion");
 
     assert_eq!(y.data().shape(), &[2, 3]);
-    assert_eq!(
-        f64_data(&row_major),
-        &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]
-    );
+    assert_eq!(f64_data(&row_major), &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]);
 }
 
 #[test]

--- a/tenferro/tests/symbolic_input.rs
+++ b/tenferro/tests/symbolic_input.rs
@@ -51,6 +51,28 @@ fn addition_of_two_symbolic_inputs() {
 }
 
 #[test]
+fn row_major_symbolic_input_uses_logical_shape_and_values() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let mut y = &x + &x;
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let bound = Tensor::from_vec_row_major(
+        vec![2, 3],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    );
+    let out = y
+        .eval_with_inputs(&mut engine, &[(&x, &bound)])
+        .expect("eval_with_inputs");
+    let row_major = out.to_row_major().expect("row-major conversion");
+
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(
+        f64_data(&row_major),
+        &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]
+    );
+}
+
+#[test]
 fn same_symbolic_graph_reused_with_different_shapes() {
     // Build the graph once.
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);

--- a/tenferro/tests/symbolic_input.rs
+++ b/tenferro/tests/symbolic_input.rs
@@ -56,20 +56,14 @@ fn row_major_symbolic_input_uses_logical_shape_and_values() {
     let mut y = &x + &x;
 
     let mut engine = Engine::new(CpuBackend::new());
-    let bound = Tensor::from_vec_row_major(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    );
+    let bound = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
     let out = y
         .eval_with_inputs(&mut engine, &[(&x, &bound)])
         .expect("eval_with_inputs");
     let row_major = out.to_row_major().expect("row-major conversion");
 
     assert_eq!(out.shape(), &[2, 3]);
-    assert_eq!(
-        f64_data(&row_major),
-        &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]
-    );
+    assert_eq!(f64_data(&row_major), &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add owned contiguous `MemoryOrder` metadata plus row/column-major Vec import/export and conversion helpers
- make CPU tensor views, GEMM, indexing, linalg boundary paths, eager inputs, and symbolic graph inputs respect row-major owned tensors
- keep GPU device tensors column-major by canonicalizing row-major host uploads and rejecting row-major GPU bindings
- remove the unused workspace `ndarray` dependency and document the no-core-ndarray interop design

## Tests
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo test -p tenferro-tensor --features cubecl metadata_tests`