### PR TITLE
[codex] correct CUDA API guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,12 @@ The workspace contains active implementations alongside evolving APIs. Implement
 
 ### GPU Status
 
-GPU support is still partial and experimental. CUDA-only allocation,
-CPU<->GPU transfer, and limited cuTENSOR-backed primitive execution now exist,
-but broader GPU coverage is incomplete and HIP remains stubbed. Outside
-explicit GPU implementation tasks, do not assume a GPU path works just because
-the symbol is present.
+CUDA GPU support is implemented through the feature-gated CubeCL backend across
+the concrete tensor, eager, and traced execution surfaces. Performance
+optimization and exhaustive dtype/op parity are still active work, and
+HIP/ROCm remains stubbed. Outside explicit GPU implementation tasks, check the
+current CUDA/CubeCL backend and tests before assuming a specific
+op/dtype/backend combination is supported.
 
 ### Documentation Requirements
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ General-purpose dense tensor computation in Rust, inspired by PyTorch and JAX.
 
 tenferro's complete default path is CPU: eager tensor operations with
 scalar-loss reverse-mode autodiff, lazy traced execution, einsum, linear
-algebra, and transform AD (VJP/JVP/HVP). The experimental CUDA backend supports
-a partial subset of tensor operations with explicit CPU/GPU transfers.
+algebra, and transform AD (VJP/JVP/HVP). CUDA execution is available through
+the feature-gated CubeCL backend with explicit CPU/GPU transfers.
 
 AD shape and dtype metadata is owned by the live eager/traced tensor handles
 that need it. The backing lookup table is process-global, but entries are

--- a/ai/agent-assets.lock
+++ b/ai/agent-assets.lock
@@ -2,7 +2,7 @@
   "assets": {
     "build-docs-site-script": {
       "path": "scripts/build_docs_site.sh",
-      "sha256": "f2240cf0ecedc6bdf3bb94d9e21ae323145a2c1856053e0bbe8453ab118a219d"
+      "sha256": "8265a659f3665af1d3f09275eaab51e1b1d2fac0e485d65d3882fca3905d2ac1"
     },
     "check-agent-assets-command": {
       "path": ".claude/commands/check-agent-assets.md",
@@ -14,7 +14,7 @@
     },
     "check-docs-site-script": {
       "path": "scripts/check-docs-site.py",
-      "sha256": "6d5a7b057cd11f78d6a80482b70f91cd730049c50462b86d0291de12ddbdcc18"
+      "sha256": "4ac6a6ee0e008ab6ee349f483f49913f8ecea8fe5f5a4c7a8de235d04233d645"
     },
     "check-repo-settings-script": {
       "path": "scripts/check-repo-settings.sh",

--- a/docs/architecture/tenferro-crates.md
+++ b/docs/architecture/tenferro-crates.md
@@ -252,7 +252,7 @@ depending on the dispatch category.
 that encapsulates standard tensor kernel dispatch. `TensorExec` is the
 session-scoped companion trait used for batches of backend ops inside one
 execution context. `CpuBackend` lives in tenferro-tensor and implements
-`TensorBackend`; the CubeCL GPU backend is partial and feature-gated.
+`TensorBackend`; the CubeCL GPU backend is feature-gated.
 
 Canonical trait signatures: [`spec/backend-contract.md`](../spec/backend-contract.md).
 

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -7,10 +7,12 @@ surface is the CubeCL backend in `tenferro-tensor/src/cubecl/`, gated by the
 internal `cubecl` feature. It targets NVIDIA CUDA devices through CubeCL and
 CubeCL-CUDA, with CUDA library support for cuTENSOR, cuSOLVER, and cuBLAS.
 
-GPU support is partial and experimental. CUDA allocation, explicit CPU/GPU
-transfer, many structural/elementwise/reduction kernels, selected cuTENSOR
-contractions, and selected cuSOLVER/cuBLAS linear algebra paths exist. HIP/ROCm
-is still a feature stub and is not a supported execution path.
+CUDA GPU support is implemented through the feature-gated CubeCL backend across
+the concrete tensor, eager, and traced execution surfaces. Coverage includes
+allocation, explicit CPU/GPU transfer, broad structural/elementwise/reduction
+kernels, cuTENSOR contractions, and cuSOLVER/cuBLAS linear algebra paths.
+Performance optimization and exhaustive dtype/op parity are still active work,
+and HIP/ROCm is still a feature stub rather than a supported execution path.
 
 See also:
 
@@ -200,17 +202,17 @@ Error behavior:
 
 ## Implemented Coverage
 
-The public CUDA backend implements enough of `TensorBackend` to run a growing
-subset of compiled tensor programs on CUDA. Internally, that coverage is
-provided by CubeCL kernels and CUDA library calls:
+The public CUDA backend implements `TensorBackend` for the main dense CUDA
+execution surface. Internally, that coverage is provided by CubeCL kernels and
+CUDA library calls:
 
 | Category | Current status |
 | --- | --- |
 | Allocation/transfer | CUDA allocation, upload, download, raw pointer bridge |
-| Elementwise | many float ops; selected complex ops; unsupported complex analytic ops return `BackendFailure` |
+| Elementwise | broad real coverage; selected complex ops; unsupported complex analytic ops return `BackendFailure` |
 | Reductions | sum/prod for real and complex; min/max for real |
 | Structural | transpose, reshape, broadcast, reverse, concatenate, diagonal extraction/embedding, triangular masks |
-| Indexing | selected gather/scatter/slice/pad/reverse paths through CubeCL kernels |
+| Indexing | gather/scatter/slice/pad/reverse paths through CubeCL kernels where dtype support exists |
 | Contraction | cuTENSOR/cuBLAS-backed paths for supported real dtypes |
 | Linalg | cuSOLVER/cuBLAS-backed SVD, QR, Cholesky, LU, Eigh, and triangular solve where supported |
 
@@ -228,8 +230,8 @@ The following are intentionally outside the current batch:
 - GPU benchmark work,
 - HIP/ROCm implementation,
 - replacing the CubeCL fork,
-- broad complex kernel expansion before upstream CubeCL support lands,
-- making every CPU tensor op have a GPU implementation,
+- remaining complex kernel expansion before upstream CubeCL support lands,
+- closing remaining CPU/GPU op and dtype parity gaps,
 - changing the public placement contract.
 
 ## Tests

--- a/docs/design/supported-ops.md
+++ b/docs/design/supported-ops.md
@@ -56,14 +56,14 @@ the `cuda` feature. Internally, the `cubecl` feature enables
 cuTENSOR, cuSOLVER, and cuBLAS. Static kernels live in the internal
 `tenferro-cubecl` crate.
 
-Implemented GPU coverage is partial:
+Implemented GPU coverage is broad, with remaining op/dtype gaps:
 
 - explicit upload/download and device pointer bridge,
-- many elementwise operations on real dtypes and selected complex operations,
+- broad elementwise coverage on real dtypes and selected complex operations,
 - reductions including sum/product for real and complex and min/max for real,
 - structural operations including transpose, reshape, broadcast, reverse,
   concatenate, diagonal extraction/embedding, and triangular masks,
-- selected indexing operations,
+- indexing operations where dtype support exists,
 - selected cuTENSOR/cuBLAS contraction paths,
 - selected cuSOLVER/cuBLAS linalg paths.
 
@@ -119,10 +119,10 @@ Implemented public surfaces include:
   paths.
 - Compiled execution through `ExecProgram` / `eval_exec_ir`.
 
-The facade is CPU-first. It can evaluate through the CUDA backend when the
-program uses GPU-supported operations and tensors are placed explicitly by the
-execution pipeline or caller. Unsupported GPU ops return errors rather than
-silently falling back to CPU.
+The facade can evaluate through `CpuBackend` or the CUDA backend when the
+program uses operations supported by that backend and tensors are placed
+explicitly by the execution pipeline or caller. Unsupported GPU ops return
+errors rather than silently falling back to CPU.
 
 ## `tenferro-device`
 

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -14,9 +14,9 @@ tenferro provides four tensor types for different use cases:
 Choose the simplest layer that meets your needs:
 
 - **Compile-time dtype safety** -> `TypedTensor<T>` + a backend such as `CpuBackend`
-- **No AD needed** -> `Tensor` + `CpuBackend`
-- **PyTorch-style scalar-loss backward** -> `EagerTensor` + `EagerContext`
-- **Transform AD or graph reuse** -> `TracedTensor` + `Engine`
+- **No AD needed** -> `Tensor` + a backend
+- **PyTorch-style scalar-loss backward** -> `EagerTensor<B>` + `EagerContext<B>`
+- **Transform AD or graph reuse** -> `TracedTensor` + `Engine<B>`
 
 ## TypedTensor<T>: statically typed storage
 
@@ -99,9 +99,9 @@ Input data -> TracedTensor -> operations -> .eval(&mut engine) -> Tensor result
 
 | Library | Mental model | tenferro equivalent |
 |---|---|---|
-| NumPy | Eager, no AD | `Tensor` + `CpuBackend` |
-| PyTorch (eager) | Eager with autograd | `EagerTensor` + `EagerContext` |
-| JAX (`jit`) | Staged/lazy computation | `TracedTensor` + `Engine` |
+| NumPy | Eager, no AD | `Tensor` + a backend |
+| PyTorch (eager) | Eager with autograd | `EagerTensor<B>` + `EagerContext<B>` |
+| JAX (`jit`) | Staged/lazy computation | `TracedTensor` + `Engine<B>` |
 
 ## Minimal examples
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,8 +1,8 @@
 # Getting Started
 
 tenferro supports direct CPU tensor computation, eager scalar-loss AD, traced
-execution, transform AD, einsum, linear algebra, and experimental CUDA
-execution for selected operations.
+execution, transform AD, einsum, linear algebra, and CUDA execution through the
+feature-gated CubeCL backend.
 
 ## Installation
 

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -6,13 +6,13 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 
 | Concept | PyTorch | JAX | tenferro |
 |---|---|---|---|
-| Eager tensor | `numpy.ndarray` | — | `Tensor` + `CpuBackend` |
+| Eager tensor | `numpy.ndarray` | — | `Tensor` + a backend |
 | Tensor handle | `torch.Tensor` | `jax.Array` / `jnp.ndarray` | `TracedTensor` |
 | Concrete result | `torch.Tensor` | `jax.Array` | `Tensor` returned by `.eval(&mut engine)` |
 | Execution | Eager by default | Eager arrays, often staged with `jit` | Eager (`Tensor` / `EagerTensor`) or lazy traced (`TracedTensor` + `.eval()`) |
 | Eager gradients | `loss.backward()` | — | `EagerTensor::backward()` with accumulation |
 | Transform AD | `torch.autograd.grad(...)` | `jax.grad`, `jax.vjp`, `jax.jvp`, `hvp` via composition | `loss.grad(&x)`, `.vjp()`, `.jvp()` |
-| Device/runtime | Device is attached to tensors | Device is attached to arrays | Backend lives inside `Engine` |
+| Device/runtime | Device is attached to tensors | Device is attached to arrays | Backend lives in direct tensor calls, `EagerContext`, or `Engine` |
 | CUDA execution | `x.to("cuda")` | `jax.device_put(x)` | `tenferro::cuda::upload_tensor(...)` and `download_tensor(...)` |
 | Matrix contraction | `torch.einsum` | `jnp.einsum` | `tenferro::einsum::einsum` |
 
@@ -59,9 +59,9 @@ between devices implicitly. Upload CPU tensors with
 `tenferro::cuda::upload_tensor` before CUDA backend operations, and download
 with `tenferro::cuda::download_tensor` before inspecting values on the host.
 
-CUDA support is partial and experimental, and currently targets NVIDIA CUDA.
-See [Devices and GPU](../guides/devices-and-gpu.md) for the current coverage
-and setup commands.
+CUDA support targets NVIDIA CUDA through the CubeCL backend. See
+[Devices and GPU](../guides/devices-and-gpu.md) for the current coverage and
+setup commands.
 
 ### Lazy evaluation
 

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -4,17 +4,24 @@ Use the simplest tensor layer that matches the workflow.
 
 | Need | Use |
 | --- | --- |
-| Direct concrete computation | `Tensor` + `CpuBackend` |
+| Direct concrete computation on a selected backend | `Tensor` + a `TensorBackend` |
 | Compile-time scalar type while still owning dense data | `TypedTensor<T>` |
-| PyTorch-style scalar-loss `backward()` | `EagerTensor` + `EagerContext` |
-| `grad`, `vjp`, `jvp`, HVP, graph optimization | `TracedTensor` + `Engine` |
+| PyTorch-style scalar-loss `backward()` | `EagerTensor<B>` + `EagerContext<B>` |
+| `grad`, `vjp`, `jvp`, HVP, graph optimization | `TracedTensor` + `Engine<B>` |
 
 ## Rule of Thumb
 
-Start with `Tensor` for concrete CPU work. Move to `EagerTensor` when you need
+Start with `Tensor` for direct concrete work. Move to `EagerTensor` when you need
 gradient accumulation, and move to `TracedTensor` when you need transform AD or
 graph reuse.
 
-`Tensor` and `TypedTensor<T>` are concrete data containers. `EagerTensor` keeps
-PyTorch-style gradient state for immediate workflows. `TracedTensor` builds a
-lazy expression graph that an `Engine` can evaluate and reuse.
+`Tensor` and `TypedTensor<T>` are concrete data containers. They represent CPU
+data by default, and under the `cuda` feature they can also represent
+explicitly uploaded CUDA-resident data. `EagerTensor<B>` keeps PyTorch-style
+gradient state for immediate workflows on a backend `B`. `TracedTensor` builds
+a lazy expression graph that an `Engine<B>` can evaluate and reuse.
+
+CUDA support is provided by the feature-gated CubeCL backend for concrete,
+eager, and traced workflows. GPU tensors use explicit upload/download at
+backend boundaries; tenferro does not silently fall back to CPU when a GPU
+operation or dtype is unavailable.

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -4,8 +4,8 @@ tenferro follows the PyTorch convention: no implicit CPU/GPU transfer. Upload
 CPU tensors before CUDA backend operations and download results before host
 inspection.
 
-CUDA support is partial and experimental. It currently targets NVIDIA CUDA.
-AMD/ROCm is not a supported execution path yet.
+CUDA support targets NVIDIA CUDA through the CubeCL backend. AMD/ROCm is not a
+supported execution path yet.
 
 ## CUDA Quickstart
 
@@ -55,8 +55,8 @@ The example downloads the result back to CPU and asserts the expected values.
 | Area | Status |
 | --- | --- |
 | Allocation and transfer | CUDA supported |
-| Elementwise and reductions | partial |
-| Structural/indexing | partial |
+| Elementwise and reductions | broad real coverage, selected complex coverage |
+| Structural/indexing | broad coverage where dtype support exists |
 | Contractions | selected cuTENSOR/cuBLAS-backed paths |
 | Linalg | selected cuSOLVER/cuBLAS-backed paths |
 | General `eig` | not supported by cuSOLVER; download to CPU |

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -14,7 +14,9 @@ let mut ctx = CpuBackend::new();
 ```
 
 Every eager operation requires a backend context. `CpuBackend` is the standard
-CPU backend using the faer linear algebra library.
+CPU backend using the faer linear algebra library. With the `cuda` feature, the
+same concrete and eager APIs can execute supported operations on the CubeCL/CUDA
+backend when tensors are explicitly placed on the GPU.
 
 `EagerContext` is the gradient-owning wrapper for eager AD state. If you share
 one context across multiple tracked tensors, their gradients accumulate into
@@ -197,9 +199,9 @@ assert!(y.grad().is_none());
 
 | Scenario | Recommended |
 |----------|-------------|
-| Data preprocessing | Eager (`Tensor` + `CpuBackend`) |
+| Data preprocessing | Eager (`Tensor` + a backend) |
 | TCI inner loops | Eager |
 | Exploratory computation | Eager |
 | Need scalar-loss reverse-mode gradients | Eager (`EagerTensor::backward()`) |
-| Need transform AD (`grad` / `vjp` / `jvp` / HVP) | Lazy traced (`TracedTensor` + `Engine`) |
-| CUDA execution for supported operations | Lazy traced or direct backend calls with explicit upload/download |
+| Need transform AD (`grad` / `vjp` / `jvp` / HVP) | Lazy traced (`TracedTensor` + `Engine<B>`) |
+| CUDA execution for supported operations | Eager (`Tensor` / `EagerTensor<B>`) or lazy traced (`TracedTensor` + `Engine<B>`) with explicit upload/download |

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -46,8 +46,8 @@ CUDA support is enabled with the `cuda` feature alias:
 tenferro = { path = "/path/to/tenferro-rs/tenferro", features = ["cuda"] }
 ```
 
-CUDA support is partial and experimental. It currently targets NVIDIA CUDA.
-See [Devices and GPU](devices-and-gpu.md) for the transfer model and current
+CUDA support targets NVIDIA CUDA through the CubeCL backend. See
+[Devices and GPU](devices-and-gpu.md) for the transfer model and current
 coverage.
 
 Common CUDA runtime environment variables:

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,12 @@ backend control.
 
 It supports:
 
-- eager CPU tensor operations with `Tensor`, `TypedTensor`, and `CpuBackend`,
+- eager tensor operations with `Tensor`, `TypedTensor`, and a backend,
 - eager scalar-loss reverse-mode AD with `EagerTensor`,
 - lazy traced execution with `TracedTensor` and `Engine`,
 - transform AD with `grad`, `vjp`, `jvp`, and HVP composition,
 - einsum and linear algebra,
-- experimental CUDA execution for selected operations.
+- CUDA execution through the feature-gated CubeCL backend.
 
 ## Start Here
 

--- a/tenferro/README.md
+++ b/tenferro/README.md
@@ -68,6 +68,6 @@ fn main() {
 
 - `Tensor` is the concrete dense runtime value at graph boundaries.
 - `TracedTensor` is the graph-aware lazy wrapper.
-- GPU support is partial and experimental.
+- CUDA GPU support is available through the feature-gated CubeCL backend.
 - The crate no longer exposes the older runtime-installation and dynamic-carrier
   API family.


### PR DESCRIPTION
## Summary

- Correct docs that still described CUDA GPU support as partial or CPU-only for the concrete/eager/traced API surfaces.
- Clarify that CUDA support is available through the feature-gated CubeCL backend, while performance tuning and remaining op/dtype parity work continue.
- Refresh the agent GPU-status guidance and managed asset lock hashes for the current checked-in scripts.

## Verification

- `cargo fmt --all --check`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/check-doc-snippets.py`
- `bash scripts/check-agent-assets.sh --quiet`
- `git diff --check`

## Documentation

- Reviewed `README.md`, `docs/design/**`, `docs/api_index.md`, and public rustdoc for consistency.

Generated with [OpenAI Codex](https://openai.com/codex)