### PR TITLE
[codex] add precise CUDA support matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,12 @@ The workspace contains active implementations alongside evolving APIs. Implement
 
 CUDA GPU support is implemented through the feature-gated CubeCL backend across
 the concrete tensor, eager, and traced execution surfaces. Performance
-optimization and exhaustive dtype/op parity are still active work, and
-HIP/ROCm remains stubbed. Outside explicit GPU implementation tasks, check the
-current CUDA/CubeCL backend and tests before assuming a specific
-op/dtype/backend combination is supported.
+optimization is still active work. The remaining CUDA limitations are specific:
+`eig`, `full_piv_lu`, `full_piv_lu_solve`, `dynamic_update_slice`, `I64`
+numeric/linalg gaps, and selected complex analytic or ordering operations.
+HIP/ROCm remains stubbed. Outside explicit GPU implementation tasks, check
+`docs/guides/devices-and-gpu.md` and the current CUDA/CubeCL backend tests
+before assuming a specific op/dtype/backend combination is supported.
 
 ### Documentation Requirements
 

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -11,8 +11,11 @@ CUDA GPU support is implemented through the feature-gated CubeCL backend across
 the concrete tensor, eager, and traced execution surfaces. Coverage includes
 allocation, explicit CPU/GPU transfer, broad structural/elementwise/reduction
 kernels, cuTENSOR contractions, and cuSOLVER/cuBLAS linear algebra paths.
-Performance optimization and exhaustive dtype/op parity are still active work,
-and HIP/ROCm is still a feature stub rather than a supported execution path.
+Performance optimization is still active work. The remaining unsupported CUDA
+cases are operation-specific: `eig`, `full_piv_lu`, `full_piv_lu_solve`,
+`dynamic_update_slice`, `I64` numeric/linalg gaps, and selected complex
+analytic or ordering operations. HIP/ROCm is still a feature stub rather than
+a supported execution path.
 
 See also:
 
@@ -209,19 +212,21 @@ CUDA library calls:
 | Category | Current status |
 | --- | --- |
 | Allocation/transfer | CUDA allocation, upload, download, raw pointer bridge |
-| Elementwise | broad real coverage; selected complex ops; unsupported complex analytic ops return `BackendFailure` |
-| Reductions | sum/prod for real and complex; min/max for real |
-| Structural | transpose, reshape, broadcast, reverse, concatenate, diagonal extraction/embedding, triangular masks |
-| Indexing | gather/scatter/slice/pad/reverse paths through CubeCL kernels where dtype support exists |
-| Contraction | cuTENSOR/cuBLAS-backed paths for supported real dtypes |
-| Linalg | cuSOLVER/cuBLAS-backed SVD, QR, Cholesky, LU, Eigh, and triangular solve where supported |
+| Elementwise | `F32`/`F64` arithmetic, comparison, selection, clamp, and analytic unary ops; `C32`/`C64` add/mul/div/neg/conj |
+| Reductions | sum/prod for all tensor dtypes; min/max for `F32`/`F64` |
+| Structural | transpose, reshape, broadcast, reverse, concatenate, diagonal extraction/embedding, triangular masks for all tensor dtypes |
+| Indexing | slice/pad/concatenate/reverse for all tensor dtypes; gather/scatter/dynamic_slice for floating and complex data with numeric index tensors |
+| Contraction | cuTENSOR-backed paths for supported real and complex floating dtypes |
+| Linalg | cuSOLVER/cuBLAS-backed SVD, QR, Cholesky, LU, Eigh, LU solve, and triangular solve for supported real and complex floating dtypes |
+
+The published [`Devices and GPU`](../guides/devices-and-gpu.md) guide contains
+the current CUDA operation and dtype matrix. Keep that matrix synchronized with
+the `CubeclBackend` `TensorBackend` implementation when adding or removing CUDA
+dispatch arms.
 
 General eigendecomposition (`eig`, LAPACK `dgeev` style) is not provided by
 cuSOLVER. The CUDA backend returns `BackendFailure`; users must explicitly
 download to CPU and call the CPU backend.
-
-Complex CubeCL support is intentionally not expanded in this batch because the
-required CubeCL support is being handled upstream.
 
 ## Unsupported And Deferred Work
 
@@ -230,8 +235,10 @@ The following are intentionally outside the current batch:
 - GPU benchmark work,
 - HIP/ROCm implementation,
 - replacing the CubeCL fork,
-- remaining complex kernel expansion before upstream CubeCL support lands,
-- closing remaining CPU/GPU op and dtype parity gaps,
+- selected complex analytic kernels and ordering operations,
+- CUDA implementations for `full_piv_lu`, `full_piv_lu_solve`, and
+  `dynamic_update_slice`,
+- `I64` numeric/linalg CUDA kernels beyond structural and reduction paths,
 - changing the public placement contract.
 
 ## Tests

--- a/docs/design/supported-ops.md
+++ b/docs/design/supported-ops.md
@@ -56,18 +56,28 @@ the `cuda` feature. Internally, the `cubecl` feature enables
 cuTENSOR, cuSOLVER, and cuBLAS. Static kernels live in the internal
 `tenferro-cubecl` crate.
 
-Implemented GPU coverage is broad, with remaining op/dtype gaps:
+Implemented GPU coverage is broad. The user-facing
+[`Devices and GPU`](../guides/devices-and-gpu.md) guide contains the current
+CUDA operation and dtype matrix. The high-level categories are:
 
 - explicit upload/download and device pointer bridge,
-- broad elementwise coverage on real dtypes and selected complex operations,
-- reductions including sum/product for real and complex and min/max for real,
+- `F32`/`F64` elementwise arithmetic, comparison, selection, clamp, and
+  analytic unary operations, plus `C32`/`C64` add/mul/div/neg/conj,
+- reductions including sum/product for all tensor dtypes and min/max for
+  `F32`/`F64`,
 - structural operations including transpose, reshape, broadcast, reverse,
-  concatenate, diagonal extraction/embedding, and triangular masks,
-- indexing operations where dtype support exists,
-- selected cuTENSOR/cuBLAS contraction paths,
-- selected cuSOLVER/cuBLAS linalg paths.
+  concatenate, diagonal extraction/embedding, and triangular masks for all
+  tensor dtypes,
+- slice/pad/concatenate/reverse for all tensor dtypes and
+  gather/scatter/dynamic_slice for floating and complex data with numeric
+  index tensors,
+- cuTENSOR-backed contraction paths for real and complex floating dtypes,
+- cuSOLVER/cuBLAS linalg paths for real and complex floating dtypes.
 
 Unsupported GPU operations and unsupported dtypes return `BackendFailure`.
+Known CUDA backend limitations are operation-specific: `eig`,
+`full_piv_lu`, `full_piv_lu_solve`, `dynamic_update_slice`, `I64`
+numeric/linalg gaps, and selected complex analytic or ordering operations.
 `eig` is not provided by cuSOLVER and permanently returns `BackendFailure` on
 CubeCL. ROCm is only a feature stub.
 

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -24,4 +24,5 @@ a lazy expression graph that an `Engine<B>` can evaluate and reuse.
 CUDA support is provided by the feature-gated CubeCL backend for concrete,
 eager, and traced workflows. GPU tensors use explicit upload/download at
 backend boundaries; tenferro does not silently fall back to CPU when a GPU
-operation or dtype is unavailable.
+operation or dtype is unavailable. See [Devices and GPU](devices-and-gpu.md)
+for the current CUDA operation and dtype matrix.

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -52,15 +52,41 @@ The example downloads the result back to CPU and asserts the expected values.
 
 ## Coverage
 
-| Area | Status |
-| --- | --- |
-| Allocation and transfer | CUDA supported |
-| Elementwise and reductions | broad real coverage, selected complex coverage |
-| Structural/indexing | broad coverage where dtype support exists |
-| Contractions | selected cuTENSOR/cuBLAS-backed paths |
-| Linalg | selected cuSOLVER/cuBLAS-backed paths |
-| General `eig` | not supported by cuSOLVER; download to CPU |
-| AMD/ROCm | not supported yet |
+The CUDA backend uses the same concrete, eager, and traced tensor surfaces as
+the CPU backend. The table below describes the current CUDA backend dispatch
+coverage for CUDA-resident `Tensor` values. It is not an autodiff coverage table.
+
+Legend:
+
+- `F32`, `F64`, `I64`, `C32`, and `C64` are the current public `Tensor` dtypes.
+- Listed dtypes have CUDA implementations for that operation.
+- Missing dtypes or rows marked "No CUDA implementation" return an error
+  rather than silently falling back to CPU.
+
+| Operation or family | CUDA dtype support | Notes |
+| --- | --- | --- |
+| Allocation, upload, download | `F32`, `F64`, `I64`, `C32`, `C64` | Explicit CPU/GPU transfer only |
+| `add`, `mul`, `div` | `F32`, `F64`, `C32`, `C64` | Same dtype inputs only; `I64` arithmetic is not implemented |
+| `neg` | `F32`, `F64`, `C32`, `C64` | `I64` is not implemented |
+| `conj` | `F32`, `F64`, `C32`, `C64` | Real dtypes are identity; `I64` is not implemented |
+| `abs`, `sign` | `F32`, `F64` | Complex and `I64` inputs are not implemented |
+| `maximum`, `minimum`, `compare`, `select`, `clamp` | `F32`, `F64` | Complex ordering is not defined; `compare` returns a numeric 0/1 tensor |
+| `exp`, `log`, `sin`, `cos`, `tanh`, `sqrt`, `rsqrt`, `expm1`, `log1p` | `F32`, `F64` | Complex analytic kernels are not implemented |
+| `pow` | `F32`, `F64` | Same dtype inputs only |
+| `transpose`, `reshape`, `broadcast_in_dim`, `extract_diagonal`, `embed_diagonal`, `tril`, `triu` | `F32`, `F64`, `I64`, `C32`, `C64` | Structural tensor operations |
+| `convert` | `F32`, `F64`, `C32`, `C64` among those dtypes; `I64` identity only | Conversion to or from `I64` is not implemented except `I64 -> I64` |
+| `reduce_sum`, `reduce_prod` | `F32`, `F64`, `I64`, `C32`, `C64` | Multi-axis reductions are composed from single-axis kernels |
+| `reduce_max`, `reduce_min` | `F32`, `F64` | Complex ordering is not defined; `I64` min/max is not implemented |
+| `dot_general` | `F32`, `F64`, `C32`, `C64` | cuTENSOR-backed contraction; same dtype inputs only |
+| `gather` | operand `F32`, `F64`, `C32`, `C64`; indices `F32`, `F64`, or `I64` | Complex index tensors and `I64` operands are not implemented |
+| `scatter` | operand/update `F32`, `F64`, `C32`, `C64`; indices `F32`, `F64`, or `I64` | Add-scatter semantics; complex index tensors and `I64` operands are not implemented |
+| `slice`, `pad`, `concatenate`, `reverse` | `F32`, `F64`, `I64`, `C32`, `C64` | Dense structural/indexing operations |
+| `dynamic_slice` | input `F32`, `F64`, `C32`, `C64`; starts `F32`, `F64`, or `I64` | Complex start tensors and `I64` inputs are not implemented |
+| `dynamic_update_slice` | No CUDA implementation | Returns an error |
+| `cholesky`, `triangular_solve`, `lu`, `svd`, `qr`, `eigh`, `solve` | `F32`, `F64`, `C32`, `C64` | cuSOLVER/cuBLAS-backed; `svd` and `eigh` return real singular/eigenvalue tensors for complex inputs |
+| `full_piv_lu`, `full_piv_lu_solve` | No CUDA implementation | Returns an error |
+| General `eig` | No CUDA implementation | cuSOLVER does not provide LAPACK `dgeev`-style general eigendecomposition; download to CPU explicitly |
+| AMD/ROCm | No supported backend | ROCm remains a feature stub |
 
 If cuTENSOR, cuSOLVER, or cuBLAS are installed outside normal dynamic-linker
 paths, set `TENFERRO_CUTENSOR_PATH`, `TENFERRO_CUSOLVER_PATH`, or


### PR DESCRIPTION
## Summary

- Add a precise CUDA operation/dtype support matrix to the public Devices and GPU guide.
- Replace vague CUDA op/dtype parity wording with specific unsupported cases.
- Link API-selection guidance and implementation-facing docs to the matrix.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `python3 scripts/check-doc-snippets.py`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `bash scripts/check-agent-assets.sh --quiet`

Generated with [OpenAI Codex](https://openai.com/codex)