### PR TITLE
Add tensor element access APIs

### DIFF
--- a/tenferro-tensor/Cargo.toml
+++ b/tenferro-tensor/Cargo.toml
@@ -44,3 +44,10 @@ cubecl = { workspace = true, optional = true }
 cubecl-cuda = { workspace = true, optional = true }
 cubecl-runtime = { workspace = true, optional = true }
 tenferro-cubecl = { workspace = true, optional = true }
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "element_access"
+harness = false

--- a/tenferro-tensor/benches/element_access.rs
+++ b/tenferro-tensor/benches/element_access.rs
@@ -1,0 +1,365 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use tenferro_tensor::{MemoryOrder, Tensor, TypedTensor};
+
+const INDEX_COUNT: usize = 4096;
+
+fn tensor_with_order<const R: usize>(shape: [usize; R], order: MemoryOrder) -> TypedTensor<f64> {
+    let len = shape.iter().product();
+    let data = (0..len).map(|value| value as f64).collect();
+    TypedTensor::from_vec_with_order(shape.to_vec(), data, order)
+}
+
+fn dynamic_tensor_with_order<const R: usize>(shape: [usize; R], order: MemoryOrder) -> Tensor {
+    let len = shape.iter().product();
+    let data = (0..len).map(|value| value as f64).collect();
+    Tensor::from_vec_with_order(shape.to_vec(), data, order)
+}
+
+fn index_workload<const R: usize>(shape: [usize; R]) -> Vec<[usize; R]> {
+    let mut indices = Vec::with_capacity(INDEX_COUNT);
+    for n in 0..INDEX_COUNT {
+        let mut idx = [0usize; R];
+        for axis in 0..R {
+            let factor = 17 + axis * 12;
+            idx[axis] = (n.wrapping_mul(factor) + axis * 7) % shape[axis];
+        }
+        indices.push(idx);
+    }
+    indices
+}
+
+fn offset_for_order<const R: usize>(
+    shape: &[usize; R],
+    index: &[usize; R],
+    order: MemoryOrder,
+) -> usize {
+    match order {
+        MemoryOrder::ColMajor => {
+            let mut offset = 0usize;
+            let mut stride = 1usize;
+            for axis in 0..R {
+                offset += index[axis] * stride;
+                stride *= shape[axis];
+            }
+            offset
+        }
+        MemoryOrder::RowMajor => {
+            let mut offset = 0usize;
+            let mut stride = 1usize;
+            for axis in (0..R).rev() {
+                offset += index[axis] * stride;
+                stride *= shape[axis];
+            }
+            offset
+        }
+    }
+}
+
+fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) {
+    let indices = index_workload(shape);
+
+    for order in [MemoryOrder::ColMajor, MemoryOrder::RowMajor] {
+        let order_name = match order {
+            MemoryOrder::ColMajor => "col_major",
+            MemoryOrder::RowMajor => "row_major",
+        };
+        let tensor = tensor_with_order(shape, order);
+        let offsets = indices
+            .iter()
+            .map(|index| offset_for_order(&shape, index, order))
+            .collect::<Vec<_>>();
+        let mut group = c.benchmark_group(format!("element_access/{name}/{order_name}"));
+
+        group.bench_function(BenchmarkId::new("direct_slice", INDEX_COUNT), |b| {
+            let data = tensor.as_slice();
+            b.iter(|| {
+                let mut sum = 0.0;
+                for &offset in &offsets {
+                    sum += black_box(data[black_box(offset)]);
+                }
+                black_box(sum)
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("direct_slice_mut", INDEX_COUNT), |b| {
+            b.iter_batched(
+                || tensor.clone(),
+                |mut tensor| {
+                    let data = tensor.host_data_mut();
+                    for &offset in &offsets {
+                        data[black_box(offset)] += black_box(1.0);
+                    }
+                    black_box(data[0])
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("linear_offset", INDEX_COUNT), |b| {
+            b.iter(|| {
+                let mut sum = 0usize;
+                for index in &indices {
+                    sum = sum.wrapping_add(tensor.linear_offset(black_box(index.as_slice())));
+                }
+                black_box(sum)
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("get", INDEX_COUNT), |b| {
+            b.iter(|| {
+                let mut sum = 0.0;
+                for index in &indices {
+                    sum += *black_box(tensor.get(black_box(index.as_slice())));
+                }
+                black_box(sum)
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("try_get", INDEX_COUNT), |b| {
+            b.iter(|| {
+                let mut sum = 0.0;
+                for index in &indices {
+                    sum += *black_box(tensor.try_get(black_box(index.as_slice())).unwrap());
+                }
+                black_box(sum)
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("get_unchecked", INDEX_COUNT), |b| {
+            b.iter(|| {
+                let mut sum = 0.0;
+                for index in &indices {
+                    sum += *black_box(unsafe { tensor.get_unchecked(black_box(index.as_slice())) });
+                }
+                black_box(sum)
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("get_mut", INDEX_COUNT), |b| {
+            b.iter_batched(
+                || tensor.clone(),
+                |mut tensor| {
+                    for index in &indices {
+                        *tensor.get_mut(black_box(index.as_slice())) += black_box(1.0);
+                    }
+                    black_box(tensor.as_slice()[0])
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("try_get_mut", INDEX_COUNT), |b| {
+            b.iter_batched(
+                || tensor.clone(),
+                |mut tensor| {
+                    for index in &indices {
+                        *tensor.try_get_mut(black_box(index.as_slice())).unwrap() += black_box(1.0);
+                    }
+                    black_box(tensor.as_slice()[0])
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("get_unchecked_mut", INDEX_COUNT), |b| {
+            b.iter_batched(
+                || tensor.clone(),
+                |mut tensor| {
+                    for index in &indices {
+                        unsafe {
+                            *tensor.get_unchecked_mut(black_box(index.as_slice())) +=
+                                black_box(1.0);
+                        }
+                    }
+                    black_box(tensor.as_slice()[0])
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+}
+
+fn element_access(c: &mut Criterion) {
+    bench_rank(c, "2d", [64, 64]);
+    bench_rank(c, "3d", [32, 16, 8]);
+    bench_rank(c, "4d", [16, 8, 8, 4]);
+    bench_rank2_fixed(c);
+    bench_rank3_fixed(c);
+    bench_linear_iteration(c);
+}
+
+fn bench_rank2_fixed(c: &mut Criterion) {
+    let shape = [64usize, 64];
+    let indices = index_workload(shape);
+    for order in [MemoryOrder::ColMajor, MemoryOrder::RowMajor] {
+        let order_name = match order {
+            MemoryOrder::ColMajor => "col_major",
+            MemoryOrder::RowMajor => "row_major",
+        };
+        let tensor = tensor_with_order(shape, order);
+        let mut group = c.benchmark_group(format!("rank_fixed/2d/{order_name}"));
+
+        group.bench_function(BenchmarkId::new("linear_offset2", INDEX_COUNT), |b| {
+            b.iter(|| {
+                let mut sum = 0usize;
+                for [i, j] in &indices {
+                    sum = sum.wrapping_add(tensor.linear_offset2(black_box(*i), black_box(*j)));
+                }
+                black_box(sum)
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("get2", INDEX_COUNT), |b| {
+            b.iter(|| {
+                let mut sum = 0.0;
+                for [i, j] in &indices {
+                    sum += *black_box(tensor.get2(black_box(*i), black_box(*j)));
+                }
+                black_box(sum)
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("get_mut2", INDEX_COUNT), |b| {
+            b.iter_batched(
+                || tensor.clone(),
+                |mut tensor| {
+                    for [i, j] in &indices {
+                        *tensor.get_mut2(black_box(*i), black_box(*j)) += black_box(1.0);
+                    }
+                    black_box(tensor.as_slice()[0])
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+}
+
+fn bench_rank3_fixed(c: &mut Criterion) {
+    let shape = [32usize, 16, 8];
+    let indices = index_workload(shape);
+    for order in [MemoryOrder::ColMajor, MemoryOrder::RowMajor] {
+        let order_name = match order {
+            MemoryOrder::ColMajor => "col_major",
+            MemoryOrder::RowMajor => "row_major",
+        };
+        let tensor = tensor_with_order(shape, order);
+        let mut group = c.benchmark_group(format!("rank_fixed/3d/{order_name}"));
+
+        group.bench_function(BenchmarkId::new("linear_offset3", INDEX_COUNT), |b| {
+            b.iter(|| {
+                let mut sum = 0usize;
+                for [i, j, k] in &indices {
+                    sum = sum.wrapping_add(tensor.linear_offset3(
+                        black_box(*i),
+                        black_box(*j),
+                        black_box(*k),
+                    ));
+                }
+                black_box(sum)
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("get3", INDEX_COUNT), |b| {
+            b.iter(|| {
+                let mut sum = 0.0;
+                for [i, j, k] in &indices {
+                    sum += *black_box(tensor.get3(black_box(*i), black_box(*j), black_box(*k)));
+                }
+                black_box(sum)
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("get_mut3", INDEX_COUNT), |b| {
+            b.iter_batched(
+                || tensor.clone(),
+                |mut tensor| {
+                    for [i, j, k] in &indices {
+                        *tensor.get_mut3(black_box(*i), black_box(*j), black_box(*k)) +=
+                            black_box(1.0);
+                    }
+                    black_box(tensor.as_slice()[0])
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+}
+
+fn bench_linear_iteration(c: &mut Criterion) {
+    let shape = [256usize, 256];
+    for order in [MemoryOrder::ColMajor, MemoryOrder::RowMajor] {
+        let order_name = match order {
+            MemoryOrder::ColMajor => "col_major",
+            MemoryOrder::RowMajor => "row_major",
+        };
+        let tensor = tensor_with_order(shape, order);
+        let dynamic_tensor = dynamic_tensor_with_order(shape, order);
+        let mut group = c.benchmark_group(format!("linear_iteration/{order_name}"));
+
+        group.bench_function("as_slice_iter", |b| {
+            b.iter(|| {
+                let sum = tensor
+                    .as_slice()
+                    .iter()
+                    .fold(0.0, |acc, value| acc + black_box(*value));
+                black_box(sum)
+            });
+        });
+
+        group.bench_function("tensor_iter", |b| {
+            b.iter(|| {
+                let sum = tensor
+                    .iter()
+                    .fold(0.0, |acc, value| acc + black_box(*value));
+                black_box(sum)
+            });
+        });
+
+        group.bench_function("dynamic_tensor_iter", |b| {
+            b.iter(|| {
+                let sum = dynamic_tensor
+                    .iter::<f64>()
+                    .unwrap()
+                    .fold(0.0, |acc, value| acc + black_box(*value));
+                black_box(sum)
+            });
+        });
+
+        group.bench_function("tensor_iter_mut", |b| {
+            b.iter_batched(
+                || tensor.clone(),
+                |mut tensor| {
+                    for value in tensor.iter_mut() {
+                        *value += black_box(1.0);
+                    }
+                    black_box(tensor.as_slice()[0])
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function("dynamic_tensor_iter_mut", |b| {
+            b.iter_batched(
+                || dynamic_tensor.clone(),
+                |mut tensor| {
+                    for value in tensor.iter_mut::<f64>().unwrap() {
+                        *value += black_box(1.0);
+                    }
+                    black_box(tensor.as_slice::<f64>().unwrap()[0])
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, element_access);
+criterion_main!(benches);

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -93,6 +93,123 @@ fn row_major_typed_tensor_uses_logical_indices() {
 }
 
 #[test]
+fn typed_tensor_linear_offsets_cover_higher_rank_orders() {
+    let col = TypedTensor::<f64>::zeros(vec![2, 3, 5]);
+    let row = TypedTensor::from_vec_row_major(vec![2, 3, 5], vec![0.0_f64; 30]);
+
+    assert_eq!(col.linear_offset(&[1, 2, 4]), 1 + 2 * 2 + 4 * 2 * 3);
+    assert_eq!(row.linear_offset(&[1, 2, 4]), 4 + 2 * 5 + 1 * 3 * 5);
+}
+
+#[test]
+fn typed_tensor_iterators_follow_physical_buffer_order() {
+    let tensor =
+        TypedTensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    assert_eq!(
+        tensor.iter().copied().collect::<Vec<_>>(),
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    );
+
+    let mut tensor = TypedTensor::from_vec_col_major(vec![3], vec![1_i64, 2, 3]);
+    for value in tensor.iter_mut() {
+        *value *= 2;
+    }
+    assert_eq!(tensor.as_slice(), &[2, 4, 6]);
+}
+
+#[test]
+fn tensor_iterators_are_typed_by_requested_scalar() {
+    let mut tensor = Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]);
+
+    assert_eq!(
+        tensor.iter::<f64>().unwrap().copied().collect::<Vec<_>>(),
+        vec![1.0, 2.0, 3.0]
+    );
+    assert!(tensor.iter::<f32>().is_none());
+
+    for value in tensor.iter_mut::<f64>().unwrap() {
+        *value += 1.0;
+    }
+
+    assert_eq!(tensor.as_slice::<f64>().unwrap(), &[2.0, 3.0, 4.0]);
+    assert!(tensor.as_slice_mut::<f32>().is_none());
+}
+
+#[test]
+fn typed_tensor_checked_and_unchecked_accessors_work() {
+    let mut tensor =
+        TypedTensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    assert_eq!(tensor.as_physical_slice(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    assert_eq!(tensor.try_get(&[1, 2]), Some(&6.0));
+    assert_eq!(tensor.try_get(&[2, 0]), None);
+    assert_eq!(tensor.try_get(&[0]), None);
+
+    *tensor.try_get_mut(&[0, 1]).unwrap() = 20.0;
+    assert_eq!(tensor.as_physical_slice()[1], 20.0);
+
+    tensor.as_physical_slice_mut()[0] = 10.0;
+    assert_eq!(unsafe { *tensor.get_unchecked(&[0, 0]) }, 10.0);
+
+    unsafe {
+        *tensor.get_unchecked_mut(&[1, 0]) = 40.0;
+    }
+    assert_eq!(tensor.try_get(&[1, 0]), Some(&40.0));
+}
+
+#[test]
+fn typed_tensor_rank_fixed_accessors_use_memory_order() {
+    let mut col2 = TypedTensor::from_vec_col_major(vec![2, 3], vec![1_i64, 2, 3, 4, 5, 6]);
+    let row2 = TypedTensor::from_vec_row_major(vec![2, 3], vec![1_i64, 2, 3, 4, 5, 6]);
+
+    assert_eq!(col2.linear_offset2(1, 2), 5);
+    assert_eq!(row2.linear_offset2(1, 0), 3);
+    assert_eq!(*col2.get2(1, 2), 6);
+    *col2.get_mut2(0, 1) = 30;
+    assert_eq!(col2.as_physical_slice()[2], 30);
+
+    let mut col3 = TypedTensor::from_vec_col_major(vec![2, 3, 2], (0_i64..12).collect());
+    let row3 = TypedTensor::from_vec_row_major(vec![2, 3, 2], (0_i64..12).collect());
+
+    assert_eq!(col3.linear_offset3(1, 2, 1), 11);
+    assert_eq!(row3.linear_offset3(1, 0, 1), 7);
+    assert_eq!(*col3.get3(1, 2, 1), 11);
+    *col3.get_mut3(0, 1, 1) = 60;
+    assert_eq!(col3.as_physical_slice()[8], 60);
+}
+
+#[test]
+fn tensor_checked_accessors_are_typed_and_use_physical_order() {
+    let mut tensor = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    assert_eq!(
+        tensor.as_physical_slice::<f64>().unwrap(),
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    );
+    assert_eq!(tensor.linear_offset(&[1, 0]), 3);
+    assert_eq!(tensor.linear_offset2(1, 0), 3);
+    assert_eq!(tensor.try_get::<f64>(&[1, 2]), Some(&6.0));
+    assert_eq!(tensor.try_get::<f32>(&[1, 2]), None);
+    assert_eq!(tensor.try_get::<f64>(&[2, 0]), None);
+
+    tensor.as_physical_slice_mut::<f64>().unwrap()[0] = 10.0;
+    *tensor.try_get_mut::<f64>(&[0, 1]).unwrap() = 20.0;
+
+    assert_eq!(
+        unsafe { *tensor.get_unchecked::<f64>(&[0, 0]).unwrap() },
+        10.0
+    );
+    unsafe {
+        *tensor.get_unchecked_mut::<f64>(&[1, 0]).unwrap() = 40.0;
+    }
+
+    assert_eq!(
+        tensor.as_physical_slice::<f64>().unwrap(),
+        &[10.0, 20.0, 3.0, 40.0, 5.0, 6.0]
+    );
+}
+
+#[test]
 fn row_major_to_col_major_reorders_owned_buffer() {
     let tensor = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
 

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -3,6 +3,8 @@ use num_traits::{One, Zero};
 
 use crate::{DotGeneralConfig, TensorBackend};
 
+mod accessors;
+
 /// Memory location for tensor storage.
 ///
 /// # Examples
@@ -239,6 +241,20 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// Try to borrow the host data from a [`Tensor`].
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]>;
 
+    /// Try to mutably borrow the host data from a [`Tensor`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorScalar};
+    ///
+    /// let mut tensor = Tensor::from_vec(vec![1], vec![2.0_f64]);
+    /// <f64 as TensorScalar>::try_as_slice_mut(&mut tensor).unwrap()[0] = 3.0;
+    ///
+    /// assert_eq!(tensor.as_slice::<f64>().unwrap(), &[3.0]);
+    /// ```
+    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]>;
+
     /// Try to extract a [`TypedTensor<Self>`] from a dynamic [`Tensor`].
     ///
     /// Returns `None` if the tensor dtype does not match `Self`.
@@ -284,6 +300,13 @@ impl TensorScalar for f64 {
         }
     }
 
+    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
+        match tensor {
+            Tensor::F64(t) => Some(t.host_data_mut()),
+            _ => None,
+        }
+    }
+
     fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
         match tensor {
             Tensor::F64(inner) => Some(inner),
@@ -306,6 +329,13 @@ impl TensorScalar for f32 {
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
         match tensor {
             Tensor::F32(t) => Some(t.host_data()),
+            _ => None,
+        }
+    }
+
+    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
+        match tensor {
+            Tensor::F32(t) => Some(t.host_data_mut()),
             _ => None,
         }
     }
@@ -336,6 +366,13 @@ impl TensorScalar for i64 {
         }
     }
 
+    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
+        match tensor {
+            Tensor::I64(t) => Some(t.host_data_mut()),
+            _ => None,
+        }
+    }
+
     fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
         match tensor {
             Tensor::I64(inner) => Some(inner),
@@ -362,6 +399,13 @@ impl TensorScalar for Complex64 {
         }
     }
 
+    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
+        match tensor {
+            Tensor::C64(t) => Some(t.host_data_mut()),
+            _ => None,
+        }
+    }
+
     fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
         match tensor {
             Tensor::C64(inner) => Some(inner),
@@ -384,6 +428,13 @@ impl TensorScalar for Complex32 {
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
         match tensor {
             Tensor::C32(t) => Some(t.host_data()),
+            _ => None,
+        }
+    }
+
+    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
+        match tensor {
+            Tensor::C32(t) => Some(t.host_data_mut()),
             _ => None,
         }
     }
@@ -570,28 +621,46 @@ pub fn contiguous_strides(shape: &[usize], order: MemoryOrder) -> Vec<isize> {
 
 fn linear_offset_for_order(shape: &[usize], indices: &[usize], order: MemoryOrder) -> usize {
     assert_eq!(indices.len(), shape.len());
-    let strides = contiguous_strides(shape, order);
-    let mut offset = 0usize;
-    for (axis, (&idx, &extent)) in indices.iter().zip(shape).enumerate() {
-        assert!(idx < extent, "index out of bounds");
-        offset += idx * strides[axis] as usize;
+    match order {
+        MemoryOrder::ColMajor => {
+            let mut offset = 0usize;
+            let mut stride = 1usize;
+            for (&idx, &extent) in indices.iter().zip(shape) {
+                assert!(idx < extent, "index out of bounds");
+                offset += idx * stride;
+                stride *= extent;
+            }
+            offset
+        }
+        MemoryOrder::RowMajor => {
+            let mut offset = 0usize;
+            let mut stride = 1usize;
+            for (&idx, &extent) in indices.iter().zip(shape).rev() {
+                assert!(idx < extent, "index out of bounds");
+                offset += idx * stride;
+                stride *= extent;
+            }
+            offset
+        }
     }
-    offset
 }
 
 fn flat_to_multi_for_order(flat: usize, shape: &[usize], order: MemoryOrder, out: &mut [usize]) {
     assert_eq!(shape.len(), out.len());
-    if shape.is_empty() {
-        return;
-    }
-    let strides = contiguous_strides(shape, order);
     let mut remaining = flat;
-    let mut axes: Vec<usize> = (0..shape.len()).collect();
-    axes.sort_by_key(|&axis| std::cmp::Reverse(strides[axis]));
-    for axis in axes {
-        let stride = strides[axis] as usize;
-        out[axis] = remaining / stride;
-        remaining %= stride;
+    match order {
+        MemoryOrder::ColMajor => {
+            for (&extent, slot) in shape.iter().zip(out.iter_mut()) {
+                *slot = remaining % extent;
+                remaining /= extent;
+            }
+        }
+        MemoryOrder::RowMajor => {
+            for (&extent, slot) in shape.iter().zip(out.iter_mut()).rev() {
+                *slot = remaining % extent;
+                remaining /= extent;
+            }
+        }
     }
 }
 
@@ -972,7 +1041,7 @@ impl<T: Clone> TypedTensor<T> {
         }
     }
 
-    /// Compute the linear column-major offset for an index.
+    /// Compute the linear physical-buffer offset for a logical index.
     ///
     /// # Examples
     ///

--- a/tenferro-tensor/src/types/accessors.rs
+++ b/tenferro-tensor/src/types/accessors.rs
@@ -1,0 +1,604 @@
+use super::{linear_offset_for_order, MemoryOrder, Tensor, TensorScalar, TypedTensor};
+
+fn try_linear_offset_for_order(
+    shape: &[usize],
+    indices: &[usize],
+    order: MemoryOrder,
+) -> Option<usize> {
+    if indices.len() != shape.len() {
+        return None;
+    }
+    match order {
+        MemoryOrder::ColMajor => {
+            let mut offset = 0usize;
+            let mut stride = 1usize;
+            for (&idx, &extent) in indices.iter().zip(shape) {
+                if idx >= extent {
+                    return None;
+                }
+                offset += idx * stride;
+                stride *= extent;
+            }
+            Some(offset)
+        }
+        MemoryOrder::RowMajor => {
+            let mut offset = 0usize;
+            let mut stride = 1usize;
+            for (&idx, &extent) in indices.iter().zip(shape).rev() {
+                if idx >= extent {
+                    return None;
+                }
+                offset += idx * stride;
+                stride *= extent;
+            }
+            Some(offset)
+        }
+    }
+}
+
+fn debug_assert_index_in_bounds(shape: &[usize], indices: &[usize]) {
+    debug_assert_eq!(indices.len(), shape.len());
+    for (&idx, &extent) in indices.iter().zip(shape) {
+        debug_assert!(idx < extent, "index out of bounds");
+    }
+}
+
+fn linear_offset_unchecked_for_order(
+    shape: &[usize],
+    indices: &[usize],
+    order: MemoryOrder,
+) -> usize {
+    debug_assert_index_in_bounds(shape, indices);
+    match order {
+        MemoryOrder::ColMajor => {
+            let mut offset = 0usize;
+            let mut stride = 1usize;
+            for (&idx, &extent) in indices.iter().zip(shape) {
+                offset += idx * stride;
+                stride *= extent;
+            }
+            offset
+        }
+        MemoryOrder::RowMajor => {
+            let mut offset = 0usize;
+            let mut stride = 1usize;
+            for (&idx, &extent) in indices.iter().zip(shape).rev() {
+                offset += idx * stride;
+                stride *= extent;
+            }
+            offset
+        }
+    }
+}
+
+fn linear_offset2_for_order(shape: &[usize], i: usize, j: usize, order: MemoryOrder) -> usize {
+    assert_eq!(shape.len(), 2);
+    assert!(i < shape[0], "index out of bounds");
+    assert!(j < shape[1], "index out of bounds");
+    linear_offset2_unchecked_for_order(shape, i, j, order)
+}
+
+fn linear_offset2_unchecked_for_order(
+    shape: &[usize],
+    i: usize,
+    j: usize,
+    order: MemoryOrder,
+) -> usize {
+    debug_assert_eq!(shape.len(), 2);
+    debug_assert!(i < shape[0], "index out of bounds");
+    debug_assert!(j < shape[1], "index out of bounds");
+    match order {
+        MemoryOrder::ColMajor => i + shape[0] * j,
+        MemoryOrder::RowMajor => j + shape[1] * i,
+    }
+}
+
+fn linear_offset3_for_order(
+    shape: &[usize],
+    i: usize,
+    j: usize,
+    k: usize,
+    order: MemoryOrder,
+) -> usize {
+    assert_eq!(shape.len(), 3);
+    assert!(i < shape[0], "index out of bounds");
+    assert!(j < shape[1], "index out of bounds");
+    assert!(k < shape[2], "index out of bounds");
+    linear_offset3_unchecked_for_order(shape, i, j, k, order)
+}
+
+fn linear_offset3_unchecked_for_order(
+    shape: &[usize],
+    i: usize,
+    j: usize,
+    k: usize,
+    order: MemoryOrder,
+) -> usize {
+    debug_assert_eq!(shape.len(), 3);
+    debug_assert!(i < shape[0], "index out of bounds");
+    debug_assert!(j < shape[1], "index out of bounds");
+    debug_assert!(k < shape[2], "index out of bounds");
+    match order {
+        MemoryOrder::ColMajor => i + shape[0] * (j + shape[1] * k),
+        MemoryOrder::RowMajor => k + shape[2] * (j + shape[1] * i),
+    }
+}
+
+impl<T: Clone> TypedTensor<T> {
+    /// View the tensor data as a flat slice in physical memory order.
+    ///
+    /// This is an explicit alias for [`TypedTensor::as_slice`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2], vec![1.0, 2.0]);
+    /// assert_eq!(t.as_physical_slice(), &[1.0, 2.0]);
+    /// ```
+    pub fn as_physical_slice(&self) -> &[T] {
+        self.host_data()
+    }
+
+    /// Iterate over the contiguous host buffer in physical memory order.
+    ///
+    /// For column-major tensors this visits the leftmost logical dimension
+    /// fastest. For row-major tensors it visits the rightmost logical
+    /// dimension fastest.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec(vec![2], vec![1.0, 2.0]);
+    /// let sum: f64 = t.iter().copied().sum();
+    /// assert_eq!(sum, 3.0);
+    /// ```
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.host_data().iter()
+    }
+
+    /// Mutably view the tensor data as a flat slice in physical memory order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let mut t = TypedTensor::<f64>::from_vec(vec![2], vec![1.0, 2.0]);
+    /// t.as_physical_slice_mut()[1] = 5.0;
+    /// assert_eq!(t.as_physical_slice(), &[1.0, 5.0]);
+    /// ```
+    pub fn as_physical_slice_mut(&mut self) -> &mut [T] {
+        self.host_data_mut()
+    }
+
+    /// Mutably iterate over the contiguous host buffer in physical memory
+    /// order.
+    ///
+    /// For column-major tensors this visits the leftmost logical dimension
+    /// fastest. For row-major tensors it visits the rightmost logical
+    /// dimension fastest.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let mut t = TypedTensor::<f64>::from_vec(vec![2], vec![1.0, 2.0]);
+    /// for value in t.iter_mut() {
+    ///     *value *= 2.0;
+    /// }
+    /// assert_eq!(t.as_slice(), &[2.0, 4.0]);
+    /// ```
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
+        self.host_data_mut().iter_mut()
+    }
+
+    /// Compute the linear physical-buffer offset for a rank-2 logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]);
+    /// assert_eq!(t.linear_offset2(1, 2), 5);
+    /// ```
+    pub fn linear_offset2(&self, i: usize, j: usize) -> usize {
+        linear_offset2_for_order(&self.shape, i, j, self.order)
+    }
+
+    /// Compute the linear physical-buffer offset for a rank-3 logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 3, 2], vec![0.0; 12]);
+    /// assert_eq!(t.linear_offset3(1, 2, 1), 11);
+    /// ```
+    pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> usize {
+        linear_offset3_for_order(&self.shape, i, j, k, self.order)
+    }
+
+    /// Try to borrow a single element by multi-index.
+    ///
+    /// Returns `None` when the rank or any index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec(vec![2], vec![1.0, 2.0]);
+    /// assert_eq!(t.try_get(&[1]), Some(&2.0));
+    /// assert_eq!(t.try_get(&[2]), None);
+    /// ```
+    pub fn try_get(&self, indices: &[usize]) -> Option<&T> {
+        let off = try_linear_offset_for_order(&self.shape, indices, self.order)?;
+        self.host_data().get(off)
+    }
+
+    /// Borrow a single element by rank-2 logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    /// assert_eq!(t.get2(1, 0), &2.0);
+    /// ```
+    pub fn get2(&self, i: usize, j: usize) -> &T {
+        let off = self.linear_offset2(i, j);
+        &self.host_data()[off]
+    }
+
+    /// Borrow a single element by rank-3 logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![1, 1, 2], vec![3.0, 4.0]);
+    /// assert_eq!(t.get3(0, 0, 1), &4.0);
+    /// ```
+    pub fn get3(&self, i: usize, j: usize, k: usize) -> &T {
+        let off = self.linear_offset3(i, j, k);
+        &self.host_data()[off]
+    }
+
+    /// Borrow a single element by multi-index without release-mode bounds
+    /// checks.
+    ///
+    /// Debug builds still validate the rank and bounds.
+    ///
+    /// # Safety
+    ///
+    /// `indices` must have the same rank as this tensor and every index must
+    /// be in bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::from_vec(vec![2], vec![1.0, 2.0]);
+    /// assert_eq!(unsafe { *t.get_unchecked(&[1]) }, 2.0);
+    /// ```
+    pub unsafe fn get_unchecked(&self, indices: &[usize]) -> &T {
+        let off = linear_offset_unchecked_for_order(&self.shape, indices, self.order);
+        unsafe { self.host_data().get_unchecked(off) }
+    }
+
+    /// Try to mutably borrow a single element by multi-index.
+    ///
+    /// Returns `None` when the rank or any index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let mut t = TypedTensor::<f64>::from_vec(vec![1], vec![1.0]);
+    /// *t.try_get_mut(&[0]).unwrap() = 2.0;
+    /// assert_eq!(t.as_slice(), &[2.0]);
+    /// ```
+    pub fn try_get_mut(&mut self, indices: &[usize]) -> Option<&mut T> {
+        let off = try_linear_offset_for_order(&self.shape, indices, self.order)?;
+        self.host_data_mut().get_mut(off)
+    }
+
+    /// Mutably borrow a single element by rank-2 logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let mut t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    /// *t.get_mut2(1, 0) = 5.0;
+    /// assert_eq!(t.as_slice(), &[1.0, 5.0, 3.0, 4.0]);
+    /// ```
+    pub fn get_mut2(&mut self, i: usize, j: usize) -> &mut T {
+        let off = self.linear_offset2(i, j);
+        &mut self.host_data_mut()[off]
+    }
+
+    /// Mutably borrow a single element by rank-3 logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let mut t = TypedTensor::<f64>::from_vec_col_major(vec![1, 1, 2], vec![3.0, 4.0]);
+    /// *t.get_mut3(0, 0, 1) = 5.0;
+    /// assert_eq!(t.as_slice(), &[3.0, 5.0]);
+    /// ```
+    pub fn get_mut3(&mut self, i: usize, j: usize, k: usize) -> &mut T {
+        let off = self.linear_offset3(i, j, k);
+        &mut self.host_data_mut()[off]
+    }
+
+    /// Mutably borrow a single element by multi-index without release-mode
+    /// bounds checks.
+    ///
+    /// Debug builds still validate the rank and bounds.
+    ///
+    /// # Safety
+    ///
+    /// `indices` must have the same rank as this tensor and every index must
+    /// be in bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let mut t = TypedTensor::<f64>::from_vec(vec![1], vec![1.0]);
+    /// unsafe {
+    ///     *t.get_unchecked_mut(&[0]) = 2.0;
+    /// }
+    /// assert_eq!(t.as_slice(), &[2.0]);
+    /// ```
+    pub unsafe fn get_unchecked_mut(&mut self, indices: &[usize]) -> &mut T {
+        let off = linear_offset_unchecked_for_order(&self.shape, indices, self.order);
+        unsafe { self.host_data_mut().get_unchecked_mut(off) }
+    }
+}
+
+impl Tensor {
+    /// Compute the linear physical-buffer offset for a logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec_row_major(vec![2, 3], vec![0.0_f64; 6]);
+    /// assert_eq!(t.linear_offset(&[1, 0]), 3);
+    /// ```
+    pub fn linear_offset(&self, indices: &[usize]) -> usize {
+        linear_offset_for_order(self.shape(), indices, self.order())
+    }
+
+    /// Compute the linear physical-buffer offset for a rank-2 logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec_row_major(vec![2, 3], vec![0.0_f64; 6]);
+    /// assert_eq!(t.linear_offset2(1, 0), 3);
+    /// ```
+    pub fn linear_offset2(&self, i: usize, j: usize) -> usize {
+        linear_offset2_for_order(self.shape(), i, j, self.order())
+    }
+
+    /// Compute the linear physical-buffer offset for a rank-3 logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec_col_major(vec![2, 3, 2], vec![0.0_f64; 12]);
+    /// assert_eq!(t.linear_offset3(1, 2, 1), 11);
+    /// ```
+    pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> usize {
+        linear_offset3_for_order(self.shape(), i, j, k, self.order())
+    }
+
+    /// Try to borrow the host data as a typed physical-memory-order slice.
+    ///
+    /// This is an explicit alias for [`Tensor::as_slice`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    /// assert_eq!(t.as_physical_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    pub fn as_physical_slice<T: TensorScalar>(&self) -> Option<&[T]> {
+        self.as_slice::<T>()
+    }
+
+    /// Try to mutably borrow the host data as a typed physical-memory-order
+    /// slice.
+    ///
+    /// This is an explicit alias for [`Tensor::as_slice_mut`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let mut t = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    /// t.as_physical_slice_mut::<f64>().unwrap()[1] = 5.0;
+    /// assert_eq!(t.as_physical_slice::<f64>().unwrap(), &[1.0, 5.0]);
+    /// ```
+    pub fn as_physical_slice_mut<T: TensorScalar>(&mut self) -> Option<&mut [T]> {
+        self.as_slice_mut::<T>()
+    }
+
+    /// Try to borrow a single typed element by multi-index.
+    ///
+    /// Returns `None` when the dtype does not match `T`, the rank does not
+    /// match, or any index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    /// assert_eq!(t.try_get::<f64>(&[1]), Some(&2.0));
+    /// assert_eq!(t.try_get::<f32>(&[1]), None);
+    /// ```
+    pub fn try_get<T: TensorScalar>(&self, indices: &[usize]) -> Option<&T> {
+        let off = try_linear_offset_for_order(self.shape(), indices, self.order())?;
+        self.as_slice::<T>()?.get(off)
+    }
+
+    /// Try to mutably borrow a single typed element by multi-index.
+    ///
+    /// Returns `None` when the dtype does not match `T`, the rank does not
+    /// match, or any index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let mut t = Tensor::from_vec(vec![1], vec![1.0_f64]);
+    /// *t.try_get_mut::<f64>(&[0]).unwrap() = 2.0;
+    /// assert_eq!(t.as_slice::<f64>().unwrap(), &[2.0]);
+    /// ```
+    pub fn try_get_mut<T: TensorScalar>(&mut self, indices: &[usize]) -> Option<&mut T> {
+        let off = try_linear_offset_for_order(self.shape(), indices, self.order())?;
+        self.as_slice_mut::<T>()?.get_mut(off)
+    }
+
+    /// Try to borrow a single typed element by multi-index without
+    /// release-mode bounds checks.
+    ///
+    /// Returns `None` when the dtype does not match `T`. Debug builds still
+    /// validate the rank and bounds.
+    ///
+    /// # Safety
+    ///
+    /// `indices` must have the same rank as this tensor and every index must
+    /// be in bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    /// assert_eq!(unsafe { *t.get_unchecked::<f64>(&[1]).unwrap() }, 2.0);
+    /// ```
+    pub unsafe fn get_unchecked<T: TensorScalar>(&self, indices: &[usize]) -> Option<&T> {
+        let off = linear_offset_unchecked_for_order(self.shape(), indices, self.order());
+        let data = self.as_slice::<T>()?;
+        Some(unsafe { data.get_unchecked(off) })
+    }
+
+    /// Try to mutably borrow a single typed element by multi-index without
+    /// release-mode bounds checks.
+    ///
+    /// Returns `None` when the dtype does not match `T`. Debug builds still
+    /// validate the rank and bounds.
+    ///
+    /// # Safety
+    ///
+    /// `indices` must have the same rank as this tensor and every index must
+    /// be in bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let mut t = Tensor::from_vec(vec![1], vec![1.0_f64]);
+    /// unsafe {
+    ///     *t.get_unchecked_mut::<f64>(&[0]).unwrap() = 2.0;
+    /// }
+    /// assert_eq!(t.as_slice::<f64>().unwrap(), &[2.0]);
+    /// ```
+    pub unsafe fn get_unchecked_mut<T: TensorScalar>(
+        &mut self,
+        indices: &[usize],
+    ) -> Option<&mut T> {
+        let off = linear_offset_unchecked_for_order(self.shape(), indices, self.order());
+        let data = self.as_slice_mut::<T>()?;
+        Some(unsafe { data.get_unchecked_mut(off) })
+    }
+
+    /// Try to mutably borrow the host data as a typed slice.
+    ///
+    /// Returns `None` if the tensor dtype does not match `T`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let mut t = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    /// t.as_slice_mut::<f64>().unwrap()[0] = 3.0;
+    /// assert_eq!(t.as_slice::<f64>().unwrap(), &[3.0, 2.0]);
+    /// assert_eq!(t.as_slice_mut::<f32>(), None);
+    /// ```
+    pub fn as_slice_mut<T: TensorScalar>(&mut self) -> Option<&mut [T]> {
+        T::try_as_slice_mut(self)
+    }
+
+    /// Try to iterate over the contiguous host buffer in physical memory
+    /// order.
+    ///
+    /// Returns `None` if the tensor dtype does not match `T`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    /// let sum: f64 = t.iter::<f64>().unwrap().copied().sum();
+    /// assert_eq!(sum, 3.0);
+    /// assert!(t.iter::<f32>().is_none());
+    /// ```
+    pub fn iter<T: TensorScalar>(&self) -> Option<std::slice::Iter<'_, T>> {
+        self.as_slice::<T>().map(|slice| slice.iter())
+    }
+
+    /// Try to mutably iterate over the contiguous host buffer in physical
+    /// memory order.
+    ///
+    /// Returns `None` if the tensor dtype does not match `T`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let mut t = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    /// for value in t.iter_mut::<f64>().unwrap() {
+    ///     *value += 1.0;
+    /// }
+    /// assert_eq!(t.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
+    /// assert!(t.iter_mut::<f32>().is_none());
+    /// ```
+    pub fn iter_mut<T: TensorScalar>(&mut self) -> Option<std::slice::IterMut<'_, T>> {
+        self.as_slice_mut::<T>().map(|slice| slice.iter_mut())
+    }
+}


### PR DESCRIPTION
## Summary
- add checked, unchecked, rank-fixed, and iterator APIs for TypedTensor and Tensor element access
- make logical-to-physical offset calculation allocation-free for row-major and col-major tensors
- add Criterion benchmarks for scalar element access and linear iteration

## Verification
- cargo fmt --all --check
- cargo test --workspace --release
- cargo llvm-cov --workspace --release --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py
- cargo bench -p tenferro-tensor --bench element_access --no-run