### PR TITLE
[codex] Add index_select shape packing APIs

### DIFF
--- a/docs/design/supported-ops.md
+++ b/docs/design/supported-ops.md
@@ -31,6 +31,8 @@ implementation-facing page also names the CubeCL layer that backs it.
 - Reductions: sum, product, max, min.
 - Contraction: `dot_general`.
 - Indexing: gather, scatter, slice, dynamic slice, pad, concatenate, reverse.
+- Shape packing helpers: `Tensor::stack` and `Tensor::index_select` compose
+  reshape/concatenate/gather for host-known positions.
 - Linalg: Cholesky, triangular solve, LU, full-pivot LU, full-pivot LU solve,
   SVD, QR, symmetric/Hermitian eigendecomposition, and general eigendecomposition
   where the backend supports it.
@@ -128,6 +130,9 @@ Implemented public surfaces include:
 - Public AD transforms such as VJP/JVP/HVP over supported traced dense numeric
   paths.
 - Compiled execution through `ExecProgram` / `eval_exec_ir`.
+- Shape packing on concrete, eager, and traced tensors: use `stack(..., -1)`
+  to create a trailing batch axis and `index_select(-1, positions)` to align
+  entries along that axis.
 
 The facade can evaluate through `CpuBackend` or the CUDA backend when the
 program uses operations supported by that backend and tensors are placed

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -21,6 +21,10 @@ explicitly uploaded CUDA-resident data. `EagerTensor<B>` keeps PyTorch-style
 gradient state for immediate workflows on a backend `B`. `TracedTensor` builds
 a lazy expression graph that an `Engine<B>` can evaluate and reuse.
 
+Across concrete, eager, and traced workflows, use `stack(..., -1)` to create a
+trailing batch axis and `index_select(-1, positions)` to align entries along
+that axis.
+
 CUDA support is provided by the feature-gated CubeCL backend for concrete,
 eager, and traced workflows. GPU tensors use explicit upload/download at
 backend boundaries; tenferro does not silently fall back to CPU when a GPU

--- a/docs/plans/2026-05-14-issue-856-index-select-design.md
+++ b/docs/plans/2026-05-14-issue-856-index-select-design.md
@@ -1,0 +1,218 @@
+# Issue 856 Index-Select Design
+
+**Goal:** Add AD-preserving trailing-batch gather/index-select support for
+TreeTN-style batched contractions without adding TreeTN-specific operations or
+backward-compatibility shims.
+
+**Architecture:** Expose `index_select` as a first-class standard tensor API
+and lower it to the existing `Gather` primitive. Keep reverse-mode semantics
+owned by the existing `Gather` to `Scatter` transpose rule, so repeated
+positions accumulate through scatter-add. Add only the minimal missing
+rightmost-batch packing surface needed by #856; do not duplicate a separate
+stack/cat subsystem.
+
+**Tech Stack:** Rust, `tenferro-tensor`, `tenferro`, `tenferro-ops`,
+existing `StdTensorOp::Gather` / `StdTensorOp::Scatter`, CPU `BufferPool`,
+existing traced/eager AD pipeline.
+
+---
+
+## Current State
+
+`origin/main` already has the core substrate that should own this behavior:
+
+- `tenferro_tensor::GatherConfig` and `ScatterConfig`.
+- CPU and CubeCL backend entrypoints for `gather` and `scatter`.
+- `StdTensorOp::Gather` and `StdTensorOp::Scatter`.
+- Forward-mode gather linearization that gathers the operand tangent.
+- Reverse-mode gather transpose that emits scatter-add into a zero operand.
+- `StdTensorOp::Concatenate`, including eager/traced execution and AD.
+
+The missing piece is not a new primitive. The missing piece is a public,
+ergonomic axis-select API that builds the right `GatherConfig` and a
+rightmost-batch packing path that downstream code can use without host-side
+scalar materialization.
+
+The current CPU indexing helpers allocate some fully-overwritten outputs with
+ad hoc `Vec::with_capacity` / uninitialized vectors outside the backend buffer
+pool. Issue 856 makes this an API-contract concern for stack/gather workloads,
+so the CPU indexing path should be moved onto the normal backend/session
+allocation path where practical.
+
+## Public API
+
+Add axis-select methods at the three surfaces that users currently exercise:
+
+```rust
+impl Tensor {
+    pub fn index_select(
+        &self,
+        axis: isize,
+        positions: &[usize],
+        ctx: &mut impl TensorBackend,
+    ) -> tenferro_tensor::Result<Self>;
+}
+
+impl<B: TensorBackend> EagerTensor<B> {
+    pub fn index_select(&self, axis: isize, positions: &[usize]) -> tenferro::Result<Self>;
+}
+
+impl TracedTensor {
+    pub fn index_select(&self, axis: isize, positions: &[usize]) -> tenferro::Result<Self>;
+}
+```
+
+`axis` follows torch-style negative indexing. For a rank `r` tensor, valid
+values are `[-r, r - 1]`. `axis = -1` selects the trailing dimension and is the
+canonical TreeTN batch-axis path.
+
+`positions` is host-known and non-differentiable. Repeated positions are valid.
+An empty `positions` slice is valid and produces an output whose selected axis
+has extent zero.
+
+Add only the minimal stack API needed for the rightmost-batch packing path if
+it is still absent from the branch being implemented:
+
+```rust
+impl Tensor {
+    pub fn stack(
+        tensors: &[&Self],
+        dim: isize,
+        ctx: &mut impl TensorBackend,
+    ) -> tenferro_tensor::Result<Self>;
+}
+
+impl<B: TensorBackend> EagerTensor<B> {
+    pub fn stack(tensors: &[&Self], dim: isize) -> tenferro::Result<Self>;
+}
+
+impl TracedTensor {
+    pub fn stack(tensors: &[&Self], dim: isize) -> tenferro::Result<Self>;
+}
+```
+
+`stack(..., dim = -1)` inserts a new trailing axis and then concatenates along
+that axis. It should be implemented as reshape/concatenate composition rather
+than a second packing primitive.
+
+## Index-Select Lowering
+
+`index_select(axis, positions)` lowers to `Gather` with one indexed operand
+axis:
+
+```text
+operand shape:      [d0, ..., d_axis, ..., dn]
+positions:          [p]
+output shape:       [d0, ..., p, ..., dn]
+collapsed dim:      axis
+slice size:         1 on axis, full size on other axes
+start_index_map:    [axis]
+index_vector_dim:   1
+offset dims:        all output axes except axis
+```
+
+The generated start-index tensor has shape `[positions.len(), 1]` and dtype
+`I64`. It is represented as a constant leaf/input for traced/eager execution,
+not as a differentiable value.
+
+Out-of-range positions should be rejected before building the op. This avoids
+using StableHLO gather clamping for a user-facing index-select API, where
+silent clamping would hide mistakes.
+
+## AD Semantics
+
+No new AD rule is required.
+
+- Forward mode: existing `linearize_gather` applies the same gather to the
+  operand tangent and ignores the index operand.
+- Reverse mode: existing `transpose_gather` emits inverse `Scatter` into a
+  zero-like operand. Since scatter has add semantics, duplicate positions
+  accumulate correctly.
+
+For example:
+
+```text
+x shape:    [3]
+positions:  [1, 1, 2]
+weights:    [10, 20, 30]
+loss:       sum(weights * x.index_select(0, positions))
+grad x:     [0, 30, 30]
+```
+
+This should be covered by traced reverse-mode and forward-mode tests, plus an
+eager reverse-mode test where the eager surface is used directly.
+
+## Allocation And Initialization
+
+Forward stack and index-select outputs are fully overwritten. The CPU backend
+should therefore allocate their output buffers through the active
+`CpuExecSession` buffer pool and avoid zero-initializing those buffers.
+
+Design changes:
+
+- Thread `&mut BufferPool` into CPU indexing helpers used by `CpuExecSession`.
+- Use pooled uninitialized buffers for fully-overwritten gather, concatenate,
+  stack, slice, reverse, and dynamic-slice outputs where the implementation
+  can prove every element is written before read.
+- Keep zero initialization only where required by semantics, especially
+  reverse-mode scatter-add accumulation into a zero cotangent.
+- Retain explicit typed errors for unsupported dtype/device/layout cases.
+
+This issue does not need to solve every historical indexing allocation in one
+large refactor. It should cover the paths used by `stack(..., -1)` and
+`index_select(..., -1)` and avoid introducing new ad hoc allocations.
+
+## Error Behavior
+
+Use existing typed error variants where possible:
+
+- invalid normalized axis: `AxisOutOfBounds { op: "index_select", ... }`
+- position outside the selected axis extent: `InvalidConfig`
+- mismatched stack input shape: `ShapeMismatch`
+- empty stack inputs: `InvalidConfig`
+- unsupported backend/device/layout: `BackendFailure`
+
+CPU tensors should not silently transfer between devices. GPU-native support is
+not required for phase 1 if the existing CubeCL gather path cannot support the
+generated config. A typed unsupported error is acceptable.
+
+## Retained-Batch Contraction Contract
+
+The rightmost dimension is the canonical batch axis:
+
+```text
+input messages:       [bond_dims...]
+stack(..., -1):       [bond_dims..., source_assignments]
+index_select(-1):     [bond_dims..., target_assignments]
+dot_general retain b: [lhs_free..., rhs_free..., b]
+```
+
+Tests should include a small retained-batch contraction:
+
+```text
+A: [m, k, b]
+B: [k, n, b]
+C: [m, n, b]
+```
+
+This verifies that operands produced by trailing-axis stack/index-select flow
+into the existing batch-trailing GEMM convention.
+
+## Testing Plan
+
+Write tests before implementation:
+
+- `stack(..., dim = -1)` packs rank-0, rank-1, and rank-2 tensors into a
+  trailing batch axis.
+- `index_select(axis = -1, positions)` returns expected values for a
+  column-major dense tensor.
+- `index_select` supports repeated positions.
+- repeated-position reverse-mode gradient uses scatter-add.
+- forward-mode tangent follows the same positions.
+- invalid axis and out-of-range positions return typed errors.
+- retained-batch contraction keeps the batch dimension trailing.
+- CPU buffer-pool reuse is visible for forward stack/index-select outputs.
+
+Do not add an `ExtensionOp` or a TreeTN-specific API. Do not preserve old
+host-materialization workarounds.
+

--- a/docs/plans/2026-05-14-issue-856-index-select-plan.md
+++ b/docs/plans/2026-05-14-issue-856-index-select-plan.md
@@ -1,0 +1,1201 @@
+# Issue 856 Index-Select Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add public trailing-batch `stack` and `index_select` APIs that preserve no-grad, forward-mode, and reverse-mode AD without host-side scalar materialization.
+
+**Architecture:** Build the public APIs as composition over existing standard operations. `index_select` lowers to `StdTensorOp::Gather`, so existing gather linearization and gather-to-scatter transpose own AD semantics. `stack` inserts a singleton axis with `Reshape` and then uses `Concatenate`; CPU forward outputs use the backend/session buffer pool where they are fully overwritten.
+
+**Tech Stack:** Rust, `tenferro-tensor`, `tenferro`, `tenferro-ops`, existing `GatherConfig` / `ScatterConfig`, `StdTensorOp::Gather`, `StdTensorOp::Concatenate`, `CpuBackend` / `CpuExecSession`, `BufferPool`, cargo tests.
+
+---
+
+## Scope
+
+Implement #856 against current `origin/main`.
+
+In scope:
+
+- public concrete `Tensor::index_select` and `Tensor::stack`
+- public `EagerTensor::index_select` and `EagerTensor::stack`
+- public `TracedTensor::index_select` and `TracedTensor::stack`
+- negative-axis handling for the new APIs
+- repeated-position gather with scatter-add reverse semantics
+- retained-batch contraction regression with a trailing batch axis
+- CPU buffer-pool allocation for forward gather/concatenate outputs used by the new APIs
+- rustdoc examples for every new public API
+
+Out of scope:
+
+- new AD rules
+- new `StdTensorOp::IndexSelect`
+- TreeTN-specific `ExtensionOp`
+- NumPy-style advanced indexing or index tensor broadcasting
+- GPU-native work beyond the existing CubeCL gather/concatenate capabilities
+- broad restructuring of every historical indexing helper
+
+Before touching AD-related code or tests, re-read `REPOSITORY_RULES.md`. This
+plan reuses existing AD rules and should not add a new `linearize` or
+`transpose_rule` arm.
+
+## Current Pitfall To Fix
+
+The generic binary execution helpers currently promote all binary inputs. That
+is wrong for indexing ops: integer indices are parameters, not numeric data to
+promote with the operand. `Gather`, `DynamicSlice`, `Scatter`, and
+`DynamicUpdateSlice` need operand/update promotion without converting index
+operands to complex or floating dtypes.
+
+This cleanup is required for a clean `index_select` implementation. Do it as a
+root-cause fix, not as a special case inside `index_select`.
+
+---
+
+### Task 1: Concrete Tensor API Tests
+
+**Files:**
+- Modify: `tenferro-tensor/src/tests/cpu_tests.rs`
+
+**Step 1: Write failing tests for `Tensor::index_select`**
+
+Append tests near the existing gather/concatenate CPU tests:
+
+```rust
+#[test]
+fn tensor_index_select_trailing_axis_returns_expected_values() {
+    let mut backend = CpuBackend::new();
+    let input = Tensor::from_vec(
+        vec![2, 3],
+        vec![
+            1.0_f64, 2.0,
+            3.0, 4.0,
+            5.0, 6.0,
+        ],
+    );
+
+    let out = input.index_select(-1, &[2, 0, 2], &mut backend).unwrap();
+
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_f64_close(get_f64(&out, &[0, 0]), 5.0);
+    assert_f64_close(get_f64(&out, &[1, 0]), 6.0);
+    assert_f64_close(get_f64(&out, &[0, 1]), 1.0);
+    assert_f64_close(get_f64(&out, &[1, 1]), 2.0);
+    assert_f64_close(get_f64(&out, &[0, 2]), 5.0);
+    assert_f64_close(get_f64(&out, &[1, 2]), 6.0);
+}
+
+#[test]
+fn tensor_index_select_rejects_invalid_axis_and_position() {
+    let mut backend = CpuBackend::new();
+    let input = Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]);
+
+    let axis_err = input.index_select(-2, &[0], &mut backend).unwrap_err();
+    assert!(axis_err.to_string().contains("index_select"));
+    assert!(axis_err.to_string().contains("axis"));
+
+    let position_err = input.index_select(0, &[3], &mut backend).unwrap_err();
+    assert!(position_err.to_string().contains("index_select"));
+    assert!(position_err.to_string().contains("position"));
+}
+```
+
+**Step 2: Write failing tests for trailing-axis `Tensor::stack`**
+
+Add:
+
+```rust
+#[test]
+fn tensor_stack_trailing_axis_packs_scalars_vectors_and_matrices() {
+    let mut backend = CpuBackend::new();
+
+    let a = Tensor::from_vec(vec![], vec![1.0_f64]);
+    let b = Tensor::from_vec(vec![], vec![2.0_f64]);
+    let scalars = Tensor::stack(&[&a, &b], -1, &mut backend).unwrap();
+    assert_eq!(scalars.shape(), &[2]);
+    assert_eq!(scalars.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+
+    let v0 = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    let v1 = Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]);
+    let vectors = Tensor::stack(&[&v0, &v1], -1, &mut backend).unwrap();
+    assert_eq!(vectors.shape(), &[2, 2]);
+    assert_f64_close(get_f64(&vectors, &[0, 0]), 1.0);
+    assert_f64_close(get_f64(&vectors, &[1, 0]), 2.0);
+    assert_f64_close(get_f64(&vectors, &[0, 1]), 3.0);
+    assert_f64_close(get_f64(&vectors, &[1, 1]), 4.0);
+
+    let m0 = Tensor::from_vec(vec![2, 1], vec![1.0_f64, 2.0]);
+    let m1 = Tensor::from_vec(vec![2, 1], vec![3.0_f64, 4.0]);
+    let matrices = Tensor::stack(&[&m0, &m1], -1, &mut backend).unwrap();
+    assert_eq!(matrices.shape(), &[2, 1, 2]);
+}
+```
+
+**Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor tensor_index_select tensor_stack_trailing_axis -- --nocapture
+```
+
+Expected: FAIL to compile because `Tensor::index_select` and `Tensor::stack`
+do not exist.
+
+**Step 4: Commit tests**
+
+```bash
+git add tenferro-tensor/src/tests/cpu_tests.rs
+git commit -m "test: add concrete index select regressions"
+```
+
+---
+
+### Task 2: Concrete Tensor API Implementation
+
+**Files:**
+- Modify: `tenferro-tensor/src/types.rs`
+- Create: `tenferro-tensor/src/types/shape_packing.rs`
+
+**Step 1: Add a focused shape-packing module**
+
+In `tenferro-tensor/src/types.rs`, add this next to `mod accessors;`:
+
+```rust
+mod shape_packing;
+```
+
+Create `tenferro-tensor/src/types/shape_packing.rs`.
+
+**Step 2: Implement axis normalization helpers**
+
+Add:
+
+```rust
+use super::{Tensor, TensorBackend, TypedTensor};
+use crate::{GatherConfig, Result};
+
+fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
+    let normalized = if axis < 0 {
+        rank as isize + axis
+    } else {
+        axis
+    };
+    if normalized < 0 || normalized >= rank as isize {
+        return Err(crate::Error::AxisOutOfBounds {
+            op,
+            axis: axis.unsigned_abs(),
+            rank,
+        });
+    }
+    Ok(normalized as usize)
+}
+
+fn normalize_insert_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
+    let normalized = if axis < 0 {
+        rank as isize + 1 + axis
+    } else {
+        axis
+    };
+    if normalized < 0 || normalized > rank as isize {
+        return Err(crate::Error::AxisOutOfBounds {
+            op,
+            axis: axis.unsigned_abs(),
+            rank: rank + 1,
+        });
+    }
+    Ok(normalized as usize)
+}
+```
+
+If clippy objects to the `axis.unsigned_abs()` reporting detail, replace only
+the reporting expression. Keep the signed-axis validation behavior.
+
+**Step 3: Implement `index_select_parts`**
+
+Add:
+
+```rust
+fn index_select_parts(
+    shape: &[usize],
+    axis: isize,
+    positions: &[usize],
+) -> Result<(Tensor, GatherConfig, Vec<usize>)> {
+    let axis = normalize_existing_axis("index_select", axis, shape.len())?;
+    let axis_extent = shape[axis];
+    for &position in positions {
+        if position >= axis_extent {
+            return Err(crate::Error::InvalidConfig {
+                op: "index_select",
+                message: format!(
+                    "position {position} out of bounds for axis {axis} with extent {axis_extent}"
+                ),
+            });
+        }
+    }
+
+    let mut out_shape = shape.to_vec();
+    out_shape[axis] = positions.len();
+
+    let mut slice_sizes = shape.to_vec();
+    slice_sizes[axis] = 1;
+
+    let offset_dims: Vec<usize> = (0..shape.len()).filter(|&dim| dim != axis).collect();
+    let mut index_data = Vec::with_capacity(positions.len());
+    index_data.extend(positions.iter().map(|&position| position as i64));
+    let indices = Tensor::I64(TypedTensor::from_vec(vec![positions.len(), 1], index_data));
+
+    let config = GatherConfig {
+        offset_dims,
+        collapsed_slice_dims: vec![axis],
+        start_index_map: vec![axis],
+        index_vector_dim: 1,
+        slice_sizes,
+    };
+
+    Ok((indices, config, out_shape))
+}
+```
+
+**Step 4: Implement `Tensor::index_select`**
+
+Add:
+
+```rust
+impl Tensor {
+    /// Select entries from one axis using host-known positions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{cpu::CpuBackend, Tensor};
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]);
+    /// let y = x.index_select(-1, &[2, 0], &mut backend).unwrap();
+    ///
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[30.0, 10.0]);
+    /// ```
+    pub fn index_select(
+        &self,
+        axis: isize,
+        positions: &[usize],
+        ctx: &mut impl TensorBackend,
+    ) -> Result<Self> {
+        let (indices, config, _) = index_select_parts(self.shape(), axis, positions)?;
+        ctx.with_exec_session(|exec| exec.gather(self, &indices, &config))
+    }
+}
+```
+
+**Step 5: Implement `Tensor::stack`**
+
+Add:
+
+```rust
+impl Tensor {
+    /// Stack tensors along a newly inserted axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{cpu::CpuBackend, Tensor};
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec(vec![], vec![1.0_f64]);
+    /// let b = Tensor::from_vec(vec![], vec![2.0_f64]);
+    /// let out = Tensor::stack(&[&a, &b], -1, &mut backend).unwrap();
+    ///
+    /// assert_eq!(out.shape(), &[2]);
+    /// assert_eq!(out.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    pub fn stack(
+        tensors: &[&Self],
+        dim: isize,
+        ctx: &mut impl TensorBackend,
+    ) -> Result<Self> {
+        let first = tensors.first().copied().ok_or_else(|| crate::Error::InvalidConfig {
+            op: "stack",
+            message: "stack requires at least one input".into(),
+        })?;
+        let rank = first.shape().len();
+        let axis = normalize_insert_axis("stack", dim, rank)?;
+
+        for tensor in tensors.iter().copied().skip(1) {
+            if tensor.shape() != first.shape() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: "stack",
+                    lhs: first.shape().to_vec(),
+                    rhs: tensor.shape().to_vec(),
+                });
+            }
+        }
+
+        let mut expanded_shape = first.shape().to_vec();
+        expanded_shape.insert(axis, 1);
+
+        ctx.with_exec_session(|exec| {
+            let mut expanded = Vec::with_capacity(tensors.len());
+            for tensor in tensors {
+                expanded.push(exec.reshape(tensor, &expanded_shape)?);
+            }
+            let refs: Vec<&Tensor> = expanded.iter().collect();
+            exec.concatenate(&refs, axis)
+        })
+    }
+}
+```
+
+**Step 6: Run tests to verify green**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor tensor_index_select tensor_stack_trailing_axis -- --nocapture
+```
+
+Expected: PASS for the new concrete tests.
+
+**Step 7: Commit**
+
+```bash
+git add tenferro-tensor/src/types.rs tenferro-tensor/src/types/shape_packing.rs tenferro-tensor/src/tests/cpu_tests.rs
+git commit -m "feat: add concrete tensor index select"
+```
+
+---
+
+### Task 3: Index Operand Promotion Cleanup
+
+**Files:**
+- Modify: `tenferro/src/eager_exec.rs`
+- Modify: `tenferro/src/traced.rs`
+- Test: `tenferro/tests/primitive_ops.rs`
+- Test: `tenferro/tests/eager_tensor.rs`
+
+**Step 1: Write failing tests for complex operand indexing**
+
+In `tenferro/tests/primitive_ops.rs`, add:
+
+```rust
+#[test]
+fn traced_index_select_keeps_indices_integer_for_complex_operand() {
+    use num_complex::Complex64;
+
+    let x = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(
+        vec![3],
+        vec![
+            Complex64::new(1.0, 1.0),
+            Complex64::new(2.0, -1.0),
+            Complex64::new(3.0, 0.5),
+        ],
+    ));
+    let mut y = x.index_select(-1, &[2, 0]).unwrap();
+    let mut engine = Engine::new(CpuBackend::new());
+    let out = y.eval(&mut engine).unwrap();
+
+    assert_eq!(out.shape(), &[2]);
+    assert_eq!(
+        out.as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(3.0, 0.5), Complex64::new(1.0, 1.0)]
+    );
+}
+```
+
+In `tenferro/tests/eager_tensor.rs`, add:
+
+```rust
+#[test]
+fn eager_index_select_keeps_indices_integer_for_complex_operand() {
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(
+            vec![3],
+            vec![
+                Complex64::new(1.0, 1.0),
+                Complex64::new(2.0, -1.0),
+                Complex64::new(3.0, 0.5),
+            ],
+        ),
+        test_ctx(),
+    );
+
+    let y = x.index_select(-1, &[2, 0]).unwrap();
+
+    assert_eq!(y.data().shape(), &[2]);
+    assert_eq!(
+        c64_data(y.data()),
+        &[Complex64::new(3.0, 0.5), Complex64::new(1.0, 1.0)]
+    );
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p tenferro traced_index_select_keeps_indices_integer_for_complex_operand eager_index_select_keeps_indices_integer_for_complex_operand -- --nocapture
+```
+
+Expected: FAIL because `index_select` is not exposed on `TracedTensor` /
+`EagerTensor`. If the methods have been added early, the test should fail
+because a complex gather index was promoted to complex.
+
+**Step 3: Fix eager execution promotion for indexing ops**
+
+In `tenferro/src/eager_exec.rs`, replace generic `promote_binary` use for
+indexing ops:
+
+```rust
+StdTensorOp::Gather(config) => {
+    vec![exec.gather(inputs[0], inputs[1], config)?]
+}
+StdTensorOp::GatherDynamicSliceSizes { ... } => {
+    ...
+    vec![exec.gather(inputs[0], inputs[1], &config)?]
+}
+StdTensorOp::DynamicSlice { slice_sizes } => {
+    vec![exec.dynamic_slice(inputs[0], inputs[1], slice_sizes)?]
+}
+StdTensorOp::Scatter(config) => {
+    let promoted = promote_dtype_for_binary_op(op, inputs[0].dtype(), inputs[2].dtype());
+    let operand = if inputs[0].dtype() != promoted {
+        exec.convert(inputs[0], promoted).map_err(Error::from)?
+    } else {
+        inputs[0].clone()
+    };
+    let updates = if inputs[2].dtype() != promoted {
+        exec.convert(inputs[2], promoted).map_err(Error::from)?
+    } else {
+        inputs[2].clone()
+    };
+    vec![exec.scatter(&operand, inputs[1], &updates, config)?]
+}
+StdTensorOp::DynamicUpdateSlice => {
+    let promoted = promote_dtype_for_binary_op(op, inputs[0].dtype(), inputs[1].dtype());
+    let operand = if inputs[0].dtype() != promoted {
+        exec.convert(inputs[0], promoted).map_err(Error::from)?
+    } else {
+        inputs[0].clone()
+    };
+    let update = if inputs[1].dtype() != promoted {
+        exec.convert(inputs[1], promoted).map_err(Error::from)?
+    } else {
+        inputs[1].clone()
+    };
+    vec![exec.dynamic_update_slice(&operand, &update, inputs[2])?]
+}
+```
+
+Keep the helper small. If duplicated promotion becomes noisy, extract a local
+`promote_data_pair(exec, op, lhs, rhs)` helper in the same file.
+
+**Step 4: Add traced construction helpers that do not promote indices**
+
+In `tenferro/src/traced.rs`, add a `pub(crate)` helper near `apply_binary`:
+
+```rust
+pub(crate) fn apply_binary_preserve_input_dtypes(
+    op: StdTensorOp,
+    lhs: &TracedTensor,
+    rhs: &TracedTensor,
+    out_rank: usize,
+    out_shape_hint: Option<Vec<SymDim>>,
+    out_dtype: DType,
+) -> TracedTensor {
+    // Same body shape as apply_binary, but do not insert Convert ops.
+}
+```
+
+Implement it by copying the graph-building, input-map merge, extra-root merge,
+checkpoint-chain merge, and metadata-scope merge from `apply_binary`, but omit
+the conversion block and use `out_dtype` directly.
+
+**Step 5: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p tenferro traced_index_select_keeps_indices_integer_for_complex_operand eager_index_select_keeps_indices_integer_for_complex_operand -- --nocapture
+```
+
+Expected: still FAIL if frontend methods are not implemented yet, but indexing
+promotion is now ready for them. If methods are already present, expected PASS.
+
+**Step 6: Commit**
+
+```bash
+git add tenferro/src/eager_exec.rs tenferro/src/traced.rs tenferro/tests/primitive_ops.rs tenferro/tests/eager_tensor.rs
+git commit -m "fix: keep indexing operands unpromoted"
+```
+
+---
+
+### Task 4: Eager And Traced Public APIs
+
+**Files:**
+- Create: `tenferro/src/shape_packing.rs`
+- Modify: `tenferro/src/lib.rs`
+- Modify: `tenferro/src/traced.rs`
+- Modify: `tenferro/src/eager_ops.rs`
+- Test: `tenferro/tests/primitive_ops.rs`
+- Test: `tenferro/tests/eager_tensor.rs`
+
+**Step 1: Write failing tests for primal APIs**
+
+In `tenferro/tests/primitive_ops.rs`, add:
+
+```rust
+#[test]
+fn traced_stack_trailing_axis_and_index_select_feed_batched_dot_general() {
+    let a0 = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
+    let a1 = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]));
+    let b0 = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![2.0, 3.0]));
+    let b1 = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![4.0, 5.0]));
+
+    let a = TracedTensor::stack(&[&a0, &a1], -1).unwrap();
+    let b = TracedTensor::stack(&[&b0, &b1], -1).unwrap().index_select(-1, &[1, 0]).unwrap();
+    let mut c = a.dot_general(
+        &b,
+        DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![2],
+            rhs_batch_dims: vec![2],
+        },
+    );
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let out = c.eval(&mut engine).unwrap();
+
+    assert_eq!(out.shape(), &[2, 1, 2]);
+    assert_eq!(get_f64_data(out), &[19.0, 28.0, 23.0, 34.0]);
+}
+```
+
+In `tenferro/tests/eager_tensor.rs`, add:
+
+```rust
+#[test]
+fn eager_stack_trailing_axis_and_index_select_primal() {
+    let x0 = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), test_ctx());
+    let x1 = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), test_ctx());
+
+    let stacked = EagerTensor::stack(&[&x0, &x1], -1).unwrap();
+    let selected = stacked.index_select(-1, &[1, 0, 1]).unwrap();
+
+    assert_eq!(selected.data().shape(), &[2, 3]);
+    assert_close_slice(f64_data(selected.data()), &[3.0, 4.0, 1.0, 2.0, 3.0, 4.0], TOL);
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p tenferro traced_stack_trailing_axis_and_index_select_feed_batched_dot_general eager_stack_trailing_axis_and_index_select_primal -- --nocapture
+```
+
+Expected: FAIL because public frontend APIs are missing.
+
+**Step 3: Create `tenferro/src/shape_packing.rs`**
+
+Add `mod shape_packing;` to `tenferro/src/lib.rs`.
+
+In `shape_packing.rs`, implement shared helpers. Keep the code in this module
+where possible, but import private helpers from their actual owning modules
+after inspecting current visibility rather than following the illustrative list
+below verbatim:
+
+```rust
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use computegraph::fragment::FragmentBuilder;
+use computegraph::types::{OpMode, ValRef};
+use tenferro_ops::dim_expr::DimExpr;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_tensor::{DType, GatherConfig, Tensor, TensorBackend, TypedTensor};
+
+use crate::checkpoint::CheckpointNode;
+use crate::eager::{record_eager_outputs, EagerContext, EagerTensor};
+use crate::error::{Error, Result};
+use crate::metadata::{metadata_scopes_with_new, push_metadata_scope, register_scoped_fragment_metadata};
+use crate::shape_infer::promote_dtypes;
+use crate::sym_dim::SymDim;
+use crate::traced::{apply_binary_preserve_input_dtypes, TracedTensor};
+```
+
+If Rust privacy requires narrower imports or small `pub(crate)` helper
+adjustments, make those changes without changing the module boundary. Keep the
+implementation in this new module rather than growing `traced.rs`.
+
+**Step 4: Add frontend `index_select` config construction**
+
+Implement a helper equivalent to the concrete `index_select_parts`, but using
+`SymDim` for traced shape hints:
+
+```rust
+fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> { ... }
+
+fn index_select_config(
+    shape: &[usize],
+    axis: isize,
+    positions: &[usize],
+) -> Result<(Tensor, GatherConfig, Vec<usize>)> { ... }
+```
+
+For `TracedTensor::index_select`, require a concrete `shape_hint` for
+position validation. If `shape_hint` is absent, return `Error::Internal` with a
+message saying `index_select currently requires a concrete shape hint`. Do not
+silently defer out-of-range checking to backend gather clamping.
+
+**Step 5: Implement `EagerTensor::index_select`**
+
+Add:
+
+```rust
+impl<B: TensorBackend> EagerTensor<B> {
+    /// Select entries from one axis using host-known positions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]), ctx);
+    /// let y = x.index_select(-1, &[2, 0]).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[30.0, 10.0]);
+    /// ```
+    pub fn index_select(&self, axis: isize, positions: &[usize]) -> Result<Self> {
+        let (indices, config, _) = index_select_config(self.data.shape(), axis, positions)?;
+        let indices = self.ctx.constant_from(indices);
+        self.gather(&indices, config)
+    }
+}
+```
+
+**Step 6: Implement `TracedTensor::index_select`**
+
+Add:
+
+```rust
+impl TracedTensor {
+    /// Select entries from one axis using host-known positions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine, Tensor, TracedTensor};
+    ///
+    /// let x = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]));
+    /// let mut y = x.index_select(-1, &[2, 0]).unwrap();
+    /// let mut engine = Engine::new(CpuBackend::new());
+    ///
+    /// assert_eq!(y.eval(&mut engine).unwrap().as_slice::<f64>().unwrap(), &[30.0, 10.0]);
+    /// ```
+    pub fn index_select(&self, axis: isize, positions: &[usize]) -> Result<Self> {
+        let shape = crate::traced::try_concrete_shape(self)
+            .ok_or_else(|| Error::Internal("index_select currently requires a concrete shape hint".into()))?;
+        let (indices_tensor, config, out_shape) = index_select_config(&shape, axis, positions)?;
+        let indices = TracedTensor::from_tensor_concrete_shape(indices_tensor);
+        Ok(apply_binary_preserve_input_dtypes(
+            StdTensorOp::Gather(config),
+            self,
+            &indices,
+            out_shape.len(),
+            Some(out_shape.into_iter().map(SymDim::from).collect()),
+            self.dtype,
+        ))
+    }
+}
+```
+
+**Step 7: Implement `EagerTensor::stack`**
+
+Add:
+
+```rust
+impl<B: TensorBackend> EagerTensor<B> {
+    /// Stack tensors along a newly inserted axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![], vec![1.0_f64]), ctx.clone());
+    /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![], vec![2.0_f64]), ctx);
+    /// let out = EagerTensor::stack(&[&a, &b], -1).unwrap();
+    ///
+    /// assert_eq!(out.data().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    pub fn stack(tensors: &[&Self], dim: isize) -> Result<Self> {
+        let first = tensors.first().copied().ok_or_else(|| Error::TensorRuntime(
+            tenferro_tensor::Error::InvalidConfig {
+                op: "stack",
+                message: "stack requires at least one input".into(),
+            },
+        ))?;
+        let axis = normalize_insert_axis("stack", dim, first.data.shape().len())?;
+        let mut expanded = Vec::with_capacity(tensors.len());
+        let mut expanded_shape = first.data.shape().to_vec();
+        expanded_shape.insert(axis, 1);
+        for tensor in tensors {
+            expanded.push(tensor.reshape(&expanded_shape)?);
+        }
+        let refs: Vec<&Self> = expanded.iter().collect();
+        Self::concatenate(&refs, axis)
+    }
+}
+```
+
+**Step 8: Implement `TracedTensor::stack`**
+
+Add an internal `apply_nary` helper in `tenferro/src/traced.rs` or the new
+module. It must:
+
+- optionally convert inputs to a common dtype for `Concatenate`
+- add all parent fragments
+- add the n-ary op with all external value refs
+- merge all input maps
+- merge all extra roots and checkpoint chains
+- merge metadata scopes
+
+Then implement:
+
+```rust
+impl TracedTensor {
+    /// Stack tensors along a newly inserted axis.
+    pub fn stack(tensors: &[&Self], dim: isize) -> Result<Self> {
+        let first = tensors.first().copied().ok_or_else(|| Error::TensorRuntime(
+            tenferro_tensor::Error::InvalidConfig {
+                op: "stack",
+                message: "stack requires at least one input".into(),
+            },
+        ))?;
+        let axis = normalize_insert_axis("stack", dim, first.rank)?;
+        let first_shape = crate::traced::try_concrete_shape(first)
+            .ok_or_else(|| Error::Internal("stack currently requires concrete shape hints".into()))?;
+
+        for tensor in tensors.iter().copied().skip(1) {
+            let shape = crate::traced::try_concrete_shape(tensor)
+                .ok_or_else(|| Error::Internal("stack currently requires concrete shape hints".into()))?;
+            if shape != first_shape {
+                return Err(Error::TensorRuntime(tenferro_tensor::Error::ShapeMismatch {
+                    op: "stack",
+                    lhs: first_shape.clone(),
+                    rhs: shape,
+                }));
+            }
+        }
+
+        let mut expanded_shape = first_shape;
+        expanded_shape.insert(axis, 1);
+        let expanded: Vec<_> = tensors.iter().map(|tensor| tensor.reshape(&expanded_shape)).collect();
+        let refs: Vec<&TracedTensor> = expanded.iter().collect();
+        Ok(apply_nary_concatenate(&refs, axis))
+    }
+}
+```
+
+**Step 9: Run frontend primal tests**
+
+Run:
+
+```bash
+cargo test -p tenferro traced_stack_trailing_axis_and_index_select_feed_batched_dot_general eager_stack_trailing_axis_and_index_select_primal traced_index_select_keeps_indices_integer_for_complex_operand eager_index_select_keeps_indices_integer_for_complex_operand -- --nocapture
+```
+
+Expected: PASS.
+
+**Step 10: Commit**
+
+```bash
+git add tenferro/src/lib.rs tenferro/src/shape_packing.rs tenferro/src/traced.rs tenferro/src/eager_ops.rs tenferro/tests/primitive_ops.rs tenferro/tests/eager_tensor.rs
+git commit -m "feat: expose eager and traced index select"
+```
+
+---
+
+### Task 5: AD Regression Tests
+
+**Files:**
+- Modify: `tenferro/tests/ad.rs`
+- Modify: `tenferro/tests/eager_tensor.rs`
+
+**Step 1: Write failing reverse-mode test for repeated positions**
+
+In `tenferro/tests/ad.rs`, add near the existing gather AD tests:
+
+```rust
+#[test]
+fn grad_traced_index_select_repeated_positions_accumulates() {
+    let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
+    let weights = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![10.0, 20.0, 30.0]));
+
+    let selected = x.index_select(0, &[1, 1, 2]).unwrap();
+    let loss = (&selected * &weights).reduce_sum(&[0]);
+    let grad = eval_tensor(loss.grad(&x).unwrap());
+
+    assert_eq!(grad.shape(), &[3]);
+    assert_close_slice(get_f64_data(&grad), &[0.0, 30.0, 30.0]);
+}
+```
+
+**Step 2: Write failing forward-mode test**
+
+In `tenferro/tests/ad.rs`, add:
+
+```rust
+#[test]
+fn jvp_traced_index_select_gathers_tangent() {
+    let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]));
+    let tangent = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![0.5, 1.5, 2.5, 3.5]));
+
+    let y = x.index_select(0, &[3, 1, 3]).unwrap();
+    let tangent_y = eval_tensor(y.jvp(&x, &tangent));
+
+    assert_eq!(tangent_y.shape(), &[3]);
+    assert_close_slice(get_f64_data(&tangent_y), &[3.5, 1.5, 3.5]);
+}
+```
+
+**Step 3: Write eager reverse-mode test**
+
+In `tenferro/tests/eager_tensor.rs`, add:
+
+```rust
+#[test]
+fn eager_index_select_repeated_positions_accumulates_grad() {
+    let ctx = test_ctx();
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        ctx.clone(),
+    );
+    let weights = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]),
+        ctx,
+    );
+
+    let selected = x.index_select(0, &[1, 1, 2]).unwrap();
+    let loss = (&selected * &weights).reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+
+    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[0.0, 30.0, 30.0], TOL);
+}
+```
+
+**Step 4: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p tenferro index_select_repeated_positions jvp_traced_index_select -- --nocapture
+```
+
+Expected: FAIL if any graph metadata, AD wiring, or shape hint handling is
+missing.
+
+**Step 5: Implement only missing glue**
+
+If failures are in metadata registration for the new helper-created index
+tensor, fix the `metadata_scopes` merge in the new traced helper. If failures
+are in eager reverse execution, confirm that `record_eager_outputs` sees the
+index tensor as inactive through existing `StdTensorOp::Gather` rules.
+
+Do not add a new AD rule. The expected final AD graph must still use existing
+`Gather` and inverse `Scatter`.
+
+**Step 6: Run tests to verify green**
+
+Run:
+
+```bash
+cargo test -p tenferro index_select_repeated_positions jvp_traced_index_select -- --nocapture
+```
+
+Expected: PASS.
+
+**Step 7: Commit**
+
+```bash
+git add tenferro/tests/ad.rs tenferro/tests/eager_tensor.rs tenferro/src
+git commit -m "test: cover index select ad semantics"
+```
+
+---
+
+### Task 6: CPU Buffer-Pool Allocation For Gather And Concatenate
+
+**Files:**
+- Modify: `tenferro-tensor/src/cpu/mod.rs`
+- Create: `tenferro-tensor/src/cpu/indexing_alloc.rs`
+- Modify: `tenferro-tensor/src/cpu/indexing.rs`
+- Modify: `tenferro-tensor/src/cpu/backend.rs`
+- Modify: `tenferro-tensor/src/cpu/exec_session.rs`
+- Test: `tenferro-tensor/src/tests/cpu_tests.rs`
+
+**Step 1: Write failing buffer-pool reuse tests**
+
+In `tenferro-tensor/src/tests/cpu_tests.rs`, add:
+
+```rust
+#[test]
+fn tensor_index_select_reuses_reclaimed_cpu_buffer() {
+    let mut backend = CpuBackend::new();
+    let reusable = Tensor::from_vec(vec![2, 3], vec![0.0_f64; 6]);
+    let expected_ptr = reusable.as_slice::<f64>().unwrap().as_ptr();
+    backend.reclaim_buffer(reusable);
+
+    let input = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let out = input.index_select(-1, &[2, 0, 1], &mut backend).unwrap();
+
+    assert_eq!(out.as_slice::<f64>().unwrap().as_ptr(), expected_ptr);
+}
+
+#[test]
+fn tensor_stack_reuses_reclaimed_cpu_buffer() {
+    let mut backend = CpuBackend::new();
+    let reusable = Tensor::from_vec(vec![2, 2], vec![0.0_f64; 4]);
+    let expected_ptr = reusable.as_slice::<f64>().unwrap().as_ptr();
+    backend.reclaim_buffer(reusable);
+
+    let x0 = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    let x1 = Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]);
+    let out = Tensor::stack(&[&x0, &x1], -1, &mut backend).unwrap();
+
+    assert_eq!(out.as_slice::<f64>().unwrap().as_ptr(), expected_ptr);
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor reuses_reclaimed_cpu_buffer -- --nocapture
+```
+
+Expected: FAIL because gather/concatenate allocate outside the backend pool.
+
+**Step 3: Add pooled allocation helper**
+
+Create `tenferro-tensor/src/cpu/indexing_alloc.rs`:
+
+```rust
+use crate::buffer_pool::{BufferPool, PoolScalar};
+use crate::TypedTensor;
+
+pub(crate) fn pooled_uninit_tensor<T>(
+    buffers: &mut BufferPool,
+    shape: Vec<usize>,
+) -> TypedTensor<T>
+where
+    T: Clone + PoolScalar,
+{
+    let len = shape.iter().product();
+    let data = unsafe { T::pool_acquire(buffers, len) };
+    TypedTensor::from_vec(shape, data)
+}
+```
+
+In `tenferro-tensor/src/cpu/mod.rs`, add:
+
+```rust
+mod indexing_alloc;
+```
+
+**Step 4: Thread `BufferPool` into gather and concatenate**
+
+In `tenferro-tensor/src/cpu/indexing.rs`:
+
+- keep public `gather` and `concatenate` wrappers for compatibility
+- add `gather_with_pool(buffers, operand, start_indices, config)`
+- add `concatenate_with_pool(buffers, inputs, axis)`
+- make `typed_gather` and `typed_concatenate` take `&mut BufferPool`
+- replace `typed_tensor_uninit(out_shape.clone())` with
+  `pooled_uninit_tensor(buffers, out_shape.clone())`
+
+Use trait bounds:
+
+```rust
+fn typed_gather<T: Copy + Clone + Zero + PoolScalar>(...)
+fn typed_concatenate<T: Copy + Clone + PoolScalar>(...)
+```
+
+For the old public wrappers, create a local `BufferPool::new()` and call the
+`*_with_pool` functions. That keeps the public `cpu::gather` behavior while
+making backend execution use the real pool.
+
+**Step 5: Wire CPU backend/session to pooled helpers**
+
+In `tenferro-tensor/src/cpu/backend.rs`, change:
+
+```rust
+self.install(|| indexing::gather(operand, start_indices, config))
+```
+
+to:
+
+```rust
+self.install_with_pool(|buffers| indexing::gather_with_pool(buffers, operand, start_indices, config))
+```
+
+Do the same for `concatenate`.
+
+In `tenferro-tensor/src/cpu/exec_session.rs`, change gather and concatenate
+delegation to call the `*_with_pool` functions with `self.buffers`.
+
+**Step 6: Run tests to verify green**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor reuses_reclaimed_cpu_buffer tensor_index_select tensor_stack_trailing_axis -- --nocapture
+```
+
+Expected: PASS.
+
+**Step 7: Commit**
+
+```bash
+git add tenferro-tensor/src/cpu/mod.rs tenferro-tensor/src/cpu/indexing_alloc.rs tenferro-tensor/src/cpu/indexing.rs tenferro-tensor/src/cpu/backend.rs tenferro-tensor/src/cpu/exec_session.rs tenferro-tensor/src/tests/cpu_tests.rs
+git commit -m "perf: allocate indexing outputs from cpu buffer pool"
+```
+
+---
+
+### Task 7: Documentation And Public Surface Checks
+
+**Files:**
+- Modify: `tenferro/src/lib.rs`
+- Modify: `tenferro-tensor/src/types/shape_packing.rs`
+- Modify: `tenferro/src/shape_packing.rs`
+- Modify: `docs/design/supported-ops.md`
+- Modify if needed: `docs/guides/choosing-an-api.md`
+
+**Step 1: Add or verify rustdoc examples**
+
+Every new public method must have a compiling `# Examples` section:
+
+- `tenferro_tensor::Tensor::index_select`
+- `tenferro_tensor::Tensor::stack`
+- `tenferro::EagerTensor::index_select`
+- `tenferro::EagerTensor::stack`
+- `tenferro::TracedTensor::index_select`
+- `tenferro::TracedTensor::stack`
+
+Examples must run as doctests. Do not use `ignore` or `no_run`.
+
+**Step 2: Update user-facing docs only where appropriate**
+
+If docs mention supported indexing or packing operations, add concise user-facing
+language:
+
+```text
+Use `stack(..., -1)` to create a trailing batch axis and
+`index_select(-1, positions)` to align entries along that axis.
+```
+
+Do not expose internal terms such as `StdTensorOp`, `Fragment`, or `GatherConfig`
+in user-facing docs.
+
+**Step 3: Run targeted tests and doctests**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test -p tenferro-tensor tensor_index_select tensor_stack_trailing_axis reuses_reclaimed_cpu_buffer -- --nocapture
+cargo test -p tenferro index_select stack_trailing_axis -- --nocapture
+cargo test --doc -p tenferro-tensor
+cargo test --doc -p tenferro
+```
+
+Expected: PASS.
+
+If formatting fails, run:
+
+```bash
+cargo fmt --all
+```
+
+Then rerun `cargo fmt --all --check`.
+
+**Step 4: Commit**
+
+```bash
+git add tenferro/src/lib.rs tenferro-tensor/src/types/shape_packing.rs tenferro/src/shape_packing.rs docs/design/supported-ops.md docs/guides/choosing-an-api.md
+git commit -m "docs: document trailing batch index select"
+```
+
+---
+
+### Task 8: Final Verification
+
+**Files:**
+- No code changes expected.
+
+**Step 1: Re-read repository rules**
+
+Run:
+
+```bash
+sed -n '1,260p' REPOSITORY_RULES.md
+```
+
+Check the final diff against the AD rule, documentation, and CPU threading
+contracts.
+
+**Step 2: Run pre-push checks as far as practical**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test --workspace --release
+cargo test --doc --workspace --release
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+```
+
+If time permits and `cargo llvm-cov` is available:
+
+```bash
+cargo llvm-cov --workspace --release --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
+```
+
+Expected: PASS. If any command fails, fix the root cause before marking the
+work complete.
+
+**Step 3: Review final diff**
+
+Run:
+
+```bash
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD
+```
+
+Confirm:
+
+- no `ExtensionOp` was added
+- no new AD rule was added
+- `index_select` lowers through existing `Gather`
+- reverse duplicate accumulation is covered by tests
+- new public APIs have doctest examples
+- no host scalar materialization path was introduced
+
+**Step 4: Commit any final fixes**
+
+If the verification step required changes:
+
+```bash
+git add <changed-files>
+git commit -m "chore: finish issue 856 verification fixes"
+```

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -388,7 +388,9 @@ impl TensorBackend for CpuBackend {
         start_indices: &Tensor,
         config: &GatherConfig,
     ) -> crate::Result<Tensor> {
-        self.install(|| indexing::gather(operand, start_indices, config))
+        self.install_with_pool(|buffers| {
+            indexing::gather_with_pool(buffers, operand, start_indices, config)
+        })
     }
 
     fn scatter(
@@ -428,7 +430,7 @@ impl TensorBackend for CpuBackend {
     }
 
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
-        self.install(|| indexing::try_concatenate(inputs, axis))
+        self.install_with_pool(|buffers| indexing::try_concatenate_with_pool(buffers, inputs, axis))
     }
 
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -210,14 +210,21 @@ impl TensorExec for CpuExecSession<'_> {
     }
 
     // Indexing
-    delegate!(gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) => indexing::gather(operand, start_indices, config));
+    fn gather(
+        &mut self,
+        operand: &Tensor,
+        start_indices: &Tensor,
+        config: &GatherConfig,
+    ) -> crate::Result<Tensor> {
+        indexing::gather_with_pool(self.buffers, operand, start_indices, config)
+    }
     delegate!(scatter(operand: &Tensor, indices: &Tensor, updates: &Tensor, config: &ScatterConfig) => indexing::scatter(operand, indices, updates, config));
     delegate!(slice(input: &Tensor, config: &SliceConfig) => indexing::try_slice(input, config));
     delegate!(dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) => indexing::dynamic_slice(input, starts, slice_sizes));
     delegate!(dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) => indexing::dynamic_update_slice(operand, update, starts));
     delegate!(pad(input: &Tensor, config: &PadConfig) => indexing::try_pad(input, config));
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
-        indexing::try_concatenate(inputs, axis)
+        indexing::try_concatenate_with_pool(self.buffers, inputs, axis)
     }
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         indexing::reverse(input, axes)

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -2,6 +2,8 @@ use std::ops::Add;
 
 use num_traits::Zero;
 
+use super::indexing_alloc::pooled_uninit_tensor;
+use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::config::{GatherConfig, PadConfig, ScatterConfig, SliceConfig};
 use crate::types::{flat_to_multi, Tensor, TypedTensor};
 
@@ -59,12 +61,22 @@ pub fn gather(
     start_indices: &Tensor,
     config: &GatherConfig,
 ) -> crate::Result<Tensor> {
+    let mut buffers = BufferPool::new();
+    gather_with_pool(&mut buffers, operand, start_indices, config)
+}
+
+pub(crate) fn gather_with_pool(
+    buffers: &mut BufferPool,
+    operand: &Tensor,
+    start_indices: &Tensor,
+    config: &GatherConfig,
+) -> crate::Result<Tensor> {
     let start_indices = try_index_tensor(start_indices)?;
     match operand {
-        Tensor::F32(t) => typed_gather(t, &start_indices, config).map(Tensor::F32),
-        Tensor::F64(t) => typed_gather(t, &start_indices, config).map(Tensor::F64),
-        Tensor::C32(t) => typed_gather(t, &start_indices, config).map(Tensor::C32),
-        Tensor::C64(t) => typed_gather(t, &start_indices, config).map(Tensor::C64),
+        Tensor::F32(t) => typed_gather(buffers, t, &start_indices, config).map(Tensor::F32),
+        Tensor::F64(t) => typed_gather(buffers, t, &start_indices, config).map(Tensor::F64),
+        Tensor::C32(t) => typed_gather(buffers, t, &start_indices, config).map(Tensor::C32),
+        Tensor::C64(t) => typed_gather(buffers, t, &start_indices, config).map(Tensor::C64),
         Tensor::I64(_) => Err(crate::Error::BackendFailure {
             op: "gather",
             message: "I64 data tensors are not supported by this operation".into(),
@@ -202,6 +214,15 @@ pub fn concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
 }
 
 pub fn try_concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
+    let mut buffers = BufferPool::new();
+    try_concatenate_with_pool(&mut buffers, inputs, axis)
+}
+
+pub(crate) fn try_concatenate_with_pool(
+    buffers: &mut BufferPool,
+    inputs: &[&Tensor],
+    axis: usize,
+) -> crate::Result<Tensor> {
     let first = inputs
         .first()
         .copied()
@@ -211,19 +232,19 @@ pub fn try_concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>
         })?;
     match first {
         Tensor::F32(t) => Ok(Tensor::F32(typed_concatenate_from_dyn_inputs(
-            t, inputs, axis,
+            buffers, t, inputs, axis,
         )?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_concatenate_from_dyn_inputs(
-            t, inputs, axis,
+            buffers, t, inputs, axis,
         )?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_concatenate_from_dyn_inputs(
-            t, inputs, axis,
+            buffers, t, inputs, axis,
         )?)),
         Tensor::C32(t) => Ok(Tensor::C32(typed_concatenate_from_dyn_inputs(
-            t, inputs, axis,
+            buffers, t, inputs, axis,
         )?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_concatenate_from_dyn_inputs(
-            t, inputs, axis,
+            buffers, t, inputs, axis,
         )?)),
     }
 }
@@ -324,17 +345,18 @@ fn typed_slice<T: Copy + Clone>(
 }
 
 fn typed_concatenate_from_dyn_inputs<T>(
+    buffers: &mut BufferPool,
     _first: &TypedTensor<T>,
     inputs: &[&Tensor],
     axis: usize,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone,
+    T: Copy + Clone + PoolScalar,
     Tensor: TensorAsTyped<T>,
 {
     let first_dtype = inputs[0].dtype();
     let typed_inputs = collect_typed_inputs(first_dtype, inputs)?;
-    typed_concatenate(&typed_inputs, axis)
+    typed_concatenate(buffers, &typed_inputs, axis)
 }
 
 fn collect_typed_inputs<'a, T>(
@@ -356,7 +378,8 @@ where
         .collect()
 }
 
-fn typed_concatenate<T: Copy + Clone>(
+fn typed_concatenate<T: Copy + Clone + PoolScalar>(
+    buffers: &mut BufferPool,
     inputs: &[&TypedTensor<T>],
     axis: usize,
 ) -> crate::Result<TypedTensor<T>> {
@@ -403,7 +426,7 @@ fn typed_concatenate<T: Copy + Clone>(
         .collect();
 
     let out_len: usize = out_shape.iter().product();
-    let mut out_data = Vec::with_capacity(out_len);
+    let mut out = pooled_uninit_tensor(buffers, out_shape.clone());
     let mut out_idx = vec![0usize; rank];
     let mut in_idx = vec![0usize; rank];
 
@@ -425,10 +448,10 @@ fn typed_concatenate<T: Copy + Clone>(
 
         in_idx.copy_from_slice(&out_idx);
         in_idx[axis] -= axis_base;
-        out_data.push(*inputs[input_pos].get(&in_idx));
+        *out.get_mut(&out_idx) = *inputs[input_pos].get(&in_idx);
     }
 
-    Ok(TypedTensor::from_vec(out_shape, out_data))
+    Ok(out)
 }
 
 fn typed_reverse<T: Copy + Clone>(
@@ -667,7 +690,8 @@ fn operand_window_dims(rank: usize, collapsed_or_inserted: &[usize]) -> Vec<usiz
         .collect()
 }
 
-fn typed_gather<T: Copy + Clone + Zero>(
+fn typed_gather<T: Copy + Clone + Zero + PoolScalar>(
+    buffers: &mut BufferPool,
     operand: &TypedTensor<T>,
     start_indices: &IndexTensor,
     config: &GatherConfig,
@@ -803,7 +827,7 @@ fn typed_gather<T: Copy + Clone + Zero>(
         let _ = component;
     }
 
-    let mut out = typed_tensor_uninit(out_shape.clone());
+    let mut out = pooled_uninit_tensor(buffers, out_shape.clone());
     let mut out_idx = vec![0usize; out_rank];
     let mut batch_idx = vec![0usize; batch_shape.len()];
     let mut operand_idx = vec![0usize; rank];

--- a/tenferro-tensor/src/cpu/indexing_alloc.rs
+++ b/tenferro-tensor/src/cpu/indexing_alloc.rs
@@ -1,0 +1,13 @@
+use crate::buffer_pool::{BufferPool, PoolScalar};
+use crate::TypedTensor;
+
+pub(crate) fn pooled_uninit_tensor<T>(buffers: &mut BufferPool, shape: Vec<usize>) -> TypedTensor<T>
+where
+    T: Clone + PoolScalar,
+{
+    let len = shape.iter().product();
+    // SAFETY: callers use this helper only for outputs that are fully written
+    // before any read.
+    let data = unsafe { T::pool_acquire(buffers, len) };
+    TypedTensor::from_vec(shape, data)
+}

--- a/tenferro-tensor/src/cpu/mod.rs
+++ b/tenferro-tensor/src/cpu/mod.rs
@@ -6,6 +6,7 @@ pub mod elementwise;
 mod exec_session;
 pub mod gemm;
 pub mod indexing;
+mod indexing_alloc;
 pub mod linalg;
 pub mod reduction;
 pub mod structural;

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -848,6 +848,65 @@ fn test_reverse_accepts_i64_data_tensor() {
 }
 
 #[test]
+fn tensor_index_select_trailing_axis_returns_expected_values() {
+    let mut backend = CpuBackend::new();
+    let input = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let out = input.index_select(-1, &[2, 0, 2], &mut backend).unwrap();
+
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_f64_close(get_f64(&out, &[0, 0]), 5.0);
+    assert_f64_close(get_f64(&out, &[1, 0]), 6.0);
+    assert_f64_close(get_f64(&out, &[0, 1]), 1.0);
+    assert_f64_close(get_f64(&out, &[1, 1]), 2.0);
+    assert_f64_close(get_f64(&out, &[0, 2]), 5.0);
+    assert_f64_close(get_f64(&out, &[1, 2]), 6.0);
+}
+
+#[test]
+fn tensor_index_select_rejects_invalid_axis_and_position() {
+    let mut backend = CpuBackend::new();
+    let input = Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]);
+
+    let axis_err = input.index_select(-2, &[0], &mut backend).unwrap_err();
+    assert!(axis_err.to_string().contains("index_select"));
+    assert!(axis_err.to_string().contains("axis"));
+
+    let position_err = input.index_select(0, &[3], &mut backend).unwrap_err();
+    assert!(position_err.to_string().contains("index_select"));
+    assert!(position_err.to_string().contains("position"));
+}
+
+#[test]
+fn tensor_stack_trailing_axis_packs_scalars_vectors_and_matrices() {
+    let mut backend = CpuBackend::new();
+
+    let a = Tensor::from_vec(vec![], vec![1.0_f64]);
+    let b = Tensor::from_vec(vec![], vec![2.0_f64]);
+    let scalars = Tensor::stack(&[&a, &b], -1, &mut backend).unwrap();
+    assert_eq!(scalars.shape(), &[2]);
+    assert_eq!(scalars.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+
+    let v0 = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    let v1 = Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]);
+    let vectors = Tensor::stack(&[&v0, &v1], -1, &mut backend).unwrap();
+    assert_eq!(vectors.shape(), &[2, 2]);
+    assert_f64_close(get_f64(&vectors, &[0, 0]), 1.0);
+    assert_f64_close(get_f64(&vectors, &[1, 0]), 2.0);
+    assert_f64_close(get_f64(&vectors, &[0, 1]), 3.0);
+    assert_f64_close(get_f64(&vectors, &[1, 1]), 4.0);
+
+    let m0 = Tensor::from_vec(vec![2, 1], vec![1.0_f64, 2.0]);
+    let m1 = Tensor::from_vec(vec![2, 1], vec![3.0_f64, 4.0]);
+    let matrices = Tensor::stack(&[&m0, &m1], -1, &mut backend).unwrap();
+    assert_eq!(matrices.shape(), &[2, 1, 2]);
+    assert_f64_close(get_f64(&matrices, &[0, 0, 0]), 1.0);
+    assert_f64_close(get_f64(&matrices, &[1, 0, 0]), 2.0);
+    assert_f64_close(get_f64(&matrices, &[0, 0, 1]), 3.0);
+    assert_f64_close(get_f64(&matrices, &[1, 0, 1]), 4.0);
+}
+
+#[test]
 fn test_reverse_axis_out_of_bounds_returns_error() {
     let input = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
     let mut backend = CpuBackend::new();

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -907,6 +907,33 @@ fn tensor_stack_trailing_axis_packs_scalars_vectors_and_matrices() {
 }
 
 #[test]
+fn tensor_index_select_reuses_reclaimed_cpu_buffer() {
+    let mut backend = CpuBackend::new();
+    let reusable = Tensor::from_vec(vec![2, 3], vec![0.0_f64; 6]);
+    let expected_ptr = reusable.as_slice::<f64>().unwrap().as_ptr();
+    backend.reclaim_buffer(reusable);
+
+    let input = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let out = input.index_select(-1, &[2, 0, 1], &mut backend).unwrap();
+
+    assert_eq!(out.as_slice::<f64>().unwrap().as_ptr(), expected_ptr);
+}
+
+#[test]
+fn tensor_stack_reuses_reclaimed_cpu_buffer() {
+    let mut backend = CpuBackend::new();
+    let reusable = Tensor::from_vec(vec![2, 2], vec![0.0_f64; 4]);
+    let expected_ptr = reusable.as_slice::<f64>().unwrap().as_ptr();
+    backend.reclaim_buffer(reusable);
+
+    let x0 = Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    let x1 = Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]);
+    let out = Tensor::stack(&[&x0, &x1], -1, &mut backend).unwrap();
+
+    assert_eq!(out.as_slice::<f64>().unwrap().as_ptr(), expected_ptr);
+}
+
+#[test]
 fn test_reverse_axis_out_of_bounds_returns_error() {
     let input = Tensor::F64(TypedTensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]));
     let mut backend = CpuBackend::new();

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -4,6 +4,7 @@ use num_traits::{One, Zero};
 use crate::{DotGeneralConfig, TensorBackend};
 
 mod accessors;
+mod shape_packing;
 
 /// Memory location for tensor storage.
 ///

--- a/tenferro-tensor/src/types/shape_packing.rs
+++ b/tenferro-tensor/src/types/shape_packing.rs
@@ -1,0 +1,152 @@
+use crate::{GatherConfig, TensorBackend};
+
+use super::{Tensor, TypedTensor};
+
+fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> crate::Result<usize> {
+    let normalized = if axis < 0 { rank as isize + axis } else { axis };
+    if normalized < 0 || normalized >= rank as isize {
+        return Err(crate::Error::AxisOutOfBounds {
+            op,
+            axis: axis.unsigned_abs(),
+            rank,
+        });
+    }
+    Ok(normalized as usize)
+}
+
+fn normalize_insert_axis(op: &'static str, axis: isize, rank: usize) -> crate::Result<usize> {
+    let normalized = if axis < 0 {
+        rank as isize + 1 + axis
+    } else {
+        axis
+    };
+    if normalized < 0 || normalized > rank as isize {
+        return Err(crate::Error::AxisOutOfBounds {
+            op,
+            axis: axis.unsigned_abs(),
+            rank: rank + 1,
+        });
+    }
+    Ok(normalized as usize)
+}
+
+fn index_select_parts(
+    shape: &[usize],
+    axis: isize,
+    positions: &[usize],
+) -> crate::Result<(Tensor, GatherConfig)> {
+    let axis = normalize_existing_axis("index_select", axis, shape.len())?;
+    let axis_extent = shape[axis];
+    for &position in positions {
+        if position >= axis_extent {
+            return Err(crate::Error::InvalidConfig {
+                op: "index_select",
+                message: format!(
+                    "position {position} out of bounds for axis {axis} with extent {axis_extent}"
+                ),
+            });
+        }
+    }
+
+    let mut slice_sizes = shape.to_vec();
+    slice_sizes[axis] = 1;
+
+    let offset_dims = (0..shape.len()).filter(|&dim| dim != axis).collect();
+    let index_data = positions
+        .iter()
+        .map(|&position| {
+            i64::try_from(position).map_err(|_| crate::Error::InvalidConfig {
+                op: "index_select",
+                message: format!("position {position} cannot be represented as i64"),
+            })
+        })
+        .collect::<crate::Result<Vec<_>>>()?;
+    let indices = Tensor::I64(TypedTensor::from_vec(vec![positions.len(), 1], index_data));
+
+    let config = GatherConfig {
+        offset_dims,
+        collapsed_slice_dims: vec![axis],
+        start_index_map: vec![axis],
+        index_vector_dim: 1,
+        slice_sizes,
+    };
+
+    Ok((indices, config))
+}
+
+impl Tensor {
+    /// Select entries from one axis using host-known positions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{cpu::CpuBackend, Tensor};
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]);
+    /// let y = x.index_select(-1, &[2, 0], &mut backend).unwrap();
+    ///
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[30.0, 10.0]);
+    /// ```
+    pub fn index_select(
+        &self,
+        axis: isize,
+        positions: &[usize],
+        ctx: &mut impl TensorBackend,
+    ) -> crate::Result<Self> {
+        let (indices, config) = index_select_parts(self.shape(), axis, positions)?;
+        ctx.with_exec_session(|exec| exec.gather(self, &indices, &config))
+    }
+
+    /// Stack tensors along a newly inserted axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{cpu::CpuBackend, Tensor};
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec(vec![], vec![1.0_f64]);
+    /// let b = Tensor::from_vec(vec![], vec![2.0_f64]);
+    /// let out = Tensor::stack(&[&a, &b], -1, &mut backend).unwrap();
+    ///
+    /// assert_eq!(out.shape(), &[2]);
+    /// assert_eq!(out.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    pub fn stack(
+        tensors: &[&Self],
+        dim: isize,
+        ctx: &mut impl TensorBackend,
+    ) -> crate::Result<Self> {
+        let first = tensors
+            .first()
+            .copied()
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "stack",
+                message: "stack requires at least one input".into(),
+            })?;
+        let axis = normalize_insert_axis("stack", dim, first.shape().len())?;
+
+        for tensor in tensors.iter().copied().skip(1) {
+            if tensor.shape() != first.shape() {
+                return Err(crate::Error::ShapeMismatch {
+                    op: "stack",
+                    lhs: first.shape().to_vec(),
+                    rhs: tensor.shape().to_vec(),
+                });
+            }
+        }
+
+        let mut expanded_shape = first.shape().to_vec();
+        expanded_shape.insert(axis, 1);
+
+        ctx.with_exec_session(|exec| {
+            let mut expanded = Vec::with_capacity(tensors.len());
+            for tensor in tensors {
+                expanded.push(exec.reshape(tensor, &expanded_shape)?);
+            }
+            let refs = expanded.iter().collect::<Vec<_>>();
+            exec.concatenate(&refs, axis)
+        })
+    }
+}

--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -7,7 +7,7 @@ use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_tensor::cpu::CpuBackend;
-use tenferro_tensor::{Tensor, TensorBackend};
+use tenferro_tensor::{Tensor, TensorBackend, TypedTensor};
 use tidu::{
     topo_sort_grad_dag, try_backward_dag, BackwardCallbacks, EagerOutput, EagerValue, GradNode,
     LinearFragment,
@@ -759,13 +759,14 @@ pub(crate) fn exec_single_output<B: TensorBackend>(
     Ok(outputs.remove(0))
 }
 
-pub(crate) fn zero_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor {
-    let neg = input
-        .neg(backend)
-        .unwrap_or_else(|err| panic!("zero_like neg failed: {}", err));
-    input
-        .add(&neg, backend)
-        .unwrap_or_else(|err| panic!("zero_like add failed: {}", err))
+pub(crate) fn zero_like_tensor<B: TensorBackend>(input: &Tensor, _backend: &mut B) -> Tensor {
+    match input {
+        Tensor::F32(tensor) => Tensor::F32(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::F64(tensor) => Tensor::F64(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::I64(tensor) => Tensor::I64(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::C32(tensor) => Tensor::C32(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::C64(tensor) => Tensor::C64(TypedTensor::zeros(tensor.shape.clone())),
+    }
 }
 
 pub(crate) fn one_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor {

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -159,8 +159,7 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
                 unreachable!("NaryEinsum is handled before opening an exec session")
             }
             StdTensorOp::Gather(config) => {
-                let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.gather(&a, &b, config)?]
+                vec![exec.gather(inputs[0], inputs[1], config)?]
             }
             StdTensorOp::GatherDynamicSliceSizes {
                 offset_dims,
@@ -177,22 +176,18 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
                     index_vector_dim: *index_vector_dim,
                     slice_sizes,
                 };
-                let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.gather(&a, &b, &config)?]
+                vec![exec.gather(inputs[0], inputs[1], &config)?]
             }
             StdTensorOp::Scatter(config) => {
-                let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                let (a, c) = promote_binary(exec, &a, inputs[2], op)?;
-                vec![exec.scatter(&a, &b, &c, config)?]
+                let (operand, updates) = promote_binary(exec, inputs[0], inputs[2], op)?;
+                vec![exec.scatter(&operand, inputs[1], &updates, config)?]
             }
             StdTensorOp::DynamicSlice { slice_sizes } => {
-                let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.dynamic_slice(&a, &b, slice_sizes)?]
+                vec![exec.dynamic_slice(inputs[0], inputs[1], slice_sizes)?]
             }
             StdTensorOp::DynamicUpdateSlice => {
-                let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                let (a, c) = promote_binary(exec, &a, inputs[2], op)?;
-                vec![exec.dynamic_update_slice(&a, &b, &c)?]
+                let (operand, update) = promote_binary(exec, inputs[0], inputs[1], op)?;
+                vec![exec.dynamic_update_slice(&operand, &update, inputs[2])?]
             }
             StdTensorOp::Cholesky { .. } => vec![exec.cholesky(inputs[0])?],
             StdTensorOp::TriangularSolve {

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -36,6 +36,7 @@ mod metadata;
 mod scalar_semantics;
 pub mod segment;
 pub mod shape_infer;
+mod shape_packing;
 pub mod sym_dim;
 pub mod traced;
 

--- a/tenferro/src/shape_infer.rs
+++ b/tenferro/src/shape_infer.rs
@@ -116,8 +116,6 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         | StdTensorOp::NaryEinsum { .. }
         | StdTensorOp::TriangularSolve { .. }
         | StdTensorOp::FullPivLuSolve { .. }
-        | StdTensorOp::DynamicSlice { .. }
-        | StdTensorOp::DynamicUpdateSlice
         | StdTensorOp::Concatenate { .. }
         | StdTensorOp::PadToMatch { .. }
         | StdTensorOp::DynamicTruncate { .. }
@@ -125,10 +123,8 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         StdTensorOp::Div | StdTensorOp::Pow => {
             promote_dtype_div_like(input_dtypes[0], input_dtypes[1])
         }
-        StdTensorOp::Scatter(_) => promote_dtype(
-            promote_dtype(input_dtypes[0], input_dtypes[1]),
-            input_dtypes[2],
-        ),
+        StdTensorOp::Scatter(_) => promote_dtype(input_dtypes[0], input_dtypes[2]),
+        StdTensorOp::DynamicUpdateSlice => promote_dtype(input_dtypes[0], input_dtypes[1]),
         // Unary / structural — output dtype equals input dtype.
         StdTensorOp::Neg
         | StdTensorOp::Conj
@@ -156,6 +152,7 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         | StdTensorOp::Triu { .. }
         | StdTensorOp::Gather(_)
         | StdTensorOp::GatherDynamicSliceSizes { .. }
+        | StdTensorOp::DynamicSlice { .. }
         | StdTensorOp::Slice(_)
         | StdTensorOp::Pad(_)
         | StdTensorOp::Reverse { .. }

--- a/tenferro/src/shape_packing.rs
+++ b/tenferro/src/shape_packing.rs
@@ -1,0 +1,340 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use computegraph::fragment::FragmentBuilder;
+use computegraph::types::{OpMode, ValRef};
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_tensor::{GatherConfig, Tensor, TensorBackend, TypedTensor};
+
+use crate::checkpoint::CheckpointNode;
+use crate::eager::EagerTensor;
+use crate::error::{Error, Result};
+use crate::metadata::{metadata_scopes_with_new, register_scoped_fragment_metadata};
+use crate::shape_infer::promote_dtypes;
+use crate::sym_dim::SymDim;
+use crate::traced::{apply_binary_preserve_input_dtypes, next_traced_id, try_concrete_shape};
+use crate::TracedTensor;
+
+fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
+    let normalized = if axis < 0 { rank as isize + axis } else { axis };
+    if normalized < 0 || normalized >= rank as isize {
+        return Err(tenferro_tensor::Error::AxisOutOfBounds {
+            op,
+            axis: axis.unsigned_abs(),
+            rank,
+        }
+        .into());
+    }
+    Ok(normalized as usize)
+}
+
+fn normalize_insert_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
+    let normalized = if axis < 0 {
+        rank as isize + 1 + axis
+    } else {
+        axis
+    };
+    if normalized < 0 || normalized > rank as isize {
+        return Err(tenferro_tensor::Error::AxisOutOfBounds {
+            op,
+            axis: axis.unsigned_abs(),
+            rank: rank + 1,
+        }
+        .into());
+    }
+    Ok(normalized as usize)
+}
+
+fn index_select_config(
+    shape: &[usize],
+    axis: isize,
+    positions: &[usize],
+) -> Result<(Tensor, GatherConfig, Vec<usize>)> {
+    let axis = normalize_existing_axis("index_select", axis, shape.len())?;
+    let axis_extent = shape[axis];
+    for &position in positions {
+        if position >= axis_extent {
+            return Err(tenferro_tensor::Error::InvalidConfig {
+                op: "index_select",
+                message: format!(
+                    "position {position} out of bounds for axis {axis} with extent {axis_extent}"
+                ),
+            }
+            .into());
+        }
+    }
+
+    let mut out_shape = shape.to_vec();
+    out_shape[axis] = positions.len();
+
+    let mut slice_sizes = shape.to_vec();
+    slice_sizes[axis] = 1;
+
+    let offset_dims = (0..shape.len()).filter(|&dim| dim != axis).collect();
+    let index_data = positions
+        .iter()
+        .map(|&position| {
+            i64::try_from(position).map_err(|_| tenferro_tensor::Error::InvalidConfig {
+                op: "index_select",
+                message: format!("position {position} cannot be represented as i64"),
+            })
+        })
+        .collect::<tenferro_tensor::Result<Vec<_>>>()?;
+    let indices = Tensor::I64(TypedTensor::from_vec(vec![positions.len(), 1], index_data));
+
+    let config = GatherConfig {
+        offset_dims,
+        collapsed_slice_dims: vec![axis],
+        start_index_map: vec![axis],
+        index_vector_dim: 1,
+        slice_sizes,
+    };
+
+    Ok((indices, config, out_shape))
+}
+
+fn validate_stack_shapes(op: &'static str, shapes: &[&[usize]]) -> Result<()> {
+    let Some(first) = shapes.first() else {
+        return Err(tenferro_tensor::Error::InvalidConfig {
+            op,
+            message: "stack requires at least one input".into(),
+        }
+        .into());
+    };
+    for shape in shapes.iter().skip(1) {
+        if *shape != *first {
+            return Err(tenferro_tensor::Error::ShapeMismatch {
+                op,
+                lhs: first.to_vec(),
+                rhs: shape.to_vec(),
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+impl<B: TensorBackend> EagerTensor<B> {
+    /// Select entries from one axis using host-known positions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]),
+    ///     ctx,
+    /// );
+    /// let y = x.index_select(-1, &[2, 0]).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[30.0, 10.0]);
+    /// ```
+    pub fn index_select(&self, axis: isize, positions: &[usize]) -> Result<Self> {
+        let (indices, config, _) = index_select_config(self.data().shape(), axis, positions)?;
+        let indices = self.ctx.constant_from(indices);
+        self.gather(&indices, config)
+    }
+
+    /// Stack tensors along a newly inserted axis.
+    ///
+    /// The returned tensor uses the context of the first input, matching
+    /// [`Self::concatenate`]. All inputs must belong to that same context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![], vec![1.0_f64]), ctx.clone());
+    /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![], vec![2.0_f64]), ctx);
+    /// let out = EagerTensor::stack(&[&a, &b], -1).unwrap();
+    ///
+    /// assert_eq!(out.data().shape(), &[2]);
+    /// assert_eq!(out.data().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    pub fn stack(tensors: &[&Self], dim: isize) -> Result<Self> {
+        let first = tensors.first().copied().ok_or_else(|| {
+            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+                op: "stack",
+                message: "stack requires at least one input".into(),
+            })
+        })?;
+        let shapes = tensors
+            .iter()
+            .map(|tensor| tensor.data().shape())
+            .collect::<Vec<_>>();
+        validate_stack_shapes("stack", &shapes)?;
+
+        let axis = normalize_insert_axis("stack", dim, first.data().shape().len())?;
+        let mut expanded_shape = first.data().shape().to_vec();
+        expanded_shape.insert(axis, 1);
+
+        let expanded = tensors
+            .iter()
+            .map(|tensor| tensor.reshape(&expanded_shape))
+            .collect::<Result<Vec<_>>>()?;
+        let refs = expanded.iter().collect::<Vec<_>>();
+        Self::concatenate(&refs, axis)
+    }
+}
+
+impl TracedTensor {
+    /// Select entries from one axis using host-known positions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine, Tensor, TracedTensor};
+    ///
+    /// let x = TracedTensor::from_tensor_concrete_shape(
+    ///     Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]),
+    /// );
+    /// let mut y = x.index_select(-1, &[2, 0]).unwrap();
+    /// let mut engine = Engine::new(CpuBackend::new());
+    ///
+    /// assert_eq!(
+    ///     y.eval(&mut engine).unwrap().as_slice::<f64>().unwrap(),
+    ///     &[30.0, 10.0],
+    /// );
+    /// ```
+    pub fn index_select(&self, axis: isize, positions: &[usize]) -> Result<Self> {
+        let shape = try_concrete_shape(self).ok_or_else(|| {
+            Error::Internal("index_select currently requires a concrete shape hint".into())
+        })?;
+        let (indices_tensor, config, out_shape) = index_select_config(&shape, axis, positions)?;
+        let indices = TracedTensor::from_tensor_concrete_shape(indices_tensor);
+        Ok(apply_binary_preserve_input_dtypes(
+            StdTensorOp::Gather(config),
+            self,
+            &indices,
+            out_shape.len(),
+            Some(out_shape.into_iter().map(SymDim::from).collect()),
+            self.dtype,
+        ))
+    }
+
+    /// Stack tensors along a newly inserted axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine, Tensor, TracedTensor};
+    ///
+    /// let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(vec![], vec![1.0_f64]));
+    /// let b = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(vec![], vec![2.0_f64]));
+    /// let mut out = TracedTensor::stack(&[&a, &b], -1).unwrap();
+    /// let mut engine = Engine::new(CpuBackend::new());
+    ///
+    /// assert_eq!(
+    ///     out.eval(&mut engine).unwrap().as_slice::<f64>().unwrap(),
+    ///     &[1.0, 2.0],
+    /// );
+    /// ```
+    pub fn stack(tensors: &[&Self], dim: isize) -> Result<Self> {
+        let first = tensors.first().copied().ok_or_else(|| {
+            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+                op: "stack",
+                message: "stack requires at least one input".into(),
+            })
+        })?;
+        let first_shape = try_concrete_shape(first).ok_or_else(|| {
+            Error::Internal("stack currently requires concrete shape hints".into())
+        })?;
+        let mut shapes = Vec::with_capacity(tensors.len());
+        shapes.push(first_shape.as_slice());
+        let mut owned_shapes = Vec::with_capacity(tensors.len().saturating_sub(1));
+        for tensor in tensors.iter().copied().skip(1) {
+            owned_shapes.push(try_concrete_shape(tensor).ok_or_else(|| {
+                Error::Internal("stack currently requires concrete shape hints".into())
+            })?);
+        }
+        shapes.extend(owned_shapes.iter().map(Vec::as_slice));
+        validate_stack_shapes("stack", &shapes)?;
+
+        let axis = normalize_insert_axis("stack", dim, first.rank)?;
+        let mut expanded_shape = first_shape;
+        expanded_shape.insert(axis, 1);
+        let mut out_shape = expanded_shape.clone();
+        out_shape[axis] = tensors.len();
+        let expanded = tensors
+            .iter()
+            .map(|tensor| tensor.reshape(&expanded_shape))
+            .collect::<Vec<_>>();
+        let refs = expanded.iter().collect::<Vec<_>>();
+        Ok(apply_nary_concatenate(&refs, axis, out_shape))
+    }
+}
+
+fn apply_nary_concatenate(
+    tensors: &[&TracedTensor],
+    axis: usize,
+    out_shape: Vec<usize>,
+) -> TracedTensor {
+    let out_dtype = promote_dtypes(tensors.iter().map(|tensor| tensor.dtype));
+    let tensors = tensors
+        .iter()
+        .map(|tensor| {
+            if tensor.dtype != out_dtype {
+                tensor.convert(out_dtype)
+            } else {
+                (*tensor).clone()
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut builder = FragmentBuilder::new();
+    for tensor in &tensors {
+        builder.add_parent(tensor.fragment.clone());
+    }
+    let input_refs = tensors
+        .iter()
+        .map(|tensor| ValRef::External(tensor.fragment.vals()[tensor.val].key.clone()))
+        .collect::<Vec<_>>();
+    let outputs = builder.add_op(
+        StdTensorOp::Concatenate {
+            axis,
+            n_inputs: tensors.len(),
+        },
+        input_refs,
+        OpMode::Primal,
+    );
+    builder.set_outputs(outputs.clone());
+    let fragment = Arc::new(builder.build());
+    let metadata_scope = register_scoped_fragment_metadata(fragment.as_ref(), std::iter::empty());
+
+    let mut inputs_map = HashMap::new();
+    let mut extra_roots = Vec::new();
+    let mut checkpoint_chain = None;
+    for tensor in &tensors {
+        inputs_map.extend(
+            tensor
+                .inputs_map
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone())),
+        );
+        extra_roots.extend(tensor.extra_roots.iter().cloned());
+        checkpoint_chain =
+            CheckpointNode::merge_chains(checkpoint_chain, tensor.checkpoint_chain.clone());
+    }
+    let inherited_scopes = tensors
+        .iter()
+        .map(|tensor| tensor.metadata_scopes.as_slice())
+        .collect::<Vec<_>>();
+
+    TracedTensor {
+        id: next_traced_id(),
+        rank: out_shape.len(),
+        dtype: out_dtype,
+        fragment,
+        val: outputs[0],
+        data: None,
+        shape_hint: Some(out_shape.into_iter().map(SymDim::from).collect()),
+        inputs_map: Arc::new(inputs_map),
+        extra_roots,
+        checkpoint_chain,
+        metadata_scopes: metadata_scopes_with_new(metadata_scope, inherited_scopes),
+    }
+}

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -2095,6 +2095,28 @@ pub(crate) fn apply_binary(
         rhs.clone()
     };
 
+    apply_binary_with_output_dtype(op, &lhs, &rhs, out_rank, out_shape_hint, out_dtype)
+}
+
+pub(crate) fn apply_binary_preserve_input_dtypes(
+    op: StdTensorOp,
+    lhs: &TracedTensor,
+    rhs: &TracedTensor,
+    out_rank: usize,
+    out_shape_hint: Option<Vec<SymDim>>,
+    out_dtype: DType,
+) -> TracedTensor {
+    apply_binary_with_output_dtype(op, lhs, rhs, out_rank, out_shape_hint, out_dtype)
+}
+
+fn apply_binary_with_output_dtype(
+    op: StdTensorOp,
+    lhs: &TracedTensor,
+    rhs: &TracedTensor,
+    out_rank: usize,
+    out_shape_hint: Option<Vec<SymDim>>,
+    out_dtype: DType,
+) -> TracedTensor {
     let lhs_ref = ValRef::External(lhs.fragment.vals()[lhs.val].key.clone());
     let rhs_ref = ValRef::External(rhs.fragment.vals()[rhs.val].key.clone());
 

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -3167,6 +3167,33 @@ fn grad_gather_reduce_sum_accumulates_indices_correctly() {
     assert_close_slice(get_f64_data(&grad), &[1.0, 0.0, 3.0, 0.0, 1.0]);
 }
 
+#[test]
+fn grad_traced_index_select_repeated_positions_accumulates() {
+    let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
+    let weights =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![10.0, 20.0, 30.0]));
+
+    let selected = x.index_select(0, &[1, 1, 2]).unwrap();
+    let loss = (&selected * &weights).reduce_sum(&[0]);
+    let grad = eval_tensor(loss.grad(&x).unwrap());
+
+    assert_eq!(grad.shape(), &[3]);
+    assert_close_slice(get_f64_data(&grad), &[0.0, 30.0, 30.0]);
+}
+
+#[test]
+fn jvp_traced_index_select_gathers_tangent() {
+    let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]));
+    let tangent =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![0.5, 1.5, 2.5, 3.5]));
+
+    let y = x.index_select(0, &[3, 1, 3]).unwrap();
+    let tangent_y = eval_tensor(y.jvp(&x, &tangent));
+
+    assert_eq!(tangent_y.shape(), &[3]);
+    assert_close_slice(get_f64_data(&tangent_y), &[3.5, 1.5, 3.5]);
+}
+
 /// Build `y = ReduceSum(Scatter(operand, indices, updates, config))`,
 /// where the Scatter output has the same shape as `operand`.
 fn build_scatter_reduce_sum_fragment(

--- a/tenferro/tests/dtype_propagation.rs
+++ b/tenferro/tests/dtype_propagation.rs
@@ -1,7 +1,7 @@
 use tenferro::shape_infer::infer_output_dtype;
 use tenferro::{eig, Tensor, TracedTensor, TypedTensor};
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_tensor::{DType, DotGeneralConfig};
+use tenferro_tensor::{DType, DotGeneralConfig, GatherConfig, ScatterConfig};
 
 #[test]
 fn test_add_preserves_f32() {
@@ -90,6 +90,48 @@ fn test_dot_general_preserves_lhs_dtype() {
     };
     assert_eq!(
         infer_output_dtype(&op, &[DType::F32, DType::F32]),
+        DType::F32
+    );
+}
+
+#[test]
+fn test_indexing_dtype_inference_ignores_index_operands() {
+    let gather = StdTensorOp::Gather(GatherConfig {
+        offset_dims: vec![],
+        collapsed_slice_dims: vec![0],
+        start_index_map: vec![0],
+        index_vector_dim: 1,
+        slice_sizes: vec![1],
+    });
+    assert_eq!(
+        infer_output_dtype(&gather, &[DType::C64, DType::I64]),
+        DType::C64
+    );
+
+    let dynamic_slice = StdTensorOp::DynamicSlice {
+        slice_sizes: vec![1],
+    };
+    assert_eq!(
+        infer_output_dtype(&dynamic_slice, &[DType::F32, DType::I64]),
+        DType::F32
+    );
+
+    let scatter = StdTensorOp::Scatter(ScatterConfig {
+        update_window_dims: vec![],
+        inserted_window_dims: vec![0],
+        scatter_dims_to_operand_dims: vec![0],
+        index_vector_dim: 1,
+    });
+    assert_eq!(
+        infer_output_dtype(&scatter, &[DType::F32, DType::I64, DType::F32]),
+        DType::F32
+    );
+
+    assert_eq!(
+        infer_output_dtype(
+            &StdTensorOp::DynamicUpdateSlice,
+            &[DType::F32, DType::F32, DType::I64],
+        ),
         DType::F32
     );
 }

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -179,6 +179,27 @@ fn eager_stack_trailing_axis_and_index_select_primal() {
 }
 
 #[test]
+fn eager_index_select_repeated_positions_accumulates_grad() {
+    let ctx = test_ctx();
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        ctx.clone(),
+    );
+    let weights =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]), ctx);
+
+    let selected = x.index_select(0, &[1, 1, 2]).unwrap();
+    let loss = (&selected * &weights).reduce_sum(&[0]).unwrap();
+    let _ = loss.backward().unwrap();
+
+    assert_close_slice(
+        f64_data(x.grad().unwrap().as_ref()),
+        &[0.0, 30.0, 30.0],
+        TOL,
+    );
+}
+
+#[test]
 fn eager_x_squared_gradient_matches_finite_difference() {
     let x_data = vec![1.0, 2.0, 3.0];
     let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], x_data.clone()), test_ctx());

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -179,6 +179,45 @@ fn eager_stack_trailing_axis_and_index_select_primal() {
 }
 
 #[test]
+fn eager_index_select_rejects_invalid_axis_and_position() {
+    let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), test_ctx());
+
+    let axis_err = x.index_select(1, &[0]).err().unwrap().to_string();
+    assert!(axis_err.contains("index_select"), "got: {axis_err}");
+    assert!(axis_err.contains("axis"), "got: {axis_err}");
+
+    let position_err = x.index_select(0, &[2]).err().unwrap().to_string();
+    assert!(position_err.contains("index_select"), "got: {position_err}");
+    assert!(
+        position_err.contains("position 2 out of bounds"),
+        "got: {position_err}"
+    );
+}
+
+#[test]
+fn eager_stack_rejects_empty_mismatched_shapes_and_invalid_axis() {
+    let empty: [&EagerTensor<CpuBackend>; 0] = [];
+    let empty_err = EagerTensor::stack(&empty, 0).err().unwrap().to_string();
+    assert!(empty_err.contains("stack requires at least one input"));
+
+    let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), test_ctx());
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3], vec![3.0_f64, 4.0, 5.0]),
+        test_ctx(),
+    );
+    let shape_err = EagerTensor::stack(&[&a, &b], -1).err().unwrap().to_string();
+    assert!(shape_err.contains("shape mismatch"), "got: {shape_err}");
+
+    let axis_err = EagerTensor::stack(&[&a], 2).err().unwrap().to_string();
+    assert!(axis_err.contains("axis"), "got: {axis_err}");
+
+    let c = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), test_ctx());
+    let out = EagerTensor::stack(&[&a, &c], 0).unwrap();
+    assert_eq!(out.data().shape(), &[2, 2]);
+    assert_close_slice(f64_data(out.data()), &[1.0, 3.0, 2.0, 4.0], TOL);
+}
+
+#[test]
 fn eager_index_select_repeated_positions_accumulates_grad() {
     let ctx = test_ctx();
     let x = EagerTensor::requires_grad_in(

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -140,6 +140,45 @@ fn eager_gather_keeps_indices_integer_for_complex_operand() {
 }
 
 #[test]
+fn eager_index_select_keeps_indices_integer_for_complex_operand() {
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(
+            vec![3],
+            vec![
+                Complex64::new(1.0, 1.0),
+                Complex64::new(2.0, -1.0),
+                Complex64::new(3.0, 0.5),
+            ],
+        ),
+        test_ctx(),
+    );
+
+    let y = x.index_select(-1, &[2, 0]).unwrap();
+
+    assert_eq!(y.data().shape(), &[2]);
+    assert_eq!(
+        c64_data(y.data()),
+        &[Complex64::new(3.0, 0.5), Complex64::new(1.0, 1.0)]
+    );
+}
+
+#[test]
+fn eager_stack_trailing_axis_and_index_select_primal() {
+    let x0 = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), test_ctx());
+    let x1 = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), test_ctx());
+
+    let stacked = EagerTensor::stack(&[&x0, &x1], -1).unwrap();
+    let selected = stacked.index_select(-1, &[1, 0, 1]).unwrap();
+
+    assert_eq!(selected.data().shape(), &[2, 3]);
+    assert_close_slice(
+        f64_data(selected.data()),
+        &[3.0, 4.0, 1.0, 2.0, 3.0, 4.0],
+        TOL,
+    );
+}
+
+#[test]
 fn eager_x_squared_gradient_matches_finite_difference() {
     let x_data = vec![1.0, 2.0, 3.0];
     let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], x_data.clone()), test_ctx());

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -104,6 +104,42 @@ fn row_major_eager_input_uses_logical_shape_and_values() {
 }
 
 #[test]
+fn eager_gather_keeps_indices_integer_for_complex_operand() {
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(
+            vec![3],
+            vec![
+                Complex64::new(1.0, 1.0),
+                Complex64::new(2.0, -1.0),
+                Complex64::new(3.0, 0.5),
+            ],
+        ),
+        test_ctx(),
+    );
+    let indices =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![2_i64, 0]), test_ctx());
+
+    let y = x
+        .gather(
+            &indices,
+            GatherConfig {
+                offset_dims: vec![],
+                collapsed_slice_dims: vec![0],
+                start_index_map: vec![0],
+                index_vector_dim: 1,
+                slice_sizes: vec![1],
+            },
+        )
+        .unwrap();
+
+    assert_eq!(y.data().shape(), &[2]);
+    assert_eq!(
+        c64_data(y.data()),
+        &[Complex64::new(3.0, 0.5), Complex64::new(1.0, 1.0)]
+    );
+}
+
+#[test]
 fn eager_x_squared_gradient_matches_finite_difference() {
     let x_data = vec![1.0, 2.0, 3.0];
     let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], x_data.clone()), test_ctx());

--- a/tenferro/tests/primitive_ops.rs
+++ b/tenferro/tests/primitive_ops.rs
@@ -190,6 +190,60 @@ fn test_reshape() {
 }
 
 #[test]
+fn traced_index_select_keeps_indices_integer_for_complex_operand() {
+    use num_complex::Complex64;
+
+    let x = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(
+        vec![3],
+        vec![
+            Complex64::new(1.0, 1.0),
+            Complex64::new(2.0, -1.0),
+            Complex64::new(3.0, 0.5),
+        ],
+    ));
+    let mut y = x.index_select(-1, &[2, 0]).unwrap();
+    let mut engine = Engine::new(CpuBackend::new());
+    let out = y.eval(&mut engine).unwrap();
+
+    assert_eq!(out.shape(), &[2]);
+    assert_eq!(
+        out.as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(3.0, 0.5), Complex64::new(1.0, 1.0)]
+    );
+}
+
+#[test]
+fn traced_stack_trailing_axis_and_index_select_feed_batched_dot_general() {
+    let a0 =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
+    let a1 =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]));
+    let b0 = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![2.0, 3.0]));
+    let b1 = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![4.0, 5.0]));
+
+    let a = TracedTensor::stack(&[&a0, &a1], -1).unwrap();
+    let b = TracedTensor::stack(&[&b0, &b1], -1)
+        .unwrap()
+        .index_select(-1, &[1, 0])
+        .unwrap();
+    let mut c = a.dot_general(
+        &b,
+        DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![2],
+            rhs_batch_dims: vec![2],
+        },
+    );
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let out = c.eval(&mut engine).unwrap();
+
+    assert_eq!(out.shape(), &[2, 1, 2]);
+    assert_eq!(get_f64_data(out), &[19.0, 28.0, 31.0, 36.0]);
+}
+
+#[test]
 fn test_eval_all() {
     let a = f64_tensor(vec![2], vec![1.0, 2.0]);
     let b = f64_tensor(vec![2], vec![3.0, 4.0]);

--- a/tenferro/tests/primitive_ops.rs
+++ b/tenferro/tests/primitive_ops.rs
@@ -1,6 +1,7 @@
 use tenferro::engine::Engine;
 use tenferro::pow;
 use tenferro::traced::{eval_all, TracedTensor};
+use tenferro::DType;
 use tenferro_tensor::cpu::CpuBackend;
 use tenferro_tensor::{DotGeneralConfig, Tensor, TypedTensor};
 
@@ -241,6 +242,79 @@ fn traced_stack_trailing_axis_and_index_select_feed_batched_dot_general() {
 
     assert_eq!(out.shape(), &[2, 1, 2]);
     assert_eq!(get_f64_data(out), &[19.0, 28.0, 31.0, 36.0]);
+}
+
+#[test]
+fn traced_index_select_rejects_invalid_axis_position_and_symbolic_shape() {
+    let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![1.0, 2.0]));
+
+    let axis_err = x.index_select(1, &[0]).err().unwrap().to_string();
+    assert!(axis_err.contains("index_select"), "got: {axis_err}");
+    assert!(axis_err.contains("axis"), "got: {axis_err}");
+
+    let position_err = x.index_select(0, &[2]).err().unwrap().to_string();
+    assert!(
+        position_err.contains("position 2 out of bounds"),
+        "got: {position_err}"
+    );
+
+    let symbolic = TracedTensor::input_symbolic_shape(DType::F64, 1);
+    let shape_err = symbolic.index_select(0, &[0]).err().unwrap().to_string();
+    assert!(
+        shape_err.contains("concrete shape hint"),
+        "got: {shape_err}"
+    );
+}
+
+#[test]
+fn traced_stack_rejects_empty_mismatched_invalid_axis_and_symbolic_shapes() {
+    let empty: [&TracedTensor; 0] = [];
+    let empty_err = TracedTensor::stack(&empty, 0).err().unwrap().to_string();
+    assert!(empty_err.contains("stack requires at least one input"));
+
+    let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![1.0, 2.0]));
+    let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![3.0, 4.0, 5.0]));
+    let shape_err = TracedTensor::stack(&[&a, &b], -1)
+        .err()
+        .unwrap()
+        .to_string();
+    assert!(shape_err.contains("shape mismatch"), "got: {shape_err}");
+
+    let axis_err = TracedTensor::stack(&[&a], 2).err().unwrap().to_string();
+    assert!(axis_err.contains("axis"), "got: {axis_err}");
+
+    let symbolic_first = TracedTensor::input_symbolic_shape(DType::F64, 1);
+    let first_shape_err = TracedTensor::stack(&[&symbolic_first], -1)
+        .err()
+        .unwrap()
+        .to_string();
+    assert!(
+        first_shape_err.contains("concrete shape hints"),
+        "got: {first_shape_err}"
+    );
+
+    let symbolic_second = TracedTensor::input_symbolic_shape(DType::F64, 1);
+    let second_shape_err = TracedTensor::stack(&[&a, &symbolic_second], -1)
+        .err()
+        .unwrap()
+        .to_string();
+    assert!(
+        second_shape_err.contains("concrete shape hints"),
+        "got: {second_shape_err}"
+    );
+}
+
+#[test]
+fn traced_stack_positive_axis_promotes_mixed_input_dtypes() {
+    let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(vec![2], vec![1.0_f32, 2.0]));
+    let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![3.0, 4.0]));
+
+    let mut out = TracedTensor::stack(&[&a, &b], 0).unwrap();
+    let mut engine = Engine::new(CpuBackend::new());
+    let result = out.eval(&mut engine).unwrap();
+
+    assert_eq!(result.shape(), &[2, 2]);
+    assert_eq!(get_f64_data(result), &[1.0, 3.0, 2.0, 4.0]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add concrete, eager, and traced `index_select` plus `stack` APIs for shape packing workflows.
- Lower `index_select` through existing `Gather` semantics and `stack` through reshape + concatenate, without adding a new AD rule or extension op.
- Keep indexing operands unpromoted, reuse CPU buffer-pool allocation for gather/concatenate outputs, and document trailing batch usage.
- Covers Issue #856.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

## Notes
This intentionally reuses existing gather/scatter transpose semantics for AD. No backward-compatibility shim or ad hoc op layer was added.