### PR TITLE
Add FFT extension and CubeCL launch guards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [
     # External extension crates depend only on the public `tenferro` facade
     # where possible, are NOT core workspace members, and run their own tests
     # standalone.
+    "tenferro-fft",
     "ext/tropical",
 ]
 default-members = [

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -36,6 +36,8 @@ website:
           - guides/tensor-operations.md
           - guides/einsum.md
           - guides/linear-algebra.md
+          - guides/custom-operations.md
+          - guides/tenferro-fft.md
           - guides/autodiff.md
           - guides/devices-and-gpu.md
           - guides/memory-order.md

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -49,8 +49,8 @@ let a = TracedTensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0
 
 then the columns are `[1, 2]`, `[3, 4]`, and `[5, 6]`.
 
-Use `Tensor::from_vec_row_major` when the flat input data is already in
-PyTorch, NumPy, or JAX row-major order.
+Convert flat input data first when it is already in PyTorch, NumPy, or JAX
+row-major order, then construct the tensor with `Tensor::from_vec`.
 
 ### Explicit CUDA transfer
 

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -8,6 +8,7 @@ Use the simplest tensor layer that matches the workflow.
 | Compile-time scalar type while still owning dense data | `TypedTensor<T>` |
 | PyTorch-style scalar-loss `backward()` | `EagerTensor<B>` + `EagerContext<B>` |
 | `grad`, `vjp`, `jvp`, HVP, graph optimization | `TracedTensor` + `Engine<B>` |
+| Tensor operation not built into tenferro | an extension crate; see [Custom Tensor Operations](custom-operations.md) |
 
 ## Rule of Thumb
 
@@ -30,3 +31,8 @@ eager, and traced workflows. GPU tensors use explicit upload/download at
 backend boundaries; tenferro does not silently fall back to CPU when a GPU
 operation or dtype is unavailable. See [Devices and GPU](devices-and-gpu.md)
 for the current CUDA operation and dtype matrix.
+
+When a project needs a tensor operation outside the built-in surface, prefer a
+focused extension crate over adding application-specific APIs to tenferro
+itself. The [tenferro-fft](tenferro-fft.md) package shows this pattern for
+Fourier transforms.

--- a/docs/guides/custom-operations.md
+++ b/docs/guides/custom-operations.md
@@ -1,0 +1,49 @@
+# Custom Tensor Operations
+
+tenferro covers common dense tensor workflows in the `tenferro` crate. When a
+project needs an operation that is not part of that built-in surface, an
+extension crate can define a custom tensor operation and expose it as a normal
+Rust API.
+
+Use an extension operation when the implementation needs a specialized kernel,
+an external library, or a domain-specific operation that would be awkward or
+too slow to express only with existing tensor methods. Prefer ordinary tensor
+composition when the operation is small and the built-in ops already describe
+it clearly.
+
+## How Extensions Fit
+
+An extension operation is a tensor operation supplied by another crate. The
+extension crate owns the public function names, validates arguments, and
+registers the operation with tenferro through `tenferro::extension`.
+
+An extension can participate in the same eager and traced workflows as built-in
+tensor operations when it provides the required metadata and execution hooks.
+If the extension also registers automatic-differentiation rules, gradients can
+flow through it. If it does not, AD reports the operation as unsupported rather
+than silently dropping the gradient.
+
+For most users, the expected workflow is to depend on an extension crate and
+call its public functions. Directly implementing the lower-level extension
+traits is for authors of those crates.
+
+## What An Extension Crate Provides
+
+An extension crate is responsible for:
+
+- a stable operation family and payload, so graphs can compare and cache it,
+- output dtype and shape inference,
+- concrete execution for the supported backend and device combinations,
+- optional JVP/VJP rules for automatic differentiation,
+- clear errors when a dtype, shape, backend, or AD path is not supported.
+
+The detailed trait contract is documented in the internal
+[ExtensionOp specification](../spec/extension-op.md). User-facing extension
+crates should wrap that machinery in small APIs that look like the equivalent
+PyTorch or JAX operation.
+
+## Example: FFT
+
+[`tenferro-fft`](tenferro-fft.md) is the first extension package following this
+pattern. It provides Fourier transforms as tensor extension operations while
+keeping the core tenferro crate focused on the common dense operation set.

--- a/docs/guides/memory-order.md
+++ b/docs/guides/memory-order.md
@@ -1,51 +1,73 @@
 # Memory Order
 
-tenferro stores dense tensors in column-major order by default. In a 2D tensor,
-the leftmost dimension varies fastest in memory.
+tenferro dense tensors use column-major flat buffers. The leftmost dimension
+varies fastest in memory.
 
 ```rust
-use tenferro::{MemoryOrder, Tensor};
+use tenferro::Tensor;
 
-let col = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-assert_eq!(col.order(), MemoryOrder::ColMajor);
+let tensor = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+assert_eq!(tensor.shape(), &[2, 3]);
+assert_eq!(
+    tensor.as_slice::<f64>().unwrap(),
+    &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
+);
 ```
 
-For PyTorch, NumPy, and JAX-style row-major flat data, import with
-`Tensor::from_vec_row_major`:
+The logical matrix is:
+
+```text
+[[1, 2, 3],
+ [4, 5, 6]]
+```
+
+## Importing Row-Major Data
+
+PyTorch, NumPy, and JAX examples often show row-major flat buffers. Convert
+those buffers to column-major before constructing a tenferro tensor.
 
 ```rust
-use tenferro::{MemoryOrder, Tensor};
+use tenferro::Tensor;
 
-let row = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-assert_eq!(row.order(), MemoryOrder::RowMajor);
+fn row_major_to_column_major<T: Copy>(shape: &[usize], data: &[T]) -> Vec<T> {
+    assert_eq!(shape.len(), 2);
+    let rows = shape[0];
+    let cols = shape[1];
+    assert_eq!(data.len(), rows * cols);
 
-let col = row.to_col_major().unwrap();
-assert_eq!(col.order(), MemoryOrder::ColMajor);
-assert_eq!(col.as_slice::<f64>().unwrap(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let mut out = Vec::with_capacity(data.len());
+    for col in 0..cols {
+        for row in 0..rows {
+            out.push(data[row * cols + col]);
+        }
+    }
+    out
+}
+
+let shape = vec![2, 3];
+let row_major = vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+let column_major = row_major_to_column_major(&shape, &row_major);
+let tensor = Tensor::from_vec(shape, column_major);
+
+assert_eq!(
+    tensor.as_slice::<f64>().unwrap(),
+    &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
+);
 ```
-
-Use `to_col_major()` or `to_row_major()` when you need a specific owned memory
-order. These methods preserve the logical tensor values and reorder the owned
-buffer when needed.
 
 ## Owned Export
 
-Owned export is zero-copy only when the tensor already has the requested
-memory order:
+Owned export returns the column-major host buffer:
 
 ```rust
-use tenferro::{MemoryOrder, Tensor};
+use tenferro::Tensor;
 
-let row = Tensor::from_vec_row_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
-let (shape, data) = row.try_into_vec_row_major::<f64>().unwrap();
+let tensor = Tensor::from_vec(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
+let (shape, data) = tensor.try_into_vec::<f64>().unwrap();
+
 assert_eq!(shape, vec![2, 2]);
-assert_eq!(data, vec![1.0, 2.0, 3.0, 4.0]);
-
-let col = Tensor::from_vec(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
-let (_shape, data) = col.try_into_vec_with_order::<f64>(MemoryOrder::ColMajor).unwrap();
 assert_eq!(data, vec![1.0, 3.0, 2.0, 4.0]);
 ```
 
-If the order does not match, convert first with `to_col_major()` or
-`to_row_major()`, then export with `try_into_vec_col_major()`,
-`try_into_vec_row_major()`, or `try_into_vec_with_order::<T>(...)`.
+Convert the exported buffer in your application if a consumer expects
+row-major data.

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -27,11 +27,9 @@ not:
 ```
 
 If you are porting examples from PyTorch or JAX, check the flat-data order first.
-Use `Tensor::from_vec_row_major` for row-major flat data, and use
-`to_col_major()` or `to_row_major()` when you need an owned tensor in a
-specific memory order. Owned export through `try_into_vec_col_major()`,
-`try_into_vec_row_major()`, or `try_into_vec_with_order::<T>(...)` is zero-copy
-only when the tensor already has the requested order.
+Convert row-major flat data to column-major before calling `Tensor::from_vec`,
+or write literals directly in column-major order. Owned export through
+`try_into_vec::<T>()` returns the column-major host buffer.
 
 ## Control CPU thread count
 

--- a/docs/guides/tenferro-fft.md
+++ b/docs/guides/tenferro-fft.md
@@ -1,0 +1,105 @@
+# tenferro-fft
+
+`tenferro-fft` is the FFT extension package for tenferro. It is an extension
+crate, not part of the core `tenferro` facade: users add the package, import
+its functions, and use them with `TracedTensor` graphs.
+
+The current implementation provides one-dimensional CPU-host transforms backed
+by `rustfft` through tenferro extension operations. The public functions are
+ordinary Rust wrappers, so most users do not need to work with the lower-level
+extension machinery directly.
+
+## Current API
+
+The initial surface mirrors the common PyTorch and JAX one-dimensional FFT
+families:
+
+| Operation family | Purpose |
+| --- | --- |
+| `fft`, `ifft` | complex-to-complex transforms; real input may be promoted to complex output |
+| `rfft`, `irfft` | real-to-complex and complex-to-real one-dimensional transforms |
+
+Each function accepts an optional transform length `n`, an `axis`, and an
+`FftNorm` value. Negative axes are normalized relative to the input rank. The
+normalization modes are:
+
+| Mode | Behavior |
+| --- | --- |
+| `FftNorm::Backward` | forward unscaled, inverse scaled by `1 / n` |
+| `FftNorm::Forward` | forward scaled by `1 / n`, inverse unscaled |
+| `FftNorm::Ortho` | forward and inverse scaled by `1 / sqrt(n)` |
+
+`Backward` is the default and matches NumPy, PyTorch, and JAX.
+
+```rust
+use num_complex::Complex64;
+use tenferro::{CpuBackend, Engine, TracedTensor};
+use tenferro_fft::{fft, FftNorm};
+
+let x = TracedTensor::from_vec(
+    vec![4],
+    vec![
+        Complex64::new(1.0, 0.0),
+        Complex64::new(2.0, 0.0),
+        Complex64::new(3.0, 0.0),
+        Complex64::new(4.0, 0.0),
+    ],
+);
+let mut y = fft(&x, None, -1, FftNorm::Backward);
+
+let mut engine = Engine::new(CpuBackend::new());
+let out = y.eval(&mut engine)?;
+assert_eq!(out.shape(), &[4]);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+For real-input transforms, the transformed axis follows the standard
+half-spectrum shape rule: input length `n` produces `n / 2 + 1` complex values
+using integer division. Inverse real transforms need an explicit output length
+when odd and even original signal sizes would otherwise be ambiguous.
+
+## Planned Extensions
+
+The remaining FFT families are planned but not part of the initial surface:
+
+| Operation family | Purpose |
+| --- | --- |
+| `fftn`, `ifftn` | multidimensional complex transforms |
+| `rfftn`, `irfftn` | multidimensional real/half-spectrum transforms |
+| `fft2`, `ifft2`, `rfft2`, `irfft2` | two-dimensional convenience wrappers |
+
+## Compatibility Target
+
+The compatibility target is the behavior users expect from:
+
+- `torch.fft.fft`, `torch.fft.ifft`, `torch.fft.rfft`, `torch.fft.irfft`,
+  and their `n`/`2` variants,
+- `jax.numpy.fft.fft`, `jax.numpy.fft.ifft`, `jax.numpy.fft.rfft`,
+  `jax.numpy.fft.irfft`, and their `n`/`2` variants.
+
+The extension should canonicalize axes and lengths before execution, then
+return results in the same logical axis order as the input. Backend-specific
+layout or transposition needed to call an FFT implementation should stay inside
+the extension.
+
+## Automatic Differentiation
+
+FFT is linear, so the extension can support AD through registered extension
+rules. The current package registers JVP/VJP rules for complex-to-complex
+`fft` and `ifft`: the tangent or cotangent is transformed with the same
+extension op and normalization.
+
+Real-to-complex and complex-to-real AD are not enabled yet. They require the
+usual Hermitian symmetry handling so cotangents match the half-spectrum
+convention; until those rules are implemented and tested, AD through `rfft` and
+`irfft` reports an unsupported operation instead of returning an incorrect
+gradient.
+
+## Status
+
+`tenferro-fft` currently lives in the top-level `tenferro-fft` crate. It
+supports 1D `fft`, `ifft`, `rfft`, and `irfft` on host tensors. CUDA/cuFFT and
+multidimensional transforms remain future work.
+
+For the general extension mechanism, see
+[Custom Tensor Operations](custom-operations.md).

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -58,8 +58,9 @@ supported scalar type.
 ## Column-Major and Row-Major Confusion
 
 `Tensor::from_vec` reads flat data as column-major. When porting PyTorch,
-NumPy, or JAX examples that use row-major flat data, use
-`Tensor::from_vec_row_major` or convert with `to_row_major()` before exporting.
+NumPy, or JAX examples that use row-major flat data, convert the data to
+column-major before construction. If another library expects row-major output,
+convert the exported `try_into_vec::<T>()` buffer at that boundary.
 See [Memory Order](memory-order.md).
 
 ## CPU Backend Feature Conflicts

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ It supports:
 
 - [Getting Started](getting-started/index.md)
 - [Choosing an API](guides/choosing-an-api.md)
+- [Custom Tensor Operations](guides/custom-operations.md)
 - [Devices and GPU](guides/devices-and-gpu.md)
 - [API Reference](api/index.md)
 

--- a/docs/plans/2026-05-16-remove-row-major-design.md
+++ b/docs/plans/2026-05-16-remove-row-major-design.md
@@ -1,0 +1,70 @@
+# Remove Row-Major Tensor Surface Design
+
+## Goal
+
+Remove row-major storage from the concrete tensor surface for now. tenferro
+will expose one dense owned tensor layout: contiguous column-major.
+
+## Decision
+
+`Tensor` and `TypedTensor` should no longer carry a public runtime
+`MemoryOrder` choice. The row-major APIs added for boundary convenience are
+removed instead of kept as compatibility shims.
+
+This means:
+
+- `Tensor::from_vec` and `TypedTensor::from_vec` accept column-major buffers.
+- owned host export returns column-major buffers.
+- CPU, GPU, einsum, and linalg paths can assume contiguous column-major tensor
+  storage.
+- NumPy, PyTorch, JAX, ndarray, and oracle inputs that start as row-major flat
+  buffers must be converted before constructing a tensor, using local helper
+  code outside the public tensor API.
+
+## Rationale
+
+The current runtime `MemoryOrder` tag is not represented in the type system. If
+row-major and column-major tensors share the same `Tensor` type, output order
+policy becomes implicit and hard to reason about. Sticky output order would make
+operation results depend on input provenance, while canonicalizing outputs to
+column-major would reduce row-major to an import/export convenience.
+
+Because tenferro's internal performance model, linalg layout, einsum layout,
+and CubeCL GPU storage are already column-major, a single public column-major
+tensor surface is simpler and less error-prone.
+
+## Scope
+
+Remove:
+
+- `MemoryOrder::RowMajor` and the runtime tensor `order` field if it becomes
+  unnecessary.
+- `from_vec_row_major`, `from_vec_col_major`, and `from_vec_with_order` when
+  they only exist to expose layout choice.
+- `to_row_major`, `to_col_major`, `to_order`, `try_into_vec_row_major`,
+  `try_into_vec_col_major`, and `try_into_vec_with_order`.
+- row-major behavior claims from user-facing docs.
+- row-major-specific production tests.
+
+Keep:
+
+- column-major shape, indexing, and buffer semantics.
+- private or test-local row-major-to-column-major conversion helpers when an
+  external fixture format requires them.
+- explicit documentation that tenferro flat buffers are column-major.
+
+## Compatibility
+
+This is a breaking API cleanup. Do not add deprecated aliases or hidden
+compatibility shims. Call sites should be updated to construct column-major
+tensors directly or perform explicit conversion before construction.
+
+## Testing
+
+The implementation should verify:
+
+- tensor construction and owned export still round-trip column-major buffers;
+- element access still follows column-major offsets;
+- CPU operation tests remain correct without row-major variants;
+- CubeCL upload/download tests no longer mention row-major canonicalization;
+- user docs and doctests no longer reference removed row-major APIs.

--- a/docs/plans/2026-05-16-remove-row-major-implementation.md
+++ b/docs/plans/2026-05-16-remove-row-major-implementation.md
@@ -1,0 +1,325 @@
+# Remove Row-Major Tensor Surface Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove row-major tensor storage from the public and concrete tensor surface, leaving one contiguous column-major tensor layout.
+
+**Architecture:** `Tensor` and `TypedTensor` become column-major-only owned dense tensors. CPU helpers construct column-major `StridedView`s directly, GPU upload no longer canonicalizes row-major host buffers, and docs/tests stop advertising row-major APIs. External row-major data conversion stays outside the public tensor API.
+
+**Tech Stack:** Rust workspace crates `tenferro-tensor` and `tenferro`, strided-kernel views, CubeCL feature-gated tests/docs, repository docs under `docs/guides` and `docs/getting-started`.
+
+---
+
+### Task 1: Collapse Tensor Storage Metadata To Column-Major
+
+**Files:**
+- Modify: `tenferro-tensor/src/types.rs`
+- Modify: `tenferro-tensor/src/types/accessors.rs`
+- Modify: `tenferro-tensor/src/cpu/mod.rs`
+- Test: `tenferro-tensor/src/tests/types_tests.rs`
+
+**Step 1: Update tests first**
+
+Replace row-major-specific tests in `tenferro-tensor/src/tests/types_tests.rs` with column-major-only coverage:
+
+```rust
+#[test]
+fn tensor_owned_export_returns_column_major_buffer() {
+    let tensor = Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+
+    let (shape, data) = tensor.try_into_vec::<f64>().unwrap();
+
+    assert_eq!(shape, vec![2, 2]);
+    assert_eq!(data, vec![1.0, 2.0, 3.0, 4.0]);
+}
+```
+
+Also update accessor tests so they use only `TypedTensor::from_vec` / `Tensor::from_vec` and assert column-major offsets.
+
+**Step 2: Run focused tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor types_tests
+```
+
+Expected: FAIL because `try_into_vec` does not exist yet and old row-major APIs still exist.
+
+**Step 3: Remove runtime memory-order API**
+
+In `tenferro-tensor/src/types.rs`:
+
+- delete `MemoryOrder`;
+- remove `order: MemoryOrder` from `TypedTensor<T>`;
+- remove `row_major_strides`, `contiguous_strides`, `linear_offset_for_order`, `flat_to_multi_for_order`, and `reorder_contiguous` when no remaining caller needs them;
+- simplify `TensorScalar` to expose only `into_tensor(shape, data)`;
+- make every `TensorScalar` implementation construct via `TypedTensor::from_vec`;
+- keep `TypedTensor::from_vec(shape, data)` as the only typed owned constructor;
+- add `TypedTensor::try_into_vec(self) -> crate::Result<(Vec<usize>, Vec<T>)>`;
+- add `Tensor::try_into_vec<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)>`;
+- remove `from_vec_row_major`, `from_vec_col_major`, `from_vec_with_order`, `order`, `to_order`, `to_col_major`, `to_row_major`, and all `try_into_vec_*_major` / `try_into_vec_with_order` methods.
+
+Use `op: "try_into_vec"` in new owned-export errors.
+
+**Step 4: Simplify accessors**
+
+In `tenferro-tensor/src/types/accessors.rs`, remove `MemoryOrder` imports and order-dispatch helpers. `linear_offset`, `linear_offset2`, and `linear_offset3` should use column-major formulas only:
+
+```rust
+fn linear_offset2(shape: &[usize], i: usize, j: usize) -> usize {
+    i + shape[0] * j
+}
+```
+
+Keep checked rank and bounds behavior unchanged.
+
+**Step 5: Simplify CPU views**
+
+In `tenferro-tensor/src/cpu/mod.rs`, replace `crate::contiguous_strides(&tensor.shape, tensor.order)` with `col_major_strides(&tensor.shape)`.
+
+**Step 6: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor types_tests
+cargo test -p tenferro-tensor cpu_tests
+```
+
+Expected: PASS after downstream compile fixes in later tasks.
+
+**Step 7: Commit**
+
+```bash
+git add tenferro-tensor/src/types.rs tenferro-tensor/src/types/accessors.rs tenferro-tensor/src/cpu/mod.rs tenferro-tensor/src/tests/types_tests.rs
+git commit -m "refactor(tensor): remove runtime memory order"
+```
+
+### Task 2: Fix CPU, GPU, And Linalg Call Sites
+
+**Files:**
+- Modify: `tenferro-tensor/src/cpu/backend.rs`
+- Modify: `tenferro-tensor/src/cpu/indexing.rs`
+- Modify: `tenferro-tensor/src/cpu/gemm/mod.rs`
+- Modify: `tenferro-tensor/src/cpu/linalg/faer_linalg.rs`
+- Modify: `tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs`
+- Modify: `tenferro-tensor/src/cubecl/memory.rs`
+- Modify: `tenferro-tensor/src/cubecl/dispatch.rs`
+- Test: `tenferro-tensor/src/cubecl/tests/metadata_tests.rs`
+- Test: `tenferro-tensor/src/tests/cpu_tests.rs`
+
+**Step 1: Update tests first**
+
+Remove row-major CPU comparison tests from `tenferro-tensor/src/tests/cpu_tests.rs`; keep the existing operation correctness tests that use column-major fixtures.
+
+In `tenferro-tensor/src/cubecl/tests/metadata_tests.rs`, delete:
+
+- `typed_tensor_binding_rejects_row_major_gpu_tensor`;
+- `upload_canonicalizes_row_major_host_tensor_to_col_major`.
+
+Keep buffer length and shape overflow tests.
+
+**Step 2: Run compile check and verify failure list**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor --no-run
+```
+
+Expected: FAIL at old `.to_col_major()`, `MemoryOrder::ColMajor`, and struct `order` fields.
+
+**Step 3: Remove production conversions and fields**
+
+Replace `.to_col_major()?` calls in CPU backend/indexing paths with direct cloned or borrowed tensors as appropriate. Remove `order: crate::MemoryOrder::ColMajor` from direct `TypedTensor` initializers in GEMM/linalg helpers.
+
+In `tenferro-tensor/src/cubecl/memory.rs`:
+
+- remove `Cow` usage and `canonical_host_tensor_for_upload`;
+- upload host buffers directly;
+- return downloaded tensors through `TypedTensor::from_vec`.
+
+In `tenferro-tensor/src/cubecl/dispatch.rs`:
+
+- remove `MemoryOrder` import;
+- remove the `tensor.order != MemoryOrder::ColMajor` rejection from `typed_tensor_binding`;
+- keep shape product and buffer length validation.
+
+**Step 4: Run focused CPU verification**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor --no-run
+cargo test -p tenferro-tensor cpu_tests
+```
+
+Expected: PASS.
+
+**Step 5: Run CubeCL metadata compile/test**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor --features cubecl metadata_tests
+```
+
+Expected: PASS on CPU-only machines because these metadata tests do not require ignored GPU execution.
+
+**Step 6: Commit**
+
+```bash
+git add tenferro-tensor/src/cpu tenferro-tensor/src/cubecl tenferro-tensor/src/tests/cpu_tests.rs
+git commit -m "refactor(tensor): assume column-major backend tensors"
+```
+
+### Task 3: Update Public Facade, Integration Tests, And User Docs
+
+**Files:**
+- Modify: `tenferro/src/lib.rs`
+- Modify: `tenferro/tests/symbolic_input.rs`
+- Modify: `docs/guides/memory-order.md`
+- Modify: `docs/guides/performance.md`
+- Modify: `docs/guides/troubleshooting.md`
+- Modify: `docs/getting-started/pytorch-jax-mapping.md`
+- Modify: `docs/guides/eager-operations.md`
+
+**Step 1: Update tests first**
+
+In `tenferro/tests/symbolic_input.rs`, replace `row_major_symbolic_input_uses_logical_shape_and_values` with a column-major symbolic input test:
+
+```rust
+#[test]
+fn matrix_symbolic_input_uses_column_major_values() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let mut y = &x + &x;
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let bound = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let out = y
+        .eval_with_inputs(&mut engine, &[(&x, &bound)])
+        .expect("eval_with_inputs");
+
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(f64_data(out), &[2.0, 8.0, 4.0, 10.0, 6.0, 12.0]);
+}
+```
+
+**Step 2: Remove facade export**
+
+In `tenferro/src/lib.rs`, remove `MemoryOrder` from the `pub use tenferro_tensor::{...}` list.
+
+**Step 3: Rewrite user-facing docs**
+
+Update docs to say tenferro flat buffers are column-major. Do not mention removed row-major APIs.
+
+For `docs/guides/memory-order.md`, rewrite examples to use:
+
+```rust
+use tenferro::Tensor;
+
+let tensor = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+assert_eq!(tensor.shape(), &[2, 3]);
+assert_eq!(tensor.as_slice::<f64>().unwrap(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+```
+
+Mention that NumPy/PyTorch row-major flat buffers must be converted before construction. Keep imports as `use tenferro::{...}` in user docs.
+
+**Step 4: Search for stale public claims**
+
+Run:
+
+```bash
+rg -n "MemoryOrder|RowMajor|from_vec_row_major|from_vec_col_major|from_vec_with_order|to_row_major|to_col_major|to_order|try_into_vec_row_major|try_into_vec_col_major|try_into_vec_with_order|row-major|row major" README.md tenferro tenferro-tensor docs/guides docs/getting-started
+```
+
+Expected: only intentional plain-English statements about external row-major formats remain; no removed API names remain in active docs or source.
+
+**Step 5: Run public-facing focused tests**
+
+Run:
+
+```bash
+cargo test -p tenferro symbolic_input
+cargo test -p tenferro-tensor --doc
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add tenferro/src/lib.rs tenferro/tests/symbolic_input.rs docs/guides docs/getting-started
+git commit -m "docs: document column-major-only tensor buffers"
+```
+
+### Task 4: Workspace Verification And Cleanup
+
+**Files:**
+- Review all changed files from Tasks 1-3.
+
+**Step 1: Format**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all --check
+```
+
+Expected: PASS.
+
+**Step 2: Run focused no-run checks**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor --no-run
+cargo test -p tenferro --no-run
+```
+
+Expected: PASS.
+
+**Step 3: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor types_tests
+cargo test -p tenferro-tensor cpu_tests
+cargo test -p tenferro symbolic_input
+```
+
+Expected: PASS.
+
+**Step 4: Run docs checks affected by public API removal**
+
+Run:
+
+```bash
+cargo test --doc -p tenferro-tensor
+cargo test --doc -p tenferro
+python3 scripts/check-docs-site.py
+```
+
+Expected: PASS.
+
+**Step 5: Final stale API search**
+
+Run:
+
+```bash
+rg -n "MemoryOrder|RowMajor|from_vec_row_major|from_vec_col_major|from_vec_with_order|to_row_major|to_col_major|to_order|try_into_vec_row_major|try_into_vec_col_major|try_into_vec_with_order" tenferro tenferro-tensor docs/guides docs/getting-started README.md
+```
+
+Expected: no matches.
+
+**Step 6: Commit verification fixes if needed**
+
+If formatting or docs changes are produced:
+
+```bash
+git add .
+git commit -m "chore: finish row-major removal cleanup"
+```

--- a/tenferro-cubecl/src/reduce/launch.rs
+++ b/tenferro-cubecl/src/reduce/launch.rs
@@ -123,6 +123,11 @@ pub fn launch_sum_float<R: Runtime, F: Float + CubeElement>(
         launch_with_unit_settings(client, problem, strategy);
 
     unsafe {
+        // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
+        // and keepdims output shapes are compatible and the reduce axis is
+        // non-empty. `launch_with_unit_settings` derives the launched output
+        // domain from that validated problem; the reduction kernel uses
+        // `output_len == problem.reduce_count` to guard output indexing.
         kernels::reduce_sum_float::launch_unchecked::<F, R>(
             client,
             cube_count,
@@ -164,6 +169,11 @@ pub fn launch_sum_int<R: Runtime, I: Int + CubeElement>(
         launch_with_unit_settings(client, problem, strategy);
 
     unsafe {
+        // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
+        // and keepdims output shapes are compatible and the reduce axis is
+        // non-empty. `launch_with_unit_settings` derives the launched output
+        // domain from that validated problem; the reduction kernel uses
+        // `output_len == problem.reduce_count` to guard output indexing.
         kernels::reduce_sum_int::launch_unchecked::<I, R>(
             client,
             cube_count,
@@ -206,6 +216,11 @@ pub fn launch_sum_complex<R: Runtime, C: Complex + CubeElement>(
         launch_with_unit_settings(client, problem, strategy);
 
     unsafe {
+        // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
+        // and keepdims output shapes are compatible and the reduce axis is
+        // non-empty. `launch_with_unit_settings` derives the launched output
+        // domain from that validated problem; the reduction kernel uses
+        // `output_len == problem.reduce_count` to guard output indexing.
         kernels::reduce_sum_complex::launch_unchecked::<C, R>(
             client,
             cube_count,
@@ -247,6 +262,11 @@ pub fn launch_prod_float<R: Runtime, F: Float + CubeElement>(
         launch_with_unit_settings(client, problem, strategy);
 
     unsafe {
+        // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
+        // and keepdims output shapes are compatible and the reduce axis is
+        // non-empty. `launch_with_unit_settings` derives the launched output
+        // domain from that validated problem; the reduction kernel uses
+        // `output_len == problem.reduce_count` to guard output indexing.
         kernels::reduce_prod_float::launch_unchecked::<F, R>(
             client,
             cube_count,
@@ -288,6 +308,11 @@ pub fn launch_prod_int<R: Runtime, I: Int + CubeElement>(
         launch_with_unit_settings(client, problem, strategy);
 
     unsafe {
+        // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
+        // and keepdims output shapes are compatible and the reduce axis is
+        // non-empty. `launch_with_unit_settings` derives the launched output
+        // domain from that validated problem; the reduction kernel uses
+        // `output_len == problem.reduce_count` to guard output indexing.
         kernels::reduce_prod_int::launch_unchecked::<I, R>(
             client,
             cube_count,
@@ -330,6 +355,11 @@ pub fn launch_prod_complex<R: Runtime, C: Complex + CubeElement>(
         launch_with_unit_settings(client, problem, strategy);
 
     unsafe {
+        // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
+        // and keepdims output shapes are compatible and the reduce axis is
+        // non-empty. `launch_with_unit_settings` derives the launched output
+        // domain from that validated problem; the reduction kernel uses
+        // `output_len == problem.reduce_count` to guard output indexing.
         kernels::reduce_prod_complex::launch_unchecked::<C, R>(
             client,
             cube_count,
@@ -371,6 +401,11 @@ pub fn launch_max_float<R: Runtime, F: Float + CubeElement>(
         launch_with_unit_settings(client, problem, strategy);
 
     unsafe {
+        // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
+        // and keepdims output shapes are compatible and the reduce axis is
+        // non-empty. `launch_with_unit_settings` derives the launched output
+        // domain from that validated problem; the reduction kernel uses
+        // `output_len == problem.reduce_count` to guard output indexing.
         kernels::reduce_max_float::launch_unchecked::<F, R>(
             client,
             cube_count,
@@ -412,6 +447,11 @@ pub fn launch_min_float<R: Runtime, F: Float + CubeElement>(
         launch_with_unit_settings(client, problem, strategy);
 
     unsafe {
+        // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
+        // and keepdims output shapes are compatible and the reduce axis is
+        // non-empty. `launch_with_unit_settings` derives the launched output
+        // domain from that validated problem; the reduction kernel uses
+        // `output_len == problem.reduce_count` to guard output indexing.
         kernels::reduce_min_float::launch_unchecked::<F, R>(
             client,
             cube_count,

--- a/tenferro-fft/Cargo.toml
+++ b/tenferro-fft/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tenferro-fft"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+authors = ["Hiroshi Shinaoka <h.shinaoka@gmail.com>"]
+publish = false
+description = "FFT extension operations for tenferro."
+
+[workspace]
+
+[dependencies]
+tenferro = { path = "../tenferro" }
+tenferro-tensor = { path = "../tenferro-tensor" }
+tenferro-ops = { path = "../tenferro-ops" }
+chainrules-core = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "da3f2b50ba2e6a0738737e4e4b2ec8f5c8243469", package = "chainrules" }
+computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "8306196" }
+num-complex = "0.4"
+num-traits = "0.2"
+rustfft = "6"

--- a/tenferro-fft/src/lib.rs
+++ b/tenferro-fft/src/lib.rs
@@ -1,0 +1,811 @@
+//! FFT extension operations for tenferro.
+//!
+//! This crate is an out-of-tree `ExtensionOp` package. The initial
+//! implementation executes on host tensors through `rustfft`; it does not add
+//! FFT to the core `tenferro` backend trait surface.
+//!
+//! # Examples
+//!
+//! ```
+//! use num_complex::Complex64;
+//! use tenferro::{CpuBackend, Engine, TracedTensor};
+//! use tenferro_fft::{fft, FftNorm};
+//!
+//! let x = TracedTensor::from_vec(
+//!     vec![4],
+//!     vec![
+//!         Complex64::new(1.0, 0.0),
+//!         Complex64::new(2.0, 0.0),
+//!         Complex64::new(3.0, 0.0),
+//!         Complex64::new(4.0, 0.0),
+//!     ],
+//! );
+//! let mut y = fft(&x, None, -1, FftNorm::Backward);
+//!
+//! let mut engine = Engine::new(CpuBackend::new());
+//! let out = y.eval(&mut engine).unwrap();
+//! assert_eq!(out.shape(), &[4]);
+//! assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(10.0, 0.0));
+//! ```
+
+use std::any::Any;
+use std::hash::Hasher;
+use std::sync::Arc;
+
+use chainrules_core::{ADRuleError, ADRuleKind, ADRuleResult};
+use computegraph::fragment::FragmentBuilder;
+use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
+use computegraph::OpEmitter;
+use num_complex::Complex;
+use num_traits::{Float, FromPrimitive, Zero};
+use rustfft::{FftNum, FftPlanner};
+use tenferro::extension::{
+    apply, register_extension, register_extension_rule, ExtensionAdRuleTrait, ExtensionFactory,
+    ExtensionOpTrait, ExtensionRegistryError,
+};
+use tenferro::TracedTensor;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_ops::{ShapeGuardContext, SymDim};
+use tenferro_tensor::{DType, Tensor, TypedTensor};
+
+const FFT_FAMILY_ID: &str = "tenferro-fft.fft.v1";
+const FFT_VERSION: u32 = 1;
+
+/// FFT normalization convention.
+///
+/// `Backward` matches NumPy, JAX, and PyTorch defaults: the forward transform
+/// is unscaled and the inverse transform is scaled by `1 / n`.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_fft::FftNorm;
+///
+/// assert_eq!(FftNorm::default(), FftNorm::Backward);
+/// ```
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum FftNorm {
+    /// Scale inverse transforms by `1 / n`.
+    #[default]
+    Backward,
+    /// Scale forward transforms by `1 / n`.
+    Forward,
+    /// Scale both forward and inverse transforms by `1 / sqrt(n)`.
+    Ortho,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FftKind {
+    C2C { forward: bool },
+    R2C { onesided: bool },
+    C2R,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct FftOp {
+    kind: FftKind,
+    axis: usize,
+    n: Option<usize>,
+    norm: FftNorm,
+}
+
+impl FftOp {
+    fn new(kind: FftKind, axis: usize, n: Option<usize>, norm: FftNorm) -> Self {
+        Self {
+            kind,
+            axis,
+            n,
+            norm,
+        }
+    }
+}
+
+impl ExtensionOpTrait for FftOp {
+    fn family_id(&self) -> &'static str {
+        FFT_FAMILY_ID
+    }
+
+    fn payload_hash(&self, hasher: &mut dyn Hasher) {
+        let kind = match self.kind {
+            FftKind::C2C { forward: true } => 0,
+            FftKind::C2C { forward: false } => 1,
+            FftKind::R2C { onesided: true } => 2,
+            FftKind::R2C { onesided: false } => 3,
+            FftKind::C2R => 4,
+        };
+        hasher.write_u8(kind);
+        hasher.write_usize(self.axis);
+        match self.n {
+            Some(n) => {
+                hasher.write_u8(1);
+                hasher.write_usize(n);
+            }
+            None => hasher.write_u8(0),
+        }
+        let norm = match self.norm {
+            FftNorm::Backward => 0,
+            FftNorm::Forward => 1,
+            FftNorm::Ortho => 2,
+        };
+        hasher.write_u8(norm);
+    }
+
+    fn payload_eq(&self, other: &dyn ExtensionOpTrait) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<FftOp>()
+            .is_some_and(|that| self == that)
+    }
+
+    fn clone_arc(&self) -> Arc<dyn ExtensionOpTrait> {
+        Arc::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn n_inputs(&self) -> usize {
+        1
+    }
+
+    fn n_outputs(&self) -> usize {
+        1
+    }
+
+    fn infer_output_meta(
+        &self,
+        input_dtypes: &[DType],
+        input_shapes: &[&[SymDim]],
+    ) -> Vec<(DType, Vec<SymDim>)> {
+        assert_eq!(
+            input_dtypes.len(),
+            1,
+            "tenferro-fft expects exactly one input"
+        );
+        assert_eq!(
+            input_shapes.len(),
+            1,
+            "tenferro-fft expects exactly one input shape"
+        );
+        assert!(
+            self.axis < input_shapes[0].len(),
+            "tenferro-fft axis {} out of bounds for rank {}",
+            self.axis,
+            input_shapes[0].len()
+        );
+
+        let mut out_shape = input_shapes[0].to_vec();
+        let output_dtype = match self.kind {
+            FftKind::C2C { .. } => {
+                assert!(
+                    matches!(input_dtypes[0], DType::C32 | DType::C64),
+                    "fft/ifft expect C32 or C64 input for complex-to-complex transforms; got {:?}",
+                    input_dtypes[0]
+                );
+                input_dtypes[0]
+            }
+            FftKind::R2C { onesided } => {
+                assert!(
+                    matches!(input_dtypes[0], DType::F32 | DType::F64),
+                    "rfft expects F32 or F64 input; got {:?}",
+                    input_dtypes[0]
+                );
+                let len = transform_len_dim(self.n, &input_shapes[0][self.axis]);
+                out_shape[self.axis] = if onesided { len / 2usize + 1usize } else { len };
+                match input_dtypes[0] {
+                    DType::F32 => DType::C32,
+                    DType::F64 => DType::C64,
+                    _ => unreachable!(),
+                }
+            }
+            FftKind::C2R => {
+                assert!(
+                    matches!(input_dtypes[0], DType::C32 | DType::C64),
+                    "irfft expects C32 or C64 input; got {:?}",
+                    input_dtypes[0]
+                );
+                out_shape[self.axis] = match self.n {
+                    Some(n) => SymDim::from(n),
+                    None => (input_shapes[0][self.axis].clone() - 1usize) * 2usize,
+                };
+                match input_dtypes[0] {
+                    DType::C32 => DType::F32,
+                    DType::C64 => DType::F64,
+                    _ => unreachable!(),
+                }
+            }
+        };
+
+        if matches!(self.kind, FftKind::C2C { .. }) {
+            out_shape[self.axis] = transform_len_dim(self.n, &input_shapes[0][self.axis]);
+        }
+
+        vec![(output_dtype, out_shape)]
+    }
+
+    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+        if inputs.len() != 1 {
+            return Err(tenferro_tensor::Error::InvalidConfig {
+                op: "tenferro-fft",
+                message: format!("expected 1 input, got {}", inputs.len()),
+            });
+        }
+
+        let output = match (self.kind, inputs[0]) {
+            (FftKind::C2C { forward }, Tensor::C64(input)) => Tensor::C64(TypedTensor::from_vec(
+                output_shape_c2c(input.shape.as_slice(), self.axis, self.n)?,
+                execute_c2c(input, self.axis, self.n, forward, self.norm)?,
+            )),
+            (FftKind::C2C { forward }, Tensor::C32(input)) => Tensor::C32(TypedTensor::from_vec(
+                output_shape_c2c(input.shape.as_slice(), self.axis, self.n)?,
+                execute_c2c(input, self.axis, self.n, forward, self.norm)?,
+            )),
+            (FftKind::R2C { onesided }, Tensor::F64(input)) => Tensor::C64(TypedTensor::from_vec(
+                output_shape_r2c(input.shape.as_slice(), self.axis, self.n, onesided)?,
+                execute_r2c(input, self.axis, self.n, onesided, self.norm)?,
+            )),
+            (FftKind::R2C { onesided }, Tensor::F32(input)) => Tensor::C32(TypedTensor::from_vec(
+                output_shape_r2c(input.shape.as_slice(), self.axis, self.n, onesided)?,
+                execute_r2c(input, self.axis, self.n, onesided, self.norm)?,
+            )),
+            (FftKind::C2R, Tensor::C64(input)) => Tensor::F64(TypedTensor::from_vec(
+                output_shape_c2r(input.shape.as_slice(), self.axis, self.n)?,
+                execute_c2r(input, self.axis, self.n, self.norm)?,
+            )),
+            (FftKind::C2R, Tensor::C32(input)) => Tensor::F32(TypedTensor::from_vec(
+                output_shape_c2r(input.shape.as_slice(), self.axis, self.n)?,
+                execute_c2r(input, self.axis, self.n, self.norm)?,
+            )),
+            (kind, other) => {
+                return Err(tenferro_tensor::Error::DTypeMismatch {
+                    op: match kind {
+                        FftKind::C2C { .. } => "fft",
+                        FftKind::R2C { .. } => "rfft",
+                        FftKind::C2R => "irfft",
+                    },
+                    lhs: expected_dtype_for(kind),
+                    rhs: other.dtype(),
+                });
+            }
+        };
+        Ok(vec![output])
+    }
+}
+
+#[derive(Debug)]
+struct FftFactory;
+
+impl ExtensionFactory for FftFactory {
+    fn family_id(&self) -> &'static str {
+        FFT_FAMILY_ID
+    }
+
+    fn version(&self) -> u32 {
+        FFT_VERSION
+    }
+
+    fn instantiate_default(&self) -> Option<Arc<dyn ExtensionOpTrait>> {
+        Some(Arc::new(FftOp::new(
+            FftKind::C2C { forward: true },
+            0,
+            None,
+            FftNorm::Backward,
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct FftAdRule;
+
+impl ExtensionAdRuleTrait for FftAdRule {
+    fn family_id(&self) -> &'static str {
+        FFT_FAMILY_ID
+    }
+
+    fn linearize(
+        &self,
+        op: &dyn ExtensionOpTrait,
+        builder: &mut FragmentBuilder<StdTensorOp>,
+        _primal_in: &[GlobalValKey<StdTensorOp>],
+        _primal_out: &[GlobalValKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValId>],
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        let fft_op = fft_payload(op, ADRuleKind::Linearize)?;
+        if !matches!(fft_op.kind, FftKind::C2C { .. }) {
+            return Err(ADRuleError::unsupported(
+                FFT_FAMILY_ID,
+                ADRuleKind::Linearize,
+            ));
+        }
+
+        match tangent_in[0] {
+            Some(dx) => {
+                let outputs = builder.add_op(
+                    StdTensorOp::Extension(Arc::new(fft_op.clone())),
+                    vec![ValRef::Local(dx)],
+                    OpMode::Linear {
+                        active_mask: vec![true],
+                    },
+                );
+                Ok(vec![Some(outputs[0])])
+            }
+            None => Ok(vec![None]),
+        }
+    }
+
+    fn transpose_rule(
+        &self,
+        op: &dyn ExtensionOpTrait,
+        emitter: &mut dyn OpEmitter<StdTensorOp>,
+        cotangent_out: &[Option<LocalValId>],
+        _inputs: &[ValRef<StdTensorOp>],
+        _mode: &OpMode,
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        let fft_op = fft_payload(op, ADRuleKind::Transpose)?;
+        if !matches!(fft_op.kind, FftKind::C2C { .. }) {
+            return Err(ADRuleError::unsupported(
+                FFT_FAMILY_ID,
+                ADRuleKind::Transpose,
+            ));
+        }
+
+        match cotangent_out[0] {
+            Some(ct) => {
+                let outputs = emitter.add_op(
+                    StdTensorOp::Extension(Arc::new(fft_op.clone())),
+                    vec![ValRef::Local(ct)],
+                    OpMode::Linear {
+                        active_mask: vec![true],
+                    },
+                );
+                Ok(vec![Some(outputs[0])])
+            }
+            None => Ok(vec![None]),
+        }
+    }
+}
+
+/// Register the FFT extension family and its AD rule.
+///
+/// Calling this function more than once in a process is harmless. The public
+/// wrapper functions call it automatically before building traced graphs.
+///
+/// # Examples
+///
+/// ```
+/// tenferro_fft::register_fft().unwrap();
+/// tenferro_fft::register_fft().unwrap();
+/// ```
+pub fn register_fft() -> Result<(), ExtensionRegistryError> {
+    match register_extension(Arc::new(FftFactory)) {
+        Ok(()) | Err(ExtensionRegistryError::Duplicate { .. }) => {}
+        Err(err) => return Err(err),
+    }
+    match register_extension_rule(Arc::new(FftAdRule)) {
+        Ok(()) | Err(ExtensionRegistryError::DuplicateRule { .. }) => {}
+        Err(err) => return Err(err),
+    }
+    Ok(())
+}
+
+/// Build a one-dimensional FFT along `axis`.
+///
+/// Complex inputs use a complex-to-complex transform. Real inputs use a
+/// real-to-complex transform that returns the full complex spectrum.
+///
+/// # Examples
+///
+/// ```
+/// use num_complex::Complex64;
+/// use tenferro::{CpuBackend, Engine, TracedTensor};
+/// use tenferro_fft::{fft, FftNorm};
+///
+/// let x = TracedTensor::from_vec(vec![2], vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)]);
+/// let mut y = fft(&x, None, -1, FftNorm::Backward);
+///
+/// let mut engine = Engine::new(CpuBackend::new());
+/// let out = y.eval(&mut engine).unwrap();
+/// assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(3.0, 0.0));
+/// ```
+pub fn fft(input: &TracedTensor, n: Option<usize>, axis: isize, norm: FftNorm) -> TracedTensor {
+    let kind = match input.dtype {
+        DType::C32 | DType::C64 => FftKind::C2C { forward: true },
+        DType::F32 | DType::F64 => FftKind::R2C { onesided: false },
+        DType::I64 => panic!("fft expects real or complex floating input, got I64"),
+    };
+    apply_unary_fft(input, kind, n, axis, norm)
+}
+
+/// Build a one-dimensional inverse FFT along `axis`.
+///
+/// # Examples
+///
+/// ```
+/// use num_complex::Complex64;
+/// use tenferro::{CpuBackend, Engine, TracedTensor};
+/// use tenferro_fft::{ifft, FftNorm};
+///
+/// let spectrum = TracedTensor::from_vec(vec![2], vec![Complex64::new(3.0, 0.0), Complex64::new(-1.0, 0.0)]);
+/// let mut y = ifft(&spectrum, None, -1, FftNorm::Backward);
+///
+/// let mut engine = Engine::new(CpuBackend::new());
+/// let out = y.eval(&mut engine).unwrap();
+/// assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(1.0, 0.0));
+/// ```
+pub fn ifft(input: &TracedTensor, n: Option<usize>, axis: isize, norm: FftNorm) -> TracedTensor {
+    assert!(
+        matches!(input.dtype, DType::C32 | DType::C64),
+        "ifft expects C32 or C64 input; got {:?}",
+        input.dtype
+    );
+    apply_unary_fft(input, FftKind::C2C { forward: false }, n, axis, norm)
+}
+
+/// Build a one-dimensional real FFT along `axis`.
+///
+/// The output keeps only the Hermitian one-sided spectrum with axis length
+/// `n / 2 + 1`.
+///
+/// # Examples
+///
+/// ```
+/// use num_complex::Complex64;
+/// use tenferro::{CpuBackend, Engine, TracedTensor};
+/// use tenferro_fft::{rfft, FftNorm};
+///
+/// let x = TracedTensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+/// let mut y = rfft(&x, None, -1, FftNorm::Backward);
+///
+/// let mut engine = Engine::new(CpuBackend::new());
+/// let out = y.eval(&mut engine).unwrap();
+/// assert_eq!(out.shape(), &[2]);
+/// assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(3.0, 0.0));
+/// ```
+pub fn rfft(input: &TracedTensor, n: Option<usize>, axis: isize, norm: FftNorm) -> TracedTensor {
+    assert!(
+        matches!(input.dtype, DType::F32 | DType::F64),
+        "rfft expects F32 or F64 input; got {:?}",
+        input.dtype
+    );
+    apply_unary_fft(input, FftKind::R2C { onesided: true }, n, axis, norm)
+}
+
+/// Build a one-dimensional inverse real FFT along `axis`.
+///
+/// If `n` is `None`, the output length is inferred as
+/// `2 * (input_len - 1)`.
+///
+/// # Examples
+///
+/// ```
+/// use num_complex::Complex64;
+/// use tenferro::{CpuBackend, Engine, TracedTensor};
+/// use tenferro_fft::{irfft, FftNorm};
+///
+/// let spectrum = TracedTensor::from_vec(
+///     vec![2],
+///     vec![Complex64::new(3.0, 0.0), Complex64::new(-1.0, 0.0)],
+/// );
+/// let mut y = irfft(&spectrum, Some(2), -1, FftNorm::Backward);
+///
+/// let mut engine = Engine::new(CpuBackend::new());
+/// let out = y.eval(&mut engine).unwrap();
+/// assert_eq!(out.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+/// ```
+pub fn irfft(input: &TracedTensor, n: Option<usize>, axis: isize, norm: FftNorm) -> TracedTensor {
+    assert!(
+        matches!(input.dtype, DType::C32 | DType::C64),
+        "irfft expects C32 or C64 input; got {:?}",
+        input.dtype
+    );
+    apply_unary_fft(input, FftKind::C2R, n, axis, norm)
+}
+
+fn apply_unary_fft(
+    input: &TracedTensor,
+    kind: FftKind,
+    n: Option<usize>,
+    axis: isize,
+    norm: FftNorm,
+) -> TracedTensor {
+    register_fft().expect("register tenferro-fft extension");
+    validate_n(n);
+    let axis = normalize_axis(axis, input.rank);
+    let op = Arc::new(FftOp::new(kind, axis, n, norm));
+    let mut outputs = apply(op, &[input]);
+    outputs
+        .pop()
+        .expect("FFT extension declares exactly one output")
+}
+
+fn normalize_axis(axis: isize, rank: usize) -> usize {
+    assert!(rank > 0, "tenferro-fft requires rank >= 1");
+    let rank_isize = rank as isize;
+    let normalized = if axis < 0 { rank_isize + axis } else { axis };
+    assert!(
+        normalized >= 0 && normalized < rank_isize,
+        "tenferro-fft axis {axis} out of bounds for rank {rank}"
+    );
+    normalized as usize
+}
+
+fn validate_n(n: Option<usize>) {
+    assert!(
+        n != Some(0),
+        "tenferro-fft transform length n must be positive"
+    );
+}
+
+fn transform_len_dim(n: Option<usize>, input_dim: &SymDim) -> SymDim {
+    n.map(SymDim::from).unwrap_or_else(|| input_dim.clone())
+}
+
+fn expected_dtype_for(kind: FftKind) -> DType {
+    match kind {
+        FftKind::C2C { .. } | FftKind::C2R => DType::C64,
+        FftKind::R2C { .. } => DType::F64,
+    }
+}
+
+fn fft_payload<'a>(op: &'a dyn ExtensionOpTrait, rule: ADRuleKind) -> ADRuleResult<&'a FftOp> {
+    op.as_any()
+        .downcast_ref::<FftOp>()
+        .ok_or_else(|| ADRuleError::unsupported(FFT_FAMILY_ID, rule))
+}
+
+fn output_shape_c2c(
+    shape: &[usize],
+    axis: usize,
+    n: Option<usize>,
+) -> tenferro_tensor::Result<Vec<usize>> {
+    let len = transform_len(shape, axis, n)?;
+    let mut out_shape = shape.to_vec();
+    out_shape[axis] = len;
+    Ok(out_shape)
+}
+
+fn output_shape_r2c(
+    shape: &[usize],
+    axis: usize,
+    n: Option<usize>,
+    onesided: bool,
+) -> tenferro_tensor::Result<Vec<usize>> {
+    let len = transform_len(shape, axis, n)?;
+    let mut out_shape = shape.to_vec();
+    out_shape[axis] = if onesided { len / 2 + 1 } else { len };
+    Ok(out_shape)
+}
+
+fn output_shape_c2r(
+    shape: &[usize],
+    axis: usize,
+    n: Option<usize>,
+) -> tenferro_tensor::Result<Vec<usize>> {
+    validate_axis("irfft", shape, axis)?;
+    let input_len = shape[axis];
+    if input_len == 0 {
+        return Err(tenferro_tensor::Error::InvalidConfig {
+            op: "irfft",
+            message: "input spectrum axis length must be positive".to_string(),
+        });
+    }
+    let len = n.unwrap_or_else(|| 2 * (input_len - 1));
+    if len == 0 {
+        return Err(tenferro_tensor::Error::InvalidConfig {
+            op: "irfft",
+            message: "output length must be positive".to_string(),
+        });
+    }
+    let mut out_shape = shape.to_vec();
+    out_shape[axis] = len;
+    Ok(out_shape)
+}
+
+fn transform_len(shape: &[usize], axis: usize, n: Option<usize>) -> tenferro_tensor::Result<usize> {
+    validate_axis("fft", shape, axis)?;
+    let len = n.unwrap_or(shape[axis]);
+    if len == 0 {
+        return Err(tenferro_tensor::Error::InvalidConfig {
+            op: "fft",
+            message: "transform length must be positive".to_string(),
+        });
+    }
+    Ok(len)
+}
+
+fn validate_axis(op: &'static str, shape: &[usize], axis: usize) -> tenferro_tensor::Result<()> {
+    if axis >= shape.len() {
+        return Err(tenferro_tensor::Error::AxisOutOfBounds {
+            op,
+            axis,
+            rank: shape.len(),
+        });
+    }
+    Ok(())
+}
+
+fn execute_c2c<T>(
+    input: &TypedTensor<Complex<T>>,
+    axis: usize,
+    n: Option<usize>,
+    forward: bool,
+    norm: FftNorm,
+) -> tenferro_tensor::Result<Vec<Complex<T>>>
+where
+    T: FftNum + Float + FromPrimitive,
+{
+    let in_shape = input.shape.as_slice();
+    let fft_len = transform_len(in_shape, axis, n)?;
+    let out_shape = output_shape_c2c(in_shape, axis, n)?;
+    let out_axis_len = out_shape[axis];
+    let input_data = input.host_data();
+    let mut output = vec![Complex::zero(); out_shape.iter().product()];
+    let mut planner = FftPlanner::<T>::new();
+    let fft_plan = if forward {
+        planner.plan_fft_forward(fft_len)
+    } else {
+        planner.plan_fft_inverse(fft_len)
+    };
+    let scale: T = scale_for(norm, forward, fft_len);
+    let mut lane = vec![Complex::zero(); fft_len];
+
+    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
+        lane.fill(Complex::zero());
+        let copy_len = lane_ctx.in_axis_len.min(fft_len);
+        for (k, slot) in lane.iter_mut().take(copy_len).enumerate() {
+            *slot = input_data[lane_ctx.input_offset(k)];
+        }
+        fft_plan.process(&mut lane);
+        if scale != T::one() {
+            for value in &mut lane {
+                *value = *value * scale;
+            }
+        }
+        for (k, value) in lane.iter().take(out_axis_len).copied().enumerate() {
+            output[lane_ctx.output_offset(k)] = value;
+        }
+    });
+
+    Ok(output)
+}
+
+fn execute_r2c<T>(
+    input: &TypedTensor<T>,
+    axis: usize,
+    n: Option<usize>,
+    onesided: bool,
+    norm: FftNorm,
+) -> tenferro_tensor::Result<Vec<Complex<T>>>
+where
+    T: FftNum + Float + FromPrimitive,
+{
+    let in_shape = input.shape.as_slice();
+    let fft_len = transform_len(in_shape, axis, n)?;
+    let out_shape = output_shape_r2c(in_shape, axis, n, onesided)?;
+    let out_axis_len = out_shape[axis];
+    let input_data = input.host_data();
+    let mut output = vec![Complex::zero(); out_shape.iter().product()];
+    let mut planner = FftPlanner::<T>::new();
+    let fft_plan = planner.plan_fft_forward(fft_len);
+    let scale: T = scale_for(norm, true, fft_len);
+    let mut lane = vec![Complex::zero(); fft_len];
+
+    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
+        lane.fill(Complex::zero());
+        let copy_len = lane_ctx.in_axis_len.min(fft_len);
+        for (k, slot) in lane.iter_mut().take(copy_len).enumerate() {
+            *slot = Complex::new(input_data[lane_ctx.input_offset(k)], T::zero());
+        }
+        fft_plan.process(&mut lane);
+        if scale != T::one() {
+            for value in &mut lane {
+                *value = *value * scale;
+            }
+        }
+        for (k, value) in lane.iter().take(out_axis_len).copied().enumerate() {
+            output[lane_ctx.output_offset(k)] = value;
+        }
+    });
+
+    Ok(output)
+}
+
+fn execute_c2r<T>(
+    input: &TypedTensor<Complex<T>>,
+    axis: usize,
+    n: Option<usize>,
+    norm: FftNorm,
+) -> tenferro_tensor::Result<Vec<T>>
+where
+    T: FftNum + Float + FromPrimitive,
+{
+    let in_shape = input.shape.as_slice();
+    let out_shape = output_shape_c2r(in_shape, axis, n)?;
+    let out_axis_len = out_shape[axis];
+    let expected_half = out_axis_len / 2 + 1;
+    let input_data = input.host_data();
+    let mut output = vec![T::zero(); out_shape.iter().product()];
+    let mut planner = FftPlanner::<T>::new();
+    let fft_plan = planner.plan_fft_inverse(out_axis_len);
+    let scale: T = scale_for(norm, false, out_axis_len);
+    let mut lane = vec![Complex::zero(); out_axis_len];
+
+    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
+        lane.fill(Complex::zero());
+        let copy_len = lane_ctx.in_axis_len.min(expected_half);
+        for (k, slot) in lane.iter_mut().take(copy_len).enumerate() {
+            *slot = input_data[lane_ctx.input_offset(k)];
+        }
+        for k in expected_half..out_axis_len {
+            let mirror = out_axis_len - k;
+            if mirror < lane.len() {
+                lane[k] = lane[mirror].conj();
+            }
+        }
+        fft_plan.process(&mut lane);
+        for (k, value) in lane.iter().take(out_axis_len).enumerate() {
+            output[lane_ctx.output_offset(k)] = value.re * scale;
+        }
+    });
+
+    Ok(output)
+}
+
+fn scale_for<T>(norm: FftNorm, forward: bool, n: usize) -> T
+where
+    T: Float + FromPrimitive,
+{
+    let len = T::from_usize(n).expect("FFT length must convert to scalar");
+    match (norm, forward) {
+        (FftNorm::Backward, true) | (FftNorm::Forward, false) => T::one(),
+        (FftNorm::Backward, false) | (FftNorm::Forward, true) => T::one() / len,
+        (FftNorm::Ortho, _) => T::one() / len.sqrt(),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct LaneContext {
+    input_base: usize,
+    output_base: usize,
+    axis_stride: usize,
+    in_axis_len: usize,
+}
+
+impl LaneContext {
+    fn input_offset(self, k: usize) -> usize {
+        self.input_base + k * self.axis_stride
+    }
+
+    fn output_offset(self, k: usize) -> usize {
+        self.output_base + k * self.axis_stride
+    }
+}
+
+fn for_axis_lane(
+    in_shape: &[usize],
+    axis: usize,
+    out_axis_len: usize,
+    mut f: impl FnMut(LaneContext),
+) {
+    let in_axis_len = in_shape[axis];
+    let axis_stride: usize = in_shape[..axis].iter().product();
+    let outer: usize = in_shape[axis + 1..].iter().product();
+    let in_block = axis_stride * in_axis_len;
+    let out_block = axis_stride * out_axis_len;
+
+    for outer_idx in 0..outer {
+        let in_outer_base = outer_idx * in_block;
+        let out_outer_base = outer_idx * out_block;
+        for inner in 0..axis_stride {
+            f(LaneContext {
+                input_base: in_outer_base + inner,
+                output_base: out_outer_base + inner,
+                axis_stride,
+                in_axis_len,
+            });
+        }
+    }
+}

--- a/tenferro-fft/tests/fft_ops.rs
+++ b/tenferro-fft/tests/fft_ops.rs
@@ -1,0 +1,151 @@
+use num_complex::Complex64;
+use tenferro::{CpuBackend, Engine, TracedTensor};
+use tenferro_fft::{fft, ifft, irfft, rfft, FftNorm};
+
+fn assert_c64_close(actual: &[Complex64], expected: &[Complex64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (a, e)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (a.re - e.re).abs() < 1e-10 && (a.im - e.im).abs() < 1e-10,
+            "idx {idx}: actual={a:?}, expected={e:?}"
+        );
+    }
+}
+
+fn assert_f64_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (a, e)) in actual.iter().zip(expected).enumerate() {
+        assert!((a - e).abs() < 1e-10, "idx {idx}: actual={a}, expected={e}");
+    }
+}
+
+#[test]
+fn fft_c64_matches_numpy_convention() {
+    let x = TracedTensor::from_vec(
+        vec![4],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    );
+    let mut y = fft(&x, None, -1, FftNorm::Backward);
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let out = y.eval(&mut engine).unwrap();
+
+    assert_eq!(out.shape(), &[4]);
+    assert_c64_close(
+        out.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+            Complex64::new(-2.0, -2.0),
+        ],
+    );
+}
+
+#[test]
+fn ifft_c64_applies_backward_normalization() {
+    let spectrum = TracedTensor::from_vec(
+        vec![4],
+        vec![
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+            Complex64::new(-2.0, -2.0),
+        ],
+    );
+    let mut y = ifft(&spectrum, None, -1, FftNorm::Backward);
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let out = y.eval(&mut engine).unwrap();
+
+    assert_c64_close(
+        out.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    );
+}
+
+#[test]
+fn rfft_f64_returns_onesided_spectrum() {
+    let x = TracedTensor::from_vec(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let mut y = rfft(&x, None, -1, FftNorm::Backward);
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let out = y.eval(&mut engine).unwrap();
+
+    assert_eq!(out.shape(), &[3]);
+    assert_c64_close(
+        out.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+        ],
+    );
+}
+
+#[test]
+fn irfft_c64_reconstructs_real_signal() {
+    let spectrum = TracedTensor::from_vec(
+        vec![3],
+        vec![
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+        ],
+    );
+    let mut y = irfft(&spectrum, Some(4), -1, FftNorm::Backward);
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let out = y.eval(&mut engine).unwrap();
+
+    assert_eq!(out.shape(), &[4]);
+    assert_f64_close(out.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn fft_c64_jvp_applies_fft_to_tangent() {
+    let x = TracedTensor::from_vec(
+        vec![4],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    );
+    let dx = TracedTensor::from_vec(
+        vec![4],
+        vec![
+            Complex64::new(0.0, 0.0),
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(-1.0, 0.0),
+        ],
+    );
+
+    let y = fft(&x, None, -1, FftNorm::Backward);
+    let mut dy = y.jvp(&x, &dx);
+
+    let mut engine = Engine::new(CpuBackend::new());
+    let out = dy.eval(&mut engine).unwrap();
+
+    assert_c64_close(
+        out.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, -2.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 2.0),
+        ],
+    );
+}

--- a/tenferro-tensor/benches/element_access.rs
+++ b/tenferro-tensor/benches/element_access.rs
@@ -1,18 +1,18 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use tenferro_tensor::{MemoryOrder, Tensor, TypedTensor};
+use tenferro_tensor::{Tensor, TypedTensor};
 
 const INDEX_COUNT: usize = 4096;
 
-fn tensor_with_order<const R: usize>(shape: [usize; R], order: MemoryOrder) -> TypedTensor<f64> {
+fn typed_tensor<const R: usize>(shape: [usize; R]) -> TypedTensor<f64> {
     let len = shape.iter().product();
     let data = (0..len).map(|value| value as f64).collect();
-    TypedTensor::from_vec_with_order(shape.to_vec(), data, order)
+    TypedTensor::from_vec(shape.to_vec(), data)
 }
 
-fn dynamic_tensor_with_order<const R: usize>(shape: [usize; R], order: MemoryOrder) -> Tensor {
+fn dynamic_tensor<const R: usize>(shape: [usize; R]) -> Tensor {
     let len = shape.iter().product();
     let data = (0..len).map(|value| value as f64).collect();
-    Tensor::from_vec_with_order(shape.to_vec(), data, order)
+    Tensor::from_vec(shape.to_vec(), data)
 }
 
 fn index_workload<const R: usize>(shape: [usize; R]) -> Vec<[usize; R]> {
@@ -28,157 +28,132 @@ fn index_workload<const R: usize>(shape: [usize; R]) -> Vec<[usize; R]> {
     indices
 }
 
-fn offset_for_order<const R: usize>(
-    shape: &[usize; R],
-    index: &[usize; R],
-    order: MemoryOrder,
-) -> usize {
-    match order {
-        MemoryOrder::ColMajor => {
-            let mut offset = 0usize;
-            let mut stride = 1usize;
-            for axis in 0..R {
-                offset += index[axis] * stride;
-                stride *= shape[axis];
-            }
-            offset
-        }
-        MemoryOrder::RowMajor => {
-            let mut offset = 0usize;
-            let mut stride = 1usize;
-            for axis in (0..R).rev() {
-                offset += index[axis] * stride;
-                stride *= shape[axis];
-            }
-            offset
-        }
+fn col_major_offset<const R: usize>(shape: &[usize; R], index: &[usize; R]) -> usize {
+    let mut offset = 0usize;
+    let mut stride = 1usize;
+    for axis in 0..R {
+        offset += index[axis] * stride;
+        stride *= shape[axis];
     }
+    offset
 }
 
 fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) {
     let indices = index_workload(shape);
+    let tensor = typed_tensor(shape);
+    let offsets = indices
+        .iter()
+        .map(|index| col_major_offset(&shape, index))
+        .collect::<Vec<_>>();
+    let mut group = c.benchmark_group(format!("element_access/{name}/col_major"));
 
-    for order in [MemoryOrder::ColMajor, MemoryOrder::RowMajor] {
-        let order_name = match order {
-            MemoryOrder::ColMajor => "col_major",
-            MemoryOrder::RowMajor => "row_major",
-        };
-        let tensor = tensor_with_order(shape, order);
-        let offsets = indices
-            .iter()
-            .map(|index| offset_for_order(&shape, index, order))
-            .collect::<Vec<_>>();
-        let mut group = c.benchmark_group(format!("element_access/{name}/{order_name}"));
+    group.bench_function(BenchmarkId::new("direct_slice", INDEX_COUNT), |b| {
+        let data = tensor.as_slice();
+        b.iter(|| {
+            let mut sum = 0.0;
+            for &offset in &offsets {
+                sum += black_box(data[black_box(offset)]);
+            }
+            black_box(sum)
+        });
+    });
 
-        group.bench_function(BenchmarkId::new("direct_slice", INDEX_COUNT), |b| {
-            let data = tensor.as_slice();
-            b.iter(|| {
-                let mut sum = 0.0;
+    group.bench_function(BenchmarkId::new("direct_slice_mut", INDEX_COUNT), |b| {
+        b.iter_batched(
+            || tensor.clone(),
+            |mut tensor| {
+                let data = tensor.host_data_mut();
                 for &offset in &offsets {
-                    sum += black_box(data[black_box(offset)]);
+                    data[black_box(offset)] += black_box(1.0);
                 }
-                black_box(sum)
-            });
-        });
+                black_box(data[0])
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
-        group.bench_function(BenchmarkId::new("direct_slice_mut", INDEX_COUNT), |b| {
-            b.iter_batched(
-                || tensor.clone(),
-                |mut tensor| {
-                    let data = tensor.host_data_mut();
-                    for &offset in &offsets {
-                        data[black_box(offset)] += black_box(1.0);
-                    }
-                    black_box(data[0])
-                },
-                BatchSize::SmallInput,
-            );
+    group.bench_function(BenchmarkId::new("linear_offset", INDEX_COUNT), |b| {
+        b.iter(|| {
+            let mut sum = 0usize;
+            for index in &indices {
+                sum = sum.wrapping_add(tensor.linear_offset(black_box(index.as_slice())));
+            }
+            black_box(sum)
         });
+    });
 
-        group.bench_function(BenchmarkId::new("linear_offset", INDEX_COUNT), |b| {
-            b.iter(|| {
-                let mut sum = 0usize;
+    group.bench_function(BenchmarkId::new("get", INDEX_COUNT), |b| {
+        b.iter(|| {
+            let mut sum = 0.0;
+            for index in &indices {
+                sum += *black_box(tensor.get(black_box(index.as_slice())));
+            }
+            black_box(sum)
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("try_get", INDEX_COUNT), |b| {
+        b.iter(|| {
+            let mut sum = 0.0;
+            for index in &indices {
+                sum += *black_box(tensor.try_get(black_box(index.as_slice())).unwrap());
+            }
+            black_box(sum)
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("get_unchecked", INDEX_COUNT), |b| {
+        b.iter(|| {
+            let mut sum = 0.0;
+            for index in &indices {
+                sum += *black_box(unsafe { tensor.get_unchecked(black_box(index.as_slice())) });
+            }
+            black_box(sum)
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("get_mut", INDEX_COUNT), |b| {
+        b.iter_batched(
+            || tensor.clone(),
+            |mut tensor| {
                 for index in &indices {
-                    sum = sum.wrapping_add(tensor.linear_offset(black_box(index.as_slice())));
+                    *tensor.get_mut(black_box(index.as_slice())) += black_box(1.0);
                 }
-                black_box(sum)
-            });
-        });
+                black_box(tensor.as_slice()[0])
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
-        group.bench_function(BenchmarkId::new("get", INDEX_COUNT), |b| {
-            b.iter(|| {
-                let mut sum = 0.0;
+    group.bench_function(BenchmarkId::new("try_get_mut", INDEX_COUNT), |b| {
+        b.iter_batched(
+            || tensor.clone(),
+            |mut tensor| {
                 for index in &indices {
-                    sum += *black_box(tensor.get(black_box(index.as_slice())));
+                    *tensor.try_get_mut(black_box(index.as_slice())).unwrap() += black_box(1.0);
                 }
-                black_box(sum)
-            });
-        });
+                black_box(tensor.as_slice()[0])
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
-        group.bench_function(BenchmarkId::new("try_get", INDEX_COUNT), |b| {
-            b.iter(|| {
-                let mut sum = 0.0;
+    group.bench_function(BenchmarkId::new("get_unchecked_mut", INDEX_COUNT), |b| {
+        b.iter_batched(
+            || tensor.clone(),
+            |mut tensor| {
                 for index in &indices {
-                    sum += *black_box(tensor.try_get(black_box(index.as_slice())).unwrap());
+                    unsafe {
+                        *tensor.get_unchecked_mut(black_box(index.as_slice())) += black_box(1.0);
+                    }
                 }
-                black_box(sum)
-            });
-        });
+                black_box(tensor.as_slice()[0])
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
-        group.bench_function(BenchmarkId::new("get_unchecked", INDEX_COUNT), |b| {
-            b.iter(|| {
-                let mut sum = 0.0;
-                for index in &indices {
-                    sum += *black_box(unsafe { tensor.get_unchecked(black_box(index.as_slice())) });
-                }
-                black_box(sum)
-            });
-        });
-
-        group.bench_function(BenchmarkId::new("get_mut", INDEX_COUNT), |b| {
-            b.iter_batched(
-                || tensor.clone(),
-                |mut tensor| {
-                    for index in &indices {
-                        *tensor.get_mut(black_box(index.as_slice())) += black_box(1.0);
-                    }
-                    black_box(tensor.as_slice()[0])
-                },
-                BatchSize::SmallInput,
-            );
-        });
-
-        group.bench_function(BenchmarkId::new("try_get_mut", INDEX_COUNT), |b| {
-            b.iter_batched(
-                || tensor.clone(),
-                |mut tensor| {
-                    for index in &indices {
-                        *tensor.try_get_mut(black_box(index.as_slice())).unwrap() += black_box(1.0);
-                    }
-                    black_box(tensor.as_slice()[0])
-                },
-                BatchSize::SmallInput,
-            );
-        });
-
-        group.bench_function(BenchmarkId::new("get_unchecked_mut", INDEX_COUNT), |b| {
-            b.iter_batched(
-                || tensor.clone(),
-                |mut tensor| {
-                    for index in &indices {
-                        unsafe {
-                            *tensor.get_unchecked_mut(black_box(index.as_slice())) +=
-                                black_box(1.0);
-                        }
-                    }
-                    black_box(tensor.as_slice()[0])
-                },
-                BatchSize::SmallInput,
-            );
-        });
-
-        group.finish();
-    }
+    group.finish();
 }
 
 fn element_access(c: &mut Criterion) {
@@ -193,172 +168,153 @@ fn element_access(c: &mut Criterion) {
 fn bench_rank2_fixed(c: &mut Criterion) {
     let shape = [64usize, 64];
     let indices = index_workload(shape);
-    for order in [MemoryOrder::ColMajor, MemoryOrder::RowMajor] {
-        let order_name = match order {
-            MemoryOrder::ColMajor => "col_major",
-            MemoryOrder::RowMajor => "row_major",
-        };
-        let tensor = tensor_with_order(shape, order);
-        let mut group = c.benchmark_group(format!("rank_fixed/2d/{order_name}"));
+    let tensor = typed_tensor(shape);
+    let mut group = c.benchmark_group("rank_fixed/2d/col_major");
 
-        group.bench_function(BenchmarkId::new("linear_offset2", INDEX_COUNT), |b| {
-            b.iter(|| {
-                let mut sum = 0usize;
+    group.bench_function(BenchmarkId::new("linear_offset2", INDEX_COUNT), |b| {
+        b.iter(|| {
+            let mut sum = 0usize;
+            for [i, j] in &indices {
+                sum = sum.wrapping_add(tensor.linear_offset2(black_box(*i), black_box(*j)));
+            }
+            black_box(sum)
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("get2", INDEX_COUNT), |b| {
+        b.iter(|| {
+            let mut sum = 0.0;
+            for [i, j] in &indices {
+                sum += *black_box(tensor.get2(black_box(*i), black_box(*j)));
+            }
+            black_box(sum)
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("get_mut2", INDEX_COUNT), |b| {
+        b.iter_batched(
+            || tensor.clone(),
+            |mut tensor| {
                 for [i, j] in &indices {
-                    sum = sum.wrapping_add(tensor.linear_offset2(black_box(*i), black_box(*j)));
+                    *tensor.get_mut2(black_box(*i), black_box(*j)) += black_box(1.0);
                 }
-                black_box(sum)
-            });
-        });
+                black_box(tensor.as_slice()[0])
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
-        group.bench_function(BenchmarkId::new("get2", INDEX_COUNT), |b| {
-            b.iter(|| {
-                let mut sum = 0.0;
-                for [i, j] in &indices {
-                    sum += *black_box(tensor.get2(black_box(*i), black_box(*j)));
-                }
-                black_box(sum)
-            });
-        });
-
-        group.bench_function(BenchmarkId::new("get_mut2", INDEX_COUNT), |b| {
-            b.iter_batched(
-                || tensor.clone(),
-                |mut tensor| {
-                    for [i, j] in &indices {
-                        *tensor.get_mut2(black_box(*i), black_box(*j)) += black_box(1.0);
-                    }
-                    black_box(tensor.as_slice()[0])
-                },
-                BatchSize::SmallInput,
-            );
-        });
-
-        group.finish();
-    }
+    group.finish();
 }
 
 fn bench_rank3_fixed(c: &mut Criterion) {
     let shape = [32usize, 16, 8];
     let indices = index_workload(shape);
-    for order in [MemoryOrder::ColMajor, MemoryOrder::RowMajor] {
-        let order_name = match order {
-            MemoryOrder::ColMajor => "col_major",
-            MemoryOrder::RowMajor => "row_major",
-        };
-        let tensor = tensor_with_order(shape, order);
-        let mut group = c.benchmark_group(format!("rank_fixed/3d/{order_name}"));
+    let tensor = typed_tensor(shape);
+    let mut group = c.benchmark_group("rank_fixed/3d/col_major");
 
-        group.bench_function(BenchmarkId::new("linear_offset3", INDEX_COUNT), |b| {
-            b.iter(|| {
-                let mut sum = 0usize;
+    group.bench_function(BenchmarkId::new("linear_offset3", INDEX_COUNT), |b| {
+        b.iter(|| {
+            let mut sum = 0usize;
+            for [i, j, k] in &indices {
+                sum = sum.wrapping_add(tensor.linear_offset3(
+                    black_box(*i),
+                    black_box(*j),
+                    black_box(*k),
+                ));
+            }
+            black_box(sum)
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("get3", INDEX_COUNT), |b| {
+        b.iter(|| {
+            let mut sum = 0.0;
+            for [i, j, k] in &indices {
+                sum += *black_box(tensor.get3(black_box(*i), black_box(*j), black_box(*k)));
+            }
+            black_box(sum)
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("get_mut3", INDEX_COUNT), |b| {
+        b.iter_batched(
+            || tensor.clone(),
+            |mut tensor| {
                 for [i, j, k] in &indices {
-                    sum = sum.wrapping_add(tensor.linear_offset3(
-                        black_box(*i),
-                        black_box(*j),
-                        black_box(*k),
-                    ));
+                    *tensor.get_mut3(black_box(*i), black_box(*j), black_box(*k)) += black_box(1.0);
                 }
-                black_box(sum)
-            });
-        });
+                black_box(tensor.as_slice()[0])
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
-        group.bench_function(BenchmarkId::new("get3", INDEX_COUNT), |b| {
-            b.iter(|| {
-                let mut sum = 0.0;
-                for [i, j, k] in &indices {
-                    sum += *black_box(tensor.get3(black_box(*i), black_box(*j), black_box(*k)));
-                }
-                black_box(sum)
-            });
-        });
-
-        group.bench_function(BenchmarkId::new("get_mut3", INDEX_COUNT), |b| {
-            b.iter_batched(
-                || tensor.clone(),
-                |mut tensor| {
-                    for [i, j, k] in &indices {
-                        *tensor.get_mut3(black_box(*i), black_box(*j), black_box(*k)) +=
-                            black_box(1.0);
-                    }
-                    black_box(tensor.as_slice()[0])
-                },
-                BatchSize::SmallInput,
-            );
-        });
-
-        group.finish();
-    }
+    group.finish();
 }
 
 fn bench_linear_iteration(c: &mut Criterion) {
     let shape = [256usize, 256];
-    for order in [MemoryOrder::ColMajor, MemoryOrder::RowMajor] {
-        let order_name = match order {
-            MemoryOrder::ColMajor => "col_major",
-            MemoryOrder::RowMajor => "row_major",
-        };
-        let tensor = tensor_with_order(shape, order);
-        let dynamic_tensor = dynamic_tensor_with_order(shape, order);
-        let mut group = c.benchmark_group(format!("linear_iteration/{order_name}"));
+    let tensor = typed_tensor(shape);
+    let dynamic_tensor = dynamic_tensor(shape);
+    let mut group = c.benchmark_group("linear_iteration/col_major");
 
-        group.bench_function("as_slice_iter", |b| {
-            b.iter(|| {
-                let sum = tensor
-                    .as_slice()
-                    .iter()
-                    .fold(0.0, |acc, value| acc + black_box(*value));
-                black_box(sum)
-            });
+    group.bench_function("as_slice_iter", |b| {
+        b.iter(|| {
+            let sum = tensor
+                .as_slice()
+                .iter()
+                .fold(0.0, |acc, value| acc + black_box(*value));
+            black_box(sum)
         });
+    });
 
-        group.bench_function("tensor_iter", |b| {
-            b.iter(|| {
-                let sum = tensor
-                    .iter()
-                    .fold(0.0, |acc, value| acc + black_box(*value));
-                black_box(sum)
-            });
+    group.bench_function("tensor_iter", |b| {
+        b.iter(|| {
+            let sum = tensor
+                .iter()
+                .fold(0.0, |acc, value| acc + black_box(*value));
+            black_box(sum)
         });
+    });
 
-        group.bench_function("dynamic_tensor_iter", |b| {
-            b.iter(|| {
-                let sum = dynamic_tensor
-                    .iter::<f64>()
-                    .unwrap()
-                    .fold(0.0, |acc, value| acc + black_box(*value));
-                black_box(sum)
-            });
+    group.bench_function("dynamic_tensor_iter", |b| {
+        b.iter(|| {
+            let sum = dynamic_tensor
+                .iter::<f64>()
+                .unwrap()
+                .fold(0.0, |acc, value| acc + black_box(*value));
+            black_box(sum)
         });
+    });
 
-        group.bench_function("tensor_iter_mut", |b| {
-            b.iter_batched(
-                || tensor.clone(),
-                |mut tensor| {
-                    for value in tensor.iter_mut() {
-                        *value += black_box(1.0);
-                    }
-                    black_box(tensor.as_slice()[0])
-                },
-                BatchSize::SmallInput,
-            );
-        });
+    group.bench_function("tensor_iter_mut", |b| {
+        b.iter_batched(
+            || tensor.clone(),
+            |mut tensor| {
+                for value in tensor.iter_mut() {
+                    *value += black_box(1.0);
+                }
+                black_box(tensor.as_slice()[0])
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
-        group.bench_function("dynamic_tensor_iter_mut", |b| {
-            b.iter_batched(
-                || dynamic_tensor.clone(),
-                |mut tensor| {
-                    for value in tensor.iter_mut::<f64>().unwrap() {
-                        *value += black_box(1.0);
-                    }
-                    black_box(tensor.as_slice::<f64>().unwrap()[0])
-                },
-                BatchSize::SmallInput,
-            );
-        });
+    group.bench_function("dynamic_tensor_iter_mut", |b| {
+        b.iter_batched(
+            || dynamic_tensor.clone(),
+            |mut tensor| {
+                for value in tensor.iter_mut::<f64>().unwrap() {
+                    *value += black_box(1.0);
+                }
+                black_box(tensor.as_slice::<f64>().unwrap()[0])
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
-        group.finish();
-    }
+    group.finish();
 }
 
 criterion_group!(benches, element_access);

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -438,10 +438,9 @@ impl TensorBackend for CpuBackend {
     }
 
     fn cholesky(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match &input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::cholesky(ctx.as_ref(), buffers, t).map(Tensor::F32),
             #[cfg(feature = "cpu-blas")]
@@ -471,11 +470,9 @@ impl TensorBackend for CpuBackend {
         transpose_a: bool,
         unit_diagonal: bool,
     ) -> crate::Result<Tensor> {
-        let a = a.to_col_major()?;
-        let b = b.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match (&a, &b) {
+        self.install_with_pool(|buffers| match (a, b) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F32(a), Tensor::F32(b)) => linalg::triangular_solve(
                 ctx.as_ref(),
@@ -583,10 +580,9 @@ impl TensorBackend for CpuBackend {
     }
 
     fn lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match &input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -620,10 +616,9 @@ impl TensorBackend for CpuBackend {
     }
 
     fn full_piv_lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match &input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::full_piv_lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -673,9 +668,7 @@ impl TensorBackend for CpuBackend {
 
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        let a = a.to_col_major()?;
-        let rhs = rhs.to_col_major()?;
-        let result = self.install_with_pool(|buffers| match (&a, &rhs) {
+        let result = self.install_with_pool(|buffers| match (a, &rhs) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F32(a), Tensor::F32(b)) => {
                 linalg::full_piv_lu_solve(ctx.as_ref(), buffers, a, b, transpose_a).map(Tensor::F32)
@@ -729,10 +722,9 @@ impl TensorBackend for CpuBackend {
     }
 
     fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match &input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::svd(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -762,10 +754,9 @@ impl TensorBackend for CpuBackend {
     }
 
     fn qr(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match &input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::qr(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -799,10 +790,9 @@ impl TensorBackend for CpuBackend {
     }
 
     fn eigh(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match &input {
+        self.install_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::eigh(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -838,17 +828,16 @@ impl TensorBackend for CpuBackend {
         ) {
             return Err(unsupported_dtype("eig", input.dtype()));
         }
-        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
         self.install_with_pool(|buffers| {
             #[cfg(feature = "cpu-faer")]
             {
-                linalg::eig(ctx.as_ref(), buffers, &input)
+                linalg::eig(ctx.as_ref(), buffers, input)
             }
             #[cfg(feature = "cpu-blas")]
             {
-                linalg::eig(buffers, &input)
+                linalg::eig(buffers, input)
             }
         })
     }

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -26,8 +26,7 @@ macro_rules! delegate {
 macro_rules! linalg_single {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-            let input = input.to_col_major()?;
-            match &input {
+            match input {
                 Tensor::F32(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::F32),
                 Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::F64),
                 Tensor::C32(t) => linalg::$name(self.ctx, self.buffers, t).map(Tensor::C32),
@@ -43,8 +42,7 @@ macro_rules! linalg_single {
 macro_rules! linalg_single {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-            let input = input.to_col_major()?;
-            match &input {
+            match input {
                 Tensor::F32(t) => linalg::$name(self.buffers, t).map(Tensor::F32),
                 Tensor::F64(t) => linalg::$name(self.buffers, t).map(Tensor::F64),
                 Tensor::C32(t) => linalg::$name(self.buffers, t).map(Tensor::C32),
@@ -60,8 +58,7 @@ macro_rules! linalg_single {
 macro_rules! linalg_multi {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-            let input = input.to_col_major()?;
-            match &input {
+            match input {
                 Tensor::F32(t) => linalg::$name(self.ctx, self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                 Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t)
@@ -81,8 +78,7 @@ macro_rules! linalg_multi {
 macro_rules! linalg_multi_result {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-            let input = input.to_col_major()?;
-            match &input {
+            match input {
                 Tensor::F32(t) => linalg::$name(self.ctx, self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                 Tensor::F64(t) => linalg::$name(self.ctx, self.buffers, t)
@@ -102,8 +98,7 @@ macro_rules! linalg_multi_result {
 macro_rules! linalg_multi {
     ($name:ident) => {
         fn $name(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
-            let input = input.to_col_major()?;
-            match &input {
+            match input {
                 Tensor::F32(t) => linalg::$name(self.buffers, t)
                     .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                 Tensor::F64(t) => linalg::$name(self.buffers, t)
@@ -251,14 +246,13 @@ impl TensorExec for CpuExecSession<'_> {
         ) {
             return Err(unsupported_dtype("eig", input.dtype()));
         }
-        let input = input.to_col_major()?;
         #[cfg(feature = "cpu-faer")]
         {
-            linalg::eig(self.ctx, self.buffers, &input)
+            linalg::eig(self.ctx, self.buffers, input)
         }
         #[cfg(feature = "cpu-blas")]
         {
-            linalg::eig(self.buffers, &input)
+            linalg::eig(self.buffers, input)
         }
     }
 
@@ -271,9 +265,7 @@ impl TensorExec for CpuExecSession<'_> {
         transpose_a: bool,
         unit_diagonal: bool,
     ) -> crate::Result<Tensor> {
-        let a = a.to_col_major()?;
-        let b = b.to_col_major()?;
-        match (&a, &b) {
+        match (a, b) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F32(a), Tensor::F32(b)) => linalg::triangular_solve(
                 self.ctx,
@@ -386,9 +378,7 @@ impl TensorExec for CpuExecSession<'_> {
         b: &Tensor,
         transpose_a: bool,
     ) -> crate::Result<Tensor> {
-        let a = a.to_col_major()?;
-        let b = b.to_col_major()?;
-        match (&a, &b) {
+        match (a, b) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F32(a), Tensor::F32(b)) => {
                 linalg::full_piv_lu_solve(self.ctx, self.buffers, a, b, transpose_a)

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -4,7 +4,7 @@ use smallvec::SmallVec;
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::config::DotGeneralConfig;
 use crate::cpu::structural::typed_transpose;
-use crate::types::{col_major_strides, contiguous_strides, Buffer, TypedTensor};
+use crate::types::{col_major_strides, Buffer, TypedTensor};
 use crate::Error;
 
 #[cfg(feature = "cpu-blas")]
@@ -261,12 +261,8 @@ fn analyse_gemm<T>(
         .filter(|d| !config.rhs_contracting_dims.contains(d) && !config.rhs_batch_dims.contains(d))
         .collect();
 
-    let lhs_strides: SmallVec<[isize; 8]> = contiguous_strides(&lhs.shape, lhs.order)
-        .into_iter()
-        .collect();
-    let rhs_strides: SmallVec<[isize; 8]> = contiguous_strides(&rhs.shape, rhs.order)
-        .into_iter()
-        .collect();
+    let lhs_strides: SmallVec<[isize; 8]> = col_major_strides(&lhs.shape).into_iter().collect();
+    let rhs_strides: SmallVec<[isize; 8]> = col_major_strides(&rhs.shape).into_iter().collect();
 
     let batch_shapes: SmallVec<[usize; 8]> = config
         .lhs_batch_dims
@@ -416,7 +412,6 @@ where
             buffer: Buffer::Host(vec![T::zero(); out_n]),
             shape: dims.out_shape.into_vec(),
             placement: lhs.placement.clone(),
-            order: crate::MemoryOrder::ColMajor,
         });
     }
 
@@ -466,7 +461,6 @@ where
         buffer: Buffer::Host(out_data),
         shape: dims.out_shape.into_vec(),
         placement: lhs.placement.clone(),
-        order: crate::MemoryOrder::ColMajor,
     })
 }
 
@@ -527,7 +521,6 @@ where
             buffer: Buffer::Host(vec![T::zero(); out_n]),
             shape: dims.out_shape.into_vec(),
             placement: lhs.placement.clone(),
-            order: crate::MemoryOrder::ColMajor,
         }));
     }
 
@@ -602,7 +595,6 @@ where
         buffer: Buffer::Host(out),
         shape: dims.out_shape.into_vec(),
         placement: lhs.placement.clone(),
-        order: crate::MemoryOrder::ColMajor,
     }))
 }
 

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -523,15 +523,11 @@ fn f64_index_to_i64(value: f64) -> crate::Result<i64> {
 
 fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor> {
     match tensor {
-        Tensor::I64(t) => {
-            let t = t.to_col_major()?;
-            Ok(IndexTensor {
-                shape: t.shape.clone(),
-                values: t.host_data().to_vec(),
-            })
-        }
+        Tensor::I64(t) => Ok(IndexTensor {
+            shape: t.shape.clone(),
+            values: t.host_data().to_vec(),
+        }),
         Tensor::F32(t) => {
-            let t = t.to_col_major()?;
             let values: crate::Result<Vec<i64>> = t
                 .host_data()
                 .iter()
@@ -543,7 +539,6 @@ fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor> {
             })
         }
         Tensor::F64(t) => {
-            let t = t.to_col_major()?;
             let values: crate::Result<Vec<i64>> = t
                 .host_data()
                 .iter()

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -93,7 +93,6 @@ fn tensor_from_vec_with_template<T: Clone, U>(
         buffer: Buffer::Host(data),
         shape,
         placement: template.placement.clone(),
-        order: crate::MemoryOrder::ColMajor,
     }
 }
 

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/helpers.rs
@@ -39,7 +39,6 @@ pub(crate) fn tensor_from_vec_with_template<T: Clone, U>(
         buffer: crate::Buffer::Host(data),
         shape,
         placement: template.placement.clone(),
-        order: crate::MemoryOrder::ColMajor,
     }
 }
 

--- a/tenferro-tensor/src/cpu/mod.rs
+++ b/tenferro-tensor/src/cpu/mod.rs
@@ -30,7 +30,7 @@ pub use structural::{
 pub(crate) fn typed_view<T: Copy>(tensor: &TypedTensor<T>) -> StridedView<'_, T> {
     match &tensor.buffer {
         Buffer::Host(data) => {
-            let strides = crate::contiguous_strides(&tensor.shape, tensor.order);
+            let strides = col_major_strides(&tensor.shape);
             StridedView::new(data, &tensor.shape, &strides, 0).expect("contiguous host tensor")
         }
         Buffer::Backend(_) => todo!("typed_view for backend buffers"),

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -1,6 +1,6 @@
 use num_complex::{Complex32, Complex64};
 use num_traits::Zero;
-use strided_kernel::{copy_into, map_into, Identity, StridedView};
+use strided_kernel::{col_major_strides, copy_into, map_into, Identity, StridedView};
 
 use crate::{
     types::{flat_to_multi, Tensor, TypedTensor},
@@ -65,7 +65,7 @@ fn validate_permutation(op: &'static str, perm: &[usize], rank: usize) -> crate:
 fn host_view<T: Copy>(tensor: &TypedTensor<T>) -> crate::Result<StridedView<'_, T, Identity>> {
     match &tensor.buffer {
         crate::Buffer::Host(data) => {
-            let strides = crate::contiguous_strides(&tensor.shape, tensor.order);
+            let strides = col_major_strides(&tensor.shape);
             StridedView::new(data, &tensor.shape, &strides, 0)
                 .map_err(|err| backend_failure("structural", err))
         }
@@ -231,7 +231,6 @@ pub fn typed_reshape<T: Clone>(
         buffer: tensor.buffer.clone(),
         shape: shape.to_vec(),
         placement: tensor.placement.clone(),
-        order: tensor.order,
     })
 }
 
@@ -244,7 +243,7 @@ pub fn typed_broadcast_in_dim<T: Copy + Zero + Clone>(
     let mut seen = vec![false; shape.len()];
     let mut base_dims = vec![1usize; shape.len()];
     let mut base_strides = vec![0isize; shape.len()];
-    let source_strides = crate::contiguous_strides(&tensor.shape, tensor.order);
+    let source_strides = col_major_strides(&tensor.shape);
     for (src_axis, &dst_axis) in dims.iter().enumerate() {
         validate_axis("broadcast_in_dim", dst_axis, shape.len())?;
         if seen[dst_axis] {

--- a/tenferro-tensor/src/cubecl/dispatch.rs
+++ b/tenferro-tensor/src/cubecl/dispatch.rs
@@ -53,22 +53,22 @@ pub(crate) fn cubecl_shape_and_strides(shape: &[usize]) -> (Vec<usize>, Vec<usiz
     (shape.to_vec(), strides)
 }
 
-pub(crate) fn typed_tensor_binding<T: CubeElement + Clone>(
-    tensor: &TypedTensor<T>,
-    op: &'static str,
-) -> crate::Result<TensorBinding<CudaRuntime>> {
-    let buffer = cubecl_buffer(tensor, op)?;
-    let expected_len = tensor
-        .shape
+fn checked_shape_product(op: &'static str, shape: &[usize]) -> crate::Result<usize> {
+    shape
         .iter()
         .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
         .ok_or_else(|| crate::Error::BackendFailure {
             op,
-            message: format!(
-                "shape product overflow for CubeCL tensor shape {:?}",
-                tensor.shape
-            ),
-        })?;
+            message: format!("shape product overflow for CubeCL tensor shape {shape:?}"),
+        })
+}
+
+fn validate_cubecl_buffer_len<T>(
+    tensor: &TypedTensor<T>,
+    buffer: &CubeclBuffer<T>,
+    op: &'static str,
+) -> crate::Result<()> {
+    let expected_len = checked_shape_product(op, &tensor.shape)?;
     if expected_len != buffer.len {
         return Err(crate::Error::BackendFailure {
             op,
@@ -78,6 +78,45 @@ pub(crate) fn typed_tensor_binding<T: CubeElement + Clone>(
             ),
         });
     }
+    Ok(())
+}
+
+fn validate_raw_unary_shapes<TIn>(
+    input: &TypedTensor<TIn>,
+    out_shape: &[usize],
+    op: &'static str,
+) -> crate::Result<()> {
+    ensure_same_shape(op, &input.shape, out_shape)
+}
+
+fn validate_raw_binary_shapes<TLhs, TRhs>(
+    lhs: &TypedTensor<TLhs>,
+    rhs: &TypedTensor<TRhs>,
+    out_shape: &[usize],
+    op: &'static str,
+) -> crate::Result<()> {
+    ensure_same_shape(op, &lhs.shape, out_shape)?;
+    ensure_same_shape(op, &rhs.shape, out_shape)
+}
+
+fn validate_raw_ternary_shapes<TA, TB, TC>(
+    a: &TypedTensor<TA>,
+    b: &TypedTensor<TB>,
+    c: &TypedTensor<TC>,
+    out_shape: &[usize],
+    op: &'static str,
+) -> crate::Result<()> {
+    ensure_same_shape(op, &a.shape, out_shape)?;
+    ensure_same_shape(op, &b.shape, out_shape)?;
+    ensure_same_shape(op, &c.shape, out_shape)
+}
+
+pub(crate) fn typed_tensor_binding<T: CubeElement + Clone>(
+    tensor: &TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<TensorBinding<CudaRuntime>> {
+    let buffer = cubecl_buffer(tensor, op)?;
+    validate_cubecl_buffer_len(tensor, buffer, op)?;
     let (shape, strides) = cubecl_shape_and_strides(&tensor.shape);
 
     // SAFETY: `buffer.handle` references the CubeCL allocation for `tensor`.
@@ -162,7 +201,12 @@ pub(crate) fn typed_tensor_array_arg<T: CubeElement + Clone>(
     op: &'static str,
 ) -> crate::Result<ArrayArg<CudaRuntime>> {
     let buffer = cubecl_buffer(tensor, op)?;
-    // SAFETY: `CubeclBuffer::len` tracks the allocation length in elements.
+    validate_cubecl_buffer_len(tensor, buffer, op)?;
+
+    // SAFETY: `buffer.handle` references the CubeCL allocation for `tensor`.
+    // `validate_cubecl_buffer_len` proves `buffer.len` equals the dense shape
+    // product, so raw linear kernels that index `0..out.len()` cannot observe
+    // an array longer than the logical tensor allocation.
     Ok(unsafe { ArrayArg::from_raw_parts(buffer.handle.clone(), buffer.len) })
 }
 
@@ -176,6 +220,7 @@ where
     U: CubeElement + Clone,
 {
     let buffer = cubecl_buffer(tensor, op)?;
+    validate_cubecl_buffer_len(tensor, buffer, op)?;
     let requested_bytes =
         len.checked_mul(core::mem::size_of::<U>())
             .ok_or_else(|| crate::Error::BackendFailure {
@@ -201,9 +246,12 @@ where
         });
     }
 
-    // SAFETY: The checked byte-size invariant proves the requested view stays
-    // within the same CubeCL allocation. Kernels using this helper are
-    // responsible for using a representation-compatible scalar view.
+    // SAFETY: `validate_cubecl_buffer_len` first proves the typed tensor shape
+    // matches the backing allocation. The checked byte-size invariant then
+    // proves the requested representation view stays within the same
+    // allocation. Kernels using this helper are responsible for using a
+    // representation-compatible scalar view, for example complex values as
+    // their real and imaginary scalar parts.
     Ok(unsafe { ArrayArg::from_raw_parts(buffer.handle.clone(), len) })
 }
 
@@ -224,6 +272,7 @@ where
     TIn: CubeElement + Clone,
     TOut: CubeElement + Clone,
 {
+    validate_raw_unary_shapes(input, out_shape, op)?;
     let output = alloc_output::<TOut>(rt, out_shape);
     let len = output.n_elements();
     if len == 0 {
@@ -232,6 +281,12 @@ where
     let client = rt.client();
     let output_arg = typed_tensor_array_arg(&output, op)?;
     let input_arg = typed_tensor_array_arg(input, op)?;
+    // SAFETY: This helper is the host-side unchecked launch boundary for raw
+    // shape-preserving unary kernels. The shape validation above proves input
+    // and output have the same dense element count; `typed_tensor_array_arg`
+    // proves each raw array length matches its tensor shape. The launch domain
+    // covers `len == output.n_elements()`, and these kernels guard writes with
+    // `ABSOLUTE_POS < out.len()`.
     launch(
         client,
         cube_count_for_len(len),
@@ -267,6 +322,11 @@ where
     let client = rt.client();
     let output_arg = typed_tensor_binding(&output, op)?;
     let input_arg = typed_tensor_binding(input, op)?;
+    // SAFETY: Logical tensor kernels use `TensorBinding`, whose construction
+    // validates shape product against the CubeCL allocation length. The caller
+    // supplies output shape and launch metadata already validated for the
+    // specific structural/indexing operation, and the kernels guard their
+    // launched index domain before mapping logical indices.
     launch(
         client,
         cube_count_for_len(len),
@@ -292,6 +352,9 @@ where
         return Ok(());
     }
     let output_arg = typed_tensor_array_arg(output, op)?;
+    // SAFETY: Nullary raw kernels write only to the validated output array.
+    // The caller-supplied `count`/`dim` must describe the initialized domain,
+    // and kernels using this path guard with `ABSOLUTE_POS < out.len()`.
     launch(rt.client(), count, dim, output_arg);
     Ok(())
 }
@@ -320,6 +383,10 @@ where
     }
     let output_arg = typed_tensor_binding(output, op)?;
     let input_arg = typed_tensor_binding(input, op)?;
+    // SAFETY: `TensorBinding` construction validates shape and backing buffer
+    // length for both tensors. The caller supplies a launch domain derived
+    // from validated operation metadata, and the target kernel guards the
+    // output or update domain before logical tensor indexing.
     launch(rt.client(), count, dim, output_arg, input_arg);
     Ok(())
 }
@@ -344,6 +411,7 @@ where
     TRhs: CubeElement + Clone,
     TOut: CubeElement + Clone,
 {
+    validate_raw_binary_shapes(lhs, rhs, out_shape, op)?;
     let output = alloc_output::<TOut>(rt, out_shape);
     let len = output.n_elements();
     if len == 0 {
@@ -353,6 +421,12 @@ where
     let output_arg = typed_tensor_array_arg(&output, op)?;
     let lhs_arg = typed_tensor_array_arg(lhs, op)?;
     let rhs_arg = typed_tensor_array_arg(rhs, op)?;
+    // SAFETY: This helper is the host-side unchecked launch boundary for raw
+    // shape-preserving binary kernels. The shared shape validation above
+    // proves all arrays have the same dense element count; the raw array
+    // helpers prove every CubeCL buffer length matches its tensor shape. The
+    // launch covers `len == output.n_elements()`, and elementwise kernels guard
+    // with `ABSOLUTE_POS < out.len()`.
     launch(
         client,
         cube_count_for_len(len),
@@ -393,6 +467,11 @@ where
     let output_arg = typed_tensor_binding(&output, op)?;
     let lhs_arg = typed_tensor_binding(lhs, op)?;
     let rhs_arg = typed_tensor_binding(rhs, op)?;
+    // SAFETY: Logical tensor kernels receive only `TensorBinding` arguments,
+    // each validated against its backing buffer length. Shape/config
+    // compatibility is checked by the operation-specific metadata builder
+    // before this launch helper is called, and the kernel guards its launched
+    // index domain.
     launch(
         client,
         cube_count_for_len(len),
@@ -427,6 +506,7 @@ where
     TC: CubeElement + Clone,
     TOut: CubeElement + Clone,
 {
+    validate_raw_ternary_shapes(a, b, c, out_shape, op)?;
     let output = alloc_output::<TOut>(rt, out_shape);
     let len = output.n_elements();
     if len == 0 {
@@ -437,6 +517,11 @@ where
     let a_arg = typed_tensor_array_arg(a, op)?;
     let b_arg = typed_tensor_array_arg(b, op)?;
     let c_arg = typed_tensor_array_arg(c, op)?;
+    // SAFETY: This helper is the host-side unchecked launch boundary for raw
+    // shape-preserving ternary kernels. The shared shape validation above
+    // proves all inputs and output have the same dense element count; raw array
+    // construction validates each backing buffer length. Kernels launched by
+    // this helper guard with `ABSOLUTE_POS < out.len()`.
     launch(
         client,
         cube_count_for_len(len),

--- a/tenferro-tensor/src/cubecl/dispatch.rs
+++ b/tenferro-tensor/src/cubecl/dispatch.rs
@@ -5,7 +5,7 @@ use cubecl_cuda::CudaRuntime;
 use crate::config::CompareDir;
 use crate::cubecl::CubeclRuntime;
 use crate::types::{
-    Buffer, ComputeDevice, CubeclBuffer, MemoryKind, MemoryOrder, Placement, Tensor, TypedTensor,
+    Buffer, ComputeDevice, CubeclBuffer, MemoryKind, Placement, Tensor, TypedTensor,
 };
 
 pub(crate) const DEFAULT_CUBE_DIM_X: u32 = 256;
@@ -78,12 +78,6 @@ pub(crate) fn typed_tensor_binding<T: CubeElement + Clone>(
             ),
         });
     }
-    if tensor.order != MemoryOrder::ColMajor {
-        return Err(crate::Error::BackendFailure {
-            op,
-            message: "expected column-major GPU tensor; row-major host tensors must be canonicalized during upload".into(),
-        });
-    }
     let (shape, strides) = cubecl_shape_and_strides(&tensor.shape);
 
     // SAFETY: `buffer.handle` references the CubeCL allocation for `tensor`.
@@ -147,7 +141,6 @@ pub(crate) fn typed_from_cubecl<T>(
                 ordinal: device_ordinal,
             }),
         },
-        order: crate::MemoryOrder::ColMajor,
     }
 }
 

--- a/tenferro-tensor/src/cubecl/fusion/launch.rs
+++ b/tenferro-tensor/src/cubecl/fusion/launch.rs
@@ -44,6 +44,11 @@ where
         _marker: PhantomData,
     };
     unsafe {
+        // SAFETY: `ClassifiedFusion` proves all inputs share one dense output
+        // shape, and `typed_tensor_array_arg` validates every raw array length
+        // against its tensor shape. The generated kernel reads `out.len()`,
+        // launches over `classified.n_elements`, and guards the body with
+        // `ABSOLUTE_POS < out.len()`.
         launcher.launch_unchecked(
             cube_count_for_len(classified.n_elements),
             kernel,

--- a/tenferro-tensor/src/cubecl/linalg.rs
+++ b/tenferro-tensor/src/cubecl/linalg.rs
@@ -1013,7 +1013,6 @@ fn upload_host_tensor<T>(
 where
     T: CubeElement + Clone,
 {
-    let tensor = tensor.to_col_major()?;
     let (shape, data) = match tensor.buffer {
         crate::Buffer::Host(data) => (tensor.shape, data),
         crate::Buffer::Backend(_) | crate::Buffer::Cubecl(_) => {

--- a/tenferro-tensor/src/cubecl/memory.rs
+++ b/tenferro-tensor/src/cubecl/memory.rs
@@ -1,7 +1,5 @@
 //! Host-to-device and device-to-host transfers via CubeCL-managed allocations.
 
-use std::borrow::Cow;
-
 use cubecl::client::ComputeClient;
 use cubecl::prelude::CubeElement;
 use cubecl_cuda::CudaRuntime;
@@ -9,7 +7,7 @@ use num_complex::{Complex32, Complex64};
 
 use crate::cubecl::runtime::CubeclRuntime;
 use crate::types::{
-    Buffer, ComputeDevice, CubeclBuffer, MemoryKind, MemoryOrder, Placement, Tensor, TypedTensor,
+    Buffer, ComputeDevice, CubeclBuffer, MemoryKind, Placement, Tensor, TypedTensor,
 };
 
 /// Upload a host tensor into a CubeCL-managed GPU allocation.
@@ -85,32 +83,8 @@ fn upload_typed<T: CubeElement + Clone>(
     device_ordinal: usize,
     typed: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>> {
-    let upload_source = canonical_host_tensor_for_upload(typed)?;
-    let host_data = match &upload_source.buffer {
+    let host_data = match &typed.buffer {
         Buffer::Host(data) => data,
-        Buffer::Backend(_) | Buffer::Cubecl(_) => unreachable!("canonical upload source is host"),
-    };
-
-    let handle = client.create_from_slice(T::as_bytes(host_data));
-    Ok(TypedTensor {
-        buffer: Buffer::Cubecl(CubeclBuffer::new(handle, host_data.len())),
-        shape: upload_source.shape.clone(),
-        placement: Placement {
-            memory_kind: MemoryKind::Device,
-            resident_device: Some(ComputeDevice {
-                kind: "cuda".into(),
-                ordinal: device_ordinal,
-            }),
-        },
-        order: MemoryOrder::ColMajor,
-    })
-}
-
-pub(crate) fn canonical_host_tensor_for_upload<T: Clone>(
-    typed: &TypedTensor<T>,
-) -> crate::Result<Cow<'_, TypedTensor<T>>> {
-    match &typed.buffer {
-        Buffer::Host(_) => {}
         Buffer::Backend(_) => {
             return Err(crate::Error::BackendFailure {
                 op: "upload",
@@ -124,11 +98,19 @@ pub(crate) fn canonical_host_tensor_for_upload<T: Clone>(
             });
         }
     };
-    if typed.order == MemoryOrder::ColMajor {
-        Ok(Cow::Borrowed(typed))
-    } else {
-        typed.to_col_major().map(Cow::Owned)
-    }
+
+    let handle = client.create_from_slice(T::as_bytes(host_data));
+    Ok(TypedTensor {
+        buffer: Buffer::Cubecl(CubeclBuffer::new(handle, host_data.len())),
+        shape: typed.shape.clone(),
+        placement: Placement {
+            memory_kind: MemoryKind::Device,
+            resident_device: Some(ComputeDevice {
+                kind: "cuda".into(),
+                ordinal: device_ordinal,
+            }),
+        },
+    })
 }
 
 fn download_typed<T: CubeElement + Clone>(

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -2301,31 +2301,26 @@ impl TensorBackend for CubeclBackend {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
-                order: t.order,
             })),
             Tensor::F64(t) => Ok(Tensor::F64(TypedTensor {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
-                order: t.order,
             })),
             Tensor::I64(t) => Ok(Tensor::I64(TypedTensor {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
-                order: t.order,
             })),
             Tensor::C32(t) => Ok(Tensor::C32(TypedTensor {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
-                order: t.order,
             })),
             Tensor::C64(t) => Ok(Tensor::C64(TypedTensor {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
-                order: t.order,
             })),
         }
     }

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -78,7 +78,9 @@ use std::cell::OnceCell;
 
 use cubecl::client::ComputeClient;
 use cubecl::features::AtomicUsage;
-use cubecl::prelude::{Complex as CubeComplex, CubeElement, CubePrimitive, Float as CubeFloat};
+use cubecl::prelude::{
+    ArrayArg, Complex as CubeComplex, CubeElement, CubePrimitive, Float as CubeFloat,
+};
 use cubecl::prelude::{Int as CubeInt, StorageType, TensorBinding, Type};
 use cubecl_cuda::CudaRuntime;
 use num_complex::{Complex32, Complex64};
@@ -103,8 +105,8 @@ use dispatch::{
     alloc_output, comptime_sequence, cube_count_for_len, cube_dim_1d, dtype_mismatch,
     ensure_axes_unique, ensure_axis, ensure_rank, ensure_resident_on_runtime, launch_binary,
     launch_binary_tensor, launch_nullary_into, launch_ternary, launch_unary, launch_unary_tensor,
-    launch_unary_tensor_into, ternary_dtype_mismatch, typed_from_cubecl, typed_tensor_array_arg_as,
-    typed_tensor_binding,
+    launch_unary_tensor_into, ternary_dtype_mismatch, typed_tensor_array_arg,
+    typed_tensor_array_arg_as, typed_tensor_binding,
 };
 
 pub use memory::{device_ptr, download_tensor, upload_tensor};
@@ -375,132 +377,124 @@ impl CubeclBackend {
         &self,
         input: &TypedTensor<f32>,
     ) -> crate::Result<TypedTensor<Complex32>> {
-        self.convert_float_to_complex_raw::<f32, Complex32>(
-            input,
-            std::mem::size_of::<f32>(),
-            |client, out_h, inp_h, n| {
-                let count = cubecl::prelude::CubeCount::new_single();
-                let dim = cubecl::prelude::CubeDim::new_1d(n as u32);
-                unsafe {
-                    structural::convert_f32_to_c32_raw::launch_unchecked::<CudaRuntime>(
-                        client,
-                        count,
-                        dim,
-                        cubecl::prelude::ArrayArg::from_raw_parts(out_h, n * 2),
-                        cubecl::prelude::ArrayArg::from_raw_parts(inp_h, n),
-                    );
-                }
-            },
-        )
+        self.convert_float_to_complex_raw::<f32, Complex32, f32>(input, |client, out, input, n| {
+            unsafe {
+                // SAFETY: `convert_float_to_complex_raw` validated that
+                // `input` has `n` elements and `out` has `2 * n` scalar
+                // components. The kernel launches exactly `n` logical input
+                // positions and guards with `ABSOLUTE_POS < input.len()`.
+                structural::convert_f32_to_c32_raw::launch_unchecked::<CudaRuntime>(
+                    client,
+                    cube_count_for_len(n),
+                    cube_dim_1d(),
+                    out,
+                    input,
+                );
+            }
+        })
     }
 
     fn convert_f32_to_c64(
         &self,
         input: &TypedTensor<f32>,
     ) -> crate::Result<TypedTensor<Complex64>> {
-        self.convert_float_to_complex_raw::<f32, Complex64>(
-            input,
-            std::mem::size_of::<f64>(),
-            |client, out_h, inp_h, n| {
-                let count = cubecl::prelude::CubeCount::new_single();
-                let dim = cubecl::prelude::CubeDim::new_1d(n as u32);
-                unsafe {
-                    structural::convert_f32_to_c64_raw::launch_unchecked::<CudaRuntime>(
-                        client,
-                        count,
-                        dim,
-                        cubecl::prelude::ArrayArg::from_raw_parts(out_h, n * 2),
-                        cubecl::prelude::ArrayArg::from_raw_parts(inp_h, n),
-                    );
-                }
-            },
-        )
+        self.convert_float_to_complex_raw::<f32, Complex64, f64>(input, |client, out, input, n| {
+            unsafe {
+                // SAFETY: `convert_float_to_complex_raw` validated that
+                // `input` has `n` elements and `out` has `2 * n` scalar
+                // components. The kernel launches exactly `n` logical input
+                // positions and guards with `ABSOLUTE_POS < input.len()`.
+                structural::convert_f32_to_c64_raw::launch_unchecked::<CudaRuntime>(
+                    client,
+                    cube_count_for_len(n),
+                    cube_dim_1d(),
+                    out,
+                    input,
+                );
+            }
+        })
     }
 
     fn convert_f64_to_c32(
         &self,
         input: &TypedTensor<f64>,
     ) -> crate::Result<TypedTensor<Complex32>> {
-        self.convert_float_to_complex_raw::<f64, Complex32>(
-            input,
-            std::mem::size_of::<f32>(),
-            |client, out_h, inp_h, n| {
-                let count = cubecl::prelude::CubeCount::new_single();
-                let dim = cubecl::prelude::CubeDim::new_1d(n as u32);
-                unsafe {
-                    structural::convert_f64_to_c32_raw::launch_unchecked::<CudaRuntime>(
-                        client,
-                        count,
-                        dim,
-                        cubecl::prelude::ArrayArg::from_raw_parts(out_h, n * 2),
-                        cubecl::prelude::ArrayArg::from_raw_parts(inp_h, n),
-                    );
-                }
-            },
-        )
+        self.convert_float_to_complex_raw::<f64, Complex32, f32>(input, |client, out, input, n| {
+            unsafe {
+                // SAFETY: `convert_float_to_complex_raw` validated that
+                // `input` has `n` elements and `out` has `2 * n` scalar
+                // components. The kernel launches exactly `n` logical input
+                // positions and guards with `ABSOLUTE_POS < input.len()`.
+                structural::convert_f64_to_c32_raw::launch_unchecked::<CudaRuntime>(
+                    client,
+                    cube_count_for_len(n),
+                    cube_dim_1d(),
+                    out,
+                    input,
+                );
+            }
+        })
     }
 
     fn convert_f64_to_c64(
         &self,
         input: &TypedTensor<f64>,
     ) -> crate::Result<TypedTensor<Complex64>> {
-        self.convert_float_to_complex_raw::<f64, Complex64>(
-            input,
-            std::mem::size_of::<f64>(),
-            |client, out_h, inp_h, n| {
-                let count = cubecl::prelude::CubeCount::new_single();
-                let dim = cubecl::prelude::CubeDim::new_1d(n as u32);
-                unsafe {
-                    structural::convert_f64_to_c64_raw::launch_unchecked::<CudaRuntime>(
-                        client,
-                        count,
-                        dim,
-                        cubecl::prelude::ArrayArg::from_raw_parts(out_h, n * 2),
-                        cubecl::prelude::ArrayArg::from_raw_parts(inp_h, n),
-                    );
-                }
-            },
-        )
+        self.convert_float_to_complex_raw::<f64, Complex64, f64>(input, |client, out, input, n| {
+            unsafe {
+                // SAFETY: `convert_float_to_complex_raw` validated that
+                // `input` has `n` elements and `out` has `2 * n` scalar
+                // components. The kernel launches exactly `n` logical input
+                // positions and guards with `ABSOLUTE_POS < input.len()`.
+                structural::convert_f64_to_c64_raw::launch_unchecked::<CudaRuntime>(
+                    client,
+                    cube_count_for_len(n),
+                    cube_dim_1d(),
+                    out,
+                    input,
+                );
+            }
+        })
     }
 
     /// Generic float-to-complex conversion via raw interleaved kernel.
     ///
     /// The kernel writes `(re, 0, re, 0, ...)` into a raw float buffer that
-    /// is then reinterpreted as complex. `out_float_size` is the byte size of
-    /// each real output component.
-    fn convert_float_to_complex_raw<InFloat, OutComplex>(
+    /// is then reinterpreted as complex.
+    fn convert_float_to_complex_raw<InFloat, OutComplex, OutFloat>(
         &self,
         input: &TypedTensor<InFloat>,
-        out_float_size: usize,
         launch: impl FnOnce(
             &cubecl::client::ComputeClient<CudaRuntime>,
-            cubecl::server::Handle,
-            cubecl::server::Handle,
+            ArrayArg<CudaRuntime>,
+            ArrayArg<CudaRuntime>,
             usize,
         ),
     ) -> crate::Result<TypedTensor<OutComplex>>
     where
         InFloat: CubeElement + Clone,
-        OutComplex: Clone,
+        OutComplex: CubeElement + Clone,
+        OutFloat: CubeElement + Clone,
     {
-        let n = input.shape.iter().product::<usize>();
-        let client = self.rt.client();
-        let input_handle = match &input.buffer {
-            crate::Buffer::Cubecl(buf) => buf.handle.clone(),
-            _ => {
-                return Err(crate::Error::BackendFailure {
-                    op: "convert",
-                    message: "expected cubecl buffer".into(),
-                })
-            }
-        };
-        let out_handle = client.empty(n * 2 * out_float_size);
-        launch(client, out_handle.clone(), input_handle, n);
-        Ok(typed_from_cubecl(
-            input.shape.clone(),
-            crate::CubeclBuffer::new(out_handle, n),
-            self.rt.device_ordinal(),
-        ))
+        let n = input.n_elements();
+        let output = alloc_output::<OutComplex>(self.runtime(), &input.shape);
+        if n == 0 {
+            return Ok(output);
+        }
+        let output_part_len = n
+            .checked_mul(2)
+            .ok_or_else(|| crate::Error::BackendFailure {
+                op: "convert",
+                message: "complex output part length overflow".into(),
+            })?;
+        let output_parts =
+            typed_tensor_array_arg_as::<OutComplex, OutFloat>(&output, output_part_len, "convert")?;
+        let input_arg = typed_tensor_array_arg(input, "convert")?;
+        // SAFETY: The checked raw-array helpers prove that `input_arg` covers
+        // exactly the dense input shape and `output_parts` covers the complete
+        // real/imaginary scalar representation of the output allocation.
+        launch(self.runtime().client(), output_parts, input_arg, n);
+        Ok(output)
     }
 
     fn convert_c32_to_f32(
@@ -1202,6 +1196,11 @@ impl CubeclBackend {
         let scatter_arg = typed_tensor_binding(scatter_indices, "scatter")?;
         let updates_arg = typed_tensor_binding(updates, "scatter")?;
         unsafe {
+            // SAFETY: `scatter_launch_meta` validates the scatter/update
+            // shapes and dimension-number mappings. `typed_tensor_binding`
+            // validates every logical tensor buffer length. The launch domain
+            // is `scatter_update_len(meta)`, and the kernel maps each launched
+            // update through the validated metadata before indexing.
             indexing::scatter_float_kernel::launch_unchecked::<T, I, CudaRuntime>(
                 client,
                 cube_count_for_len(update_len),
@@ -1295,6 +1294,13 @@ impl CubeclBackend {
         let scatter_arg = typed_tensor_binding(scatter_indices, "scatter")?;
         let updates_arg = typed_tensor_binding(updates, "scatter")?;
         unsafe {
+            // SAFETY: `scatter_launch_meta` validates the scatter/update
+            // shapes and dimension-number mappings. `typed_tensor_binding`
+            // validates logical tensor buffers, while `typed_tensor_array_arg_as`
+            // proves complex real/imaginary part arrays stay within their
+            // backing allocations. The launch domain is
+            // `scatter_update_len(meta)` and the kernel indexes via the
+            // validated metadata.
             indexing::scatter_complex_kernel::launch_unchecked::<T, F, I, CudaRuntime>(
                 client,
                 cube_count_for_len(update_len),
@@ -1322,140 +1328,116 @@ impl CubeclBackend {
 impl TensorBackend for CubeclBackend {
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         match (lhs, rhs) {
-            (Tensor::F32(lhs), Tensor::F32(rhs)) => {
-                dispatch::ensure_same_shape("add", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "add",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::add_float::launch_unchecked::<f32, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F32)
-            }
-            (Tensor::F64(lhs), Tensor::F64(rhs)) => {
-                dispatch::ensure_same_shape("add", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "add",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::add_float::launch_unchecked::<f64, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F64)
-            }
-            (Tensor::C32(lhs), Tensor::C32(rhs)) => {
-                dispatch::ensure_same_shape("add", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "add",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::add_complex::launch_unchecked::<Complex32, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::C32)
-            }
-            (Tensor::C64(lhs), Tensor::C64(rhs)) => {
-                dispatch::ensure_same_shape("add", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "add",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::add_complex::launch_unchecked::<Complex64, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::C64)
-            }
+            (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "add",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::add_float::launch_unchecked::<f32, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F32),
+            (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "add",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::add_float::launch_unchecked::<f64, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F64),
+            (Tensor::C32(lhs), Tensor::C32(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "add",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::add_complex::launch_unchecked::<Complex32, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::C32),
+            (Tensor::C64(lhs), Tensor::C64(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "add",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::add_complex::launch_unchecked::<Complex64, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::C64),
             _ => Err(dtype_mismatch("add", lhs, rhs)),
         }
     }
 
     fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         match (lhs, rhs) {
-            (Tensor::F32(lhs), Tensor::F32(rhs)) => {
-                dispatch::ensure_same_shape("mul", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "mul",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::mul_float::launch_unchecked::<f32, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F32)
-            }
-            (Tensor::F64(lhs), Tensor::F64(rhs)) => {
-                dispatch::ensure_same_shape("mul", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "mul",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::mul_float::launch_unchecked::<f64, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F64)
-            }
-            (Tensor::C32(lhs), Tensor::C32(rhs)) => {
-                dispatch::ensure_same_shape("mul", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "mul",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::mul_complex::launch_unchecked::<Complex32, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::C32)
-            }
-            (Tensor::C64(lhs), Tensor::C64(rhs)) => {
-                dispatch::ensure_same_shape("mul", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "mul",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::mul_complex::launch_unchecked::<Complex64, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::C64)
-            }
+            (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "mul",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::mul_float::launch_unchecked::<f32, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F32),
+            (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "mul",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::mul_float::launch_unchecked::<f64, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F64),
+            (Tensor::C32(lhs), Tensor::C32(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "mul",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::mul_complex::launch_unchecked::<Complex32, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::C32),
+            (Tensor::C64(lhs), Tensor::C64(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "mul",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::mul_complex::launch_unchecked::<Complex64, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::C64),
             _ => Err(dtype_mismatch("mul", lhs, rhs)),
         }
     }
@@ -1554,70 +1536,58 @@ impl TensorBackend for CubeclBackend {
 
     fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         match (lhs, rhs) {
-            (Tensor::F32(lhs), Tensor::F32(rhs)) => {
-                dispatch::ensure_same_shape("div", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "div",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::div_float::launch_unchecked::<f32, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F32)
-            }
-            (Tensor::F64(lhs), Tensor::F64(rhs)) => {
-                dispatch::ensure_same_shape("div", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "div",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::div_float::launch_unchecked::<f64, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F64)
-            }
-            (Tensor::C32(lhs), Tensor::C32(rhs)) => {
-                dispatch::ensure_same_shape("div", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "div",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::div_complex::launch_unchecked::<Complex32, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::C32)
-            }
-            (Tensor::C64(lhs), Tensor::C64(rhs)) => {
-                dispatch::ensure_same_shape("div", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "div",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::div_complex::launch_unchecked::<Complex64, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::C64)
-            }
+            (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "div",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::div_float::launch_unchecked::<f32, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F32),
+            (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "div",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::div_float::launch_unchecked::<f64, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F64),
+            (Tensor::C32(lhs), Tensor::C32(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "div",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::div_complex::launch_unchecked::<Complex32, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::C32),
+            (Tensor::C64(lhs), Tensor::C64(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "div",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::div_complex::launch_unchecked::<Complex64, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::C64),
             _ => Err(dtype_mismatch("div", lhs, rhs)),
         }
     }
@@ -1690,38 +1660,32 @@ impl TensorBackend for CubeclBackend {
 
     fn maximum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         match (lhs, rhs) {
-            (Tensor::F32(lhs), Tensor::F32(rhs)) => {
-                dispatch::ensure_same_shape("maximum", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "maximum",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::maximum_float::launch_unchecked::<f32, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F32)
-            }
-            (Tensor::F64(lhs), Tensor::F64(rhs)) => {
-                dispatch::ensure_same_shape("maximum", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "maximum",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::maximum_float::launch_unchecked::<f64, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F64)
-            }
+            (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "maximum",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::maximum_float::launch_unchecked::<f32, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F32),
+            (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "maximum",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::maximum_float::launch_unchecked::<f64, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F64),
             (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => {
                 Err(crate::Error::BackendFailure {
                     op: "maximum",
@@ -1734,38 +1698,32 @@ impl TensorBackend for CubeclBackend {
 
     fn minimum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         match (lhs, rhs) {
-            (Tensor::F32(lhs), Tensor::F32(rhs)) => {
-                dispatch::ensure_same_shape("minimum", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "minimum",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::minimum_float::launch_unchecked::<f32, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F32)
-            }
-            (Tensor::F64(lhs), Tensor::F64(rhs)) => {
-                dispatch::ensure_same_shape("minimum", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "minimum",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::minimum_float::launch_unchecked::<f64, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F64)
-            }
+            (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "minimum",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::minimum_float::launch_unchecked::<f32, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F32),
+            (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "minimum",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::minimum_float::launch_unchecked::<f64, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F64),
             (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => {
                 Err(crate::Error::BackendFailure {
                     op: "minimum",
@@ -1778,50 +1736,44 @@ impl TensorBackend for CubeclBackend {
 
     fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor> {
         match (lhs, rhs) {
-            (Tensor::F32(lhs), Tensor::F32(rhs)) => {
-                dispatch::ensure_same_shape("compare", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "compare",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::compare_float::launch_unchecked::<f32, CudaRuntime>(
-                            client,
-                            count,
-                            dim,
-                            out,
-                            lhs_arg,
-                            rhs_arg,
-                            dispatch::compare_mode(dir),
-                        );
-                    },
-                )
-                .map(Tensor::F32)
-            }
-            (Tensor::F64(lhs), Tensor::F64(rhs)) => {
-                dispatch::ensure_same_shape("compare", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "compare",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::compare_float::launch_unchecked::<f64, CudaRuntime>(
-                            client,
-                            count,
-                            dim,
-                            out,
-                            lhs_arg,
-                            rhs_arg,
-                            dispatch::compare_mode(dir),
-                        );
-                    },
-                )
-                .map(Tensor::F64)
-            }
+            (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "compare",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::compare_float::launch_unchecked::<f32, CudaRuntime>(
+                        client,
+                        count,
+                        dim,
+                        out,
+                        lhs_arg,
+                        rhs_arg,
+                        dispatch::compare_mode(dir),
+                    );
+                },
+            )
+            .map(Tensor::F32),
+            (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "compare",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::compare_float::launch_unchecked::<f64, CudaRuntime>(
+                        client,
+                        count,
+                        dim,
+                        out,
+                        lhs_arg,
+                        rhs_arg,
+                        dispatch::compare_mode(dir),
+                    );
+                },
+            )
+            .map(Tensor::F64),
             (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => {
                 Err(crate::Error::BackendFailure {
                     op: "compare",
@@ -1839,42 +1791,34 @@ impl TensorBackend for CubeclBackend {
         on_false: &Tensor,
     ) -> crate::Result<Tensor> {
         match (pred, on_true, on_false) {
-            (Tensor::F32(pred), Tensor::F32(on_true), Tensor::F32(on_false)) => {
-                dispatch::ensure_same_shape("select", &pred.shape, &on_true.shape)?;
-                dispatch::ensure_same_shape("select", &pred.shape, &on_false.shape)?;
-                launch_ternary(
-                    self.runtime(),
-                    pred,
-                    on_true,
-                    on_false,
-                    &pred.shape,
-                    "select",
-                    |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
-                        elementwise::select_float::launch_unchecked::<f32, CudaRuntime>(
-                            client, count, dim, out, pred_arg, true_arg, false_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F32)
-            }
-            (Tensor::F64(pred), Tensor::F64(on_true), Tensor::F64(on_false)) => {
-                dispatch::ensure_same_shape("select", &pred.shape, &on_true.shape)?;
-                dispatch::ensure_same_shape("select", &pred.shape, &on_false.shape)?;
-                launch_ternary(
-                    self.runtime(),
-                    pred,
-                    on_true,
-                    on_false,
-                    &pred.shape,
-                    "select",
-                    |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
-                        elementwise::select_float::launch_unchecked::<f64, CudaRuntime>(
-                            client, count, dim, out, pred_arg, true_arg, false_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F64)
-            }
+            (Tensor::F32(pred), Tensor::F32(on_true), Tensor::F32(on_false)) => launch_ternary(
+                self.runtime(),
+                pred,
+                on_true,
+                on_false,
+                &pred.shape,
+                "select",
+                |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
+                    elementwise::select_float::launch_unchecked::<f32, CudaRuntime>(
+                        client, count, dim, out, pred_arg, true_arg, false_arg,
+                    );
+                },
+            )
+            .map(Tensor::F32),
+            (Tensor::F64(pred), Tensor::F64(on_true), Tensor::F64(on_false)) => launch_ternary(
+                self.runtime(),
+                pred,
+                on_true,
+                on_false,
+                &pred.shape,
+                "select",
+                |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
+                    elementwise::select_float::launch_unchecked::<f64, CudaRuntime>(
+                        client, count, dim, out, pred_arg, true_arg, false_arg,
+                    );
+                },
+            )
+            .map(Tensor::F64),
             (Tensor::C32(_), Tensor::C32(_), Tensor::C32(_))
             | (Tensor::C64(_), Tensor::C64(_), Tensor::C64(_)) => {
                 Err(crate::Error::BackendFailure {
@@ -1888,42 +1832,34 @@ impl TensorBackend for CubeclBackend {
 
     fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor> {
         match (input, lower, upper) {
-            (Tensor::F32(input), Tensor::F32(lower), Tensor::F32(upper)) => {
-                dispatch::ensure_same_shape("clamp", &input.shape, &lower.shape)?;
-                dispatch::ensure_same_shape("clamp", &input.shape, &upper.shape)?;
-                launch_ternary(
-                    self.runtime(),
-                    input,
-                    lower,
-                    upper,
-                    &input.shape,
-                    "clamp",
-                    |client, count, dim, out, input_arg, lower_arg, upper_arg| unsafe {
-                        elementwise::clamp_float::launch_unchecked::<f32, CudaRuntime>(
-                            client, count, dim, out, input_arg, lower_arg, upper_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F32)
-            }
-            (Tensor::F64(input), Tensor::F64(lower), Tensor::F64(upper)) => {
-                dispatch::ensure_same_shape("clamp", &input.shape, &lower.shape)?;
-                dispatch::ensure_same_shape("clamp", &input.shape, &upper.shape)?;
-                launch_ternary(
-                    self.runtime(),
-                    input,
-                    lower,
-                    upper,
-                    &input.shape,
-                    "clamp",
-                    |client, count, dim, out, input_arg, lower_arg, upper_arg| unsafe {
-                        elementwise::clamp_float::launch_unchecked::<f64, CudaRuntime>(
-                            client, count, dim, out, input_arg, lower_arg, upper_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F64)
-            }
+            (Tensor::F32(input), Tensor::F32(lower), Tensor::F32(upper)) => launch_ternary(
+                self.runtime(),
+                input,
+                lower,
+                upper,
+                &input.shape,
+                "clamp",
+                |client, count, dim, out, input_arg, lower_arg, upper_arg| unsafe {
+                    elementwise::clamp_float::launch_unchecked::<f32, CudaRuntime>(
+                        client, count, dim, out, input_arg, lower_arg, upper_arg,
+                    );
+                },
+            )
+            .map(Tensor::F32),
+            (Tensor::F64(input), Tensor::F64(lower), Tensor::F64(upper)) => launch_ternary(
+                self.runtime(),
+                input,
+                lower,
+                upper,
+                &input.shape,
+                "clamp",
+                |client, count, dim, out, input_arg, lower_arg, upper_arg| unsafe {
+                    elementwise::clamp_float::launch_unchecked::<f64, CudaRuntime>(
+                        client, count, dim, out, input_arg, lower_arg, upper_arg,
+                    );
+                },
+            )
+            .map(Tensor::F64),
             (Tensor::C32(_), Tensor::C32(_), Tensor::C32(_))
             | (Tensor::C64(_), Tensor::C64(_), Tensor::C64(_)) => {
                 Err(crate::Error::BackendFailure {
@@ -2168,38 +2104,32 @@ impl TensorBackend for CubeclBackend {
 
     fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         match (lhs, rhs) {
-            (Tensor::F32(lhs), Tensor::F32(rhs)) => {
-                dispatch::ensure_same_shape("pow", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "pow",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::pow_float::launch_unchecked::<f32, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F32)
-            }
-            (Tensor::F64(lhs), Tensor::F64(rhs)) => {
-                dispatch::ensure_same_shape("pow", &lhs.shape, &rhs.shape)?;
-                launch_binary(
-                    self.runtime(),
-                    lhs,
-                    rhs,
-                    &lhs.shape,
-                    "pow",
-                    |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                        elementwise::pow_float::launch_unchecked::<f64, CudaRuntime>(
-                            client, count, dim, out, lhs_arg, rhs_arg,
-                        );
-                    },
-                )
-                .map(Tensor::F64)
-            }
+            (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "pow",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::pow_float::launch_unchecked::<f32, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F32),
+            (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_binary(
+                self.runtime(),
+                lhs,
+                rhs,
+                &lhs.shape,
+                "pow",
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::pow_float::launch_unchecked::<f64, CudaRuntime>(
+                        client, count, dim, out, lhs_arg, rhs_arg,
+                    );
+                },
+            )
+            .map(Tensor::F64),
             (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => {
                 Err(crate::Error::BackendFailure {
                     op: "pow",

--- a/tenferro-tensor/src/cubecl/tests/metadata_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/metadata_tests.rs
@@ -1,6 +1,8 @@
 use cubecl::stream_id::StreamId;
 
-use crate::cubecl::dispatch::{cubecl_shape_and_strides, typed_tensor_binding};
+use crate::cubecl::dispatch::{
+    cubecl_shape_and_strides, typed_tensor_array_arg, typed_tensor_binding,
+};
 use crate::{Buffer, ComputeDevice, CubeclBuffer, MemoryKind, Placement, TypedTensor};
 
 #[test]
@@ -17,6 +19,25 @@ fn typed_tensor_binding_rejects_shape_buffer_len_mismatch() {
     let tensor = cubecl_tensor_with_len(vec![2, 3], 5);
 
     let err = typed_tensor_binding(&tensor, "metadata_test").unwrap_err();
+
+    match err {
+        crate::Error::BackendFailure { op, message } => {
+            assert_eq!(op, "metadata_test");
+            assert!(message.contains("expected shape product 6"));
+            assert!(message.contains("actual CubeclBuffer::len 5"));
+        }
+        other => panic!("expected BackendFailure, got {other:?}"),
+    }
+}
+
+#[test]
+fn typed_tensor_array_arg_rejects_shape_buffer_len_mismatch() {
+    let tensor = cubecl_tensor_with_len(vec![2, 3], 5);
+
+    let err = match typed_tensor_array_arg(&tensor, "metadata_test") {
+        Ok(_) => panic!("expected typed_tensor_array_arg to reject buffer length mismatch"),
+        Err(err) => err,
+    };
 
     match err {
         crate::Error::BackendFailure { op, message } => {

--- a/tenferro-tensor/src/cubecl/tests/metadata_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/metadata_tests.rs
@@ -1,8 +1,7 @@
 use cubecl::stream_id::StreamId;
 
 use crate::cubecl::dispatch::{cubecl_shape_and_strides, typed_tensor_binding};
-use crate::cubecl::memory::canonical_host_tensor_for_upload;
-use crate::{Buffer, ComputeDevice, CubeclBuffer, MemoryKind, MemoryOrder, Placement, TypedTensor};
+use crate::{Buffer, ComputeDevice, CubeclBuffer, MemoryKind, Placement, TypedTensor};
 
 #[test]
 fn cubecl_metadata_uses_dense_column_major_strides() {
@@ -45,48 +44,6 @@ fn typed_tensor_binding_rejects_shape_product_overflow() {
     }
 }
 
-#[test]
-fn typed_tensor_binding_rejects_row_major_gpu_tensor() {
-    let mut tensor = cubecl_tensor_with_len(vec![2, 3], 6);
-    tensor.order = MemoryOrder::RowMajor;
-
-    let err = typed_tensor_binding(&tensor, "metadata_test").unwrap_err();
-
-    match err {
-        crate::Error::BackendFailure { op, message } => {
-            assert_eq!(op, "metadata_test");
-            assert!(message.contains("column-major GPU tensor"));
-        }
-        other => panic!("expected BackendFailure, got {other:?}"),
-    }
-}
-
-#[test]
-fn upload_canonicalizes_row_major_host_tensor_to_col_major() {
-    let tensor =
-        TypedTensor::from_vec_row_major(vec![2, 3], vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0]);
-
-    let upload_source = canonical_host_tensor_for_upload(&tensor).unwrap();
-
-    assert_eq!(upload_source.order(), MemoryOrder::ColMajor);
-    assert_eq!(upload_source.host_data(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
-}
-
-#[test]
-fn upload_canonicalization_rejects_non_host_tensors() {
-    let tensor = cubecl_tensor_with_len(vec![2], 2);
-
-    let err = canonical_host_tensor_for_upload(&tensor).unwrap_err();
-
-    match err {
-        crate::Error::BackendFailure { op, message } => {
-            assert_eq!(op, "upload");
-            assert!(message.contains("already backed by CubeCL"));
-        }
-        other => panic!("expected BackendFailure, got {other:?}"),
-    }
-}
-
 fn cubecl_tensor_with_len(shape: Vec<usize>, len: usize) -> TypedTensor<f32> {
     let handle = cubecl::server::Handle::new(
         StreamId::current(),
@@ -102,6 +59,5 @@ fn cubecl_tensor_with_len(shape: Vec<usize>, len: usize) -> TypedTensor<f32> {
                 ordinal: 0,
             }),
         },
-        order: crate::MemoryOrder::ColMajor,
     }
 }

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -186,120 +186,6 @@ fn matrix_f64_from_tensor(t: &Tensor, rows: usize, cols: usize) -> Vec<f64> {
     out
 }
 
-fn assert_same_f64_tensor(name: &str, actual: &Tensor, expected: &Tensor) {
-    assert_eq!(actual.shape(), expected.shape(), "{name}: shape mismatch");
-    let actual = actual.to_col_major().unwrap();
-    let expected = expected.to_col_major().unwrap();
-    assert_eq!(
-        actual.as_slice::<f64>().unwrap().len(),
-        expected.as_slice::<f64>().unwrap().len(),
-        "{name}: element count mismatch"
-    );
-    for (index, (&actual, &expected)) in actual
-        .as_slice::<f64>()
-        .unwrap()
-        .iter()
-        .zip(expected.as_slice::<f64>().unwrap())
-        .enumerate()
-    {
-        assert_f64_close_tol(actual, expected, 1.0e-10);
-        let _ = index;
-    }
-}
-
-fn assert_row_major_unary_matches_col_major(
-    name: &str,
-    input: &Tensor,
-    op: impl Fn(&Tensor) -> crate::Result<Tensor>,
-) {
-    let expected = op(input).unwrap();
-    let row_input = input.to_row_major().unwrap();
-    let actual = op(&row_input).unwrap();
-
-    assert_same_f64_tensor(name, &actual, &expected);
-}
-
-fn assert_row_major_binary_matches_col_major(
-    name: &str,
-    lhs: &Tensor,
-    rhs: &Tensor,
-    op: impl Fn(&Tensor, &Tensor) -> crate::Result<Tensor>,
-) {
-    let expected = op(lhs, rhs).unwrap();
-    let row_lhs = lhs.to_row_major().unwrap();
-    let row_rhs = rhs.to_row_major().unwrap();
-    let actual = op(&row_lhs, &row_rhs).unwrap();
-
-    assert_same_f64_tensor(name, &actual, &expected);
-}
-
-#[test]
-fn row_major_computation_matches_col_major_for_elementwise_and_structural_ops() {
-    let input = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
-    let other = Tensor::from_vec(vec![2, 3], vec![10.0_f64, 40.0, 20.0, 50.0, 30.0, 60.0]);
-
-    assert_row_major_binary_matches_col_major("add", &input, &other, add);
-    assert_row_major_binary_matches_col_major("mul", &input, &other, mul);
-    assert_row_major_unary_matches_col_major("neg", &input, neg);
-    assert_row_major_unary_matches_col_major("transpose", &input, |x| transpose(x, &[1, 0]));
-    assert_row_major_unary_matches_col_major("reduce_sum", &input, |x| reduce_sum(x, &[1]));
-    assert_row_major_unary_matches_col_major("broadcast_in_dim", &input, |x| {
-        broadcast_in_dim(x, &[2, 3, 2], &[0, 1])
-    });
-    assert_row_major_unary_matches_col_major("slice", &input, |x| {
-        crate::cpu::indexing::try_slice(
-            x,
-            &SliceConfig {
-                starts: vec![0, 1],
-                limits: vec![2, 3],
-                strides: vec![1, 1],
-            },
-        )
-    });
-}
-
-#[test]
-fn row_major_computation_matches_col_major_for_gemm_indexing_and_linalg_ops() {
-    let lhs = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
-    let rhs = Tensor::from_vec(vec![3, 2], vec![7.0_f64, 9.0, 11.0, 8.0, 10.0, 12.0]);
-    assert_row_major_binary_matches_col_major("dot_general", &lhs, &rhs, |a, b| {
-        let mut backend = CpuBackend::with_threads(1);
-        backend.dot_general(
-            a,
-            b,
-            &DotGeneralConfig {
-                lhs_contracting_dims: vec![1],
-                rhs_contracting_dims: vec![0],
-                lhs_batch_dims: vec![],
-                rhs_batch_dims: vec![],
-            },
-        )
-    });
-
-    let operand = Tensor::from_vec(
-        vec![3, 3],
-        vec![1.0_f64, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0],
-    );
-    let start_indices = Tensor::from_vec(vec![2, 2], vec![0_i64, 1, 2, 0]);
-    let config = GatherConfig {
-        offset_dims: vec![],
-        collapsed_slice_dims: vec![0, 1],
-        start_index_map: vec![0, 1],
-        index_vector_dim: 1,
-        slice_sizes: vec![1, 1],
-    };
-    assert_row_major_binary_matches_col_major("gather", &operand, &start_indices, |x, indices| {
-        gather(x, indices, &config)
-    });
-
-    let a = Tensor::from_vec(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
-    let b = Tensor::from_vec(vec![2], vec![5.0_f64, 11.0]);
-    assert_row_major_binary_matches_col_major("solve", &a, &b, |a, b| {
-        let mut backend = CpuBackend::with_threads(1);
-        backend.solve(a, b)
-    });
-}
-
 fn batch_vector_f64_from_tensor(t: &Tensor, len: usize, batch_idx: usize) -> Vec<f64> {
     let mut out = vec![0.0; len];
     for i in 0..len {
@@ -550,7 +436,7 @@ fn test_zeros_ones() {
 }
 
 #[test]
-fn test_from_vec_col_major() {
+fn test_from_vec_uses_column_major_indices() {
     let t = TypedTensor::<f64>::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     assert_eq!(*t.get(&[0, 0]), 1.0);
     assert_eq!(*t.get(&[1, 0]), 2.0);

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -4,7 +4,7 @@ use num_complex::{Complex32, Complex64};
 
 use crate::types::{
     col_major_strides, flat_to_multi, Buffer, BufferHandle, ComputeDevice, ConjElem, DType,
-    MemoryKind, MemoryOrder, Placement, Tensor, TensorScalar, TypedTensor,
+    MemoryKind, Placement, Tensor, TensorScalar, TypedTensor,
 };
 use crate::Error;
 
@@ -54,63 +54,50 @@ fn typed_tensor_rank_zero_access_and_mutation_work() {
 }
 
 #[test]
-fn typed_tensor_explicit_memory_order_constructors_set_order() {
-    let col = TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
-    let row = TypedTensor::from_vec_row_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
-
-    assert_eq!(col.order(), MemoryOrder::ColMajor);
-    assert_eq!(row.order(), MemoryOrder::RowMajor);
-    assert_eq!(
-        TypedTensor::from_vec(vec![1], vec![1.0_f64]).order(),
-        MemoryOrder::ColMajor
-    );
-}
-
-#[test]
-fn tensor_owned_export_is_zero_copy_only_for_matching_order() {
+fn tensor_owned_export_returns_column_major_buffer() {
     let data = vec![1.0_f64, 2.0, 3.0, 4.0];
     let ptr = data.as_ptr();
-    let tensor = Tensor::from_vec_row_major(vec![2, 2], data);
+    let tensor = Tensor::from_vec(vec![2, 2], data);
 
-    let (shape, out) = tensor.try_into_vec_row_major::<f64>().unwrap();
+    let (shape, out) = tensor.try_into_vec::<f64>().unwrap();
 
     assert_eq!(shape, vec![2, 2]);
     assert_eq!(out.as_ptr(), ptr);
-
-    let mismatch = Tensor::from_vec_row_major(vec![1], vec![1.0_f64])
-        .try_into_vec_col_major::<f64>()
-        .unwrap_err();
-    assert!(mismatch.to_string().contains("memory order"));
 }
 
 #[test]
-fn row_major_typed_tensor_uses_logical_indices() {
-    let tensor =
-        TypedTensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+fn tensor_owned_export_reports_dtype_mismatch() {
+    let err = Tensor::from_vec(vec![1], vec![1.0_f64])
+        .try_into_vec::<f32>()
+        .unwrap_err();
+
+    assert!(matches!(err, Error::DTypeMismatch { .. }));
+}
+
+#[test]
+fn col_major_typed_tensor_uses_logical_indices() {
+    let tensor = TypedTensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
 
     assert_eq!(*tensor.get(&[0, 2]), 3.0);
     assert_eq!(*tensor.get(&[1, 0]), 4.0);
 }
 
 #[test]
-fn typed_tensor_linear_offsets_cover_higher_rank_orders() {
-    let col = TypedTensor::<f64>::zeros(vec![2, 3, 5]);
-    let row = TypedTensor::from_vec_row_major(vec![2, 3, 5], vec![0.0_f64; 30]);
+fn typed_tensor_linear_offsets_cover_higher_rank_shapes() {
+    let tensor = TypedTensor::<f64>::zeros(vec![2, 3, 5]);
 
-    assert_eq!(col.linear_offset(&[1, 2, 4]), 1 + 2 * 2 + 4 * 2 * 3);
-    assert_eq!(row.linear_offset(&[1, 2, 4]), 4 + 2 * 5 + 1 * 3 * 5);
+    assert_eq!(tensor.linear_offset(&[1, 2, 4]), 1 + 2 * 2 + 4 * 2 * 3);
 }
 
 #[test]
 fn typed_tensor_iterators_follow_physical_buffer_order() {
-    let tensor =
-        TypedTensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let tensor = TypedTensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
     assert_eq!(
         tensor.iter().copied().collect::<Vec<_>>(),
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
     );
 
-    let mut tensor = TypedTensor::from_vec_col_major(vec![3], vec![1_i64, 2, 3]);
+    let mut tensor = TypedTensor::from_vec(vec![3], vec![1_i64, 2, 3]);
     for value in tensor.iter_mut() {
         *value *= 2;
     }
@@ -137,16 +124,15 @@ fn tensor_iterators_are_typed_by_requested_scalar() {
 
 #[test]
 fn typed_tensor_checked_and_unchecked_accessors_work() {
-    let mut tensor =
-        TypedTensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let mut tensor = TypedTensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
 
-    assert_eq!(tensor.as_physical_slice(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    assert_eq!(tensor.as_physical_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
     assert_eq!(tensor.try_get(&[1, 2]), Some(&6.0));
     assert_eq!(tensor.try_get(&[2, 0]), None);
     assert_eq!(tensor.try_get(&[0]), None);
 
     *tensor.try_get_mut(&[0, 1]).unwrap() = 20.0;
-    assert_eq!(tensor.as_physical_slice()[1], 20.0);
+    assert_eq!(tensor.as_physical_slice()[2], 20.0);
 
     tensor.as_physical_slice_mut()[0] = 10.0;
     assert_eq!(unsafe { *tensor.get_unchecked(&[0, 0]) }, 10.0);
@@ -158,21 +144,17 @@ fn typed_tensor_checked_and_unchecked_accessors_work() {
 }
 
 #[test]
-fn typed_tensor_rank_fixed_accessors_use_memory_order() {
-    let mut col2 = TypedTensor::from_vec_col_major(vec![2, 3], vec![1_i64, 2, 3, 4, 5, 6]);
-    let row2 = TypedTensor::from_vec_row_major(vec![2, 3], vec![1_i64, 2, 3, 4, 5, 6]);
+fn typed_tensor_rank_fixed_accessors_use_column_major_offsets() {
+    let mut col2 = TypedTensor::from_vec(vec![2, 3], vec![1_i64, 2, 3, 4, 5, 6]);
 
     assert_eq!(col2.linear_offset2(1, 2), 5);
-    assert_eq!(row2.linear_offset2(1, 0), 3);
     assert_eq!(*col2.get2(1, 2), 6);
     *col2.get_mut2(0, 1) = 30;
     assert_eq!(col2.as_physical_slice()[2], 30);
 
-    let mut col3 = TypedTensor::from_vec_col_major(vec![2, 3, 2], (0_i64..12).collect());
-    let row3 = TypedTensor::from_vec_row_major(vec![2, 3, 2], (0_i64..12).collect());
+    let mut col3 = TypedTensor::from_vec(vec![2, 3, 2], (0_i64..12).collect());
 
     assert_eq!(col3.linear_offset3(1, 2, 1), 11);
-    assert_eq!(row3.linear_offset3(1, 0, 1), 7);
     assert_eq!(*col3.get3(1, 2, 1), 11);
     *col3.get_mut3(0, 1, 1) = 60;
     assert_eq!(col3.as_physical_slice()[8], 60);
@@ -180,14 +162,14 @@ fn typed_tensor_rank_fixed_accessors_use_memory_order() {
 
 #[test]
 fn tensor_checked_accessors_are_typed_and_use_physical_order() {
-    let mut tensor = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let mut tensor = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
 
     assert_eq!(
         tensor.as_physical_slice::<f64>().unwrap(),
-        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
     );
-    assert_eq!(tensor.linear_offset(&[1, 0]), 3);
-    assert_eq!(tensor.linear_offset2(1, 0), 3);
+    assert_eq!(tensor.linear_offset(&[1, 0]), 1);
+    assert_eq!(tensor.linear_offset2(1, 0), 1);
     assert_eq!(tensor.try_get::<f64>(&[1, 2]), Some(&6.0));
     assert_eq!(tensor.try_get::<f32>(&[1, 2]), None);
     assert_eq!(tensor.try_get::<f64>(&[2, 0]), None);
@@ -205,20 +187,7 @@ fn tensor_checked_accessors_are_typed_and_use_physical_order() {
 
     assert_eq!(
         tensor.as_physical_slice::<f64>().unwrap(),
-        &[10.0, 20.0, 3.0, 40.0, 5.0, 6.0]
-    );
-}
-
-#[test]
-fn row_major_to_col_major_reorders_owned_buffer() {
-    let tensor = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-
-    let converted = tensor.to_col_major().unwrap();
-
-    assert_eq!(converted.order(), MemoryOrder::ColMajor);
-    assert_eq!(
-        converted.as_slice::<f64>().unwrap(),
-        &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
+        &[10.0, 40.0, 20.0, 5.0, 3.0, 6.0]
     );
 }
 
@@ -248,7 +217,6 @@ fn backend_buffers_panic_when_host_access_is_requested() {
         buffer: Buffer::Backend(BufferHandle::<f64>::new(7)),
         shape: vec![1],
         placement: placement.clone(),
-        order: MemoryOrder::ColMajor,
     };
     assert_eq!(
         tensor.placement.resident_device.as_ref().unwrap().ordinal,
@@ -262,7 +230,6 @@ fn backend_buffers_panic_when_host_access_is_requested() {
         buffer: Buffer::Backend(BufferHandle::<f64>::new(8)),
         shape: vec![1],
         placement,
-        order: MemoryOrder::ColMajor,
     };
     let host_data_mut = catch_unwind(AssertUnwindSafe(|| {
         let _ = mutable_tensor.host_data_mut();

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -161,26 +161,6 @@ pub struct TypedTensor<T> {
     pub buffer: Buffer<T>,
     pub shape: Vec<usize>,
     pub placement: Placement,
-    pub order: MemoryOrder,
-}
-
-/// Physical memory order for contiguous tensor storage.
-///
-/// The tensor shape is always logical. This tag records how logical indices
-/// are laid out in the owned contiguous buffer.
-///
-/// # Examples
-///
-/// ```
-/// use tenferro_tensor::MemoryOrder;
-///
-/// assert_eq!(MemoryOrder::ColMajor, MemoryOrder::ColMajor);
-/// assert_ne!(MemoryOrder::ColMajor, MemoryOrder::RowMajor);
-/// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum MemoryOrder {
-    ColMajor,
-    RowMajor,
 }
 
 /// Runtime scalar dtype tag.
@@ -231,13 +211,7 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     fn dtype() -> DType;
 
     /// Wrap typed column-major data into a [`Tensor`] enum variant.
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Self::into_tensor_with_order(shape, data, MemoryOrder::ColMajor)
-    }
-
-    /// Wrap typed data with an explicit memory order into a [`Tensor`] enum
-    /// variant.
-    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor;
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor;
 
     /// Try to borrow the host data from a [`Tensor`].
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]>;
@@ -290,8 +264,8 @@ impl TensorScalar for f64 {
         DType::F64
     }
 
-    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor {
-        Tensor::F64(TypedTensor::from_vec_with_order(shape, data, order))
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::F64(TypedTensor::from_vec(shape, data))
     }
 
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -323,8 +297,8 @@ impl TensorScalar for f32 {
         DType::F32
     }
 
-    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor {
-        Tensor::F32(TypedTensor::from_vec_with_order(shape, data, order))
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::F32(TypedTensor::from_vec(shape, data))
     }
 
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -356,8 +330,8 @@ impl TensorScalar for i64 {
         DType::I64
     }
 
-    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor {
-        Tensor::I64(TypedTensor::from_vec_with_order(shape, data, order))
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::I64(TypedTensor::from_vec(shape, data))
     }
 
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -389,8 +363,8 @@ impl TensorScalar for Complex64 {
         DType::C64
     }
 
-    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor {
-        Tensor::C64(TypedTensor::from_vec_with_order(shape, data, order))
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::C64(TypedTensor::from_vec(shape, data))
     }
 
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -422,8 +396,8 @@ impl TensorScalar for Complex32 {
         DType::C32
     }
 
-    fn into_tensor_with_order(shape: Vec<usize>, data: Vec<Self>, order: MemoryOrder) -> Tensor {
-        Tensor::C32(TypedTensor::from_vec_with_order(shape, data, order))
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::C32(TypedTensor::from_vec(shape, data))
     }
 
     fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -583,106 +557,16 @@ pub fn col_major_strides(shape: &[usize]) -> Vec<isize> {
     strides
 }
 
-/// Row-major strides derived from a shape.
-///
-/// # Examples
-///
-/// ```
-/// use tenferro_tensor::row_major_strides;
-///
-/// assert_eq!(row_major_strides(&[2, 3]), vec![3, 1]);
-/// ```
-pub fn row_major_strides(shape: &[usize]) -> Vec<isize> {
-    if shape.is_empty() {
-        return vec![];
-    }
-    let mut strides = vec![1isize; shape.len()];
-    for i in (0..shape.len() - 1).rev() {
-        strides[i] = strides[i + 1] * shape[i + 1] as isize;
-    }
-    strides
-}
-
-/// Contiguous strides derived from a shape and memory order.
-///
-/// # Examples
-///
-/// ```
-/// use tenferro_tensor::{contiguous_strides, MemoryOrder};
-///
-/// assert_eq!(contiguous_strides(&[2, 3], MemoryOrder::ColMajor), vec![1, 2]);
-/// assert_eq!(contiguous_strides(&[2, 3], MemoryOrder::RowMajor), vec![3, 1]);
-/// ```
-pub fn contiguous_strides(shape: &[usize], order: MemoryOrder) -> Vec<isize> {
-    match order {
-        MemoryOrder::ColMajor => col_major_strides(shape),
-        MemoryOrder::RowMajor => row_major_strides(shape),
-    }
-}
-
-fn linear_offset_for_order(shape: &[usize], indices: &[usize], order: MemoryOrder) -> usize {
+fn linear_offset(shape: &[usize], indices: &[usize]) -> usize {
     assert_eq!(indices.len(), shape.len());
-    match order {
-        MemoryOrder::ColMajor => {
-            let mut offset = 0usize;
-            let mut stride = 1usize;
-            for (&idx, &extent) in indices.iter().zip(shape) {
-                assert!(idx < extent, "index out of bounds");
-                offset += idx * stride;
-                stride *= extent;
-            }
-            offset
-        }
-        MemoryOrder::RowMajor => {
-            let mut offset = 0usize;
-            let mut stride = 1usize;
-            for (&idx, &extent) in indices.iter().zip(shape).rev() {
-                assert!(idx < extent, "index out of bounds");
-                offset += idx * stride;
-                stride *= extent;
-            }
-            offset
-        }
+    let mut offset = 0usize;
+    let mut stride = 1usize;
+    for (&idx, &extent) in indices.iter().zip(shape) {
+        assert!(idx < extent, "index out of bounds");
+        offset += idx * stride;
+        stride *= extent;
     }
-}
-
-fn flat_to_multi_for_order(flat: usize, shape: &[usize], order: MemoryOrder, out: &mut [usize]) {
-    assert_eq!(shape.len(), out.len());
-    let mut remaining = flat;
-    match order {
-        MemoryOrder::ColMajor => {
-            for (&extent, slot) in shape.iter().zip(out.iter_mut()) {
-                *slot = remaining % extent;
-                remaining /= extent;
-            }
-        }
-        MemoryOrder::RowMajor => {
-            for (&extent, slot) in shape.iter().zip(out.iter_mut()).rev() {
-                *slot = remaining % extent;
-                remaining /= extent;
-            }
-        }
-    }
-}
-
-fn reorder_contiguous<T: Clone>(
-    shape: &[usize],
-    data: &[T],
-    from: MemoryOrder,
-    to: MemoryOrder,
-) -> Vec<T> {
-    if from == to {
-        return data.to_vec();
-    }
-    let total: usize = shape.iter().product();
-    let mut out = Vec::with_capacity(total);
-    let mut idx = vec![0usize; shape.len()];
-    for dst_flat in 0..total {
-        flat_to_multi_for_order(dst_flat, shape, to, &mut idx);
-        let src = linear_offset_for_order(shape, &idx, from);
-        out.push(data[src].clone());
-    }
-    out
+    offset
 }
 
 pub(crate) fn default_placement() -> Placement {
@@ -709,7 +593,6 @@ impl<T: Clone + Zero> TypedTensor<T> {
             buffer: Buffer::Host(vec![T::zero(); n]),
             shape,
             placement: default_placement(),
-            order: MemoryOrder::ColMajor,
         }
     }
 }
@@ -731,7 +614,6 @@ impl<T: Clone + One + Zero> TypedTensor<T> {
             buffer: Buffer::Host(vec![T::one(); n]),
             shape,
             placement: default_placement(),
-            order: MemoryOrder::ColMajor,
         }
     }
 }
@@ -748,52 +630,6 @@ impl<T: Clone> TypedTensor<T> {
     /// assert_eq!(t.get(&[1, 0]), &2.0);
     /// ```
     pub fn from_vec(shape: Vec<usize>, data: Vec<T>) -> Self {
-        Self::from_vec_col_major(shape, data)
-    }
-
-    /// Create a tensor from a contiguous column-major buffer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(t.order(), MemoryOrder::ColMajor);
-    /// ```
-    pub fn from_vec_col_major(shape: Vec<usize>, data: Vec<T>) -> Self {
-        Self::from_vec_with_order(shape, data, MemoryOrder::ColMajor)
-    }
-
-    /// Create a tensor from a contiguous row-major buffer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(t.order(), MemoryOrder::RowMajor);
-    /// ```
-    pub fn from_vec_row_major(shape: Vec<usize>, data: Vec<T>) -> Self {
-        Self::from_vec_with_order(shape, data, MemoryOrder::RowMajor)
-    }
-
-    /// Create a tensor from a contiguous buffer with an explicit memory order.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_with_order(
-    ///     vec![2],
-    ///     vec![1.0, 2.0],
-    ///     MemoryOrder::RowMajor,
-    /// );
-    /// assert_eq!(t.order(), MemoryOrder::RowMajor);
-    /// ```
-    pub fn from_vec_with_order(shape: Vec<usize>, data: Vec<T>, order: MemoryOrder) -> Self {
         let n: usize = shape.iter().product();
         assert_eq!(
             data.len(),
@@ -806,160 +642,34 @@ impl<T: Clone> TypedTensor<T> {
             buffer: Buffer::Host(data),
             shape,
             placement: default_placement(),
-            order,
         }
     }
 
-    /// Return the physical memory order of this contiguous tensor.
+    /// Consume this tensor and return its owned column-major host buffer.
     ///
     /// # Examples
     ///
     /// ```
-    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
+    /// use tenferro_tensor::TypedTensor;
     ///
-    /// let t = TypedTensor::<f64>::from_vec(vec![1], vec![1.0]);
-    /// assert_eq!(t.order(), MemoryOrder::ColMajor);
-    /// ```
-    pub fn order(&self) -> MemoryOrder {
-        self.order
-    }
-
-    /// Consume this tensor and return its owned buffer if the memory order
-    /// matches `order`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2], vec![1.0, 2.0]);
-    /// let (shape, data) = t.try_into_vec_with_order(MemoryOrder::RowMajor).unwrap();
+    /// let t = TypedTensor::<f64>::from_vec(vec![2], vec![1.0, 2.0]);
+    /// let (shape, data) = t.try_into_vec().unwrap();
     /// assert_eq!(shape, vec![2]);
     /// assert_eq!(data, vec![1.0, 2.0]);
     /// ```
-    pub fn try_into_vec_with_order(
-        self,
-        order: MemoryOrder,
-    ) -> crate::Result<(Vec<usize>, Vec<T>)> {
-        if self.order != order {
-            return Err(crate::Error::InvalidConfig {
-                op: "try_into_vec_with_order",
-                message: format!(
-                    "memory order mismatch: tensor is {:?}, requested {:?}",
-                    self.order, order
-                ),
-            });
-        }
+    pub fn try_into_vec(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
         match self.buffer {
             Buffer::Host(data) => Ok((self.shape, data)),
             Buffer::Backend(_) => Err(crate::Error::BackendFailure {
-                op: "try_into_vec_with_order",
+                op: "try_into_vec",
                 message: "backend buffers cannot be exported as host Vec".into(),
             }),
             #[cfg(feature = "cubecl")]
             Buffer::Cubecl(_) => Err(crate::Error::BackendFailure {
-                op: "try_into_vec_with_order",
+                op: "try_into_vec",
                 message: "GPU buffers cannot be exported as host Vec".into(),
             }),
         }
-    }
-
-    /// Consume this tensor and return its owned column-major buffer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::TypedTensor;
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![3.0]);
-    /// assert_eq!(t.try_into_vec_col_major().unwrap().1, vec![3.0]);
-    /// ```
-    pub fn try_into_vec_col_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
-        self.try_into_vec_with_order(MemoryOrder::ColMajor)
-    }
-
-    /// Consume this tensor and return its owned row-major buffer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::TypedTensor;
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![1], vec![3.0]);
-    /// assert_eq!(t.try_into_vec_row_major().unwrap().1, vec![3.0]);
-    /// ```
-    pub fn try_into_vec_row_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
-        self.try_into_vec_with_order(MemoryOrder::RowMajor)
-    }
-
-    /// Return a tensor with the requested contiguous memory order.
-    ///
-    /// This clones the tensor when the order already matches and allocates a
-    /// reordered host buffer when conversion is required.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(t.to_order(MemoryOrder::ColMajor).unwrap().order(), MemoryOrder::ColMajor);
-    /// ```
-    pub fn to_order(&self, order: MemoryOrder) -> crate::Result<Self> {
-        if self.order == order {
-            return Ok(self.clone());
-        }
-        let data = match &self.buffer {
-            Buffer::Host(data) => reorder_contiguous(&self.shape, data, self.order, order),
-            Buffer::Backend(_) => {
-                return Err(crate::Error::BackendFailure {
-                    op: "to_order",
-                    message: "backend buffers cannot be reordered on host".into(),
-                })
-            }
-            #[cfg(feature = "cubecl")]
-            Buffer::Cubecl(_) => {
-                return Err(crate::Error::BackendFailure {
-                    op: "to_order",
-                    message: "GPU buffers cannot be reordered on host".into(),
-                })
-            }
-        };
-        Ok(Self {
-            buffer: Buffer::Host(data),
-            shape: self.shape.clone(),
-            placement: self.placement.clone(),
-            order,
-        })
-    }
-
-    /// Return a column-major tensor, allocating only when conversion is
-    /// required.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(t.to_col_major().unwrap().order(), MemoryOrder::ColMajor);
-    /// ```
-    pub fn to_col_major(&self) -> crate::Result<Self> {
-        self.to_order(MemoryOrder::ColMajor)
-    }
-
-    /// Return a row-major tensor, allocating only when conversion is required.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, TypedTensor};
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(t.to_row_major().unwrap().order(), MemoryOrder::RowMajor);
-    /// ```
-    pub fn to_row_major(&self) -> crate::Result<Self> {
-        self.to_order(MemoryOrder::RowMajor)
     }
 
     /// Number of elements in the tensor.
@@ -1053,7 +763,7 @@ impl<T: Clone> TypedTensor<T> {
     /// assert_eq!(t.linear_offset(&[1, 2]), 5);
     /// ```
     pub fn linear_offset(&self, indices: &[usize]) -> usize {
-        linear_offset_for_order(&self.shape, indices, self.order)
+        linear_offset(&self.shape, indices)
     }
 
     /// Borrow a single element by multi-index.
@@ -1135,52 +845,6 @@ impl Tensor {
         T::into_tensor(shape, data)
     }
 
-    /// Create a tensor from a contiguous column-major buffer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, Tensor};
-    ///
-    /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    /// assert_eq!(t.order(), MemoryOrder::ColMajor);
-    /// ```
-    pub fn from_vec_col_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Self {
-        T::into_tensor_with_order(shape, data, MemoryOrder::ColMajor)
-    }
-
-    /// Create a tensor from a contiguous row-major buffer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, Tensor};
-    ///
-    /// let t = Tensor::from_vec_row_major(vec![2], vec![1.0_f64, 2.0]);
-    /// assert_eq!(t.order(), MemoryOrder::RowMajor);
-    /// ```
-    pub fn from_vec_row_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Self {
-        T::into_tensor_with_order(shape, data, MemoryOrder::RowMajor)
-    }
-
-    /// Create a tensor from a contiguous buffer with an explicit memory order.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, Tensor};
-    ///
-    /// let t = Tensor::from_vec_with_order(vec![1], vec![4.0_f64], MemoryOrder::RowMajor);
-    /// assert_eq!(t.order(), MemoryOrder::RowMajor);
-    /// ```
-    pub fn from_vec_with_order<T: TensorScalar>(
-        shape: Vec<usize>,
-        data: Vec<T>,
-        order: MemoryOrder,
-    ) -> Self {
-        T::into_tensor_with_order(shape, data, order)
-    }
-
     /// Tensor shape.
     ///
     /// # Examples
@@ -1221,26 +885,6 @@ impl Tensor {
         }
     }
 
-    /// Physical memory order of the underlying contiguous buffer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, Tensor};
-    ///
-    /// let t = Tensor::from_vec(vec![1], vec![1.0_f64]);
-    /// assert_eq!(t.order(), MemoryOrder::ColMajor);
-    /// ```
-    pub fn order(&self) -> MemoryOrder {
-        match self {
-            Tensor::F32(t) => t.order(),
-            Tensor::F64(t) => t.order(),
-            Tensor::I64(t) => t.order(),
-            Tensor::C32(t) => t.order(),
-            Tensor::C64(t) => t.order(),
-        }
-    }
-
     /// Try to borrow the host data as a typed slice.
     ///
     /// Returns `None` if the tensor dtype does not match `T`.
@@ -1259,109 +903,24 @@ impl Tensor {
     }
 
     /// Consume this tensor and return its owned column-major buffer when the
-    /// dtype and memory order match.
+    /// dtype matches.
     ///
     /// # Examples
     ///
     /// ```
     /// use tenferro_tensor::Tensor;
     ///
-    /// let t = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]);
-    /// assert_eq!(t.try_into_vec_col_major::<f64>().unwrap().1, vec![2.0]);
+    /// let t = Tensor::from_vec(vec![1], vec![2.0_f64]);
+    /// assert_eq!(t.try_into_vec::<f64>().unwrap().1, vec![2.0]);
     /// ```
-    pub fn try_into_vec_col_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
-        self.try_into_vec_with_order::<T>(MemoryOrder::ColMajor)
-    }
-
-    /// Consume this tensor and return its owned row-major buffer when the
-    /// dtype and memory order match.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::Tensor;
-    ///
-    /// let t = Tensor::from_vec_row_major(vec![1], vec![2.0_f64]);
-    /// assert_eq!(t.try_into_vec_row_major::<f64>().unwrap().1, vec![2.0]);
-    /// ```
-    pub fn try_into_vec_row_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
-        self.try_into_vec_with_order::<T>(MemoryOrder::RowMajor)
-    }
-
-    /// Consume this tensor and return its owned buffer when dtype and memory
-    /// order match.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, Tensor};
-    ///
-    /// let t = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]);
-    /// assert_eq!(
-    ///     t.try_into_vec_with_order::<f64>(MemoryOrder::ColMajor).unwrap().1,
-    ///     vec![2.0],
-    /// );
-    /// ```
-    pub fn try_into_vec_with_order<T: TensorScalar>(
-        self,
-        order: MemoryOrder,
-    ) -> crate::Result<(Vec<usize>, Vec<T>)> {
+    pub fn try_into_vec<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
         let actual = self.dtype();
         let typed = T::try_into_typed(self).ok_or(crate::Error::DTypeMismatch {
-            op: "try_into_vec_with_order",
+            op: "try_into_vec",
             lhs: T::dtype(),
             rhs: actual,
         })?;
-        typed.try_into_vec_with_order(order)
-    }
-
-    /// Return a tensor with the requested contiguous memory order.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, Tensor};
-    ///
-    /// let t = Tensor::from_vec_row_major(vec![2], vec![1.0_f64, 2.0]);
-    /// assert_eq!(t.to_col_major().unwrap().order(), MemoryOrder::ColMajor);
-    /// ```
-    pub fn to_order(&self, order: MemoryOrder) -> crate::Result<Self> {
-        match self {
-            Tensor::F32(t) => Ok(Tensor::F32(t.to_order(order)?)),
-            Tensor::F64(t) => Ok(Tensor::F64(t.to_order(order)?)),
-            Tensor::I64(t) => Ok(Tensor::I64(t.to_order(order)?)),
-            Tensor::C32(t) => Ok(Tensor::C32(t.to_order(order)?)),
-            Tensor::C64(t) => Ok(Tensor::C64(t.to_order(order)?)),
-        }
-    }
-
-    /// Return a column-major tensor, allocating only when conversion is
-    /// required.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, Tensor};
-    ///
-    /// let t = Tensor::from_vec_row_major(vec![2], vec![1.0_f64, 2.0]);
-    /// assert_eq!(t.to_col_major().unwrap().order(), MemoryOrder::ColMajor);
-    /// ```
-    pub fn to_col_major(&self) -> crate::Result<Self> {
-        self.to_order(MemoryOrder::ColMajor)
-    }
-
-    /// Return a row-major tensor, allocating only when conversion is required.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{MemoryOrder, Tensor};
-    ///
-    /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    /// assert_eq!(t.to_row_major().unwrap().order(), MemoryOrder::RowMajor);
-    /// ```
-    pub fn to_row_major(&self) -> crate::Result<Self> {
-        self.to_order(MemoryOrder::RowMajor)
+        typed.try_into_vec()
     }
 
     /// Singular value decomposition: `A = U diag(S) Vt`.

--- a/tenferro-tensor/src/types/accessors.rs
+++ b/tenferro-tensor/src/types/accessors.rs
@@ -1,39 +1,19 @@
-use super::{linear_offset_for_order, MemoryOrder, Tensor, TensorScalar, TypedTensor};
+use super::{linear_offset, Tensor, TensorScalar, TypedTensor};
 
-fn try_linear_offset_for_order(
-    shape: &[usize],
-    indices: &[usize],
-    order: MemoryOrder,
-) -> Option<usize> {
+fn try_linear_offset(shape: &[usize], indices: &[usize]) -> Option<usize> {
     if indices.len() != shape.len() {
         return None;
     }
-    match order {
-        MemoryOrder::ColMajor => {
-            let mut offset = 0usize;
-            let mut stride = 1usize;
-            for (&idx, &extent) in indices.iter().zip(shape) {
-                if idx >= extent {
-                    return None;
-                }
-                offset += idx * stride;
-                stride *= extent;
-            }
-            Some(offset)
+    let mut offset = 0usize;
+    let mut stride = 1usize;
+    for (&idx, &extent) in indices.iter().zip(shape) {
+        if idx >= extent {
+            return None;
         }
-        MemoryOrder::RowMajor => {
-            let mut offset = 0usize;
-            let mut stride = 1usize;
-            for (&idx, &extent) in indices.iter().zip(shape).rev() {
-                if idx >= extent {
-                    return None;
-                }
-                offset += idx * stride;
-                stride *= extent;
-            }
-            Some(offset)
-        }
+        offset += idx * stride;
+        stride *= extent;
     }
+    Some(offset)
 }
 
 fn debug_assert_index_in_bounds(shape: &[usize], indices: &[usize]) {
@@ -43,85 +23,45 @@ fn debug_assert_index_in_bounds(shape: &[usize], indices: &[usize]) {
     }
 }
 
-fn linear_offset_unchecked_for_order(
-    shape: &[usize],
-    indices: &[usize],
-    order: MemoryOrder,
-) -> usize {
+fn linear_offset_unchecked(shape: &[usize], indices: &[usize]) -> usize {
     debug_assert_index_in_bounds(shape, indices);
-    match order {
-        MemoryOrder::ColMajor => {
-            let mut offset = 0usize;
-            let mut stride = 1usize;
-            for (&idx, &extent) in indices.iter().zip(shape) {
-                offset += idx * stride;
-                stride *= extent;
-            }
-            offset
-        }
-        MemoryOrder::RowMajor => {
-            let mut offset = 0usize;
-            let mut stride = 1usize;
-            for (&idx, &extent) in indices.iter().zip(shape).rev() {
-                offset += idx * stride;
-                stride *= extent;
-            }
-            offset
-        }
+    let mut offset = 0usize;
+    let mut stride = 1usize;
+    for (&idx, &extent) in indices.iter().zip(shape) {
+        offset += idx * stride;
+        stride *= extent;
     }
+    offset
 }
 
-fn linear_offset2_for_order(shape: &[usize], i: usize, j: usize, order: MemoryOrder) -> usize {
+fn linear_offset2(shape: &[usize], i: usize, j: usize) -> usize {
     assert_eq!(shape.len(), 2);
     assert!(i < shape[0], "index out of bounds");
     assert!(j < shape[1], "index out of bounds");
-    linear_offset2_unchecked_for_order(shape, i, j, order)
+    linear_offset2_unchecked(shape, i, j)
 }
 
-fn linear_offset2_unchecked_for_order(
-    shape: &[usize],
-    i: usize,
-    j: usize,
-    order: MemoryOrder,
-) -> usize {
+fn linear_offset2_unchecked(shape: &[usize], i: usize, j: usize) -> usize {
     debug_assert_eq!(shape.len(), 2);
     debug_assert!(i < shape[0], "index out of bounds");
     debug_assert!(j < shape[1], "index out of bounds");
-    match order {
-        MemoryOrder::ColMajor => i + shape[0] * j,
-        MemoryOrder::RowMajor => j + shape[1] * i,
-    }
+    i + shape[0] * j
 }
 
-fn linear_offset3_for_order(
-    shape: &[usize],
-    i: usize,
-    j: usize,
-    k: usize,
-    order: MemoryOrder,
-) -> usize {
+fn linear_offset3(shape: &[usize], i: usize, j: usize, k: usize) -> usize {
     assert_eq!(shape.len(), 3);
     assert!(i < shape[0], "index out of bounds");
     assert!(j < shape[1], "index out of bounds");
     assert!(k < shape[2], "index out of bounds");
-    linear_offset3_unchecked_for_order(shape, i, j, k, order)
+    linear_offset3_unchecked(shape, i, j, k)
 }
 
-fn linear_offset3_unchecked_for_order(
-    shape: &[usize],
-    i: usize,
-    j: usize,
-    k: usize,
-    order: MemoryOrder,
-) -> usize {
+fn linear_offset3_unchecked(shape: &[usize], i: usize, j: usize, k: usize) -> usize {
     debug_assert_eq!(shape.len(), 3);
     debug_assert!(i < shape[0], "index out of bounds");
     debug_assert!(j < shape[1], "index out of bounds");
     debug_assert!(k < shape[2], "index out of bounds");
-    match order {
-        MemoryOrder::ColMajor => i + shape[0] * (j + shape[1] * k),
-        MemoryOrder::RowMajor => k + shape[2] * (j + shape[1] * i),
-    }
+    i + shape[0] * (j + shape[1] * k)
 }
 
 impl<T: Clone> TypedTensor<T> {
@@ -134,18 +74,14 @@ impl<T: Clone> TypedTensor<T> {
     /// ```
     /// use tenferro_tensor::TypedTensor;
     ///
-    /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2], vec![1.0, 2.0]);
+    /// let t = TypedTensor::<f64>::from_vec(vec![2], vec![1.0, 2.0]);
     /// assert_eq!(t.as_physical_slice(), &[1.0, 2.0]);
     /// ```
     pub fn as_physical_slice(&self) -> &[T] {
         self.host_data()
     }
 
-    /// Iterate over the contiguous host buffer in physical memory order.
-    ///
-    /// For column-major tensors this visits the leftmost logical dimension
-    /// fastest. For row-major tensors it visits the rightmost logical
-    /// dimension fastest.
+    /// Iterate over the contiguous column-major host buffer.
     ///
     /// # Examples
     ///
@@ -175,12 +111,7 @@ impl<T: Clone> TypedTensor<T> {
         self.host_data_mut()
     }
 
-    /// Mutably iterate over the contiguous host buffer in physical memory
-    /// order.
-    ///
-    /// For column-major tensors this visits the leftmost logical dimension
-    /// fastest. For row-major tensors it visits the rightmost logical
-    /// dimension fastest.
+    /// Mutably iterate over the contiguous column-major host buffer.
     ///
     /// # Examples
     ///
@@ -204,11 +135,11 @@ impl<T: Clone> TypedTensor<T> {
     /// ```
     /// use tenferro_tensor::TypedTensor;
     ///
-    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]);
+    /// let t = TypedTensor::<f64>::from_vec(vec![2, 3], vec![0.0; 6]);
     /// assert_eq!(t.linear_offset2(1, 2), 5);
     /// ```
     pub fn linear_offset2(&self, i: usize, j: usize) -> usize {
-        linear_offset2_for_order(&self.shape, i, j, self.order)
+        linear_offset2(&self.shape, i, j)
     }
 
     /// Compute the linear physical-buffer offset for a rank-3 logical index.
@@ -218,11 +149,11 @@ impl<T: Clone> TypedTensor<T> {
     /// ```
     /// use tenferro_tensor::TypedTensor;
     ///
-    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 3, 2], vec![0.0; 12]);
+    /// let t = TypedTensor::<f64>::from_vec(vec![2, 3, 2], vec![0.0; 12]);
     /// assert_eq!(t.linear_offset3(1, 2, 1), 11);
     /// ```
     pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> usize {
-        linear_offset3_for_order(&self.shape, i, j, k, self.order)
+        linear_offset3(&self.shape, i, j, k)
     }
 
     /// Try to borrow a single element by multi-index.
@@ -239,7 +170,7 @@ impl<T: Clone> TypedTensor<T> {
     /// assert_eq!(t.try_get(&[2]), None);
     /// ```
     pub fn try_get(&self, indices: &[usize]) -> Option<&T> {
-        let off = try_linear_offset_for_order(&self.shape, indices, self.order)?;
+        let off = try_linear_offset(&self.shape, indices)?;
         self.host_data().get(off)
     }
 
@@ -250,7 +181,7 @@ impl<T: Clone> TypedTensor<T> {
     /// ```
     /// use tenferro_tensor::TypedTensor;
     ///
-    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    /// let t = TypedTensor::<f64>::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
     /// assert_eq!(t.get2(1, 0), &2.0);
     /// ```
     pub fn get2(&self, i: usize, j: usize) -> &T {
@@ -265,7 +196,7 @@ impl<T: Clone> TypedTensor<T> {
     /// ```
     /// use tenferro_tensor::TypedTensor;
     ///
-    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![1, 1, 2], vec![3.0, 4.0]);
+    /// let t = TypedTensor::<f64>::from_vec(vec![1, 1, 2], vec![3.0, 4.0]);
     /// assert_eq!(t.get3(0, 0, 1), &4.0);
     /// ```
     pub fn get3(&self, i: usize, j: usize, k: usize) -> &T {
@@ -292,7 +223,7 @@ impl<T: Clone> TypedTensor<T> {
     /// assert_eq!(unsafe { *t.get_unchecked(&[1]) }, 2.0);
     /// ```
     pub unsafe fn get_unchecked(&self, indices: &[usize]) -> &T {
-        let off = linear_offset_unchecked_for_order(&self.shape, indices, self.order);
+        let off = linear_offset_unchecked(&self.shape, indices);
         unsafe { self.host_data().get_unchecked(off) }
     }
 
@@ -310,7 +241,7 @@ impl<T: Clone> TypedTensor<T> {
     /// assert_eq!(t.as_slice(), &[2.0]);
     /// ```
     pub fn try_get_mut(&mut self, indices: &[usize]) -> Option<&mut T> {
-        let off = try_linear_offset_for_order(&self.shape, indices, self.order)?;
+        let off = try_linear_offset(&self.shape, indices)?;
         self.host_data_mut().get_mut(off)
     }
 
@@ -321,7 +252,7 @@ impl<T: Clone> TypedTensor<T> {
     /// ```
     /// use tenferro_tensor::TypedTensor;
     ///
-    /// let mut t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    /// let mut t = TypedTensor::<f64>::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
     /// *t.get_mut2(1, 0) = 5.0;
     /// assert_eq!(t.as_slice(), &[1.0, 5.0, 3.0, 4.0]);
     /// ```
@@ -337,7 +268,7 @@ impl<T: Clone> TypedTensor<T> {
     /// ```
     /// use tenferro_tensor::TypedTensor;
     ///
-    /// let mut t = TypedTensor::<f64>::from_vec_col_major(vec![1, 1, 2], vec![3.0, 4.0]);
+    /// let mut t = TypedTensor::<f64>::from_vec(vec![1, 1, 2], vec![3.0, 4.0]);
     /// *t.get_mut3(0, 0, 1) = 5.0;
     /// assert_eq!(t.as_slice(), &[3.0, 5.0]);
     /// ```
@@ -368,7 +299,7 @@ impl<T: Clone> TypedTensor<T> {
     /// assert_eq!(t.as_slice(), &[2.0]);
     /// ```
     pub unsafe fn get_unchecked_mut(&mut self, indices: &[usize]) -> &mut T {
-        let off = linear_offset_unchecked_for_order(&self.shape, indices, self.order);
+        let off = linear_offset_unchecked(&self.shape, indices);
         unsafe { self.host_data_mut().get_unchecked_mut(off) }
     }
 }
@@ -381,11 +312,11 @@ impl Tensor {
     /// ```
     /// use tenferro_tensor::Tensor;
     ///
-    /// let t = Tensor::from_vec_row_major(vec![2, 3], vec![0.0_f64; 6]);
-    /// assert_eq!(t.linear_offset(&[1, 0]), 3);
+    /// let t = Tensor::from_vec(vec![2, 3], vec![0.0_f64; 6]);
+    /// assert_eq!(t.linear_offset(&[1, 2]), 5);
     /// ```
     pub fn linear_offset(&self, indices: &[usize]) -> usize {
-        linear_offset_for_order(self.shape(), indices, self.order())
+        linear_offset(self.shape(), indices)
     }
 
     /// Compute the linear physical-buffer offset for a rank-2 logical index.
@@ -395,11 +326,11 @@ impl Tensor {
     /// ```
     /// use tenferro_tensor::Tensor;
     ///
-    /// let t = Tensor::from_vec_row_major(vec![2, 3], vec![0.0_f64; 6]);
-    /// assert_eq!(t.linear_offset2(1, 0), 3);
+    /// let t = Tensor::from_vec(vec![2, 3], vec![0.0_f64; 6]);
+    /// assert_eq!(t.linear_offset2(1, 2), 5);
     /// ```
     pub fn linear_offset2(&self, i: usize, j: usize) -> usize {
-        linear_offset2_for_order(self.shape(), i, j, self.order())
+        linear_offset2(self.shape(), i, j)
     }
 
     /// Compute the linear physical-buffer offset for a rank-3 logical index.
@@ -409,11 +340,11 @@ impl Tensor {
     /// ```
     /// use tenferro_tensor::Tensor;
     ///
-    /// let t = Tensor::from_vec_col_major(vec![2, 3, 2], vec![0.0_f64; 12]);
+    /// let t = Tensor::from_vec(vec![2, 3, 2], vec![0.0_f64; 12]);
     /// assert_eq!(t.linear_offset3(1, 2, 1), 11);
     /// ```
     pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> usize {
-        linear_offset3_for_order(self.shape(), i, j, k, self.order())
+        linear_offset3(self.shape(), i, j, k)
     }
 
     /// Try to borrow the host data as a typed physical-memory-order slice.
@@ -465,7 +396,7 @@ impl Tensor {
     /// assert_eq!(t.try_get::<f32>(&[1]), None);
     /// ```
     pub fn try_get<T: TensorScalar>(&self, indices: &[usize]) -> Option<&T> {
-        let off = try_linear_offset_for_order(self.shape(), indices, self.order())?;
+        let off = try_linear_offset(self.shape(), indices)?;
         self.as_slice::<T>()?.get(off)
     }
 
@@ -484,7 +415,7 @@ impl Tensor {
     /// assert_eq!(t.as_slice::<f64>().unwrap(), &[2.0]);
     /// ```
     pub fn try_get_mut<T: TensorScalar>(&mut self, indices: &[usize]) -> Option<&mut T> {
-        let off = try_linear_offset_for_order(self.shape(), indices, self.order())?;
+        let off = try_linear_offset(self.shape(), indices)?;
         self.as_slice_mut::<T>()?.get_mut(off)
     }
 
@@ -508,7 +439,7 @@ impl Tensor {
     /// assert_eq!(unsafe { *t.get_unchecked::<f64>(&[1]).unwrap() }, 2.0);
     /// ```
     pub unsafe fn get_unchecked<T: TensorScalar>(&self, indices: &[usize]) -> Option<&T> {
-        let off = linear_offset_unchecked_for_order(self.shape(), indices, self.order());
+        let off = linear_offset_unchecked(self.shape(), indices);
         let data = self.as_slice::<T>()?;
         Some(unsafe { data.get_unchecked(off) })
     }
@@ -539,7 +470,7 @@ impl Tensor {
         &mut self,
         indices: &[usize],
     ) -> Option<&mut T> {
-        let off = linear_offset_unchecked_for_order(self.shape(), indices, self.order());
+        let off = linear_offset_unchecked(self.shape(), indices);
         let data = self.as_slice_mut::<T>()?;
         Some(unsafe { data.get_unchecked_mut(off) })
     }

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -125,6 +125,69 @@ impl<B: TensorBackend> EagerTensor<B> {
         self.binary_op(other, StdTensorOp::DotGeneral { config })
     }
 
+    /// Matrix multiplication for rank-2 tensors.
+    ///
+    /// This is a convenience wrapper over [`Self::dot_general`] that
+    /// contracts the left matrix's column axis with the right matrix's row
+    /// axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+    ///     ctx.clone(),
+    /// );
+    /// let b = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec(vec![2, 1], vec![5.0_f64, 6.0]),
+    ///     ctx,
+    /// );
+    /// let c = a.matmul(&b).unwrap();
+    ///
+    /// assert_eq!(c.data().shape(), &[2, 1]);
+    /// assert_eq!(c.data().as_slice::<f64>().unwrap(), &[23.0, 34.0]);
+    /// ```
+    pub fn matmul(&self, other: &Self) -> Result<Self> {
+        let lhs_shape = self.data().shape();
+        let rhs_shape = other.data().shape();
+        if lhs_shape.len() != 2 {
+            return Err(tenferro_tensor::Error::RankMismatch {
+                op: "matmul",
+                expected: 2,
+                actual: lhs_shape.len(),
+            }
+            .into());
+        }
+        if rhs_shape.len() != 2 {
+            return Err(tenferro_tensor::Error::RankMismatch {
+                op: "matmul",
+                expected: 2,
+                actual: rhs_shape.len(),
+            }
+            .into());
+        }
+        if lhs_shape[1] != rhs_shape[0] {
+            return Err(tenferro_tensor::Error::ShapeMismatch {
+                op: "matmul",
+                lhs: lhs_shape.to_vec(),
+                rhs: rhs_shape.to_vec(),
+            }
+            .into());
+        }
+        self.dot_general(
+            other,
+            DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        )
+    }
+
     /// Permute tensor axes.
     ///
     /// # Examples

--- a/tenferro/src/eager_ops_linalg.rs
+++ b/tenferro/src/eager_ops_linalg.rs
@@ -147,6 +147,76 @@ impl<B: TensorBackend> EagerTensor<B> {
         self.binary_op(b, StdTensorOp::FullPivLuSolve { transpose_a: false })
     }
 
+    /// Solve `A x = rhs` using complete-pivoting LU factorization.
+    ///
+    /// This is a shorter alias for [`Self::full_piv_lu_solve`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]), ctx.clone());
+    /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![4.0_f64, 8.0]), ctx);
+    /// let x = a.solve(&b).unwrap();
+    ///
+    /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[2.0, 2.0]);
+    /// ```
+    pub fn solve(&self, rhs: &Self) -> Result<Self> {
+        self.full_piv_lu_solve(rhs)
+    }
+
+    /// Solve `x A = rhs`, returning `rhs * A^{-1}` without forming an inverse.
+    ///
+    /// This uses the identity `rhs * A^{-1} = (A^T \ rhs^T)^T`, so AD flows
+    /// through the existing linear solve rule.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]), ctx.clone());
+    /// let rhs = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1, 2], vec![4.0_f64, 8.0]), ctx);
+    /// let x = a.right_solve(&rhs).unwrap();
+    ///
+    /// assert_eq!(x.data().shape(), &[1, 2]);
+    /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[2.0, 2.0]);
+    /// ```
+    pub fn right_solve(&self, rhs: &Self) -> Result<Self> {
+        let lhs_shape = self.data().shape();
+        let rhs_shape = rhs.data().shape();
+        if lhs_shape.len() != 2 {
+            return Err(tenferro_tensor::Error::RankMismatch {
+                op: "right_solve",
+                expected: 2,
+                actual: lhs_shape.len(),
+            }
+            .into());
+        }
+        if rhs_shape.len() != 2 {
+            return Err(tenferro_tensor::Error::RankMismatch {
+                op: "right_solve",
+                expected: 2,
+                actual: rhs_shape.len(),
+            }
+            .into());
+        }
+        if lhs_shape[1] != rhs_shape[1] {
+            return Err(tenferro_tensor::Error::ShapeMismatch {
+                op: "right_solve",
+                lhs: lhs_shape.to_vec(),
+                rhs: rhs_shape.to_vec(),
+            }
+            .into());
+        }
+        let a_t = self.transpose(&[1, 0])?;
+        let rhs_t = rhs.transpose(&[1, 0])?;
+        a_t.full_piv_lu_solve(&rhs_t)?.transpose(&[1, 0])
+    }
+
     /// Cholesky factorization: `A = L L^T` for real inputs.
     ///
     /// # Examples

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -50,7 +50,7 @@ pub use linalg_api::{
 };
 pub use sym_dim::SymDim;
 pub use tenferro_tensor::cpu::CpuBackend;
-pub use tenferro_tensor::{DType, MemoryOrder, Tensor, TensorBackend, TensorScalar, TypedTensor};
+pub use tenferro_tensor::{DType, Tensor, TensorBackend, TensorScalar, TypedTensor};
 pub use traced::TracedTensor;
 
 #[cfg(feature = "cubecl")]

--- a/tenferro/src/shape_packing.rs
+++ b/tenferro/src/shape_packing.rs
@@ -115,6 +115,102 @@ fn validate_stack_shapes(op: &'static str, shapes: &[&[usize]]) -> Result<()> {
 }
 
 impl<B: TensorBackend> EagerTensor<B> {
+    /// Select entries from one axis using host-known indices.
+    ///
+    /// The index list is primal metadata: gradients flow to `self`, including
+    /// accumulation for repeated indices, but not to the selected positions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]),
+    ///     ctx,
+    /// );
+    /// let y = x.take_axis(0, &[2, 0]).unwrap();
+    ///
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[30.0, 10.0]);
+    /// ```
+    pub fn take_axis(&self, axis: usize, indices: &[usize]) -> Result<Self> {
+        let axis = isize::try_from(axis).map_err(|_| {
+            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+                op: "take_axis",
+                message: format!("axis {axis} cannot be represented as isize"),
+            })
+        })?;
+        self.index_select(axis, indices)
+    }
+
+    /// Select matrix rows using host-known row indices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+    ///     ctx,
+    /// );
+    /// let y = x.take_rows(&[1]).unwrap();
+    ///
+    /// assert_eq!(y.data().shape(), &[1, 2]);
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+    /// ```
+    pub fn take_rows(&self, rows: &[usize]) -> Result<Self> {
+        self.take_axis(0, rows)
+    }
+
+    /// Select matrix columns using host-known column indices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+    ///     ctx,
+    /// );
+    /// let y = x.take_cols(&[1]).unwrap();
+    ///
+    /// assert_eq!(y.data().shape(), &[2, 1]);
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
+    /// ```
+    pub fn take_cols(&self, cols: &[usize]) -> Result<Self> {
+        self.take_axis(1, cols)
+    }
+
+    /// Select a matrix block using host-known row and column indices.
+    ///
+    /// This is a convenience wrapper over row selection followed by column
+    /// selection. The row and column lists, plus the approximation rank implied
+    /// by their lengths, are fixed primal metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+    ///     ctx,
+    /// );
+    /// let y = x.take_block(&[1], &[0]).unwrap();
+    ///
+    /// assert_eq!(y.data().shape(), &[1, 1]);
+    /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[2.0]);
+    /// ```
+    pub fn take_block(&self, rows: &[usize], cols: &[usize]) -> Result<Self> {
+        self.take_rows(rows)?.take_cols(cols)
+    }
+
     /// Select entries from one axis using host-known positions.
     ///
     /// # Examples

--- a/tenferro/tests/eager_fixed_pivot_cross.rs
+++ b/tenferro/tests/eager_fixed_pivot_cross.rs
@@ -1,0 +1,171 @@
+use std::sync::Arc;
+
+use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+
+const FD_H: f64 = 1.0e-6;
+const TOL: f64 = 1.0e-10;
+const FD_TOL: f64 = 5.0e-4;
+
+fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
+    EagerContext::with_backend(CpuBackend::new())
+}
+
+fn f64_data(tensor: &Tensor) -> &[f64] {
+    tensor.as_slice::<f64>().unwrap()
+}
+
+fn assert_close_slice(actual: &[f64], expected: &[f64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).abs() <= tol,
+            "idx {idx}: expected {expected}, got {actual}"
+        );
+    }
+}
+
+fn fixed_pivot_cross_loss(data: &[f64]) -> f64 {
+    let a = |row: usize, col: usize| data[row + 3 * col];
+
+    let p00 = a(0, 0);
+    let p01 = a(0, 2);
+    let p10 = a(2, 0);
+    let p11 = a(2, 2);
+    let det = p00 * p11 - p01 * p10;
+
+    let mut loss = 0.0;
+    for col in 0..3 {
+        let r0 = a(0, col);
+        let r1 = a(2, col);
+        let x0 = (p11 * r0 - p01 * r1) / det;
+        let x1 = (-p10 * r0 + p00 * r1) / det;
+
+        for row in 0..3 {
+            loss += a(row, 0) * x0 + a(row, 2) * x1;
+        }
+    }
+    loss
+}
+
+fn finite_diff_grad(data: &[f64]) -> Vec<f64> {
+    (0..data.len())
+        .map(|idx| {
+            let mut plus = data.to_vec();
+            let mut minus = data.to_vec();
+            plus[idx] += FD_H;
+            minus[idx] -= FD_H;
+            (fixed_pivot_cross_loss(&plus) - fixed_pivot_cross_loss(&minus)) / (2.0 * FD_H)
+        })
+        .collect()
+}
+
+#[test]
+fn take_axis_rows_cols_and_block_select_static_indices() {
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec(
+            vec![3, 4],
+            vec![
+                1.0_f64, 2.0, 3.0, //
+                4.0, 5.0, 6.0, //
+                7.0, 8.0, 9.0, //
+                10.0, 11.0, 12.0,
+            ],
+        ),
+        test_ctx(),
+    );
+
+    let rows = x.take_rows(&[2, 0]).unwrap();
+    assert_eq!(rows.data().shape(), &[2, 4]);
+    assert_close_slice(
+        f64_data(rows.data()),
+        &[3.0, 1.0, 6.0, 4.0, 9.0, 7.0, 12.0, 10.0],
+        TOL,
+    );
+
+    let cols = x.take_cols(&[3, 1]).unwrap();
+    assert_eq!(cols.data().shape(), &[3, 2]);
+    assert_close_slice(
+        f64_data(cols.data()),
+        &[10.0, 11.0, 12.0, 4.0, 5.0, 6.0],
+        TOL,
+    );
+
+    let block = x.take_block(&[2, 0], &[3, 1]).unwrap();
+    assert_eq!(block.data().shape(), &[2, 2]);
+    assert_close_slice(f64_data(block.data()), &[12.0, 10.0, 6.0, 4.0], TOL);
+
+    let axis = x.take_axis(1, &[0, 2]).unwrap();
+    assert_eq!(axis.data().shape(), &[3, 2]);
+    assert_close_slice(f64_data(axis.data()), &[1.0, 2.0, 3.0, 7.0, 8.0, 9.0], TOL);
+}
+
+#[test]
+fn take_block_backward_accumulates_to_source() {
+    let ctx = test_ctx();
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec(
+            vec![3, 4],
+            vec![
+                1.0_f64, 2.0, 3.0, //
+                4.0, 5.0, 6.0, //
+                7.0, 8.0, 9.0, //
+                10.0, 11.0, 12.0,
+            ],
+        ),
+        ctx.clone(),
+    );
+    let weights = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx,
+    );
+
+    let block = x.take_block(&[2, 0, 2], &[3, 1]).unwrap();
+    let loss = block.mul(&weights).unwrap().reduce_sum(&[0, 1]).unwrap();
+    let _ = loss.backward().unwrap();
+
+    assert_close_slice(
+        f64_data(x.grad().unwrap().as_ref()),
+        &[0.0, 0.0, 0.0, 5.0, 0.0, 10.0, 0.0, 0.0, 0.0, 2.0, 0.0, 4.0],
+        TOL,
+    );
+}
+
+#[test]
+fn fixed_pivot_cross_matches_solve_formula_and_gradients() {
+    // Fixed rows/columns, and the rank implied by their length, are
+    // primal-only metadata. This test differentiates only the construction
+    // C * P^{-1} * R for those fixed pivots.
+    let a_data = vec![
+        2.0_f64, 3.0, 1.0, //
+        1.0, 4.0, 0.0, //
+        0.0, 5.0, 3.0,
+    ];
+    let ctx = test_ctx();
+    let a = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3, 3], a_data.clone()), ctx);
+
+    let c = a.take_cols(&[0, 2]).unwrap();
+    let r = a.take_rows(&[0, 2]).unwrap();
+    let p = a.take_block(&[0, 2], &[0, 2]).unwrap();
+
+    let right = p.solve(&r).unwrap();
+    let approx = c.matmul(&right).unwrap();
+    assert_eq!(approx.data().shape(), &[3, 3]);
+    assert_close_slice(
+        f64_data(approx.data()),
+        &[2.0, 3.0, 1.0, 1.0, 2.0 / 3.0, 0.0, 0.0, 5.0, 3.0],
+        TOL,
+    );
+
+    let left = p.right_solve(&c).unwrap();
+    let approx_from_left = left.matmul(&r).unwrap();
+    assert_close_slice(
+        f64_data(approx_from_left.data()),
+        f64_data(approx.data()),
+        TOL,
+    );
+
+    let loss = approx.reduce_sum(&[0, 1]).unwrap();
+    let _ = loss.backward().unwrap();
+    let expected = finite_diff_grad(&a_data);
+    assert_close_slice(f64_data(a.grad().unwrap().as_ref()), &expected, FD_TOL);
+}

--- a/tenferro/tests/eager_linalg.rs
+++ b/tenferro/tests/eager_linalg.rs
@@ -135,6 +135,49 @@ fn full_piv_lu_solve_returns_expected_solution() {
 }
 
 #[test]
+fn solve_alias_and_right_solve_cover_success_and_validation_errors() {
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]),
+        test_ctx(),
+    );
+    let b =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![4.0_f64, 8.0]), test_ctx());
+    let x = a.solve(&b).unwrap();
+    assert_eq!(x.data().shape(), &[2, 1]);
+    assert_eq!(f64_data(x.data()), &[2.0, 2.0]);
+
+    let rhs =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![1, 2], vec![4.0_f64, 8.0]), test_ctx());
+    let right = a.right_solve(&rhs).unwrap();
+    assert_eq!(right.data().shape(), &[1, 2]);
+    assert_eq!(f64_data(right.data()), &[2.0, 2.0]);
+
+    let vector =
+        EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), test_ctx());
+    let lhs_rank_err = match vector.right_solve(&rhs) {
+        Ok(_) => panic!("expected lhs rank mismatch"),
+        Err(err) => err,
+    };
+    assert!(lhs_rank_err.to_string().contains("rank mismatch"));
+
+    let rhs_rank_err = match a.right_solve(&vector) {
+        Ok(_) => panic!("expected rhs rank mismatch"),
+        Err(err) => err,
+    };
+    assert!(rhs_rank_err.to_string().contains("rank mismatch"));
+
+    let bad_rhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![1, 3], vec![1.0_f64, 2.0, 3.0]),
+        test_ctx(),
+    );
+    let shape_err = match a.right_solve(&bad_rhs) {
+        Ok(_) => panic!("expected shape mismatch"),
+        Err(err) => err,
+    };
+    assert!(shape_err.to_string().contains("shape mismatch"));
+}
+
+#[test]
 fn eigh_returns_expected_values_for_diagonal_matrix() {
     let a = EagerTensor::from_tensor_in(
         Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]),

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -91,16 +91,15 @@ fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
 }
 
 #[test]
-fn row_major_eager_input_uses_logical_shape_and_values() {
+fn matrix_eager_input_uses_column_major_values() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]),
         test_ctx(),
     );
     let y = &x + &x;
-    let row_major = y.data().to_row_major().expect("row-major conversion");
 
     assert_eq!(y.data().shape(), &[2, 3]);
-    assert_eq!(f64_data(&row_major), &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]);
+    assert_eq!(f64_data(y.data()), &[2.0, 8.0, 4.0, 10.0, 6.0, 12.0]);
 }
 
 #[test]

--- a/tenferro/tests/einsum.rs
+++ b/tenferro/tests/einsum.rs
@@ -1,6 +1,6 @@
 //! Ported v1 einsum tests adapted for the v2 traced pipeline.
 //!
-//! Data is stored in **column-major** order. A helper `row_to_col_major` is
+//! Data is stored in **column-major** order. A helper `row_major_to_column_major` is
 //! available for converting row-major test data when needed.
 
 use num_complex::Complex64;
@@ -36,7 +36,7 @@ fn get_v2(t: &Tensor, idx: &[usize]) -> f64 {
 
 /// Convert row-major data to column-major for a given shape.
 #[allow(dead_code)]
-fn row_to_col_major(data: &[f64], shape: &[usize]) -> Vec<f64> {
+fn row_major_to_column_major(data: &[f64], shape: &[usize]) -> Vec<f64> {
     let n: usize = shape.iter().product();
     let mut col_data = vec![0.0; n];
     let rank = shape.len();

--- a/tenferro/tests/oracle_replay/decode.rs
+++ b/tenferro/tests/oracle_replay/decode.rs
@@ -130,7 +130,7 @@ pub fn tensor_data_as_col_major(td: &TensorData) -> Result<Vec<f64>, String> {
         ));
     }
     match td.order.as_str() {
-        "row_major" => Ok(row_to_col_major_blocks(&td.data, &td.shape, 1)),
+        "row_major" => Ok(row_major_to_column_major_blocks(&td.data, &td.shape, 1)),
         "col_major" => Ok(td.data.clone()),
         other => Err(format!("unsupported tensor storage order {other}")),
     }
@@ -150,7 +150,7 @@ pub fn complex_tensor_data_as_col_major(td: &TensorData) -> Result<Vec<Complex64
     }
 
     let flat = match td.order.as_str() {
-        "row_major" => row_to_col_major_blocks(&td.data, &td.shape, 2),
+        "row_major" => row_major_to_column_major_blocks(&td.data, &td.shape, 2),
         "col_major" => td.data.clone(),
         other => return Err(format!("unsupported tensor storage order {other}")),
     };
@@ -162,11 +162,11 @@ pub fn complex_tensor_data_as_col_major(td: &TensorData) -> Result<Vec<Complex64
     Ok(out)
 }
 
-pub fn row_to_col_major(data: &[f64], shape: &[usize]) -> Vec<f64> {
-    row_to_col_major_blocks(data, shape, 1)
+pub fn row_major_to_column_major(data: &[f64], shape: &[usize]) -> Vec<f64> {
+    row_major_to_column_major_blocks(data, shape, 1)
 }
 
-pub fn row_to_col_major_blocks(data: &[f64], shape: &[usize], block: usize) -> Vec<f64> {
+pub fn row_major_to_column_major_blocks(data: &[f64], shape: &[usize], block: usize) -> Vec<f64> {
     let total: usize = shape.iter().product();
     if total == 0 {
         return Vec::new();

--- a/tenferro/tests/symbolic_input.rs
+++ b/tenferro/tests/symbolic_input.rs
@@ -51,19 +51,18 @@ fn addition_of_two_symbolic_inputs() {
 }
 
 #[test]
-fn row_major_symbolic_input_uses_logical_shape_and_values() {
+fn matrix_symbolic_input_uses_column_major_values() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let mut y = &x + &x;
 
     let mut engine = Engine::new(CpuBackend::new());
-    let bound = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let bound = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
     let out = y
         .eval_with_inputs(&mut engine, &[(&x, &bound)])
         .expect("eval_with_inputs");
-    let row_major = out.to_row_major().expect("row-major conversion");
 
     assert_eq!(out.shape(), &[2, 3]);
-    assert_eq!(f64_data(&row_major), &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]);
+    assert_eq!(f64_data(out), &[2.0, 8.0, 4.0, 10.0, 6.0, 12.0]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add the out-of-tree `tenferro-fft` extension crate with 1D host FFT APIs, tests, and user-facing docs for custom tensor operations
- add eager convenience APIs for shape packing, matrix multiply, solve, and right-solve with regression coverage
- centralize CubeCL raw launch shape/buffer guards and document unchecked launch safety for elementwise, scatter, fusion, and reduce paths

## Issues

Closes #851
Closes #858
Refs #422

## Verification

- `cargo fmt --all --check`
- `cargo fmt --manifest-path tenferro-fft/Cargo.toml --check`
- `git diff --check`
- `cargo test --manifest-path tenferro-fft/Cargo.toml`
- `cargo test -p tenferro-tensor --features cubecl typed_tensor_array_arg_rejects_shape_buffer_len_mismatch`
- `cargo test -p tenferro-tensor --features cubecl metadata_tests`
- `cargo test -p tenferro-cubecl`
- `cargo test -p tenferro-tensor --features cubecl --lib`
- `cargo test -p tenferro --test eager_linalg solve_alias_and_right_solve_cover_success_and_validation_errors`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo doc --manifest-path tenferro-fft/Cargo.toml --no-deps`
- `cargo build -p tenferro --features cuda`

Note: `cargo build -p tenferro --features cuda` still reports the existing unused `CusolverLibrary::version` warning.
