### PR TITLE
[codex] Update AD stack revisions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-chainrules-core = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "da3f2b50ba2e6a0738737e4e4b2ec8f5c8243469", package = "chainrules" }
-chainrules = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "da3f2b50ba2e6a0738737e4e4b2ec8f5c8243469" }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "1d4a4c1d1c3923b79a509467ea4af4be2a148aaf" }
+chainrules-core = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2d7662140d92f0dd73b2402aefc2272feafc9270", package = "chainrules" }
+chainrules = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2d7662140d92f0dd73b2402aefc2272feafc9270" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "1351fa42cf98852d821963682e4fc5d0835ba6d4" }
 strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722", features = ["parallel"] }
@@ -63,4 +63,4 @@ cubecl-runtime = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a
 tenferro-cubecl = { path = "tenferro-cubecl" }
 sha2 = "0.10"
 omeco = "0.2.4"
-computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "8306196" }
+computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "c20e8912560ef11166418bcea089126ef50443cc" }


### PR DESCRIPTION
## Summary

- Pin `chainrules` / `chainrules-core` to tensor4all/chainrules-rs#14.
- Pin `tidu` to tensor4all/tidu-rs#24.
- Pin `computegraph` to tensor4all/computegraph-rs#3.

## Impact

This lets tenferro consume the merged `GlobalOpKey` fingerprint/shared-key updates throughout the AD stack while keeping the dependency graph on a single computegraph revision.

## Validation

- `cargo fmt --all --check`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `/Users/hiroshi/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 scripts/check-docs-site.py`

Generated with Codex.