### PR TITLE
[codex] Add integer einsum and cached dot-general paths

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -5,6 +5,23 @@
 - `README`, rustdoc, and examples must not claim capabilities beyond the current public surface.
 - When the public API changes, check for stale names, stale capability claims, and deleted paths in `README`, rustdoc, and examples before considering the work complete.
 
+## Public Surface Discipline
+
+- Keep the public API intentionally small. Prefer `pub(crate)` for types,
+  functions, traits, modules, fields, and helper constructors unless external
+  users are expected to call them directly.
+- Do not make implementation details public just because another module needs
+  them. First consider whether the code belongs in the same crate/module, or
+  whether a narrower crate-private helper is the right abstraction.
+- Public APIs should be selected deliberately and documented as user-facing
+  contracts. If an item is primarily for tests, benchmarks, internal planning,
+  execution dispatch, lowering, caching, or backend glue, it should normally be
+  private or `pub(crate)`.
+- Before adding or keeping a `pub` item, ask whether it is useful outside this
+  repository and whether tenferro is prepared to support its semantics as a
+  public contract. If the answer is unclear, keep it `pub(crate)` and expose a
+  smaller high-level API instead.
+
 ## Oracle Gate
 
 - Do not add or keep an AD `frule` or `rrule` in the mainline without a corresponding oracle family.

--- a/docs/design/dot-general-overhead.md
+++ b/docs/design/dot-general-overhead.md
@@ -1,0 +1,81 @@
+# Dot-General Fixed Overhead
+
+This note records the current interpretation of the
+`tenferro-tensor/benches/dot_general_overhead.rs` benchmark. It is a
+developer-facing performance note for small, repeated contractions such as MPS
+inner products.
+
+## Benchmark Shape
+
+The benchmark contracts a length-32 complex MPS inner product using two
+`dot_general_with_conj` calls per site. It compares three execution styles:
+
+| Variant | What it measures |
+|---------|------------------|
+| `fresh_backend_cache` | Calls `backend.dot_general_with_conj` for every local contraction. |
+| `persistent_backend_cache` | Reuses the backend runtime cache but still calls the backend method for every contraction. |
+| `single_exec_session` | Opens one `backend.with_exec_session_cached` around the whole MPS contraction and calls `TensorExec` methods inside it. |
+
+Representative one-thread timings from the May 2026 investigation:
+
+| `L = 32`, `d = 2`, `Complex64` | `chi = 4` | `chi = 8` | `chi = 16` | `chi = 32` | `chi = 64` |
+|--------------------------------|----------:|----------:|-----------:|-----------:|-----------:|
+| `fresh_backend_cache` | ~445 us | ~446 us | ~445 us | ~1.53 ms | ~8.69 ms |
+| `persistent_backend_cache` | ~421 us | ~434 us | ~444 us | ~1.52 ms | ~8.67 ms |
+| `single_exec_session` | ~45.8 us | ~61.2 us | ~190 us | ~1.12 ms | ~8.12 ms |
+
+Exact numbers vary by machine and allocator state. The important signal is the
+scaling difference between per-op backend calls and a single execution session.
+
+## Interpretation
+
+For small contractions, the dominant overhead is not GEMM analysis cache misses,
+hash-map-heavy label handling, or contraction path search. The main fixed cost is
+opening the full backend wrapper path for each local contraction:
+
+```text
+backend.dot_general_with_conj(...)
+  -> backend.with_exec_session(...)
+       -> CpuContext::install(...)
+            -> dtype dispatch
+                 -> Tensor wrapper / enum dispatch
+                      -> CpuExecSession::dot_general_with_conj(...)
+                           -> GEMM planning / execution
+```
+
+When this sequence is repeated for every tiny local contraction, the
+`backend.with_exec_session` / `ctx.install` / dtype dispatch / wrapper path
+cost dominates. Reusing a persistent runtime cache helps only slightly in this
+benchmark, which indicates that GEMM analysis caching is not the principal
+bottleneck for low bond dimensions.
+
+For larger bond dimensions the actual GEMM work becomes dominant, so the gap
+between `fresh_backend_cache` and `single_exec_session` naturally shrinks.
+
+## Design Consequences
+
+- Prefer executing many small contractions inside one `TensorExec` session when
+  the caller naturally owns a loop or compiled program.
+- Do not add ad hoc MPS-specific fast paths to bypass the public backend API.
+  The general abstraction to improve is an execution-session surface that can be
+  reused by tensor-network code and compiled graph execution alike.
+- Further SmallVec/hash-map tuning in contraction metadata is unlikely to move
+  this benchmark unless profiling shows that the workload has shifted away from
+  backend/session fixed costs.
+- A future public or crate-private batched eager execution API should make
+  session lifetime explicit, so callers can avoid opening one backend session
+  per small contraction without reaching into backend internals.
+
+## Reproduction
+
+Run with one CPU worker and one BLAS worker to avoid hiding fixed costs behind
+parallel scheduling noise:
+
+```bash
+RAYON_NUM_THREADS=1 \
+VECLIB_MAXIMUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 \
+OMP_NUM_THREADS=1 \
+MKL_NUM_THREADS=1 \
+cargo bench -p tenferro-tensor --bench dot_general_overhead
+```

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -15,6 +15,7 @@ architecture see [Architecture](../architecture/). For normative specs see
 | [algebra.md](./algebra.md) | Algebra boundary, external numeric extensions, tropical paths |
 | [einsum.md](./einsum.md) | Einsum public API, N-ary contraction tree, algebra dispatch |
 | [contraction-pipeline.md](./contraction-pipeline.md) | Binary contraction pipeline, copy elision |
+| [dot-general-overhead.md](./dot-general-overhead.md) | Fixed-cost analysis for many small `dot_general` contractions |
 | [dynamic-symbolic-shapes.md](./dynamic-symbolic-shapes.md) | Dynamic and symbolic shape metadata contract |
 | [einsum-dyadtensor.md](./einsum-dyadtensor.md) | AD integration for einsum + frontend |
 | [gpu-backend-design.md](./gpu-backend-design.md) | GPU backend architecture |

--- a/tenferro-einsum/src/eager.rs
+++ b/tenferro-einsum/src/eager.rs
@@ -1,28 +1,146 @@
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
+use std::env;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 
-use tenferro_tensor::{DotGeneralConfig, Error, Result, Tensor, TensorBackend, TensorExec};
+use tenferro_tensor::{
+    DotGeneralConfig, Error, Result, Tensor, TensorBackend, TensorExec, TensorRead, TensorView,
+};
 
 use crate::{ContractionTree, Subscripts};
 
 const EAGER_EINSUM_OP: &str = "eager_einsum";
 
+#[derive(Debug, Default, Clone)]
+struct EagerEinsumProfileEntry {
+    calls: usize,
+    total_time: Duration,
+}
+
+thread_local! {
+    static EAGER_EINSUM_PROFILE_STATE: RefCell<HashMap<&'static str, EagerEinsumProfileEntry>> =
+        RefCell::new(HashMap::new());
+    static EAGER_EINSUM_PLAN_CACHE: RefCell<HashMap<EagerEinsumPlanCacheKey, Arc<ContractionTree>>> =
+        RefCell::new(HashMap::new());
+}
+
+type EagerEinsumPlanCacheKey = (Subscripts, Vec<Vec<usize>>);
+
+fn eager_einsum_profile_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| env::var("TENFERRO_PROFILE_EAGER_EINSUM_AGG").is_ok())
+}
+
+fn eager_einsum_trace_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| env::var("TENFERRO_PROFILE_EAGER_EINSUM").is_ok())
+}
+
+fn eager_einsum_cache_disabled() -> bool {
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| env::var("TENFERRO_DISABLE_EAGER_EINSUM_CACHE").is_ok())
+}
+
+fn record_eager_einsum_profile(section: &'static str, elapsed: Duration) {
+    if !eager_einsum_profile_enabled() {
+        return;
+    }
+    EAGER_EINSUM_PROFILE_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let entry = state.entry(section).or_default();
+        entry.calls += 1;
+        entry.total_time += elapsed;
+    });
+}
+
+fn profile_eager_einsum_section<T>(section: &'static str, f: impl FnOnce() -> T) -> T {
+    if !eager_einsum_profile_enabled() {
+        return f();
+    }
+    let started = Instant::now();
+    let result = f();
+    record_eager_einsum_profile(section, started.elapsed());
+    result
+}
+
+fn maybe_print_eager_einsum_profile() {
+    if !eager_einsum_profile_enabled() {
+        return;
+    }
+    let Ok(print_every) = env::var("TENFERRO_PROFILE_EAGER_EINSUM_PRINT_EVERY") else {
+        return;
+    };
+    let Ok(print_every) = print_every.parse::<usize>() else {
+        return;
+    };
+    if print_every == 0 {
+        return;
+    }
+
+    let should_print = EAGER_EINSUM_PROFILE_STATE.with(|state| {
+        state
+            .borrow()
+            .get("total")
+            .is_some_and(|entry| entry.calls % print_every == 0)
+    });
+    if should_print {
+        print_and_reset_eager_einsum_profile();
+    }
+}
+
+fn print_and_reset_eager_einsum_profile() {
+    EAGER_EINSUM_PROFILE_STATE.with(|state| {
+        let mut entries: Vec<_> = state
+            .borrow()
+            .iter()
+            .map(|(section, entry)| (*section, entry.clone()))
+            .collect();
+        state.borrow_mut().clear();
+        entries.sort_by_key(|(_, entry)| Reverse(entry.total_time));
+
+        eprintln!("=== tenferro eager einsum profile ===");
+        for (section, entry) in entries {
+            eprintln!(
+                "{section}: calls={} total={:.6}ms per_call={:.3}us",
+                entry.calls,
+                entry.total_time.as_secs_f64() * 1.0e3,
+                entry.total_time.as_secs_f64() * 1.0e6 / entry.calls as f64,
+            );
+        }
+    });
+}
+
 enum TensorValue<'a> {
     Borrowed(&'a Tensor),
+    View(TensorView<'a>),
     Owned(Tensor),
 }
 
 impl TensorValue<'_> {
-    fn as_tensor(&self) -> &Tensor {
+    fn as_tensor(&self) -> Option<&Tensor> {
         match self {
-            Self::Borrowed(tensor) => tensor,
-            Self::Owned(tensor) => tensor,
+            Self::Borrowed(tensor) => Some(tensor),
+            Self::View(_) => None,
+            Self::Owned(tensor) => Some(tensor),
         }
     }
 
     fn into_tensor(self) -> Tensor {
         match self {
             Self::Borrowed(tensor) => tensor.clone(),
+            Self::View(view) => view.to_tensor(),
             Self::Owned(tensor) => tensor,
+        }
+    }
+
+    fn tensor_read(&self) -> TensorRead<'_> {
+        match self {
+            Self::Borrowed(tensor) => TensorRead::from_tensor(tensor),
+            Self::View(view) => TensorRead::from_view(*view),
+            Self::Owned(tensor) => TensorRead::from_tensor(tensor),
         }
     }
 
@@ -39,17 +157,154 @@ struct LabeledTensor<'a> {
 }
 
 impl LabeledTensor<'_> {
-    fn tensor(&self) -> &Tensor {
+    fn tensor(&self) -> Option<&Tensor> {
         self.tensor.as_tensor()
     }
 
+    fn tensor_read(&self) -> TensorRead<'_> {
+        self.tensor.tensor_read()
+    }
+
+    fn tensor_cow(&self) -> Cow<'_, Tensor> {
+        match self.tensor() {
+            Some(tensor) => Cow::Borrowed(tensor),
+            None => Cow::Owned(self.tensor_read().to_tensor()),
+        }
+    }
+
     fn shape(&self) -> &[usize] {
-        self.tensor().shape()
+        match &self.tensor {
+            TensorValue::Borrowed(tensor) => tensor.shape(),
+            TensorValue::View(view) => view.shape(),
+            TensorValue::Owned(tensor) => tensor.shape(),
+        }
     }
 
     fn reclaim_if_owned(self, exec: &mut dyn TensorExec) {
         self.tensor.reclaim_if_owned(exec);
     }
+}
+
+#[derive(Debug)]
+struct BinaryDotFastPlan {
+    result_labels: Vec<u32>,
+    target_labels: Vec<u32>,
+    config: DotGeneralConfig,
+}
+
+fn small_contains(labels: &[u32], label: u32) -> bool {
+    labels.iter().any(|candidate| *candidate == label)
+}
+
+fn labels_are_unique(labels: &[u32]) -> bool {
+    let mut seen = Vec::with_capacity(labels.len());
+    for &label in labels {
+        if small_contains(&seen, label) {
+            return false;
+        }
+        seen.push(label);
+    }
+    true
+}
+
+fn try_build_binary_dot_fast_plan(
+    lhs_labels: &[u32],
+    rhs_labels: &[u32],
+    output_labels: &[u32],
+) -> Option<BinaryDotFastPlan> {
+    if !labels_are_unique(lhs_labels)
+        || !labels_are_unique(rhs_labels)
+        || !labels_are_unique(output_labels)
+    {
+        return None;
+    }
+
+    let mut lhs_contracting_dims = Vec::new();
+    let mut rhs_contracting_dims = Vec::new();
+    let mut lhs_batch_dims = Vec::new();
+    let mut rhs_batch_dims = Vec::new();
+    let mut lhs_free_labels = Vec::new();
+    let mut rhs_free_labels = Vec::new();
+    let mut batch_labels = Vec::new();
+
+    for (lhs_axis, &label) in lhs_labels.iter().enumerate() {
+        let rhs_axis = rhs_labels.iter().position(|candidate| *candidate == label);
+        let in_output = small_contains(output_labels, label);
+        match (rhs_axis, in_output) {
+            (Some(rhs_axis), true) => {
+                lhs_batch_dims.push(lhs_axis);
+                rhs_batch_dims.push(rhs_axis);
+                batch_labels.push(label);
+            }
+            (Some(rhs_axis), false) => {
+                lhs_contracting_dims.push(lhs_axis);
+                rhs_contracting_dims.push(rhs_axis);
+            }
+            (None, true) => lhs_free_labels.push(label),
+            (None, false) => return None,
+        }
+    }
+
+    for &label in rhs_labels {
+        if !small_contains(lhs_labels, label) {
+            if small_contains(output_labels, label) {
+                rhs_free_labels.push(label);
+            } else {
+                return None;
+            }
+        }
+    }
+
+    if lhs_contracting_dims.is_empty() {
+        return None;
+    }
+
+    for &label in output_labels {
+        if !small_contains(lhs_labels, label) && !small_contains(rhs_labels, label) {
+            return None;
+        }
+    }
+
+    let mut result_labels =
+        Vec::with_capacity(lhs_free_labels.len() + rhs_free_labels.len() + batch_labels.len());
+    result_labels.extend(lhs_free_labels);
+    result_labels.extend(rhs_free_labels);
+    result_labels.extend(batch_labels);
+
+    Some(BinaryDotFastPlan {
+        result_labels,
+        target_labels: output_labels.to_vec(),
+        config: DotGeneralConfig {
+            lhs_contracting_dims,
+            rhs_contracting_dims,
+            lhs_batch_dims,
+            rhs_batch_dims,
+        },
+    })
+}
+
+fn execute_binary_dot_fast_plan<'a>(
+    exec: &mut dyn TensorExec,
+    lhs: LabeledTensor<'a>,
+    rhs: LabeledTensor<'a>,
+    plan: BinaryDotFastPlan,
+    reorder_result: bool,
+) -> Result<LabeledTensor<'a>> {
+    let tensor = profile_eager_einsum_section("binary.fast_dot_general", || {
+        exec.dot_general_read(lhs.tensor_read(), rhs.tensor_read(), &plan.config)
+    })?;
+    lhs.reclaim_if_owned(exec);
+    rhs.reclaim_if_owned(exec);
+
+    let result = LabeledTensor {
+        tensor: TensorValue::Owned(tensor),
+        labels: plan.result_labels,
+    };
+
+    if !reorder_result || result.labels == plan.target_labels {
+        return Ok(result);
+    }
+    transpose_to_labels(exec, result, &plan.target_labels)
 }
 
 fn eager_invalid_config(message: impl Into<String>) -> Error {
@@ -59,15 +314,13 @@ fn eager_invalid_config(message: impl Into<String>) -> Error {
     }
 }
 
-fn parse_and_plan(subscripts: &str, input_shapes: &[&[usize]]) -> Result<ContractionTree> {
+fn plan_subscripts(subs: &Subscripts, input_shapes: &[&[usize]]) -> Result<ContractionTree> {
     if input_shapes.is_empty() {
         return Err(eager_invalid_config(
             "eager einsum requires at least one input tensor",
         ));
     }
 
-    let subs = Subscripts::parse(subscripts)
-        .map_err(|err| eager_invalid_config(format!("invalid subscripts: {err}")))?;
     if subs.inputs.len() != input_shapes.len() {
         return Err(eager_invalid_config(format!(
             "eager einsum subscripts expect {} inputs, got {}",
@@ -76,8 +329,42 @@ fn parse_and_plan(subscripts: &str, input_shapes: &[&[usize]]) -> Result<Contrac
         )));
     }
 
-    ContractionTree::optimize(&subs, input_shapes)
+    ContractionTree::optimize(subs, input_shapes)
         .map_err(|err| eager_invalid_config(format!("failed to optimize contraction tree: {err}")))
+}
+
+fn cached_plan_subscripts(
+    subs: &Subscripts,
+    input_shapes: &[&[usize]],
+) -> Result<Arc<ContractionTree>> {
+    if eager_einsum_cache_disabled() {
+        return Ok(Arc::new(plan_subscripts(subs, input_shapes)?));
+    }
+
+    let key = profile_eager_einsum_section("plan_cache_key", || {
+        (
+            subs.clone(),
+            input_shapes
+                .iter()
+                .map(|shape| shape.to_vec())
+                .collect::<Vec<_>>(),
+        )
+    });
+
+    if let Some(tree) = profile_eager_einsum_section("plan_cache_lookup", || {
+        EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow().get(&key).cloned())
+    }) {
+        return Ok(tree);
+    }
+
+    let tree = profile_eager_einsum_section("plan_cache_miss_optimize", || {
+        plan_subscripts(subs, input_shapes)
+    })?;
+    let tree = Arc::new(tree);
+    EAGER_EINSUM_PLAN_CACHE.with(|cache| {
+        cache.borrow_mut().insert(key, Arc::clone(&tree));
+    });
+    Ok(tree)
 }
 
 fn take_labeled<'a>(
@@ -142,7 +429,8 @@ fn reduce_tensor<'a>(
         .filter(|(axis, _)| !reduce_set.contains(axis))
         .map(|(_, label)| *label)
         .collect();
-    let tensor = exec.reduce_sum(operand.tensor(), &reduce_axes)?;
+    let operand_tensor = operand.tensor_cow();
+    let tensor = exec.reduce_sum(&operand_tensor, &reduce_axes)?;
     operand.reclaim_if_owned(exec);
     Ok(LabeledTensor {
         tensor: TensorValue::Owned(tensor),
@@ -168,7 +456,8 @@ fn diagonalize_repeated<'a>(
             return Ok(operand);
         };
 
-        let tensor = exec.extract_diagonal(operand.tensor(), axis_a, axis_b)?;
+        let operand_tensor = operand.tensor_cow();
+        let tensor = exec.extract_diagonal(&operand_tensor, axis_a, axis_b)?;
         let mut labels = operand.labels.clone();
         labels.remove(axis_b);
         operand.reclaim_if_owned(exec);
@@ -199,7 +488,8 @@ fn embed_repeated<'a>(
             if output_count > current_count {
                 let axis_a = find_label_axis(&operand.labels, label)?;
                 let axis_b = axis_a + 1;
-                let tensor = exec.embed_diagonal(operand.tensor(), axis_a, axis_b)?;
+                let operand_tensor = operand.tensor_cow();
+                let tensor = exec.embed_diagonal(&operand_tensor, axis_a, axis_b)?;
                 let mut labels = operand.labels.clone();
                 labels.insert(axis_b, label);
                 operand.reclaim_if_owned(exec);
@@ -239,7 +529,8 @@ fn transpose_to_labels<'a>(
         return Ok(operand);
     }
 
-    let tensor = exec.transpose(operand.tensor(), &perm)?;
+    let operand_tensor = operand.tensor_cow();
+    let tensor = exec.transpose(&operand_tensor, &perm)?;
     operand.reclaim_if_owned(exec);
     Ok(LabeledTensor {
         tensor: TensorValue::Owned(tensor),
@@ -256,7 +547,9 @@ fn outer_product<'a>(
     rhs_free_labels: &[u32],
 ) -> Result<LabeledTensor<'a>> {
     if lhs.labels == rhs.labels {
-        let tensor = exec.mul(lhs.tensor(), rhs.tensor())?;
+        let lhs_tensor = lhs.tensor_cow();
+        let rhs_tensor = rhs.tensor_cow();
+        let tensor = exec.mul(&lhs_tensor, &rhs_tensor)?;
         let labels = lhs.labels.clone();
         lhs.reclaim_if_owned(exec);
         rhs.reclaim_if_owned(exec);
@@ -287,8 +580,10 @@ fn outer_product<'a>(
         .map(|label| find_label_axis(&combined_labels, *label))
         .collect::<Result<_>>()?;
 
-    let lhs_tensor = exec.broadcast_in_dim(lhs.tensor(), &combined_shape, &lhs_dims)?;
-    let rhs_tensor = exec.broadcast_in_dim(rhs.tensor(), &combined_shape, &rhs_dims)?;
+    let lhs_input = lhs.tensor_cow();
+    let rhs_input = rhs.tensor_cow();
+    let lhs_tensor = exec.broadcast_in_dim(&lhs_input, &combined_shape, &lhs_dims)?;
+    let rhs_tensor = exec.broadcast_in_dim(&rhs_input, &combined_shape, &rhs_dims)?;
     let tensor = exec.mul(&lhs_tensor, &rhs_tensor)?;
     lhs.reclaim_if_owned(exec);
     rhs.reclaim_if_owned(exec);
@@ -307,53 +602,76 @@ fn binary_contract<'a>(
     survive_labels: &[u32],
     reorder_result: bool,
 ) -> Result<LabeledTensor<'a>> {
-    let survive_set: HashSet<u32> = survive_labels.iter().copied().collect();
-    let rhs_label_set: HashSet<u32> = rhs.labels.iter().copied().collect();
-    let lhs_label_set: HashSet<u32> = lhs.labels.iter().copied().collect();
+    if let Some(plan) = try_build_binary_dot_fast_plan(&lhs.labels, &rhs.labels, survive_labels) {
+        return profile_eager_einsum_section("binary.fast_path", || {
+            execute_binary_dot_fast_plan(exec, lhs, rhs, plan, reorder_result)
+        });
+    }
 
-    let lhs_reduce: HashSet<u32> = lhs
-        .labels
-        .iter()
-        .filter(|label| !rhs_label_set.contains(label) && !survive_set.contains(label))
-        .copied()
-        .collect();
-    let rhs_reduce: HashSet<u32> = rhs
-        .labels
-        .iter()
-        .filter(|label| !lhs_label_set.contains(label) && !survive_set.contains(label))
-        .copied()
-        .collect();
+    let (survive_set, lhs_reduce, rhs_reduce) =
+        profile_eager_einsum_section("binary.pre_reduce_label_analysis", || {
+            let survive_set: HashSet<u32> = survive_labels.iter().copied().collect();
+            let rhs_label_set: HashSet<u32> = rhs.labels.iter().copied().collect();
+            let lhs_label_set: HashSet<u32> = lhs.labels.iter().copied().collect();
 
-    let lhs = reduce_tensor(exec, lhs, &lhs_reduce)?;
-    let rhs = reduce_tensor(exec, rhs, &rhs_reduce)?;
+            let lhs_reduce: HashSet<u32> = lhs
+                .labels
+                .iter()
+                .filter(|label| !rhs_label_set.contains(label) && !survive_set.contains(label))
+                .copied()
+                .collect();
+            let rhs_reduce: HashSet<u32> = rhs
+                .labels
+                .iter()
+                .filter(|label| !lhs_label_set.contains(label) && !survive_set.contains(label))
+                .copied()
+                .collect();
+            (survive_set, lhs_reduce, rhs_reduce)
+        });
 
-    let lhs_label_set: HashSet<u32> = lhs.labels.iter().copied().collect();
-    let rhs_label_set: HashSet<u32> = rhs.labels.iter().copied().collect();
+    let lhs = profile_eager_einsum_section("binary.reduce_lhs", || {
+        reduce_tensor(exec, lhs, &lhs_reduce)
+    })?;
+    let rhs = profile_eager_einsum_section("binary.reduce_rhs", || {
+        reduce_tensor(exec, rhs, &rhs_reduce)
+    })?;
 
-    let mut batch_labels = Vec::new();
-    let mut contracting_labels = Vec::new();
-    let mut lhs_free_labels = Vec::new();
-    let mut rhs_free_labels = Vec::new();
+    let (batch_labels, contracting_labels, lhs_free_labels, rhs_free_labels) =
+        profile_eager_einsum_section("binary.classify_labels", || {
+            let lhs_label_set: HashSet<u32> = lhs.labels.iter().copied().collect();
+            let rhs_label_set: HashSet<u32> = rhs.labels.iter().copied().collect();
 
-    for &label in &lhs.labels {
-        if rhs_label_set.contains(&label) {
-            if survive_set.contains(&label) {
-                if !batch_labels.contains(&label) {
-                    batch_labels.push(label);
+            let mut batch_labels = Vec::new();
+            let mut contracting_labels = Vec::new();
+            let mut lhs_free_labels = Vec::new();
+            let mut rhs_free_labels = Vec::new();
+
+            for &label in &lhs.labels {
+                if rhs_label_set.contains(&label) {
+                    if survive_set.contains(&label) {
+                        if !batch_labels.contains(&label) {
+                            batch_labels.push(label);
+                        }
+                    } else if !contracting_labels.contains(&label) {
+                        contracting_labels.push(label);
+                    }
+                } else if !lhs_free_labels.contains(&label) {
+                    lhs_free_labels.push(label);
                 }
-            } else if !contracting_labels.contains(&label) {
-                contracting_labels.push(label);
             }
-        } else if !lhs_free_labels.contains(&label) {
-            lhs_free_labels.push(label);
-        }
-    }
 
-    for &label in &rhs.labels {
-        if !lhs_label_set.contains(&label) && !rhs_free_labels.contains(&label) {
-            rhs_free_labels.push(label);
-        }
-    }
+            for &label in &rhs.labels {
+                if !lhs_label_set.contains(&label) && !rhs_free_labels.contains(&label) {
+                    rhs_free_labels.push(label);
+                }
+            }
+            (
+                batch_labels,
+                contracting_labels,
+                lhs_free_labels,
+                rhs_free_labels,
+            )
+        });
 
     let result = if contracting_labels.is_empty() {
         outer_product(
@@ -365,35 +683,40 @@ fn binary_contract<'a>(
             &rhs_free_labels,
         )?
     } else {
-        let lhs_contracting_dims: Vec<usize> = contracting_labels
-            .iter()
-            .map(|label| find_label_axis(&lhs.labels, *label))
-            .collect::<Result<_>>()?;
-        let rhs_contracting_dims: Vec<usize> = contracting_labels
-            .iter()
-            .map(|label| find_label_axis(&rhs.labels, *label))
-            .collect::<Result<_>>()?;
-        let lhs_batch_dims: Vec<usize> = batch_labels
-            .iter()
-            .map(|label| find_label_axis(&lhs.labels, *label))
-            .collect::<Result<_>>()?;
-        let rhs_batch_dims: Vec<usize> = batch_labels
-            .iter()
-            .map(|label| find_label_axis(&rhs.labels, *label))
-            .collect::<Result<_>>()?;
-        let labels: Vec<u32> = lhs_free_labels
-            .iter()
-            .chain(rhs_free_labels.iter())
-            .chain(batch_labels.iter())
-            .copied()
-            .collect();
-        let config = DotGeneralConfig {
-            lhs_contracting_dims,
-            rhs_contracting_dims,
-            lhs_batch_dims,
-            rhs_batch_dims,
-        };
-        let tensor = exec.dot_general(lhs.tensor(), rhs.tensor(), &config)?;
+        let (labels, config) = profile_eager_einsum_section("binary.build_dot_config", || {
+            let lhs_contracting_dims: Vec<usize> = contracting_labels
+                .iter()
+                .map(|label| find_label_axis(&lhs.labels, *label))
+                .collect::<Result<_>>()?;
+            let rhs_contracting_dims: Vec<usize> = contracting_labels
+                .iter()
+                .map(|label| find_label_axis(&rhs.labels, *label))
+                .collect::<Result<_>>()?;
+            let lhs_batch_dims: Vec<usize> = batch_labels
+                .iter()
+                .map(|label| find_label_axis(&lhs.labels, *label))
+                .collect::<Result<_>>()?;
+            let rhs_batch_dims: Vec<usize> = batch_labels
+                .iter()
+                .map(|label| find_label_axis(&rhs.labels, *label))
+                .collect::<Result<_>>()?;
+            let labels: Vec<u32> = lhs_free_labels
+                .iter()
+                .chain(rhs_free_labels.iter())
+                .chain(batch_labels.iter())
+                .copied()
+                .collect();
+            let config = DotGeneralConfig {
+                lhs_contracting_dims,
+                rhs_contracting_dims,
+                lhs_batch_dims,
+                rhs_batch_dims,
+            };
+            Ok::<_, Error>((labels, config))
+        })?;
+        let tensor = profile_eager_einsum_section("binary.dot_general", || {
+            exec.dot_general_read(lhs.tensor_read(), rhs.tensor_read(), &config)
+        })?;
         lhs.reclaim_if_owned(exec);
         rhs.reclaim_if_owned(exec);
         LabeledTensor {
@@ -412,7 +735,9 @@ fn binary_contract<'a>(
         .filter(|label| result_label_set.contains(label))
         .copied()
         .collect();
-    transpose_to_labels(exec, result, &target_labels)
+    profile_eager_einsum_section("binary.final_transpose", || {
+        transpose_to_labels(exec, result, &target_labels)
+    })
 }
 
 fn eager_einsum_exec_values<'a>(
@@ -420,25 +745,32 @@ fn eager_einsum_exec_values<'a>(
     inputs: Vec<TensorValue<'a>>,
     tree: &ContractionTree,
 ) -> Result<Tensor> {
+    record_eager_einsum_profile("exec_values.enter", Duration::ZERO);
     let subscripts = &tree.subscripts;
     let n_inputs = subscripts.inputs.len();
     let output_labels = &subscripts.output;
 
-    let mut labeled: Vec<Option<LabeledTensor<'a>>> = inputs
-        .into_iter()
-        .zip(subscripts.inputs.iter())
-        .map(|(tensor, labels)| {
-            Some(LabeledTensor {
-                tensor,
-                labels: labels.clone(),
-            })
-        })
-        .collect();
+    let mut labeled: Vec<Option<LabeledTensor<'a>>> =
+        profile_eager_einsum_section("exec.init_labeled", || {
+            inputs
+                .into_iter()
+                .zip(subscripts.inputs.iter())
+                .map(|(tensor, labels)| {
+                    Some(LabeledTensor {
+                        tensor,
+                        labels: labels.clone(),
+                    })
+                })
+                .collect()
+        });
 
-    for index in 0..labeled.len() {
-        let operand = take_labeled(&mut labeled, index, "input")?;
-        labeled[index] = Some(diagonalize_repeated(exec, operand)?);
-    }
+    profile_eager_einsum_section("exec.diagonalize_inputs", || -> Result<()> {
+        for index in 0..labeled.len() {
+            let operand = take_labeled(&mut labeled, index, "input")?;
+            labeled[index] = Some(diagonalize_repeated(exec, operand)?);
+        }
+        Ok(())
+    })?;
 
     if n_inputs == 1 || tree.step_count() == 0 {
         let operand = take_labeled(&mut labeled, 0, "input")?;
@@ -466,27 +798,36 @@ fn eager_einsum_exec_values<'a>(
         })?;
         let lhs = take_labeled(&mut labeled, left, "lhs")?;
         let rhs = take_labeled(&mut labeled, right, "rhs")?;
-        let result = binary_contract(
-            exec,
-            lhs,
-            rhs,
-            step_output_labels,
-            step_idx + 1 == tree.step_count(),
-        )?;
+        let result = profile_eager_einsum_section("exec.binary_contract", || {
+            binary_contract(
+                exec,
+                lhs,
+                rhs,
+                step_output_labels,
+                step_idx + 1 == tree.step_count(),
+            )
+        })?;
         labeled.push(Some(result));
     }
 
     let final_index = n_inputs + tree.step_count() - 1;
     let result = take_labeled(&mut labeled, final_index, "result")?;
-    let output_set: HashSet<u32> = output_labels.iter().copied().collect();
-    let extra_labels: HashSet<u32> = result
-        .labels
-        .iter()
-        .filter(|label| !output_set.contains(label))
-        .copied()
-        .collect();
-    let reduced = reduce_tensor(exec, result, &extra_labels)?;
-    let reordered = transpose_to_labels(exec, reduced, output_labels)?;
+    let extra_labels: HashSet<u32> =
+        profile_eager_einsum_section("exec.final_label_analysis", || {
+            let output_set: HashSet<u32> = output_labels.iter().copied().collect();
+            result
+                .labels
+                .iter()
+                .filter(|label| !output_set.contains(label))
+                .copied()
+                .collect()
+        });
+    let reduced = profile_eager_einsum_section("exec.final_reduce", || {
+        reduce_tensor(exec, result, &extra_labels)
+    })?;
+    let reordered = profile_eager_einsum_section("exec.final_transpose", || {
+        transpose_to_labels(exec, reduced, output_labels)
+    })?;
     Ok(reordered.tensor.into_tensor())
 }
 
@@ -495,11 +836,86 @@ fn eager_einsum_exec(
     inputs: &[&Tensor],
     tree: &ContractionTree,
 ) -> Result<Tensor> {
+    record_eager_einsum_profile("exec.enter", Duration::ZERO);
     let values = inputs
         .iter()
         .map(|tensor| TensorValue::Borrowed(*tensor))
         .collect();
     eager_einsum_exec_values(exec, values, tree)
+}
+
+fn eager_einsum_exec_read(
+    exec: &mut dyn TensorExec,
+    inputs: &[TensorRead<'_>],
+    tree: &ContractionTree,
+) -> Result<Tensor> {
+    record_eager_einsum_profile("exec_read.enter", Duration::ZERO);
+    let values = inputs
+        .iter()
+        .map(|input| match input {
+            TensorRead::Tensor(tensor) => TensorValue::Borrowed(*tensor),
+            TensorRead::View(view) => TensorValue::View(*view),
+        })
+        .collect();
+    eager_einsum_exec_values(exec, values, tree)
+}
+
+fn tensor_value_from_read(input: TensorRead<'_>) -> TensorValue<'_> {
+    match input {
+        TensorRead::Tensor(tensor) => TensorValue::Borrowed(tensor),
+        TensorRead::View(view) => TensorValue::View(view),
+    }
+}
+
+fn eager_einsum_exec_binary_read_fast(
+    exec: &mut dyn TensorExec,
+    inputs: &[TensorRead<'_>],
+    subscripts: &Subscripts,
+    plan: BinaryDotFastPlan,
+) -> Result<Tensor> {
+    let lhs = LabeledTensor {
+        tensor: tensor_value_from_read(inputs[0]),
+        labels: subscripts.inputs[0].clone(),
+    };
+    let rhs = LabeledTensor {
+        tensor: tensor_value_from_read(inputs[1]),
+        labels: subscripts.inputs[1].clone(),
+    };
+    execute_binary_dot_fast_plan(exec, lhs, rhs, plan, true)
+        .map(|result| result.tensor.into_tensor())
+}
+
+fn try_eager_einsum_binary_read_fast(
+    ctx: &mut impl TensorBackend,
+    inputs: &[TensorRead<'_>],
+    subscripts: &Subscripts,
+) -> Option<Result<Tensor>> {
+    let total_started = eager_einsum_profile_enabled().then(Instant::now);
+    if inputs.len() != 2 || subscripts.inputs.len() != 2 {
+        return None;
+    }
+    if inputs[0].shape().len() != subscripts.inputs[0].len()
+        || inputs[1].shape().len() != subscripts.inputs[1].len()
+    {
+        return None;
+    }
+    let plan = profile_eager_einsum_section("fast.build_plan", || {
+        try_build_binary_dot_fast_plan(
+            &subscripts.inputs[0],
+            &subscripts.inputs[1],
+            &subscripts.output,
+        )
+    })?;
+    let result = profile_eager_einsum_section("fast.with_exec_session", || {
+        ctx.with_exec_session(|exec| {
+            eager_einsum_exec_binary_read_fast(exec, inputs, subscripts, plan)
+        })
+    });
+    if let Some(started) = total_started {
+        record_eager_einsum_profile("total", started.elapsed());
+        maybe_print_eager_einsum_profile();
+    }
+    Some(result)
 }
 
 /// Eager N-ary einsum on concrete [`Tensor`] values.
@@ -527,9 +943,92 @@ pub fn eager_einsum(
     inputs: &[&Tensor],
     subscripts: &str,
 ) -> Result<Tensor> {
+    let subscripts = Subscripts::parse(subscripts)
+        .map_err(|err| eager_invalid_config(format!("invalid subscripts: {err}")))?;
+    eager_einsum_subscripts(ctx, inputs, &subscripts)
+}
+
+/// Eager N-ary einsum on concrete [`Tensor`] values using integer labels.
+pub fn eager_einsum_subscripts(
+    ctx: &mut impl TensorBackend,
+    inputs: &[&Tensor],
+    subscripts: &Subscripts,
+) -> Result<Tensor> {
+    if inputs.len() == 2 {
+        let read_inputs = [
+            TensorRead::from_tensor(inputs[0]),
+            TensorRead::from_tensor(inputs[1]),
+        ];
+        if let Some(result) = try_eager_einsum_binary_read_fast(ctx, &read_inputs, subscripts) {
+            return result;
+        }
+    }
+
+    if eager_einsum_profile_enabled() {
+        let total_started = Instant::now();
+        let shapes = profile_eager_einsum_section("shape_collect", || {
+            inputs
+                .iter()
+                .map(|tensor| tensor.shape())
+                .collect::<Vec<_>>()
+        });
+        let tree = profile_eager_einsum_section("plan_subscripts", || {
+            cached_plan_subscripts(subscripts, &shapes)
+        })?;
+        let result = profile_eager_einsum_section("with_exec_session", || {
+            ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, tree.as_ref()))
+        });
+        record_eager_einsum_profile("total", total_started.elapsed());
+        maybe_print_eager_einsum_profile();
+        return result;
+    }
+
+    if eager_einsum_trace_enabled() {
+        let total_started = Instant::now();
+        let started = Instant::now();
+        let shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
+        let shape_us = started.elapsed().as_secs_f64() * 1.0e6;
+
+        let started = Instant::now();
+        let tree = cached_plan_subscripts(subscripts, &shapes)?;
+        let plan_us = started.elapsed().as_secs_f64() * 1.0e6;
+
+        let started = Instant::now();
+        let result = ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, tree.as_ref()));
+        let exec_us = started.elapsed().as_secs_f64() * 1.0e6;
+        let total_us = total_started.elapsed().as_secs_f64() * 1.0e6;
+
+        eprintln!(
+            "tenferro_eager_einsum_profile,n_inputs={},shapes={:?},steps={},shape_us={shape_us:.3},plan_us={plan_us:.3},exec_us={exec_us:.3},total_us={total_us:.3}",
+            inputs.len(),
+            shapes,
+            tree.step_count(),
+        );
+        return result;
+    }
+
     let shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
-    let tree = parse_and_plan(subscripts, &shapes)?;
-    ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, &tree))
+    let tree = cached_plan_subscripts(subscripts, &shapes)?;
+    ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, tree.as_ref()))
+}
+
+/// Eager N-ary einsum on read-only tensor inputs.
+///
+/// Owned tensors and borrowed host views share this entry point. Backends may
+/// consume views directly when their execution model supports it, or
+/// materialize/upload them inside the execution session.
+pub fn eager_einsum_read_subscripts(
+    ctx: &mut impl TensorBackend,
+    inputs: &[TensorRead<'_>],
+    subscripts: &Subscripts,
+) -> Result<Tensor> {
+    if let Some(result) = try_eager_einsum_binary_read_fast(ctx, inputs, subscripts) {
+        return result;
+    }
+
+    let shapes: Vec<&[usize]> = inputs.iter().map(TensorRead::shape).collect();
+    let tree = cached_plan_subscripts(subscripts, &shapes)?;
+    ctx.with_exec_session(|exec| eager_einsum_exec_read(exec, inputs, tree.as_ref()))
 }
 
 /// Eager N-ary einsum that consumes concrete [`Tensor`] inputs.
@@ -562,8 +1061,19 @@ pub fn eager_einsum_owned(
     inputs: Vec<Tensor>,
     subscripts: &str,
 ) -> Result<Tensor> {
+    let subscripts = Subscripts::parse(subscripts)
+        .map_err(|err| eager_invalid_config(format!("invalid subscripts: {err}")))?;
+    eager_einsum_owned_subscripts(ctx, inputs, &subscripts)
+}
+
+/// Eager N-ary einsum that consumes concrete [`Tensor`] inputs using integer labels.
+pub fn eager_einsum_owned_subscripts(
+    ctx: &mut impl TensorBackend,
+    inputs: Vec<Tensor>,
+    subscripts: &Subscripts,
+) -> Result<Tensor> {
     let shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
-    let tree = parse_and_plan(subscripts, &shapes)?;
+    let tree = cached_plan_subscripts(subscripts, &shapes)?;
     let values = inputs.into_iter().map(TensorValue::Owned).collect();
-    ctx.with_exec_session(|exec| eager_einsum_exec_values(exec, values, &tree))
+    ctx.with_exec_session(|exec| eager_einsum_exec_values(exec, values, tree.as_ref()))
 }

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -46,7 +46,10 @@ pub(crate) mod util;
 
 // Re-exports for convenience
 pub use builder::build_einsum_fragment;
-pub use eager::{eager_einsum, eager_einsum_owned};
+pub use eager::{
+    eager_einsum, eager_einsum_owned, eager_einsum_owned_subscripts, eager_einsum_read_subscripts,
+    eager_einsum_subscripts,
+};
 pub use planning::tree::{ContractionOptimizerOptions, ContractionTree};
 pub use syntax::nested::NestedEinsum;
 pub use syntax::subscripts::Subscripts;

--- a/tenferro-einsum/src/syntax/subscripts.rs
+++ b/tenferro-einsum/src/syntax/subscripts.rs
@@ -42,7 +42,7 @@ use crate::syntax::notation::{char_to_label, split_and_validate_notation};
 /// assert_eq!(embed.output, vec![b'i' as u32, b'i' as u32]);
 /// assert_eq!(higher_rank.inputs[0], vec![b'i' as u32, b'i' as u32, b'j' as u32]);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Subscripts {
     /// Index labels for each input tensor.
     pub inputs: Vec<Vec<u32>>,

--- a/tenferro-einsum/src/tests/eager_tests.rs
+++ b/tenferro-einsum/src/tests/eager_tests.rs
@@ -1,6 +1,6 @@
-use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend};
+use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend, TensorRead, TensorView};
 
-use crate::{eager_einsum, eager_einsum_owned};
+use crate::{eager_einsum, eager_einsum_owned, eager_einsum_read_subscripts, Subscripts};
 
 fn assert_f64_tensor(tensor: &Tensor, shape: &[usize], expected: &[f64]) {
     assert_eq!(tensor.shape(), shape);
@@ -74,6 +74,76 @@ fn eager_einsum_handles_higher_rank_repeated_labels() {
         diagonal.as_slice::<f64>(),
         Some([1.0, 4.0, 5.0, 8.0, 9.0, 12.0].as_slice())
     );
+}
+
+#[test]
+fn eager_einsum_read_views_match_owned_inputs() {
+    let a_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let b_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let a_shape = [2, 3];
+    let b_shape = [3, 2];
+    let a_owned = Tensor::from_vec(a_shape.to_vec(), a_data.to_vec());
+    let b_owned = Tensor::from_vec(b_shape.to_vec(), b_data.to_vec());
+
+    let mut owned_ctx = CpuBackend::new();
+    let owned = eager_einsum(&mut owned_ctx, &[&a_owned, &b_owned], "ij,jk->ik").unwrap();
+
+    let inputs = [
+        TensorRead::from_view(TensorView::f64(&a_shape, &a_data).unwrap()),
+        TensorRead::from_view(TensorView::f64(&b_shape, &b_data).unwrap()),
+    ];
+    let subscripts = Subscripts::parse("ij,jk->ik").unwrap();
+    let mut read_ctx = CpuBackend::new();
+    let read = eager_einsum_read_subscripts(&mut read_ctx, &inputs, &subscripts).unwrap();
+
+    assert_eq!(read.shape(), owned.shape());
+    assert_eq!(read.as_slice::<f64>(), owned.as_slice::<f64>());
+}
+
+#[test]
+fn eager_einsum_binary_contract_reorders_fast_path_output() {
+    let mut ctx = CpuBackend::new();
+    let a = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let b = Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let result = eager_einsum(&mut ctx, &[&a, &b], "ij,jk->ki").unwrap();
+
+    assert_f64_tensor(&result, &[2, 2], &[22.0, 49.0, 28.0, 64.0]);
+}
+
+#[test]
+fn eager_einsum_read_fast_path_handles_batched_contracts() {
+    let lhs_data = [
+        1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+    ];
+    let rhs_data = [
+        0.5_f64, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5,
+    ];
+    let lhs_shape = [2, 2, 3];
+    let rhs_shape = [2, 3, 2];
+    let mut expected = vec![0.0; 2 * 2 * 2];
+    for b in 0..2 {
+        for i in 0..2 {
+            for k in 0..2 {
+                let mut value = 0.0;
+                for j in 0..3 {
+                    value += lhs_data[b + 2 * (i + 2 * j)] * rhs_data[b + 2 * (j + 3 * k)];
+                }
+                expected[b + 2 * (i + 2 * k)] = value;
+            }
+        }
+    }
+
+    let inputs = [
+        TensorRead::from_view(TensorView::f64(&lhs_shape, &lhs_data).unwrap()),
+        TensorRead::from_view(TensorView::f64(&rhs_shape, &rhs_data).unwrap()),
+    ];
+    let subscripts = Subscripts::parse("bij,bjk->bik").unwrap();
+    let mut read_ctx = CpuBackend::new();
+    let read = eager_einsum_read_subscripts(&mut read_ctx, &inputs, &subscripts).unwrap();
+
+    assert_eq!(read.shape(), &[2, 2, 2]);
+    assert_eq!(read.as_slice::<f64>(), Some(expected.as_slice()));
 }
 
 #[test]

--- a/tenferro-einsum/tests/typed_eager.rs
+++ b/tenferro-einsum/tests/typed_eager.rs
@@ -1,7 +1,10 @@
-use tenferro_einsum::typed_eager_einsum;
+use tenferro_einsum::{
+    eager_einsum_owned_subscripts, eager_einsum_read_subscripts, eager_einsum_subscripts,
+    typed_eager_einsum, Subscripts,
+};
 use tenferro_tensor::{
     cpu::CpuBackend, CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
-    SliceConfig, Tensor, TensorBackend, TypedTensor,
+    SliceConfig, Tensor, TensorBackend, TensorRead, TensorView, TypedTensor,
 };
 
 #[derive(Default)]
@@ -94,6 +97,10 @@ impl TensorBackend for WrongDTypeBackend {
 
 #[test]
 fn typed_einsum_f64() {
+    unsafe {
+        std::env::set_var("TENFERRO_PROFILE_EAGER_EINSUM_AGG", "1");
+        std::env::set_var("TENFERRO_PROFILE_EAGER_EINSUM_PRINT_EVERY", "1");
+    }
     let mut ctx = CpuBackend::new();
     let lhs = TypedTensor::<f64>::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     let rhs = TypedTensor::<f64>::from_vec(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
@@ -102,6 +109,54 @@ fn typed_einsum_f64() {
 
     assert_eq!(result.shape, vec![2, 2]);
     assert_eq!(result.as_slice(), &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn eager_einsum_subscripts_and_read_views_use_integer_api() {
+    unsafe {
+        std::env::set_var("TENFERRO_PROFILE_EAGER_EINSUM_AGG", "1");
+        std::env::set_var("TENFERRO_PROFILE_EAGER_EINSUM_PRINT_EVERY", "1");
+    }
+    let mut ctx = CpuBackend::new();
+    let lhs = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let rhs_shape = [3usize, 2];
+    let rhs_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let rhs = Tensor::from_vec(rhs_shape.to_vec(), rhs_data.to_vec());
+    let subscripts = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+
+    let borrowed = eager_einsum_subscripts(&mut ctx, &[&lhs, &rhs], &subscripts).unwrap();
+    let read = eager_einsum_read_subscripts(
+        &mut ctx,
+        &[
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_view(TensorView::f64(&rhs_shape, &rhs_data).unwrap()),
+        ],
+        &subscripts,
+    )
+    .unwrap();
+
+    assert_eq!(
+        borrowed.as_slice::<f64>().unwrap(),
+        &[22.0, 28.0, 49.0, 64.0]
+    );
+    assert_eq!(read.as_slice::<f64>(), borrowed.as_slice::<f64>());
+}
+
+#[test]
+fn eager_einsum_owned_subscripts_handles_three_operands() {
+    let mut ctx = CpuBackend::new();
+    let a = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let b = Tensor::from_vec(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]);
+    let c = Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 1.0, 3.0]);
+    let subscripts = Subscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]);
+
+    let result = eager_einsum_owned_subscripts(&mut ctx, vec![a, b, c], &subscripts).unwrap();
+
+    assert_eq!(result.shape(), &[2, 2]);
+    assert_eq!(
+        result.as_slice::<f64>().unwrap(),
+        &[152.0, 200.0, 385.0, 508.0]
+    );
 }
 
 #[test]
@@ -154,6 +209,26 @@ fn tensor_backend_default_cached_methods_delegate_to_backend_ops() {
             .unwrap();
     assert_eq!(direct.shape(), &[2, 2]);
 
+    let read = TensorBackend::dot_general_read(
+        &mut backend,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &config,
+    )
+    .unwrap();
+    assert_eq!(read.shape(), &[2, 2]);
+
+    let rhs_shape = [1usize, 1];
+    let rhs_data = [3.0_f64];
+    let read_view = TensorBackend::dot_general_read(
+        &mut backend,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_view(TensorView::f64(&rhs_shape, &rhs_data).unwrap()),
+        &config,
+    )
+    .unwrap();
+    assert_eq!(read_view.shape(), &[2, 2]);
+
     let folded =
         TensorBackend::dot_general_with_conj(&mut backend, &lhs, &rhs, &config, true, true)
             .unwrap();
@@ -166,7 +241,14 @@ fn tensor_backend_default_cached_methods_delegate_to_backend_ops() {
         let folded = exec
             .dot_general_with_conj_cached(Some(5), &lhs, &rhs, &config, false, false)
             .unwrap();
-        cached.shape().len() + folded.shape().len()
+        let read = exec
+            .dot_general_read(
+                TensorRead::from_tensor(&lhs),
+                TensorRead::from_view(TensorView::f64(&rhs_shape, &rhs_data).unwrap()),
+                &config,
+            )
+            .unwrap();
+        cached.shape().len() + folded.shape().len() + read.shape().len()
     });
-    assert_eq!(value, 4);
+    assert_eq!(value, 6);
 }

--- a/tenferro-ops/src/ad/contraction.rs
+++ b/tenferro-ops/src/ad/contraction.rs
@@ -5,7 +5,7 @@ use tenferro_tensor::{CompareDir, DotGeneralConfig};
 
 use crate::ad::context::ShapeGuardContext;
 use crate::dim_expr::DimExpr;
-use crate::std_tensor_op::StdTensorOp;
+use crate::std_tensor_op::{EinsumSubscripts, StdTensorOp};
 use crate::sym_dim::SymDim;
 
 pub fn linearize_dot_general(
@@ -73,7 +73,7 @@ pub fn linearize_nary_einsum(
     builder: &mut FragmentBuilder<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
-    subscripts: &str,
+    subscripts: &EinsumSubscripts,
 ) -> Vec<Option<LocalValId>> {
     let mut terms = Vec::new();
 
@@ -93,7 +93,7 @@ pub fn linearize_nary_einsum(
 
         let out = builder.add_op(
             StdTensorOp::NaryEinsum {
-                subscripts: subscripts.to_string(),
+                subscripts: subscripts.clone(),
             },
             inputs,
             OpMode::Linear {
@@ -329,12 +329,10 @@ pub fn transpose_nary_einsum(
     cotangent_out: &[Option<LocalValId>],
     inputs: &[ValRef<StdTensorOp>],
     mode: &OpMode,
-    subscripts: &str,
+    subscripts: &EinsumSubscripts,
 ) -> Vec<Option<LocalValId>> {
-    let Some((input_part, output_labels)) = subscripts.split_once("->") else {
-        panic!("NaryEinsum subscripts must contain '->': {subscripts}");
-    };
-    let input_labels: Vec<&str> = input_part.split(',').collect();
+    let input_labels = &subscripts.inputs;
+    let output_labels = &subscripts.output;
     let n_inputs = input_labels.len();
 
     let ct = match cotangent_out[0] {
@@ -354,10 +352,10 @@ pub fn transpose_nary_einsum(
             continue;
         }
 
-        let mut vjp_input_parts = Vec::with_capacity(n_inputs);
+        let mut vjp_input_labels = Vec::with_capacity(n_inputs);
         let mut vjp_inputs = Vec::with_capacity(n_inputs);
 
-        vjp_input_parts.push(output_labels.to_string());
+        vjp_input_labels.push(output_labels.clone());
         vjp_inputs.push(ValRef::Local(ct));
 
         for input_idx in 0..n_inputs {
@@ -365,7 +363,7 @@ pub fn transpose_nary_einsum(
                 continue;
             }
 
-            vjp_input_parts.push(input_labels[input_idx].to_string());
+            vjp_input_labels.push(input_labels[input_idx].clone());
             let conjugated = emitter.add_op(
                 StdTensorOp::Conj,
                 vec![inputs[input_idx].clone()],
@@ -376,11 +374,10 @@ pub fn transpose_nary_einsum(
 
         let out = emitter.add_op(
             StdTensorOp::NaryEinsum {
-                subscripts: format!(
-                    "{}->{}",
-                    vjp_input_parts.join(","),
-                    input_labels[active_idx]
-                ),
+                subscripts: EinsumSubscripts {
+                    inputs: vjp_input_labels,
+                    output: input_labels[active_idx].clone(),
+                },
             },
             vjp_inputs,
             OpMode::Linear {

--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -14,6 +14,55 @@ use tenferro_tensor::{
     CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
 
+/// Canonical N-ary einsum subscripts using integer labels.
+///
+/// String notation is a user-facing convenience handled by higher-level
+/// crates. Graph ops keep this integer representation so execution, shape
+/// inference, and AD do not need to parse strings.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct EinsumSubscripts {
+    /// Index labels for each input tensor.
+    pub inputs: Vec<Vec<u32>>,
+    /// Index labels for the output tensor.
+    pub output: Vec<u32>,
+}
+
+impl EinsumSubscripts {
+    /// Create subscripts from integer label arrays.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ops::std_tensor_op::EinsumSubscripts;
+    ///
+    /// let subscripts = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+    ///
+    /// assert_eq!(subscripts.inputs, vec![vec![0, 1], vec![1, 2]]);
+    /// assert_eq!(subscripts.output, vec![0, 2]);
+    /// ```
+    pub fn new(inputs: &[&[u32]], output: &[u32]) -> Self {
+        Self {
+            inputs: inputs.iter().map(|labels| labels.to_vec()).collect(),
+            output: output.to_vec(),
+        }
+    }
+
+    /// Number of input operands described by this specification.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ops::std_tensor_op::EinsumSubscripts;
+    ///
+    /// let subscripts = EinsumSubscripts::new(&[&[0], &[0]], &[]);
+    ///
+    /// assert_eq!(subscripts.n_inputs(), 2);
+    /// ```
+    pub fn n_inputs(&self) -> usize {
+        self.inputs.len()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum StdTensorOp {
     // Semiring arithmetic core
@@ -103,7 +152,7 @@ pub enum StdTensorOp {
     /// N-ary einsum kept as a single graph node.
     /// Contraction path is optimized at execution time from actual input shapes.
     NaryEinsum {
-        subscripts: String,
+        subscripts: EinsumSubscripts,
     },
     Concatenate {
         axis: usize,
@@ -549,15 +598,6 @@ fn n_inputs_from_dim_exprs(min_inputs: usize, exprs: &[&[DimExpr]]) -> usize {
     max_idx.max(min_inputs)
 }
 
-/// Count the number of inputs in an einsum subscript string.
-///
-/// The subscript string is expected to be in the form `"<in_1>,<in_2>,...-><out>"`.
-/// This counts comma-separated input subscripts before the `->` marker.
-pub(crate) fn n_inputs_from_einsum_subscripts(subscripts: &str) -> usize {
-    let input_part = subscripts.split_once("->").map_or(subscripts, |(i, _)| i);
-    input_part.split(',').count()
-}
-
 impl GraphOp for StdTensorOp {
     type Operand = tenferro_tensor::Tensor;
     type Context = ();
@@ -591,7 +631,7 @@ impl GraphOp for StdTensorOp {
             Self::Div | Self::Maximum | Self::Minimum | Self::Pow | Self::DynamicSlice { .. } => 2,
             Self::Constant { .. } => 0,
             Self::Scatter(_) | Self::DynamicUpdateSlice => 3,
-            Self::NaryEinsum { subscripts } => n_inputs_from_einsum_subscripts(subscripts),
+            Self::NaryEinsum { subscripts } => subscripts.n_inputs(),
             Self::Concatenate { n_inputs, .. } => *n_inputs,
             Self::Abs
             | Self::Sign

--- a/tenferro-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-ops/src/tests/std_tensor_op_tests.rs
@@ -1,7 +1,7 @@
 use crate::ad::context::ShapeGuardContext;
 use crate::dim_expr::DimExpr;
 use crate::ext_op::{register_extension_rule, ExtensionAdRule, ExtensionOp};
-use crate::std_tensor_op::StdTensorOp;
+use crate::std_tensor_op::{EinsumSubscripts, StdTensorOp};
 use crate::{SymDim, TensorMeta};
 use chainrules_core::{ADRuleKind, ADRuleResult, PrimitiveOp};
 use computegraph::fragment::{Fragment, FragmentBuilder};
@@ -21,6 +21,35 @@ macro_rules! shape {
     ($($dim:expr),* $(,)?) => {
         DimExpr::from_concrete(&[$($dim),*])
     };
+}
+
+fn subs_ij_jk_ik() -> EinsumSubscripts {
+    EinsumSubscripts::new(
+        &[&[b'i' as u32, b'j' as u32], &[b'j' as u32, b'k' as u32]],
+        &[b'i' as u32, b'k' as u32],
+    )
+}
+
+fn subs_ij_jk_kl_il() -> EinsumSubscripts {
+    EinsumSubscripts::new(
+        &[
+            &[b'i' as u32, b'j' as u32],
+            &[b'j' as u32, b'k' as u32],
+            &[b'k' as u32, b'l' as u32],
+        ],
+        &[b'i' as u32, b'l' as u32],
+    )
+}
+
+fn subs_il_ij_kl_jk() -> EinsumSubscripts {
+    EinsumSubscripts::new(
+        &[
+            &[b'i' as u32, b'l' as u32],
+            &[b'i' as u32, b'j' as u32],
+            &[b'k' as u32, b'l' as u32],
+        ],
+        &[b'j' as u32, b'k' as u32],
+    )
 }
 
 fn tensor_input_key(id: u64) -> TensorInputKey {
@@ -282,7 +311,7 @@ fn test_std_tensor_op_input_output_counts() {
     assert_eq!(StdTensorOp::DynamicUpdateSlice.n_inputs(), 3);
     assert_eq!(
         StdTensorOp::NaryEinsum {
-            subscripts: "ij,jk,kl->il".into(),
+            subscripts: subs_ij_jk_kl_il(),
         }
         .n_inputs(),
         3
@@ -310,7 +339,7 @@ fn test_std_tensor_op_input_output_counts() {
     assert_eq!(StdTensorOp::constant_f64(1.0).n_outputs(), 1);
     assert_eq!(
         StdTensorOp::NaryEinsum {
-            subscripts: "ij,jk->ik".into(),
+            subscripts: subs_ij_jk_ik(),
         }
         .n_outputs(),
         1
@@ -563,7 +592,7 @@ fn test_std_tensor_op_hash_covers_remaining_variants() {
             to: DType::C64,
         },
         StdTensorOp::NaryEinsum {
-            subscripts: "ij,jk,kl->il".into(),
+            subscripts: subs_ij_jk_kl_il(),
         },
         StdTensorOp::Concatenate {
             axis: 1,
@@ -594,7 +623,7 @@ fn test_std_tensor_op_hash_covers_remaining_variants() {
 #[test]
 fn test_std_tensor_op_nary_einsum_linearize_emits_term_sum() {
     let op = StdTensorOp::NaryEinsum {
-        subscripts: "ij,jk,kl->il".into(),
+        subscripts: subs_ij_jk_kl_il(),
     };
     let (result, fragment) = run_linearize_case(op.clone(), 3, 0, &[true, false, true]);
 
@@ -620,7 +649,7 @@ fn test_std_tensor_op_nary_einsum_linearize_emits_term_sum() {
 #[test]
 fn test_std_tensor_op_nary_einsum_transpose_emits_conjugates_and_vjp_term() {
     let op = StdTensorOp::NaryEinsum {
-        subscripts: "ij,jk,kl->il".into(),
+        subscripts: subs_ij_jk_kl_il(),
     };
     let (result, _, fragment) = run_transpose_case(op, 3, &[false, true, false], true);
 
@@ -633,7 +662,7 @@ fn test_std_tensor_op_nary_einsum_transpose_emits_conjugates_and_vjp_term() {
     assert_eq!(
         fragment.ops()[2].op,
         StdTensorOp::NaryEinsum {
-            subscripts: "il,ij,kl->jk".into(),
+            subscripts: subs_il_ij_kl_jk(),
         }
     );
     assert_eq!(

--- a/tenferro-tensor/Cargo.toml
+++ b/tenferro-tensor/Cargo.toml
@@ -51,3 +51,7 @@ criterion.workspace = true
 [[bench]]
 name = "element_access"
 harness = false
+
+[[bench]]
+name = "dot_general_overhead"
+harness = false

--- a/tenferro-tensor/benches/dot_general_overhead.rs
+++ b/tenferro-tensor/benches/dot_general_overhead.rs
@@ -1,0 +1,239 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use num_complex::Complex64;
+use tenferro_tensor::{cpu::CpuBackend, DotGeneralConfig, Tensor, TensorBackend};
+
+const L: usize = 32;
+const PHYS_DIM: usize = 2;
+const CHIS: &[usize] = &[4, 8, 16, 32, 64];
+
+struct MpsFixture {
+    bra_tensors: Vec<Tensor>,
+    ket_tensors: Vec<Tensor>,
+}
+
+struct LocalPathConfigs {
+    env_bra: DotGeneralConfig,
+    tmp_ket: DotGeneralConfig,
+}
+
+impl LocalPathConfigs {
+    fn new() -> Self {
+        Self {
+            env_bra: DotGeneralConfig {
+                lhs_contracting_dims: vec![0],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+            tmp_ket: DotGeneralConfig {
+                lhs_contracting_dims: vec![0, 1],
+                rhs_contracting_dims: vec![0, 1],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        }
+    }
+}
+
+fn mps_shapes(sites: usize, phys_dim: usize, bond_dim: usize) -> Vec<Vec<usize>> {
+    (0..sites)
+        .map(|site| {
+            let left = if site == 0 { 1 } else { bond_dim };
+            let right = if site + 1 == sites { 1 } else { bond_dim };
+            vec![left, phys_dim, right]
+        })
+        .collect()
+}
+
+fn complex_tensor(shape: &[usize], seed: usize) -> Tensor {
+    let len = shape.iter().product();
+    let data = (0..len)
+        .map(|idx| {
+            let real = ((idx * 17 + seed * 13 + 3) % 97) as f64 / 97.0 - 0.5;
+            let imag = ((idx * 29 + seed * 7 + 5) % 89) as f64 / 89.0 - 0.5;
+            Complex64::new(real, imag)
+        })
+        .collect();
+    Tensor::from_vec(shape.to_vec(), data)
+}
+
+fn build_mps_fixture(sites: usize, phys_dim: usize, bond_dim: usize) -> MpsFixture {
+    let shapes = mps_shapes(sites, phys_dim, bond_dim);
+    let bra_tensors = shapes
+        .iter()
+        .enumerate()
+        .map(|(site, shape)| complex_tensor(shape, site + 1))
+        .collect();
+    let ket_tensors = shapes
+        .iter()
+        .enumerate()
+        .map(|(site, shape)| complex_tensor(shape, sites + site + 1))
+        .collect();
+
+    MpsFixture {
+        bra_tensors,
+        ket_tensors,
+    }
+}
+
+fn scalar_one() -> Tensor {
+    Tensor::from_vec(vec![1, 1], vec![Complex64::new(1.0, 0.0)])
+}
+
+fn inner_fresh_backend_cache(
+    backend: &mut CpuBackend,
+    bra: &[Tensor],
+    ket: &[Tensor],
+    configs: &LocalPathConfigs,
+) -> Tensor {
+    let mut env = scalar_one();
+    for (bra_core, ket_core) in bra.iter().zip(ket) {
+        let tmp = backend
+            .dot_general_with_conj(&env, bra_core, &configs.env_bra, false, true)
+            .expect("environment and conjugated bra contraction should succeed");
+        env = backend
+            .dot_general_with_conj(&tmp, ket_core, &configs.tmp_ket, false, false)
+            .expect("normal ket contraction should succeed");
+    }
+    env
+}
+
+fn inner_persistent_backend_cache(
+    backend: &mut CpuBackend,
+    cache: &mut <CpuBackend as TensorBackend>::RuntimeCache,
+    bra: &[Tensor],
+    ket: &[Tensor],
+    configs: &LocalPathConfigs,
+) -> Tensor {
+    let mut env = scalar_one();
+    for (site, (bra_core, ket_core)) in bra.iter().zip(ket).enumerate() {
+        let tmp = backend
+            .dot_general_with_conj_cached(
+                cache,
+                Some(2 * site),
+                &env,
+                bra_core,
+                &configs.env_bra,
+                false,
+                true,
+            )
+            .expect("environment and conjugated bra contraction should succeed");
+        env = backend
+            .dot_general_with_conj_cached(
+                cache,
+                Some(2 * site + 1),
+                &tmp,
+                ket_core,
+                &configs.tmp_ket,
+                false,
+                false,
+            )
+            .expect("normal ket contraction should succeed");
+    }
+    env
+}
+
+fn inner_single_exec_session(
+    backend: &mut CpuBackend,
+    cache: &mut <CpuBackend as TensorBackend>::RuntimeCache,
+    bra: &[Tensor],
+    ket: &[Tensor],
+    configs: &LocalPathConfigs,
+) -> Tensor {
+    let mut env = scalar_one();
+    backend
+        .with_exec_session_cached(cache, |exec| {
+            for (site, (bra_core, ket_core)) in bra.iter().zip(ket).enumerate() {
+                let tmp = exec.dot_general_with_conj_cached(
+                    Some(2 * site),
+                    &env,
+                    bra_core,
+                    &configs.env_bra,
+                    false,
+                    true,
+                )?;
+                env = exec.dot_general_with_conj_cached(
+                    Some(2 * site + 1),
+                    &tmp,
+                    ket_core,
+                    &configs.tmp_ket,
+                    false,
+                    false,
+                )?;
+            }
+            Ok::<(), tenferro_tensor::Error>(())
+        })
+        .expect("single exec session inner product should succeed");
+    env
+}
+
+fn bench_dot_general_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dot_general_overhead/c64/one_thread");
+    for &chi in CHIS {
+        let fixture = build_mps_fixture(L, PHYS_DIM, chi);
+        let configs = LocalPathConfigs::new();
+        let params = format!("L_{L}_chi_{chi}_d_{PHYS_DIM}");
+
+        group.bench_function(BenchmarkId::new("fresh_backend_cache", &params), |b| {
+            b.iter(|| {
+                let mut backend = CpuBackend::with_threads(1);
+                let output = inner_fresh_backend_cache(
+                    black_box(&mut backend),
+                    black_box(&fixture.bra_tensors),
+                    black_box(&fixture.ket_tensors),
+                    black_box(&configs),
+                );
+                black_box(output.shape().to_vec());
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("persistent_backend_cache", &params), |b| {
+            b.iter_batched(
+                || {
+                    (
+                        CpuBackend::with_threads(1),
+                        <CpuBackend as TensorBackend>::RuntimeCache::default(),
+                    )
+                },
+                |(mut backend, mut cache)| {
+                    let output = inner_persistent_backend_cache(
+                        black_box(&mut backend),
+                        black_box(&mut cache),
+                        black_box(&fixture.bra_tensors),
+                        black_box(&fixture.ket_tensors),
+                        black_box(&configs),
+                    );
+                    black_box(output.shape().to_vec());
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("single_exec_session", &params), |b| {
+            b.iter_batched(
+                || {
+                    (
+                        CpuBackend::with_threads(1),
+                        <CpuBackend as TensorBackend>::RuntimeCache::default(),
+                    )
+                },
+                |(mut backend, mut cache)| {
+                    let output = inner_single_exec_session(
+                        black_box(&mut backend),
+                        black_box(&mut cache),
+                        black_box(&fixture.bra_tensors),
+                        black_box(&fixture.ket_tensors),
+                        black_box(&configs),
+                    );
+                    black_box(output.shape().to_vec());
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_dot_general_overhead);
+criterion_main!(benches);

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -1,7 +1,7 @@
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use crate::Tensor;
+use crate::{Tensor, TensorRead};
 
 /// Canonical elementwise fusion plan shared between segmented execution and backends.
 #[doc(hidden)]
@@ -132,6 +132,23 @@ pub trait TensorExec {
         rhs: &Tensor,
         config: &DotGeneralConfig,
     ) -> crate::Result<Tensor>;
+
+    #[doc(hidden)]
+    fn dot_general_read(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        match (lhs.as_tensor(), rhs.as_tensor()) {
+            (Some(lhs), Some(rhs)) => self.dot_general(lhs, rhs, config),
+            _ => {
+                let lhs = lhs.to_tensor();
+                let rhs = rhs.to_tensor();
+                self.dot_general(&lhs, &rhs, config)
+            }
+        }
+    }
 
     #[doc(hidden)]
     fn dot_general_cached(
@@ -267,6 +284,15 @@ macro_rules! forward_exec_to_backend {
 }
 
 impl<B: TensorBackend + ?Sized> TensorExec for BackendExecAdapter<'_, B> {
+    fn dot_general_read(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        self.backend.dot_general_read(lhs, rhs, config)
+    }
+
     forward_exec_to_backend! {
         add(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
         mul(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
@@ -446,6 +472,23 @@ pub trait TensorBackend {
         rhs: &Tensor,
         config: &DotGeneralConfig,
     ) -> crate::Result<Tensor>;
+
+    #[doc(hidden)]
+    fn dot_general_read(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        match (lhs.as_tensor(), rhs.as_tensor()) {
+            (Some(lhs), Some(rhs)) => self.dot_general(lhs, rhs, config),
+            _ => {
+                let lhs = self.upload_host_tensor(&lhs.to_tensor())?;
+                let rhs = self.upload_host_tensor(&rhs.to_tensor())?;
+                self.dot_general(&lhs, &rhs, config)
+            }
+        }
+    }
 
     #[doc(hidden)]
     fn dot_general_cached(

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -1,4 +1,8 @@
-use std::sync::Arc;
+use std::cmp::Reverse;
+use std::collections::HashMap;
+use std::env;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use crate::backend::{TensorBackend, TensorExec};
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
@@ -6,10 +10,96 @@ use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
 use crate::validate::validate_nonsingular_u;
-use crate::{Buffer, Tensor, TypedTensor};
+use crate::{Buffer, Tensor, TensorRead, TypedTensor};
 
 use super::exec_session::CpuExecSession;
 use super::{analytic, elementwise, gemm, indexing, linalg, reduction, structural, CpuContext};
+
+#[derive(Debug, Default, Clone)]
+struct CpuSessionProfileEntry {
+    calls: usize,
+    total_time: Duration,
+}
+
+fn cpu_session_profile_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| env::var("TENFERRO_PROFILE_CPU_SESSION").is_ok())
+}
+
+fn cpu_session_profile_print_every() -> Option<usize> {
+    static PRINT_EVERY: OnceLock<Option<usize>> = OnceLock::new();
+    *PRINT_EVERY.get_or_init(|| {
+        env::var("TENFERRO_PROFILE_CPU_SESSION_PRINT_EVERY")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|&value| value > 0)
+    })
+}
+
+fn cpu_session_profile_state() -> &'static Mutex<HashMap<&'static str, CpuSessionProfileEntry>> {
+    static STATE: OnceLock<Mutex<HashMap<&'static str, CpuSessionProfileEntry>>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn record_cpu_session_profile(section: &'static str, elapsed: Duration) {
+    if !cpu_session_profile_enabled() {
+        return;
+    }
+    let mut state = cpu_session_profile_state()
+        .lock()
+        .expect("CPU session profile mutex poisoned");
+    let entry = state.entry(section).or_default();
+    entry.calls += 1;
+    entry.total_time += elapsed;
+}
+
+fn profile_cpu_session_section<T>(section: &'static str, f: impl FnOnce() -> T) -> T {
+    if !cpu_session_profile_enabled() {
+        return f();
+    }
+    let started = Instant::now();
+    let result = f();
+    record_cpu_session_profile(section, started.elapsed());
+    result
+}
+
+fn maybe_print_cpu_session_profile() {
+    let Some(print_every) = cpu_session_profile_print_every() else {
+        return;
+    };
+    let should_print = {
+        let state = cpu_session_profile_state()
+            .lock()
+            .expect("CPU session profile mutex poisoned");
+        state
+            .get("with_exec_session_cached.total")
+            .is_some_and(|entry| entry.calls % print_every == 0)
+    };
+    if !should_print {
+        return;
+    }
+    let mut entries = {
+        let mut state = cpu_session_profile_state()
+            .lock()
+            .expect("CPU session profile mutex poisoned");
+        let entries = state
+            .iter()
+            .map(|(section, entry)| (*section, entry.clone()))
+            .collect::<Vec<_>>();
+        state.clear();
+        entries
+    };
+    entries.sort_by_key(|(_, entry)| Reverse(entry.total_time));
+    eprintln!("=== tenferro CPU session profile ===");
+    for (section, entry) in entries {
+        eprintln!(
+            "{section}: calls={} total={:.6}ms per_call={:.3}us",
+            entry.calls,
+            entry.total_time.as_secs_f64() * 1.0e3,
+            entry.total_time.as_secs_f64() * 1.0e6 / entry.calls as f64,
+        );
+    }
+}
 
 /// CPU execution backend.
 ///
@@ -458,6 +548,42 @@ impl TensorBackend for CpuBackend {
                 rhs: rhs.dtype(),
             }),
         })
+    }
+
+    fn dot_general_read(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        let mut cache = gemm::GemmAnalysisCache::default();
+        #[cfg(feature = "cpu-faer")]
+        let ctx = Arc::clone(&self.ctx);
+        let direct = self.install_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
+            #[cfg(feature = "cpu-faer")]
+            {
+                gemm::dot_general_read_cached(
+                    buffers,
+                    cache,
+                    Some(0),
+                    ctx.as_ref(),
+                    lhs,
+                    rhs,
+                    config,
+                )
+            }
+            #[cfg(feature = "cpu-blas")]
+            {
+                gemm::dot_general_read_cached(buffers, cache, Some(0), lhs, rhs, config)
+            }
+        })?;
+        if let Some(result) = direct {
+            return Ok(result);
+        }
+
+        let lhs = lhs.to_tensor();
+        let rhs = rhs.to_tensor();
+        self.dot_general_cached(&mut cache, Some(0), &lhs, &rhs, config)
     }
 
     fn dot_general_with_conj(
@@ -1062,7 +1188,9 @@ impl TensorBackend for CpuBackend {
     }
 
     fn with_exec_session<R: Send>(&mut self, f: impl FnOnce(&mut dyn TensorExec) -> R + Send) -> R {
-        let mut cache = gemm::GemmAnalysisCache::default();
+        let mut cache = profile_cpu_session_section("with_exec_session.cache_default", || {
+            gemm::GemmAnalysisCache::default()
+        });
         self.with_exec_session_cached(&mut cache, f)
     }
 
@@ -1071,18 +1199,56 @@ impl TensorBackend for CpuBackend {
         cache: &mut Self::RuntimeCache,
         f: impl FnOnce(&mut dyn TensorExec) -> R + Send,
     ) -> R {
-        let mut buffers = std::mem::take(&mut self.buffers);
+        if !cpu_session_profile_enabled() {
+            let mut buffers = std::mem::take(&mut self.buffers);
+            let ctx = Arc::clone(&self.ctx);
+            let (result, buffers) = ctx.install(|| {
+                let mut session = CpuExecSession {
+                    ctx: ctx.as_ref(),
+                    buffers: &mut buffers,
+                    gemm_analysis_cache: cache,
+                };
+                let result = f(&mut session);
+                (result, buffers)
+            });
+            self.buffers = buffers;
+            return result;
+        }
+
+        let total_started = Instant::now();
+        let mut buffers =
+            profile_cpu_session_section("with_exec_session_cached.take_buffers", || {
+                std::mem::take(&mut self.buffers)
+            });
         let ctx = Arc::clone(&self.ctx);
-        let (result, buffers) = ctx.install(|| {
-            let mut session = CpuExecSession {
-                ctx: ctx.as_ref(),
-                buffers: &mut buffers,
-                gemm_analysis_cache: cache,
-            };
-            let result = f(&mut session);
-            (result, buffers)
+        let (result, buffers) =
+            profile_cpu_session_section("with_exec_session_cached.ctx_install", || {
+                ctx.install(|| {
+                    let session_started = Instant::now();
+                    let mut session = CpuExecSession {
+                        ctx: ctx.as_ref(),
+                        buffers: &mut buffers,
+                        gemm_analysis_cache: cache,
+                    };
+                    record_cpu_session_profile(
+                        "with_exec_session_cached.session_construct",
+                        session_started.elapsed(),
+                    );
+
+                    let exec_started = Instant::now();
+                    let result = f(&mut session);
+                    record_cpu_session_profile(
+                        "with_exec_session_cached.exec_body",
+                        exec_started.elapsed(),
+                    );
+                    (result, buffers)
+                })
+            });
+        profile_cpu_session_section("with_exec_session_cached.restore_buffers", || {
+            self.buffers = buffers;
         });
-        self.buffers = buffers;
+        record_cpu_session_profile("with_exec_session_cached.total", total_started.elapsed());
+        maybe_print_cpu_session_profile();
         result
     }
 

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -3,7 +3,7 @@ use crate::buffer_pool::BufferPool;
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use crate::Tensor;
+use crate::{Tensor, TensorRead};
 
 use super::backend::{reclaim_typed, unsupported_dtype};
 use super::{analytic, elementwise, gemm, indexing, linalg, reduction, structural, CpuContext};
@@ -274,6 +274,41 @@ impl TensorExec for CpuExecSession<'_> {
                 rhs: rhs.dtype(),
             }),
         }
+    }
+
+    fn dot_general_read(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        #[cfg(feature = "cpu-faer")]
+        if let Some(result) = gemm::dot_general_read_cached(
+            self.buffers,
+            self.gemm_analysis_cache,
+            None,
+            self.ctx,
+            lhs,
+            rhs,
+            config,
+        )? {
+            return Ok(result);
+        }
+        #[cfg(feature = "cpu-blas")]
+        if let Some(result) = gemm::dot_general_read_cached(
+            self.buffers,
+            self.gemm_analysis_cache,
+            None,
+            lhs,
+            rhs,
+            config,
+        )? {
+            return Ok(result);
+        }
+
+        let lhs = lhs.to_tensor();
+        let rhs = rhs.to_tensor();
+        self.dot_general_cached(None, &lhs, &rhs, config)
     }
 
     fn dot_general_with_conj(

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -8,7 +8,10 @@ use crate::cpu::elementwise::typed_conj_with_pool;
 use crate::cpu::structural::typed_transpose_with_pool;
 #[cfg(feature = "cpu-blas")]
 use crate::types::ConjElem;
-use crate::types::{col_major_strides, Buffer, TypedTensor};
+use crate::types::{
+    col_major_strides, default_placement, Buffer, TensorRead, TensorView, TypedTensor,
+    TypedTensorView,
+};
 use crate::Error;
 
 #[cfg(feature = "cpu-blas")]
@@ -62,15 +65,54 @@ enum GemmAnalysisCacheKind {
 }
 
 impl GemmAnalysisPlan {
-    fn matches<T>(
-        &self,
-        lhs: &TypedTensor<T>,
-        rhs: &TypedTensor<T>,
-        config: &DotGeneralConfig,
-    ) -> bool {
-        self.lhs_shape.as_slice() == lhs.shape.as_slice()
-            && self.rhs_shape.as_slice() == rhs.shape.as_slice()
+    fn matches<L, R, T>(&self, lhs: &L, rhs: &R, config: &DotGeneralConfig) -> bool
+    where
+        L: TypedTensorRead<T>,
+        R: TypedTensorRead<T>,
+    {
+        self.lhs_shape.as_slice() == lhs.shape()
+            && self.rhs_shape.as_slice() == rhs.shape()
             && self.config == *config
+    }
+}
+
+trait TypedTensorRead<T> {
+    fn shape(&self) -> &[usize];
+    fn host_data_opt(&self) -> Option<&[T]>;
+}
+
+impl<T> TypedTensorRead<T> for TypedTensor<T> {
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn host_data_opt(&self) -> Option<&[T]> {
+        match &self.buffer {
+            Buffer::Host(v) => Some(v),
+            Buffer::Backend(_) => None,
+            #[cfg(feature = "cubecl")]
+            Buffer::Cubecl(_) => None,
+        }
+    }
+}
+
+impl<T> TypedTensorRead<T> for TypedTensorView<'_, T> {
+    fn shape(&self) -> &[usize] {
+        self.shape
+    }
+
+    fn host_data_opt(&self) -> Option<&[T]> {
+        Some(self.data)
+    }
+}
+
+impl<T: Clone> TypedTensorRead<T> for std::borrow::Cow<'_, TypedTensor<T>> {
+    fn shape(&self) -> &[usize] {
+        self.as_ref().shape()
+    }
+
+    fn host_data_opt(&self) -> Option<&[T]> {
+        self.as_ref().host_data_opt()
     }
 }
 
@@ -97,14 +139,18 @@ pub struct GemmAnalysisCache {
 }
 
 impl GemmAnalysisCache {
-    fn cached_dims<T>(
+    fn cached_dims<L, R, T>(
         &self,
         slot: usize,
         kind: GemmAnalysisCacheKind,
-        lhs: &TypedTensor<T>,
-        rhs: &TypedTensor<T>,
+        lhs: &L,
+        rhs: &R,
         config: &DotGeneralConfig,
-    ) -> Option<Option<GemmDims>> {
+    ) -> Option<Option<GemmDims>>
+    where
+        L: TypedTensorRead<T>,
+        R: TypedTensorRead<T>,
+    {
         self.slots
             .get(slot)
             .and_then(|entry| entry.get(kind))
@@ -178,12 +224,14 @@ fn validate_role_disjoint(
     Ok(())
 }
 
-fn validate_dot_general<T>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    config: &DotGeneralConfig,
-) -> crate::Result<()> {
+fn validate_dot_general<L, R, T>(lhs: &L, rhs: &R, config: &DotGeneralConfig) -> crate::Result<()>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+{
     const OP: &str = "dot_general";
+    let lhs_shape = lhs.shape();
+    let rhs_shape = rhs.shape();
 
     if config.lhs_contracting_dims.len() != config.rhs_contracting_dims.len() {
         return Err(Error::InvalidConfig {
@@ -198,8 +246,8 @@ fn validate_dot_general<T>(
         });
     }
 
-    let lhs_rank = lhs.shape.len();
-    let rhs_rank = rhs.shape.len();
+    let lhs_rank = lhs_shape.len();
+    let rhs_rank = rhs_shape.len();
     validate_axis_list(
         OP,
         "lhs_contracting",
@@ -234,23 +282,23 @@ fn validate_dot_general<T>(
         .iter()
         .zip(&config.rhs_contracting_dims)
     {
-        if lhs.shape[lhs_axis] != rhs.shape[rhs_axis] {
+        if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
             return Err(Error::InvalidConfig {
                 op: OP,
                 message: format!(
                     "contracting dim size mismatch: lhs axis {lhs_axis}={} rhs axis {rhs_axis}={}",
-                    lhs.shape[lhs_axis], rhs.shape[rhs_axis]
+                    lhs_shape[lhs_axis], rhs_shape[rhs_axis]
                 ),
             });
         }
     }
     for (&lhs_axis, &rhs_axis) in config.lhs_batch_dims.iter().zip(&config.rhs_batch_dims) {
-        if lhs.shape[lhs_axis] != rhs.shape[rhs_axis] {
+        if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
             return Err(Error::InvalidConfig {
                 op: OP,
                 message: format!(
                     "batch dim size mismatch: lhs axis {lhs_axis}={} rhs axis {rhs_axis}={}",
-                    lhs.shape[lhs_axis], rhs.shape[rhs_axis]
+                    lhs_shape[lhs_axis], rhs_shape[rhs_axis]
                 ),
             });
         }
@@ -351,13 +399,15 @@ fn is_identity_perm(perm: &[usize]) -> bool {
     perm.iter().enumerate().all(|(i, &p)| i == p)
 }
 
-fn analyse_gemm<T>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    config: &DotGeneralConfig,
-) -> Option<GemmDims> {
-    let lhs_rank = lhs.shape.len();
-    let rhs_rank = rhs.shape.len();
+fn analyse_gemm<L, R, T>(lhs: &L, rhs: &R, config: &DotGeneralConfig) -> Option<GemmDims>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+{
+    let lhs_shape = lhs.shape();
+    let rhs_shape = rhs.shape();
+    let lhs_rank = lhs_shape.len();
+    let rhs_rank = rhs_shape.len();
 
     let lhs_free: SmallVec<[usize; 8]> = (0..lhs_rank)
         .filter(|d| !config.lhs_contracting_dims.contains(d) && !config.lhs_batch_dims.contains(d))
@@ -366,22 +416,22 @@ fn analyse_gemm<T>(
         .filter(|d| !config.rhs_contracting_dims.contains(d) && !config.rhs_batch_dims.contains(d))
         .collect();
 
-    let lhs_strides: SmallVec<[isize; 8]> = col_major_strides(&lhs.shape).into_iter().collect();
-    let rhs_strides: SmallVec<[isize; 8]> = col_major_strides(&rhs.shape).into_iter().collect();
+    let lhs_strides: SmallVec<[isize; 8]> = col_major_strides(lhs_shape).into_iter().collect();
+    let rhs_strides: SmallVec<[isize; 8]> = col_major_strides(rhs_shape).into_iter().collect();
 
     let batch_shapes: SmallVec<[usize; 8]> = config
         .lhs_batch_dims
         .iter()
-        .map(|&d| lhs.shape[d])
+        .map(|&d| lhs_shape[d])
         .collect();
     let batch_total = checked_product(&batch_shapes)?;
 
-    let lhs_free_shapes: SmallVec<[usize; 8]> = lhs_free.iter().map(|&d| lhs.shape[d]).collect();
-    let rhs_free_shapes: SmallVec<[usize; 8]> = rhs_free.iter().map(|&d| rhs.shape[d]).collect();
+    let lhs_free_shapes: SmallVec<[usize; 8]> = lhs_free.iter().map(|&d| lhs_shape[d]).collect();
+    let rhs_free_shapes: SmallVec<[usize; 8]> = rhs_free.iter().map(|&d| rhs_shape[d]).collect();
     let contract_shapes: SmallVec<[usize; 8]> = config
         .lhs_contracting_dims
         .iter()
-        .map(|&d| lhs.shape[d])
+        .map(|&d| lhs_shape[d])
         .collect();
 
     let m = checked_product(&lhs_free_shapes)?;
@@ -464,14 +514,18 @@ fn analyse_gemm<T>(
     })
 }
 
-fn analyse_gemm_cached<T>(
+fn analyse_gemm_cached<L, R, T>(
     cache: &mut GemmAnalysisCache,
     cache_slot: Option<usize>,
     cache_kind: GemmAnalysisCacheKind,
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
+    lhs: &L,
+    rhs: &R,
     config: &DotGeneralConfig,
-) -> crate::Result<Option<GemmDims>> {
+) -> crate::Result<Option<GemmDims>>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+{
     let cache_slot = cache_slot.filter(|&slot| slot < GEMM_ANALYSIS_CACHE_MAX);
     if let Some(slot) = cache_slot {
         if let Some(cached) = cache.cached_dims(slot, cache_kind, lhs, rhs, config) {
@@ -485,8 +539,8 @@ fn analyse_gemm_cached<T>(
         cache.store(
             slot,
             cache_kind,
-            lhs.shape.clone(),
-            rhs.shape.clone(),
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
             config.clone(),
             dims.clone(),
         );
@@ -608,19 +662,127 @@ where
 }
 
 #[cfg(feature = "cpu-faer")]
-fn typed_faer_gemm<T>(
+pub(crate) fn dot_general_read_cached(
+    buffers: &mut BufferPool,
+    cache: &mut GemmAnalysisCache,
+    cache_slot: Option<usize>,
+    ctx: &crate::cpu::CpuContext,
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &DotGeneralConfig,
+) -> crate::Result<Option<crate::Tensor>> {
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident, $wrap:ident) => {
+            match (lhs, rhs) {
+                (
+                    TensorRead::Tensor(crate::Tensor::$owned(a)),
+                    TensorRead::Tensor(crate::Tensor::$owned(b)),
+                ) => {
+                    return typed_faer_gemm(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        GemmAnalysisCacheKind::Direct,
+                        ctx,
+                        a,
+                        b,
+                        config,
+                        false,
+                        false,
+                    )
+                    .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                (
+                    TensorRead::Tensor(crate::Tensor::$owned(a)),
+                    TensorRead::View(TensorView::$view(b)),
+                ) => {
+                    return typed_faer_gemm(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        GemmAnalysisCacheKind::Direct,
+                        ctx,
+                        a,
+                        &b,
+                        config,
+                        false,
+                        false,
+                    )
+                    .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                (
+                    TensorRead::View(TensorView::$view(a)),
+                    TensorRead::Tensor(crate::Tensor::$owned(b)),
+                ) => {
+                    return typed_faer_gemm(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        GemmAnalysisCacheKind::Direct,
+                        ctx,
+                        &a,
+                        b,
+                        config,
+                        false,
+                        false,
+                    )
+                    .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                (
+                    TensorRead::View(TensorView::$view(a)),
+                    TensorRead::View(TensorView::$view(b)),
+                ) => {
+                    return typed_faer_gemm(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        GemmAnalysisCacheKind::Direct,
+                        ctx,
+                        &a,
+                        &b,
+                        config,
+                        false,
+                        false,
+                    )
+                    .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                _ => {}
+            }
+        };
+    }
+
+    dispatch!(F32, F32, F32);
+    dispatch!(F64, F64, F64);
+    dispatch!(C32, C32, C32);
+    dispatch!(C64, C64, C64);
+
+    if lhs.dtype() == rhs.dtype() {
+        Ok(None)
+    } else {
+        Err(Error::DTypeMismatch {
+            op: "dot_general",
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        })
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+fn typed_faer_gemm<L, R, T>(
     buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,
     cache_slot: Option<usize>,
     cache_kind: GemmAnalysisCacheKind,
     ctx: &crate::cpu::CpuContext,
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
+    lhs: &L,
+    rhs: &R,
     config: &DotGeneralConfig,
     lhs_conj: bool,
     rhs_conj: bool,
 ) -> crate::Result<Option<TypedTensor<T>>>
 where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
     T: FaerGemm + PoolScalar + Copy + Clone + Zero + One + PartialEq,
 {
     let Some(dims) = analyse_gemm_cached(cache, cache_slot, cache_kind, lhs, rhs, config)? else {
@@ -637,21 +799,15 @@ where
         return Ok(Some(TypedTensor {
             buffer: Buffer::Host(data),
             shape: dims.out_shape.into_vec(),
-            placement: lhs.placement.clone(),
+            placement: default_placement(),
         }));
     }
 
-    let a_data = match &lhs.buffer {
-        Buffer::Host(v) => v.as_ptr(),
-        Buffer::Backend(_) => return Ok(None),
-        #[cfg(feature = "cubecl")]
-        Buffer::Cubecl(_) => panic!("GPU tensor (Buffer::Cubecl) passed to CPU backend. Use cubecl::download_tensor() to transfer to CPU first."),
+    let Some(a_data) = lhs.host_data_opt().map(<[T]>::as_ptr) else {
+        return Ok(None);
     };
-    let b_data = match &rhs.buffer {
-        Buffer::Host(v) => v.as_ptr(),
-        Buffer::Backend(_) => return Ok(None),
-        #[cfg(feature = "cubecl")]
-        Buffer::Cubecl(_) => panic!("GPU tensor (Buffer::Cubecl) passed to CPU backend. Use cubecl::download_tensor() to transfer to CPU first."),
+    let Some(b_data) = rhs.host_data_opt().map(<[T]>::as_ptr) else {
+        return Ok(None);
     };
 
     // SAFETY: this GEMM path uses beta = 0 and overwrites every output element.
@@ -720,7 +876,7 @@ where
     Ok(Some(TypedTensor {
         buffer: Buffer::Host(out_data),
         shape: dims.out_shape.into_vec(),
-        placement: lhs.placement.clone(),
+        placement: default_placement(),
     }))
 }
 
@@ -881,18 +1037,113 @@ where
 }
 
 #[cfg(feature = "cpu-blas")]
-fn typed_blas_gemm_with_conj<T>(
+pub(crate) fn dot_general_read_cached(
+    buffers: &mut BufferPool,
+    cache: &mut GemmAnalysisCache,
+    cache_slot: Option<usize>,
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &DotGeneralConfig,
+) -> crate::Result<Option<crate::Tensor>> {
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident, $wrap:ident) => {
+            match (lhs, rhs) {
+                (
+                    TensorRead::Tensor(crate::Tensor::$owned(a)),
+                    TensorRead::Tensor(crate::Tensor::$owned(b)),
+                ) => {
+                    return typed_blas_gemm(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        GemmAnalysisCacheKind::Direct,
+                        a,
+                        b,
+                        config,
+                    )
+                    .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                (
+                    TensorRead::Tensor(crate::Tensor::$owned(a)),
+                    TensorRead::View(TensorView::$view(b)),
+                ) => {
+                    return typed_blas_gemm(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        GemmAnalysisCacheKind::Direct,
+                        a,
+                        &b,
+                        config,
+                    )
+                    .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                (
+                    TensorRead::View(TensorView::$view(a)),
+                    TensorRead::Tensor(crate::Tensor::$owned(b)),
+                ) => {
+                    return typed_blas_gemm(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        GemmAnalysisCacheKind::Direct,
+                        &a,
+                        b,
+                        config,
+                    )
+                    .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                (
+                    TensorRead::View(TensorView::$view(a)),
+                    TensorRead::View(TensorView::$view(b)),
+                ) => {
+                    return typed_blas_gemm(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        GemmAnalysisCacheKind::Direct,
+                        &a,
+                        &b,
+                        config,
+                    )
+                    .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                _ => {}
+            }
+        };
+    }
+
+    dispatch!(F32, F32, F32);
+    dispatch!(F64, F64, F64);
+    dispatch!(C32, C32, C32);
+    dispatch!(C64, C64, C64);
+
+    if lhs.dtype() == rhs.dtype() {
+        Ok(None)
+    } else {
+        Err(Error::DTypeMismatch {
+            op: "dot_general",
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        })
+    }
+}
+
+#[cfg(feature = "cpu-blas")]
+fn typed_blas_gemm_with_conj<L, R, T>(
     buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,
     cache_slot: Option<usize>,
     cache_kind: GemmAnalysisCacheKind,
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
+    lhs: &L,
+    rhs: &R,
     config: &DotGeneralConfig,
     lhs_conj: bool,
     rhs_conj: bool,
 ) -> crate::Result<Option<TypedTensor<T>>>
 where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
     T: BlasGemm + PoolScalar + Copy + Clone + Zero + One,
 {
     let dims = match analyse_gemm_cached(cache, cache_slot, cache_kind, lhs, rhs, config)? {
@@ -910,7 +1161,7 @@ where
         return Ok(Some(TypedTensor {
             buffer: Buffer::Host(data),
             shape: dims.out_shape.into_vec(),
-            placement: lhs.placement.clone(),
+            placement: default_placement(),
         }));
     }
 
@@ -928,17 +1179,11 @@ where
         return Ok(None);
     }
 
-    let a_data = match &lhs.buffer {
-        Buffer::Host(v) => v.as_ptr(),
-        Buffer::Backend(_) => return Ok(None),
-        #[cfg(feature = "cubecl")]
-        Buffer::Cubecl(_) => panic!("GPU tensor (Buffer::Cubecl) passed to CPU backend. Use cubecl::download_tensor() to transfer to CPU first."),
+    let Some(a_data) = lhs.host_data_opt().map(<[T]>::as_ptr) else {
+        return Ok(None);
     };
-    let b_data = match &rhs.buffer {
-        Buffer::Host(v) => v.as_ptr(),
-        Buffer::Backend(_) => return Ok(None),
-        #[cfg(feature = "cubecl")]
-        Buffer::Cubecl(_) => panic!("GPU tensor (Buffer::Cubecl) passed to CPU backend. Use cubecl::download_tensor() to transfer to CPU first."),
+    let Some(b_data) = rhs.host_data_opt().map(<[T]>::as_ptr) else {
+        return Ok(None);
     };
 
     // SAFETY: each batch GEMM writes its full output block with beta = 0 when
@@ -990,21 +1235,23 @@ where
     Ok(Some(TypedTensor {
         buffer: Buffer::Host(out),
         shape: dims.out_shape.into_vec(),
-        placement: lhs.placement.clone(),
+        placement: default_placement(),
     }))
 }
 
 #[cfg(feature = "cpu-blas")]
-fn typed_blas_gemm<T>(
+fn typed_blas_gemm<L, R, T>(
     buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,
     cache_slot: Option<usize>,
     cache_kind: GemmAnalysisCacheKind,
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
+    lhs: &L,
+    rhs: &R,
     config: &DotGeneralConfig,
 ) -> crate::Result<Option<TypedTensor<T>>>
 where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
     T: BlasGemm + PoolScalar + Copy + Clone + Zero + One,
 {
     let dims = match analyse_gemm_cached(cache, cache_slot, cache_kind, lhs, rhs, config)? {
@@ -1022,7 +1269,7 @@ where
         return Ok(Some(TypedTensor {
             buffer: Buffer::Host(data),
             shape: dims.out_shape.into_vec(),
-            placement: lhs.placement.clone(),
+            placement: default_placement(),
         }));
     }
 
@@ -1040,17 +1287,11 @@ where
         return Ok(None);
     }
 
-    let a_data = match &lhs.buffer {
-        Buffer::Host(v) => v.as_ptr(),
-        Buffer::Backend(_) => return Ok(None),
-        #[cfg(feature = "cubecl")]
-        Buffer::Cubecl(_) => panic!("GPU tensor (Buffer::Cubecl) passed to CPU backend. Use cubecl::download_tensor() to transfer to CPU first."),
+    let Some(a_data) = lhs.host_data_opt().map(<[T]>::as_ptr) else {
+        return Ok(None);
     };
-    let b_data = match &rhs.buffer {
-        Buffer::Host(v) => v.as_ptr(),
-        Buffer::Backend(_) => return Ok(None),
-        #[cfg(feature = "cubecl")]
-        Buffer::Cubecl(_) => panic!("GPU tensor (Buffer::Cubecl) passed to CPU backend. Use cubecl::download_tensor() to transfer to CPU first."),
+    let Some(b_data) = rhs.host_data_opt().map(<[T]>::as_ptr) else {
+        return Ok(None);
     };
 
     // SAFETY: each batch GEMM writes its full output block with beta = 0.
@@ -1096,7 +1337,7 @@ where
     Ok(Some(TypedTensor {
         buffer: Buffer::Host(out),
         shape: dims.out_shape.into_vec(),
-        placement: lhs.placement.clone(),
+        placement: default_placement(),
     }))
 }
 

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -18,7 +18,7 @@ use crate::cpu::{
     reduce_min, reduce_prod, reduce_sum, reshape, scatter, select, sign, transpose, tril, triu,
     CpuBackend, CpuContext,
 };
-use crate::types::{DType, Tensor, TypedTensor};
+use crate::types::{DType, Tensor, TensorRead, TensorView, TypedTensor};
 
 fn get_f64(t: &Tensor, idx: &[usize]) -> f64 {
     match t {
@@ -1139,6 +1139,44 @@ fn test_dot_general_with_conj_matches_materialized_complex_matmul() {
             );
         }
     }
+}
+
+#[test]
+fn test_dot_general_read_accepts_tensor_and_view_inputs() {
+    let lhs = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let rhs_shape = [3usize, 2];
+    let rhs_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let rhs_view = TensorView::f64(&rhs_shape, &rhs_data).unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let mut backend = CpuBackend::new();
+
+    let direct = backend
+        .dot_general_read(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_view(rhs_view),
+            &config,
+        )
+        .unwrap();
+    assert_eq!(direct.shape(), &[2, 2]);
+    assert_eq!(direct.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+
+    let session = backend.with_exec_session(|exec| {
+        exec.dot_general_read(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_view(rhs_view),
+            &config,
+        )
+    });
+    let session = session.unwrap();
+    assert_eq!(
+        session.as_slice::<f64>().unwrap(),
+        &[22.0, 28.0, 49.0, 64.0]
+    );
 }
 
 #[test]
@@ -3735,8 +3773,90 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         }
     }
 
+    struct DefaultOnlyExec;
+
+    impl crate::backend::TensorExec for DefaultOnlyExec {
+        panic_backend_methods! {
+            add(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+            mul(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+            neg(input: &Tensor) -> crate::Result<Tensor>;
+            div(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+            abs(input: &Tensor) -> crate::Result<Tensor>;
+            sign(input: &Tensor) -> crate::Result<Tensor>;
+            maximum(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+            minimum(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+            compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor>;
+            select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> crate::Result<Tensor>;
+            clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor>;
+            exp(input: &Tensor) -> crate::Result<Tensor>;
+            log(input: &Tensor) -> crate::Result<Tensor>;
+            sin(input: &Tensor) -> crate::Result<Tensor>;
+            cos(input: &Tensor) -> crate::Result<Tensor>;
+            tanh(input: &Tensor) -> crate::Result<Tensor>;
+            sqrt(input: &Tensor) -> crate::Result<Tensor>;
+            rsqrt(input: &Tensor) -> crate::Result<Tensor>;
+            pow(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+            expm1(input: &Tensor) -> crate::Result<Tensor>;
+            log1p(input: &Tensor) -> crate::Result<Tensor>;
+            transpose(input: &Tensor, perm: &[usize]) -> crate::Result<Tensor>;
+            reshape(input: &Tensor, shape: &[usize]) -> crate::Result<Tensor>;
+            broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> crate::Result<Tensor>;
+            convert(input: &Tensor, to: DType) -> crate::Result<Tensor>;
+            extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor>;
+            embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor>;
+            tril(input: &Tensor, k: i64) -> crate::Result<Tensor>;
+            triu(input: &Tensor, k: i64) -> crate::Result<Tensor>;
+            reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+            reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+            reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+            reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+            gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> crate::Result<Tensor>;
+            scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> crate::Result<Tensor>;
+            slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor>;
+            dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> crate::Result<Tensor>;
+            dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> crate::Result<Tensor>;
+            pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
+            concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;
+            reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+            cholesky(input: &Tensor) -> crate::Result<Tensor>;
+            triangular_solve(
+                a: &Tensor,
+                b: &Tensor,
+                left_side: bool,
+                lower: bool,
+                transpose_a: bool,
+                unit_diagonal: bool
+            ) -> crate::Result<Tensor>;
+            lu(input: &Tensor) -> crate::Result<Vec<Tensor>>;
+            full_piv_lu(input: &Tensor) -> crate::Result<Vec<Tensor>>;
+            full_piv_lu_solve(a: &Tensor, b: &Tensor, transpose_a: bool) -> crate::Result<Tensor>;
+            svd(input: &Tensor) -> crate::Result<Vec<Tensor>>;
+            qr(input: &Tensor) -> crate::Result<Vec<Tensor>>;
+            eigh(input: &Tensor) -> crate::Result<Vec<Tensor>>;
+            eig(input: &Tensor) -> crate::Result<Vec<Tensor>>;
+        }
+
+        fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+            CpuBackend::new().conj(input)
+        }
+
+        fn dot_general(
+            &mut self,
+            lhs: &Tensor,
+            rhs: &Tensor,
+            config: &DotGeneralConfig,
+        ) -> crate::Result<Tensor> {
+            CpuBackend::new().dot_general(lhs, rhs, config)
+        }
+
+        fn reclaim_buffer(&mut self, _tensor: Tensor) {}
+    }
+
     let lhs = Tensor::from_vec(vec![1, 1], vec![2.0_f64]);
     let rhs = Tensor::from_vec(vec![1, 1], vec![3.0_f64]);
+    let one_shape = [1usize, 1];
+    let lhs_data = [2.0_f64];
+    let rhs_data = [3.0_f64];
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -3755,6 +3875,20 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         TensorBackend::dot_general_with_conj(&mut backend, &lhs, &rhs, &config, true, false)
             .unwrap();
     assert_eq!(lhs_folded.as_slice::<f64>().unwrap(), &[6.0]);
+
+    let both_folded =
+        TensorBackend::dot_general_with_conj(&mut backend, &lhs, &rhs, &config, true, true)
+            .unwrap();
+    assert_eq!(both_folded.as_slice::<f64>().unwrap(), &[6.0]);
+
+    let read_views = TensorBackend::dot_general_read(
+        &mut backend,
+        TensorRead::from_view(TensorView::f64(&one_shape, &lhs_data).unwrap()),
+        TensorRead::from_view(TensorView::f64(&one_shape, &rhs_data).unwrap()),
+        &config,
+    )
+    .unwrap();
+    assert_eq!(read_views.as_slice::<f64>().unwrap(), &[6.0]);
 
     let rhs_folded = TensorBackend::dot_general_with_conj_cached(
         &mut backend,
@@ -3796,6 +3930,44 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         cached.as_slice::<f64>().unwrap()[0] + folded.as_slice::<f64>().unwrap()[0]
     });
     assert_eq!(session_value, 12.0);
+
+    let mut exec = DefaultOnlyExec;
+    let exec_read_tensor = crate::backend::TensorExec::dot_general_read(
+        &mut exec,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &config,
+    )
+    .unwrap();
+    assert_eq!(exec_read_tensor.as_slice::<f64>().unwrap(), &[6.0]);
+    let exec_read_views = crate::backend::TensorExec::dot_general_read(
+        &mut exec,
+        TensorRead::from_view(TensorView::f64(&one_shape, &lhs_data).unwrap()),
+        TensorRead::from_view(TensorView::f64(&one_shape, &rhs_data).unwrap()),
+        &config,
+    )
+    .unwrap();
+    assert_eq!(exec_read_views.as_slice::<f64>().unwrap(), &[6.0]);
+    let exec_no_conj = crate::backend::TensorExec::dot_general_with_conj(
+        &mut exec, &lhs, &rhs, &config, false, false,
+    )
+    .unwrap();
+    assert_eq!(exec_no_conj.as_slice::<f64>().unwrap(), &[6.0]);
+    let exec_lhs_conj = crate::backend::TensorExec::dot_general_with_conj(
+        &mut exec, &lhs, &rhs, &config, true, false,
+    )
+    .unwrap();
+    assert_eq!(exec_lhs_conj.as_slice::<f64>().unwrap(), &[6.0]);
+    let exec_rhs_conj = crate::backend::TensorExec::dot_general_with_conj(
+        &mut exec, &lhs, &rhs, &config, false, true,
+    )
+    .unwrap();
+    assert_eq!(exec_rhs_conj.as_slice::<f64>().unwrap(), &[6.0]);
+    let exec_both_conj = crate::backend::TensorExec::dot_general_with_conj(
+        &mut exec, &lhs, &rhs, &config, true, true,
+    )
+    .unwrap();
+    assert_eq!(exec_both_conj.as_slice::<f64>().unwrap(), &[6.0]);
 }
 
 #[test]

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -4,7 +4,8 @@ use num_complex::{Complex32, Complex64};
 
 use crate::types::{
     col_major_strides, flat_to_multi, Buffer, BufferHandle, ComputeDevice, ConjElem, DType,
-    MemoryKind, Placement, Tensor, TensorScalar, TypedTensor,
+    MemoryKind, Placement, Tensor, TensorRead, TensorScalar, TensorView, TypedTensor,
+    TypedTensorView,
 };
 use crate::Error;
 
@@ -258,6 +259,72 @@ fn tensor_shape_and_dtype_cover_all_variants() {
     assert_eq!(c32_tensor.dtype(), DType::C32);
     assert_eq!(c64_tensor.shape(), &[1, 1]);
     assert_eq!(c64_tensor.dtype(), DType::C64);
+}
+
+#[test]
+fn typed_tensor_view_validates_shape_and_exposes_slice() {
+    let shape = [2, 2];
+    let data = [1.0_f64, 2.0, 3.0, 4.0];
+    let view = TypedTensorView::new(&shape, &data).unwrap();
+
+    assert_eq!(view.shape, &[2, 2]);
+    assert_eq!(view.as_slice(), &[1.0, 2.0, 3.0, 4.0]);
+
+    let err = TypedTensorView::new(&shape, &data[..3]).unwrap_err();
+    assert!(matches!(err, Error::InvalidConfig { .. }));
+}
+
+#[test]
+fn tensor_view_covers_dtype_shape_and_materialization() {
+    let f32_data = [1.0_f32, 2.0];
+    let f64_data = [1.0_f64, 2.0];
+    let i64_data = [1_i64, 2];
+    let c32_data = [Complex32::new(1.0, -1.0), Complex32::new(2.0, 0.5)];
+    let c64_data = [Complex64::new(1.0, -1.0), Complex64::new(2.0, 0.5)];
+    let shape = [2usize];
+
+    let views = [
+        TensorView::f32(&shape, &f32_data).unwrap(),
+        TensorView::f64(&shape, &f64_data).unwrap(),
+        TensorView::i64(&shape, &i64_data).unwrap(),
+        TensorView::c32(&shape, &c32_data).unwrap(),
+        TensorView::c64(&shape, &c64_data).unwrap(),
+    ];
+    let dtypes = [DType::F32, DType::F64, DType::I64, DType::C32, DType::C64];
+
+    for (view, dtype) in views.iter().zip(dtypes) {
+        assert_eq!(view.dtype(), dtype);
+        assert_eq!(view.shape(), &[2]);
+        let tensor = view.to_tensor();
+        assert_eq!(tensor.dtype(), dtype);
+        assert_eq!(tensor.shape(), &[2]);
+    }
+}
+
+#[test]
+fn tensor_read_wraps_owned_tensor_or_borrowed_view() {
+    let tensor = Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]);
+    let read_tensor = TensorRead::from_tensor(&tensor);
+
+    assert_eq!(read_tensor.dtype(), DType::F64);
+    assert_eq!(read_tensor.shape(), &[2]);
+    assert!(read_tensor.as_tensor().is_some());
+    assert_eq!(
+        read_tensor.to_tensor().as_slice::<f64>().unwrap(),
+        &[3.0, 4.0]
+    );
+
+    let shape = [2usize];
+    let data = [5.0_f64, 6.0];
+    let read_view = TensorRead::from_view(TensorView::f64(&shape, &data).unwrap());
+
+    assert_eq!(read_view.dtype(), DType::F64);
+    assert_eq!(read_view.shape(), &[2]);
+    assert!(read_view.as_tensor().is_none());
+    assert_eq!(
+        read_view.to_tensor().as_slice::<f64>().unwrap(),
+        &[5.0, 6.0]
+    );
 }
 
 tensor_scalar_roundtrip_test!(

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -163,6 +163,39 @@ pub struct TypedTensor<T> {
     pub placement: Placement,
 }
 
+/// Read-only borrowed view of a typed, contiguous column-major tensor.
+///
+/// This is intentionally not a general tensor storage variant. It is an input
+/// view for synchronous eager kernels that can consume host slices without
+/// taking ownership of them.
+#[derive(Clone, Copy, Debug)]
+pub struct TypedTensorView<'a, T> {
+    pub data: &'a [T],
+    pub shape: &'a [usize],
+}
+
+impl<'a, T> TypedTensorView<'a, T> {
+    /// Create a borrowed tensor view from a column-major slice.
+    pub fn new(shape: &'a [usize], data: &'a [T]) -> crate::Result<Self> {
+        let n: usize = shape.iter().product();
+        if data.len() != n {
+            return Err(crate::Error::InvalidConfig {
+                op: "TensorView::new",
+                message: format!(
+                    "data length {} does not match shape product {}",
+                    data.len(),
+                    n
+                ),
+            });
+        }
+        Ok(Self { data, shape })
+    }
+
+    pub fn as_slice(&self) -> &'a [T] {
+        self.data
+    }
+}
+
 /// Runtime scalar dtype tag.
 ///
 /// # Examples
@@ -441,6 +474,23 @@ pub enum Tensor {
     C64(TypedTensor<Complex<f64>>),
 }
 
+/// Dynamic read-only borrowed tensor view.
+#[derive(Clone, Copy, Debug)]
+pub enum TensorView<'a> {
+    F32(TypedTensorView<'a, f32>),
+    F64(TypedTensorView<'a, f64>),
+    I64(TypedTensorView<'a, i64>),
+    C32(TypedTensorView<'a, Complex<f32>>),
+    C64(TypedTensorView<'a, Complex<f64>>),
+}
+
+/// Read-only tensor input accepted by synchronous eager kernels.
+#[derive(Clone, Copy, Debug)]
+pub enum TensorRead<'a> {
+    Tensor(&'a Tensor),
+    View(TensorView<'a>),
+}
+
 /// Wrap an `f64` [`TypedTensor`] into the corresponding [`Tensor`] variant.
 ///
 /// # Examples
@@ -534,6 +584,96 @@ impl From<TypedTensor<Complex<f64>>> for Tensor {
 impl From<TypedTensor<Complex<f32>>> for Tensor {
     fn from(t: TypedTensor<Complex<f32>>) -> Self {
         Tensor::C32(t)
+    }
+}
+
+impl<'a> TensorView<'a> {
+    pub fn f32(shape: &'a [usize], data: &'a [f32]) -> crate::Result<Self> {
+        Ok(Self::F32(TypedTensorView::new(shape, data)?))
+    }
+
+    pub fn f64(shape: &'a [usize], data: &'a [f64]) -> crate::Result<Self> {
+        Ok(Self::F64(TypedTensorView::new(shape, data)?))
+    }
+
+    pub fn i64(shape: &'a [usize], data: &'a [i64]) -> crate::Result<Self> {
+        Ok(Self::I64(TypedTensorView::new(shape, data)?))
+    }
+
+    pub fn c32(shape: &'a [usize], data: &'a [Complex32]) -> crate::Result<Self> {
+        Ok(Self::C32(TypedTensorView::new(shape, data)?))
+    }
+
+    pub fn c64(shape: &'a [usize], data: &'a [Complex64]) -> crate::Result<Self> {
+        Ok(Self::C64(TypedTensorView::new(shape, data)?))
+    }
+
+    pub fn dtype(&self) -> DType {
+        match self {
+            Self::F32(_) => DType::F32,
+            Self::F64(_) => DType::F64,
+            Self::I64(_) => DType::I64,
+            Self::C32(_) => DType::C32,
+            Self::C64(_) => DType::C64,
+        }
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        match self {
+            Self::F32(t) => t.shape,
+            Self::F64(t) => t.shape,
+            Self::I64(t) => t.shape,
+            Self::C32(t) => t.shape,
+            Self::C64(t) => t.shape,
+        }
+    }
+
+    pub fn to_tensor(&self) -> Tensor {
+        match self {
+            Self::F32(t) => Tensor::from_vec(t.shape.to_vec(), t.data.to_vec()),
+            Self::F64(t) => Tensor::from_vec(t.shape.to_vec(), t.data.to_vec()),
+            Self::I64(t) => Tensor::from_vec(t.shape.to_vec(), t.data.to_vec()),
+            Self::C32(t) => Tensor::from_vec(t.shape.to_vec(), t.data.to_vec()),
+            Self::C64(t) => Tensor::from_vec(t.shape.to_vec(), t.data.to_vec()),
+        }
+    }
+}
+
+impl<'a> TensorRead<'a> {
+    pub fn from_tensor(tensor: &'a Tensor) -> Self {
+        Self::Tensor(tensor)
+    }
+
+    pub fn from_view(view: TensorView<'a>) -> Self {
+        Self::View(view)
+    }
+
+    pub fn dtype(&self) -> DType {
+        match self {
+            Self::Tensor(tensor) => tensor.dtype(),
+            Self::View(view) => view.dtype(),
+        }
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        match self {
+            Self::Tensor(tensor) => tensor.shape(),
+            Self::View(view) => view.shape(),
+        }
+    }
+
+    pub fn as_tensor(&self) -> Option<&'a Tensor> {
+        match self {
+            Self::Tensor(tensor) => Some(*tensor),
+            Self::View(_) => None,
+        }
+    }
+
+    pub fn to_tensor(&self) -> Tensor {
+        match self {
+            Self::Tensor(tensor) => (*tensor).clone(),
+            Self::View(view) => view.to_tensor(),
+        }
     }
 }
 

--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -1,5 +1,9 @@
+use std::cell::RefCell;
+use std::cmp::Reverse;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, Weak};
+use std::env;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::time::{Duration, Instant};
 
 use computegraph::fragment::Fragment;
 use computegraph::{GlobalValKey, ValRef};
@@ -25,6 +29,91 @@ use crate::traced::next_input_key;
 
 pub(crate) type GradSlot = Arc<Mutex<Option<Arc<Tensor>>>>;
 pub(crate) type WeakGradSlot = Weak<Mutex<Option<Arc<Tensor>>>>;
+
+#[derive(Debug, Default, Clone)]
+struct EagerOpProfileEntry {
+    calls: usize,
+    total_time: Duration,
+}
+
+thread_local! {
+    static EAGER_OP_PROFILE_STATE: RefCell<HashMap<&'static str, EagerOpProfileEntry>> =
+        RefCell::new(HashMap::new());
+}
+
+pub(crate) fn eager_op_profile_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| env::var("TENFERRO_PROFILE_EAGER_OP_AGG").is_ok())
+}
+
+pub(crate) fn record_eager_op_profile(section: &'static str, elapsed: Duration) {
+    if !eager_op_profile_enabled() {
+        return;
+    }
+    EAGER_OP_PROFILE_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let entry = state.entry(section).or_default();
+        entry.calls += 1;
+        entry.total_time += elapsed;
+    });
+}
+
+pub(crate) fn profile_eager_op_section<T>(section: &'static str, f: impl FnOnce() -> T) -> T {
+    if !eager_op_profile_enabled() {
+        return f();
+    }
+    let started = Instant::now();
+    let result = f();
+    record_eager_op_profile(section, started.elapsed());
+    result
+}
+
+pub(crate) fn maybe_print_eager_op_profile() {
+    if !eager_op_profile_enabled() {
+        return;
+    }
+    let Ok(print_every) = env::var("TENFERRO_PROFILE_EAGER_OP_PRINT_EVERY") else {
+        return;
+    };
+    let Ok(print_every) = print_every.parse::<usize>() else {
+        return;
+    };
+    if print_every == 0 {
+        return;
+    }
+
+    let should_print = EAGER_OP_PROFILE_STATE.with(|state| {
+        state
+            .borrow()
+            .get("nary_op.total")
+            .is_some_and(|entry| entry.calls % print_every == 0)
+    });
+    if should_print {
+        print_and_reset_eager_op_profile();
+    }
+}
+
+pub(crate) fn print_and_reset_eager_op_profile() {
+    EAGER_OP_PROFILE_STATE.with(|state| {
+        let mut entries: Vec<_> = state
+            .borrow()
+            .iter()
+            .map(|(section, entry)| (*section, entry.clone()))
+            .collect();
+        state.borrow_mut().clear();
+        entries.sort_by_key(|(_, entry)| Reverse(entry.total_time));
+
+        eprintln!("=== tenferro eager op profile ===");
+        for (section, entry) in entries {
+            eprintln!(
+                "{section}: calls={} total={:.6}ms per_call={:.3}us",
+                entry.calls,
+                entry.total_time.as_secs_f64() * 1.0e3,
+                entry.total_time.as_secs_f64() * 1.0e6 / entry.calls as f64,
+            );
+        }
+    });
+}
 
 /// Shared eager execution context for tensors on a backend.
 ///
@@ -751,8 +840,12 @@ pub(crate) fn exec_single_output<B: TensorBackend>(
     inputs: &[&Tensor],
     ctx: &EagerContext<B>,
 ) -> Result<Tensor> {
-    let mut backend = ctx.backend.lock().unwrap();
-    let mut outputs = exec_op_on_tensors(op, inputs, &mut *backend)?;
+    let mut backend = profile_eager_op_section("exec_single_output.lock_backend", || {
+        ctx.backend.lock().unwrap()
+    });
+    let mut outputs = profile_eager_op_section("exec_single_output.exec_op", || {
+        exec_op_on_tensors(op, inputs, &mut *backend)
+    })?;
     if outputs.len() != 1 {
         return Err(Error::Internal(format!(
             "expected one eager output for {:?}, got {}",
@@ -760,7 +853,10 @@ pub(crate) fn exec_single_output<B: TensorBackend>(
             outputs.len()
         )));
     }
-    Ok(outputs.remove(0))
+    Ok(profile_eager_op_section(
+        "exec_single_output.remove_output",
+        || outputs.remove(0),
+    ))
 }
 
 pub(crate) fn zero_like_tensor<B: TensorBackend>(input: &Tensor, _backend: &mut B) -> Tensor {

--- a/tenferro/src/eager_einsum.rs
+++ b/tenferro/src/eager_einsum.rs
@@ -16,11 +16,12 @@
 //! assert_eq!(y.grad().unwrap().as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0]);
 //! ```
 
-use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_ops::std_tensor_op::{EinsumSubscripts, StdTensorOp};
 use tenferro_tensor::TensorBackend;
 
 use crate::eager::EagerTensor;
 use crate::error::Result;
+use crate::parse_einsum_subscripts;
 
 /// Execute an einsum eagerly and record it when any input requires gradients.
 ///
@@ -48,10 +49,19 @@ pub fn einsum<B: TensorBackend>(
     inputs: &[&EagerTensor<B>],
     subscripts: &str,
 ) -> Result<EagerTensor<B>> {
+    let subscripts = parse_einsum_subscripts(subscripts)?;
+    einsum_subscripts(inputs, &subscripts)
+}
+
+/// Execute an einsum eagerly from integer labels and record it when any input requires gradients.
+pub fn einsum_subscripts<B: TensorBackend>(
+    inputs: &[&EagerTensor<B>],
+    subscripts: &EinsumSubscripts,
+) -> Result<EagerTensor<B>> {
     EagerTensor::nary_op(
         inputs,
         StdTensorOp::NaryEinsum {
-            subscripts: subscripts.to_string(),
+            subscripts: subscripts.clone(),
         },
     )
 }

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -6,6 +6,7 @@ use tenferro_tensor::{
     DType, DotGeneralConfig, PadConfig, SliceConfig, Tensor, TensorBackend, TensorExec, TypedTensor,
 };
 
+use crate::einsum_subscripts::to_einsum_subscripts;
 use crate::error::{Error, Result};
 use crate::scalar_semantics::dynamic_truncate_size;
 use crate::shape_infer::promote_dtype_for_binary_op;
@@ -68,8 +69,9 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
     backend: &mut B,
 ) -> Result<Vec<Tensor>> {
     if let StdTensorOp::NaryEinsum { subscripts, .. } = op {
-        return Ok(vec![tenferro_einsum::eager_einsum(
-            backend, inputs, subscripts,
+        let parsed = to_einsum_subscripts(subscripts);
+        return Ok(vec![tenferro_einsum::eager_einsum_subscripts(
+            backend, inputs, &parsed,
         )?]);
     }
 

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -7,7 +7,10 @@ use tenferro_tensor::{
     TensorBackend,
 };
 
-use crate::eager::{exec_single_output, record_eager_outputs, EagerTensor};
+use crate::eager::{
+    exec_single_output, maybe_print_eager_op_profile, profile_eager_op_section,
+    record_eager_op_profile, record_eager_outputs, EagerTensor,
+};
 use crate::eager_exec::{exec_dot_general_with_conj_on_tensors, exec_op_on_tensors};
 use crate::error::{Error, Result};
 use crate::metadata::push_metadata_scope;
@@ -699,6 +702,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     }
 
     pub(crate) fn nary_op(tensors: &[&Self], op: StdTensorOp) -> Result<Self> {
+        let total_started = std::time::Instant::now();
         let Some(first) = tensors.first() else {
             return Err(Error::Internal(
                 "nary eager op requires at least one input tensor".to_string(),
@@ -706,24 +710,41 @@ impl<B: TensorBackend> EagerTensor<B> {
         };
 
         let ctx = Arc::clone(&first.ctx);
-        for tensor in tensors.iter().skip(1) {
-            if !first.same_context(tensor) {
-                return Err(Error::ContextMismatch {
-                    lhs: first.ctx_id(),
-                    rhs: tensor.ctx_id(),
-                });
+        profile_eager_op_section("nary_op.context_check", || -> Result<()> {
+            for tensor in tensors.iter().skip(1) {
+                if !first.same_context(tensor) {
+                    return Err(Error::ContextMismatch {
+                        lhs: first.ctx_id(),
+                        rhs: tensor.ctx_id(),
+                    });
+                }
             }
-        }
+            Ok(())
+        })?;
 
-        let inputs: Vec<&Tensor> = tensors.iter().map(|tensor| tensor.data.as_ref()).collect();
-        let output = exec_single_output(&op, &inputs, &ctx)?;
-        if !tensors.iter().any(|tensor| tensor.requires_grad) {
-            return Ok(Self::new_untracked_result(ctx, output));
+        let inputs: Vec<&Tensor> = profile_eager_op_section("nary_op.collect_inputs", || {
+            tensors.iter().map(|tensor| tensor.data.as_ref()).collect()
+        });
+        let output = profile_eager_op_section("nary_op.exec_single_output", || {
+            exec_single_output(&op, &inputs, &ctx)
+        })?;
+        let any_requires_grad = profile_eager_op_section("nary_op.requires_grad_scan", || {
+            tensors.iter().any(|tensor| tensor.requires_grad)
+        });
+        if !any_requires_grad {
+            let result = profile_eager_op_section("nary_op.new_untracked_result", || {
+                Self::new_untracked_result(ctx, output)
+            });
+            record_eager_op_profile("nary_op.total", total_started.elapsed());
+            maybe_print_eager_op_profile();
+            return Ok(result);
         }
 
         let output = Arc::new(output);
         let outputs = vec![Arc::clone(&output)];
-        let mut recorded = record_eager_outputs(&op, &outputs, tensors);
+        let mut recorded = profile_eager_op_section("nary_op.record_outputs", || {
+            record_eager_outputs(&op, &outputs, tensors)
+        });
         let trace = recorded.traces.pop().ok_or_else(|| {
             Error::Internal(format!("expected one eager trace for {:?}, got 0", op))
         })?;
@@ -734,13 +755,18 @@ impl<B: TensorBackend> EagerTensor<B> {
             }
         }
 
-        Ok(Self::new_result(
-            ctx,
-            trace.key,
-            output.as_ref().clone(),
-            trace.requires_grad,
-            trace.node,
-            metadata_scopes,
-        ))
+        let result = profile_eager_op_section("nary_op.new_tracked_result", || {
+            Self::new_result(
+                ctx,
+                trace.key,
+                output.as_ref().clone(),
+                trace.requires_grad,
+                trace.node,
+                metadata_scopes,
+            )
+        });
+        record_eager_op_profile("nary_op.total", total_started.elapsed());
+        maybe_print_eager_op_profile();
+        Ok(result)
     }
 }

--- a/tenferro/src/eager_tensor.rs
+++ b/tenferro/src/eager_tensor.rs
@@ -6,6 +6,7 @@
 use tenferro_tensor::TensorBackend;
 
 use crate::error::Result;
+use crate::EinsumSubscripts;
 
 pub use crate::eager::{EagerContext, EagerTensor};
 
@@ -37,4 +38,27 @@ pub fn einsum<B: TensorBackend>(
     subscripts: &str,
 ) -> Result<EagerTensor<B>> {
     crate::eager_einsum::einsum(inputs, subscripts)
+}
+
+/// Execute an einsum eagerly from integer labels and record it when any input requires gradients.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::eager_tensor::{einsum_subscripts, EagerContext, EagerTensor};
+/// use tenferro::{CpuBackend, EinsumSubscripts, Tensor};
+///
+/// let ctx = EagerContext::with_backend(CpuBackend::new());
+/// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
+/// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx);
+/// let subscripts = EinsumSubscripts::new(&[&[0], &[0]], &[]);
+/// let dot = einsum_subscripts(&[&a, &b], &subscripts).unwrap();
+///
+/// assert_eq!(dot.data().as_slice::<f64>().unwrap(), &[32.0]);
+/// ```
+pub fn einsum_subscripts<B: TensorBackend>(
+    inputs: &[&EagerTensor<B>],
+    subscripts: &EinsumSubscripts,
+) -> Result<EagerTensor<B>> {
+    crate::eager_einsum::einsum_subscripts(inputs, subscripts)
 }

--- a/tenferro/src/einsum.rs
+++ b/tenferro/src/einsum.rs
@@ -28,10 +28,11 @@ use computegraph::types::ValRef;
 use omeco::ScoreFunction;
 use tenferro_einsum::builder::build_einsum_fragment;
 use tenferro_einsum::{ContractionOptimizerOptions, ContractionTree, NestedEinsum, Subscripts};
-use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_ops::std_tensor_op::{EinsumSubscripts, StdTensorOp};
 use tenferro_tensor::TensorBackend;
 
 use super::checkpoint::CheckpointNode;
+use super::einsum_subscripts::{parse_einsum_subscripts, to_einsum_subscripts};
 use super::engine::{Engine, ParsedEinsum};
 use super::error::{Error, Result};
 use super::metadata::{metadata_scopes_with_new, register_scoped_fragment_metadata};
@@ -221,6 +222,31 @@ pub fn einsum<B: TensorBackend>(
     einsum_with(engine, inputs, subscripts, EinsumOptimize::default())
 }
 
+/// N-ary einsum using integer labels and the default contraction strategy.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::traced_tensor::einsum_subscripts;
+/// use tenferro::{CpuBackend, Engine, EinsumSubscripts, Tensor, TracedTensor};
+///
+/// let mut engine = Engine::new(CpuBackend::new());
+/// let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+/// let b = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]));
+/// let subscripts = EinsumSubscripts::new(&[&[0], &[0]], &[]);
+/// let mut dot = einsum_subscripts(&mut engine, &[&a, &b], &subscripts).unwrap();
+/// let result = dot.eval(&mut engine).unwrap();
+///
+/// assert_eq!(result.as_slice::<f64>().unwrap(), &[32.0]);
+/// ```
+pub fn einsum_subscripts<B: TensorBackend>(
+    engine: &mut Engine<B>,
+    inputs: &[&TracedTensor],
+    subscripts: &EinsumSubscripts,
+) -> Result<TracedTensor> {
+    einsum_subscripts_with(engine, inputs, subscripts, EinsumOptimize::default())
+}
+
 /// N-ary einsum with explicit contraction strategy.
 ///
 /// See [`EinsumOptimize`] for all available strategies and examples.
@@ -246,14 +272,46 @@ pub fn einsum_with<B: TensorBackend>(
     subscripts: &str,
     optimize: EinsumOptimize,
 ) -> Result<TracedTensor> {
+    let parsed = cached_subscripts(engine, subscripts)?;
+    einsum_subscripts_with(engine, inputs, &parsed.subscripts, optimize)
+}
+
+/// N-ary einsum with integer labels and explicit contraction strategy.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::traced_tensor::{einsum_subscripts_with, EinsumOptimize};
+/// use tenferro::{CpuBackend, Engine, EinsumSubscripts, Tensor, TracedTensor};
+///
+/// let mut engine = Engine::new(CpuBackend::new());
+/// let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]));
+/// let b = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]));
+/// let subscripts = EinsumSubscripts::new(&[&[0], &[0]], &[]);
+/// let mut dot = einsum_subscripts_with(
+///     &mut engine,
+///     &[&a, &b],
+///     &subscripts,
+///     EinsumOptimize::False,
+/// )
+/// .unwrap();
+/// let result = dot.eval(&mut engine).unwrap();
+///
+/// assert_eq!(result.as_slice::<f64>().unwrap(), &[32.0]);
+/// ```
+pub fn einsum_subscripts_with<B: TensorBackend>(
+    engine: &mut Engine<B>,
+    inputs: &[&TracedTensor],
+    subscripts: &EinsumSubscripts,
+    optimize: EinsumOptimize,
+) -> Result<TracedTensor> {
     if inputs.is_empty() {
         return Err(Error::ContractionError(
             "einsum requires at least one input tensor".into(),
         ));
     }
 
-    let parsed = cached_subscripts(engine, subscripts)?;
-    let subs = &parsed.subscripts;
+    let subs = to_einsum_subscripts(subscripts);
     if subs.inputs.len() != inputs.len() {
         return Err(Error::ContractionError(format!(
             "einsum subscripts expect {} inputs, got {}",
@@ -262,11 +320,7 @@ pub fn einsum_with<B: TensorBackend>(
         )));
     }
     if inputs.iter().any(|tensor| !has_concrete_shape(tensor)) {
-        return Ok(build_symbolic_nary_einsum(
-            inputs,
-            parsed.notation.as_ref(),
-            subs,
-        ));
+        return Ok(build_symbolic_nary_einsum(inputs, subscripts, &subs));
     }
     let shapes: Vec<Vec<usize>> = inputs.iter().map(|t| concrete_shape(t)).collect();
     let shape_refs: Vec<&[usize]> = shapes.iter().map(|s| s.as_slice()).collect();
@@ -274,7 +328,7 @@ pub fn einsum_with<B: TensorBackend>(
     match optimize {
         // Reuse TreeSA results for repeated calls with the same equation and input shapes.
         EinsumOptimize::Auto(opts) => {
-            let cache_key = (Arc::clone(&parsed.notation), shapes.clone());
+            let cache_key = (subscripts.clone(), shapes.clone());
             let tree = if let Some(cached) = engine.einsum_cache.get(&cache_key) {
                 cached.clone()
             } else {
@@ -309,12 +363,8 @@ fn cached_subscripts<B: TensorBackend>(
         return Ok(Arc::clone(cached));
     }
 
-    let parsed =
-        Subscripts::parse(subscripts).map_err(|e| Error::InvalidSubscripts(format!("{e}")))?;
-    let cached = Arc::new(ParsedEinsum {
-        notation: Arc::<str>::from(subscripts),
-        subscripts: parsed,
-    });
+    let parsed = parse_einsum_subscripts(subscripts)?;
+    let cached = Arc::new(ParsedEinsum { subscripts: parsed });
     engine
         .einsum_parse_cache
         .put(subscripts.to_owned(), Arc::clone(&cached));
@@ -323,7 +373,7 @@ fn cached_subscripts<B: TensorBackend>(
 
 fn build_symbolic_nary_einsum(
     inputs: &[&TracedTensor],
-    subscripts: &str,
+    subscripts: &EinsumSubscripts,
     parsed: &Subscripts,
 ) -> TracedTensor {
     let mut builder = FragmentBuilder::new();
@@ -347,7 +397,7 @@ fn build_symbolic_nary_einsum(
 
     let outputs = builder.add_op(
         StdTensorOp::NaryEinsum {
-            subscripts: subscripts.to_string(),
+            subscripts: subscripts.clone(),
         },
         input_vals,
         computegraph::types::OpMode::Primal,

--- a/tenferro/src/einsum_subscripts.rs
+++ b/tenferro/src/einsum_subscripts.rs
@@ -1,0 +1,32 @@
+use tenferro_einsum::Subscripts;
+use tenferro_ops::std_tensor_op::EinsumSubscripts;
+
+use crate::error::{Error, Result};
+
+/// Parse string einsum notation into tenferro's canonical integer labels.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::parse_einsum_subscripts;
+///
+/// let subscripts = parse_einsum_subscripts("ij,jk->ik").unwrap();
+///
+/// assert_eq!(subscripts.inputs.len(), 2);
+/// assert_eq!(subscripts.output, vec![b'i' as u32, b'k' as u32]);
+/// ```
+pub fn parse_einsum_subscripts(notation: &str) -> Result<EinsumSubscripts> {
+    let parsed =
+        Subscripts::parse(notation).map_err(|err| Error::InvalidSubscripts(format!("{err}")))?;
+    Ok(EinsumSubscripts {
+        inputs: parsed.inputs,
+        output: parsed.output,
+    })
+}
+
+pub(crate) fn to_einsum_subscripts(subscripts: &EinsumSubscripts) -> Subscripts {
+    Subscripts {
+        inputs: subscripts.inputs.clone(),
+        output: subscripts.output.clone(),
+    }
+}

--- a/tenferro/src/engine.rs
+++ b/tenferro/src/engine.rs
@@ -6,16 +6,16 @@ use lru::LruCache;
 
 use super::exec::ExecProgram;
 use tenferro_einsum::{ContractionTree, Subscripts};
+use tenferro_ops::std_tensor_op::EinsumSubscripts;
 use tenferro_tensor::{buffer_pool::BufferPoolStats, cpu::CpuBackend, Tensor, TensorBackend};
 
 /// Parsed einsum notation retained separately from shape-specific plans.
 pub(crate) struct ParsedEinsum {
-    pub(crate) notation: Arc<str>,
-    pub(crate) subscripts: Subscripts,
+    pub(crate) subscripts: EinsumSubscripts,
 }
 
-/// Key used for the N-ary einsum cache: `(interned_subscripts, shapes)`.
-pub(crate) type EinsumCacheKey = (Arc<str>, Vec<Vec<usize>>);
+/// Key used for the N-ary einsum cache: `(integer_subscripts, shapes)`.
+pub(crate) type EinsumCacheKey = (EinsumSubscripts, Vec<Vec<usize>>);
 
 /// LRU cache of optimized contraction trees keyed by einsum subscripts + input shapes.
 pub(crate) type NaryEinsumCache = LruCache<EinsumCacheKey, Arc<ContractionTree>>;
@@ -207,8 +207,22 @@ impl<B: TensorBackend> Engine<B> {
     /// assert!(!engine.einsum_cache_contains(&key));
     /// ```
     pub fn einsum_cache_contains(&self, key: &(String, Vec<Vec<usize>>)) -> bool {
-        let key = (Arc::<str>::from(key.0.as_str()), key.1.clone());
+        let subscripts = Subscripts::parse(&key.0)
+            .map(|subscripts| EinsumSubscripts {
+                inputs: subscripts.inputs,
+                output: subscripts.output,
+            })
+            .expect("invalid einsum_cache_contains key");
+        let key = (subscripts, key.1.clone());
         self.einsum_cache.contains(&key)
+    }
+
+    /// Returns `true` if the einsum cache contains a tree for integer labels.
+    pub fn einsum_cache_contains_subscripts(
+        &self,
+        key: &(EinsumSubscripts, Vec<Vec<usize>>),
+    ) -> bool {
+        self.einsum_cache.contains(key)
     }
 
     /// Look up a cached ExecProgram, or cache and return the given one.

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -11,7 +11,7 @@ use computegraph::types::{GlobalValKey, ValRef};
 use num_complex::{Complex32, Complex64};
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::input_key::TensorInputKey;
-use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_ops::std_tensor_op::{EinsumSubscripts, StdTensorOp};
 use tenferro_ops::{dim_expr::DimExpr, ShapeExtent};
 use tenferro_tensor::validate::validate_nonsingular_u;
 use tenferro_tensor::Error as TensorError;
@@ -48,7 +48,7 @@ pub enum ExecOp {
         rhs_conj: bool,
     },
     NaryEinsum {
-        subscripts: String,
+        subscripts: EinsumSubscripts,
     },
     ReduceSum {
         axes: Vec<usize>,
@@ -944,13 +944,11 @@ fn collect_tensor_refs<'a>(
 fn execute_nary_einsum<B: TensorBackend>(
     backend: &mut B,
     inputs: &[&Tensor],
-    subscripts: &str,
+    subscripts: &EinsumSubscripts,
     mode: DispatchMode,
     cache: &mut NaryEinsumCache,
 ) -> Result<Tensor> {
-    use tenferro_einsum::{
-        build_einsum_fragment, ContractionOptimizerOptions, ContractionTree, Subscripts,
-    };
+    use tenferro_einsum::{build_einsum_fragment, ContractionOptimizerOptions, ContractionTree};
 
     if inputs.is_empty() {
         return Err(Error::ContractionError(
@@ -958,14 +956,13 @@ fn execute_nary_einsum<B: TensorBackend>(
         ));
     }
 
-    let subs =
-        Subscripts::parse(subscripts).map_err(|e| Error::InvalidSubscripts(format!("{e}")))?;
+    let subs = crate::einsum_subscripts::to_einsum_subscripts(subscripts);
     let shapes: Vec<Vec<usize>> = inputs
         .iter()
         .map(|tensor| tensor.shape().to_vec())
         .collect();
     let shape_refs: Vec<&[usize]> = shapes.iter().map(Vec::as_slice).collect();
-    let cache_key = (Arc::<str>::from(subscripts), shapes.clone());
+    let cache_key = (subscripts.clone(), shapes.clone());
     let tree_arc = if let Some(cached) = cache.get(&cache_key) {
         cached.clone()
     } else {
@@ -1018,7 +1015,7 @@ fn execute_nary_einsum<B: TensorBackend>(
                 let input_idx = *id as usize;
                 let tensor = inputs.get(input_idx).ok_or_else(|| {
                     Error::Internal(format!(
-                        "runtime nary einsum input {input_idx} missing for subscripts {subscripts}"
+                        "runtime nary einsum input {input_idx} missing for subscripts {subscripts:?}"
                     ))
                 })?;
                 program_inputs.push((*tensor).clone());

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -28,6 +28,7 @@ pub(crate) mod eager_ops_elementwise;
 pub(crate) mod eager_ops_linalg;
 pub mod eager_tensor;
 mod einsum;
+mod einsum_subscripts;
 pub mod engine;
 pub mod error;
 pub mod exec;
@@ -45,11 +46,16 @@ pub mod traced_tensor;
 pub mod typed_tensor;
 
 pub use eager::{EagerContext, EagerTensor};
+pub use einsum_subscripts::parse_einsum_subscripts;
 pub use engine::Engine;
 pub use error::ContextId;
 pub use sym_dim::SymDim;
+pub use tenferro_ops::std_tensor_op::EinsumSubscripts;
 pub use tenferro_tensor::cpu::CpuBackend;
-pub use tenferro_tensor::{DType, Tensor, TensorBackend, TensorScalar, TypedTensor};
+pub use tenferro_tensor::{
+    DType, Tensor, TensorBackend, TensorRead, TensorScalar, TensorView, TypedTensor,
+    TypedTensorView,
+};
 pub use traced::TracedTensor;
 
 #[cfg(feature = "cubecl")]

--- a/tenferro/src/shape_infer.rs
+++ b/tenferro/src/shape_infer.rs
@@ -5,10 +5,9 @@
 
 use std::collections::HashMap;
 
-use tenferro_einsum::Subscripts;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::ext_op::ExtensionOp;
-use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_ops::std_tensor_op::{EinsumSubscripts, StdTensorOp};
 use tenferro_ops::sym_dim::SymDim;
 use tenferro_ops::ShapeExtent;
 use tenferro_tensor::{DType, DotGeneralConfig, GatherConfig, PadConfig, SliceConfig};
@@ -777,19 +776,17 @@ fn concatenate_shape(input_shapes: &[&[DimExpr]], axis: usize) -> Vec<DimExpr> {
     output_shape
 }
 
-fn einsum_output_shape(subscripts: &str, input_shapes: &[&[DimExpr]]) -> Vec<DimExpr> {
-    let parsed = Subscripts::parse(subscripts)
-        .unwrap_or_else(|err| panic!("invalid einsum subscripts {subscripts:?}: {err}"));
+fn einsum_output_shape(subscripts: &EinsumSubscripts, input_shapes: &[&[DimExpr]]) -> Vec<DimExpr> {
     assert_eq!(
-        parsed.inputs.len(),
+        subscripts.inputs.len(),
         input_shapes.len(),
         "einsum subscripts expect {} inputs, got {}",
-        parsed.inputs.len(),
+        subscripts.inputs.len(),
         input_shapes.len()
     );
 
     let mut label_dims: HashMap<u32, DimExpr> = HashMap::new();
-    for (labels, shape) in parsed.inputs.iter().zip(input_shapes.iter()) {
+    for (labels, shape) in subscripts.inputs.iter().zip(input_shapes.iter()) {
         assert_eq!(
             labels.len(),
             shape.len(),
@@ -811,7 +808,7 @@ fn einsum_output_shape(subscripts: &str, input_shapes: &[&[DimExpr]]) -> Vec<Dim
         }
     }
 
-    parsed
+    subscripts
         .output
         .iter()
         .map(|label| {

--- a/tenferro/src/tensor.rs
+++ b/tenferro/src/tensor.rs
@@ -6,6 +6,9 @@
 pub use tenferro_tensor::Tensor;
 use tenferro_tensor::{Result, TensorBackend};
 
+use crate::einsum_subscripts::to_einsum_subscripts;
+use crate::EinsumSubscripts;
+
 /// Execute an einsum immediately on borrowed concrete tensors.
 ///
 /// # Examples
@@ -29,6 +32,30 @@ pub fn einsum(
     tenferro_einsum::eager_einsum(ctx, inputs, subscripts)
 }
 
+/// Execute an einsum immediately on borrowed concrete tensors using integer labels.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::tensor::einsum_subscripts;
+/// use tenferro::{CpuBackend, EinsumSubscripts, Tensor};
+///
+/// let mut backend = CpuBackend::new();
+/// let a = Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]);
+/// let b = Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]);
+/// let subscripts = EinsumSubscripts::new(&[&[0], &[0]], &[]);
+/// let dot = einsum_subscripts(&mut backend, &[&a, &b], &subscripts).unwrap();
+///
+/// assert_eq!(dot.as_slice::<f64>().unwrap(), &[32.0]);
+/// ```
+pub fn einsum_subscripts(
+    ctx: &mut impl TensorBackend,
+    inputs: &[&Tensor],
+    subscripts: &EinsumSubscripts,
+) -> Result<Tensor> {
+    tenferro_einsum::eager_einsum_subscripts(ctx, inputs, &to_einsum_subscripts(subscripts))
+}
+
 /// Execute an einsum immediately, allowing owned inputs to be consumed.
 ///
 /// # Examples
@@ -50,4 +77,28 @@ pub fn einsum_owned(
     subscripts: &str,
 ) -> Result<Tensor> {
     tenferro_einsum::eager_einsum_owned(ctx, inputs, subscripts)
+}
+
+/// Execute an einsum immediately, consuming concrete tensors, using integer labels.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::tensor::einsum_owned_subscripts;
+/// use tenferro::{CpuBackend, EinsumSubscripts, Tensor};
+///
+/// let mut backend = CpuBackend::new();
+/// let a = Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]);
+/// let b = Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]);
+/// let subscripts = EinsumSubscripts::new(&[&[0], &[0]], &[]);
+/// let dot = einsum_owned_subscripts(&mut backend, vec![a, b], &subscripts).unwrap();
+///
+/// assert_eq!(dot.as_slice::<f64>().unwrap(), &[32.0]);
+/// ```
+pub fn einsum_owned_subscripts(
+    ctx: &mut impl TensorBackend,
+    inputs: Vec<Tensor>,
+    subscripts: &EinsumSubscripts,
+) -> Result<Tensor> {
+    tenferro_einsum::eager_einsum_owned_subscripts(ctx, inputs, &to_einsum_subscripts(subscripts))
 }

--- a/tenferro/src/traced_tensor.rs
+++ b/tenferro/src/traced_tensor.rs
@@ -6,7 +6,9 @@
 
 use crate::DotGeneralConfig;
 
-pub use crate::einsum::{einsum, einsum_with, EinsumOptimize};
+pub use crate::einsum::{
+    einsum, einsum_subscripts, einsum_subscripts_with, einsum_with, EinsumOptimize,
+};
 pub use crate::linalg_api::{
     cholesky, convert, det, eig, eigh, eigh_with_eps, eigvals, eigvalsh, full_piv_lu,
     full_piv_lu_solve, inv, lu, norm, pinv, pinv_with_rtol, qr, slogdet, solve, svd, svd_with_eps,

--- a/tenferro/src/typed_tensor.rs
+++ b/tenferro/src/typed_tensor.rs
@@ -6,6 +6,9 @@
 pub use tenferro_tensor::TypedTensor;
 use tenferro_tensor::{Result, TensorBackend, TensorScalar};
 
+use crate::einsum_subscripts::to_einsum_subscripts;
+use crate::EinsumSubscripts;
+
 /// Execute an einsum immediately on borrowed typed tensors.
 ///
 /// # Examples
@@ -28,4 +31,41 @@ pub fn einsum<T: TensorScalar>(
     subscripts: &str,
 ) -> Result<TypedTensor<T>> {
     tenferro_einsum::typed_eager_einsum(ctx, inputs, subscripts)
+}
+
+/// Execute an einsum immediately on borrowed typed tensors using integer labels.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::typed_tensor::{einsum_subscripts, TypedTensor};
+/// use tenferro::{CpuBackend, EinsumSubscripts};
+///
+/// let mut backend = CpuBackend::new();
+/// let a = TypedTensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]);
+/// let b = TypedTensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]);
+/// let subscripts = EinsumSubscripts::new(&[&[0], &[0]], &[]);
+/// let dot = einsum_subscripts(&mut backend, &[&a, &b], &subscripts).unwrap();
+///
+/// assert!(dot.shape.is_empty());
+/// assert_eq!(dot.host_data(), &[32.0]);
+/// ```
+pub fn einsum_subscripts<T: TensorScalar>(
+    ctx: &mut impl TensorBackend,
+    inputs: &[&TypedTensor<T>],
+    subscripts: &EinsumSubscripts,
+) -> Result<TypedTensor<T>> {
+    let parsed = to_einsum_subscripts(subscripts);
+    let tensors: Vec<tenferro_tensor::Tensor> = inputs
+        .iter()
+        .map(|tensor| T::into_tensor(tensor.shape.clone(), tensor.host_data().to_vec()))
+        .collect();
+    let refs: Vec<&tenferro_tensor::Tensor> = tensors.iter().collect();
+    let result = tenferro_einsum::eager_einsum_subscripts(ctx, &refs, &parsed)?;
+    let actual = result.dtype();
+    T::try_into_typed(result).ok_or_else(|| tenferro_tensor::Error::DTypeMismatch {
+        op: "typed_eager_einsum",
+        lhs: actual,
+        rhs: T::dtype(),
+    })
 }

--- a/tenferro/tests/compiler_wiring.rs
+++ b/tenferro/tests/compiler_wiring.rs
@@ -2,6 +2,7 @@ use computegraph::compile::{CompiledProgram, Instruction};
 use num_complex::Complex64;
 use tenferro::compiler::compile_std_to_exec;
 use tenferro::exec::ExecOp;
+use tenferro::parse_einsum_subscripts;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeExtent;
@@ -123,7 +124,7 @@ fn compile_std_to_exec_wires_nary_einsum_with_shape_and_dtype() {
     let program = CompiledProgram {
         instructions: vec![make_instr(
             StdTensorOp::NaryEinsum {
-                subscripts: "ij,jk->ik".into(),
+                subscripts: parse_einsum_subscripts("ij,jk->ik").unwrap(),
             },
             vec![0, 1],
             vec![2],
@@ -141,7 +142,8 @@ fn compile_std_to_exec_wires_nary_einsum_with_shape_and_dtype() {
 
     assert!(matches!(
         exec.instructions[0].op,
-        ExecOp::NaryEinsum { ref subscripts } if subscripts == "ij,jk->ik"
+        ExecOp::NaryEinsum { ref subscripts }
+            if subscripts == &parse_einsum_subscripts("ij,jk->ik").unwrap()
     ));
     assert_eq!(exec.instructions[0].dtype, DType::F32);
     assert_eq!(exec.instructions[0].output_shapes, vec![dim_shape(&[2, 4])]);

--- a/tenferro/tests/eager_tensor_einsum.rs
+++ b/tenferro/tests/eager_tensor_einsum.rs
@@ -1,13 +1,17 @@
 use std::sync::Arc;
 
-use tenferro::eager_tensor::einsum;
-use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
+use tenferro::eager_tensor::{einsum, einsum_subscripts};
+use tenferro::{CpuBackend, EagerContext, EagerTensor, EinsumSubscripts, Tensor};
 
 fn f64_data(tensor: &Tensor) -> &[f64] {
     tensor.as_slice::<f64>().unwrap()
 }
 
 fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
+    unsafe {
+        std::env::set_var("TENFERRO_PROFILE_EAGER_OP_AGG", "1");
+        std::env::set_var("TENFERRO_PROFILE_EAGER_OP_PRINT_EVERY", "1");
+    }
     EagerContext::with_backend(CpuBackend::new())
 }
 
@@ -24,6 +28,25 @@ fn eager_tensor_einsum_matmul_primal_matches_expected_values() {
     );
 
     let c = einsum(&[&a, &b], "ij,jk->ik").unwrap();
+
+    assert_eq!(c.data().shape(), &[2, 2]);
+    assert_eq!(f64_data(c.data()), &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn eager_tensor_einsum_integer_subscripts_match_string_path() {
+    let ctx = test_ctx();
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
+    let subscripts = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+
+    let c = einsum_subscripts(&[&a, &b], &subscripts).unwrap();
 
     assert_eq!(c.data().shape(), &[2, 2]);
     assert_eq!(f64_data(c.data()), &[22.0, 28.0, 49.0, 64.0]);

--- a/tenferro/tests/exec_dispatch.rs
+++ b/tenferro/tests/exec_dispatch.rs
@@ -1,6 +1,7 @@
 use num_complex::Complex64;
 use tenferro::error::Error;
 use tenferro::exec::{eval_exec_ir, ExecInstruction, ExecOp, ExecProgram};
+use tenferro::parse_einsum_subscripts;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::ShapeExtent;
 use tenferro_tensor::cpu::CpuBackend;
@@ -521,7 +522,7 @@ fn eval_exec_ir_executes_nary_einsum_via_nested_program() {
     let mut backend = CpuBackend::new();
     let program = single_instruction_program(
         ExecOp::NaryEinsum {
-            subscripts: "ij,jk->ik".into(),
+            subscripts: parse_einsum_subscripts("ij,jk->ik").unwrap(),
         },
         2,
     );

--- a/tenferro/tests/segment_tests.rs
+++ b/tenferro/tests/segment_tests.rs
@@ -352,7 +352,7 @@ fn gpu_nary_einsum_program() -> ExecProgram {
     ExecProgram {
         instructions: vec![ExecInstruction {
             op: ExecOp::NaryEinsum {
-                subscripts: "ij,jk->ik".into(),
+                subscripts: tenferro::parse_einsum_subscripts("ij,jk->ik").unwrap(),
             },
             input_slots: vec![0, 1],
             output_slots: vec![2],

--- a/tenferro/tests/shape_inference.rs
+++ b/tenferro/tests/shape_inference.rs
@@ -1,3 +1,4 @@
+use tenferro::parse_einsum_subscripts;
 use tenferro::shape_infer::{infer_output_extents, infer_output_shapes};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -269,7 +270,7 @@ fn test_structural_indexing_and_dynamic_shapes() {
     );
 
     let einsum = StdTensorOp::NaryEinsum {
-        subscripts: "ij,jk->ik".into(),
+        subscripts: parse_einsum_subscripts("ij,jk->ik").unwrap(),
     };
     let lhs = vec![cst(3), cst(4)];
     let rhs = vec![cst(4), cst(6)];

--- a/tenferro/tests/tensor_einsum.rs
+++ b/tenferro/tests/tensor_einsum.rs
@@ -1,6 +1,8 @@
-use tenferro::tensor::{einsum, einsum_owned};
-use tenferro::typed_tensor::{einsum as typed_einsum, TypedTensor};
-use tenferro::{CpuBackend, Tensor};
+use tenferro::tensor::{einsum, einsum_owned, einsum_owned_subscripts, einsum_subscripts};
+use tenferro::typed_tensor::{
+    einsum as typed_einsum, einsum_subscripts as typed_einsum_subscripts, TypedTensor,
+};
+use tenferro::{CpuBackend, EinsumSubscripts, Tensor};
 
 #[test]
 fn tensor_einsum_owned_matches_borrowed() {
@@ -25,6 +27,39 @@ fn typed_tensor_einsum_facade_matches_tensor_values() {
     let mut backend = CpuBackend::new();
 
     let out = typed_einsum(&mut backend, &[&lhs, &rhs], "ij,jk->ik").unwrap();
+
+    assert_eq!(out.shape, vec![2, 2]);
+    assert_eq!(out.host_data(), &[23.0, 34.0, 31.0, 46.0]);
+}
+
+#[test]
+fn tensor_einsum_integer_subscripts_match_string_paths() {
+    let a = Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let b = Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let subscripts = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+
+    let mut borrowed_ctx = CpuBackend::new();
+    let borrowed = einsum_subscripts(&mut borrowed_ctx, &[&a, &b], &subscripts).unwrap();
+
+    let mut owned_ctx = CpuBackend::new();
+    let owned = einsum_owned_subscripts(&mut owned_ctx, vec![a, b], &subscripts).unwrap();
+
+    assert_eq!(borrowed.shape(), &[2, 2]);
+    assert_eq!(
+        borrowed.as_slice::<f64>().unwrap(),
+        &[22.0, 28.0, 49.0, 64.0]
+    );
+    assert_eq!(owned.as_slice::<f64>(), borrowed.as_slice::<f64>());
+}
+
+#[test]
+fn typed_tensor_einsum_integer_subscripts_match_string_path() {
+    let lhs = TypedTensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let rhs = TypedTensor::from_vec(vec![2, 2], vec![5.0_f64, 6.0, 7.0, 8.0]);
+    let subscripts = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+    let mut backend = CpuBackend::new();
+
+    let out = typed_einsum_subscripts(&mut backend, &[&lhs, &rhs], &subscripts).unwrap();
 
     assert_eq!(out.shape, vec![2, 2]);
     assert_eq!(out.host_data(), &[23.0, 34.0, 31.0, 46.0]);


### PR DESCRIPTION
## Summary

- Add a canonical integer-label `EinsumSubscripts` representation for traced/eager/concrete einsum paths, with string APIs kept as parsing wrappers.
- Thread integer subscripts through execution, shape inference, AD, and tensor4all-facing eager/concrete APIs to avoid reparsing string labels on internal paths.
- Add cached `dot_general_with_conj` execution paths and a `dot_general_overhead` benchmark to characterize repeated small contraction overhead.
- Document the current small-contraction bottleneck and the repository rule that public APIs should be intentionally small.

## Motivation

tensor4all needs a cleaner, lower-overhead contraction path that can pass structural labels directly into tenferro. This PR makes the integer-label API the graph/runtime representation and records the performance finding that repeated small contractions are dominated by per-op backend session/context dispatch, not by contraction planning metadata.

## Validation

- `cargo fmt --all --check`
- `cargo test --release -q -p tenferro-tensor -p tenferro-einsum -p tenferro-ops -p tenferro`
