### PR TITLE
[codex] Erase eager backend type parameter

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -15,7 +15,7 @@ Choose the simplest layer that meets your needs:
 
 - **Compile-time dtype safety** -> `TypedTensor<T>` + a backend such as `CpuBackend`
 - **No AD needed** -> `Tensor` + a backend
-- **PyTorch-style scalar-loss backward** -> `EagerTensor<B>` + `EagerContext<B>`
+- **PyTorch-style scalar-loss backward** -> `EagerTensor` + `EagerContext`
 - **Transform AD or graph reuse** -> `TracedTensor` + `Engine<B>`
 
 ## TypedTensor<T>: statically typed storage
@@ -100,7 +100,7 @@ Input data -> TracedTensor -> operations -> .eval(&mut engine) -> Tensor result
 | Library | Mental model | tenferro equivalent |
 |---|---|---|
 | NumPy | Eager, no AD | `Tensor` + a backend |
-| PyTorch (eager) | Eager with autograd | `EagerTensor<B>` + `EagerContext<B>` |
+| PyTorch (eager) | Eager with autograd | `EagerTensor` + `EagerContext` |
 | JAX (`jit`) | Staged/lazy computation | `TracedTensor` + `Engine<B>` |
 
 ## Minimal examples

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -6,7 +6,7 @@ Use the simplest tensor layer that matches the workflow.
 | --- | --- |
 | Direct concrete computation on a selected backend | `Tensor` + a `TensorBackend` |
 | Compile-time scalar type while still owning dense data | `TypedTensor<T>` |
-| PyTorch-style scalar-loss `backward()` | `EagerTensor<B>` + `EagerContext<B>` |
+| PyTorch-style scalar-loss `backward()` | `EagerTensor` + `EagerContext` |
 | `grad`, `vjp`, `jvp`, HVP, graph optimization | `TracedTensor` + `Engine<B>` |
 | Tensor operation not built into tenferro | an extension crate; see [Custom Tensor Operations](custom-operations.md) |
 
@@ -18,9 +18,9 @@ graph reuse.
 
 `Tensor` and `TypedTensor<T>` are concrete data containers. They represent CPU
 data by default, and under the `cuda` feature they can also represent
-explicitly uploaded CUDA-resident data. `EagerTensor<B>` keeps PyTorch-style
-gradient state for immediate workflows on a backend `B`. `TracedTensor` builds
-a lazy expression graph that an `Engine<B>` can evaluate and reuse.
+explicitly uploaded CUDA-resident data. `EagerTensor` keeps PyTorch-style
+gradient state for immediate workflows inside an `EagerContext`. `TracedTensor`
+builds a lazy expression graph that an `Engine<B>` can evaluate and reuse.
 
 Across concrete, eager, and traced workflows, use `stack(..., -1)` to create a
 trailing batch axis and `index_select(-1, positions)` to align entries along

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -171,7 +171,7 @@ explicitly when you want a fresh pass.
 ```rust
 use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 
-let ctx = EagerContext::with_backend(CpuBackend::new());
+let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
 let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
 let y = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
 
@@ -204,4 +204,4 @@ assert!(y.grad().is_none());
 | Exploratory computation | Eager |
 | Need scalar-loss reverse-mode gradients | Eager (`EagerTensor::backward()`) |
 | Need transform AD (`grad` / `vjp` / `jvp` / HVP) | Lazy traced (`TracedTensor` + `Engine<B>`) |
-| CUDA execution for supported operations | Eager (`Tensor` / `EagerTensor<B>`) or lazy traced (`TracedTensor` + `Engine<B>`) with explicit upload/download |
+| CUDA execution for supported operations | Eager (`Tensor` / `EagerTensor`) or lazy traced (`TracedTensor` + `Engine<B>`) with explicit upload/download |

--- a/tenferro/README.md
+++ b/tenferro/README.md
@@ -30,9 +30,10 @@ einsum helpers, and public multi-output linalg helpers.
 ## Eager Example
 
 ```rust
-use tenferro::{EagerTensor, Tensor};
+use tenferro::{EagerContext, Tensor};
 
-let x = EagerTensor::requires_grad(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+let ctx = EagerContext::new();
+let x = ctx.variable_from(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
 let loss = (&x * &x).reduce_sum(&[0]).unwrap();
 loss.backward().unwrap();
 

--- a/tenferro/benches/mps_inner_product_eager.rs
+++ b/tenferro/benches/mps_inner_product_eager.rs
@@ -78,10 +78,7 @@ fn build_mps_fixture(sites: usize, phys_dim: usize, bond_dim: usize) -> MpsFixtu
     }
 }
 
-fn eager_mps_tensors(
-    ctx: &Arc<EagerContext<CpuBackend>>,
-    tensors: &[Tensor],
-) -> Vec<EagerTensor<CpuBackend>> {
+fn eager_mps_tensors(ctx: &Arc<EagerContext>, tensors: &[Tensor]) -> Vec<EagerTensor> {
     tensors
         .iter()
         .cloned()
@@ -90,11 +87,11 @@ fn eager_mps_tensors(
 }
 
 fn eager_inner_product_local_path(
-    ctx: &Arc<EagerContext<CpuBackend>>,
-    bra: &[EagerTensor<CpuBackend>],
-    ket: &[EagerTensor<CpuBackend>],
+    ctx: &Arc<EagerContext>,
+    bra: &[EagerTensor],
+    ket: &[EagerTensor],
     configs: &LocalPathConfigs,
-) -> EagerTensor<CpuBackend> {
+) -> EagerTensor {
     let mut env = EagerTensor::from_tensor_in(
         Tensor::from_vec(vec![1, 1], vec![Complex64::new(1.0, 0.0)]),
         ctx.clone(),
@@ -117,7 +114,7 @@ fn bench_mps_inner_product_eager(c: &mut Criterion) {
     let mut group = c.benchmark_group("mps_inner_product_eager/c64/one_thread");
     for &chi in CHIS {
         let fixture = build_mps_fixture(L, PHYS_DIM, chi);
-        let ctx = EagerContext::with_backend(CpuBackend::with_threads(1));
+        let ctx = EagerContext::with_cpu_backend(CpuBackend::with_threads(1));
         let bra = eager_mps_tensors(&ctx, &fixture.bra_tensors);
         let ket = eager_mps_tensors(&ctx, &fixture.ket_tensors);
         let configs = LocalPathConfigs::new();

--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -11,12 +11,15 @@ use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_tensor::cpu::CpuBackend;
+#[cfg(feature = "cubecl")]
+use tenferro_tensor::cubecl::CubeclBackend;
 use tenferro_tensor::{Tensor, TensorBackend, TypedTensor};
 use tidu::{
     topo_sort_grad_dag, try_backward_dag, BackwardCallbacks, EagerOutput, EagerValue, GradNode,
     LinearFragment,
 };
 
+use crate::eager_backend::EagerBackend;
 use crate::eager_emitter::EagerEmitter;
 use crate::eager_exec::exec_op_on_tensors;
 use crate::error::{ContextId, Error, Result};
@@ -125,38 +128,68 @@ pub(crate) fn print_and_reset_eager_op_profile() {
 /// ```
 /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 ///
-/// let ctx = EagerContext::with_backend(CpuBackend::new());
+/// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
 /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx.clone());
 /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![2.0_f64]), ctx);
 /// let z = &x + &y;
 ///
 /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[3.0]);
 /// ```
-pub struct EagerContext<B: TensorBackend> {
-    pub(crate) backend: Mutex<B>,
+pub struct EagerContext {
+    pub(crate) backend: Mutex<EagerBackend>,
     grad_slots: Mutex<HashMap<GlobalValKey<StdTensorOp>, WeakGradSlot>>,
 }
 
-impl<B: TensorBackend> EagerContext<B> {
-    fn new(backend: B) -> Self {
+impl EagerContext {
+    fn from_backend(backend: EagerBackend) -> Self {
         Self {
             backend: Mutex::new(backend),
             grad_slots: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Create a shared eager execution context for the provided backend.
+    /// Create a shared CPU eager execution context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::EagerContext;
+    ///
+    /// let ctx = EagerContext::new();
+    /// assert_eq!(std::sync::Arc::strong_count(&ctx), 1);
+    /// ```
+    pub fn new() -> Arc<Self> {
+        Self::with_cpu_backend(CpuBackend::new())
+    }
+
+    /// Create a shared eager execution context from a configured CPU backend.
     ///
     /// # Examples
     ///
     /// ```
     /// use tenferro::{CpuBackend, EagerContext};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::with_threads(1));
     /// assert_eq!(std::sync::Arc::strong_count(&ctx), 1);
     /// ```
-    pub fn with_backend(backend: B) -> Arc<Self> {
-        Arc::new(Self::new(backend))
+    pub fn with_cpu_backend(backend: CpuBackend) -> Arc<Self> {
+        Arc::new(Self::from_backend(EagerBackend::cpu(backend)))
+    }
+
+    /// Create a shared eager execution context from a configured CUDA backend.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::cuda::CudaBackend;
+    /// use tenferro::EagerContext;
+    ///
+    /// let _ctor: fn(CudaBackend) -> std::sync::Arc<EagerContext> =
+    ///     EagerContext::with_cuda_backend;
+    /// ```
+    #[cfg(feature = "cubecl")]
+    pub fn with_cuda_backend(backend: CubeclBackend) -> Arc<Self> {
+        Arc::new(Self::from_backend(EagerBackend::cuda(backend)))
     }
 
     /// Return an opaque identifier for this context.
@@ -166,8 +199,8 @@ impl<B: TensorBackend> EagerContext<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
-    /// assert_ne!(ctx.id(), EagerContext::with_backend(CpuBackend::new()).id());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
+    /// assert_ne!(ctx.id(), EagerContext::with_cpu_backend(CpuBackend::new()).id());
     /// ```
     pub fn id(&self) -> ContextId {
         ContextId::from_ptr(self)
@@ -190,7 +223,7 @@ impl<B: TensorBackend> EagerContext<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
     /// let y = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx.clone());
     /// let loss = (&x * &y).reduce_sum(&[0]).unwrap();
@@ -223,14 +256,14 @@ impl<B: TensorBackend> EagerContext<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let c = ctx.constant_from(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx);
     /// let z = x.add(&c).unwrap();
     ///
     /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[4.0, 6.0]);
     /// ```
-    pub fn constant_from(self: &Arc<Self>, tensor: Tensor) -> EagerTensor<B> {
+    pub fn constant_from(self: &Arc<Self>, tensor: Tensor) -> EagerTensor {
         EagerTensor::new_leaf(Arc::clone(self), tensor, false)
     }
 
@@ -244,7 +277,7 @@ impl<B: TensorBackend> EagerContext<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let p = ctx.variable_from(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
     /// let loss = p.exp().unwrap().reduce_sum(&[0]).unwrap();
     /// let _ = loss.backward().unwrap();
@@ -252,14 +285,14 @@ impl<B: TensorBackend> EagerContext<B> {
     /// let grad = p.grad().unwrap();
     /// assert_eq!(grad.shape(), &[2]);
     /// ```
-    pub fn variable_from(self: &Arc<Self>, tensor: Tensor) -> EagerTensor<B> {
+    pub fn variable_from(self: &Arc<Self>, tensor: Tensor) -> EagerTensor {
         EagerTensor::new_leaf(Arc::clone(self), tensor, true)
     }
 
     fn store_grads(
         &self,
         cotangents: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
-        backend: &mut B,
+        backend: &mut EagerBackend,
     ) -> Result<()> {
         let mut updates = Vec::new();
         let mut staged = Vec::new();
@@ -309,7 +342,7 @@ impl<B: TensorBackend> EagerContext<B> {
 /// ```
 /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 ///
-/// let ctx = EagerContext::with_backend(CpuBackend::new());
+/// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
 /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx);
 /// let loss = (&x * &x).reduce_sum(&[0]).unwrap();
 /// let _cotangents = loss.backward().unwrap();
@@ -322,41 +355,41 @@ impl<B: TensorBackend> EagerContext<B> {
 /// assert!(x.grad().is_none());
 /// ```
 #[derive(Clone)]
-pub struct EagerTensor<B: TensorBackend = CpuBackend> {
+pub struct EagerTensor {
     pub(crate) data: Arc<Tensor>,
     pub(crate) key: GlobalValKey<StdTensorOp>,
     pub(crate) grad_node: Option<Arc<GradNode<StdTensorOp>>>,
     pub(crate) requires_grad: bool,
     grad_slot: GradSlot,
     pub(crate) metadata_scopes: Vec<Arc<MetadataScope>>,
-    pub(crate) ctx: Arc<EagerContext<B>>,
+    pub(crate) ctx: Arc<EagerContext>,
 }
 
-impl<B: TensorBackend> std::ops::Add for &EagerTensor<B> {
-    type Output = EagerTensor<B>;
+impl std::ops::Add for &EagerTensor {
+    type Output = EagerTensor;
 
-    fn add(self, rhs: &EagerTensor<B>) -> Self::Output {
+    fn add(self, rhs: &EagerTensor) -> Self::Output {
         EagerTensor::add(self, rhs).unwrap_or_else(|err| panic!("eager add failed: {}", err))
     }
 }
 
-impl<B: TensorBackend> std::ops::Mul for &EagerTensor<B> {
-    type Output = EagerTensor<B>;
+impl std::ops::Mul for &EagerTensor {
+    type Output = EagerTensor;
 
-    fn mul(self, rhs: &EagerTensor<B>) -> Self::Output {
+    fn mul(self, rhs: &EagerTensor) -> Self::Output {
         EagerTensor::mul(self, rhs).unwrap_or_else(|err| panic!("eager mul failed: {}", err))
     }
 }
 
-impl<B: TensorBackend> std::ops::Neg for &EagerTensor<B> {
-    type Output = EagerTensor<B>;
+impl std::ops::Neg for &EagerTensor {
+    type Output = EagerTensor;
 
     fn neg(self) -> Self::Output {
         EagerTensor::neg(self).unwrap_or_else(|err| panic!("eager neg failed: {}", err))
     }
 }
 
-impl<B: TensorBackend> EagerTensor<B> {
+impl EagerTensor {
     /// Create an untracked eager tensor inside an existing eager context.
     ///
     /// # Examples
@@ -364,12 +397,12 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx);
     ///
     /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
     /// ```
-    pub fn from_tensor_in(tensor: Tensor, ctx: Arc<EagerContext<B>>) -> Self {
+    pub fn from_tensor_in(tensor: Tensor, ctx: Arc<EagerContext>) -> Self {
         Self::new_leaf(ctx, tensor, false)
     }
 
@@ -380,16 +413,16 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx);
     ///
     /// assert!(x.grad().is_none());
     /// ```
-    pub fn requires_grad_in(tensor: Tensor, ctx: Arc<EagerContext<B>>) -> Self {
+    pub fn requires_grad_in(tensor: Tensor, ctx: Arc<EagerContext>) -> Self {
         Self::new_leaf(ctx, tensor, true)
     }
 
-    pub(crate) fn new_leaf(ctx: Arc<EagerContext<B>>, tensor: Tensor, requires_grad: bool) -> Self {
+    pub(crate) fn new_leaf(ctx: Arc<EagerContext>, tensor: Tensor, requires_grad: bool) -> Self {
         let key = eager_val_key();
         let metadata_scope =
             register_scoped_value_metadata(key.clone(), tensor_meta_from_tensor(&tensor));
@@ -410,7 +443,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     }
 
     pub(crate) fn new_result(
-        ctx: Arc<EagerContext<B>>,
+        ctx: Arc<EagerContext>,
         key: GlobalValKey<StdTensorOp>,
         tensor: Tensor,
         requires_grad: bool,
@@ -433,7 +466,7 @@ impl<B: TensorBackend> EagerTensor<B> {
         }
     }
 
-    pub(crate) fn new_untracked_result(ctx: Arc<EagerContext<B>>, tensor: Tensor) -> Self {
+    pub(crate) fn new_untracked_result(ctx: Arc<EagerContext>, tensor: Tensor) -> Self {
         Self::new_result(ctx, eager_val_key(), tensor, false, None, Vec::new())
     }
 
@@ -447,7 +480,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx);
     /// let y = x.detach();
     ///
@@ -466,15 +499,15 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx_a = EagerContext::with_backend(CpuBackend::new());
-    /// let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx_a = EagerContext::with_cpu_backend(CpuBackend::new());
+    /// let ctx_b = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a);
     /// let d = x.detach_into(&ctx_b);
     ///
     /// assert!(!d.tracks_grad());
     /// assert_eq!(d.ctx_id(), ctx_b.id());
     /// ```
-    pub fn detach_into(&self, ctx: &Arc<EagerContext<B>>) -> Self {
+    pub fn detach_into(&self, ctx: &Arc<EagerContext>) -> Self {
         Self::new_leaf(Arc::clone(ctx), self.data.as_ref().clone(), false)
     }
 
@@ -485,7 +518,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![3.0_f64]), ctx);
     /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[3.0]);
     /// ```
@@ -503,7 +536,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx);
     /// let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
@@ -526,7 +559,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
     /// let y = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx);
     /// let loss = (&x * &y).reduce_sum(&[0]).unwrap();
@@ -551,7 +584,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let plain = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
     /// let tracked = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let detached = tracked.detach();
@@ -571,7 +604,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx.clone());
     ///
     /// assert_eq!(x.ctx_id(), ctx.id());
@@ -587,7 +620,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx.clone());
     /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![2.0_f64]), ctx);
     ///
@@ -608,7 +641,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx);
     /// let loss = (&x + &x).reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
@@ -793,7 +826,7 @@ impl tidu::EagerKeySource<StdTensorOp> for EagerTensorKeySource {
     }
 }
 
-pub(crate) fn eager_value<B: TensorBackend>(tensor: &EagerTensor<B>) -> EagerValue<StdTensorOp> {
+pub(crate) fn eager_value(tensor: &EagerTensor) -> EagerValue<StdTensorOp> {
     EagerValue {
         key: tensor.key.clone(),
         node: tensor.grad_node.clone(),
@@ -807,10 +840,10 @@ pub(crate) struct RecordedEagerOutputs {
     pub(crate) metadata_scope: Arc<MetadataScope>,
 }
 
-pub(crate) fn record_eager_outputs<B: TensorBackend>(
+pub(crate) fn record_eager_outputs(
     op: &StdTensorOp,
     outputs: &[Arc<Tensor>],
-    inputs: &[&EagerTensor<B>],
+    inputs: &[&EagerTensor],
 ) -> RecordedEagerOutputs {
     let input_values: Vec<_> = inputs.iter().map(|tensor| eager_value(*tensor)).collect();
     let mut key_source = EagerTensorKeySource;
@@ -835,10 +868,10 @@ pub(crate) fn record_eager_outputs<B: TensorBackend>(
     }
 }
 
-pub(crate) fn exec_single_output<B: TensorBackend>(
+pub(crate) fn exec_single_output(
     op: &StdTensorOp,
     inputs: &[&Tensor],
-    ctx: &EagerContext<B>,
+    ctx: &EagerContext,
 ) -> Result<Tensor> {
     let mut backend = profile_eager_op_section("exec_single_output.lock_backend", || {
         ctx.backend.lock().unwrap()

--- a/tenferro/src/eager_backend.rs
+++ b/tenferro/src/eager_backend.rs
@@ -1,0 +1,118 @@
+use tenferro_tensor::cpu::CpuBackend;
+#[cfg(feature = "cubecl")]
+use tenferro_tensor::cubecl::CubeclBackend;
+use tenferro_tensor::{
+    CompareDir, DType, DotGeneralConfig, ElementwiseFusionPlan, GatherConfig, PadConfig,
+    Result as TensorResult, ScatterConfig, SliceConfig, Tensor, TensorBackend, TensorExec,
+    TensorRead,
+};
+
+pub(crate) enum EagerBackend {
+    Cpu(CpuBackend),
+    #[cfg(feature = "cubecl")]
+    Cuda(CubeclBackend),
+}
+
+impl EagerBackend {
+    pub(crate) fn cpu(backend: CpuBackend) -> Self {
+        Self::Cpu(backend)
+    }
+
+    #[cfg(feature = "cubecl")]
+    pub(crate) fn cuda(backend: CubeclBackend) -> Self {
+        Self::Cuda(backend)
+    }
+}
+
+macro_rules! dispatch {
+    ($backend:expr, $method:ident($($arg:expr),* $(,)?)) => {
+        match $backend {
+            EagerBackend::Cpu(backend) => backend.$method($($arg),*),
+            #[cfg(feature = "cubecl")]
+            EagerBackend::Cuda(backend) => backend.$method($($arg),*),
+        }
+    };
+}
+
+macro_rules! delegate_tensor_backend_methods {
+    ($(fn $method:ident($($arg:ident: $ty:ty),* $(,)?) -> $ret:ty;)*) => {
+        $(
+            fn $method(&mut self, $($arg: $ty),*) -> $ret {
+                dispatch!(self, $method($($arg),*))
+            }
+        )*
+    };
+}
+
+impl TensorBackend for EagerBackend {
+    type RuntimeCache = ();
+
+    delegate_tensor_backend_methods! {
+        fn add(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn mul(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn neg(input: &Tensor) -> TensorResult<Tensor>;
+        fn conj(input: &Tensor) -> TensorResult<Tensor>;
+        fn div(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn abs(input: &Tensor) -> TensorResult<Tensor>;
+        fn sign(input: &Tensor) -> TensorResult<Tensor>;
+        fn maximum(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn minimum(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> TensorResult<Tensor>;
+        fn select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> TensorResult<Tensor>;
+        fn clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> TensorResult<Tensor>;
+        fn exp(input: &Tensor) -> TensorResult<Tensor>;
+        fn log(input: &Tensor) -> TensorResult<Tensor>;
+        fn sin(input: &Tensor) -> TensorResult<Tensor>;
+        fn cos(input: &Tensor) -> TensorResult<Tensor>;
+        fn tanh(input: &Tensor) -> TensorResult<Tensor>;
+        fn sqrt(input: &Tensor) -> TensorResult<Tensor>;
+        fn rsqrt(input: &Tensor) -> TensorResult<Tensor>;
+        fn pow(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn expm1(input: &Tensor) -> TensorResult<Tensor>;
+        fn log1p(input: &Tensor) -> TensorResult<Tensor>;
+        fn transpose(input: &Tensor, perm: &[usize]) -> TensorResult<Tensor>;
+        fn reshape(input: &Tensor, shape: &[usize]) -> TensorResult<Tensor>;
+        fn broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> TensorResult<Tensor>;
+        fn convert(input: &Tensor, to: DType) -> TensorResult<Tensor>;
+        fn extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult<Tensor>;
+        fn embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult<Tensor>;
+        fn tril(input: &Tensor, k: i64) -> TensorResult<Tensor>;
+        fn triu(input: &Tensor, k: i64) -> TensorResult<Tensor>;
+        fn reduce_sum(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+        fn reduce_prod(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+        fn reduce_max(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+        fn reduce_min(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+        fn dot_general(lhs: &Tensor, rhs: &Tensor, config: &DotGeneralConfig) -> TensorResult<Tensor>;
+        fn dot_general_read(lhs: TensorRead<'_>, rhs: TensorRead<'_>, config: &DotGeneralConfig) -> TensorResult<Tensor>;
+        fn dot_general_with_conj(lhs: &Tensor, rhs: &Tensor, config: &DotGeneralConfig, lhs_conj: bool, rhs_conj: bool) -> TensorResult<Tensor>;
+        fn gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> TensorResult<Tensor>;
+        fn scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> TensorResult<Tensor>;
+        fn slice(input: &Tensor, config: &SliceConfig) -> TensorResult<Tensor>;
+        fn dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> TensorResult<Tensor>;
+        fn dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> TensorResult<Tensor>;
+        fn pad(input: &Tensor, config: &PadConfig) -> TensorResult<Tensor>;
+        fn concatenate(inputs: &[&Tensor], axis: usize) -> TensorResult<Tensor>;
+        fn reverse(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+        fn cholesky(input: &Tensor) -> TensorResult<Tensor>;
+        fn triangular_solve(a: &Tensor, b: &Tensor, left_side: bool, lower: bool, transpose_a: bool, unit_diagonal: bool) -> TensorResult<Tensor>;
+        fn lu(input: &Tensor) -> TensorResult<Vec<Tensor>>;
+        fn full_piv_lu(input: &Tensor) -> TensorResult<Vec<Tensor>>;
+        fn full_piv_lu_solve(a: &Tensor, b: &Tensor, transpose_a: bool) -> TensorResult<Tensor>;
+        fn svd(input: &Tensor) -> TensorResult<Vec<Tensor>>;
+        fn qr(input: &Tensor) -> TensorResult<Vec<Tensor>>;
+        fn eigh(input: &Tensor) -> TensorResult<Vec<Tensor>>;
+        fn eig(input: &Tensor) -> TensorResult<Vec<Tensor>>;
+        fn solve(a: &Tensor, b: &Tensor) -> TensorResult<Tensor>;
+    }
+
+    fn with_exec_session<R: Send>(&mut self, f: impl FnOnce(&mut dyn TensorExec) -> R + Send) -> R {
+        dispatch!(self, with_exec_session(f))
+    }
+
+    delegate_tensor_backend_methods! {
+        fn download_to_host(tensor: &Tensor) -> TensorResult<Tensor>;
+        fn upload_host_tensor(tensor: &Tensor) -> TensorResult<Tensor>;
+        fn reclaim_buffer(tensor: Tensor) -> ();
+        fn execute_elementwise_fusion(inputs: &[&Tensor], plan: &ElementwiseFusionPlan) -> TensorResult<Option<Vec<Tensor>>>;
+    }
+}

--- a/tenferro/src/eager_einsum.rs
+++ b/tenferro/src/eager_einsum.rs
@@ -6,7 +6,7 @@
 //! use tenferro::eager_tensor::einsum;
 //! use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 //!
-//! let ctx = EagerContext::with_backend(CpuBackend::new());
+//! let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
 //! let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
 //! let y = EagerTensor::requires_grad_in(Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx);
 //! let loss = einsum(&[&x, &y], "i,i->").unwrap();
@@ -17,7 +17,6 @@
 //! ```
 
 use tenferro_ops::std_tensor_op::{EinsumSubscripts, StdTensorOp};
-use tenferro_tensor::TensorBackend;
 
 use crate::eager::EagerTensor;
 use crate::error::Result;
@@ -31,7 +30,7 @@ use crate::parse_einsum_subscripts;
 /// use tenferro::eager_tensor::einsum;
 /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 ///
-/// let ctx = EagerContext::with_backend(CpuBackend::new());
+/// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
 /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(
 ///     vec![2, 3],
 ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -45,19 +44,16 @@ use crate::parse_einsum_subscripts;
 /// assert_eq!(c.data().shape(), &[2, 2]);
 /// assert_eq!(c.data().as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 /// ```
-pub fn einsum<B: TensorBackend>(
-    inputs: &[&EagerTensor<B>],
-    subscripts: &str,
-) -> Result<EagerTensor<B>> {
+pub fn einsum(inputs: &[&EagerTensor], subscripts: &str) -> Result<EagerTensor> {
     let subscripts = parse_einsum_subscripts(subscripts)?;
     einsum_subscripts(inputs, &subscripts)
 }
 
 /// Execute an einsum eagerly from integer labels and record it when any input requires gradients.
-pub fn einsum_subscripts<B: TensorBackend>(
-    inputs: &[&EagerTensor<B>],
+pub fn einsum_subscripts(
+    inputs: &[&EagerTensor],
     subscripts: &EinsumSubscripts,
-) -> Result<EagerTensor<B>> {
+) -> Result<EagerTensor> {
     EagerTensor::nary_op(
         inputs,
         StdTensorOp::NaryEinsum {

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -4,7 +4,6 @@ use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{
     DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor,
-    TensorBackend,
 };
 
 use crate::eager::{
@@ -15,7 +14,7 @@ use crate::eager_exec::{exec_dot_general_with_conj_on_tensors, exec_op_on_tensor
 use crate::error::{Error, Result};
 use crate::metadata::push_metadata_scope;
 
-impl<B: TensorBackend> EagerTensor<B> {
+impl EagerTensor {
     /// Elementwise addition.
     ///
     /// # Examples
@@ -23,7 +22,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
     /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let z = x.add(&y).unwrap();
@@ -41,7 +40,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
     /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let z = x.mul(&y).unwrap();
@@ -59,7 +58,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, -2.0]), ctx.clone());
     /// let y = x.neg().unwrap();
     ///
@@ -76,7 +75,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.exp().unwrap();
     ///
@@ -93,7 +92,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.reduce_sum(&[0, 1]).unwrap();
     ///
@@ -112,7 +111,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, DotGeneralConfig, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]), ctx.clone());
     /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]), ctx.clone());
     /// let c = a.dot_general(&b, DotGeneralConfig {
@@ -190,7 +189,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(
     ///     Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
     ///     ctx.clone(),
@@ -249,7 +248,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(
     ///     vec![2, 3],
     ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -272,7 +271,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(
     ///     vec![2, 3],
     ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -295,7 +294,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, SliceConfig, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x
     ///     .slice(SliceConfig {
@@ -318,7 +317,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
     /// let y = x.broadcast_in_dim(&[3, 2], &[0]).unwrap();
     ///
@@ -338,7 +337,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, DType, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, -2.0]), ctx.clone());
     /// let y = x.convert(DType::C64).unwrap();
     ///
@@ -359,7 +358,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, PadConfig, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
     /// let y = x
     ///     .pad(PadConfig {
@@ -382,7 +381,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.reverse(&[0]).unwrap();
     ///
@@ -401,7 +400,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, GatherConfig, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(
     ///     vec![5],
     ///     vec![10.0_f64, 20.0, 30.0, 40.0, 50.0],
@@ -433,7 +432,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, ScatterConfig, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let operand = EagerTensor::from_tensor_in(Tensor::from_vec(vec![4], vec![0.0_f64, 0.0, 0.0, 0.0]), ctx.clone());
     /// let indices = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![1_i64, 3]), ctx.clone());
     /// let updates = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![5.0_f64, 7.0]), ctx.clone());
@@ -463,7 +462,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]), ctx.clone());
     /// let starts = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![2_i64]), ctx.clone());
     /// let y = x.dynamic_slice(&starts, &[2]).unwrap();
@@ -486,7 +485,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
     /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let z = EagerTensor::concatenate(&[&x, &y], 0).unwrap();
@@ -510,7 +509,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(
     ///     vec![3, 3],
     ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
@@ -530,7 +529,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
     /// let y = x.embed_diag(0, 1).unwrap();
     ///
@@ -548,7 +547,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.tril(0).unwrap();
     ///
@@ -565,7 +564,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.triu(0).unwrap();
     ///
@@ -582,7 +581,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.reduce_prod(&[0, 1]).unwrap();
     ///
@@ -601,7 +600,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.reduce_max(&[0, 1]).unwrap();
     ///
@@ -620,7 +619,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx.clone());
     /// let y = x.reduce_min(&[0, 1]).unwrap();
     ///

--- a/tenferro/src/eager_ops_elementwise.rs
+++ b/tenferro/src/eager_ops_elementwise.rs
@@ -1,10 +1,9 @@
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_tensor::TensorBackend;
 
 use crate::eager::EagerTensor;
 use crate::error::Result;
 
-impl<B: TensorBackend> EagerTensor<B> {
+impl EagerTensor {
     /// Elementwise absolute value.
     ///
     /// # Examples
@@ -12,7 +11,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![-1.0_f64, 2.0]), ctx.clone());
     /// let y = x.abs().unwrap();
     ///
@@ -29,7 +28,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, -2.0]), ctx.clone());
     /// let y = x.conj().unwrap();
     ///
@@ -46,7 +45,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![-2.0_f64, 3.0]), ctx.clone());
     /// let y = x.sign().unwrap();
     ///
@@ -63,7 +62,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx.clone());
     /// let y = x.log().unwrap();
     ///
@@ -80,7 +79,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![4.0_f64]), ctx.clone());
     /// let y = x.sqrt().unwrap();
     ///
@@ -97,7 +96,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![4.0_f64]), ctx.clone());
     /// let y = x.rsqrt().unwrap();
     ///
@@ -114,7 +113,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.sin().unwrap();
     ///
@@ -131,7 +130,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.cos().unwrap();
     ///
@@ -148,7 +147,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.tanh().unwrap();
     ///
@@ -165,7 +164,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.expm1().unwrap();
     ///
@@ -182,7 +181,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![0.0_f64]), ctx.clone());
     /// let y = x.log1p().unwrap();
     ///
@@ -199,7 +198,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![8.0_f64, -6.0, 9.0]), ctx.clone());
     /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![2.0_f64, 3.0, 3.0]), ctx.clone());
     /// let z = x.div(&y).unwrap();
@@ -217,7 +216,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let base = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![2.0_f64, 3.0]), ctx.clone());
     /// let exp = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 2.0]), ctx.clone());
     /// let y = base.pow(&exp).unwrap();
@@ -235,7 +234,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 5.0]), ctx.clone());
     /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let z = x.maximum(&y).unwrap();
@@ -253,7 +252,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 5.0]), ctx.clone());
     /// let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
     /// let z = x.minimum(&y).unwrap();
@@ -271,7 +270,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let condition = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![0.0_f64, 1.0]), ctx.clone());
     /// let on_true = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![10.0_f64, 20.0]), ctx.clone());
     /// let on_false = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
@@ -290,7 +289,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![-2.0_f64, 0.5, 5.0]), ctx.clone());
     /// let lower = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![-1.0_f64, 0.0, 1.0]), ctx.clone());
     /// let upper = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 4.0]), ctx.clone());

--- a/tenferro/src/eager_ops_linalg.rs
+++ b/tenferro/src/eager_ops_linalg.rs
@@ -1,10 +1,10 @@
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_tensor::{DType, TensorBackend};
+use tenferro_tensor::DType;
 
 use crate::eager::EagerTensor;
 use crate::error::{Error, Result};
 
-impl<B: TensorBackend> EagerTensor<B> {
+impl EagerTensor {
     /// Singular value decomposition: `A = U diag(S) Vh`.
     ///
     /// # Examples
@@ -12,7 +12,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]), ctx.clone());
     /// let (u, s, vh) = a.svd().unwrap();
     ///
@@ -44,7 +44,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]), ctx.clone());
     /// let (q, r) = a.qr().unwrap();
     ///
@@ -68,7 +68,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]), ctx.clone());
     /// let (p, l, u, parity) = a.lu().unwrap();
     ///
@@ -100,7 +100,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]), ctx.clone());
     /// let (p, l, u, q, parity) = a.full_piv_lu().unwrap();
     ///
@@ -136,7 +136,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]), ctx.clone());
     /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![-1.0_f64, 5.0]), ctx.clone());
     /// let x = a.full_piv_lu_solve(&b).unwrap();
@@ -156,7 +156,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]), ctx.clone());
     /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![4.0_f64, 8.0]), ctx);
     /// let x = a.solve(&b).unwrap();
@@ -177,7 +177,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]), ctx.clone());
     /// let rhs = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1, 2], vec![4.0_f64, 8.0]), ctx);
     /// let x = a.right_solve(&rhs).unwrap();
@@ -224,7 +224,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]), ctx.clone());
     /// let l = a.cholesky().unwrap();
     ///
@@ -242,7 +242,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]), ctx.clone());
     /// let (values, vectors) = a.eigh().unwrap();
     ///
@@ -268,7 +268,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]), ctx.clone());
     /// let (values, vectors) = a.eig().unwrap();
     ///
@@ -295,7 +295,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]), ctx.clone());
     /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2, 1], vec![4.0_f64, 8.0]), ctx.clone());
     /// let x = a

--- a/tenferro/src/eager_tensor.rs
+++ b/tenferro/src/eager_tensor.rs
@@ -3,8 +3,6 @@
 //! This module hosts free functions whose receiver is naturally n-ary. Unary
 //! and binary eager operations remain methods on [`EagerTensor`].
 
-use tenferro_tensor::TensorBackend;
-
 use crate::error::Result;
 use crate::EinsumSubscripts;
 
@@ -18,7 +16,7 @@ pub use crate::eager::{EagerContext, EagerTensor};
 /// use tenferro::eager_tensor::einsum;
 /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 ///
-/// let ctx = EagerContext::with_backend(CpuBackend::new());
+/// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
 /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(
 ///     vec![2, 3],
 ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -33,10 +31,7 @@ pub use crate::eager::{EagerContext, EagerTensor};
 /// assert_eq!(c.data().shape(), &[2, 2]);
 /// assert_eq!(c.data().as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 /// ```
-pub fn einsum<B: TensorBackend>(
-    inputs: &[&EagerTensor<B>],
-    subscripts: &str,
-) -> Result<EagerTensor<B>> {
+pub fn einsum(inputs: &[&EagerTensor], subscripts: &str) -> Result<EagerTensor> {
     crate::eager_einsum::einsum(inputs, subscripts)
 }
 
@@ -48,7 +43,7 @@ pub fn einsum<B: TensorBackend>(
 /// use tenferro::eager_tensor::{einsum_subscripts, EagerContext, EagerTensor};
 /// use tenferro::{CpuBackend, EinsumSubscripts, Tensor};
 ///
-/// let ctx = EagerContext::with_backend(CpuBackend::new());
+/// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
 /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
 /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx);
 /// let subscripts = EinsumSubscripts::new(&[&[0], &[0]], &[]);
@@ -56,9 +51,9 @@ pub fn einsum<B: TensorBackend>(
 ///
 /// assert_eq!(dot.data().as_slice::<f64>().unwrap(), &[32.0]);
 /// ```
-pub fn einsum_subscripts<B: TensorBackend>(
-    inputs: &[&EagerTensor<B>],
+pub fn einsum_subscripts(
+    inputs: &[&EagerTensor],
     subscripts: &EinsumSubscripts,
-) -> Result<EagerTensor<B>> {
+) -> Result<EagerTensor> {
     crate::eager_einsum::einsum_subscripts(inputs, subscripts)
 }

--- a/tenferro/src/extension.rs
+++ b/tenferro/src/extension.rs
@@ -34,7 +34,7 @@ use computegraph::GraphOp;
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::SymDim;
-use tenferro_tensor::{Tensor, TensorBackend};
+use tenferro_tensor::Tensor;
 
 use crate::checkpoint::CheckpointNode;
 use crate::eager::{record_eager_outputs, EagerTensor};
@@ -198,10 +198,7 @@ pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Vec<TracedTe
 /// usual eager execution path, then records the same `StdTensorOp::Extension`
 /// node used by traced graphs. Eager backward therefore uses registered
 /// [`ExtensionAdRuleTrait`] rules through the same AD source of truth.
-pub fn apply_eager<B: TensorBackend>(
-    op: Arc<dyn ExtensionOp>,
-    inputs: &[&EagerTensor<B>],
-) -> Result<Vec<EagerTensor<B>>> {
+pub fn apply_eager(op: Arc<dyn ExtensionOp>, inputs: &[&EagerTensor]) -> Result<Vec<EagerTensor>> {
     let Some(first) = inputs.first() else {
         return Err(Error::Internal(
             "extension::apply_eager requires at least one input tensor".to_string(),

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -20,6 +20,7 @@ pub use tenferro_tensor::{DotGeneralConfig, GatherConfig, PadConfig, ScatterConf
 mod checkpoint;
 pub mod compiler;
 mod eager;
+mod eager_backend;
 mod eager_einsum;
 mod eager_emitter;
 pub mod eager_exec;

--- a/tenferro/src/shape_packing.rs
+++ b/tenferro/src/shape_packing.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{OpMode, ValRef};
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_tensor::{GatherConfig, Tensor, TensorBackend, TypedTensor};
+use tenferro_tensor::{GatherConfig, Tensor, TypedTensor};
 
 use crate::checkpoint::CheckpointNode;
 use crate::eager::EagerTensor;
@@ -114,7 +114,7 @@ fn validate_stack_shapes(op: &'static str, shapes: &[&[usize]]) -> Result<()> {
     Ok(())
 }
 
-impl<B: TensorBackend> EagerTensor<B> {
+impl EagerTensor {
     /// Select entries from one axis using host-known indices.
     ///
     /// The index list is primal metadata: gradients flow to `self`, including
@@ -125,7 +125,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(
     ///     Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]),
     ///     ctx,
@@ -151,7 +151,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(
     ///     Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
     ///     ctx,
@@ -172,7 +172,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(
     ///     Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
     ///     ctx,
@@ -197,7 +197,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(
     ///     Tensor::from_vec(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
     ///     ctx,
@@ -218,7 +218,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(
     ///     Tensor::from_vec(vec![3], vec![10.0_f64, 20.0, 30.0]),
     ///     ctx,
@@ -243,7 +243,7 @@ impl<B: TensorBackend> EagerTensor<B> {
     /// ```
     /// use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
     ///
-    /// let ctx = EagerContext::with_backend(CpuBackend::new());
+    /// let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     /// let a = EagerTensor::from_tensor_in(Tensor::from_vec(vec![], vec![1.0_f64]), ctx.clone());
     /// let b = EagerTensor::from_tensor_in(Tensor::from_vec(vec![], vec![2.0_f64]), ctx);
     /// let out = EagerTensor::stack(&[&a, &b], -1).unwrap();

--- a/tenferro/tests/ad_structural_primitives.rs
+++ b/tenferro/tests/ad_structural_primitives.rs
@@ -19,8 +19,8 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
     }
 }
 
-fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
-    EagerContext::with_backend(CpuBackend::new())
+fn test_ctx() -> Arc<EagerContext> {
+    EagerContext::with_cpu_backend(CpuBackend::new())
 }
 
 fn finite_diff_unary(f: impl Fn(&[f64]) -> f64, base: &[f64]) -> Vec<f64> {

--- a/tenferro/tests/eager_fixed_pivot_cross.rs
+++ b/tenferro/tests/eager_fixed_pivot_cross.rs
@@ -6,8 +6,8 @@ const FD_H: f64 = 1.0e-6;
 const TOL: f64 = 1.0e-10;
 const FD_TOL: f64 = 5.0e-4;
 
-fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
-    EagerContext::with_backend(CpuBackend::new())
+fn test_ctx() -> Arc<EagerContext> {
+    EagerContext::with_cpu_backend(CpuBackend::new())
 }
 
 fn f64_data(tensor: &Tensor) -> &[f64] {

--- a/tenferro/tests/eager_linalg.rs
+++ b/tenferro/tests/eager_linalg.rs
@@ -2,9 +2,9 @@ use num_complex::Complex64;
 use std::sync::{Arc, OnceLock};
 use tenferro::{CpuBackend, EagerContext, EagerTensor, Tensor};
 
-fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
-    static CTX: OnceLock<Arc<EagerContext<CpuBackend>>> = OnceLock::new();
-    CTX.get_or_init(|| EagerContext::with_backend(CpuBackend::new()))
+fn test_ctx() -> Arc<EagerContext> {
+    static CTX: OnceLock<Arc<EagerContext>> = OnceLock::new();
+    CTX.get_or_init(|| EagerContext::with_cpu_backend(CpuBackend::new()))
         .clone()
 }
 

--- a/tenferro/tests/eager_linalg_tests.rs
+++ b/tenferro/tests/eager_linalg_tests.rs
@@ -4,9 +4,9 @@ use tenferro::{
     CpuBackend, DType, DotGeneralConfig, EagerContext, EagerTensor, ScatterConfig, Tensor,
 };
 
-fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
-    static CTX: OnceLock<Arc<EagerContext<CpuBackend>>> = OnceLock::new();
-    CTX.get_or_init(|| EagerContext::with_backend(CpuBackend::new()))
+fn test_ctx() -> Arc<EagerContext> {
+    static CTX: OnceLock<Arc<EagerContext>> = OnceLock::new();
+    CTX.get_or_init(|| EagerContext::with_cpu_backend(CpuBackend::new()))
         .clone()
 }
 

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -94,9 +94,9 @@ fn eager_matmul_sum(lhs: &[f64], rhs: &[f64]) -> f64 {
     f64_data(loss.data())[0]
 }
 
-fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
-    static CTX: OnceLock<Arc<EagerContext<CpuBackend>>> = OnceLock::new();
-    CTX.get_or_init(|| EagerContext::with_backend(CpuBackend::new()))
+fn test_ctx() -> Arc<EagerContext> {
+    static CTX: OnceLock<Arc<EagerContext>> = OnceLock::new();
+    CTX.get_or_init(|| EagerContext::with_cpu_backend(CpuBackend::new()))
         .clone()
 }
 
@@ -262,7 +262,7 @@ fn eager_index_select_rejects_invalid_axis_and_position() {
 
 #[test]
 fn eager_stack_rejects_empty_mismatched_shapes_and_invalid_axis() {
-    let empty: [&EagerTensor<CpuBackend>; 0] = [];
+    let empty: [&EagerTensor; 0] = [];
     let empty_err = EagerTensor::stack(&empty, 0).err().unwrap().to_string();
     assert!(empty_err.contains("stack requires at least one input"));
 
@@ -396,7 +396,7 @@ fn eager_fan_out_accumulates_gradient() {
 
 #[test]
 fn eager_clear_grad_resets_only_one_leaf() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
         Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
         ctx.clone(),
@@ -423,7 +423,7 @@ fn eager_clear_grad_resets_only_one_leaf() {
 
 #[test]
 fn eager_context_clear_grads_resets_all_live_leaves() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
         Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
         ctx.clone(),
@@ -450,7 +450,7 @@ fn eager_context_clear_grads_resets_all_live_leaves() {
 
 #[test]
 fn eager_unrelated_backward_keeps_existing_leaf_grad() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
         Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
         ctx.clone(),
@@ -477,7 +477,7 @@ fn eager_unrelated_backward_keeps_existing_leaf_grad() {
 
 #[test]
 fn eager_tracks_grad_reports_leaf_state() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let plain = EagerTensor::from_tensor_in(
         Tensor::from_vec(vec![3], vec![1.0_f64, 2.0, 3.0]),
         ctx.clone(),
@@ -492,8 +492,21 @@ fn eager_tracks_grad_reports_leaf_state() {
 
 #[test]
 fn eager_send_sync_contracts_compile() {
-    assert_send_sync::<EagerTensor<CpuBackend>>();
-    assert_send_sync::<EagerContext<CpuBackend>>();
+    assert_send_sync::<EagerTensor>();
+    assert_send_sync::<EagerContext>();
+}
+
+#[test]
+fn eager_context_and_tensor_are_backend_erased_public_types() {
+    assert_send_sync::<EagerTensor>();
+    assert_send_sync::<EagerContext>();
+
+    let ctx: Arc<EagerContext> = EagerContext::with_cpu_backend(CpuBackend::with_threads(1));
+    let x = ctx.variable_from(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
+    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    loss.backward().unwrap();
+
+    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
 }
 
 #[test]
@@ -862,14 +875,14 @@ fn eager_embed_diag_and_triu_primal() {
 
 #[test]
 fn context_id_is_unique() {
-    let ctx_a = EagerContext::with_backend(CpuBackend::new());
-    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let ctx_a = EagerContext::with_cpu_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_cpu_backend(CpuBackend::new());
     assert_ne!(ctx_a.id(), ctx_b.id());
 }
 
 #[test]
 fn same_context_true_for_shared_ctx() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx.clone());
     let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![2.0_f64]), ctx);
     assert!(x.same_context(&y));
@@ -878,8 +891,8 @@ fn same_context_true_for_shared_ctx() {
 
 #[test]
 fn same_context_false_for_different_ctx() {
-    let ctx_a = EagerContext::with_backend(CpuBackend::new());
-    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let ctx_a = EagerContext::with_cpu_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx_a);
     let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![1], vec![2.0_f64]), ctx_b);
     assert!(!x.same_context(&y));
@@ -888,7 +901,7 @@ fn same_context_false_for_different_ctx() {
 
 #[test]
 fn constant_from_creates_untracked_leaf() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let c = ctx.constant_from(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
     assert_eq!(c.ctx_id(), ctx.id());
     assert!(!c.tracks_grad());
@@ -897,7 +910,7 @@ fn constant_from_creates_untracked_leaf() {
 
 #[test]
 fn variable_from_creates_tracked_leaf() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let p = ctx.variable_from(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]));
     assert_eq!(p.ctx_id(), ctx.id());
     assert!(p.tracks_grad());
@@ -909,8 +922,8 @@ fn variable_from_creates_tracked_leaf() {
 
 #[test]
 fn cross_context_add_rejected() {
-    let ctx_a = EagerContext::with_backend(CpuBackend::new());
-    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let ctx_a = EagerContext::with_cpu_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a);
     let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx_b);
     let msg = match x.add(&y) {
@@ -922,8 +935,8 @@ fn cross_context_add_rejected() {
 
 #[test]
 fn cross_context_mul_rejected() {
-    let ctx_a = EagerContext::with_backend(CpuBackend::new());
-    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let ctx_a = EagerContext::with_cpu_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a);
     let y = EagerTensor::from_tensor_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx_b);
     let msg = match x.mul(&y) {
@@ -935,8 +948,8 @@ fn cross_context_mul_rejected() {
 
 #[test]
 fn cross_context_tracked_tensors_rejected() {
-    let ctx_a = EagerContext::with_backend(CpuBackend::new());
-    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let ctx_a = EagerContext::with_cpu_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a);
     let y = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![3.0_f64, 4.0]), ctx_b);
     let msg = match x.add(&y) {
@@ -948,7 +961,7 @@ fn cross_context_tracked_tensors_rejected() {
 
 #[test]
 fn constant_from_can_cross_context() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let x =
         EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
     // Import a fixed mask from a raw tensor into the same context
@@ -959,8 +972,8 @@ fn constant_from_can_cross_context() {
 
 #[test]
 fn detach_into_different_context() {
-    let ctx_a = EagerContext::with_backend(CpuBackend::new());
-    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let ctx_a = EagerContext::with_cpu_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a);
     let d = x.detach_into(&ctx_b);
     assert_eq!(d.ctx_id(), ctx_b.id());
@@ -974,8 +987,8 @@ fn detach_into_different_context() {
 
 #[test]
 fn detach_into_still_accessible_in_original_context() {
-    let ctx_a = EagerContext::with_backend(CpuBackend::new());
-    let ctx_b = EagerContext::with_backend(CpuBackend::new());
+    let ctx_a = EagerContext::with_cpu_backend(CpuBackend::new());
+    let ctx_b = EagerContext::with_cpu_backend(CpuBackend::new());
     let x =
         EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx_a.clone());
     let d = x.detach_into(&ctx_b);

--- a/tenferro/tests/eager_tensor_einsum.rs
+++ b/tenferro/tests/eager_tensor_einsum.rs
@@ -7,12 +7,12 @@ fn f64_data(tensor: &Tensor) -> &[f64] {
     tensor.as_slice::<f64>().unwrap()
 }
 
-fn test_ctx() -> Arc<EagerContext<CpuBackend>> {
+fn test_ctx() -> Arc<EagerContext> {
     unsafe {
         std::env::set_var("TENFERRO_PROFILE_EAGER_OP_AGG", "1");
         std::env::set_var("TENFERRO_PROFILE_EAGER_OP_PRINT_EVERY", "1");
     }
-    EagerContext::with_backend(CpuBackend::new())
+    EagerContext::with_cpu_backend(CpuBackend::new())
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn eager_tensor_einsum_repeated_backward_accumulates_across_calls() {
 
 #[test]
 fn eager_tensor_einsum_context_clear_grads_resets_all_live_leaves() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let a = EagerTensor::requires_grad_in(
         Tensor::from_vec(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
         ctx.clone(),

--- a/tenferro/tests/extension_op.rs
+++ b/tenferro/tests/extension_op.rs
@@ -545,7 +545,7 @@ fn scale_by_2_grad_against_reduce_sum() {
 fn scale_by_2_eager_backward_uses_registered_rule() {
     ensure_scale_by_2_registered();
 
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let x =
         EagerTensor::requires_grad_in(Tensor::from_vec(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]), ctx);
     let scaled = apply_eager(Arc::new(TestScaleBy2), &[&x])
@@ -582,7 +582,7 @@ fn missing_extension_rule_errors_in_traced_grad() {
 
 #[test]
 fn missing_extension_rule_errors_in_eager_backward() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![2], vec![1.0_f64, 2.0]), ctx);
     let y = apply_eager(Arc::new(TestNoAd), &[&x])
         .expect("forward-only eager extension apply")
@@ -619,7 +619,7 @@ fn apply_rejects_mismatched_output_metadata_count() {
 
 #[test]
 fn apply_eager_rejects_empty_input_list() {
-    let err = match apply_eager::<CpuBackend>(Arc::new(TestScaleBy2), &[]) {
+    let err = match apply_eager(Arc::new(TestScaleBy2), &[]) {
         Ok(_) => panic!("empty eager extension input list unexpectedly succeeded"),
         Err(err) => err,
     };
@@ -629,7 +629,7 @@ fn apply_eager_rejects_empty_input_list() {
 
 #[test]
 fn apply_eager_rejects_wrong_input_count() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx);
 
     let err = match apply_eager(Arc::new(TestSwap), &[&x]) {
@@ -642,8 +642,8 @@ fn apply_eager_rejects_wrong_input_count() {
 
 #[test]
 fn apply_eager_rejects_cross_context_inputs() {
-    let lhs_ctx = EagerContext::with_backend(CpuBackend::new());
-    let rhs_ctx = EagerContext::with_backend(CpuBackend::new());
+    let lhs_ctx = EagerContext::with_cpu_backend(CpuBackend::new());
+    let rhs_ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let lhs = EagerTensor::requires_grad_in(Tensor::from_vec(vec![1], vec![1.0_f64]), lhs_ctx);
     let rhs = EagerTensor::requires_grad_in(Tensor::from_vec(vec![1], vec![2.0_f64]), rhs_ctx);
 
@@ -660,7 +660,7 @@ fn apply_eager_rejects_cross_context_inputs() {
 
 #[test]
 fn apply_eager_rejects_mismatched_output_count() {
-    let ctx = EagerContext::with_backend(CpuBackend::new());
+    let ctx = EagerContext::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(Tensor::from_vec(vec![1], vec![1.0_f64]), ctx);
 
     let err = match apply_eager(Arc::new(TestBadOutputCount), &[&x]) {


### PR DESCRIPTION
## Summary
- replace public `EagerTensor<B>` / `EagerContext<B>` with backend-erased `EagerTensor` / `EagerContext`
- add internal `EagerBackend` dispatch over CPU and CUDA backends while keeping backend glue crate-private
- update eager docs, README examples, tests, and benches to the smaller public surface

Fixes #867

## Test Plan
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- README examples compiled and ran in a temporary Cargo package
- `cargo check -p tenferro --features cuda`
- `cargo test -p tenferro --doc --features cuda`
- `git diff --check && git diff --cached --check`
