### PR TITLE
[codex] Add ChainRules-style extension AD rules

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -63,5 +63,6 @@ website:
               - spec/primitive-catalog.md
               - spec/backend-contract.md
               - spec/ad-contract.md
+              - spec/extension-op.md
               - spec/optimizer-passes.md
               - spec/tensor-semantics.md

--- a/docs/guides/custom-operations.md
+++ b/docs/guides/custom-operations.md
@@ -37,6 +37,68 @@ An extension crate is responsible for:
 - optional JVP/VJP rules for automatic differentiation,
 - clear errors when a dtype, shape, backend, or AD path is not supported.
 
+## Implementing An Extension Op
+
+Implement `tenferro::extension::ExtensionOpTrait` for the op payload. The
+payload carries operation parameters such as axes, modes, constants, or kernel
+configuration. Tensor-valued parameters should usually be normal inputs, not
+payload fields.
+
+Extension op payloads do not need process-global registration. Construct
+`Arc<dyn ExtensionOpTrait>` and pass it to `tenferro::extension::apply` for
+traced tensors or `apply_eager` for eager tensors.
+
+For AD, register a rule separately:
+
+```rust
+use std::sync::Arc;
+use chainrules_core::ADRuleResult;
+use tenferro::extension::{
+    register_extension_chain_rule, ExtensionChainRuleTrait, ExtensionOpTrait,
+    FruleBuilder, RRuleBuilder,
+};
+
+#[derive(Debug)]
+struct AddScalarRule;
+
+impl ExtensionChainRuleTrait for AddScalarRule {
+    fn family_id(&self) -> &'static str { "my-crate.add_scalar.v1" }
+
+    fn frule(&self, _op: &dyn ExtensionOpTrait, cx: &mut FruleBuilder<'_>) -> ADRuleResult<()> {
+        cx.set_output_tangent(0, cx.tangent(0)?)
+    }
+
+    fn rrule(&self, _op: &dyn ExtensionOpTrait, cx: &mut RRuleBuilder<'_>) -> ADRuleResult<()> {
+        let Some(cot_y) = cx.cotangent(0)? else { return Ok(()); };
+        let cot_x = cot_y.clone();
+        let cot_a = cx.reduce_sum_all(cot_y, cx.input_rank(0)?)?;
+        cx.set_input_cotangent(0, Some(cot_x))?;
+        cx.set_input_cotangent(1, Some(cot_a))
+    }
+}
+
+register_extension_chain_rule(Arc::new(AddScalarRule)).expect("register AD rule");
+```
+
+The builder methods intentionally hide `LocalValId`. Use `tangent(i)` and
+`cotangent(i)` to read incoming AD values, use helpers such as `add`, `mul`,
+`reduce_sum_all`, `emit`, and `apply_extension` to create new values, then set
+the desired output or input cotangent.
+
+When porting Julia `frule` / `rrule` code:
+
+- map `NoTangent` / `ZeroTangent` to `None` when the tangent slot is inactive,
+- represent scalar parameters as tensor inputs when users need to vary them,
+- use `reduce_sum_all` for broadcasted scalar inputs,
+- emit only core `StdTensorOp` operations or extension ops whose AD rules are
+  registered before a later AD pass reaches them.
+
+The lower-level `ExtensionAdRuleTrait` and `register_extension_rule` remain as
+an adapter surface for code that needs direct `FragmentBuilder` / `OpEmitter`
+control. New extension authors should start with `ExtensionChainRuleTrait`.
+The old `ExtensionFactory` / `register_extension` op-registration API has been
+removed; operation payloads are carried directly in the graph.
+
 The detailed trait contract is documented in the internal
 [ExtensionOp specification](../spec/extension-op.md). User-facing extension
 crates should wrap that machinery in small APIs that look like the equivalent

--- a/docs/spec/extension-op.md
+++ b/docs/spec/extension-op.md
@@ -37,12 +37,12 @@ This spec extends the three normative contracts that already exist in
 - [`ad-contract.md`](ad-contract.md) owns the `PrimitiveOp` trait. This
   document extends it by specifying how an `ExtensionOp` participates in
   AD **without** itself implementing `PrimitiveOp`: the dispatcher in
-  `tenferro-ops/src/ad/mod.rs` routes `StdTensorOp::Extension(op)` to
-  methods on the inner `dyn ExtensionOp`, which then return cotangents
-  expressed in the core `StdTensorOp` vocabulary. The ad-contract closure
-  rule (emit only ops that implement `PrimitiveOp`) is preserved because
-  extensions emit core `StdTensorOp` values from their AD methods, never
-  other extension variants.
+  `tenferro-ops/src/ad/mod.rs` routes `StdTensorOp::Extension(op)` to a
+  registered rule for `op.family_id()`. The rule emits tangents and
+  cotangents expressed in the core `StdTensorOp` vocabulary, or in other
+  registered extension families. The ad-contract closure rule (emit only
+  ops that implement `PrimitiveOp`) is preserved at the carrier level
+  because the graph still contains only `StdTensorOp` values.
 - [`primitive-catalog.md`](primitive-catalog.md) owns the core op
   vocabulary. `ExtensionOp` does **not** add to that vocabulary; it is a
   single carrier variant `StdTensorOp::Extension(Arc<dyn ExtensionOp>)`.
@@ -188,35 +188,7 @@ pub trait ExtensionOp: std::fmt::Debug + Send + Sync + 'static {
         inputs: &[&tenferro_tensor::Tensor],
     ) -> tenferro_tensor::Result<Vec<tenferro_tensor::Tensor>>;
 
-    // ----- Backwards-compatible inline AD hooks (Section 10) -----
-
-    /// Emit the linear (JVP) rule.
-    ///
-    /// Legacy source-compatible inline hook. AD dispatch uses registered
-    /// `ExtensionAdRule` providers; new extension crates SHOULD register a
-    /// rule instead of relying on this method.
-    fn linearize(
-        &self,
-        builder: &mut computegraph::fragment::FragmentBuilder<StdTensorOp>,
-        primal_in: &[computegraph::types::GlobalValKey<StdTensorOp>],
-        primal_out: &[computegraph::types::GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<computegraph::types::LocalValId>],
-        ctx: &mut crate::ad::context::ShapeGuardContext,
-    ) -> Vec<Option<computegraph::types::LocalValId>>;
-
-    /// Emit the transpose (VJP) rule.
-    ///
-    /// Legacy source-compatible inline hook. AD dispatch uses registered
-    /// `ExtensionAdRule` providers; new extension crates SHOULD register a
-    /// rule instead of relying on this method.
-    fn transpose_rule(
-        &self,
-        emitter: &mut dyn computegraph::OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<computegraph::types::LocalValId>],
-        inputs: &[computegraph::types::ValRef<StdTensorOp>],
-        mode: &computegraph::types::OpMode,
-        ctx: &mut crate::ad::context::ShapeGuardContext,
-    ) -> Vec<Option<computegraph::types::LocalValId>>;
+    // AD rules are registered separately; see Section 10.
 }
 ```
 
@@ -576,75 +548,40 @@ the single-method design keeps the two paths congruent.
 
 ---
 
-## 9. Registration and lookup
+## 9. Operation construction and AD rule registration
 
-### Registry model (normative choice)
+### Operation construction
 
-The extension registry is a process-local
-`OnceLock<RwLock<HashMap<&'static str, Arc<dyn ExtensionFactory>>>>`,
-keyed by `family_id`. The implementation MUST provide this surface in
-`tenferro-ops` (a new module, e.g. `tenferro_ops::extension::registry`)
-and re-export it through `tenferro`.
+Extension op payloads are not registered in a process-global factory registry.
+The frontend carries the concrete payload directly as
+`StdTensorOp::Extension(Arc<dyn ExtensionOp>)`; extension crates should expose
+small public wrapper functions that construct that `Arc` and call
+`tenferro::extension::apply` or `apply_eager`.
 
-Why `OnceLock<RwLock<HashMap>>` and not a `linkme`-style
-distributed-slice:
+The removed factory registry (`ExtensionFactory` / `register_extension`) MUST
+NOT be reintroduced as a prerequisite for ordinary graph construction. If a
+future serialization format needs cross-process reconstruction by
+`family_id`, that format must define an explicit serialization registry rather
+than overloading runtime graph construction.
 
-- **Process-local determinism**: the registry is explicitly populated at
-  program start (or on first use via factories), rather than collected
-  at link time. This makes registration behaviour predictable in test
-  environments and across `cargo test`'s per-binary harnesses, where
-  linker-collected slices can subtly diverge between tests.
-- **No new build dependency**: `linkme` would add a workspace
-  dependency that is non-trivial to support on every target (notably
-  wasm). `OnceLock<RwLock<HashMap>>` is in std.
-- **Extensible implementation**: the Open Questions list (Section 15) allows a
-  later migration to `linkme` if evidence supports it.
+### AD rule registry
 
-### Factory trait
+Only AD rules are process-global. The implementation uses a process-local
+`OnceLock<RwLock<HashMap<&'static str, Arc<dyn ExtensionAdRule>>>>`, keyed by
+`family_id`. New extension crates SHOULD register a ChainRules-style rule with
+`register_extension_chain_rule`; advanced code MAY use the low-level
+`register_extension_rule`.
 
-An `ExtensionFactory` is the trait that extension crates register:
-
-```rust
-pub trait ExtensionFactory: Send + Sync + 'static {
-    /// Matches `ExtensionOp::family_id` for ops this factory produces.
-    fn family_id(&self) -> &'static str;
-
-    /// Current in-process version for this family. Used by
-    /// serialization consumers to detect `family_id` version drift.
-    fn version(&self) -> u32;
-
-    /// Optional: produce a default / zero-payload `ExtensionOp` instance
-    /// for diagnostic or cross-process reconstruction purposes. Implementations
-    /// MAY omit this when no consumer requires it.
-    fn instantiate_default(&self) -> Option<std::sync::Arc<dyn ExtensionOp>> {
-        None
-    }
-}
-```
-
-### User-facing registration API
-
-The public API MUST expose the following function (the crate path is
-illustrative):
-
-```rust
-pub fn register_extension(
-    factory: std::sync::Arc<dyn ExtensionFactory>,
-) -> Result<(), RegistrationError>;
-```
-
-An external crate SHOULD register its extensions at a well-known entry
-point (e.g. a `pub fn register()` in the extension crate's `lib.rs`).
 Double-registration under the same `family_id` MUST be rejected with
-`RegistrationError::Duplicate { family_id }`.
+`RegistrationError::DuplicateRule { family_id }`.
 
 `RegistrationError`:
 
 ```rust
 #[derive(Debug, thiserror::Error)]
 pub enum RegistrationError {
-    #[error("family_id {family_id:?} already registered")]
-    Duplicate { family_id: &'static str },
+    #[error("AD rule for family_id {family_id:?} already registered")]
+    DuplicateRule { family_id: &'static str },
     #[error("family_id {family_id:?} does not match the namespaced format")]
     MalformedFamilyId { family_id: &'static str },
 }
@@ -652,10 +589,10 @@ pub enum RegistrationError {
 
 ### Lookup
 
-The public API MUST expose a lookup function:
+The public API MUST expose a rule lookup function:
 
 ```rust
-pub fn lookup_extension_factory(family_id: &str) -> Option<std::sync::Arc<dyn ExtensionFactory>>;
+pub fn lookup_extension_rule(family_id: &str) -> Option<std::sync::Arc<dyn ExtensionAdRule>>;
 ```
 
 Lookup MUST NOT panic on a missing `family_id`. Callers decide how to
@@ -668,40 +605,54 @@ during initialization (the `OnceLock` wrapper permits exactly this).
 Concurrent readers use the `RwLock`; writers MUST complete before any
 graph-building or execution work begins on the `family_id` they added.
 
-### Version-mismatch behaviour
-
-When a graph carries an `Extension` whose `family_id`'s version segment
-does not match the `version()` returned by the currently-registered
-factory, implementations MUST:
-
-- in the in-process case, detect the mismatch at serialization boundaries
-  (Section 11);
-- in the eager / compiled path, treat the currently-registered factory
-  as the source of truth — there is no silent downgrade.
-
-If no factory is registered for a `family_id` at execution time, the
-eager / compiled path MUST NOT invent one. See Section 12 for the
-required failure mode.
-
 ### Failure signature
 
-- Registering two factories with the same `family_id` returns
-  `RegistrationError::Duplicate`.
-- Looking up an unregistered `family_id` returns `None`.
-- Running a graph that references an unregistered `family_id` returns
-  `Error::Unsupported { op, message }` where `message` contains the
-  `family_id`.
+- Registering two AD rules with the same `family_id` returns
+  `RegistrationError::DuplicateRule`.
+- Looking up an unregistered AD rule `family_id` returns `None`.
+- Running a graph that references an extension op with no registered AD rule is
+  valid for forward execution. AD through that op returns
+  `ADRuleError::Unsupported` with the `family_id` and rule kind.
 
 ---
 
 ## 10. AD API surface
 
-### Method signatures
+### Preferred ChainRules-style API
 
-Extension AD is registered independently from the primal factory through
-`register_extension_rule(Arc<dyn ExtensionAdRule>)`. Rule signatures mirror
-`PrimitiveOp::try_linearize` and `PrimitiveOp::try_transpose_rule` and return
-`ADRuleResult<_>` so missing rules can propagate without panic:
+Extension AD is registered independently from the primal op. New
+extension crates SHOULD use `register_extension_chain_rule` and implement
+`ExtensionChainRule`:
+
+```rust
+pub trait ExtensionChainRule: Debug + Send + Sync + 'static {
+    fn family_id(&self) -> &'static str;
+
+    fn frule(&self, op: &dyn ExtensionOp, cx: &mut FruleBuilder<'_>) -> ADRuleResult<()>;
+
+    fn rrule(&self, op: &dyn ExtensionOp, cx: &mut RRuleBuilder<'_>) -> ADRuleResult<()>;
+}
+```
+
+`FruleBuilder` exposes primal inputs and input tangents through
+`primal(i)` and `tangent(i)`, and records output tangents through
+`set_output_tangent(i, value)`. `RRuleBuilder` exposes primal inputs and
+output cotangents through `primal(i)` and `cotangent(i)`, and records input
+cotangents through `set_input_cotangent(i, value)`.
+
+The builders may emit any core `StdTensorOp` through `emit`, convenience
+helpers such as `add`, `mul`, `reduce_sum_all`, and registered extension ops
+through `apply_extension`. They intentionally hide `LocalValId`; extension
+authors pass opaque `AdValue` handles between builder methods.
+
+### Low-level adapter API
+
+The ChainRules-style API is adapted to the lower-level
+`register_extension_rule(Arc<dyn ExtensionAdRule>)` registry. Advanced code may
+implement `ExtensionAdRule` directly when it needs exact control over
+`FragmentBuilder`, `OpEmitter`, `LocalValId`, or `ValRef`. Rule signatures
+mirror `PrimitiveOp::try_linearize` and `PrimitiveOp::try_transpose_rule` and
+return `ADRuleResult<_>` so missing rules can propagate without panic:
 
 ```rust
 pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
@@ -729,14 +680,15 @@ pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
 }
 ```
 
-The `op` argument is the concrete extension payload as a trait object.
-Rules that need payload parameters should downcast via `op.as_any()`.
+In both APIs, the `op` argument is the concrete extension payload as a trait
+object. Rules that need payload parameters should downcast via `op.as_any()`.
 
 ### AD closure
 
-`linearize` and `transpose_rule` may emit core `StdTensorOp` values and
-`StdTensorOp::Extension` values. Emitted extension families MUST have their
-own registered `ExtensionAdRule` before a subsequent AD pass reaches them.
+`frule`, `rrule`, `linearize`, and `transpose_rule` may emit core
+`StdTensorOp` values and `StdTensorOp::Extension` values. Emitted extension
+families MUST have their own registered `ExtensionChainRule` or
+`ExtensionAdRule` before a subsequent AD pass reaches them.
 This keeps out-of-tree operations in the same compute graph while preserving
 the `PrimitiveOp` closure invariant at the `StdTensorOp` carrier level.
 
@@ -764,7 +716,7 @@ inside the extension's AD rules.
 ### Failure signature
 
 - Dispatcher reaching a `StdTensorOp::Extension` variant for an
-  `family_id` with no registered `ExtensionAdRule` returns
+  `family_id` with no registered `ExtensionChainRule` or `ExtensionAdRule` returns
   `ADRuleError::Unsupported` with the family ID and rule kind.
 
 ---
@@ -786,11 +738,11 @@ abbreviation). A deserializer MUST reject any family_id that violates
 the namespaced format in Section 5 before attempting lookup.
 
 Per Section 5, a major-version change in the `family_id` indicates a
-breaking payload / semantics change. A deserializer MUST refuse to
-load a graph whose `family_id` does not match the major version of the
-registered factory, even if the payload appears to decode. The refusal
-MUST produce `Error::Unsupported` carrying the on-wire `family_id` and
-the registered `family_id`.
+breaking payload / semantics change. A future deserializer MUST use an
+explicit serialization registry for payload reconstruction and MUST refuse
+to load a graph whose on-wire `family_id` is unsupported by that registry.
+The refusal MUST produce `Error::Unsupported` carrying the on-wire
+`family_id`.
 
 ### Cross-process policy
 
@@ -832,7 +784,7 @@ these error types / behaviours in the listed scenarios.
 | Backend lacks a capability the extension needs | The extension's `eager_execute` SHOULD return `Error::BackendFailure` with a descriptive message that includes `family_id` and the missing capability name. The core pipeline MUST NOT fall back to a different backend. |
 | Graph references an unregistered `family_id` at eager-execute time | Return `Error::Unsupported { op: "extension", message: "<family_id>: not registered" }`. |
 | Graph references an unregistered `family_id` at compile time | Return `Error::Unsupported` from `compile_std_to_exec`. |
-| AD rules (`linearize` / `transpose_rule`) encounter an `Extension` with no registered `ExtensionAdRule` | Return `ADRuleError::Unsupported` with `family_id` and rule kind; traced `grad` / eager `backward` propagate it through `tenferro::Error`. |
+| AD rules (`frule` / `rrule`, or low-level `linearize` / `transpose_rule`) encounter an `Extension` with no registered AD rule | Return `ADRuleError::Unsupported` with `family_id` and rule kind; traced `grad` / eager `backward` propagate it through `tenferro::Error`. |
 | Hash collision on `family_id` (second registration attempt) | Registry MUST reject with `RegistrationError::Duplicate`. |
 | Arity mismatch: `n_inputs()` disagrees with the `primal_in.len()` the dispatcher passed | `Error::InvalidConfig { op: "extension", message: "family_id=<id>: expected N inputs, got M" }`. |
 | Output shape disagrees with `infer_output_meta` result length | `Error::InvalidConfig` with `family_id` and the mismatched counts. |
@@ -964,42 +916,35 @@ impl ExtensionOp for FusedTropicalDotGeneral {
     ) -> tenferro_tensor::Result<Vec<tenferro_tensor::Tensor>> {
         // Fused tropical GEMM: op is (max, +) over the contracting axes.
         // Implementation dispatches to a CPU / GPU kernel that also records
-        // argmax indices for use in linearize.
+        // argmax indices for use in AD.
         todo!("tropical fused GEMM kernel")
     }
+}
+```
 
-    fn linearize(
-        &self,
-        builder: &mut FragmentBuilder<StdTensorOp>,
-        primal_in: &[GlobalValKey<StdTensorOp>],
-        primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
-        ctx: &mut ShapeGuardContext,
-    ) -> Vec<Option<LocalValId>> {
-        // Sketch only; the real implementation lives in tenferro-ext-tropical.
-        //
-        // Record argmax indices (computed alongside the primal) as auxiliary
-        // primal data, then emit:
-        //   tangent_out = Gather(lhs_tangent, argmax_indices) + Gather(rhs_tangent, argmax_indices)
-        //
-        // This uses only StdTensorOp::Gather and StdTensorOp::Add — core ops.
-        todo!("emit Gather + Add on the core op vocabulary")
+AD registration:
+
+```rust
+#[derive(Debug)]
+struct FusedTropicalDotGeneralRule;
+
+impl ExtensionChainRule for FusedTropicalDotGeneralRule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-ext-tropical.fused_dot_general.v1"
     }
 
-    fn transpose_rule(
-        &self,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<StdTensorOp>],
-        mode: &OpMode,
-        ctx: &mut ShapeGuardContext,
-    ) -> Vec<Option<LocalValId>> {
-        // Sketch only.
-        //
-        // Scatter the incoming cotangent through the saved argmax indices
-        // to recover lhs and rhs cotangents. Uses StdTensorOp::Scatter —
-        // a core op.
-        todo!("emit Scatter on the core op vocabulary")
+    fn frule(&self, op: &dyn ExtensionOp, cx: &mut FruleBuilder<'_>) -> ADRuleResult<()> {
+        let op = op.as_any().downcast_ref::<FusedTropicalDotGeneral>().unwrap();
+        // Sketch only; the real implementation lives in tenferro-ext-tropical.
+        // Emit a tangent graph using core StdTensorOp values.
+        todo!("emit the tropical JVP graph for op.config");
+    }
+
+    fn rrule(&self, op: &dyn ExtensionOp, cx: &mut RRuleBuilder<'_>) -> ADRuleResult<()> {
+        let op = op.as_any().downcast_ref::<FusedTropicalDotGeneral>().unwrap();
+        // Sketch only. Scatter or indicator-mask the incoming cotangent
+        // back to lhs and rhs cotangents using core StdTensorOp values.
+        todo!("emit the tropical VJP graph for op.config");
     }
 }
 ```
@@ -1009,8 +954,8 @@ Registration:
 ```rust
 // In tenferro-ext-tropical/src/lib.rs:
 pub fn register() -> Result<(), RegistrationError> {
-    tenferro::extension::register_extension(
-        Arc::new(FusedTropicalDotGeneralFactory) as Arc<dyn ExtensionFactory>,
+    tenferro::extension::register_extension_chain_rule(
+        Arc::new(FusedTropicalDotGeneralRule),
     )
 }
 ```
@@ -1063,8 +1008,8 @@ versioning, and failure modes all hold unchanged.
 The following are explicitly deferred. Future implementations may decide these
 without revisiting this document.
 
-1. **Exact registry data structure.** Section 9 normatively picks
-   `OnceLock<RwLock<HashMap<&'static str, Arc<dyn ExtensionFactory>>>>`.
+1. **Exact AD rule registry data structure.** Section 9 normatively picks
+   `OnceLock<RwLock<HashMap<&'static str, Arc<dyn ExtensionAdRule>>>>`.
    A future evidence-driven migration to `linkme`-style distributed
    slices is permitted but out of scope for the current contract.
 

--- a/ext/tropical/Cargo.toml
+++ b/ext/tropical/Cargo.toml
@@ -23,7 +23,8 @@ tenferro = { path = "../../tenferro" }
 tenferro-tensor = { path = "../../tenferro-tensor" }
 # `ExtensionOp` implementation surface:
 tenferro-ops = { path = "../../tenferro-ops" }
-computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "8306196" }
+chainrules-core = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2d7662140d92f0dd73b2402aefc2272feafc9270", package = "chainrules" }
+computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "c20e8912560ef11166418bcea089126ef50443cc" }
 num-traits = "0.2"
 
 [dev-dependencies]

--- a/ext/tropical/src/fused.rs
+++ b/ext/tropical/src/fused.rs
@@ -11,10 +11,9 @@
 //!   `MinPlus`). Max-mul is a possible later addition.
 //! - [`FusedTropicalDotGeneralOp`] — the [`ExtensionOp`] payload, carrying
 //!   only the [`TropicalKind`].
-//! - [`FusedTropicalDotGeneralFactory`] — the [`ExtensionFactory`] that
-//!   registers the family in the process-local registry.
-//! - [`register_fused_tropical`] — explicit registration entry point. Tests
-//!   should call it once before use; duplicate registrations are tolerated.
+//! - [`register_fused_tropical`] — explicit AD rule registration entry point.
+//!   Tests should call it once before AD use; duplicate registrations are
+//!   tolerated.
 //!
 //! # Semantics
 //!
@@ -57,12 +56,13 @@ use std::any::Any;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex, OnceLock};
 
+use chainrules_core::{ADRuleError, ADRuleKind, ADRuleResult};
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::ext_op::{
-    register_extension, ExtensionFactory, ExtensionOp, ExtensionRegistryError,
+    register_extension_rule, ExtensionAdRule, ExtensionOp, ExtensionRegistryError,
 };
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, SymDim};
@@ -263,7 +263,10 @@ impl ExtensionOp for FusedTropicalDotGeneralOp {
         }
     }
 
-    fn linearize(
+}
+
+impl FusedTropicalDotGeneralOp {
+    fn linearize_rule(
         &self,
         builder: &mut FragmentBuilder<StdTensorOp>,
         primal_in: &[GlobalValKey<StdTensorOp>],
@@ -350,7 +353,7 @@ impl ExtensionOp for FusedTropicalDotGeneralOp {
         vec![Some(out_dot)]
     }
 
-    fn transpose_rule(
+    fn transpose_rule_impl(
         &self,
         emitter: &mut dyn OpEmitter<StdTensorOp>,
         cotangent_out: &[Option<LocalValId>],
@@ -917,6 +920,7 @@ fn zero_bytes(dtype: DType) -> Vec<u8> {
             b.extend_from_slice(&0.0_f64.to_le_bytes());
             b
         }
+        DType::I64 => 0_i64.to_le_bytes().to_vec(),
     }
 }
 
@@ -936,6 +940,7 @@ fn one_bytes(dtype: DType) -> Vec<u8> {
             b.extend_from_slice(&0.0_f64.to_le_bytes());
             b
         }
+        DType::I64 => 1_i64.to_le_bytes().to_vec(),
     }
 }
 
@@ -1030,35 +1035,67 @@ fn tropical_gemm_f32(
 }
 
 // ----------------------------------------------------------------------
-// Factory and registration.
+// AD rule registration.
 // ----------------------------------------------------------------------
 
-/// [`ExtensionFactory`] for [`FusedTropicalDotGeneralOp`].
 #[derive(Debug, Default)]
-pub struct FusedTropicalDotGeneralFactory;
+struct FusedTropicalDotGeneralAdRule;
 
-impl ExtensionFactory for FusedTropicalDotGeneralFactory {
+impl ExtensionAdRule for FusedTropicalDotGeneralAdRule {
     fn family_id(&self) -> &'static str {
         FUSED_TROPICAL_DOT_GENERAL_FAMILY_ID
     }
 
-    fn version(&self) -> u32 {
-        1
+    fn linearize(
+        &self,
+        op: &dyn ExtensionOp,
+        builder: &mut FragmentBuilder<StdTensorOp>,
+        primal_in: &[GlobalValKey<StdTensorOp>],
+        primal_out: &[GlobalValKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValId>],
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        let op = fused_payload(op, ADRuleKind::Linearize)?;
+        Ok(op.linearize_rule(builder, primal_in, primal_out, tangent_in, ctx))
+    }
+
+    fn transpose_rule(
+        &self,
+        op: &dyn ExtensionOp,
+        emitter: &mut dyn OpEmitter<StdTensorOp>,
+        cotangent_out: &[Option<LocalValId>],
+        inputs: &[ValRef<StdTensorOp>],
+        mode: &OpMode,
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        let op = fused_payload(op, ADRuleKind::Transpose)?;
+        Ok(op.transpose_rule_impl(emitter, cotangent_out, inputs, mode, ctx))
     }
 }
 
-/// Explicitly register the `FusedTropicalDotGeneral` family with the
-/// extension registry. Idempotent across calls within a single process.
+fn fused_payload<'a>(
+    op: &'a dyn ExtensionOp,
+    rule: ADRuleKind,
+) -> ADRuleResult<&'a FusedTropicalDotGeneralOp> {
+    op.as_any()
+        .downcast_ref::<FusedTropicalDotGeneralOp>()
+        .ok_or_else(|| ADRuleError::unsupported(FUSED_TROPICAL_DOT_GENERAL_FAMILY_ID, rule))
+}
+
+/// Explicitly register the `FusedTropicalDotGeneral` AD rule.
+///
+/// The op payload itself is carried directly as `Arc<dyn ExtensionOp>` and
+/// does not need process-global registration. AD requires this rule
+/// registration before gradients pass through the fused op.
 ///
 /// Registration style: **explicit** (user / test code calls this, usually
 /// once at startup). Implementation tolerates duplicate calls by silently
-/// swallowing the `Duplicate` error after the first successful registration
-/// — this keeps test-harness ordering simple (multiple integration test
-/// binaries may run in the same address space on some runners).
+/// swallowing the `DuplicateRule` error after the first successful
+/// registration — this keeps test-harness ordering simple.
 ///
 /// Returns `Err(MalformedFamilyId)` if the compiled-in family id ever
 /// drifts from the normative format — a defensive check, not a normal
-/// failure mode. Duplicate registration is mapped to `Ok(())`.
+/// failure mode. Duplicate rule registration is mapped to `Ok(())`.
 ///
 /// # Examples
 ///
@@ -1074,13 +1111,8 @@ pub fn register_fused_tropical() -> Result<(), ExtensionRegistryError> {
     if *guard {
         return Ok(());
     }
-    match register_extension(Arc::new(FusedTropicalDotGeneralFactory)) {
-        Ok(()) => {
-            *guard = true;
-            Ok(())
-        }
-        Err(ExtensionRegistryError::Duplicate { .. }) => {
-            // Another path already registered the family — still fine.
+    match register_extension_rule(Arc::new(FusedTropicalDotGeneralAdRule)) {
+        Ok(()) | Err(ExtensionRegistryError::DuplicateRule { .. }) => {
             *guard = true;
             Ok(())
         }

--- a/ext/tropical/src/lib.rs
+++ b/ext/tropical/src/lib.rs
@@ -23,9 +23,9 @@
 //! rules — no new AD math is introduced there.
 //!
 //! The fused path packages a primal (conceptually a tropical GEMM kernel) as a
-//! single `StdTensorOp::Extension(Arc<dyn ExtensionOp>)` node routed through
-//! the extension registry. The AD rule remains expressed over core ops
-//! (indicator-based VJP/JVP), preserving the AD closure contract.
+//! single `StdTensorOp::Extension(Arc<dyn ExtensionOp>)` node. The registered
+//! AD rule remains expressed over core ops (indicator-based VJP/JVP),
+//! preserving the AD closure contract.
 //!
 //! See:
 //!
@@ -68,8 +68,8 @@ pub mod newtype;
 pub mod traced;
 
 pub use fused::{
-    register_fused_tropical, FusedTropicalDotGeneralFactory, FusedTropicalDotGeneralOp,
-    TropicalKind, FUSED_TROPICAL_DOT_GENERAL_FAMILY_ID,
+    register_fused_tropical, FusedTropicalDotGeneralOp, TropicalKind,
+    FUSED_TROPICAL_DOT_GENERAL_FAMILY_ID,
 };
 pub use newtype::{MaxMul, MaxPlus, MinPlus};
 pub use traced::{

--- a/ext/tropical/tests/fused_tropical_ad.rs
+++ b/ext/tropical/tests/fused_tropical_ad.rs
@@ -1,18 +1,17 @@
 //! Integration tests for the fused tropical `ExtensionOp`.
 //!
 //! These tests are the extension contract self-test: they exercise the full
-//! path from `register_extension` through `TracedTensor` graph building,
+//! path from AD rule registration through `TracedTensor` graph building,
 //! primal execution, and both linearize- and transpose-based AD. They also
 //! cross-check the fused path against the composition-based wrapper to confirm
 //! the forward primal and AD gradient agree (modulo tie-breaking).
 
 use std::sync::Arc;
 
-use tenferro::extension::{register_extension, ExtensionFactory, ExtensionRegistryError};
 use tenferro::{CpuBackend, Engine, Tensor, TracedTensor};
 use tenferro_ext_tropical::fused::{
-    register_fused_tropical, FusedTropicalDotGeneralFactory, FusedTropicalDotGeneralOp,
-    TropicalKind, FUSED_TROPICAL_DOT_GENERAL_FAMILY_ID,
+    register_fused_tropical, FusedTropicalDotGeneralOp, TropicalKind,
+    FUSED_TROPICAL_DOT_GENERAL_FAMILY_ID,
 };
 use tenferro_ext_tropical::traced::{
     min_plus_dot_general, min_plus_dot_general_fused, tropical_dot_general,
@@ -271,52 +270,6 @@ fn family_id_matches_spec_format() {
 }
 
 #[test]
-fn duplicate_factory_registration_is_rejected() {
-    // Install the real factory first (tolerating any prior registration
-    // from other parallel tests in the same binary).
-    register_fused_tropical().expect("register");
-
-    // Now try to register another factory with the same family_id — this
-    // must fail with Duplicate, regardless of prior state.
-    struct DupFactory;
-    impl ExtensionFactory for DupFactory {
-        fn family_id(&self) -> &'static str {
-            FUSED_TROPICAL_DOT_GENERAL_FAMILY_ID
-        }
-        fn version(&self) -> u32 {
-            1
-        }
-    }
-    let err = register_extension(Arc::new(DupFactory)).expect_err("duplicate family_id must error");
-    assert!(matches!(
-        err,
-        ExtensionRegistryError::Duplicate {
-            family_id: "tenferro-ext-tropical.fused_dot_general.v1"
-        }
-    ));
-}
-
-#[test]
-fn malformed_family_id_is_rejected() {
-    struct BadFactory;
-    impl ExtensionFactory for BadFactory {
-        fn family_id(&self) -> &'static str {
-            "no-version-suffix"
-        }
-        fn version(&self) -> u32 {
-            1
-        }
-    }
-    let err = register_extension(Arc::new(BadFactory)).expect_err("malformed family_id must error");
-    assert!(matches!(
-        err,
-        ExtensionRegistryError::MalformedFamilyId {
-            family_id: "no-version-suffix"
-        }
-    ));
-}
-
-#[test]
 fn payload_eq_requires_kind_match() {
     let max =
         Arc::new(FusedTropicalDotGeneralOp::new(TropicalKind::MaxPlus)) as Arc<dyn ExtensionOp>;
@@ -329,13 +282,6 @@ fn payload_eq_requires_kind_match() {
     assert!(max.payload_eq(max2.as_ref()));
     // Different kind => payload_eq is false.
     assert!(!max.payload_eq(min.as_ref()));
-}
-
-#[test]
-fn factory_reports_version_and_family_id() {
-    let f = FusedTropicalDotGeneralFactory;
-    assert_eq!(f.family_id(), FUSED_TROPICAL_DOT_GENERAL_FAMILY_ID);
-    assert_eq!(f.version(), 1);
 }
 
 #[test]

--- a/tenferro-fft/Cargo.toml
+++ b/tenferro-fft/Cargo.toml
@@ -13,8 +13,8 @@ description = "FFT extension operations for tenferro."
 tenferro = { path = "../tenferro" }
 tenferro-tensor = { path = "../tenferro-tensor" }
 tenferro-ops = { path = "../tenferro-ops" }
-chainrules-core = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "da3f2b50ba2e6a0738737e4e4b2ec8f5c8243469", package = "chainrules" }
-computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "8306196" }
+chainrules-core = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2d7662140d92f0dd73b2402aefc2272feafc9270", package = "chainrules" }
+computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "c20e8912560ef11166418bcea089126ef50443cc" }
 num-complex = "0.4"
 num-traits = "0.2"
 rustfft = "6"

--- a/tenferro-fft/src/lib.rs
+++ b/tenferro-fft/src/lib.rs
@@ -40,8 +40,7 @@ use num_complex::Complex;
 use num_traits::{Float, FromPrimitive, Zero};
 use rustfft::{FftNum, FftPlanner};
 use tenferro::extension::{
-    apply, register_extension, register_extension_rule, ExtensionAdRuleTrait, ExtensionFactory,
-    ExtensionOpTrait, ExtensionRegistryError,
+    apply, register_extension_rule, ExtensionAdRuleTrait, ExtensionOpTrait, ExtensionRegistryError,
 };
 use tenferro::TracedTensor;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -49,7 +48,6 @@ use tenferro_ops::{ShapeGuardContext, SymDim};
 use tenferro_tensor::{DType, Tensor, TypedTensor};
 
 const FFT_FAMILY_ID: &str = "tenferro-fft.fft.v1";
-const FFT_VERSION: u32 = 1;
 
 /// FFT normalization convention.
 ///
@@ -274,28 +272,6 @@ impl ExtensionOpTrait for FftOp {
 }
 
 #[derive(Debug)]
-struct FftFactory;
-
-impl ExtensionFactory for FftFactory {
-    fn family_id(&self) -> &'static str {
-        FFT_FAMILY_ID
-    }
-
-    fn version(&self) -> u32 {
-        FFT_VERSION
-    }
-
-    fn instantiate_default(&self) -> Option<Arc<dyn ExtensionOpTrait>> {
-        Some(Arc::new(FftOp::new(
-            FftKind::C2C { forward: true },
-            0,
-            None,
-            FftNorm::Backward,
-        )))
-    }
-}
-
-#[derive(Debug)]
 struct FftAdRule;
 
 impl ExtensionAdRuleTrait for FftAdRule {
@@ -368,7 +344,7 @@ impl ExtensionAdRuleTrait for FftAdRule {
     }
 }
 
-/// Register the FFT extension family and its AD rule.
+/// Register the FFT extension AD rule.
 ///
 /// Calling this function more than once in a process is harmless. The public
 /// wrapper functions call it automatically before building traced graphs.
@@ -380,10 +356,6 @@ impl ExtensionAdRuleTrait for FftAdRule {
 /// tenferro_fft::register_fft().unwrap();
 /// ```
 pub fn register_fft() -> Result<(), ExtensionRegistryError> {
-    match register_extension(Arc::new(FftFactory)) {
-        Ok(()) | Err(ExtensionRegistryError::Duplicate { .. }) => {}
-        Err(err) => return Err(err),
-    }
     match register_extension_rule(Arc::new(FftAdRule)) {
         Ok(()) | Err(ExtensionRegistryError::DuplicateRule { .. }) => {}
         Err(err) => return Err(err),

--- a/tenferro-ops/src/ext_op.rs
+++ b/tenferro-ops/src/ext_op.rs
@@ -12,29 +12,13 @@
 //!   type-erased `Arc<dyn ExtensionOp>` carrier can satisfy
 //!   `Clone + Hash + Eq + Send + Sync + 'static` (computegraph's
 //!   `GraphOp` requirements).
-//! - AD rules are registered separately through [`ExtensionAdRule`] and
-//!   [`register_extension_rule`]. A rule may emit core [`StdTensorOp`] values
-//!   and registered `Extension` values so out-of-tree operations remain in the
-//!   same graph.
-//! - [`ExtensionFactory`] is registered at program start via
-//!   [`register_extension`]; the registry is an
-//!   `OnceLock<RwLock<HashMap<&'static str, Arc<dyn ExtensionFactory>>>>`
-//!   keyed by [`ExtensionOp::family_id`].
-//!
-//! # Examples
-//!
-//! ```ignore
-//! use std::sync::Arc;
-//! use tenferro_ops::ext_op::{register_extension, ExtensionFactory};
-//!
-//! # struct MyFactory;
-//! # impl ExtensionFactory for MyFactory {
-//! #     fn family_id(&self) -> &'static str { "my-crate.my_op.v1" }
-//! #     fn version(&self) -> u32 { 1 }
-//! # }
-//! let factory: Arc<dyn ExtensionFactory> = Arc::new(MyFactory);
-//! register_extension(factory).expect("registration");
-//! ```
+//! - AD rules are registered separately through [`ExtensionChainRule`] and
+//!   [`register_extension_chain_rule`] for ChainRules-style code, or through
+//!   the lower-level [`ExtensionAdRule`] / [`register_extension_rule`] adapter
+//!   interface. A rule may emit core [`StdTensorOp`] values and registered
+//!   `Extension` values so out-of-tree operations remain in the same graph.
+//! - Extension ops themselves do not require process-global registration.
+//!   Frontends carry them directly as `Arc<dyn ExtensionOp>`.
 
 use std::any::Any;
 use std::collections::HashMap;
@@ -45,10 +29,11 @@ use std::sync::{Arc, OnceLock, RwLock};
 use chainrules_core::{ADRuleError, ADRuleKind, ADRuleResult};
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::{GraphOp, OpEmitter};
 use tenferro_tensor::{DType, Tensor};
 
 use crate::ad::context::ShapeGuardContext;
+use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
 
@@ -64,7 +49,8 @@ use crate::sym_dim::SymDim;
 /// - shape / dtype inference via [`infer_output_meta`][Self::infer_output_meta];
 /// - forward dispatch via [`eager_execute`][Self::eager_execute] (used by both
 ///   the eager and compiled paths);
-/// - AD via a separately registered [`ExtensionAdRule`].
+/// - AD via a separately registered [`ExtensionChainRule`] or
+///   [`ExtensionAdRule`].
 ///
 /// # Downcast convention
 ///
@@ -76,38 +62,40 @@ use crate::sym_dim::SymDim;
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
+/// # use std::any::Any;
 /// use std::sync::Arc;
 /// use tenferro_ops::ext_op::ExtensionOp;
+/// use tenferro_ops::SymDim;
+/// use tenferro_tensor::{DType, Tensor};
 ///
-/// # struct MyExt;
-/// # impl std::fmt::Debug for MyExt { fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) } }
-/// # impl ExtensionOp for MyExt { /* ... */
-/// #     fn family_id(&self) -> &'static str { "my-crate.my_op.v1" }
-/// #     fn payload_hash(&self, _hasher: &mut dyn std::hash::Hasher) {}
-/// #     fn payload_eq(&self, _other: &dyn ExtensionOp) -> bool { true }
-/// #     fn clone_arc(&self) -> Arc<dyn ExtensionOp> { unimplemented!() }
-/// #     fn n_inputs(&self) -> usize { 0 }
-/// #     fn n_outputs(&self) -> usize { 0 }
-/// #     fn infer_output_meta(&self, _: &[tenferro_tensor::DType], _: &[&[tenferro_ops::SymDim]]) -> Vec<(tenferro_tensor::DType, Vec<tenferro_ops::SymDim>)> { vec![] }
-/// #     fn eager_execute(&self, _: &[&tenferro_tensor::Tensor]) -> tenferro_tensor::Result<Vec<tenferro_tensor::Tensor>> { unimplemented!() }
-/// #     fn linearize(
-/// #         &self,
-/// #         _: &mut computegraph::fragment::FragmentBuilder<tenferro_ops::std_tensor_op::StdTensorOp>,
-/// #         _: &[computegraph::types::GlobalValKey<tenferro_ops::std_tensor_op::StdTensorOp>],
-/// #         _: &[computegraph::types::GlobalValKey<tenferro_ops::std_tensor_op::StdTensorOp>],
-/// #         _: &[Option<computegraph::types::LocalValId>],
-/// #         _: &mut tenferro_ops::ShapeGuardContext,
-/// #     ) -> Vec<Option<computegraph::types::LocalValId>> { vec![] }
-/// #     fn transpose_rule(
-/// #         &self,
-/// #         _: &mut dyn computegraph::OpEmitter<tenferro_ops::std_tensor_op::StdTensorOp>,
-/// #         _: &[Option<computegraph::types::LocalValId>],
-/// #         _: &[computegraph::types::ValRef<tenferro_ops::std_tensor_op::StdTensorOp>],
-/// #         _: &computegraph::types::OpMode,
-/// #         _: &mut tenferro_ops::ShapeGuardContext,
-/// #     ) -> Vec<Option<computegraph::types::LocalValId>> { vec![] }
-/// # }
+/// #[derive(Clone, Debug)]
+/// struct IdentityExt;
+///
+/// impl ExtensionOp for IdentityExt {
+///     fn family_id(&self) -> &'static str { "example.identity.v1" }
+///     fn payload_hash(&self, _hasher: &mut dyn std::hash::Hasher) {}
+///     fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+///         other.as_any().downcast_ref::<IdentityExt>().is_some()
+///     }
+///     fn clone_arc(&self) -> Arc<dyn ExtensionOp> { Arc::new(self.clone()) }
+///     fn as_any(&self) -> &dyn Any { self }
+///     fn n_inputs(&self) -> usize { 1 }
+///     fn n_outputs(&self) -> usize { 1 }
+///     fn infer_output_meta(
+///         &self,
+///         dtypes: &[DType],
+///         shapes: &[&[SymDim]],
+///     ) -> Vec<(DType, Vec<SymDim>)> {
+///         vec![(dtypes[0], shapes[0].to_vec())]
+///     }
+///     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+///         Ok(vec![inputs[0].clone()])
+///     }
+/// }
+///
+/// let op: Arc<dyn ExtensionOp> = Arc::new(IdentityExt);
+/// assert_eq!(op.n_inputs(), 1);
 /// ```
 pub trait ExtensionOp: Debug + Send + Sync + 'static {
     // ----- Identity, hashing, equality (spec Section 5) -----
@@ -184,56 +172,16 @@ pub trait ExtensionOp: Debug + Send + Sync + 'static {
     /// be placed on a device the caller can consume.
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>>;
 
-    // ----- AD rules (spec Section 10) -----
-
-    /// Emit the linear (JVP) rule.
-    ///
-    /// This legacy inline hook is retained so existing impl blocks remain
-    /// source-compatible. AD dispatch uses registered [`ExtensionAdRule`]
-    /// providers; new extension crates should register a rule instead of
-    /// relying on this method.
-    fn linearize(
-        &self,
-        _builder: &mut FragmentBuilder<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        _tangent_in: &[Option<LocalValId>],
-        _ctx: &mut ShapeGuardContext,
-    ) -> Vec<Option<LocalValId>> {
-        panic!(
-            "extension family {:?} has no inline linearize rule; register an ExtensionAdRule",
-            self.family_id()
-        )
-    }
-
-    /// Emit the transpose (VJP) rule.
-    ///
-    /// This legacy inline hook is retained so existing impl blocks remain
-    /// source-compatible. AD dispatch uses registered [`ExtensionAdRule`]
-    /// providers; new extension crates should register a rule instead of
-    /// relying on this method.
-    fn transpose_rule(
-        &self,
-        _emitter: &mut dyn OpEmitter<StdTensorOp>,
-        _cotangent_out: &[Option<LocalValId>],
-        _inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
-        _ctx: &mut ShapeGuardContext,
-    ) -> Vec<Option<LocalValId>> {
-        panic!(
-            "extension family {:?} has no inline transpose rule; register an ExtensionAdRule",
-            self.family_id()
-        )
-    }
+    // AD rules are registered separately; see [`ExtensionChainRule`].
 }
 
 /// AD rule provider for an extension family.
 ///
-/// Rules are registered independently from [`ExtensionFactory`] so an
-/// out-of-tree crate can provide a primal operation and AD behavior as separate
-/// components. Rule methods receive the concrete [`ExtensionOp`] payload as a
-/// trait object; implementations should downcast through [`ExtensionOp::as_any`]
-/// when they need payload-specific parameters.
+/// Rules are registered independently from the primal operation so an
+/// out-of-tree crate can provide forward execution without AD, or gate AD
+/// support behind an optional feature. Rule methods receive the concrete
+/// [`ExtensionOp`] payload as a trait object; implementations should downcast
+/// through [`ExtensionOp::as_any`] when they need payload-specific parameters.
 pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
     /// The extension family this rule handles.
     fn family_id(&self) -> &'static str;
@@ -261,47 +209,594 @@ pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
     ) -> ADRuleResult<Vec<Option<LocalValId>>>;
 }
 
-/// Factory trait used at registration time.
+/// Opaque value handle used by extension `frule` and `rrule` builders.
 ///
-/// An [`ExtensionFactory`] identifies a single extension family by its
-/// [`ExtensionOp::family_id`] string and advertises the currently-registered
-/// `version`. Serialization consumers use `version` to detect drift against
-/// the on-wire `family_id`.
+/// Extension rule authors receive `AdValue`s from [`FruleBuilder::tangent`],
+/// [`FruleBuilder::primal`], [`RRuleBuilder::cotangent`], and
+/// [`RRuleBuilder::primal`], then feed them into builder helper methods. This
+/// keeps `LocalValId` construction inside tenferro while still allowing rules
+/// to emit core and extension ops.
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use std::sync::Arc;
-/// use tenferro_ops::ext_op::{register_extension, ExtensionFactory, ExtensionOp};
-///
-/// struct MyFactory;
-/// impl ExtensionFactory for MyFactory {
-///     fn family_id(&self) -> &'static str { "my-crate.my_op.v1" }
-///     fn version(&self) -> u32 { 1 }
-/// }
-///
-/// let _ = register_extension(Arc::new(MyFactory));
 /// ```
-pub trait ExtensionFactory: Send + Sync + 'static {
-    /// The [`ExtensionOp::family_id`] that this factory is registered under.
-    fn family_id(&self) -> &'static str;
+/// use tenferro_ops::ext_op::AdValue;
+///
+/// fn inspect(value: &AdValue) -> bool {
+///     value.is_active()
+/// }
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AdValue {
+    value: ValRef<StdTensorOp>,
+}
 
-    /// Current in-process version for this family.
-    fn version(&self) -> u32;
+impl AdValue {
+    fn local(local_id: LocalValId) -> Self {
+        Self {
+            value: ValRef::Local(local_id),
+        }
+    }
 
-    /// Optional: produce a default / zero-payload [`ExtensionOp`] instance
-    /// for diagnostic or cross-process reconstruction purposes.
-    fn instantiate_default(&self) -> Option<Arc<dyn ExtensionOp>> {
-        None
+    fn external(key: GlobalValKey<StdTensorOp>) -> Self {
+        Self {
+            value: ValRef::External(key),
+        }
+    }
+
+    fn as_val_ref(&self) -> &ValRef<StdTensorOp> {
+        &self.value
+    }
+
+    fn into_val_ref(self) -> ValRef<StdTensorOp> {
+        self.value
+    }
+
+    fn local_id(&self) -> Option<LocalValId> {
+        match self.value {
+            ValRef::Local(local_id) => Some(local_id),
+            ValRef::External(_) => None,
+        }
+    }
+
+    /// Returns `true` when this value is part of the active linear graph.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ops::ext_op::AdValue;
+    ///
+    /// fn is_linear_value(value: &AdValue) -> bool {
+    ///     value.is_active()
+    /// }
+    /// ```
+    pub fn is_active(&self) -> bool {
+        self.local_id().is_some()
     }
 }
 
-/// Errors returned from [`register_extension`].
+/// ChainRules-style AD rule provider for an extension family.
+///
+/// Implement [`Self::frule`] for JVP and [`Self::rrule`] for VJP. The builder
+/// arguments provide named accessors such as `tangent(0)` and `cotangent(0)`
+/// plus helper methods that emit `StdTensorOp` or registered extension ops.
+///
+/// # Examples
+///
+/// ```
+/// use chainrules_core::ADRuleResult;
+/// use tenferro_ops::ext_op::{ExtensionChainRule, ExtensionOp, FruleBuilder, RRuleBuilder};
+///
+/// #[derive(Debug)]
+/// struct IdentityRule;
+///
+/// impl ExtensionChainRule for IdentityRule {
+///     fn family_id(&self) -> &'static str { "example.identity.v1" }
+///     fn frule(&self, _op: &dyn ExtensionOp, cx: &mut FruleBuilder<'_>) -> ADRuleResult<()> {
+///         let dx = cx.tangent(0)?;
+///         cx.set_output_tangent(0, dx)
+///     }
+///     fn rrule(&self, _op: &dyn ExtensionOp, cx: &mut RRuleBuilder<'_>) -> ADRuleResult<()> {
+///         let dy = cx.cotangent(0)?;
+///         cx.set_input_cotangent(0, dy)
+///     }
+/// }
+/// ```
+pub trait ExtensionChainRule: Debug + Send + Sync + 'static {
+    /// The extension family this rule handles.
+    fn family_id(&self) -> &'static str;
+
+    /// Emit the forward-mode rule.
+    fn frule(&self, op: &dyn ExtensionOp, cx: &mut FruleBuilder<'_>) -> ADRuleResult<()>;
+
+    /// Emit the reverse-mode rule.
+    fn rrule(&self, op: &dyn ExtensionOp, cx: &mut RRuleBuilder<'_>) -> ADRuleResult<()>;
+}
+
+/// Builder passed to [`ExtensionChainRule::frule`].
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_ops::ext_op::FruleBuilder;
+///
+/// fn accepts_builder(_cx: &mut FruleBuilder<'_>) {}
+/// ```
+pub struct FruleBuilder<'a> {
+    family_id: &'static str,
+    builder: &'a mut FragmentBuilder<StdTensorOp>,
+    primal_in: &'a [GlobalValKey<StdTensorOp>],
+    primal_out: &'a [GlobalValKey<StdTensorOp>],
+    tangent_in: &'a [Option<LocalValId>],
+    ctx: &'a mut ShapeGuardContext,
+    output_tangents: Vec<Option<LocalValId>>,
+}
+
+impl<'a> FruleBuilder<'a> {
+    fn new(
+        family_id: &'static str,
+        op: &dyn ExtensionOp,
+        builder: &'a mut FragmentBuilder<StdTensorOp>,
+        primal_in: &'a [GlobalValKey<StdTensorOp>],
+        primal_out: &'a [GlobalValKey<StdTensorOp>],
+        tangent_in: &'a [Option<LocalValId>],
+        ctx: &'a mut ShapeGuardContext,
+    ) -> Self {
+        Self {
+            family_id,
+            builder,
+            primal_in,
+            primal_out,
+            tangent_in,
+            ctx,
+            output_tangents: vec![None; op.n_outputs()],
+        }
+    }
+
+    /// Return the tangent for primal input `input_index`, if active.
+    pub fn tangent(&self, input_index: usize) -> ADRuleResult<Option<AdValue>> {
+        self.tangent_in
+            .get(input_index)
+            .copied()
+            .map(|tangent| tangent.map(AdValue::local))
+            .ok_or_else(|| self.error(ADRuleKind::Linearize, "input tangent index out of bounds"))
+    }
+
+    /// Return the primal input value for `input_index`.
+    pub fn primal(&self, input_index: usize) -> ADRuleResult<AdValue> {
+        self.primal_in
+            .get(input_index)
+            .cloned()
+            .map(AdValue::external)
+            .ok_or_else(|| self.error(ADRuleKind::Linearize, "primal input index out of bounds"))
+    }
+
+    /// Return the primal output value for `output_index`.
+    pub fn output(&self, output_index: usize) -> ADRuleResult<AdValue> {
+        self.primal_out
+            .get(output_index)
+            .cloned()
+            .map(AdValue::external)
+            .ok_or_else(|| self.error(ADRuleKind::Linearize, "primal output index out of bounds"))
+    }
+
+    /// Return the rank of primal input `input_index`.
+    pub fn input_rank(&mut self, input_index: usize) -> ADRuleResult<usize> {
+        let primal = self.primal(input_index)?;
+        self.ctx
+            .try_shape_of(primal.as_val_ref())
+            .map(|shape| shape.len())
+            .ok_or_else(|| self.error(ADRuleKind::Linearize, "missing input shape metadata"))
+    }
+
+    /// Emit an arbitrary standard tensor op.
+    pub fn emit(&mut self, op: StdTensorOp, inputs: Vec<AdValue>) -> ADRuleResult<Vec<AdValue>> {
+        emit_with_builder(
+            self.family_id,
+            ADRuleKind::Linearize,
+            self.builder,
+            op,
+            inputs,
+        )
+    }
+
+    /// Emit `lhs + rhs`.
+    pub fn add(&mut self, lhs: AdValue, rhs: AdValue) -> ADRuleResult<AdValue> {
+        self.emit_one(StdTensorOp::Add, vec![lhs, rhs])
+    }
+
+    /// Emit `lhs * rhs`.
+    pub fn mul(&mut self, lhs: AdValue, rhs: AdValue) -> ADRuleResult<AdValue> {
+        self.emit_one(StdTensorOp::Mul, vec![lhs, rhs])
+    }
+
+    /// Emit `sum(value)` over axes `0..rank`.
+    pub fn reduce_sum_all(&mut self, value: AdValue, rank: usize) -> ADRuleResult<AdValue> {
+        self.emit_one(
+            StdTensorOp::ReduceSum {
+                axes: (0..rank).collect(),
+            },
+            vec![value],
+        )
+    }
+
+    /// Broadcast a scalar-like value to the shape of primal input `input_index`.
+    pub fn broadcast_scalar_to_input(
+        &mut self,
+        value: AdValue,
+        input_index: usize,
+    ) -> ADRuleResult<AdValue> {
+        let primal = self.primal(input_index)?;
+        let shape = self.input_shape_as_dim_exprs(input_index, 1)?;
+        let inputs = if shape.is_empty() {
+            vec![value]
+        } else {
+            vec![value, primal]
+        };
+        self.emit_one(
+            StdTensorOp::BroadcastInDim {
+                shape,
+                dims: Vec::new(),
+            },
+            inputs,
+        )
+    }
+
+    /// Emit a registered extension op inside this rule.
+    pub fn apply_extension(
+        &mut self,
+        op: Arc<dyn ExtensionOp>,
+        inputs: Vec<AdValue>,
+    ) -> ADRuleResult<Vec<AdValue>> {
+        self.emit(StdTensorOp::Extension(op), inputs)
+    }
+
+    /// Set the tangent for output `output_index`.
+    pub fn set_output_tangent(
+        &mut self,
+        output_index: usize,
+        tangent: Option<AdValue>,
+    ) -> ADRuleResult<()> {
+        let local = tangent
+            .map(|value| {
+                value.local_id().ok_or_else(|| {
+                    self.error(
+                        ADRuleKind::Linearize,
+                        "output tangent must be an emitted local value",
+                    )
+                })
+            })
+            .transpose()?;
+        if output_index >= self.output_tangents.len() {
+            return Err(self.error(ADRuleKind::Linearize, "output tangent index out of bounds"));
+        }
+        self.output_tangents[output_index] = local;
+        Ok(())
+    }
+
+    fn emit_one(&mut self, op: StdTensorOp, inputs: Vec<AdValue>) -> ADRuleResult<AdValue> {
+        let mut outputs = self.emit(op, inputs)?;
+        debug_assert_eq!(outputs.len(), 1);
+        Ok(outputs.remove(0))
+    }
+
+    fn input_shape_as_dim_exprs(
+        &mut self,
+        input_index: usize,
+        source_idx: usize,
+    ) -> ADRuleResult<Vec<DimExpr>> {
+        let rank = self.input_rank(input_index)?;
+        Ok((0..rank)
+            .map(|axis| DimExpr::InputDim {
+                input_idx: source_idx,
+                axis,
+            })
+            .collect())
+    }
+
+    fn finish(self) -> Vec<Option<LocalValId>> {
+        self.output_tangents
+    }
+
+    fn error(&self, rule: ADRuleKind, message: &str) -> ADRuleError {
+        chain_rule_error(self.family_id, rule, message)
+    }
+}
+
+/// Builder passed to [`ExtensionChainRule::rrule`].
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_ops::ext_op::RRuleBuilder;
+///
+/// fn accepts_builder(_cx: &mut RRuleBuilder<'_>) {}
+/// ```
+pub struct RRuleBuilder<'a> {
+    family_id: &'static str,
+    emitter: &'a mut dyn OpEmitter<StdTensorOp>,
+    cotangent_out: &'a [Option<LocalValId>],
+    inputs: &'a [ValRef<StdTensorOp>],
+    ctx: &'a mut ShapeGuardContext,
+    input_cotangents: Vec<Option<LocalValId>>,
+}
+
+impl<'a> RRuleBuilder<'a> {
+    fn new(
+        family_id: &'static str,
+        op: &dyn ExtensionOp,
+        emitter: &'a mut dyn OpEmitter<StdTensorOp>,
+        cotangent_out: &'a [Option<LocalValId>],
+        inputs: &'a [ValRef<StdTensorOp>],
+        ctx: &'a mut ShapeGuardContext,
+    ) -> Self {
+        Self {
+            family_id,
+            emitter,
+            cotangent_out,
+            inputs,
+            ctx,
+            input_cotangents: vec![None; op.n_inputs()],
+        }
+    }
+
+    /// Return the cotangent for primal output `output_index`, if active.
+    pub fn cotangent(&self, output_index: usize) -> ADRuleResult<Option<AdValue>> {
+        self.cotangent_out
+            .get(output_index)
+            .copied()
+            .map(|cotangent| cotangent.map(AdValue::local))
+            .ok_or_else(|| {
+                self.error(
+                    ADRuleKind::Transpose,
+                    "output cotangent index out of bounds",
+                )
+            })
+    }
+
+    /// Return the primal input value for `input_index`.
+    pub fn primal(&self, input_index: usize) -> ADRuleResult<AdValue> {
+        self.inputs
+            .get(input_index)
+            .cloned()
+            .map(|value| AdValue { value })
+            .ok_or_else(|| self.error(ADRuleKind::Transpose, "primal input index out of bounds"))
+    }
+
+    /// Return the rank of primal input `input_index`.
+    pub fn input_rank(&mut self, input_index: usize) -> ADRuleResult<usize> {
+        let primal = self.primal(input_index)?;
+        self.ctx
+            .try_shape_of(primal.as_val_ref())
+            .map(|shape| shape.len())
+            .ok_or_else(|| self.error(ADRuleKind::Transpose, "missing input shape metadata"))
+    }
+
+    /// Emit an arbitrary standard tensor op.
+    pub fn emit(&mut self, op: StdTensorOp, inputs: Vec<AdValue>) -> ADRuleResult<Vec<AdValue>> {
+        emit_with_emitter(
+            self.family_id,
+            ADRuleKind::Transpose,
+            self.emitter,
+            op,
+            inputs,
+        )
+    }
+
+    /// Emit `lhs + rhs`.
+    pub fn add(&mut self, lhs: AdValue, rhs: AdValue) -> ADRuleResult<AdValue> {
+        self.emit_one(StdTensorOp::Add, vec![lhs, rhs])
+    }
+
+    /// Emit `lhs * rhs`.
+    pub fn mul(&mut self, lhs: AdValue, rhs: AdValue) -> ADRuleResult<AdValue> {
+        self.emit_one(StdTensorOp::Mul, vec![lhs, rhs])
+    }
+
+    /// Emit `sum(value)` over axes `0..rank`.
+    pub fn reduce_sum_all(&mut self, value: AdValue, rank: usize) -> ADRuleResult<AdValue> {
+        self.emit_one(
+            StdTensorOp::ReduceSum {
+                axes: (0..rank).collect(),
+            },
+            vec![value],
+        )
+    }
+
+    /// Broadcast a scalar-like value to the shape of primal input `input_index`.
+    pub fn broadcast_scalar_to_input(
+        &mut self,
+        value: AdValue,
+        input_index: usize,
+    ) -> ADRuleResult<AdValue> {
+        let primal = self.primal(input_index)?;
+        let shape = self.input_shape_as_dim_exprs(input_index, 1)?;
+        let inputs = if shape.is_empty() {
+            vec![value]
+        } else {
+            vec![value, primal]
+        };
+        self.emit_one(
+            StdTensorOp::BroadcastInDim {
+                shape,
+                dims: Vec::new(),
+            },
+            inputs,
+        )
+    }
+
+    /// Emit a registered extension op inside this rule.
+    pub fn apply_extension(
+        &mut self,
+        op: Arc<dyn ExtensionOp>,
+        inputs: Vec<AdValue>,
+    ) -> ADRuleResult<Vec<AdValue>> {
+        self.emit(StdTensorOp::Extension(op), inputs)
+    }
+
+    /// Set the cotangent for input `input_index`.
+    pub fn set_input_cotangent(
+        &mut self,
+        input_index: usize,
+        cotangent: Option<AdValue>,
+    ) -> ADRuleResult<()> {
+        let local = cotangent
+            .map(|value| {
+                value.local_id().ok_or_else(|| {
+                    self.error(
+                        ADRuleKind::Transpose,
+                        "input cotangent must be an emitted local value",
+                    )
+                })
+            })
+            .transpose()?;
+        if input_index >= self.input_cotangents.len() {
+            return Err(self.error(ADRuleKind::Transpose, "input cotangent index out of bounds"));
+        }
+        self.input_cotangents[input_index] = local;
+        Ok(())
+    }
+
+    fn emit_one(&mut self, op: StdTensorOp, inputs: Vec<AdValue>) -> ADRuleResult<AdValue> {
+        let mut outputs = self.emit(op, inputs)?;
+        debug_assert_eq!(outputs.len(), 1);
+        Ok(outputs.remove(0))
+    }
+
+    fn input_shape_as_dim_exprs(
+        &mut self,
+        input_index: usize,
+        source_idx: usize,
+    ) -> ADRuleResult<Vec<DimExpr>> {
+        let rank = self.input_rank(input_index)?;
+        Ok((0..rank)
+            .map(|axis| DimExpr::InputDim {
+                input_idx: source_idx,
+                axis,
+            })
+            .collect())
+    }
+
+    fn finish(self) -> Vec<Option<LocalValId>> {
+        self.input_cotangents
+    }
+
+    fn error(&self, rule: ADRuleKind, message: &str) -> ADRuleError {
+        chain_rule_error(self.family_id, rule, message)
+    }
+}
+
+#[derive(Debug)]
+struct ChainRuleAdapter {
+    rule: Arc<dyn ExtensionChainRule>,
+}
+
+impl ExtensionAdRule for ChainRuleAdapter {
+    fn family_id(&self) -> &'static str {
+        self.rule.family_id()
+    }
+
+    fn linearize(
+        &self,
+        op: &dyn ExtensionOp,
+        builder: &mut FragmentBuilder<StdTensorOp>,
+        primal_in: &[GlobalValKey<StdTensorOp>],
+        primal_out: &[GlobalValKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValId>],
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        let mut cx = FruleBuilder::new(
+            self.family_id(),
+            op,
+            builder,
+            primal_in,
+            primal_out,
+            tangent_in,
+            ctx,
+        );
+        self.rule.frule(op, &mut cx)?;
+        Ok(cx.finish())
+    }
+
+    fn transpose_rule(
+        &self,
+        op: &dyn ExtensionOp,
+        emitter: &mut dyn OpEmitter<StdTensorOp>,
+        cotangent_out: &[Option<LocalValId>],
+        inputs: &[ValRef<StdTensorOp>],
+        _mode: &OpMode,
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        let mut cx = RRuleBuilder::new(self.family_id(), op, emitter, cotangent_out, inputs, ctx);
+        self.rule.rrule(op, &mut cx)?;
+        Ok(cx.finish())
+    }
+}
+
+fn emit_with_builder(
+    family_id: &'static str,
+    rule: ADRuleKind,
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    op: StdTensorOp,
+    inputs: Vec<AdValue>,
+) -> ADRuleResult<Vec<AdValue>> {
+    let input_count = op.n_inputs();
+    if inputs.len() != input_count {
+        return Err(chain_rule_error(
+            family_id,
+            rule,
+            "emitted op input count does not match op arity",
+        ));
+    }
+    let mode = mode_for(&inputs);
+    let inputs = inputs.into_iter().map(AdValue::into_val_ref).collect();
+    Ok(builder
+        .add_op(op, inputs, mode)
+        .into_iter()
+        .map(AdValue::local)
+        .collect())
+}
+
+fn emit_with_emitter(
+    family_id: &'static str,
+    rule: ADRuleKind,
+    emitter: &mut dyn OpEmitter<StdTensorOp>,
+    op: StdTensorOp,
+    inputs: Vec<AdValue>,
+) -> ADRuleResult<Vec<AdValue>> {
+    let input_count = op.n_inputs();
+    if inputs.len() != input_count {
+        return Err(chain_rule_error(
+            family_id,
+            rule,
+            "emitted op input count does not match op arity",
+        ));
+    }
+    let mode = mode_for(&inputs);
+    let inputs = inputs.into_iter().map(AdValue::into_val_ref).collect();
+    Ok(emitter
+        .add_op(op, inputs, mode)
+        .into_iter()
+        .map(AdValue::local)
+        .collect())
+}
+
+fn mode_for(inputs: &[AdValue]) -> OpMode {
+    let active_mask = inputs.iter().map(AdValue::is_active).collect::<Vec<_>>();
+    if active_mask.iter().any(|&active| active) {
+        OpMode::Linear { active_mask }
+    } else {
+        OpMode::Primal
+    }
+}
+
+fn chain_rule_error(family_id: &'static str, rule: ADRuleKind, message: &str) -> ADRuleError {
+    ADRuleError::unsupported(format!("{family_id}: {message}"), rule)
+}
+
+/// Errors returned from extension registries.
 #[derive(Debug, thiserror::Error)]
 pub enum ExtensionRegistryError {
-    /// A factory with the same `family_id` was already registered.
-    #[error("family_id {family_id:?} already registered")]
-    Duplicate { family_id: &'static str },
     /// An AD rule with the same `family_id` was already registered.
     #[error("AD rule for family_id {family_id:?} already registered")]
     DuplicateRule { family_id: &'static str },
@@ -311,13 +806,7 @@ pub enum ExtensionRegistryError {
     MalformedFamilyId { family_id: &'static str },
 }
 
-type FactoryMap = HashMap<&'static str, Arc<dyn ExtensionFactory>>;
 type RuleMap = HashMap<&'static str, Arc<dyn ExtensionAdRule>>;
-
-fn registry() -> &'static RwLock<FactoryMap> {
-    static REG: OnceLock<RwLock<FactoryMap>> = OnceLock::new();
-    REG.get_or_init(|| RwLock::new(HashMap::new()))
-}
 
 fn rule_registry() -> &'static RwLock<RuleMap> {
     static REG: OnceLock<RwLock<RuleMap>> = OnceLock::new();
@@ -356,51 +845,11 @@ fn is_valid_family_id(family_id: &str) -> bool {
     true
 }
 
-/// Register a new extension factory.
-///
-/// The factory's `family_id` MUST follow the reserved format
-/// `"<crate-name>.<op-name>.v<major>"` (spec Section 5) and MUST NOT collide
-/// with any already-registered family. Returns
-/// [`ExtensionRegistryError::Duplicate`] on collision and
-/// [`ExtensionRegistryError::MalformedFamilyId`] on format violation.
-///
-/// # Examples
-///
-/// ```ignore
-/// use std::sync::Arc;
-/// use tenferro_ops::ext_op::{register_extension, ExtensionFactory};
-///
-/// struct MyFactory;
-/// impl ExtensionFactory for MyFactory {
-///     fn family_id(&self) -> &'static str { "my-crate.my_op.v1" }
-///     fn version(&self) -> u32 { 1 }
-/// }
-///
-/// register_extension(Arc::new(MyFactory)).expect("first registration");
-/// ```
-pub fn register_extension(
-    factory: Arc<dyn ExtensionFactory>,
-) -> Result<(), ExtensionRegistryError> {
-    let family_id = factory.family_id();
-    if !is_valid_family_id(family_id) {
-        return Err(ExtensionRegistryError::MalformedFamilyId { family_id });
-    }
-    let mut guard = registry()
-        .write()
-        .expect("extension registry RwLock poisoned");
-    if guard.contains_key(family_id) {
-        return Err(ExtensionRegistryError::Duplicate { family_id });
-    }
-    guard.insert(family_id, factory);
-    Ok(())
-}
-
 /// Register a new extension AD rule.
 ///
-/// The rule's `family_id` uses the same validation as
-/// [`register_extension`]. Registering a rule does not require registering a
-/// factory first; this lets crates split primal construction and AD support
-/// across modules or optional features.
+/// The rule's `family_id` MUST follow the reserved format
+/// `"<crate-name>.<op-name>.v<major>"`. Registering a rule does not require
+/// registering the primal op first; frontends carry the op payload directly.
 pub fn register_extension_rule(
     rule: Arc<dyn ExtensionAdRule>,
 ) -> Result<(), ExtensionRegistryError> {
@@ -418,24 +867,42 @@ pub fn register_extension_rule(
     Ok(())
 }
 
-/// Look up a factory by `family_id`.
+/// Register a ChainRules-style extension AD rule.
 ///
-/// Returns `None` if no factory is registered for the given identifier.
-/// Callers decide how to surface the absence (spec Section 12).
+/// This is the preferred API for new extension crates. Internally it adapts
+/// [`ExtensionChainRule::frule`] and [`ExtensionChainRule::rrule`] to the
+/// lower-level [`ExtensionAdRule`] registry used by the AD dispatcher.
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use tenferro_ops::ext_op::lookup_extension_factory;
-///
-/// assert!(lookup_extension_factory("unknown.op.v1").is_none());
 /// ```
-pub fn lookup_extension_factory(family_id: &str) -> Option<Arc<dyn ExtensionFactory>> {
-    registry()
-        .read()
-        .expect("extension registry RwLock poisoned")
-        .get(family_id)
-        .cloned()
+/// use std::sync::Arc;
+/// use chainrules_core::ADRuleResult;
+/// use tenferro_ops::ext_op::{
+///     register_extension_chain_rule, ExtensionChainRule, ExtensionOp, FruleBuilder, RRuleBuilder,
+/// };
+///
+/// #[derive(Debug)]
+/// struct IdentityRule;
+///
+/// impl ExtensionChainRule for IdentityRule {
+///     fn family_id(&self) -> &'static str { "example.register_chain_rule.v1" }
+///     fn frule(&self, _op: &dyn ExtensionOp, cx: &mut FruleBuilder<'_>) -> ADRuleResult<()> {
+///         let dx = cx.tangent(0)?;
+///         cx.set_output_tangent(0, dx)
+///     }
+///     fn rrule(&self, _op: &dyn ExtensionOp, cx: &mut RRuleBuilder<'_>) -> ADRuleResult<()> {
+///         let dy = cx.cotangent(0)?;
+///         cx.set_input_cotangent(0, dy)
+///     }
+/// }
+///
+/// let _ = register_extension_chain_rule(Arc::new(IdentityRule));
+/// ```
+pub fn register_extension_chain_rule(
+    rule: Arc<dyn ExtensionChainRule>,
+) -> Result<(), ExtensionRegistryError> {
+    register_extension_rule(Arc::new(ChainRuleAdapter { rule }))
 }
 
 /// Look up an extension AD rule by `family_id`.
@@ -481,19 +948,6 @@ pub fn transpose_extension_rule(
             ADRuleKind::Transpose,
         )),
     }
-}
-
-/// Returns `true` when a factory with `family_id` is currently registered.
-///
-/// # Examples
-///
-/// ```ignore
-/// use tenferro_ops::ext_op::is_extension_registered;
-///
-/// assert!(!is_extension_registered("unknown.op.v1"));
-/// ```
-pub fn is_extension_registered(family_id: &str) -> bool {
-    lookup_extension_factory(family_id).is_some()
 }
 
 /// Returns `true` when an AD rule with `family_id` is currently registered.

--- a/tenferro-ops/src/lib.rs
+++ b/tenferro-ops/src/lib.rs
@@ -8,10 +8,10 @@ pub mod sym_dim;
 
 pub use ad::context::{ShapeGuard, ShapeGuardContext, TensorMeta};
 pub use ext_op::{
-    is_extension_registered, is_extension_rule_registered, linearize_extension_rule,
-    lookup_extension_factory, lookup_extension_rule, register_extension, register_extension_rule,
-    transpose_extension_rule, ExtensionAdRule, ExtensionFactory, ExtensionOp,
-    ExtensionRegistryError,
+    is_extension_rule_registered, linearize_extension_rule, lookup_extension_rule,
+    register_extension_chain_rule, register_extension_rule, transpose_extension_rule, AdValue,
+    ExtensionAdRule, ExtensionChainRule, ExtensionOp, ExtensionRegistryError, FruleBuilder,
+    RRuleBuilder,
 };
 pub use shape_extent::ShapeExtent;
 pub use sym_dim::SymDim;

--- a/tenferro-ops/src/tests/ext_op_tests.rs
+++ b/tenferro-ops/src/tests/ext_op_tests.rs
@@ -2,7 +2,6 @@
 
 use std::any::Any;
 use std::hash::Hasher;
-use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use chainrules_core::{ADRuleKind, ADRuleResult};
@@ -12,30 +11,15 @@ use computegraph::OpEmitter;
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ext_op::{
-    is_extension_registered, is_extension_rule_registered, linearize_extension_rule,
-    lookup_extension_factory, lookup_extension_rule, register_extension, register_extension_rule,
-    transpose_extension_rule, ExtensionAdRule, ExtensionFactory, ExtensionOp,
-    ExtensionRegistryError,
+    is_extension_rule_registered, linearize_extension_rule, lookup_extension_rule,
+    register_extension_chain_rule, register_extension_rule, transpose_extension_rule,
+    ExtensionAdRule, ExtensionChainRule, ExtensionOp, ExtensionRegistryError, FruleBuilder,
+    RRuleBuilder,
 };
+use crate::input_key::TensorInputKey;
 use crate::std_tensor_op::StdTensorOp;
-use crate::{ExtensionFamilyId, SymDim};
+use crate::{ExtensionFamilyId, SymDim, TensorMeta};
 use tenferro_tensor::{DType, Tensor};
-
-#[derive(Debug)]
-struct CoverageFamily {
-    family: &'static str,
-}
-
-impl ExtensionFactory for CoverageFamily {
-    fn family_id(&self) -> &'static str {
-        self.family
-    }
-    fn version(&self) -> u32 {
-        1
-    }
-    // `instantiate_default` intentionally left as the default (`None`) to
-    // exercise the default-impl body.
-}
 
 #[derive(Debug)]
 struct CoverageRule {
@@ -44,6 +28,12 @@ struct CoverageRule {
 
 #[derive(Clone, Debug)]
 struct NoInlineRuleOp;
+
+#[derive(Clone, Debug)]
+struct ChainScaleOp;
+
+#[derive(Clone, Debug)]
+struct BuilderCoverageOp;
 
 #[derive(ExtensionFamilyId)]
 #[tenferro_extension(namespace = "covtest", name = "macro_rule", version = 1)]
@@ -89,6 +79,89 @@ impl ExtensionOp for NoInlineRuleOp {
     }
 }
 
+impl ExtensionOp for ChainScaleOp {
+    fn family_id(&self) -> &'static str {
+        "covtest.chain_scale.v1"
+    }
+
+    fn payload_hash(&self, _hasher: &mut dyn Hasher) {}
+
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other.as_any().downcast_ref::<ChainScaleOp>().is_some()
+    }
+
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+        Arc::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn n_inputs(&self) -> usize {
+        1
+    }
+
+    fn n_outputs(&self) -> usize {
+        1
+    }
+
+    fn infer_output_meta(
+        &self,
+        input_dtypes: &[DType],
+        input_shapes: &[&[SymDim]],
+    ) -> Vec<(DType, Vec<SymDim>)> {
+        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    }
+
+    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Ok(vec![inputs[0].clone()])
+    }
+}
+
+impl ExtensionOp for BuilderCoverageOp {
+    fn family_id(&self) -> &'static str {
+        "covtest.builder_coverage.v1"
+    }
+
+    fn payload_hash(&self, _hasher: &mut dyn Hasher) {}
+
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other.as_any().downcast_ref::<BuilderCoverageOp>().is_some()
+    }
+
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+        Arc::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn n_inputs(&self) -> usize {
+        2
+    }
+
+    fn n_outputs(&self) -> usize {
+        2
+    }
+
+    fn infer_output_meta(
+        &self,
+        input_dtypes: &[DType],
+        input_shapes: &[&[SymDim]],
+    ) -> Vec<(DType, Vec<SymDim>)> {
+        vec![
+            (input_dtypes[0], input_shapes[0].to_vec()),
+            (input_dtypes[1], input_shapes[1].to_vec()),
+        ]
+    }
+
+    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Ok(vec![inputs[0].clone(), inputs[1].clone()])
+    }
+}
+
 impl ExtensionAdRule for CoverageRule {
     fn family_id(&self) -> &'static str {
         self.family
@@ -119,12 +192,92 @@ impl ExtensionAdRule for CoverageRule {
     }
 }
 
-#[test]
-fn default_instantiate_returns_none() {
-    let factory: Arc<dyn ExtensionFactory> = Arc::new(CoverageFamily {
-        family: "covtest.instantiate.v1",
-    });
-    assert!(factory.instantiate_default().is_none());
+#[derive(Debug)]
+struct ChainScaleRule;
+
+impl ExtensionChainRule for ChainScaleRule {
+    fn family_id(&self) -> &'static str {
+        "covtest.chain_scale.v1"
+    }
+
+    fn frule(&self, _op: &dyn ExtensionOp, cx: &mut FruleBuilder<'_>) -> ADRuleResult<()> {
+        let Some(dx) = cx.tangent(0)? else {
+            cx.set_output_tangent(0, None)?;
+            return Ok(());
+        };
+        let doubled = cx.add(dx.clone(), dx)?;
+        cx.set_output_tangent(0, Some(doubled))
+    }
+
+    fn rrule(&self, _op: &dyn ExtensionOp, cx: &mut RRuleBuilder<'_>) -> ADRuleResult<()> {
+        let Some(cot_y) = cx.cotangent(0)? else {
+            cx.set_input_cotangent(0, None)?;
+            return Ok(());
+        };
+        let doubled = cx.add(cot_y.clone(), cot_y)?;
+        cx.set_input_cotangent(0, Some(doubled))
+    }
+}
+
+#[derive(Debug)]
+struct BuilderCoverageRule;
+
+impl ExtensionChainRule for BuilderCoverageRule {
+    fn family_id(&self) -> &'static str {
+        "covtest.builder_coverage.v1"
+    }
+
+    fn frule(&self, _op: &dyn ExtensionOp, cx: &mut FruleBuilder<'_>) -> ADRuleResult<()> {
+        let x0 = cx.primal(0)?;
+        let _y0 = cx.output(0)?;
+        assert_eq!(cx.input_rank(0)?, 2);
+
+        let primal_sum = cx.add(x0.clone(), x0)?;
+        let primal_product = cx.mul(primal_sum.clone(), primal_sum)?;
+
+        let Some(dx0) = cx.tangent(0)? else {
+            cx.set_output_tangent(0, None)?;
+            cx.set_output_tangent(1, None)?;
+            return Ok(());
+        };
+        let squared = cx.mul(dx0.clone(), dx0)?;
+        let reduced = cx.reduce_sum_all(squared, 2)?;
+        let broadcast = cx.broadcast_scalar_to_input(reduced, 0)?;
+        let mut ext_outputs = cx.apply_extension(Arc::new(NoInlineRuleOp), vec![broadcast])?;
+        let ext_out = ext_outputs.remove(0);
+        let dy1 = match cx.tangent(1)? {
+            Some(dx1) => cx.add(ext_out.clone(), dx1)?,
+            None => cx.add(ext_out.clone(), primal_product)?,
+        };
+
+        cx.set_output_tangent(0, Some(ext_out))?;
+        cx.set_output_tangent(1, Some(dy1))
+    }
+
+    fn rrule(&self, _op: &dyn ExtensionOp, cx: &mut RRuleBuilder<'_>) -> ADRuleResult<()> {
+        let x1 = cx.primal(1)?;
+        assert_eq!(cx.input_rank(0)?, 2);
+
+        let primal_product = cx.mul(x1.clone(), x1)?;
+
+        let Some(cot_y0) = cx.cotangent(0)? else {
+            cx.set_input_cotangent(0, None)?;
+            cx.set_input_cotangent(1, None)?;
+            return Ok(());
+        };
+        let squared = cx.mul(cot_y0.clone(), cot_y0)?;
+        let reduced = cx.reduce_sum_all(squared, 2)?;
+        let broadcast = cx.broadcast_scalar_to_input(reduced, 0)?;
+        let mut ext_outputs = cx.apply_extension(Arc::new(NoInlineRuleOp), vec![broadcast])?;
+        let ext_out = ext_outputs.remove(0);
+        let dx1 = match cx.cotangent(1)? {
+            Some(cot_y1) => cx.add(ext_out.clone(), cot_y1)?,
+            None => cx.add(ext_out.clone(), primal_product)?,
+        };
+
+        cx.set_input_cotangent(0, Some(ext_out))?;
+        cx.set_input_cotangent(1, Some(dx1))
+    }
 }
 
 #[test]
@@ -172,22 +325,134 @@ fn register_rule_rejects_malformed_family_id() {
 }
 
 #[test]
-fn default_inline_rules_panic_with_registration_guidance() {
-    let op = NoInlineRuleOp;
+fn register_chain_rule_adapts_frule_and_rrule() {
+    register_extension_chain_rule(Arc::new(ChainScaleRule))
+        .expect("first chain rule registration should succeed");
 
+    let op = ChainScaleOp;
     let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let dx = builder.add_input(TensorInputKey::User { id: 10_001 });
     let mut ctx = ShapeGuardContext::default();
-    let linearize_panic = catch_unwind(AssertUnwindSafe(|| {
-        let _ = op.linearize(&mut builder, &[], &[], &[], &mut ctx);
-    }));
-    assert!(linearize_panic.is_err());
+    let jvp = linearize_extension_rule(&op, &mut builder, &[], &[], &[Some(dx)], &mut ctx)
+        .expect("chain frule should adapt to linearize");
+    assert_ne!(jvp, vec![Some(dx)]);
+    let fragment = builder.build();
+    assert_eq!(fragment.ops().len(), 1);
+    assert_eq!(fragment.ops()[0].op, StdTensorOp::Add);
+    assert_eq!(jvp, vec![Some(fragment.ops()[0].outputs[0])]);
 
     let mut emitter = FragmentBuilder::<StdTensorOp>::new();
+    let cot_y = emitter.add_input(TensorInputKey::User { id: 10_002 });
     let mut ctx = ShapeGuardContext::default();
-    let transpose_panic = catch_unwind(AssertUnwindSafe(|| {
-        let _ = op.transpose_rule(&mut emitter, &[], &[], &OpMode::Primal, &mut ctx);
+    let vjp = transpose_extension_rule(
+        &op,
+        &mut emitter,
+        &[Some(cot_y)],
+        &[],
+        &OpMode::Linear {
+            active_mask: vec![true],
+        },
+        &mut ctx,
+    )
+    .expect("chain rrule should adapt to transpose_rule");
+    assert_ne!(vjp, vec![Some(cot_y)]);
+    let fragment = emitter.build();
+    assert_eq!(fragment.ops().len(), 1);
+    assert_eq!(fragment.ops()[0].op, StdTensorOp::Add);
+    assert_eq!(vjp, vec![Some(fragment.ops()[0].outputs[0])]);
+}
+
+#[test]
+fn chain_rule_builders_cover_core_helpers() {
+    register_extension_chain_rule(Arc::new(BuilderCoverageRule))
+        .expect("first builder coverage rule registration should succeed");
+
+    let x0 = GlobalValKey::Input(TensorInputKey::User { id: 20_001 });
+    let x1 = GlobalValKey::Input(TensorInputKey::User { id: 20_002 });
+    let y0 = GlobalValKey::Input(TensorInputKey::User { id: 20_003 });
+    let y1 = GlobalValKey::Input(TensorInputKey::User { id: 20_004 });
+    let mut ctx = ShapeGuardContext::default();
+    ctx.insert_metadata(
+        x0.clone(),
+        TensorMeta::exact(DType::F64, vec![SymDim::from(2usize), SymDim::from(3usize)]),
+    );
+    ctx.insert_metadata(
+        x1.clone(),
+        TensorMeta::exact(DType::F64, vec![SymDim::from(2usize), SymDim::from(3usize)]),
+    );
+
+    let op = BuilderCoverageOp;
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let dx0 = builder.add_input(TensorInputKey::User { id: 20_005 });
+    let dx1 = builder.add_input(TensorInputKey::User { id: 20_006 });
+    let jvp = linearize_extension_rule(
+        &op,
+        &mut builder,
+        &[x0.clone(), x1.clone()],
+        &[y0, y1],
+        &[Some(dx0), Some(dx1)],
+        &mut ctx,
+    )
+    .expect("builder frule should emit helper ops");
+    assert_eq!(jvp.len(), 2);
+    assert!(jvp.iter().all(Option::is_some));
+    let fragment = builder.build();
+    assert!(fragment
+        .ops()
+        .iter()
+        .any(|node| node.op == StdTensorOp::Mul));
+    assert!(fragment.ops().iter().any(|node| {
+        matches!(
+            node.op,
+            StdTensorOp::BroadcastInDim {
+                dims: ref broadcast_dims,
+                ..
+            } if broadcast_dims.is_empty()
+        )
     }));
-    assert!(transpose_panic.is_err());
+    assert!(fragment
+        .ops()
+        .iter()
+        .any(|node| matches!(node.op, StdTensorOp::Extension(_))));
+    assert!(fragment
+        .ops()
+        .iter()
+        .any(|node| matches!(node.mode, OpMode::Primal)));
+
+    let mut emitter = FragmentBuilder::<StdTensorOp>::new();
+    let cot_y0 = emitter.add_input(TensorInputKey::User { id: 20_007 });
+    let cot_y1 = emitter.add_input(TensorInputKey::User { id: 20_008 });
+    let mut ctx = ShapeGuardContext::default();
+    ctx.insert_metadata(
+        x0.clone(),
+        TensorMeta::exact(DType::F64, vec![SymDim::from(2usize), SymDim::from(3usize)]),
+    );
+    ctx.insert_metadata(
+        x1.clone(),
+        TensorMeta::exact(DType::F64, vec![SymDim::from(2usize), SymDim::from(3usize)]),
+    );
+    let vjp = transpose_extension_rule(
+        &op,
+        &mut emitter,
+        &[Some(cot_y0), Some(cot_y1)],
+        &[ValRef::External(x0), ValRef::External(x1)],
+        &OpMode::Linear {
+            active_mask: vec![true, true],
+        },
+        &mut ctx,
+    )
+    .expect("builder rrule should emit helper ops");
+    assert_eq!(vjp.len(), 2);
+    assert!(vjp.iter().all(Option::is_some));
+    let fragment = emitter.build();
+    assert!(fragment
+        .ops()
+        .iter()
+        .any(|node| node.op == StdTensorOp::Mul));
+    assert!(fragment
+        .ops()
+        .iter()
+        .any(|node| matches!(node.op, StdTensorOp::Extension(_))));
 }
 
 #[test]
@@ -211,7 +476,7 @@ fn missing_registered_rule_helpers_return_ad_rule_errors() {
 }
 
 #[test]
-fn register_rejects_malformed_family_ids() {
+fn register_rule_rejects_malformed_family_ids() {
     // Each case targets a different reject branch in `is_valid_family_id`.
     let cases = [
         "noversion",     // rsplitn(2, '.').next() returns None on second call
@@ -225,45 +490,12 @@ fn register_rejects_malformed_family_ids() {
         "fooあ.op.v1",   // non-ASCII in crate
     ];
     for bad in cases {
-        let factory: Arc<dyn ExtensionFactory> = Arc::new(CoverageFamily { family: bad });
-        match register_extension(factory) {
+        let rule: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family: bad });
+        match register_extension_rule(rule) {
             Err(ExtensionRegistryError::MalformedFamilyId { family_id }) => {
                 assert_eq!(family_id, bad);
             }
             other => panic!("expected MalformedFamilyId for {bad:?}, got {other:?}"),
         }
     }
-}
-
-#[test]
-fn register_and_lookup_roundtrips() {
-    let family = "covtest.register_lookup.v1";
-    let factory: Arc<dyn ExtensionFactory> = Arc::new(CoverageFamily { family });
-    register_extension(factory).expect("first registration should succeed");
-
-    assert!(is_extension_registered(family));
-    let looked_up = lookup_extension_factory(family).expect("factory should be registered");
-    assert_eq!(looked_up.family_id(), family);
-    assert_eq!(looked_up.version(), 1);
-}
-
-#[test]
-fn register_rejects_duplicate_family_id() {
-    let family = "covtest.duplicate.v1";
-    let first: Arc<dyn ExtensionFactory> = Arc::new(CoverageFamily { family });
-    register_extension(first).expect("first registration should succeed");
-
-    let second: Arc<dyn ExtensionFactory> = Arc::new(CoverageFamily { family });
-    match register_extension(second) {
-        Err(ExtensionRegistryError::Duplicate { family_id }) => {
-            assert_eq!(family_id, family);
-        }
-        other => panic!("expected Duplicate for {family:?}, got {other:?}"),
-    }
-}
-
-#[test]
-fn lookup_unregistered_family_returns_none() {
-    assert!(!is_extension_registered("covtest.absent.v999"));
-    assert!(lookup_extension_factory("covtest.absent.v999").is_none());
 }

--- a/tenferro/src/extension.rs
+++ b/tenferro/src/extension.rs
@@ -2,27 +2,20 @@
 //!
 //! This module exposes the Stage 6 `ExtensionOp` mechanism through the
 //! `tenferro` facade. External crates implement
-//! [`tenferro_ops::ext_op::ExtensionOp`], register an
-//! [`ExtensionFactory`] through [`register_extension`], register AD rules
-//! through [`register_extension_rule`], and build traced or eager graphs
-//! containing the extension via [`apply`] / [`apply_eager`].
+//! [`tenferro_ops::ext_op::ExtensionOp`], optionally register ChainRules-style
+//! AD rules through [`register_extension_chain_rule`], and build traced or
+//! eager graphs containing the extension via [`apply`] / [`apply_eager`].
 //!
 //! See `docs/spec/extension-op.md` for the normative contract.
 //!
 //! # Examples
 //!
 //! ```ignore
-//! use std::sync::Arc;
-//! use tenferro::extension::{apply, register_extension, ExtensionFactory, ExtensionOp};
+//! use tenferro::extension::{apply, ExtensionOp};
 //!
-//! # struct MyFactory;
-//! # impl ExtensionFactory for MyFactory {
-//! #     fn family_id(&self) -> &'static str { "my-crate.my_op.v1" }
-//! #     fn version(&self) -> u32 { 1 }
-//! # }
-//! register_extension(Arc::new(MyFactory)).expect("register");
-//! // Once registered, construct an `Arc<dyn ExtensionOp>` and call
-//! // `apply(op, &[input])` to lower it into a `TracedTensor`.
+//! // Construct an `Arc<dyn ExtensionOp>` and call `apply(op, &[input])`
+//! // to lower it into a `TracedTensor`. AD support is added separately
+//! // with `register_extension_chain_rule`.
 //! ```
 
 use std::collections::HashMap;
@@ -44,16 +37,17 @@ use crate::metadata::{push_metadata_scope, register_scoped_fragment_metadata};
 use crate::traced::{next_traced_id, TracedTensor};
 
 pub use tenferro_ops::ext_op::{
-    is_extension_registered, is_extension_rule_registered, lookup_extension_factory,
-    lookup_extension_rule, register_extension, register_extension_rule,
-    ExtensionAdRule as _ExtensionAdRuleReexport, ExtensionFactory,
-    ExtensionOp as _ExtensionOpReexport, ExtensionRegistryError,
+    is_extension_rule_registered, lookup_extension_rule, register_extension_chain_rule,
+    register_extension_rule, AdValue, ExtensionAdRule as _ExtensionAdRuleReexport,
+    ExtensionChainRule, ExtensionOp as _ExtensionOpReexport, ExtensionRegistryError, FruleBuilder,
+    RRuleBuilder,
 };
 
 // Re-export under a canonical name (the `_ExtensionOpReexport` alias above
 // exists only so the macro-generated doc-test type bounds can find the
 // trait; downstream callers should use this name).
 pub use tenferro_ops::ext_op::ExtensionAdRule as ExtensionAdRuleTrait;
+pub use tenferro_ops::ext_op::ExtensionChainRule as ExtensionChainRuleTrait;
 pub use tenferro_ops::ext_op::ExtensionOp as ExtensionOpTrait;
 pub use tenferro_ops::ExtensionFamilyId;
 

--- a/tenferro/tests/extension_op.rs
+++ b/tenferro/tests/extension_op.rs
@@ -4,9 +4,9 @@
 //! `tenferro-ops` facades:
 //!
 //! - `TestScaleBy2`: single-input, single-output. Forward computes
-//!   `input * 2.0` via the eager backend; `linearize` and
-//!   `transpose_rule` emit core `StdTensorOp::Add` ops so the extension
-//!   participates in AD through the closure invariant.
+//!   `input * 2.0` via the eager backend; its registered AD rule emits core
+//!   `StdTensorOp::Add` ops so the extension participates in AD through the
+//!   closure invariant.
 //! - `TestSwap`: two inputs, two outputs (input-swap). Exercises
 //!   multi-input / multi-output plumbing.
 //!
@@ -22,10 +22,7 @@ use chainrules_core::ADRuleResult;
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
-use tenferro::extension::{
-    apply, apply_eager, register_extension, register_extension_rule, ExtensionAdRuleTrait,
-    ExtensionFactory,
-};
+use tenferro::extension::{apply, apply_eager, register_extension_rule, ExtensionAdRuleTrait};
 use tenferro::{CpuBackend, EagerContext, EagerTensor, Engine, Tensor, TracedTensor};
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -33,28 +30,9 @@ use tenferro_ops::{ShapeGuardContext, SymDim};
 use tenferro_tensor::{DType, TypedTensor};
 
 // ----------------------------------------------------------------------
-// Test-only registration guard. Integration tests may share a process,
+// Test-only AD rule registration guard. Integration tests may share a process,
 // so register each family at most once per process.
 // ----------------------------------------------------------------------
-fn register_once(factory: Arc<dyn ExtensionFactory>) {
-    static REGISTERED: OnceLock<Mutex<Vec<&'static str>>> = OnceLock::new();
-    let guard = REGISTERED.get_or_init(|| Mutex::new(Vec::new()));
-    let mut ids = guard.lock().expect("test registry mutex");
-    let family_id = factory.family_id();
-    if ids.contains(&family_id) {
-        return;
-    }
-    if let Err(err) = register_extension(factory) {
-        match err {
-            tenferro::extension::ExtensionRegistryError::Duplicate { .. } => {
-                // Already registered by another parallel test binary — fine.
-            }
-            other => panic!("register_extension failed: {other}"),
-        }
-    }
-    ids.push(family_id);
-}
-
 fn register_rule_once(rule: Arc<dyn ExtensionAdRuleTrait>) {
     static REGISTERED: OnceLock<Mutex<Vec<&'static str>>> = OnceLock::new();
     let guard = REGISTERED.get_or_init(|| Mutex::new(Vec::new()));
@@ -139,70 +117,9 @@ impl ExtensionOp for TestScaleBy2 {
             }),
         }
     }
-
-    fn linearize(
-        &self,
-        builder: &mut FragmentBuilder<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
-        _ctx: &mut ShapeGuardContext,
-    ) -> Vec<Option<LocalValId>> {
-        // y = x + x  =>  y_dot = x_dot + x_dot  (linear in x_dot).
-        match tangent_in[0] {
-            Some(dx) => {
-                let sum = builder.add_op(
-                    StdTensorOp::Add,
-                    vec![ValRef::Local(dx), ValRef::Local(dx)],
-                    OpMode::Linear {
-                        active_mask: vec![true, true],
-                    },
-                );
-                vec![Some(sum[0])]
-            }
-            None => vec![None],
-        }
-    }
-
-    fn transpose_rule(
-        &self,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        _inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
-        _ctx: &mut ShapeGuardContext,
-    ) -> Vec<Option<LocalValId>> {
-        // cot_x = cot_y + cot_y (dual of y_dot = x_dot + x_dot)
-        match cotangent_out[0] {
-            Some(ct) => {
-                let sum = emitter.add_op(
-                    StdTensorOp::Add,
-                    vec![ValRef::Local(ct), ValRef::Local(ct)],
-                    OpMode::Linear {
-                        active_mask: vec![true, true],
-                    },
-                );
-                vec![Some(sum[0])]
-            }
-            None => vec![None],
-        }
-    }
-}
-
-struct TestScaleBy2Factory;
-
-impl ExtensionFactory for TestScaleBy2Factory {
-    fn family_id(&self) -> &'static str {
-        "tenferro-tests.scale_by_2.v1"
-    }
-
-    fn version(&self) -> u32 {
-        1
-    }
 }
 
 fn ensure_scale_by_2_registered() {
-    register_once(Arc::new(TestScaleBy2Factory));
     register_rule_once(Arc::new(TestScaleBy2Rule));
 }
 
@@ -317,46 +234,9 @@ impl ExtensionOp for TestSwap {
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         Ok(vec![inputs[1].clone(), inputs[0].clone()])
     }
-
-    fn linearize(
-        &self,
-        _builder: &mut FragmentBuilder<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
-        _ctx: &mut ShapeGuardContext,
-    ) -> Vec<Option<LocalValId>> {
-        // Tangent rule is the same swap: [ta, tb] -> [tb, ta].
-        vec![tangent_in[1], tangent_in[0]]
-    }
-
-    fn transpose_rule(
-        &self,
-        _emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        _inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
-        _ctx: &mut ShapeGuardContext,
-    ) -> Vec<Option<LocalValId>> {
-        // Transpose of swap is swap.
-        vec![cotangent_out[1], cotangent_out[0]]
-    }
-}
-
-struct TestSwapFactory;
-
-impl ExtensionFactory for TestSwapFactory {
-    fn family_id(&self) -> &'static str {
-        "tenferro-tests.swap.v1"
-    }
-
-    fn version(&self) -> u32 {
-        1
-    }
 }
 
 fn ensure_swap_registered() {
-    register_once(Arc::new(TestSwapFactory));
     register_rule_once(Arc::new(TestSwapRule));
 }
 
@@ -795,15 +675,15 @@ fn extension_carrier_hash_and_eq_are_stable() {
 }
 
 #[test]
-fn duplicate_registration_is_rejected() {
+fn duplicate_rule_registration_is_rejected() {
     use tenferro::extension::ExtensionRegistryError;
 
     ensure_scale_by_2_registered();
-    let err = register_extension(Arc::new(TestScaleBy2Factory))
-        .expect_err("second registration must error");
+    let err = register_extension_rule(Arc::new(TestScaleBy2Rule))
+        .expect_err("second rule registration must error");
     assert!(matches!(
         err,
-        ExtensionRegistryError::Duplicate {
+        ExtensionRegistryError::DuplicateRule {
             family_id: "tenferro-tests.scale_by_2.v1"
         }
     ));
@@ -813,17 +693,38 @@ fn duplicate_registration_is_rejected() {
 fn malformed_family_id_is_rejected() {
     use tenferro::extension::ExtensionRegistryError;
 
-    struct BadFactory;
-    impl ExtensionFactory for BadFactory {
+    #[derive(Debug)]
+    struct BadRule;
+    impl ExtensionAdRuleTrait for BadRule {
         fn family_id(&self) -> &'static str {
             "no-version-suffix"
         }
-        fn version(&self) -> u32 {
-            1
+        fn linearize(
+            &self,
+            _op: &dyn ExtensionOp,
+            _builder: &mut FragmentBuilder<StdTensorOp>,
+            _primal_in: &[GlobalValKey<StdTensorOp>],
+            _primal_out: &[GlobalValKey<StdTensorOp>],
+            _tangent_in: &[Option<LocalValId>],
+            _ctx: &mut ShapeGuardContext,
+        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+            Ok(vec![])
+        }
+        fn transpose_rule(
+            &self,
+            _op: &dyn ExtensionOp,
+            _emitter: &mut dyn OpEmitter<StdTensorOp>,
+            _cotangent_out: &[Option<LocalValId>],
+            _inputs: &[ValRef<StdTensorOp>],
+            _mode: &OpMode,
+            _ctx: &mut ShapeGuardContext,
+        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+            Ok(vec![])
         }
     }
 
-    let err = register_extension(Arc::new(BadFactory)).expect_err("malformed family_id must error");
+    let err =
+        register_extension_rule(Arc::new(BadRule)).expect_err("malformed family_id must error");
     assert!(matches!(
         err,
         ExtensionRegistryError::MalformedFamilyId { .. }


### PR DESCRIPTION
## Summary

- Add a ChainRules-style extension AD API with `ExtensionChainRule`, `FruleBuilder`, `RRuleBuilder`, `AdValue`, and `register_extension_chain_rule`.
- Remove inline `ExtensionOp` AD hooks and the old extension factory registration API; extension ops are carried directly as payloads while AD rules remain registered separately.
- Migrate `tenferro-fft` and `ext/tropical` to the new registration model and update the custom operation docs/spec.

## Validation

- `cargo fmt --all --check`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Generated with Codex.

Closes #869
