### PR TITLE
[codex] Reduce CPU pairwise contraction overhead

### DIFF
--- a/benchmarks/julia/Project.toml
+++ b/benchmarks/julia/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"

--- a/docs/performance/tt-inner-product-overhead.md
+++ b/docs/performance/tt-inner-product-overhead.md
@@ -1,0 +1,423 @@
+# Tensor Train Inner Product Overhead Notes
+
+Date: 2026-05-20
+
+This note summarizes the investigation of small-bond-dimension Tensor Train
+inner-product overhead in `tenferro-rs`, compared with ITensors.jl.
+
+## Scope
+
+- Repository focus: `tenferro-rs`
+- Workload: pairwise contractions used by a TT/MPS inner product
+- Threading: one thread for all known thread pools
+- Scalar type: `Complex64` / `ComplexF64`
+- Physical dimension: `d = 2`
+- Bond dimensions: `chi = 1, 2, 4, 8, 16, 32`
+
+## Added Benchmarks
+
+- `tenferro-tensor/benches/pairwise_contraction.rs`
+  - Measures `first_site`, `env_bra`, `tmp_ket`, and `site_update`.
+  - Compares normal per-call execution with cached GEMM analysis.
+- `tenferro-tensor/benches/cpu_install_overhead.rs`
+  - Measures `CpuContext::install` and the surrounding buffer-pool wrapper.
+- `tenferro-tensor/benches/openblas_direct_overhead.rs`
+  - Measures direct `cblas_zgemm` calls for the same small pairwise shapes.
+  - Requires the `cpu-blas` feature and is intended for `src-openblas` runs.
+- `scripts/bench-itensors-pairwise-contraction.jl`
+  - Measures the matching ITensors.jl pairwise contractions.
+- `scripts/bench-pairwise-contraction.sh`
+  - Runs Rust and/or Julia benchmarks with one-thread environment variables.
+- `benchmarks/julia/Project.toml`
+  - Minimal Julia environment containing ITensors.
+
+## Commands
+
+Instantiate Julia:
+
+```bash
+JULIA_NUM_THREADS=1 julia --startup-file=no --project=benchmarks/julia \
+  -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'
+```
+
+Run ITensors.jl pairwise benchmark:
+
+```bash
+bash scripts/bench-pairwise-contraction.sh \
+  --kind julia \
+  --warm-up-time 0.5 \
+  --measurement-time 1 \
+  --sample-size 10
+```
+
+Run Rust pairwise benchmark:
+
+```bash
+bash scripts/bench-pairwise-contraction.sh \
+  --kind rust \
+  --warm-up-time 0.5 \
+  --measurement-time 1 \
+  --sample-size 10
+```
+
+Run CPU install overhead benchmark:
+
+```bash
+RAYON_NUM_THREADS=1 \
+VECLIB_MAXIMUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 \
+OMP_NUM_THREADS=1 \
+MKL_NUM_THREADS=1 \
+cargo bench -p tenferro-tensor --bench cpu_install_overhead -- \
+  --warm-up-time 0.5 \
+  --measurement-time 1 \
+  --sample-size 20
+```
+
+Run OpenBLAS-backed tenferro pairwise benchmark:
+
+```bash
+RAYON_NUM_THREADS=1 \
+VECLIB_MAXIMUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 \
+OMP_NUM_THREADS=1 \
+MKL_NUM_THREADS=1 \
+cargo bench -p tenferro-tensor \
+  --no-default-features \
+  --features src-openblas \
+  --bench pairwise_contraction -- \
+  --warm-up-time 0.5 \
+  --measurement-time 1 \
+  --sample-size 10
+```
+
+Run direct OpenBLAS microbenchmark:
+
+```bash
+RAYON_NUM_THREADS=1 \
+VECLIB_MAXIMUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 \
+OMP_NUM_THREADS=1 \
+MKL_NUM_THREADS=1 \
+cargo bench -p tenferro-tensor \
+  --no-default-features \
+  --features src-openblas \
+  --bench openblas_direct_overhead -- \
+  --warm-up-time 0.5 \
+  --measurement-time 1 \
+  --sample-size 20
+```
+
+## Pairwise Result Summary
+
+`site_update` is the two-contraction pair that corresponds to one inner-product
+site update.
+
+| chi | ITensors median | tenferro normal mean | tenferro cached mean | normal / ITensors |
+|---:|---:|---:|---:|---:|
+| 1 | 3.26 us | 20.38 us | 14.19 us | 6.3x |
+| 2 | 3.72 us | 20.65 us | 16.22 us | 5.6x |
+| 4 | 3.78 us | 19.21 us | 13.32 us | 5.1x |
+| 8 | 5.40 us | 15.59 us | 20.59 us | 2.9x |
+| 16 | 10.82 us | 19.50 us | 20.44 us | 1.8x |
+| 32 | 48.14 us | 57.19 us | 59.03 us | 1.2x |
+
+Interpretation:
+
+- At small `chi`, tenferro is dominated by per-call overhead, not arithmetic.
+- At `chi = 32`, arithmetic dominates more and tenferro approaches ITensors.
+- Cached GEMM analysis helps some small cases, but it is not enough to close
+  the gap because the main fixed cost is outside layout analysis.
+
+## OpenBLAS Tracking
+
+Julia reports `LBTConfig([ILP64] libopenblas64_.so)` with
+`LinearAlgebra.BLAS.get_config()`, and the benchmark script sets
+`BLAS.set_num_threads(1)`. Therefore the ITensors comparison is consistent with
+a one-thread OpenBLAS-backed Julia setup.
+
+Switching tenferro to `src-openblas` did not, by itself, remove the small-`chi`
+fixed cost:
+
+| chi | direct OpenBLAS 2x zgemm | direct + conj copy | tenferro OpenBLAS normal | tenferro OpenBLAS cached |
+|---:|---:|---:|---:|---:|
+| 1 | 0.17 us | 0.21 us | 20.43 us | 20.05 us |
+| 2 | 0.19 us | 0.22 us | 17.02 us | 15.90 us |
+| 4 | 0.34 us | 0.31 us | 16.43 us | 14.88 us |
+| 8 | 1.41 us | 1.53 us | 17.50 us | 14.78 us |
+| 16 | 4.41 us | 8.23 us | 27.35 us | 22.02 us |
+| 32 | 39.64 us | 52.39 us | 62.89 us | 68.23 us |
+
+The direct OpenBLAS calls are much faster than the tenferro OpenBLAS backend for
+small `chi`. At `chi <= 4`, the BLAS kernels take less than 0.4 us for the
+two-GEMM `site_update`, while tenferro takes about 15-20 us. OpenBLAS itself is
+therefore not the bottleneck.
+
+After bypassing `rayon::ThreadPool::install` for the `cpu-blas` GEMM and LAPACK
+paths, the same `site_update` benchmark improves substantially:
+
+| chi | direct OpenBLAS 2x zgemm | tenferro OpenBLAS normal | tenferro OpenBLAS cached |
+|---:|---:|---:|---:|
+| 1 | 0.17 us | 2.24 us | 0.98 us |
+| 2 | 0.19 us | 5.13 us | 2.75 us |
+| 4 | 0.34 us | 5.50 us | 3.32 us |
+| 8 | 1.41 us | 6.43 us | 3.91 us |
+| 16 | 4.41 us | 10.65 us | 8.18 us |
+| 32 | 39.64 us | 38.48 us | 35.63 us |
+
+This removes the earlier "much heavier than faer" state for OpenBLAS at small
+bond dimension. The remaining small-shape gap is mostly generic tensor overhead:
+shape validation, GEMM analysis/cache lookup, output construction, fallback
+materialization for conjugated layouts, and Rust-side dispatch around the BLAS
+call.
+
+The OpenBLAS-backed `dot_general_overhead` benchmark also shows the install
+cost clearly for an `L = 32` inner-product chain:
+
+| chi | fresh backend cache | persistent cache | single exec session |
+|---:|---:|---:|---:|
+| 4 | 812.7 us | 547.0 us | 187.1 us |
+| 8 | 635.0 us | 658.5 us | 252.9 us |
+| 16 | 901.5 us | 1073.4 us | 376.3 us |
+| 32 | 2111.7 us | 2365.9 us | 1334.7 us |
+| 64 | 9620.6 us | 9854.4 us | 14380.1 us |
+
+For `chi = 4`, moving the 64 GEMMs into one execution session saves roughly
+626 us, or about 9.8 us per GEMM. This is consistent with a combination of
+`rayon::ThreadPool::install` plus backend entry overhead dominating tiny GEMMs.
+
+After the install cost is removed by a single execution session, remaining
+small-`chi` overhead still comes from generic tensor machinery: shape
+validation, GEMM analysis/cache lookup, output allocation through `BufferPool`,
+`TypedTensor` construction, and complex conjugation/materialization when BLAS
+cannot represent the requested conjugation as a transpose flag.
+
+## Install Overhead
+
+Measured on one thread:
+
+| Case | Time |
+|---|---:|
+| `CpuContext::install(|| {})` | 5.47 us |
+| `CpuBackend::install(|| {})` | 5.37 us |
+| `BufferPool` `mem::take` / restore only | 0.21 us |
+| `ctx.install` + `BufferPool` take/restore | 5.71 us |
+| `ctx.install` + `BufferPool` + GEMM cache borrow | 5.97 us |
+
+The bottleneck is mostly `rayon::ThreadPool::install`. Buffer-pool movement is
+only about 0.2 us.
+
+For `site_update`, which performs two GEMMs, this adds roughly 11-12 us of
+fixed cost when each GEMM enters the backend separately.
+
+## Faer Global-Rayon Upper Bound
+
+The faer backend cannot currently receive a specific Rayon `ThreadPool` handle.
+`faer::Par` is only a lightweight parallelism value:
+
+```rust
+pub enum Par {
+    Seq,
+    Rayon(NonZeroUsize),
+}
+```
+
+Similarly, the lower-level `gemm_common::Parallelism` value is:
+
+```rust
+pub enum Parallelism {
+    None,
+    Rayon(usize),
+}
+```
+
+Both APIs describe the requested thread count, not the thread pool that must run
+the work. faer and spindle rely on the current Rayon context through
+`rayon::current_num_threads`, `rayon::scope`, `into_par_iter`, and
+`spindle::for_each`. Therefore tenferro currently uses
+`CpuContext::install(...)` to make its owned Rayon pool the current execution
+context before calling faer.
+
+As an upper-bound experiment, the faer backend was run with an experimental
+switch that bypasses `CpuContext::install` and lets faer/spindle use the
+current or global Rayon pool directly:
+
+```bash
+TENFERRO_EXPERIMENTAL_FAER_GLOBAL_RAYON=1
+TENFERRO_PAIRWISE_THREADS=<1|2|4|8>
+```
+
+The benchmark below is cached `site_update`, `Complex64`, `d = 2`, with all
+known BLAS/OpenMP thread pools set to one thread. Times are Criterion means in
+microseconds.
+
+| chi | faer install 1T | faer global 1T | faer install 2T | faer global 2T | faer install 4T | faer global 4T | faer global 8T |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 17.465 | 0.681 | 17.246 | 0.699 | 26.552 | 0.717 | 0.735 |
+| 2 | 17.498 | 1.053 | 18.610 | 1.061 | 28.941 | 1.073 | 1.099 |
+| 4 | 18.017 | 1.171 | 19.156 | 1.176 | 19.967 | 1.180 | 1.204 |
+| 8 | 20.151 | 1.935 | 19.959 | 1.932 | 30.154 | 1.971 | 2.010 |
+| 16 | 22.445 | 4.922 | 25.134 | 5.017 | 38.282 | 4.912 | 4.950 |
+| 32 | 40.829 | 27.842 | 54.813 | 37.542 | 61.173 | 47.744 | 53.738 |
+
+This shows that the per-call pool entry cost is a dominant faer overhead for
+small TT inner-product contractions. However, the fastest upper-bound results
+are almost always the one-thread global-Rayon run. For these small shapes,
+increasing faer thread count does not help; it usually adds parallel dispatch
+overhead. The important optimization is removing per-GEMM `install`, not making
+each tiny GEMM parallel.
+
+The experiment should not be treated as a production backend policy. Bypassing
+`install` lets faer use the current/global Rayon pool, so `CpuContext` no longer
+fully controls pool isolation, thread count, or affinity. It is useful as a
+ceiling measurement and as evidence that coarse-grained pool entry is the main
+direction to pursue.
+
+Design implications:
+
+- For one-thread faer, `Par::Seq` makes `install` unnecessary and a caller-thread
+  fast path is safe.
+- For multi-thread faer, keep tenferro pool semantics by entering the pool once
+  per larger unit of work, such as one TT contraction, one compiled graph, or
+  one linalg batch.
+- Add a small-shape policy that keeps tiny faer GEMMs sequential even when the
+  backend context has more than one thread.
+- A true pool-handle patch would need changes across faer, spindle, and the
+  lower-level gemm parallelism API. It is technically possible but invasive
+  because `Par`/`Parallelism` are currently `Copy` count-only values.
+
+## What `rayon::ThreadPool::install` Does
+
+When called outside the target Rayon pool, `install` does not run the closure on
+the caller thread. It:
+
+1. Creates a stack job holding the closure and result slot.
+2. Injects that job into the pool's external job queue.
+3. Wakes a worker.
+4. Blocks the caller on a latch.
+5. Executes the closure on the worker thread.
+6. Stores the result and notifies the latch.
+7. Wakes the caller and returns the result.
+
+This preserves Rayon pool semantics, but it is expensive for tiny GEMMs.
+
+## Current Code Changes
+
+- Normal `dot_general` and `dot_general_with_conj` no longer store GEMM analysis
+  into a throwaway local cache slot. Previously these paths used `Some(0)` even
+  though the cache was dropped immediately after the call.
+- The internal GEMM analysis cache key now uses `SmallVec` for common small
+  ranks and dimension lists. This reduces heap allocation in cached paths.
+- For the `cpu-blas` backend, `dot_general`, `dot_general_read`, and
+  `dot_general_with_conj` run the GEMM body directly on the caller thread with
+  the backend `BufferPool` and GEMM analysis cache, instead of routing through
+  `rayon::ThreadPool::install`.
+- For the `cpu-blas` backend, LAPACK-backed linalg methods now use the same
+  caller-thread pool wrapper. This covers `cholesky`, `triangular_solve`, `lu`,
+  `full_piv_lu`, `full_piv_lu_solve`, `svd`, `qr`, `eigh`, and `eig`. The
+  `cpu-faer` backend still uses `install` because faer depends on the Rayon CPU
+  context for parallel policy.
+- The BLAS conjugation path now detects row-contiguous conjugated operands before
+  acquiring an output buffer for a direct BLAS attempt that cannot succeed.
+
+No tensor values or contraction results are cached. The cache stores GEMM
+layout analysis only:
+
+- lhs/rhs shapes
+- contracting and batch dimension lists
+- GEMM dimensions `m`, `n`, `k`
+- batch count
+- input/output strides
+- output shape
+
+## Why ITensors.jl Is Faster At Small `chi`
+
+ITensors/NDTensors uses specialized dense tensor contraction paths:
+
+- Scalar-like contractions avoid GEMM entirely.
+- Dense contractions reshape/transpose views and call `mul!`.
+- Julia specializes the hot path by tensor order and storage type after JIT.
+
+For `chi = 1`, several contractions become scalar-like. ITensors therefore
+avoids most of the generic `dot_general` machinery that tenferro currently
+executes.
+
+## Compiled Graph Behavior
+
+Compiled `TracedTensor` execution does not always pay one install per GEMM.
+
+- If the whole program can run in a single `TensorExec` session, install happens
+  once for the graph evaluation.
+- Pure chains of `DotGeneral` / `DotGeneralWithConj` can use this path.
+- If segmentation finds a multi-instruction elementwise fused segment, the
+  program falls back to segment dispatch.
+- In segment dispatch, `Segment::Ffi` currently calls backend methods directly,
+  so GEMM instructions can pay one install per GEMM again.
+
+This means graph compilation helps pure GEMM chains, but install overhead can
+reappear in mixed graphs.
+
+## Cross-Repository Tracing Direction
+
+The tensor4all-rs side should keep eager values and traced graph construction as
+separate types:
+
+- `TensorDynLen` remains an eager concrete tensor. Its operations execute
+  immediately and should not implicitly build or cache semantic computation
+  graphs.
+- `TracedTensorDynLen` should be the explicit graph-building counterpart. It can
+  carry `DynIndex` metadata plus tenferro traced payload nodes, and operations
+  such as contraction, permutation, and linalg add graph nodes instead of
+  executing.
+- Runtime graph evaluation should treat each input slot as an ABI. The bound
+  `TensorDynLen` must match the traced input signature: index order, dimensions,
+  dtype, and storage structure. A different index order should be a different
+  graph, not an implicit permutation.
+- Explicit graph nodes may represent permutations, but evaluation should reject
+  accidental axis-order or structure mismatches. Diagonal/axis-class structure
+  should be part of the signature; equivalent diagonal structure may match, but
+  ambiguous differences should return an error and require building a new graph.
+
+This keeps the eager API predictable and prevents hidden graph construction from
+changing `TensorDynLen` semantics. It also gives GPU/lazy execution a clear
+entry point without making normal eager contractions context-dependent.
+
+## Optimization Candidates
+
+1. Keep `CpuContext::install` public semantics unchanged.
+2. Avoid broad "skip install when `num_threads == 1`" changes.
+3. Consider a private, narrow fast path for one-thread sequential GEMM only:
+   - `ctx.num_threads() == 1`
+   - faer parallel policy is `Par::Seq`
+   - operation is known GEMM-only
+4. Improve segmented execution so FFI GEMMs can run through an existing
+   `TensorExec` session instead of returning to backend-level calls.
+5. Add scalar-like contraction fast paths for `nnz == 1`.
+6. Add tiny GEMM direct-loop fast paths for small `m`, `n`, `k`.
+7. Consider fixed-rank / tuple-based internal paths for common rank-2/rank-3
+   contractions, while keeping the public `DotGeneralConfig` stable unless a
+   broader API cleanup is desired.
+8. Further reduce BLAS conjugation fallback cost by going directly to a
+   preconjugated or specialized contraction path when the stride pattern makes
+   `CblasConjTrans` impossible. The obvious failed direct-BLAS/output-buffer
+   attempt is already avoided.
+9. Add a direct tiny-complex contraction path for TT site updates, especially
+   shapes equivalent to `(chi x chi)' * (chi x d*chi)` and
+   `(chi*d x chi)' * (chi*d x chi)`.
+
+## Verification Performed
+
+- `cargo fmt --all -- --check`
+- `cargo bench -p tenferro-tensor --bench pairwise_contraction --no-run`
+- `cargo bench -p tenferro-tensor --bench cpu_install_overhead --no-run`
+- `cargo bench -p tenferro-tensor --no-default-features --features src-openblas --bench pairwise_contraction -- --warm-up-time 0.5 --measurement-time 1 --sample-size 10`
+- `cargo bench -p tenferro-tensor --no-default-features --features src-openblas --bench dot_general_overhead -- --warm-up-time 0.5 --measurement-time 1 --sample-size 10`
+- `cargo bench -p tenferro-tensor --no-default-features --features src-openblas --bench openblas_direct_overhead -- --warm-up-time 0.5 --measurement-time 1 --sample-size 20`
+- `cargo bench -p tenferro-tensor --no-default-features --features src-openblas --bench pairwise_contraction --no-run`
+- `cargo test -p tenferro-tensor --release dot_general -- --nocapture`
+- `cargo test -p tenferro-tensor --no-default-features --features src-openblas --release dot_general`
+- `cargo test -p tenferro-tensor --no-default-features --features src-openblas --release`
+- `bash -n scripts/bench-pairwise-contraction.sh`
+- Julia `Pkg.instantiate()` and `Pkg.precompile()`
+- ITensors version check: `0.9.27`
+- Julia BLAS config check: `LBTConfig([ILP64] libopenblas64_.so)`, one BLAS thread

--- a/scripts/bench-itensors-pairwise-contraction.jl
+++ b/scripts/bench-itensors-pairwise-contraction.jl
@@ -1,0 +1,202 @@
+#!/usr/bin/env julia
+
+using LinearAlgebra
+using Printf
+using Statistics
+using ITensors
+
+const DEFAULT_D = 2
+const DEFAULT_CHIS = [1, 2, 4, 8, 16, 32]
+const DEFAULT_WARMUP_SECONDS = 1.0
+const DEFAULT_MEASUREMENT_SECONDS = 2.0
+const DEFAULT_MIN_SAMPLES = 10
+
+function usage()
+    println("""
+Usage: julia --project=<env-with-ITensors> scripts/bench-itensors-pairwise-contraction.jl [options]
+
+Options:
+  --d N                         Physical dimension (default: $(DEFAULT_D))
+  --chis LIST                   Comma-separated bond dimensions (default: $(join(DEFAULT_CHIS, ",")))
+  --warm-up-time SECONDS        Warm-up time after the first JIT call (default: $(DEFAULT_WARMUP_SECONDS))
+  --measurement-time SECONDS    Measurement time per case (default: $(DEFAULT_MEASUREMENT_SECONDS))
+  --min-samples N               Minimum samples per case (default: $(DEFAULT_MIN_SAMPLES))
+  --blas-threads N              Julia BLAS threads (default: 1)
+  --help                        Show this help text
+""")
+end
+
+function parse_args(args)
+    opts = Dict{String, Any}(
+        "d" => DEFAULT_D,
+        "chis" => copy(DEFAULT_CHIS),
+        "warm_up_time" => DEFAULT_WARMUP_SECONDS,
+        "measurement_time" => DEFAULT_MEASUREMENT_SECONDS,
+        "min_samples" => DEFAULT_MIN_SAMPLES,
+        "blas_threads" => 1,
+    )
+
+    i = 1
+    while i <= length(args)
+        arg = args[i]
+        if arg == "--help"
+            usage()
+            exit(0)
+        elseif arg == "--d"
+            i += 1
+            opts["d"] = parse(Int, args[i])
+        elseif arg == "--chis"
+            i += 1
+            opts["chis"] = parse.(Int, split(args[i], ","))
+        elseif arg == "--warm-up-time"
+            i += 1
+            opts["warm_up_time"] = parse(Float64, args[i])
+        elseif arg == "--measurement-time"
+            i += 1
+            opts["measurement_time"] = parse(Float64, args[i])
+        elseif arg == "--min-samples"
+            i += 1
+            opts["min_samples"] = parse(Int, args[i])
+        elseif arg == "--blas-threads"
+            i += 1
+            opts["blas_threads"] = parse(Int, args[i])
+        else
+            error("unknown argument: $arg")
+        end
+        i += 1
+    end
+
+    return opts
+end
+
+function complex_value(idx::Int, seed::Int)::ComplexF64
+    real = ((idx * 17 + seed * 13 + 3) % 97) / 97 - 0.5
+    imag = ((idx * 29 + seed * 7 + 5) % 89) / 89 - 0.5
+    return ComplexF64(real, imag)
+end
+
+function deterministic_itensor(inds_tuple::Tuple, seed::Int)::ITensor
+    dims = map(dim, inds_tuple)
+    data = Vector{ComplexF64}(undef, prod(dims))
+    @inbounds for pos in eachindex(data)
+        data[pos] = complex_value(pos - 1, seed)
+    end
+    return ITensor(reshape(data, dims...), inds_tuple...)
+end
+
+function build_fixtures(d::Int, chi::Int)
+    site = Index(d, "Site")
+    left = Index(chi, "Link,left")
+    right_bra = Index(chi, "Link,bra,right")
+    right_ket = Index(chi, "Link,ket,right")
+    next_ket = Index(chi, "Link,ket,next")
+
+    bra_first = deterministic_itensor((site, right_bra), 1)
+    ket_first = deterministic_itensor((site, right_ket), 2)
+    env = deterministic_itensor((left, right_ket), 3)
+    bra_bulk = deterministic_itensor((left, site, right_bra), 4)
+    tmp = deterministic_itensor((right_ket, site, right_bra), 5)
+    ket_bulk = deterministic_itensor((right_ket, site, next_ket), 6)
+
+    return (;
+        bra_first,
+        ket_first,
+        env,
+        bra_bulk,
+        tmp,
+        ket_bulk,
+    )
+end
+
+function run_case(fixtures, case::Symbol)
+    if case == :first_site
+        return dag(fixtures.bra_first) * fixtures.ket_first
+    elseif case == :env_bra
+        return fixtures.env * dag(fixtures.bra_bulk)
+    elseif case == :tmp_ket
+        return fixtures.tmp * fixtures.ket_bulk
+    elseif case == :site_update
+        tmp = fixtures.env * dag(fixtures.bra_bulk)
+        return tmp * fixtures.ket_bulk
+    else
+        error("unknown case: $case")
+    end
+end
+
+function run_for_seconds(f; warmup_seconds::Float64, measurement_seconds::Float64, min_samples::Int)
+    sink = Ref{Any}(nothing)
+
+    sink[] = f()
+    GC.gc()
+
+    warmup_start = time_ns()
+    while (time_ns() - warmup_start) / 1.0e9 < warmup_seconds
+        sink[] = f()
+    end
+    GC.gc()
+
+    times_ns = Int[]
+    measurement_start = time_ns()
+    while (time_ns() - measurement_start) / 1.0e9 < measurement_seconds || length(times_ns) < min_samples
+        start = time_ns()
+        sink[] = f()
+        push!(times_ns, time_ns() - start)
+    end
+
+    return sink[], times_ns
+end
+
+function print_result(; case, d, chi, value, times_ns)
+    times_us = times_ns ./ 1.0e3
+    @printf(
+        "itensors_pairwise_%s,chi_%d_d_%d,%d,%.6f,%.6f,%.6f,%.6f,%s\n",
+        String(case),
+        chi,
+        d,
+        length(times_us),
+        minimum(times_us),
+        median(times_us),
+        mean(times_us),
+        maximum(times_us),
+        string(inds(value)),
+    )
+end
+
+function main()
+    opts = parse_args(ARGS)
+    BLAS.set_num_threads(opts["blas_threads"])
+
+    d = opts["d"]
+    chis = opts["chis"]
+    warmup_seconds = opts["warm_up_time"]
+    measurement_seconds = opts["measurement_time"]
+    min_samples = opts["min_samples"]
+    cases = [:first_site, :env_bra, :tmp_ket, :site_update]
+
+    println("ITensors pairwise contraction benchmark")
+    println("  Julia:            $(VERSION)")
+    println("  ITensors:         $(Base.pkgversion(ITensors))")
+    println("  threads:          Julia=$(Threads.nthreads()) BLAS=$(BLAS.get_num_threads())")
+    println("  d:                $d")
+    println("  chis:             $(join(chis, ","))")
+    println("  warm-up time:     $warmup_seconds")
+    println("  measurement time: $measurement_seconds")
+    println("  min samples:      $min_samples")
+    println()
+    println("case,params,samples,min_us,median_us,mean_us,max_us,output_inds")
+
+    for chi in chis
+        fixtures = build_fixtures(d, chi)
+        for case in cases
+            value, times_ns = run_for_seconds(
+                () -> run_case(fixtures, case);
+                warmup_seconds,
+                measurement_seconds,
+                min_samples,
+            )
+            print_result(; case, d, chi, value, times_ns)
+        end
+    end
+end
+
+main()

--- a/scripts/bench-pairwise-contraction.sh
+++ b/scripts/bench-pairwise-contraction.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+DEFAULT_JULIA_PROJECT="$ROOT_DIR/benchmarks/julia"
+JULIA_PROJECT_DIR="${JULIA_PROJECT_DIR:-$DEFAULT_JULIA_PROJECT}"
+
+KIND="both"
+WARM_UP_TIME="${WARM_UP_TIME:-0.5}"
+MEASUREMENT_TIME="${MEASUREMENT_TIME:-1}"
+SAMPLE_SIZE="${SAMPLE_SIZE:-10}"
+CRITERION_EXTRA_ARGS=()
+JULIA_EXTRA_ARGS=()
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/bench-pairwise-contraction.sh [options] [-- criterion-args...]
+
+Runs tenferro and ITensors pairwise-contraction benchmarks with all known
+thread pools pinned to one thread.
+
+Options:
+  --kind rust|julia|both         Which benchmark to run (default: both)
+  --warm-up-time SECONDS         Warm-up time (default: 0.5)
+  --measurement-time SECONDS     Measurement time (default: 1)
+  --sample-size N                Rust Criterion sample size and Julia min samples (default: 10)
+  --julia-project DIR            Julia environment with ITensors (default: benchmarks/julia)
+  --julia-arg ARG                Extra argument forwarded to the Julia benchmark; repeatable
+  --help                         Show this help text
+
+Environment overrides:
+  WARM_UP_TIME                   Same as --warm-up-time
+  MEASUREMENT_TIME               Same as --measurement-time
+  SAMPLE_SIZE                    Same as --sample-size
+  JULIA_PROJECT_DIR              Same as --julia-project
+
+Examples:
+  bash scripts/bench-pairwise-contraction.sh
+  bash scripts/bench-pairwise-contraction.sh --kind rust -- pairwise_contraction/c64/one_thread/normal_per_call
+  bash scripts/bench-pairwise-contraction.sh --kind julia --julia-arg --chis --julia-arg 4,8,16
+EOF
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+die() {
+  log "$*" >&2
+  exit 1
+}
+
+run_one_thread() {
+  log "+ $*"
+  RAYON_NUM_THREADS=1 \
+    VECLIB_MAXIMUM_THREADS=1 \
+    OPENBLAS_NUM_THREADS=1 \
+    OMP_NUM_THREADS=1 \
+    MKL_NUM_THREADS=1 \
+    JULIA_NUM_THREADS=1 \
+    "$@"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kind)
+      [[ $# -ge 2 ]] || die "--kind requires rust, julia, or both"
+      KIND="$2"
+      shift 2
+      ;;
+    --warm-up-time)
+      [[ $# -ge 2 ]] || die "--warm-up-time requires seconds"
+      WARM_UP_TIME="$2"
+      shift 2
+      ;;
+    --measurement-time)
+      [[ $# -ge 2 ]] || die "--measurement-time requires seconds"
+      MEASUREMENT_TIME="$2"
+      shift 2
+      ;;
+    --sample-size)
+      [[ $# -ge 2 ]] || die "--sample-size requires a count"
+      SAMPLE_SIZE="$2"
+      shift 2
+      ;;
+    --julia-project)
+      [[ $# -ge 2 ]] || die "--julia-project requires a directory"
+      JULIA_PROJECT_DIR="$2"
+      shift 2
+      ;;
+    --julia-arg)
+      [[ $# -ge 2 ]] || die "--julia-arg requires a value"
+      JULIA_EXTRA_ARGS+=("$2")
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      CRITERION_EXTRA_ARGS+=("$@")
+      break
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "$KIND" in
+  rust | julia | both) ;;
+  *) die "--kind must be rust, julia, or both" ;;
+esac
+
+cd "$ROOT_DIR"
+
+log "Pairwise contraction benchmark"
+log "  kind:             $KIND"
+log "  warm-up time:     $WARM_UP_TIME"
+log "  measurement time: $MEASUREMENT_TIME"
+log "  sample size:      $SAMPLE_SIZE"
+log "  threads:          RAYON=1 VECLIB=1 OPENBLAS=1 OMP=1 MKL=1 JULIA=1"
+
+if [[ "$KIND" == "rust" || "$KIND" == "both" ]]; then
+  log ""
+  log "== Rust tenferro-tensor =="
+  criterion_args=(
+    --warm-up-time "$WARM_UP_TIME"
+    --measurement-time "$MEASUREMENT_TIME"
+    --sample-size "$SAMPLE_SIZE"
+  )
+  if ((${#CRITERION_EXTRA_ARGS[@]} > 0)); then
+    criterion_args+=("${CRITERION_EXTRA_ARGS[@]}")
+  fi
+  run_one_thread \
+    cargo bench -p tenferro-tensor --bench pairwise_contraction -- \
+    "${criterion_args[@]}"
+fi
+
+if [[ "$KIND" == "julia" || "$KIND" == "both" ]]; then
+  log ""
+  log "== Julia ITensors =="
+  [[ -f "$JULIA_PROJECT_DIR/Project.toml" ]] || die "Julia project not found: $JULIA_PROJECT_DIR"
+  run_one_thread \
+    julia --startup-file=no --project="$JULIA_PROJECT_DIR" \
+    "$ROOT_DIR/scripts/bench-itensors-pairwise-contraction.jl" \
+    --warm-up-time "$WARM_UP_TIME" \
+    --measurement-time "$MEASUREMENT_TIME" \
+    --min-samples "$SAMPLE_SIZE" \
+    --blas-threads 1 \
+    "${JULIA_EXTRA_ARGS[@]}"
+fi

--- a/tenferro-tensor/Cargo.toml
+++ b/tenferro-tensor/Cargo.toml
@@ -55,3 +55,16 @@ harness = false
 [[bench]]
 name = "dot_general_overhead"
 harness = false
+
+[[bench]]
+name = "pairwise_contraction"
+harness = false
+
+[[bench]]
+name = "cpu_install_overhead"
+harness = false
+
+[[bench]]
+name = "openblas_direct_overhead"
+harness = false
+required-features = ["cpu-blas"]

--- a/tenferro-tensor/benches/cpu_install_overhead.rs
+++ b/tenferro-tensor/benches/cpu_install_overhead.rs
@@ -1,0 +1,63 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use tenferro_tensor::{
+    buffer_pool::BufferPool,
+    cpu::{CpuBackend, CpuContext},
+    TensorBackend,
+};
+
+fn bench_cpu_install_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cpu_install_overhead/one_thread");
+
+    group.bench_function("ctx_install_empty", |b| {
+        let ctx = CpuContext::with_threads(1);
+        b.iter(|| ctx.install(|| black_box(1usize)));
+    });
+
+    group.bench_function("backend_install_empty", |b| {
+        let backend = CpuBackend::with_threads(1);
+        b.iter(|| backend.install(|| black_box(1usize)));
+    });
+
+    group.bench_function("buffer_pool_take_restore_only", |b| {
+        let mut buffers = BufferPool::new();
+        b.iter(|| {
+            let taken = std::mem::take(black_box(&mut buffers));
+            buffers = black_box(taken);
+        });
+    });
+
+    group.bench_function("ctx_install_with_buffer_pool", |b| {
+        let ctx = CpuContext::with_threads(1);
+        let mut buffers = BufferPool::new();
+        b.iter(|| {
+            let mut taken = std::mem::take(black_box(&mut buffers));
+            let (result, returned) = ctx.install(|| {
+                black_box(&mut taken);
+                (black_box(1usize), taken)
+            });
+            buffers = black_box(returned);
+            black_box(result);
+        });
+    });
+
+    group.bench_function("ctx_install_with_buffer_pool_and_cache", |b| {
+        let ctx = CpuContext::with_threads(1);
+        let mut buffers = BufferPool::new();
+        let mut cache = <CpuBackend as TensorBackend>::RuntimeCache::default();
+        b.iter(|| {
+            let mut taken = std::mem::take(black_box(&mut buffers));
+            let (result, returned) = ctx.install(|| {
+                black_box(&mut taken);
+                black_box(&mut cache);
+                (black_box(1usize), taken)
+            });
+            buffers = black_box(returned);
+            black_box(result);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_cpu_install_overhead);
+criterion_main!(benches);

--- a/tenferro-tensor/benches/openblas_direct_overhead.rs
+++ b/tenferro-tensor/benches/openblas_direct_overhead.rs
@@ -1,0 +1,225 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use num_complex::Complex64;
+
+use cblas_sys::{cblas_zgemm, CBLAS_LAYOUT, CBLAS_TRANSPOSE};
+
+#[cfg(feature = "provider-src")]
+extern crate blas_src as _;
+#[cfg(feature = "provider-src")]
+extern crate cblas_src as _;
+
+const PHYS_DIM: usize = 2;
+const CHIS: &[usize] = &[1, 2, 4, 8, 16, 32];
+
+fn complex_vec(len: usize, seed: usize) -> Vec<Complex64> {
+    (0..len)
+        .map(|idx| {
+            let real = ((idx * 17 + seed * 13 + 3) % 97) as f64 / 97.0 - 0.5;
+            let imag = ((idx * 29 + seed * 7 + 5) % 89) as f64 / 89.0 - 0.5;
+            Complex64::new(real, imag)
+        })
+        .collect()
+}
+
+fn conj_vec(input: &[Complex64]) -> Vec<Complex64> {
+    input.iter().map(|value| value.conj()).collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn zgemm(
+    trans_a: CBLAS_TRANSPOSE,
+    trans_b: CBLAS_TRANSPOSE,
+    m: usize,
+    n: usize,
+    k: usize,
+    a: &[Complex64],
+    lda: usize,
+    b: &[Complex64],
+    ldb: usize,
+    c: &mut [Complex64],
+    ldc: usize,
+) {
+    let alpha = [1.0_f64, 0.0_f64];
+    let beta = [0.0_f64, 0.0_f64];
+    unsafe {
+        cblas_zgemm(
+            CBLAS_LAYOUT::CblasColMajor,
+            trans_a,
+            trans_b,
+            m as i32,
+            n as i32,
+            k as i32,
+            &alpha as *const _,
+            a.as_ptr() as *const _,
+            lda as i32,
+            b.as_ptr() as *const _,
+            ldb as i32,
+            &beta as *const _,
+            c.as_mut_ptr() as *mut _,
+            ldc as i32,
+        );
+    }
+}
+
+fn bench_openblas_direct_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("openblas_direct_overhead/c64/one_thread");
+
+    for &chi in CHIS {
+        let params = format!("chi_{chi}_d_{PHYS_DIM}");
+
+        let first_a = complex_vec(PHYS_DIM * chi, 1);
+        let first_b = complex_vec(PHYS_DIM * chi, 2);
+        let mut first_c = vec![Complex64::new(0.0, 0.0); chi * chi];
+        group.bench_function(BenchmarkId::new("first_site_zgemm", &params), |b| {
+            b.iter(|| {
+                zgemm(
+                    CBLAS_TRANSPOSE::CblasConjTrans,
+                    CBLAS_TRANSPOSE::CblasNoTrans,
+                    chi,
+                    chi,
+                    PHYS_DIM,
+                    black_box(&first_a),
+                    PHYS_DIM,
+                    black_box(&first_b),
+                    PHYS_DIM,
+                    black_box(&mut first_c),
+                    chi,
+                );
+                black_box(first_c[0]);
+            });
+        });
+
+        let env = complex_vec(chi * chi, 3);
+        let bra = complex_vec(chi * PHYS_DIM * chi, 4);
+        let bra_conj = conj_vec(&bra);
+        let mut tmp = vec![Complex64::new(0.0, 0.0); chi * PHYS_DIM * chi];
+        group.bench_function(BenchmarkId::new("env_bra_zgemm_preconj", &params), |b| {
+            b.iter(|| {
+                zgemm(
+                    CBLAS_TRANSPOSE::CblasTrans,
+                    CBLAS_TRANSPOSE::CblasNoTrans,
+                    chi,
+                    PHYS_DIM * chi,
+                    chi,
+                    black_box(&env),
+                    chi,
+                    black_box(&bra_conj),
+                    chi,
+                    black_box(&mut tmp),
+                    chi,
+                );
+                black_box(tmp[0]);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("env_bra_conj_copy", &params), |b| {
+            let mut out = vec![Complex64::new(0.0, 0.0); bra.len()];
+            b.iter(|| {
+                for (dst, src) in out.iter_mut().zip(black_box(&bra)) {
+                    *dst = src.conj();
+                }
+                black_box(out[0]);
+            });
+        });
+
+        let ket = complex_vec(chi * PHYS_DIM * chi, 6);
+        let mut out = vec![Complex64::new(0.0, 0.0); chi * chi];
+        group.bench_function(BenchmarkId::new("tmp_ket_zgemm", &params), |b| {
+            b.iter(|| {
+                zgemm(
+                    CBLAS_TRANSPOSE::CblasTrans,
+                    CBLAS_TRANSPOSE::CblasNoTrans,
+                    chi,
+                    chi,
+                    chi * PHYS_DIM,
+                    black_box(&tmp),
+                    chi * PHYS_DIM,
+                    black_box(&ket),
+                    chi * PHYS_DIM,
+                    black_box(&mut out),
+                    chi,
+                );
+                black_box(out[0]);
+            });
+        });
+
+        group.bench_function(
+            BenchmarkId::new("site_update_2_zgemm_preconj", &params),
+            |b| {
+                b.iter(|| {
+                    zgemm(
+                        CBLAS_TRANSPOSE::CblasTrans,
+                        CBLAS_TRANSPOSE::CblasNoTrans,
+                        chi,
+                        PHYS_DIM * chi,
+                        chi,
+                        black_box(&env),
+                        chi,
+                        black_box(&bra_conj),
+                        chi,
+                        black_box(&mut tmp),
+                        chi,
+                    );
+                    zgemm(
+                        CBLAS_TRANSPOSE::CblasTrans,
+                        CBLAS_TRANSPOSE::CblasNoTrans,
+                        chi,
+                        chi,
+                        chi * PHYS_DIM,
+                        black_box(&tmp),
+                        chi * PHYS_DIM,
+                        black_box(&ket),
+                        chi * PHYS_DIM,
+                        black_box(&mut out),
+                        chi,
+                    );
+                    black_box(out[0]);
+                });
+            },
+        );
+
+        group.bench_function(
+            BenchmarkId::new("site_update_conj_copy_2_zgemm", &params),
+            |b| {
+                let mut bra_conj_each_iter = vec![Complex64::new(0.0, 0.0); bra.len()];
+                b.iter(|| {
+                    for (dst, src) in bra_conj_each_iter.iter_mut().zip(black_box(&bra)) {
+                        *dst = src.conj();
+                    }
+                    zgemm(
+                        CBLAS_TRANSPOSE::CblasTrans,
+                        CBLAS_TRANSPOSE::CblasNoTrans,
+                        chi,
+                        PHYS_DIM * chi,
+                        chi,
+                        black_box(&env),
+                        chi,
+                        black_box(&bra_conj_each_iter),
+                        chi,
+                        black_box(&mut tmp),
+                        chi,
+                    );
+                    zgemm(
+                        CBLAS_TRANSPOSE::CblasTrans,
+                        CBLAS_TRANSPOSE::CblasNoTrans,
+                        chi,
+                        chi,
+                        chi * PHYS_DIM,
+                        black_box(&tmp),
+                        chi * PHYS_DIM,
+                        black_box(&ket),
+                        chi * PHYS_DIM,
+                        black_box(&mut out),
+                        chi,
+                    );
+                    black_box(out[0]);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_openblas_direct_overhead);
+criterion_main!(benches);

--- a/tenferro-tensor/benches/pairwise_contraction.rs
+++ b/tenferro-tensor/benches/pairwise_contraction.rs
@@ -1,0 +1,279 @@
+use std::env;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use num_complex::Complex64;
+use tenferro_tensor::{cpu::CpuBackend, DotGeneralConfig, Tensor, TensorBackend};
+
+const PHYS_DIM: usize = 2;
+const CHIS: &[usize] = &[1, 2, 4, 8, 16, 32];
+
+#[derive(Clone, Copy)]
+enum PairwiseCase {
+    FirstSite,
+    EnvBra,
+    TmpKet,
+    SiteUpdate,
+}
+
+impl PairwiseCase {
+    fn name(self) -> &'static str {
+        match self {
+            Self::FirstSite => "first_site",
+            Self::EnvBra => "env_bra",
+            Self::TmpKet => "tmp_ket",
+            Self::SiteUpdate => "site_update",
+        }
+    }
+}
+
+struct Fixtures {
+    bra_first: Tensor,
+    ket_first: Tensor,
+    env: Tensor,
+    bra_bulk: Tensor,
+    tmp: Tensor,
+    ket_bulk: Tensor,
+}
+
+struct Configs {
+    first_site: DotGeneralConfig,
+    env_bra: DotGeneralConfig,
+    tmp_ket: DotGeneralConfig,
+}
+
+impl Configs {
+    fn new() -> Self {
+        Self {
+            first_site: DotGeneralConfig {
+                lhs_contracting_dims: vec![0],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+            env_bra: DotGeneralConfig {
+                lhs_contracting_dims: vec![0],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+            tmp_ket: DotGeneralConfig {
+                lhs_contracting_dims: vec![0, 1],
+                rhs_contracting_dims: vec![0, 1],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        }
+    }
+}
+
+fn complex_tensor(shape: &[usize], seed: usize) -> Tensor {
+    let len = shape.iter().product();
+    let data = (0..len)
+        .map(|idx| {
+            let real = ((idx * 17 + seed * 13 + 3) % 97) as f64 / 97.0 - 0.5;
+            let imag = ((idx * 29 + seed * 7 + 5) % 89) as f64 / 89.0 - 0.5;
+            Complex64::new(real, imag)
+        })
+        .collect();
+    Tensor::from_vec(shape.to_vec(), data)
+}
+
+fn build_fixtures(phys_dim: usize, chi: usize) -> Fixtures {
+    Fixtures {
+        bra_first: complex_tensor(&[phys_dim, chi], 1),
+        ket_first: complex_tensor(&[phys_dim, chi], 2),
+        env: complex_tensor(&[chi, chi], 3),
+        bra_bulk: complex_tensor(&[chi, phys_dim, chi], 4),
+        tmp: complex_tensor(&[chi, phys_dim, chi], 5),
+        ket_bulk: complex_tensor(&[chi, phys_dim, chi], 6),
+    }
+}
+
+fn benchmark_threads() -> usize {
+    env::var("TENFERRO_PAIRWISE_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&threads| threads > 0)
+        .unwrap_or(1)
+}
+
+fn run_case_normal(
+    backend: &mut CpuBackend,
+    fixtures: &Fixtures,
+    configs: &Configs,
+    case: PairwiseCase,
+) -> Tensor {
+    match case {
+        PairwiseCase::FirstSite => backend
+            .dot_general_with_conj(
+                &fixtures.bra_first,
+                &fixtures.ket_first,
+                &configs.first_site,
+                true,
+                false,
+            )
+            .expect("first-site contraction should succeed"),
+        PairwiseCase::EnvBra => backend
+            .dot_general_with_conj(
+                &fixtures.env,
+                &fixtures.bra_bulk,
+                &configs.env_bra,
+                false,
+                true,
+            )
+            .expect("environment-bra contraction should succeed"),
+        PairwiseCase::TmpKet => backend
+            .dot_general_with_conj(
+                &fixtures.tmp,
+                &fixtures.ket_bulk,
+                &configs.tmp_ket,
+                false,
+                false,
+            )
+            .expect("temporary-ket contraction should succeed"),
+        PairwiseCase::SiteUpdate => {
+            let tmp = backend
+                .dot_general_with_conj(
+                    &fixtures.env,
+                    &fixtures.bra_bulk,
+                    &configs.env_bra,
+                    false,
+                    true,
+                )
+                .expect("environment-bra contraction should succeed");
+            backend
+                .dot_general_with_conj(&tmp, &fixtures.ket_bulk, &configs.tmp_ket, false, false)
+                .expect("temporary-ket contraction should succeed")
+        }
+    }
+}
+
+fn run_case_cached(
+    backend: &mut CpuBackend,
+    cache: &mut <CpuBackend as TensorBackend>::RuntimeCache,
+    fixtures: &Fixtures,
+    configs: &Configs,
+    case: PairwiseCase,
+) -> Tensor {
+    match case {
+        PairwiseCase::FirstSite => backend
+            .dot_general_with_conj_cached(
+                cache,
+                Some(0),
+                &fixtures.bra_first,
+                &fixtures.ket_first,
+                &configs.first_site,
+                true,
+                false,
+            )
+            .expect("first-site contraction should succeed"),
+        PairwiseCase::EnvBra => backend
+            .dot_general_with_conj_cached(
+                cache,
+                Some(0),
+                &fixtures.env,
+                &fixtures.bra_bulk,
+                &configs.env_bra,
+                false,
+                true,
+            )
+            .expect("environment-bra contraction should succeed"),
+        PairwiseCase::TmpKet => backend
+            .dot_general_with_conj_cached(
+                cache,
+                Some(0),
+                &fixtures.tmp,
+                &fixtures.ket_bulk,
+                &configs.tmp_ket,
+                false,
+                false,
+            )
+            .expect("temporary-ket contraction should succeed"),
+        PairwiseCase::SiteUpdate => {
+            let tmp = backend
+                .dot_general_with_conj_cached(
+                    cache,
+                    Some(0),
+                    &fixtures.env,
+                    &fixtures.bra_bulk,
+                    &configs.env_bra,
+                    false,
+                    true,
+                )
+                .expect("environment-bra contraction should succeed");
+            backend
+                .dot_general_with_conj_cached(
+                    cache,
+                    Some(1),
+                    &tmp,
+                    &fixtures.ket_bulk,
+                    &configs.tmp_ket,
+                    false,
+                    false,
+                )
+                .expect("temporary-ket contraction should succeed")
+        }
+    }
+}
+
+fn bench_pairwise_contraction(c: &mut Criterion) {
+    let cases = [
+        PairwiseCase::FirstSite,
+        PairwiseCase::EnvBra,
+        PairwiseCase::TmpKet,
+        PairwiseCase::SiteUpdate,
+    ];
+    let configs = Configs::new();
+    let threads = benchmark_threads();
+    let group_name = if threads == 1 {
+        "pairwise_contraction/c64/one_thread".to_string()
+    } else {
+        format!("pairwise_contraction/c64/threads_{threads}")
+    };
+    let mut group = c.benchmark_group(group_name);
+
+    for &chi in CHIS {
+        let fixtures = build_fixtures(PHYS_DIM, chi);
+        let params = format!("chi_{chi}_d_{PHYS_DIM}");
+
+        for &case in &cases {
+            let case_params = format!("{}/{}", case.name(), params);
+
+            group.bench_function(BenchmarkId::new("normal_per_call", &case_params), |b| {
+                let mut backend = CpuBackend::with_threads(threads);
+                b.iter(|| {
+                    let output = run_case_normal(
+                        black_box(&mut backend),
+                        black_box(&fixtures),
+                        black_box(&configs),
+                        black_box(case),
+                    );
+                    black_box(output.shape().to_vec());
+                });
+            });
+
+            group.bench_function(
+                BenchmarkId::new("cached_analysis_per_call", &case_params),
+                |b| {
+                    let mut backend = CpuBackend::with_threads(threads);
+                    let mut cache = <CpuBackend as TensorBackend>::RuntimeCache::default();
+                    b.iter(|| {
+                        let output = run_case_cached(
+                            black_box(&mut backend),
+                            black_box(&mut cache),
+                            black_box(&fixtures),
+                            black_box(&configs),
+                            black_box(case),
+                        );
+                        black_box(output.shape().to_vec());
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_pairwise_contraction);
+criterion_main!(benches);

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -101,6 +101,12 @@ fn maybe_print_cpu_session_profile() {
     }
 }
 
+#[cfg(feature = "cpu-faer")]
+fn faer_global_rayon_bypass_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| env::var("TENFERRO_EXPERIMENTAL_FAER_GLOBAL_RAYON").is_ok())
+}
+
 /// CPU execution backend.
 ///
 /// # Examples
@@ -291,6 +297,14 @@ impl CpuBackend {
     where
         R: Send,
     {
+        #[cfg(feature = "cpu-faer")]
+        if faer_global_rayon_bypass_enabled() {
+            let mut buffers = std::mem::take(&mut self.buffers);
+            let result = op(&mut buffers);
+            self.buffers = buffers;
+            return result;
+        }
+
         let mut buffers = std::mem::take(&mut self.buffers);
         let (result, buffers) = self.ctx.install(|| {
             let result = op(&mut buffers);
@@ -300,6 +314,28 @@ impl CpuBackend {
         result
     }
 
+    #[cfg(feature = "cpu-blas")]
+    fn run_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R) -> R {
+        let mut buffers = std::mem::take(&mut self.buffers);
+        let result = op(&mut buffers);
+        self.buffers = buffers;
+        result
+    }
+
+    #[cfg(feature = "cpu-faer")]
+    fn linalg_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R
+    where
+        R: Send,
+    {
+        self.install_with_pool(op)
+    }
+
+    #[cfg(feature = "cpu-blas")]
+    fn linalg_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R) -> R {
+        self.run_with_pool(op)
+    }
+
+    #[cfg(feature = "cpu-faer")]
     fn install_with_pool_and_gemm_cache<R>(
         &mut self,
         gemm_analysis_cache: &mut gemm::GemmAnalysisCache,
@@ -308,11 +344,30 @@ impl CpuBackend {
     where
         R: Send,
     {
+        if faer_global_rayon_bypass_enabled() {
+            let mut buffers = std::mem::take(&mut self.buffers);
+            let result = op(&mut buffers, gemm_analysis_cache);
+            self.buffers = buffers;
+            return result;
+        }
+
         let mut buffers = std::mem::take(&mut self.buffers);
         let (result, buffers) = self.ctx.install(|| {
             let result = op(&mut buffers, gemm_analysis_cache);
             (result, buffers)
         });
+        self.buffers = buffers;
+        result
+    }
+
+    #[cfg(feature = "cpu-blas")]
+    fn run_with_pool_and_gemm_cache<R>(
+        &mut self,
+        gemm_analysis_cache: &mut gemm::GemmAnalysisCache,
+        op: impl FnOnce(&mut BufferPool, &mut gemm::GemmAnalysisCache) -> R,
+    ) -> R {
+        let mut buffers = std::mem::take(&mut self.buffers);
+        let result = op(&mut buffers, gemm_analysis_cache);
         self.buffers = buffers;
         result
     }
@@ -492,7 +547,7 @@ impl TensorBackend for CpuBackend {
         config: &DotGeneralConfig,
     ) -> crate::Result<Tensor> {
         let mut cache = gemm::GemmAnalysisCache::default();
-        self.dot_general_cached(&mut cache, Some(0), lhs, rhs, config)
+        self.dot_general_cached(&mut cache, None, lhs, rhs, config)
     }
 
     fn dot_general_cached(
@@ -503,51 +558,60 @@ impl TensorBackend for CpuBackend {
         rhs: &Tensor,
         config: &DotGeneralConfig,
     ) -> crate::Result<Tensor> {
+        #[cfg(feature = "cpu-blas")]
+        {
+            return self.run_with_pool_and_gemm_cache(cache, |buffers, cache| match (lhs, rhs) {
+                (Tensor::F32(a), Tensor::F32(b)) => {
+                    gemm::dot_general_cached(buffers, cache, cache_slot, a, b, config)
+                        .map(Tensor::F32)
+                }
+                (Tensor::F64(a), Tensor::F64(b)) => {
+                    gemm::dot_general_cached(buffers, cache, cache_slot, a, b, config)
+                        .map(Tensor::F64)
+                }
+                (Tensor::C32(a), Tensor::C32(b)) => {
+                    gemm::dot_general_cached(buffers, cache, cache_slot, a, b, config)
+                        .map(Tensor::C32)
+                }
+                (Tensor::C64(a), Tensor::C64(b)) => {
+                    gemm::dot_general_cached(buffers, cache, cache_slot, a, b, config)
+                        .map(Tensor::C64)
+                }
+                _ => Err(crate::Error::DTypeMismatch {
+                    op: "dot_general",
+                    lhs: lhs.dtype(),
+                    rhs: rhs.dtype(),
+                }),
+            });
+        }
+
         #[cfg(feature = "cpu-faer")]
-        let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool_and_gemm_cache(cache, |buffers, cache| match (lhs, rhs) {
-            #[cfg(feature = "cpu-faer")]
-            (Tensor::F32(a), Tensor::F32(b)) => {
-                gemm::dot_general_cached(buffers, cache, cache_slot, ctx.as_ref(), a, b, config)
-                    .map(Tensor::F32)
-            }
-            #[cfg(feature = "cpu-faer")]
-            (Tensor::F64(a), Tensor::F64(b)) => {
-                gemm::dot_general_cached(buffers, cache, cache_slot, ctx.as_ref(), a, b, config)
-                    .map(Tensor::F64)
-            }
-            #[cfg(feature = "cpu-faer")]
-            (Tensor::C32(a), Tensor::C32(b)) => {
-                gemm::dot_general_cached(buffers, cache, cache_slot, ctx.as_ref(), a, b, config)
-                    .map(Tensor::C32)
-            }
-            #[cfg(feature = "cpu-faer")]
-            (Tensor::C64(a), Tensor::C64(b)) => {
-                gemm::dot_general_cached(buffers, cache, cache_slot, ctx.as_ref(), a, b, config)
-                    .map(Tensor::C64)
-            }
-            #[cfg(feature = "cpu-blas")]
-            (Tensor::F32(a), Tensor::F32(b)) => {
-                gemm::dot_general_cached(buffers, cache, cache_slot, a, b, config).map(Tensor::F32)
-            }
-            #[cfg(feature = "cpu-blas")]
-            (Tensor::F64(a), Tensor::F64(b)) => {
-                gemm::dot_general_cached(buffers, cache, cache_slot, a, b, config).map(Tensor::F64)
-            }
-            #[cfg(feature = "cpu-blas")]
-            (Tensor::C32(a), Tensor::C32(b)) => {
-                gemm::dot_general_cached(buffers, cache, cache_slot, a, b, config).map(Tensor::C32)
-            }
-            #[cfg(feature = "cpu-blas")]
-            (Tensor::C64(a), Tensor::C64(b)) => {
-                gemm::dot_general_cached(buffers, cache, cache_slot, a, b, config).map(Tensor::C64)
-            }
-            _ => Err(crate::Error::DTypeMismatch {
-                op: "dot_general",
-                lhs: lhs.dtype(),
-                rhs: rhs.dtype(),
-            }),
-        })
+        {
+            let ctx = Arc::clone(&self.ctx);
+            self.install_with_pool_and_gemm_cache(cache, |buffers, cache| match (lhs, rhs) {
+                (Tensor::F32(a), Tensor::F32(b)) => {
+                    gemm::dot_general_cached(buffers, cache, cache_slot, ctx.as_ref(), a, b, config)
+                        .map(Tensor::F32)
+                }
+                (Tensor::F64(a), Tensor::F64(b)) => {
+                    gemm::dot_general_cached(buffers, cache, cache_slot, ctx.as_ref(), a, b, config)
+                        .map(Tensor::F64)
+                }
+                (Tensor::C32(a), Tensor::C32(b)) => {
+                    gemm::dot_general_cached(buffers, cache, cache_slot, ctx.as_ref(), a, b, config)
+                        .map(Tensor::C32)
+                }
+                (Tensor::C64(a), Tensor::C64(b)) => {
+                    gemm::dot_general_cached(buffers, cache, cache_slot, ctx.as_ref(), a, b, config)
+                        .map(Tensor::C64)
+                }
+                _ => Err(crate::Error::DTypeMismatch {
+                    op: "dot_general",
+                    lhs: lhs.dtype(),
+                    rhs: rhs.dtype(),
+                }),
+            })
+        }
     }
 
     fn dot_general_read(
@@ -558,24 +622,15 @@ impl TensorBackend for CpuBackend {
     ) -> crate::Result<Tensor> {
         let mut cache = gemm::GemmAnalysisCache::default();
         #[cfg(feature = "cpu-faer")]
-        let ctx = Arc::clone(&self.ctx);
-        let direct = self.install_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
-            #[cfg(feature = "cpu-faer")]
-            {
-                gemm::dot_general_read_cached(
-                    buffers,
-                    cache,
-                    Some(0),
-                    ctx.as_ref(),
-                    lhs,
-                    rhs,
-                    config,
-                )
-            }
-            #[cfg(feature = "cpu-blas")]
-            {
-                gemm::dot_general_read_cached(buffers, cache, Some(0), lhs, rhs, config)
-            }
+        let direct = {
+            let ctx = Arc::clone(&self.ctx);
+            self.install_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
+                gemm::dot_general_read_cached(buffers, cache, None, ctx.as_ref(), lhs, rhs, config)
+            })?
+        };
+        #[cfg(feature = "cpu-blas")]
+        let direct = self.run_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
+            gemm::dot_general_read_cached(buffers, cache, None, lhs, rhs, config)
         })?;
         if let Some(result) = direct {
             return Ok(result);
@@ -583,7 +638,7 @@ impl TensorBackend for CpuBackend {
 
         let lhs = lhs.to_tensor();
         let rhs = rhs.to_tensor();
-        self.dot_general_cached(&mut cache, Some(0), &lhs, &rhs, config)
+        self.dot_general_cached(&mut cache, None, &lhs, &rhs, config)
     }
 
     fn dot_general_with_conj(
@@ -595,7 +650,7 @@ impl TensorBackend for CpuBackend {
         rhs_conj: bool,
     ) -> crate::Result<Tensor> {
         let mut cache = gemm::GemmAnalysisCache::default();
-        self.dot_general_with_conj_cached(&mut cache, Some(0), lhs, rhs, config, lhs_conj, rhs_conj)
+        self.dot_general_with_conj_cached(&mut cache, None, lhs, rhs, config, lhs_conj, rhs_conj)
     }
 
     fn dot_general_with_conj_cached(
@@ -608,87 +663,92 @@ impl TensorBackend for CpuBackend {
         lhs_conj: bool,
         rhs_conj: bool,
     ) -> crate::Result<Tensor> {
+        #[cfg(feature = "cpu-blas")]
+        {
+            return self.run_with_pool_and_gemm_cache(cache, |buffers, cache| match (lhs, rhs) {
+                (Tensor::F32(a), Tensor::F32(b)) => gemm::dot_general_with_conj_cached(
+                    buffers, cache, cache_slot, a, b, config, lhs_conj, rhs_conj,
+                )
+                .map(Tensor::F32),
+                (Tensor::F64(a), Tensor::F64(b)) => gemm::dot_general_with_conj_cached(
+                    buffers, cache, cache_slot, a, b, config, lhs_conj, rhs_conj,
+                )
+                .map(Tensor::F64),
+                (Tensor::C32(a), Tensor::C32(b)) => gemm::dot_general_with_conj_cached(
+                    buffers, cache, cache_slot, a, b, config, lhs_conj, rhs_conj,
+                )
+                .map(Tensor::C32),
+                (Tensor::C64(a), Tensor::C64(b)) => gemm::dot_general_with_conj_cached(
+                    buffers, cache, cache_slot, a, b, config, lhs_conj, rhs_conj,
+                )
+                .map(Tensor::C64),
+                _ => Err(crate::Error::DTypeMismatch {
+                    op: "dot_general",
+                    lhs: lhs.dtype(),
+                    rhs: rhs.dtype(),
+                }),
+            });
+        }
+
         #[cfg(feature = "cpu-faer")]
-        let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool_and_gemm_cache(cache, |buffers, cache| match (lhs, rhs) {
-            #[cfg(feature = "cpu-faer")]
-            (Tensor::F32(a), Tensor::F32(b)) => gemm::dot_general_with_conj_cached(
-                buffers,
-                cache,
-                cache_slot,
-                ctx.as_ref(),
-                a,
-                b,
-                config,
-                lhs_conj,
-                rhs_conj,
-            )
-            .map(Tensor::F32),
-            #[cfg(feature = "cpu-faer")]
-            (Tensor::F64(a), Tensor::F64(b)) => gemm::dot_general_with_conj_cached(
-                buffers,
-                cache,
-                cache_slot,
-                ctx.as_ref(),
-                a,
-                b,
-                config,
-                lhs_conj,
-                rhs_conj,
-            )
-            .map(Tensor::F64),
-            #[cfg(feature = "cpu-faer")]
-            (Tensor::C32(a), Tensor::C32(b)) => gemm::dot_general_with_conj_cached(
-                buffers,
-                cache,
-                cache_slot,
-                ctx.as_ref(),
-                a,
-                b,
-                config,
-                lhs_conj,
-                rhs_conj,
-            )
-            .map(Tensor::C32),
-            #[cfg(feature = "cpu-faer")]
-            (Tensor::C64(a), Tensor::C64(b)) => gemm::dot_general_with_conj_cached(
-                buffers,
-                cache,
-                cache_slot,
-                ctx.as_ref(),
-                a,
-                b,
-                config,
-                lhs_conj,
-                rhs_conj,
-            )
-            .map(Tensor::C64),
-            #[cfg(feature = "cpu-blas")]
-            (Tensor::F32(a), Tensor::F32(b)) => gemm::dot_general_with_conj_cached(
-                buffers, cache, cache_slot, a, b, config, lhs_conj, rhs_conj,
-            )
-            .map(Tensor::F32),
-            #[cfg(feature = "cpu-blas")]
-            (Tensor::F64(a), Tensor::F64(b)) => gemm::dot_general_with_conj_cached(
-                buffers, cache, cache_slot, a, b, config, lhs_conj, rhs_conj,
-            )
-            .map(Tensor::F64),
-            #[cfg(feature = "cpu-blas")]
-            (Tensor::C32(a), Tensor::C32(b)) => gemm::dot_general_with_conj_cached(
-                buffers, cache, cache_slot, a, b, config, lhs_conj, rhs_conj,
-            )
-            .map(Tensor::C32),
-            #[cfg(feature = "cpu-blas")]
-            (Tensor::C64(a), Tensor::C64(b)) => gemm::dot_general_with_conj_cached(
-                buffers, cache, cache_slot, a, b, config, lhs_conj, rhs_conj,
-            )
-            .map(Tensor::C64),
-            _ => Err(crate::Error::DTypeMismatch {
-                op: "dot_general",
-                lhs: lhs.dtype(),
-                rhs: rhs.dtype(),
-            }),
-        })
+        {
+            let ctx = Arc::clone(&self.ctx);
+            self.install_with_pool_and_gemm_cache(cache, |buffers, cache| match (lhs, rhs) {
+                (Tensor::F32(a), Tensor::F32(b)) => gemm::dot_general_with_conj_cached(
+                    buffers,
+                    cache,
+                    cache_slot,
+                    ctx.as_ref(),
+                    a,
+                    b,
+                    config,
+                    lhs_conj,
+                    rhs_conj,
+                )
+                .map(Tensor::F32),
+                (Tensor::F64(a), Tensor::F64(b)) => gemm::dot_general_with_conj_cached(
+                    buffers,
+                    cache,
+                    cache_slot,
+                    ctx.as_ref(),
+                    a,
+                    b,
+                    config,
+                    lhs_conj,
+                    rhs_conj,
+                )
+                .map(Tensor::F64),
+                (Tensor::C32(a), Tensor::C32(b)) => gemm::dot_general_with_conj_cached(
+                    buffers,
+                    cache,
+                    cache_slot,
+                    ctx.as_ref(),
+                    a,
+                    b,
+                    config,
+                    lhs_conj,
+                    rhs_conj,
+                )
+                .map(Tensor::C32),
+                (Tensor::C64(a), Tensor::C64(b)) => gemm::dot_general_with_conj_cached(
+                    buffers,
+                    cache,
+                    cache_slot,
+                    ctx.as_ref(),
+                    a,
+                    b,
+                    config,
+                    lhs_conj,
+                    rhs_conj,
+                )
+                .map(Tensor::C64),
+                _ => Err(crate::Error::DTypeMismatch {
+                    op: "dot_general",
+                    lhs: lhs.dtype(),
+                    rhs: rhs.dtype(),
+                }),
+            })
+        }
     }
 
     fn gather(
@@ -755,7 +815,7 @@ impl TensorBackend for CpuBackend {
     fn cholesky(&mut self, input: &Tensor) -> crate::Result<Tensor> {
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.linalg_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::cholesky(ctx.as_ref(), buffers, t).map(Tensor::F32),
             #[cfg(feature = "cpu-blas")]
@@ -787,7 +847,7 @@ impl TensorBackend for CpuBackend {
     ) -> crate::Result<Tensor> {
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match (a, b) {
+        self.linalg_with_pool(|buffers| match (a, b) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F32(a), Tensor::F32(b)) => linalg::triangular_solve(
                 ctx.as_ref(),
@@ -897,7 +957,7 @@ impl TensorBackend for CpuBackend {
     fn lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.linalg_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -933,7 +993,7 @@ impl TensorBackend for CpuBackend {
     fn full_piv_lu(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.linalg_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::full_piv_lu(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -983,7 +1043,7 @@ impl TensorBackend for CpuBackend {
 
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        let result = self.install_with_pool(|buffers| match (a, &rhs) {
+        let result = self.linalg_with_pool(|buffers| match (a, &rhs) {
             #[cfg(feature = "cpu-faer")]
             (Tensor::F32(a), Tensor::F32(b)) => {
                 linalg::full_piv_lu_solve(ctx.as_ref(), buffers, a, b, transpose_a).map(Tensor::F32)
@@ -1039,7 +1099,7 @@ impl TensorBackend for CpuBackend {
     fn svd(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.linalg_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::svd(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -1071,7 +1131,7 @@ impl TensorBackend for CpuBackend {
     fn qr(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.linalg_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::qr(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -1107,7 +1167,7 @@ impl TensorBackend for CpuBackend {
     fn eigh(&mut self, input: &Tensor) -> crate::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| match input {
+        self.linalg_with_pool(|buffers| match input {
             #[cfg(feature = "cpu-faer")]
             Tensor::F32(t) => linalg::eigh(ctx.as_ref(), buffers, t)
                 .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
@@ -1145,7 +1205,7 @@ impl TensorBackend for CpuBackend {
         }
         #[cfg(feature = "cpu-faer")]
         let ctx = Arc::clone(&self.ctx);
-        self.install_with_pool(|buffers| {
+        self.linalg_with_pool(|buffers| {
             #[cfg(feature = "cpu-faer")]
             {
                 linalg::eig(ctx.as_ref(), buffers, input)

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -44,10 +44,18 @@ struct GemmDims {
 
 #[derive(Clone)]
 struct GemmAnalysisPlan {
-    lhs_shape: Vec<usize>,
-    rhs_shape: Vec<usize>,
-    config: DotGeneralConfig,
+    lhs_shape: SmallVec<[usize; 8]>,
+    rhs_shape: SmallVec<[usize; 8]>,
+    config: GemmConfigKey,
     dims: Option<GemmDims>,
+}
+
+#[derive(Clone)]
+struct GemmConfigKey {
+    lhs_contracting_dims: SmallVec<[usize; 4]>,
+    rhs_contracting_dims: SmallVec<[usize; 4]>,
+    lhs_batch_dims: SmallVec<[usize; 4]>,
+    rhs_batch_dims: SmallVec<[usize; 4]>,
 }
 
 const GEMM_ANALYSIS_CACHE_MAX: usize = 1024;
@@ -72,7 +80,25 @@ impl GemmAnalysisPlan {
     {
         self.lhs_shape.as_slice() == lhs.shape()
             && self.rhs_shape.as_slice() == rhs.shape()
-            && self.config == *config
+            && self.config.matches(config)
+    }
+}
+
+impl GemmConfigKey {
+    fn from_config(config: &DotGeneralConfig) -> Self {
+        Self {
+            lhs_contracting_dims: config.lhs_contracting_dims.iter().copied().collect(),
+            rhs_contracting_dims: config.rhs_contracting_dims.iter().copied().collect(),
+            lhs_batch_dims: config.lhs_batch_dims.iter().copied().collect(),
+            rhs_batch_dims: config.rhs_batch_dims.iter().copied().collect(),
+        }
+    }
+
+    fn matches(&self, config: &DotGeneralConfig) -> bool {
+        self.lhs_contracting_dims.as_slice() == config.lhs_contracting_dims.as_slice()
+            && self.rhs_contracting_dims.as_slice() == config.rhs_contracting_dims.as_slice()
+            && self.lhs_batch_dims.as_slice() == config.lhs_batch_dims.as_slice()
+            && self.rhs_batch_dims.as_slice() == config.rhs_batch_dims.as_slice()
     }
 }
 
@@ -162,9 +188,9 @@ impl GemmAnalysisCache {
         &mut self,
         slot: usize,
         kind: GemmAnalysisCacheKind,
-        lhs_shape: Vec<usize>,
-        rhs_shape: Vec<usize>,
-        config: DotGeneralConfig,
+        lhs_shape: SmallVec<[usize; 8]>,
+        rhs_shape: SmallVec<[usize; 8]>,
+        config: GemmConfigKey,
         dims: Option<GemmDims>,
     ) {
         if slot >= GEMM_ANALYSIS_CACHE_MAX {
@@ -539,9 +565,9 @@ where
         cache.store(
             slot,
             cache_kind,
-            lhs.shape().to_vec(),
-            rhs.shape().to_vec(),
-            config.clone(),
+            lhs.shape().iter().copied().collect(),
+            rhs.shape().iter().copied().collect(),
+            GemmConfigKey::from_config(config),
             dims.clone(),
         );
     }
@@ -1176,6 +1202,13 @@ where
     let b_ok = b_rs == 1 || b_cs == 1;
     let c_ok = c_rs == 1;
     if !a_ok || !b_ok || !c_ok {
+        return Ok(None);
+    }
+    // `BlasGemm::strided_gemm_with_conj` maps row-contiguous operands to
+    // CblasNoTrans, which cannot express conjugation without materializing.
+    // Detect that before acquiring the output buffer for a path that will
+    // return Ok(false).
+    if (lhs_conj && a_rs == 1) || (rhs_conj && b_rs == 1) {
         return Ok(None);
     }
 


### PR DESCRIPTION
## Summary

- Add pairwise TT/MPS contraction benchmarks, Julia ITensors comparison script, and install/direct-OpenBLAS overhead microbenchmarks.
- Document the small-bond investigation, benchmark results, `rayon::ThreadPool::install` cost, OpenBLAS/faer findings, and cross-repo tracing direction.
- Reduce OpenBLAS backend overhead by bypassing `CpuContext::install` for `cpu-blas` GEMM and LAPACK-backed linalg paths.
- Lighten GEMM analysis cache keys with `SmallVec` and avoid failed BLAS conjugation direct attempts that would acquire an output buffer before falling back.
- Add an experimental faer upper-bound switch, `TENFERRO_EXPERIMENTAL_FAER_GLOBAL_RAYON=1`, for measurement only.

## Why

Small-bond Tensor Train inner products were losing to ITensors.jl because the arithmetic is tiny and per-call backend overhead dominated. Direct OpenBLAS two-GEMM site updates were sub-microsecond at small `chi`, while tenferro OpenBLAS previously spent roughly 15-20 us. The focused install benchmark measured `CpuContext::install` at about 5.5 us, which explains most of the fixed cost when every small GEMM enters the backend separately.

After bypassing install for `cpu-blas`, cached OpenBLAS `site_update` improves to roughly 1-4 us for `chi <= 8`, which is in the same range as or faster than the rerun ITensors.jl comparison.

## Tracking

- tenferro-rs tracking issue: https://github.com/tensor4all/tenferro-rs/issues/872
- tensor4all-rs tracking issue: https://github.com/tensor4all/tensor4all-rs/issues/510
- Added a tensor4all-rs issue comment clarifying the intended split between eager `TensorDynLen` and graph-building `TracedTensorDynLen`.

## Validation

Passed:

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo bench -p tenferro-tensor --bench pairwise_contraction --no-run`
- `cargo bench -p tenferro-tensor --bench cpu_install_overhead --no-run`
- `cargo bench -p tenferro-tensor --no-default-features --features src-openblas --bench pairwise_contraction --no-run`
- `cargo bench -p tenferro-tensor --no-default-features --features src-openblas --bench openblas_direct_overhead --no-run`
- `cargo test -p tenferro-tensor --release dot_general`
- `cargo test -p tenferro-tensor --no-default-features --features src-openblas --release dot_general`
- `bash -n scripts/bench-pairwise-contraction.sh`
- `git diff --check`

Known non-blocking check failure:

- `cargo clippy -p tenferro-tensor --all-targets -- -D warnings` fails on existing broad clippy warnings such as `too_many_arguments`, `manual_div_ceil`, `needless_range_loop`, `redundant_closure`, and `useless_vec` across existing backend/test code. I did not fold that cleanup into this performance PR.