### PR TITLE
Add bounded cache management APIs

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -76,10 +76,16 @@
   buried in backend internals.
 - Every cache must have a bounded default, a user-facing way to configure that
   bound, and a user-facing way to clear it.
+- Every cache must expose user-facing introspection for the number of retained
+  entries and retained bytes. Report retained bytes as the cache's owned/logical
+  payload estimate, not operating-system RSS or allocator arena usage.
+- Top-level runtime objects that own multiple caches must provide aggregate
+  clear and aggregate stats APIs in addition to cache-specific controls.
 - Backend resource pools such as buffer pools may live on the backend, but they
-  still need explicit limit/clear controls and documentation.
+  still need explicit limit/clear controls, stats APIs, and documentation.
 - Do not add a new cache without documenting its owner, lifetime, default
-  capacity, memory behavior, and clear/configuration path.
+  capacity, memory behavior, entry/byte accounting, and
+  clear/configuration/stats path.
 
 ## CPU Threading Contract
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -49,6 +49,53 @@ let mut engine = Engine::new(CpuBackend::with_threads(4));
 - Reuse it across repeated evaluations.
 - Avoid rebuilding the engine in tight loops unless you need to reset backend state.
 
+## Cache management
+
+`Engine` owns the long-lived runtime caches used by traced execution: compiled
+execution programs, parsed einsum notation, optimized N-ary einsum plans, and
+backend-specific analysis such as CPU GEMM shape analysis. These caches are
+bounded by default and can be inspected or cleared explicitly.
+
+```rust
+use std::num::NonZeroUsize;
+use tenferro::{CpuBackend, Engine};
+
+let mut engine = Engine::new(CpuBackend::new());
+
+engine.set_compile_cache_capacity(NonZeroUsize::new(128).unwrap());
+engine.set_einsum_cache_capacity(NonZeroUsize::new(128).unwrap());
+engine.set_gemm_analysis_cache_capacity(512);
+
+let stats = engine.cache_stats();
+assert_eq!(stats.compile.entries, 0);
+assert_eq!(stats.einsum_plans.entries, 0);
+assert_eq!(stats.backend.entries, 0);
+
+engine.clear_caches();
+```
+
+For CPU engines, `cpu_cache_stats()` also reports the CPU buffer pool and the
+process-wide CPU thread-pool handle cache. `clear_all_caches()` clears
+engine-owned caches, the CPU buffer pool, and the process-wide CPU thread-pool
+handle cache. Existing `CpuContext` values remain usable after the shared
+thread-pool cache is cleared because they hold their own handles.
+
+```rust
+use tenferro::{CpuBackend, Engine};
+
+let mut engine = Engine::new(CpuBackend::new());
+engine.set_buffer_pool_limit_bytes(32 * 1024 * 1024);
+
+let stats = engine.cpu_cache_stats();
+assert_eq!(stats.buffer_pool.entries, 0);
+
+engine.clear_all_caches();
+assert_eq!(engine.cpu_cache_stats().thread_pools.entries, 0);
+```
+
+`retained_bytes` in cache stats is tenferro's logical retained-payload estimate.
+It is not operating-system RSS and does not include allocator arena slack.
+
 ## Buffer reuse is automatic
 
 You do not need to manage scratch buffers manually. Keep your code simple, reuse the same `Engine`, and let tenferro reuse temporary storage behind the scenes.
@@ -68,3 +115,8 @@ For multi-input contractions, tenferro chooses a contraction order automatically
 - Start with plain `einsum(&mut engine, ...)`.
 - Reuse the same engine for repeated shapes and subscripts.
 - Benchmark before trying to outsmart the optimizer.
+
+Standalone eager einsum in the `tenferro-einsum` crate has its own per-thread
+bounded plan cache. Use `eager_einsum_cache_stats()`,
+`set_eager_einsum_cache_capacity(...)`, and `clear_eager_einsum_cache()` when
+calling that crate directly outside the `tenferro::Engine` path.

--- a/docs/plans/2026-05-19-unified-cache-management-plan.md
+++ b/docs/plans/2026-05-19-unified-cache-management-plan.md
@@ -1,6 +1,7 @@
 # Unified cache management plan
 
-Status: TODO
+Status: Implemented for CPU/engine caches in `codex/cache-management`; keep this
+file as the cache-policy inventory.
 
 After the current optimization work settles, add a unified cache-management
 surface across tenferro and tenferro-tensor.
@@ -10,6 +11,7 @@ Goals:
 - Define explicit upper bounds for every runtime/compiler cache.
 - Provide a single user-facing way to configure cache limits.
 - Provide a single user-facing way to clear caches.
+- Provide user-facing entry-count and retained-byte stats for every cache.
 - Document cache ownership, default limits, memory behavior, and clearing APIs.
 
 Initial cache inventory:
@@ -20,6 +22,9 @@ Initial cache inventory:
 - `Engine::backend_cache` for backend-specific prepared analysis, currently
   including CPU GEMM analysis slots keyed by compiled instruction index
 - `CpuBackend` buffer pool
+- `CpuContext` process-wide thread-pool handle cache
+- `tenferro-einsum` standalone eager plan cache
+- CUDA runtime/PTX compile-once caches when the CUDA feature is enabled
 - Any future compiled execution-plan caches
 
 Design notes:
@@ -32,3 +37,5 @@ Design notes:
 - Clearing should be available at both fine-grained and aggregate levels.
 - Documentation should explain which caches retain memory after `clear`, which
   release memory to the allocator, and which are per-backend or per-engine.
+- Retained-byte stats are logical owned-payload estimates. They are not process
+  RSS and do not attempt to measure allocator arenas or OS thread stacks.

--- a/tenferro-einsum/Cargo.toml
+++ b/tenferro-einsum/Cargo.toml
@@ -18,6 +18,7 @@ tenferro-device = { path = "../tenferro-device" }
 tenferro-ops = { path = "../tenferro-ops", default-features = false }
 tenferro-tensor = { path = "../tenferro-tensor", default-features = false }
 computegraph.workspace = true
+lru.workspace = true
 omeco.workspace = true
 
 [dev-dependencies]

--- a/tenferro-einsum/src/eager.rs
+++ b/tenferro-einsum/src/eager.rs
@@ -3,16 +3,22 @@ use std::cell::RefCell;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::env;
+use std::mem::size_of;
+use std::num::NonZeroUsize;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
+use lru::LruCache;
 use tenferro_tensor::{
-    DotGeneralConfig, Error, Result, Tensor, TensorBackend, TensorExec, TensorRead, TensorView,
+    CacheStats, DotGeneralConfig, Error, Result, Tensor, TensorBackend, TensorExec, TensorRead,
+    TensorView,
 };
 
 use crate::{ContractionTree, Subscripts};
 
 const EAGER_EINSUM_OP: &str = "eager_einsum";
+/// Default number of eager einsum contraction plans retained per thread.
+pub const DEFAULT_EAGER_EINSUM_CACHE_CAPACITY: usize = 256;
 
 #[derive(Debug, Default, Clone)]
 struct EagerEinsumProfileEntry {
@@ -23,11 +29,140 @@ struct EagerEinsumProfileEntry {
 thread_local! {
     static EAGER_EINSUM_PROFILE_STATE: RefCell<HashMap<&'static str, EagerEinsumProfileEntry>> =
         RefCell::new(HashMap::new());
-    static EAGER_EINSUM_PLAN_CACHE: RefCell<HashMap<EagerEinsumPlanCacheKey, Arc<ContractionTree>>> =
-        RefCell::new(HashMap::new());
+    static EAGER_EINSUM_PLAN_CACHE: RefCell<EagerEinsumPlanCache> =
+        RefCell::new(EagerEinsumPlanCache::new(default_eager_einsum_cache_capacity()));
 }
 
 type EagerEinsumPlanCacheKey = (Subscripts, Vec<Vec<usize>>);
+
+struct EagerEinsumPlanCache {
+    plans: LruCache<EagerEinsumPlanCacheKey, Arc<ContractionTree>>,
+}
+
+impl EagerEinsumPlanCache {
+    fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            plans: LruCache::new(capacity),
+        }
+    }
+
+    fn capacity(&self) -> NonZeroUsize {
+        self.plans.cap()
+    }
+
+    fn set_capacity(&mut self, capacity: NonZeroUsize) {
+        self.plans.resize(capacity);
+    }
+
+    fn clear(&mut self) {
+        self.plans.clear();
+    }
+
+    fn stats(&self) -> CacheStats {
+        let mut retained_bytes = 0usize;
+        for (key, tree) in self.plans.iter() {
+            retained_bytes += eager_plan_key_retained_bytes(key)
+                + size_of::<Arc<ContractionTree>>()
+                + tree.retained_bytes_for_cache_stats();
+        }
+        CacheStats {
+            entries: self.plans.len(),
+            retained_bytes,
+        }
+    }
+}
+
+fn default_eager_einsum_cache_capacity() -> NonZeroUsize {
+    NonZeroUsize::new(DEFAULT_EAGER_EINSUM_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN)
+}
+
+fn vec_retained_bytes<T>(values: &Vec<T>) -> usize {
+    values.capacity() * size_of::<T>()
+}
+
+fn vec_of_vec_retained_bytes<T>(values: &[Vec<T>]) -> usize {
+    values.iter().map(vec_retained_bytes).sum()
+}
+
+fn subscripts_retained_bytes(subscripts: &Subscripts) -> usize {
+    vec_of_vec_retained_bytes(&subscripts.inputs) + vec_retained_bytes(&subscripts.output)
+}
+
+fn eager_plan_key_retained_bytes(key: &EagerEinsumPlanCacheKey) -> usize {
+    subscripts_retained_bytes(&key.0) + vec_of_vec_retained_bytes(&key.1)
+}
+
+/// Return the current thread's eager einsum plan-cache capacity.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_einsum::{
+///     eager_einsum_cache_capacity, DEFAULT_EAGER_EINSUM_CACHE_CAPACITY,
+/// };
+///
+/// assert_eq!(
+///     eager_einsum_cache_capacity().get(),
+///     DEFAULT_EAGER_EINSUM_CACHE_CAPACITY,
+/// );
+/// ```
+#[must_use]
+pub fn eager_einsum_cache_capacity() -> NonZeroUsize {
+    EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow().capacity())
+}
+
+/// Resize the current thread's eager einsum plan cache.
+///
+/// Shrinking below the current length evicts least-recently-used entries.
+///
+/// # Examples
+///
+/// ```
+/// use std::num::NonZeroUsize;
+/// use tenferro_einsum::{
+///     eager_einsum_cache_capacity, set_eager_einsum_cache_capacity,
+/// };
+///
+/// set_eager_einsum_cache_capacity(NonZeroUsize::new(1).unwrap());
+/// assert_eq!(eager_einsum_cache_capacity().get(), 1);
+/// ```
+pub fn set_eager_einsum_cache_capacity(capacity: NonZeroUsize) {
+    EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow_mut().set_capacity(capacity));
+}
+
+/// Clear the current thread's eager einsum plan cache.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_einsum::{clear_eager_einsum_cache, eager_einsum_cache_stats};
+///
+/// clear_eager_einsum_cache();
+/// assert_eq!(eager_einsum_cache_stats().entries, 0);
+/// ```
+pub fn clear_eager_einsum_cache() {
+    EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow_mut().clear());
+}
+
+/// Return stats for the current thread's eager einsum plan cache.
+///
+/// `retained_bytes` is an owned payload estimate for cached contraction plans,
+/// not process RSS.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_einsum::{clear_eager_einsum_cache, eager_einsum_cache_stats};
+///
+/// clear_eager_einsum_cache();
+/// let stats = eager_einsum_cache_stats();
+/// assert_eq!(stats.entries, 0);
+/// assert_eq!(stats.retained_bytes, 0);
+/// ```
+#[must_use]
+pub fn eager_einsum_cache_stats() -> CacheStats {
+    EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow().stats())
+}
 
 fn eager_einsum_profile_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
@@ -352,7 +487,7 @@ fn cached_plan_subscripts(
     });
 
     if let Some(tree) = profile_eager_einsum_section("plan_cache_lookup", || {
-        EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow().get(&key).cloned())
+        EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow_mut().plans.get(&key).cloned())
     }) {
         return Ok(tree);
     }
@@ -362,7 +497,7 @@ fn cached_plan_subscripts(
     })?;
     let tree = Arc::new(tree);
     EAGER_EINSUM_PLAN_CACHE.with(|cache| {
-        cache.borrow_mut().insert(key, Arc::clone(&tree));
+        cache.borrow_mut().plans.put(key, Arc::clone(&tree));
     });
     Ok(tree)
 }

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -47,8 +47,9 @@ pub(crate) mod util;
 // Re-exports for convenience
 pub use builder::build_einsum_fragment;
 pub use eager::{
-    eager_einsum, eager_einsum_owned, eager_einsum_owned_subscripts, eager_einsum_read_subscripts,
-    eager_einsum_subscripts,
+    clear_eager_einsum_cache, eager_einsum, eager_einsum_cache_capacity, eager_einsum_cache_stats,
+    eager_einsum_owned, eager_einsum_owned_subscripts, eager_einsum_read_subscripts,
+    eager_einsum_subscripts, set_eager_einsum_cache_capacity, DEFAULT_EAGER_EINSUM_CACHE_CAPACITY,
 };
 pub use planning::tree::{ContractionOptimizerOptions, ContractionTree};
 pub use syntax::nested::NestedEinsum;

--- a/tenferro-einsum/src/planning/tree.rs
+++ b/tenferro-einsum/src/planning/tree.rs
@@ -1,11 +1,12 @@
 use std::collections::{HashMap, HashSet};
+use std::mem::{size_of, size_of_val};
 
 use omeco::{
     CodeOptimizer, EinCode as OmecoEinCode, Initializer, NestedEinsum, ScoreFunction, TreeSA,
 };
 use tenferro_device::{Error, Result};
 
-use crate::planning::plan::{compile_step_plans, StepPlan};
+use crate::planning::plan::{compile_step_plans, DiagPlan, GemmPlan, ReducePlan, StepPlan};
 use crate::syntax::subscripts::Subscripts;
 use crate::util::{build_size_dict, contraction_cost, intermediate_subs};
 
@@ -318,6 +319,80 @@ impl ContractionTree {
             &self.operand_subs[result_idx],
         ))
     }
+
+    #[doc(hidden)]
+    #[must_use]
+    pub fn retained_bytes_for_cache_stats(&self) -> usize {
+        size_of::<Self>()
+            + subscripts_retained_bytes(&self.subscripts)
+            + self.steps.capacity() * size_of::<ContractionStep>()
+            + self.size_dict.capacity() * (size_of::<u32>() + size_of::<usize>())
+            + vec_of_vec_retained_bytes(&self.operand_subs)
+            + self.step_plans.capacity() * size_of::<StepPlan>()
+            + self
+                .step_plans
+                .iter()
+                .map(step_plan_retained_bytes)
+                .sum::<usize>()
+    }
+}
+
+fn vec_retained_bytes<T>(values: &Vec<T>) -> usize {
+    values.capacity() * size_of::<T>()
+}
+
+fn vec_of_vec_retained_bytes<T>(values: &[Vec<T>]) -> usize {
+    values.iter().map(vec_retained_bytes).sum::<usize>()
+}
+
+fn subscripts_retained_bytes(subscripts: &Subscripts) -> usize {
+    vec_of_vec_retained_bytes(&subscripts.inputs) + vec_retained_bytes(&subscripts.output)
+}
+
+fn reduce_plan_retained_bytes(plan: &ReducePlan) -> usize {
+    vec_retained_bytes(&plan.original_subs)
+        + vec_retained_bytes(&plan.kept_subs)
+        + vec_retained_bytes(&plan.out_shape)
+}
+
+fn diag_plan_retained_bytes(plan: &DiagPlan) -> usize {
+    vec_retained_bytes(&plan.stages)
+        + plan
+            .stages
+            .iter()
+            .map(|stage| {
+                vec_retained_bytes(&stage.axis_pairs) + vec_retained_bytes(&stage.result_subs)
+            })
+            .sum::<usize>()
+        + vec_retained_bytes(&plan.result_subs)
+}
+
+fn gemm_plan_retained_bytes(plan: &GemmPlan) -> usize {
+    plan.reduce_a.as_ref().map_or(0, reduce_plan_retained_bytes)
+        + plan.reduce_b.as_ref().map_or(0, reduce_plan_retained_bytes)
+        + vec_retained_bytes(&plan.subs_a)
+        + vec_retained_bytes(&plan.subs_b)
+        + vec_retained_bytes(&plan.lo_modes)
+        + vec_retained_bytes(&plan.ro_modes)
+        + vec_retained_bytes(&plan.sum_modes)
+        + vec_retained_bytes(&plan.batch_sizes)
+        + vec_retained_bytes(&plan.target_a)
+        + vec_retained_bytes(&plan.target_b)
+        + vec_retained_bytes(&plan.c_gemm_shape)
+        + vec_retained_bytes(&plan.expanded_shape)
+        + vec_retained_bytes(&plan.canonical_modes)
+        + vec_retained_bytes(&plan.a_gemm_shape)
+        + vec_retained_bytes(&plan.b_gemm_shape)
+}
+
+fn step_plan_retained_bytes(plan: &StepPlan) -> usize {
+    plan.diag_a.as_ref().map_or(0, diag_plan_retained_bytes)
+        + plan.diag_b.as_ref().map_or(0, diag_plan_retained_bytes)
+        + plan
+            .strict_binary
+            .as_ref()
+            .map_or(0, |plan| size_of_val(plan))
+        + gemm_plan_retained_bytes(&plan.gemm)
 }
 
 fn optimize_omeco_pairs(

--- a/tenferro-einsum/tests/eager_cache.rs
+++ b/tenferro-einsum/tests/eager_cache.rs
@@ -1,0 +1,35 @@
+use std::num::NonZeroUsize;
+
+use tenferro_einsum::{
+    clear_eager_einsum_cache, eager_einsum, eager_einsum_cache_capacity, eager_einsum_cache_stats,
+    set_eager_einsum_cache_capacity, DEFAULT_EAGER_EINSUM_CACHE_CAPACITY,
+};
+use tenferro_tensor::{cpu::CpuBackend, Tensor};
+
+fn run_three_input_einsum(ctx: &mut CpuBackend, mid: usize) {
+    let a = Tensor::from_vec(vec![2, mid], vec![1.0_f64; 2 * mid]);
+    let b = Tensor::from_vec(vec![mid, 3], vec![1.0_f64; mid * 3]);
+    let c = Tensor::from_vec(vec![3, 2], vec![1.0_f64; 6]);
+    let out = eager_einsum(ctx, &[&a, &b, &c], "ij,jk,kl->il").expect("eager einsum");
+    assert_eq!(out.shape(), &[2, 2]);
+}
+
+#[test]
+fn eager_einsum_cache_is_bounded_and_reports_stats() {
+    clear_eager_einsum_cache();
+    set_eager_einsum_cache_capacity(NonZeroUsize::new(1).unwrap());
+    let mut ctx = CpuBackend::new();
+
+    run_three_input_einsum(&mut ctx, 3);
+    run_three_input_einsum(&mut ctx, 4);
+
+    assert_eq!(eager_einsum_cache_capacity().get(), 1);
+    let stats = eager_einsum_cache_stats();
+    assert_eq!(stats.entries, 1);
+    assert!(stats.retained_bytes > 0);
+
+    clear_eager_einsum_cache();
+    set_eager_einsum_cache_capacity(
+        NonZeroUsize::new(DEFAULT_EAGER_EINSUM_CACHE_CAPACITY).unwrap(),
+    );
+}

--- a/tenferro-tensor/Cargo.toml
+++ b/tenferro-tensor/Cargo.toml
@@ -28,6 +28,7 @@ num-traits.workspace = true
 num-complex.workspace = true
 smallvec.workspace = true
 libloading.workspace = true
+lru.workspace = true
 rayon = "1"
 strided-kernel.workspace = true
 thiserror.workspace = true

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -1,7 +1,7 @@
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use crate::{Tensor, TensorRead};
+use crate::{RuntimeCacheControl, Tensor, TensorRead};
 
 /// Canonical elementwise fusion plan shared between segmented execution and backends.
 #[doc(hidden)]
@@ -406,7 +406,7 @@ pub fn default_exec_session<B: TensorBackend + ?Sized, R: Send>(
 /// ```
 pub trait TensorBackend {
     #[doc(hidden)]
-    type RuntimeCache: Default;
+    type RuntimeCache: RuntimeCacheControl;
 
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
     fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;

--- a/tenferro-tensor/src/buffer_pool.rs
+++ b/tenferro-tensor/src/buffer_pool.rs
@@ -18,6 +18,8 @@ use std::mem::size_of;
 
 use num_complex::{Complex32, Complex64};
 
+use crate::CacheStats;
+
 /// Environment variable overriding the CPU buffer-pool retention cap in bytes.
 ///
 /// The value is parsed as an unsigned integer. Invalid values fall back to
@@ -296,6 +298,28 @@ impl BufferPool {
         self.max_retained_capacity_bytes
     }
 
+    /// Update the maximum retained typed host-buffer capacity in bytes.
+    ///
+    /// Shrinking below the currently retained capacity immediately evicts
+    /// retained buffers until the new cap is satisfied. A cap of zero disables
+    /// retention.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::buffer_pool::{BufferPool, PoolScalar};
+    ///
+    /// let mut pool = BufferPool::with_max_retained_capacity_bytes(1024);
+    /// <f64 as PoolScalar>::pool_release(&mut pool, Vec::with_capacity(128));
+    /// pool.set_max_retained_capacity_bytes(0);
+    /// assert_eq!(pool.max_retained_capacity_bytes(), 0);
+    /// assert!(pool.is_empty());
+    /// ```
+    pub fn set_max_retained_capacity_bytes(&mut self, max_retained_capacity_bytes: usize) {
+        self.max_retained_capacity_bytes = max_retained_capacity_bytes;
+        self.enforce_retention_limit();
+    }
+
     /// Number of retained buffers across all typed pools.
     ///
     /// # Examples
@@ -351,6 +375,30 @@ impl BufferPool {
                 + pool_len(&self.c64_pool)
                 + pool_len(&self.c32_pool),
             capacity_bytes: self.retained_capacity_bytes,
+        }
+    }
+
+    /// Return cache-style stats for the buffers retained by this pool.
+    ///
+    /// `entries` is the number of retained buffers, and `retained_bytes` is the
+    /// total retained vector capacity in bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::buffer_pool::{BufferPool, PoolScalar};
+    ///
+    /// let mut pool = BufferPool::new();
+    /// <f32 as PoolScalar>::pool_release(&mut pool, Vec::with_capacity(4));
+    /// let stats = pool.cache_stats();
+    /// assert_eq!(stats.entries, 1);
+    /// assert_eq!(stats.retained_bytes, 16);
+    /// ```
+    pub fn cache_stats(&self) -> CacheStats {
+        let stats = self.stats();
+        CacheStats {
+            entries: stats.buffers,
+            retained_bytes: stats.capacity_bytes,
         }
     }
 

--- a/tenferro-tensor/src/cache.rs
+++ b/tenferro-tensor/src/cache.rs
@@ -1,0 +1,99 @@
+//! Cache accounting primitives shared by tensor backends and facade runtimes.
+
+/// Entry and retained-byte accounting for one cache.
+///
+/// `retained_bytes` reports the cache-owned logical payload estimate. It does
+/// not include allocator arena slack, operating-system RSS, or memory retained
+/// by unrelated process allocators.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::CacheStats;
+///
+/// let stats = CacheStats {
+///     entries: 2,
+///     retained_bytes: 128,
+/// };
+/// assert_eq!(stats.entries, 2);
+/// assert_eq!(stats.retained_bytes, 128);
+/// ```
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CacheStats {
+    /// Number of cache entries currently retained.
+    pub entries: usize,
+    /// Cache-owned retained payload estimate in bytes.
+    pub retained_bytes: usize,
+}
+
+impl CacheStats {
+    /// Return an empty stats snapshot.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::CacheStats;
+    ///
+    /// let stats = CacheStats::empty();
+    /// assert_eq!(stats.entries, 0);
+    /// assert_eq!(stats.retained_bytes, 0);
+    /// ```
+    pub fn empty() -> Self {
+        Self::default()
+    }
+}
+
+/// Control surface required for backend runtime caches owned by higher-level runtimes.
+///
+/// Backend caches use this trait so an `Engine` can clear and inspect the cache
+/// without knowing backend-specific entry types.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{CacheStats, RuntimeCacheControl};
+///
+/// let mut cache = ();
+/// assert_eq!(cache.stats(), CacheStats::empty());
+/// cache.clear();
+/// assert_eq!(cache.stats().entries, 0);
+/// ```
+pub trait RuntimeCacheControl: Default {
+    /// Remove every retained cache entry.
+    fn clear(&mut self);
+
+    /// Snapshot retained entries and retained bytes.
+    fn stats(&self) -> CacheStats;
+}
+
+impl RuntimeCacheControl for () {
+    fn clear(&mut self) {}
+
+    fn stats(&self) -> CacheStats {
+        CacheStats::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CacheStats, RuntimeCacheControl};
+
+    #[test]
+    fn cache_stats_empty_reports_zeroes() {
+        assert_eq!(
+            CacheStats::empty(),
+            CacheStats {
+                entries: 0,
+                retained_bytes: 0
+            }
+        );
+    }
+
+    #[test]
+    fn unit_runtime_cache_control_is_empty_and_clearable() {
+        let mut cache = ();
+        assert_eq!(cache.stats(), CacheStats::empty());
+        cache.clear();
+        assert_eq!(cache.stats().entries, 0);
+    }
+}

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -10,7 +10,7 @@ use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
 use crate::validate::validate_nonsingular_u;
-use crate::{Buffer, Tensor, TensorRead, TypedTensor};
+use crate::{Buffer, CacheStats, Tensor, TensorRead, TypedTensor};
 
 use super::exec_session::CpuExecSession;
 use super::{analytic, elementwise, gemm, indexing, linalg, reduction, structural, CpuContext};
@@ -169,6 +169,31 @@ impl CpuBackend {
         }
     }
 
+    /// Create a CPU backend from an existing context and buffer-pool retention cap.
+    ///
+    /// The cap is measured in retained vector capacity bytes. A cap of zero
+    /// disables buffer retention.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tenferro_tensor::cpu::{CpuBackend, CpuContext};
+    ///
+    /// let ctx = Arc::new(CpuContext::with_threads(1));
+    /// let backend = CpuBackend::from_context_with_buffer_pool_limit(ctx, 0);
+    /// assert_eq!(backend.buffer_pool_limit_bytes(), 0);
+    /// ```
+    pub fn from_context_with_buffer_pool_limit(
+        ctx: Arc<CpuContext>,
+        max_retained_capacity_bytes: usize,
+    ) -> Self {
+        Self {
+            ctx,
+            buffers: BufferPool::with_max_retained_capacity_bytes(max_retained_capacity_bytes),
+        }
+    }
+
     /// Create a CPU backend with a custom thread count.
     ///
     /// # Examples
@@ -254,6 +279,60 @@ impl CpuBackend {
     /// ```
     pub fn buffer_pool_stats(&self) -> BufferPoolStats {
         self.buffers.stats()
+    }
+
+    /// Return cache-style stats for the CPU buffer pool.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::cpu::CpuBackend;
+    ///
+    /// let backend = CpuBackend::new();
+    /// let stats = backend.buffer_pool_cache_stats();
+    /// assert_eq!(stats.entries, 0);
+    /// assert_eq!(stats.retained_bytes, 0);
+    /// ```
+    pub fn buffer_pool_cache_stats(&self) -> CacheStats {
+        self.buffers.cache_stats()
+    }
+
+    /// Current CPU buffer-pool retention limit in bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tenferro_tensor::cpu::{CpuBackend, CpuContext};
+    ///
+    /// let backend = CpuBackend::from_context_with_buffer_pool_limit(
+    ///     Arc::new(CpuContext::with_threads(1)),
+    ///     4096,
+    /// );
+    /// assert_eq!(backend.buffer_pool_limit_bytes(), 4096);
+    /// ```
+    pub fn buffer_pool_limit_bytes(&self) -> usize {
+        self.buffers.max_retained_capacity_bytes()
+    }
+
+    /// Update the CPU buffer-pool retention limit in bytes.
+    ///
+    /// Shrinking the limit evicts retained buffers immediately. A limit of zero
+    /// disables buffer retention.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::cpu::CpuBackend;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// backend.set_buffer_pool_limit_bytes(0);
+    /// assert_eq!(backend.buffer_pool_limit_bytes(), 0);
+    /// assert_eq!(backend.buffer_pool_len(), 0);
+    /// ```
+    pub fn set_buffer_pool_limit_bytes(&mut self, max_retained_capacity_bytes: usize) {
+        self.buffers
+            .set_max_retained_capacity_bytes(max_retained_capacity_bytes);
     }
 
     /// Reset reusable typed host buffers currently retained by this backend.

--- a/tenferro-tensor/src/cpu/context.rs
+++ b/tenferro-tensor/src/cpu/context.rs
@@ -1,8 +1,14 @@
-use std::collections::HashMap;
 use std::env;
+use std::mem::size_of;
+use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use crate::{Error, Result};
+use lru::LruCache;
+
+use crate::{CacheStats, Error, Result};
+
+/// Default number of distinct CPU thread-pool sizes retained process-wide.
+pub const DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY: usize = 16;
 
 /// Reusable CPU execution context backed by an owned rayon thread pool.
 ///
@@ -20,9 +26,55 @@ pub struct CpuContext {
     pool: Arc<rayon::ThreadPool>,
 }
 
-fn shared_pools() -> &'static Mutex<HashMap<usize, Arc<rayon::ThreadPool>>> {
-    static POOLS: OnceLock<Mutex<HashMap<usize, Arc<rayon::ThreadPool>>>> = OnceLock::new();
-    POOLS.get_or_init(|| Mutex::new(HashMap::new()))
+struct SharedThreadPoolCache {
+    pools: LruCache<usize, Arc<rayon::ThreadPool>>,
+}
+
+impl SharedThreadPoolCache {
+    fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            pools: LruCache::new(capacity),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.pools.clear();
+    }
+
+    fn set_capacity(&mut self, capacity: NonZeroUsize) {
+        self.pools.resize(capacity);
+    }
+
+    fn stats(&self) -> CacheStats {
+        CacheStats {
+            entries: self.pools.len(),
+            retained_bytes: self.pools.len()
+                * (size_of::<usize>() + size_of::<Arc<rayon::ThreadPool>>()),
+        }
+    }
+}
+
+fn default_thread_pool_cache_capacity() -> NonZeroUsize {
+    NonZeroUsize::new(DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN)
+}
+
+fn shared_pools() -> &'static Mutex<SharedThreadPoolCache> {
+    static POOLS: OnceLock<Mutex<SharedThreadPoolCache>> = OnceLock::new();
+    POOLS.get_or_init(|| {
+        Mutex::new(SharedThreadPoolCache::new(
+            default_thread_pool_cache_capacity(),
+        ))
+    })
+}
+
+fn lock_shared_pools() -> std::sync::MutexGuard<'static, SharedThreadPoolCache> {
+    match shared_pools().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            eprintln!("tenferro-tensor: CPU thread-pool cache mutex was poisoned; recovering");
+            poisoned.into_inner()
+        }
+    }
 }
 
 pub(crate) fn try_get_or_create_pool(num_threads: usize) -> Result<Arc<rayon::ThreadPool>> {
@@ -33,14 +85,8 @@ pub(crate) fn try_get_or_create_pool(num_threads: usize) -> Result<Arc<rayon::Th
         });
     }
 
-    let mut pools = match shared_pools().lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => {
-            eprintln!("tenferro-tensor: CPU thread-pool cache mutex was poisoned; recovering");
-            poisoned.into_inner()
-        }
-    };
-    if let Some(pool) = pools.get(&num_threads) {
+    let mut pools = lock_shared_pools();
+    if let Some(pool) = pools.pools.get(&num_threads) {
         return Ok(Arc::clone(pool));
     }
 
@@ -53,7 +99,7 @@ pub(crate) fn try_get_or_create_pool(num_threads: usize) -> Result<Arc<rayon::Th
                 message: format!("failed to create rayon thread pool: {err}"),
             })?,
     );
-    pools.insert(num_threads, Arc::clone(&pool));
+    pools.pools.put(num_threads, Arc::clone(&pool));
     Ok(pool)
 }
 
@@ -147,6 +193,76 @@ impl CpuContext {
         })
     }
 
+    /// Current process-wide CPU thread-pool cache capacity.
+    ///
+    /// The cache is keyed by requested thread count. Retained-byte stats only
+    /// count tenferro's cache handles, not OS thread stacks owned by live pools.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::cpu::CpuContext;
+    ///
+    /// assert!(CpuContext::shared_pool_cache_capacity().get() > 0);
+    /// ```
+    pub fn shared_pool_cache_capacity() -> NonZeroUsize {
+        lock_shared_pools().pools.cap()
+    }
+
+    /// Resize the process-wide CPU thread-pool cache.
+    ///
+    /// Shrinking evicts least-recently-used cached handles. Existing
+    /// [`CpuContext`] values keep their own `Arc` handles alive.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::num::NonZeroUsize;
+    /// use tenferro_tensor::cpu::CpuContext;
+    ///
+    /// CpuContext::set_shared_pool_cache_capacity(NonZeroUsize::new(1).unwrap());
+    /// assert_eq!(CpuContext::shared_pool_cache_capacity().get(), 1);
+    /// ```
+    pub fn set_shared_pool_cache_capacity(capacity: NonZeroUsize) {
+        lock_shared_pools().set_capacity(capacity);
+    }
+
+    /// Clear all cached process-wide CPU thread-pool handles.
+    ///
+    /// Existing [`CpuContext`] values remain usable because they own `Arc`
+    /// handles to their pools.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::cpu::CpuContext;
+    ///
+    /// CpuContext::clear_shared_pool_cache();
+    /// assert_eq!(CpuContext::shared_pool_cache_stats().entries, 0);
+    /// ```
+    pub fn clear_shared_pool_cache() {
+        lock_shared_pools().clear();
+    }
+
+    /// Return process-wide CPU thread-pool cache stats.
+    ///
+    /// `retained_bytes` reports tenferro's retained cache handles, not OS thread
+    /// stacks or rayon's internal allocations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::cpu::CpuContext;
+    ///
+    /// CpuContext::clear_shared_pool_cache();
+    /// let stats = CpuContext::shared_pool_cache_stats();
+    /// assert_eq!(stats.entries, 0);
+    /// assert_eq!(stats.retained_bytes, 0);
+    /// ```
+    pub fn shared_pool_cache_stats() -> CacheStats {
+        lock_shared_pools().stats()
+    }
+
     /// Return the number of threads in this context's owned rayon pool.
     ///
     /// # Examples
@@ -187,5 +303,31 @@ impl CpuContext {
         } else {
             faer::Par::rayon(0)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use super::{CpuContext, DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY};
+
+    #[test]
+    fn shared_pool_cache_is_bounded_and_clearable() {
+        CpuContext::clear_shared_pool_cache();
+        CpuContext::set_shared_pool_cache_capacity(NonZeroUsize::new(1).unwrap());
+
+        let _one = CpuContext::with_threads(1);
+        let _two = CpuContext::with_threads(2);
+
+        let stats = CpuContext::shared_pool_cache_stats();
+        assert_eq!(stats.entries, 1);
+        assert!(stats.retained_bytes > 0);
+
+        CpuContext::clear_shared_pool_cache();
+        assert_eq!(CpuContext::shared_pool_cache_stats().entries, 0);
+        CpuContext::set_shared_pool_cache_capacity(
+            NonZeroUsize::new(DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY).unwrap(),
+        );
     }
 }

--- a/tenferro-tensor/src/cpu/gemm/mod.rs
+++ b/tenferro-tensor/src/cpu/gemm/mod.rs
@@ -1,7 +1,9 @@
 use num_traits::{One, Zero};
-use smallvec::SmallVec;
+use smallvec::{Array, SmallVec};
+use std::mem::size_of;
 
 use crate::buffer_pool::{BufferPool, PoolScalar};
+use crate::cache::{CacheStats, RuntimeCacheControl};
 use crate::config::DotGeneralConfig;
 #[cfg(feature = "cpu-blas")]
 use crate::cpu::elementwise::typed_conj_with_pool;
@@ -58,7 +60,7 @@ struct GemmConfigKey {
     rhs_batch_dims: SmallVec<[usize; 4]>,
 }
 
-const GEMM_ANALYSIS_CACHE_MAX: usize = 1024;
+pub(crate) const DEFAULT_GEMM_ANALYSIS_CACHE_CAPACITY: usize = 1024;
 
 #[derive(Default)]
 struct GemmAnalysisCacheSlot {
@@ -158,13 +160,31 @@ impl GemmAnalysisCacheSlot {
     }
 }
 
-#[derive(Default)]
 #[doc(hidden)]
 pub struct GemmAnalysisCache {
     slots: Vec<GemmAnalysisCacheSlot>,
+    max_slots: usize,
 }
 
 impl GemmAnalysisCache {
+    pub(crate) fn with_capacity(max_slots: usize) -> Self {
+        Self {
+            slots: Vec::new(),
+            max_slots,
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn capacity(&self) -> usize {
+        self.max_slots
+    }
+
+    #[doc(hidden)]
+    pub fn set_capacity(&mut self, max_slots: usize) {
+        self.max_slots = max_slots;
+        self.slots.truncate(max_slots);
+    }
+
     fn cached_dims<L, R, T>(
         &self,
         slot: usize,
@@ -193,7 +213,7 @@ impl GemmAnalysisCache {
         config: GemmConfigKey,
         dims: Option<GemmDims>,
     ) {
-        if slot >= GEMM_ANALYSIS_CACHE_MAX {
+        if slot >= self.max_slots {
             return;
         }
         if self.slots.len() <= slot {
@@ -209,6 +229,64 @@ impl GemmAnalysisCache {
             },
         );
     }
+}
+
+impl Default for GemmAnalysisCache {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_GEMM_ANALYSIS_CACHE_CAPACITY)
+    }
+}
+
+impl RuntimeCacheControl for GemmAnalysisCache {
+    fn clear(&mut self) {
+        self.slots.clear();
+    }
+
+    fn stats(&self) -> CacheStats {
+        let mut entries = 0usize;
+        let mut retained_bytes = self.slots.capacity() * size_of::<GemmAnalysisCacheSlot>();
+        for slot in &self.slots {
+            if let Some(plan) = &slot.direct {
+                entries += 1;
+                retained_bytes += gemm_analysis_plan_retained_bytes(plan);
+            }
+            if let Some(plan) = &slot.canonical {
+                entries += 1;
+                retained_bytes += gemm_analysis_plan_retained_bytes(plan);
+            }
+        }
+        CacheStats {
+            entries,
+            retained_bytes,
+        }
+    }
+}
+
+fn smallvec_retained_bytes<A: Array>(values: &SmallVec<A>) -> usize {
+    if values.spilled() {
+        values.capacity() * size_of::<A::Item>()
+    } else {
+        0
+    }
+}
+
+fn gemm_dims_retained_bytes(dims: &GemmDims) -> usize {
+    smallvec_retained_bytes(&dims.out_shape)
+}
+
+fn gemm_config_key_retained_bytes(config: &GemmConfigKey) -> usize {
+    smallvec_retained_bytes(&config.lhs_contracting_dims)
+        + smallvec_retained_bytes(&config.rhs_contracting_dims)
+        + smallvec_retained_bytes(&config.lhs_batch_dims)
+        + smallvec_retained_bytes(&config.rhs_batch_dims)
+}
+
+fn gemm_analysis_plan_retained_bytes(plan: &GemmAnalysisPlan) -> usize {
+    size_of::<GemmAnalysisPlan>()
+        + smallvec_retained_bytes(&plan.lhs_shape)
+        + smallvec_retained_bytes(&plan.rhs_shape)
+        + gemm_config_key_retained_bytes(&plan.config)
+        + plan.dims.as_ref().map_or(0, gemm_dims_retained_bytes)
 }
 
 fn validate_axis_list(
@@ -552,7 +630,7 @@ where
     L: TypedTensorRead<T>,
     R: TypedTensorRead<T>,
 {
-    let cache_slot = cache_slot.filter(|&slot| slot < GEMM_ANALYSIS_CACHE_MAX);
+    let cache_slot = cache_slot.filter(|&slot| slot < cache.max_slots);
     if let Some(slot) = cache_slot {
         if let Some(cached) = cache.cached_dims(slot, cache_kind, lhs, rhs, config) {
             return Ok(cached);

--- a/tenferro-tensor/src/cpu/mod.rs
+++ b/tenferro-tensor/src/cpu/mod.rs
@@ -18,7 +18,7 @@ use crate::{Buffer, TypedTensor};
 
 pub use affinity::{available_parallelism, process_cpu_affinity_count};
 pub use backend::CpuBackend;
-pub use context::CpuContext;
+pub use context::{CpuContext, DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY};
 pub use elementwise::{
     abs, add, clamp, compare, conj, div, maximum, minimum, mul, neg, select, sign,
 };

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -35,6 +35,11 @@ pub mod buffer_pool;
     any(feature = "cpu-faer", feature = "cpu-blas"),
     not(all(feature = "cpu-faer", feature = "cpu-blas"))
 ))]
+pub mod cache;
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
 pub mod config;
 #[cfg(all(
     any(feature = "cpu-faer", feature = "cpu-blas"),
@@ -83,6 +88,11 @@ pub use backend::{
     default_exec_session, ElementwiseFusionInst, ElementwiseFusionOp, ElementwiseFusionPlan,
     TensorBackend, TensorExec,
 };
+#[cfg(all(
+    any(feature = "cpu-faer", feature = "cpu-blas"),
+    not(all(feature = "cpu-faer", feature = "cpu-blas"))
+))]
+pub use cache::{CacheStats, RuntimeCacheControl};
 #[cfg(all(
     any(feature = "cpu-faer", feature = "cpu-blas"),
     not(all(feature = "cpu-faer", feature = "cpu-blas"))

--- a/tenferro/src/engine.rs
+++ b/tenferro/src/engine.rs
@@ -1,13 +1,17 @@
-use std::collections::HashMap;
+use std::mem::{size_of, size_of_val};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use lru::LruCache;
 
-use super::exec::ExecProgram;
+use super::exec::{ExecInstruction, ExecOp, ExecProgram};
 use tenferro_einsum::{ContractionTree, Subscripts};
 use tenferro_ops::std_tensor_op::EinsumSubscripts;
-use tenferro_tensor::{buffer_pool::BufferPoolStats, cpu::CpuBackend, Tensor, TensorBackend};
+use tenferro_tensor::{
+    buffer_pool::BufferPoolStats,
+    cpu::{CpuBackend, CpuContext},
+    CacheStats, RuntimeCacheControl, Tensor, TensorBackend,
+};
 
 /// Parsed einsum notation retained separately from shape-specific plans.
 pub(crate) struct ParsedEinsum {
@@ -27,6 +31,69 @@ pub(crate) type EinsumParseCache = LruCache<String, Arc<ParsedEinsum>>;
 ///
 /// Each `ContractionTree` is typically a few KB; 256 entries ≈ under 1 MB.
 pub const DEFAULT_EINSUM_CACHE_CAPACITY: usize = 256;
+
+/// Default capacity for compiled execution programs retained by an [`Engine`].
+///
+/// Each entry is a compiled `ExecProgram` plus its structural cache key. Program
+/// size depends on graph size, so the default is bounded conservatively.
+pub const DEFAULT_COMPILE_CACHE_CAPACITY: usize = 256;
+
+/// Stats for every cache owned by an [`Engine`].
+///
+/// `retained_bytes` fields are logical payload estimates, not process RSS.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::{engine::EngineCacheStats, CacheStats};
+///
+/// let stats = EngineCacheStats {
+///     compile: CacheStats::empty(),
+///     einsum_plans: CacheStats::empty(),
+///     einsum_parse: CacheStats::empty(),
+///     backend: CacheStats::empty(),
+/// };
+/// assert_eq!(stats.compile.entries, 0);
+/// ```
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EngineCacheStats {
+    /// Compiled execution-program cache.
+    pub compile: CacheStats,
+    /// N-ary einsum contraction-plan cache.
+    pub einsum_plans: CacheStats,
+    /// Parsed einsum-subscript cache.
+    pub einsum_parse: CacheStats,
+    /// Backend-specific runtime analysis cache.
+    pub backend: CacheStats,
+}
+
+/// Cache and resource-pool stats for a CPU-backed [`Engine`].
+///
+/// The CPU buffer pool is reported with cache-style accounting: entries are
+/// retained buffers, and retained bytes are retained vector capacity.
+/// `thread_pools` reports the process-wide CPU thread-pool handle cache.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::{engine::{CpuEngineCacheStats, EngineCacheStats}, CacheStats};
+///
+/// let stats = CpuEngineCacheStats {
+///     engine: EngineCacheStats::default(),
+///     buffer_pool: CacheStats::empty(),
+///     thread_pools: CacheStats::empty(),
+/// };
+/// assert_eq!(stats.buffer_pool.retained_bytes, 0);
+/// ```
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CpuEngineCacheStats {
+    /// Engine-owned caches.
+    pub engine: EngineCacheStats,
+    /// CPU backend buffer pool.
+    pub buffer_pool: CacheStats,
+    /// Process-wide CPU thread-pool handle cache.
+    pub thread_pools: CacheStats,
+}
 
 /// Cache key derived from the compiled graph topology.
 ///
@@ -62,6 +129,95 @@ fn compute_cache_key(exec: &ExecProgram) -> CacheKey {
     }
 }
 
+fn vec_retained_bytes<T>(values: &Vec<T>) -> usize {
+    values.capacity() * size_of::<T>()
+}
+
+fn vec_of_vec_retained_bytes<T>(values: &[Vec<T>]) -> usize {
+    values.iter().map(vec_retained_bytes).sum()
+}
+
+fn einsum_subscripts_retained_bytes(subscripts: &EinsumSubscripts) -> usize {
+    vec_of_vec_retained_bytes(&subscripts.inputs) + vec_retained_bytes(&subscripts.output)
+}
+
+fn exec_op_retained_bytes(op: &ExecOp) -> usize {
+    match op {
+        ExecOp::Constant { bytes, .. } => vec_retained_bytes(bytes),
+        ExecOp::NaryEinsum { subscripts } => einsum_subscripts_retained_bytes(subscripts),
+        ExecOp::Extension(extension) => size_of_val(extension),
+        _ => 0,
+    }
+}
+
+fn exec_instruction_retained_bytes(inst: &ExecInstruction) -> usize {
+    size_of::<ExecInstruction>()
+        + exec_op_retained_bytes(&inst.op)
+        + vec_retained_bytes(&inst.input_slots)
+        + vec_retained_bytes(&inst.output_slots)
+        + vec_of_vec_retained_bytes(&inst.output_shapes)
+        + vec_of_vec_retained_bytes(&inst.output_extents)
+        + vec_retained_bytes(&inst.last_use)
+}
+
+fn exec_program_retained_bytes(program: &ExecProgram) -> usize {
+    size_of::<ExecProgram>()
+        + vec_retained_bytes(&program.instructions)
+        + program
+            .instructions
+            .iter()
+            .map(exec_instruction_retained_bytes)
+            .sum::<usize>()
+        + vec_retained_bytes(&program.input_slots)
+        + vec_retained_bytes(&program.output_slots)
+}
+
+fn compile_cache_stats(cache: &LruCache<CacheKey, ExecProgram>) -> CacheStats {
+    CacheStats {
+        entries: cache.len(),
+        retained_bytes: cache
+            .iter()
+            .map(|(_, program)| size_of::<CacheKey>() + exec_program_retained_bytes(program))
+            .sum(),
+    }
+}
+
+fn einsum_cache_key_retained_bytes(key: &EinsumCacheKey) -> usize {
+    einsum_subscripts_retained_bytes(&key.0) + vec_of_vec_retained_bytes(&key.1)
+}
+
+fn nary_einsum_cache_stats(cache: &NaryEinsumCache) -> CacheStats {
+    CacheStats {
+        entries: cache.len(),
+        retained_bytes: cache
+            .iter()
+            .map(|(key, tree)| {
+                einsum_cache_key_retained_bytes(key)
+                    + size_of::<Arc<ContractionTree>>()
+                    + tree.retained_bytes_for_cache_stats()
+            })
+            .sum(),
+    }
+}
+
+fn parsed_einsum_retained_bytes(parsed: &ParsedEinsum) -> usize {
+    size_of::<ParsedEinsum>() + einsum_subscripts_retained_bytes(&parsed.subscripts)
+}
+
+fn einsum_parse_cache_stats(cache: &EinsumParseCache) -> CacheStats {
+    CacheStats {
+        entries: cache.len(),
+        retained_bytes: cache
+            .iter()
+            .map(|(notation, parsed)| {
+                notation.capacity()
+                    + size_of::<Arc<ParsedEinsum>>()
+                    + parsed_einsum_retained_bytes(parsed)
+            })
+            .sum(),
+    }
+}
+
 /// Execution engine holding the backend and compile caches.
 ///
 /// # Examples
@@ -75,7 +231,7 @@ fn compute_cache_key(exec: &ExecProgram) -> CacheKey {
 pub struct Engine<B: TensorBackend> {
     pub(crate) backend: B,
     pub(crate) backend_cache: B::RuntimeCache,
-    pub(crate) compile_cache: HashMap<CacheKey, ExecProgram>,
+    pub(crate) compile_cache: LruCache<CacheKey, ExecProgram>,
     pub(crate) einsum_cache: NaryEinsumCache,
     pub(crate) einsum_parse_cache: EinsumParseCache,
     pub(crate) slot_workspace: Vec<Option<Tensor>>,
@@ -96,7 +252,9 @@ impl<B: TensorBackend> Engine<B> {
         Self {
             backend,
             backend_cache: B::RuntimeCache::default(),
-            compile_cache: HashMap::new(),
+            compile_cache: LruCache::new(
+                NonZeroUsize::new(DEFAULT_COMPILE_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
+            ),
             einsum_cache: LruCache::new(
                 NonZeroUsize::new(DEFAULT_EINSUM_CACHE_CAPACITY)
                     .expect("DEFAULT_EINSUM_CACHE_CAPACITY must be non-zero"),
@@ -154,7 +312,9 @@ impl<B: TensorBackend> Engine<B> {
         Self {
             backend,
             backend_cache: B::RuntimeCache::default(),
-            compile_cache: HashMap::new(),
+            compile_cache: LruCache::new(
+                NonZeroUsize::new(DEFAULT_COMPILE_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
+            ),
             einsum_cache: LruCache::new(capacity),
             einsum_parse_cache: LruCache::new(capacity),
             slot_workspace: Vec::new(),
@@ -191,6 +351,139 @@ impl<B: TensorBackend> Engine<B> {
     pub fn set_einsum_cache_capacity(&mut self, capacity: NonZeroUsize) {
         self.einsum_cache.resize(capacity);
         self.einsum_parse_cache.resize(capacity);
+    }
+
+    /// Number of compiled execution programs currently retained by this engine.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let engine = Engine::new(CpuBackend::new());
+    /// assert_eq!(engine.compile_cache_len(), 0);
+    /// ```
+    pub fn compile_cache_len(&self) -> usize {
+        self.compile_cache.len()
+    }
+
+    /// Current capacity of the compiled execution-program cache.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{engine::DEFAULT_COMPILE_CACHE_CAPACITY, CpuBackend, Engine};
+    ///
+    /// let engine = Engine::new(CpuBackend::new());
+    /// assert_eq!(engine.compile_cache_capacity().get(), DEFAULT_COMPILE_CACHE_CAPACITY);
+    /// ```
+    pub fn compile_cache_capacity(&self) -> NonZeroUsize {
+        self.compile_cache.cap()
+    }
+
+    /// Resize the compiled execution-program cache.
+    ///
+    /// Shrinking below the current length evicts least-recently-used programs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::num::NonZeroUsize;
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// engine.set_compile_cache_capacity(NonZeroUsize::new(8).unwrap());
+    /// assert_eq!(engine.compile_cache_capacity().get(), 8);
+    /// ```
+    pub fn set_compile_cache_capacity(&mut self, capacity: NonZeroUsize) {
+        self.compile_cache.resize(capacity);
+    }
+
+    /// Clear the compiled execution-program cache.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// engine.clear_compile_cache();
+    /// assert_eq!(engine.compile_cache_len(), 0);
+    /// ```
+    pub fn clear_compile_cache(&mut self) {
+        self.compile_cache.clear();
+    }
+
+    /// Clear cached parsed and planned einsum entries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// engine.clear_einsum_caches();
+    /// assert_eq!(engine.einsum_cache_len(), 0);
+    /// ```
+    pub fn clear_einsum_caches(&mut self) {
+        self.einsum_cache.clear();
+        self.einsum_parse_cache.clear();
+    }
+
+    /// Clear the backend-specific runtime cache owned by this engine.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// engine.clear_backend_cache();
+    /// assert_eq!(engine.cache_stats().backend.entries, 0);
+    /// ```
+    pub fn clear_backend_cache(&mut self) {
+        self.backend_cache.clear();
+    }
+
+    /// Clear every cache owned directly by this engine.
+    ///
+    /// For CPU engines, use [`Engine::<CpuBackend>::clear_all_caches`] when the
+    /// CPU buffer pool should be cleared together with engine-owned caches.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// engine.clear_caches();
+    /// assert_eq!(engine.cache_stats().compile.entries, 0);
+    /// ```
+    pub fn clear_caches(&mut self) {
+        self.clear_compile_cache();
+        self.clear_einsum_caches();
+        self.clear_backend_cache();
+    }
+
+    /// Return stats for every cache owned directly by this engine.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let engine = Engine::new(CpuBackend::new());
+    /// let stats = engine.cache_stats();
+    /// assert_eq!(stats.compile.entries, 0);
+    /// assert_eq!(stats.einsum_plans.entries, 0);
+    /// ```
+    pub fn cache_stats(&self) -> EngineCacheStats {
+        EngineCacheStats {
+            compile: compile_cache_stats(&self.compile_cache),
+            einsum_plans: nary_einsum_cache_stats(&self.einsum_cache),
+            einsum_parse: einsum_parse_cache_stats(&self.einsum_parse_cache),
+            backend: self.backend_cache.stats(),
+        }
     }
 
     /// Returns `true` if the einsum cache contains a tree for `key`.
@@ -231,7 +524,11 @@ impl<B: TensorBackend> Engine<B> {
     /// with `self.backend`.
     pub(crate) fn get_or_compile(&mut self, exec: ExecProgram) -> ExecProgram {
         let key = compute_cache_key(&exec);
-        self.compile_cache.entry(key).or_insert(exec).clone()
+        if let Some(cached) = self.compile_cache.get(&key) {
+            return cached.clone();
+        }
+        self.compile_cache.put(key, exec.clone());
+        exec
     }
 
     /// Evaluate an `ExecProgram` through this engine, reusing the persistent
@@ -323,5 +620,106 @@ impl Engine<CpuBackend> {
     /// ```
     pub fn reset_buffer_pool(&mut self) {
         self.backend.reset_buffer_pool();
+    }
+
+    /// Return stats for engine caches and the CPU buffer pool.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let engine = Engine::new(CpuBackend::new());
+    /// let stats = engine.cpu_cache_stats();
+    /// assert_eq!(stats.engine.compile.entries, 0);
+    /// assert_eq!(stats.buffer_pool.entries, 0);
+    /// ```
+    pub fn cpu_cache_stats(&self) -> CpuEngineCacheStats {
+        CpuEngineCacheStats {
+            engine: self.cache_stats(),
+            buffer_pool: self.backend.buffer_pool_cache_stats(),
+            thread_pools: CpuContext::shared_pool_cache_stats(),
+        }
+    }
+
+    /// Clear engine-owned caches and the CPU backend buffer pool.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// engine.clear_all_caches();
+    /// assert_eq!(engine.cpu_cache_stats().buffer_pool.entries, 0);
+    /// ```
+    pub fn clear_all_caches(&mut self) {
+        self.clear_caches();
+        self.reset_buffer_pool();
+        CpuContext::clear_shared_pool_cache();
+    }
+
+    /// Return the CPU GEMM analysis-cache slot capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let engine = Engine::new(CpuBackend::new());
+    /// assert!(engine.gemm_analysis_cache_capacity() > 0);
+    /// ```
+    pub fn gemm_analysis_cache_capacity(&self) -> usize {
+        self.backend_cache.capacity()
+    }
+
+    /// Resize the CPU GEMM analysis-cache slot capacity.
+    ///
+    /// Shrinking truncates cached slots beyond the new limit. A capacity of zero
+    /// disables retention.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// engine.set_gemm_analysis_cache_capacity(0);
+    /// assert_eq!(engine.gemm_analysis_cache_capacity(), 0);
+    /// ```
+    pub fn set_gemm_analysis_cache_capacity(&mut self, capacity: usize) {
+        self.backend_cache.set_capacity(capacity);
+    }
+
+    /// Return the CPU buffer-pool retention limit in bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let engine = Engine::new(CpuBackend::new());
+    /// assert!(engine.buffer_pool_limit_bytes() > 0);
+    /// ```
+    pub fn buffer_pool_limit_bytes(&self) -> usize {
+        self.backend.buffer_pool_limit_bytes()
+    }
+
+    /// Update the CPU buffer-pool retention limit in bytes.
+    ///
+    /// A limit of zero disables buffer retention.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, Engine};
+    ///
+    /// let mut engine = Engine::new(CpuBackend::new());
+    /// engine.set_buffer_pool_limit_bytes(0);
+    /// assert_eq!(engine.buffer_pool_limit_bytes(), 0);
+    /// ```
+    pub fn set_buffer_pool_limit_bytes(&mut self, max_retained_capacity_bytes: usize) {
+        self.backend
+            .set_buffer_pool_limit_bytes(max_retained_capacity_bytes);
     }
 }

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -54,7 +54,7 @@ pub use sym_dim::SymDim;
 pub use tenferro_ops::std_tensor_op::EinsumSubscripts;
 pub use tenferro_tensor::cpu::CpuBackend;
 pub use tenferro_tensor::{
-    DType, Tensor, TensorBackend, TensorRead, TensorScalar, TensorView, TypedTensor,
+    CacheStats, DType, Tensor, TensorBackend, TensorRead, TensorScalar, TensorView, TypedTensor,
     TypedTensorView,
 };
 pub use traced::TracedTensor;

--- a/tenferro/tests/cache_management.rs
+++ b/tenferro/tests/cache_management.rs
@@ -1,0 +1,83 @@
+use std::num::NonZeroUsize;
+
+use tenferro::traced_tensor::einsum;
+use tenferro::{CpuBackend, Engine, TracedTensor};
+
+fn eval_add(engine: &mut Engine<CpuBackend>) {
+    let x = TracedTensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    let mut y = &x + &x;
+    y.eval(engine).expect("add eval");
+}
+
+fn eval_neg(engine: &mut Engine<CpuBackend>) {
+    let x = TracedTensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+    let mut y = x.neg();
+    y.eval(engine).expect("neg eval");
+}
+
+fn eval_nary_einsum(engine: &mut Engine<CpuBackend>, mid: usize) {
+    let a = TracedTensor::from_vec(vec![2, mid], vec![1.0_f64; 2 * mid]);
+    let b = TracedTensor::from_vec(vec![mid, 3], vec![1.0_f64; mid * 3]);
+    let c = TracedTensor::from_vec(vec![3, 2], vec![1.0_f64; 6]);
+    let mut out = einsum(engine, &[&a, &b, &c], "ij,jk,kl->il").expect("einsum");
+    out.eval(engine).expect("einsum eval");
+}
+
+#[test]
+fn compile_cache_is_bounded_and_reports_stats() {
+    let mut engine = Engine::new(CpuBackend::new());
+    engine.set_compile_cache_capacity(NonZeroUsize::new(1).unwrap());
+
+    eval_add(&mut engine);
+    eval_neg(&mut engine);
+
+    assert_eq!(engine.compile_cache_capacity().get(), 1);
+    let stats = engine.cache_stats();
+    assert_eq!(stats.compile.entries, 1);
+    assert!(stats.compile.retained_bytes > 0);
+}
+
+#[test]
+fn clear_caches_clears_engine_owned_cache_entries() {
+    let mut engine = Engine::new(CpuBackend::new());
+
+    eval_add(&mut engine);
+    eval_nary_einsum(&mut engine, 3);
+
+    let before = engine.cache_stats();
+    assert!(before.compile.entries > 0);
+    assert!(before.einsum_plans.entries > 0);
+    assert!(before.einsum_parse.entries > 0);
+
+    engine.clear_caches();
+
+    let after = engine.cache_stats();
+    assert_eq!(after.compile.entries, 0);
+    assert_eq!(after.einsum_plans.entries, 0);
+    assert_eq!(after.einsum_parse.entries, 0);
+    assert_eq!(after.backend.entries, 0);
+}
+
+#[test]
+fn cpu_cache_stats_include_buffer_pool_and_clear_all_caches() {
+    let mut engine = Engine::new(CpuBackend::new());
+
+    eval_add(&mut engine);
+    let before = engine.cpu_cache_stats();
+    assert!(before.engine.compile.entries > 0);
+    assert_eq!(
+        before.buffer_pool.retained_bytes,
+        engine.buffer_pool_stats().capacity_bytes
+    );
+
+    engine.clear_all_caches();
+
+    let after = engine.cpu_cache_stats();
+    assert_eq!(after.engine.compile.entries, 0);
+    assert_eq!(after.engine.einsum_plans.entries, 0);
+    assert_eq!(after.engine.einsum_parse.entries, 0);
+    assert_eq!(after.engine.backend.entries, 0);
+    assert_eq!(after.buffer_pool.entries, 0);
+    assert_eq!(after.thread_pools.entries, 0);
+    assert_eq!(engine.buffer_pool_len(), 0);
+}


### PR DESCRIPTION
## Summary

- Add common cache stats/control primitives and bounded default cache management for Engine compile/einsum/backend caches.
- Add CPU cache introspection/clear APIs covering buffer pool and shared thread-pool handle cache.
- Bound and expose stats/clear/capacity controls for standalone eager einsum plan cache.
- Document cache ownership/stats requirements in repository rules and online performance docs.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p tenferro --test cache_management --release`
- `cargo test -p tenferro-einsum --test eager_cache --release`
- `cargo test -p tenferro-tensor cpu::context::tests::shared_pool_cache_is_bounded_and_clearable --release`
- `cargo test --release -p tenferro-tensor --lib`
- `cargo test --doc --release -p tenferro -p tenferro-einsum -p tenferro-tensor`

## Notes

`cargo clippy --workspace --all-targets -- -D warnings` currently fails on pre-existing lints in `tenferro-cubecl` and existing `tenferro-tensor` code paths unrelated to this change.