### PR TITLE
[codex] Remove CPU thread pool ownership

### DIFF
--- a/docs/design/contraction-pipeline.md
+++ b/docs/design/contraction-pipeline.md
@@ -98,8 +98,8 @@ CPU execution is handled by `CpuBackend`:
 - elementwise/reduction/structural work uses strided-kernel and dedicated CPU
   implementations,
 - `dot_general` uses the selected CPU GEMM backend (`cpu-faer` or `cpu-blas`),
-- faer-backed work runs inside `CpuContext::install` through
-  `CpuExecSession`.
+- faer-backed work receives the `CpuContext` thread-count hint through
+  `CpuExecSession` without entering a tenferro-owned Rayon pool.
 
 ## CubeCL/CUDA Execution
 

--- a/docs/design/dot-general-overhead.md
+++ b/docs/design/dot-general-overhead.md
@@ -36,18 +36,18 @@ opening the full backend wrapper path for each local contraction:
 ```text
 backend.dot_general_with_conj(...)
   -> backend.with_exec_session(...)
-       -> CpuContext::install(...)
-            -> dtype dispatch
-                 -> Tensor wrapper / enum dispatch
-                      -> CpuExecSession::dot_general_with_conj(...)
-                           -> GEMM planning / execution
+       -> dtype dispatch
+            -> Tensor wrapper / enum dispatch
+                 -> CpuExecSession::dot_general_with_conj(...)
+                      -> GEMM planning / execution
 ```
 
 When this sequence is repeated for every tiny local contraction, the
-`backend.with_exec_session` / `ctx.install` / dtype dispatch / wrapper path
-cost dominates. Reusing a persistent runtime cache helps only slightly in this
-benchmark, which indicates that GEMM analysis caching is not the principal
-bottleneck for low bond dimensions.
+`backend.with_exec_session` / dtype dispatch / wrapper path cost dominates.
+Earlier measurements also included `rayon::ThreadPool::install`; current CPU
+execution no longer enters a tenferro-owned Rayon pool. Reusing a persistent
+runtime cache helps only slightly in this benchmark, which indicates that GEMM
+analysis caching is not the principal bottleneck for low bond dimensions.
 
 For larger bond dimensions the actual GEMM work becomes dominant, so the gap
 between `fresh_backend_cache` and `single_exec_session` naturally shrinks.

--- a/docs/design/exec-session.md
+++ b/docs/design/exec-session.md
@@ -3,9 +3,9 @@
 ## Overview
 
 `TensorExec` is the execution-time primitive surface. Ops run within a
-backend-owned execution scope when the backend has one, such as the owned rayon
-pool used by CPU execution. Individual ops must not re-enter the same backend
-scope.
+backend-owned execution scope when the backend has one, such as a GPU runtime
+or the CPU backend's reusable buffer scope. Individual ops must not re-enter
+the same backend scope.
 
 `TensorBackend::with_exec_session` creates the scope. `eval_exec_ir` runs
 inside the session.
@@ -24,21 +24,22 @@ eval_exec_ir(backend, program, inputs)
 
 ## Why Sessions
 
-Without sessions, each backend method independently enters the execution
-context (e.g., `rayon::ThreadPool::install()` for CPU). For N-ary einsum
-with hundreds of small GEMM steps, this per-step overhead dominates.
+Without sessions, each backend method independently prepares its execution
+state and scratch-buffer access. For N-ary einsum with hundreds of small GEMM
+steps, repeating that setup per instruction can dominate.
 
-Sessions amortize the context-entry cost: one `install()` call for the
-entire `eval_exec_ir` loop instead of one per instruction.
+Sessions amortize that setup by creating one `TensorExec` for the entire
+`eval_exec_ir` loop instead of one per instruction.
 
 ## Backend Mapping
 
 ### CPU (faer)
 
-faer's `Par::rayon(0)` uses `rayon::current_num_threads()` and
-`rayon::scope()` internally. It relies on the rayon "current pool" context
-set by `ThreadPool::install()` — there is no API to pass a ThreadPool
-reference directly.
+`CpuContext` stores the requested CPU thread count as a faer parallelism hint.
+It does not own a Rayon thread pool and `CpuContext::install` runs the closure
+on the caller thread. faer-backed kernels use `Par::Seq` for one thread and
+`Par::rayon(n)` otherwise, letting faer/rayon use the current or global Rayon
+pool without a tenferro-owned pool entry on each session.
 
 ```rust
 impl TensorBackend for CpuBackend {
@@ -48,11 +49,8 @@ impl TensorBackend for CpuBackend {
     ) -> R {
         let mut buffers = std::mem::take(&mut self.buffers);
         let ctx = Arc::clone(&self.ctx);
-        let result = ctx.install(|| {
-            // rayon context active for entire session
-            let mut session = CpuExecSession { ctx: &ctx, buffers: &mut buffers };
-            f(&mut session)
-        });
+        let mut session = CpuExecSession { ctx: &ctx, buffers: &mut buffers };
+        let result = f(&mut session);
         self.buffers = buffers;
         result
     }
@@ -60,7 +58,7 @@ impl TensorBackend for CpuBackend {
 ```
 
 `CpuExecSession` implements `TensorExec` by calling kernel functions
-directly — no `install()` or `install_with_pool()` per op.
+directly, with no Rayon pool entry per op.
 
 ### CubeCL/CUDA
 
@@ -75,11 +73,11 @@ or calls the relevant cuTENSOR/cuSOLVER/cuBLAS wrapper against the backend's
 
 | CPU concept | CubeCL/CUDA concept |
 |---|---|
-| `CpuContext` (rayon ThreadPool) | `CubeclRuntime` (CUDA device/client) |
-| `ctx.install()` | CubeCL launch through the stored runtime |
+| `CpuContext` (thread-count hint) | `CubeclRuntime` (CUDA device/client) |
+| `Par::rayon(n)` / `Par::Seq` | CubeCL launch through the stored runtime |
 | `BufferPool` (host `Vec<T>`) | CubeCL device buffers plus upload/download helpers |
-| `Par::rayon(0)` | kernel launch on stream |
-| per-step `install()` overhead | per-kernel launch/runtime dispatch overhead |
+| faer/rayon CPU work | kernel launch on stream |
+| per-step session setup overhead | per-kernel launch/runtime dispatch overhead |
 
 Future CubeCL work may introduce a dedicated GPU exec session if there is a
 measurable benefit from binding temporary workspace, stream state, or device
@@ -95,7 +93,7 @@ which wraps the backend itself as a `TensorExec` via `BackendExecAdapter`.
 
 ```
 TensorBackend          — factory: creates sessions, owns long-lived state
-  with_exec_session()  — enters execution scope
+  with_exec_session()  — creates execution scope
   dot_general()        — standalone op (with per-op context entry)
   ...
 

--- a/docs/design/tensor-prims.md
+++ b/docs/design/tensor-prims.md
@@ -66,11 +66,14 @@ does not support. Higher layers must not silently fall back across devices.
 - `cpu-blas` for BLAS/LAPACK-backed GEMM/linalg.
 
 CPU execution uses strided-kernel for elementwise/reduction/structural work and
-faer or BLAS/LAPACK for GEMM and linalg. `CpuContext` owns the rayon policy and
-is the single source of truth for faer parallelism.
+faer or BLAS/LAPACK for GEMM and linalg. `CpuContext` stores the CPU thread
+count as the single source of truth for faer parallelism, but it does not own a
+Rayon thread pool.
 
-`CpuBackend::with_exec_session` installs the owned rayon pool once and runs the
-whole compiled program through `CpuExecSession`, avoiding per-op pool entry.
+`CpuBackend::with_exec_session` runs the whole compiled program through
+`CpuExecSession`, reusing the backend buffer pool and avoiding per-op session
+setup. faer-backed kernels receive `Par::Seq` for one thread or `Par::rayon(n)`
+for multi-threaded execution.
 
 ## CubeCL Backend
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -33,13 +33,52 @@ or write literals directly in column-major order. Owned export through
 
 ## Control CPU thread count
 
-Use `CpuBackend::with_threads(n)` when you want explicit CPU parallelism control.
+Use `CpuBackend::with_threads(n)` when you want an engine-specific CPU
+parallelism hint:
 
 ```rust
 use tenferro::{CpuBackend, Engine};
 
-let mut engine = Engine::new(CpuBackend::with_threads(4));
+let engine = Engine::new(CpuBackend::with_threads(4));
+assert_eq!(engine.backend().num_threads(), 4);
 ```
+
+`CpuBackend::new()` reads `RAYON_NUM_THREADS` and falls back to the
+process-visible CPU count when the variable is unset. This is convenient for
+applications that configure parallelism at process startup:
+
+```bash
+RAYON_NUM_THREADS=4 cargo run --release
+```
+
+For the default `cpu-faer` backend, tenferro passes this value to faer as a
+kernel parallelism hint: one thread uses sequential execution, and larger values
+use faer's Rayon-backed parallel path. tenferro does not create a private Rayon
+thread pool and does not pin faer work to a socket. `RAYON_NUM_THREADS` still
+matters for applications that rely on the process-global Rayon pool, so set it
+consistently with the backend thread budget.
+
+If you need socket-level placement or independent worker pools, split the
+workload at the process level for example with MPI or `taskset`/`numactl`, and
+give each process its own CPU thread budget.
+
+For `cpu-blas` builds, also configure the BLAS/OpenMP provider. A common
+single-process setup is:
+
+```bash
+RAYON_NUM_THREADS=4 \
+OPENBLAS_NUM_THREADS=4 \
+OMP_NUM_THREADS=4 \
+MKL_NUM_THREADS=4 \
+VECLIB_MAXIMUM_THREADS=4 \
+./your-tenferro-app
+```
+
+Set only the variables used by your BLAS provider. When running many processes
+or outer task parallelism, lower both `RAYON_NUM_THREADS` and BLAS/OpenMP thread
+counts per process to avoid oversubscription. For small tensor-network
+contractions, start with one CPU thread per process and increase only after
+benchmarking the target workload.
 
 ## Reuse the same engine
 
@@ -74,11 +113,10 @@ assert_eq!(stats.backend.entries, 0);
 engine.clear_caches();
 ```
 
-For CPU engines, `cpu_cache_stats()` also reports the CPU buffer pool and the
-process-wide CPU thread-pool handle cache. `clear_all_caches()` clears
-engine-owned caches, the CPU buffer pool, and the process-wide CPU thread-pool
-handle cache. Existing `CpuContext` values remain usable after the shared
-thread-pool cache is cleared because they hold their own handles.
+For CPU engines, `cpu_cache_stats()` also reports the CPU buffer pool.
+`clear_all_caches()` clears engine-owned caches and the CPU buffer pool.
+CPU thread count is a kernel-level parallelism hint; tenferro does not retain
+or expose a process-wide CPU thread-pool cache.
 
 ```rust
 use tenferro::{CpuBackend, Engine};
@@ -90,7 +128,7 @@ let stats = engine.cpu_cache_stats();
 assert_eq!(stats.buffer_pool.entries, 0);
 
 engine.clear_all_caches();
-assert_eq!(engine.cpu_cache_stats().thread_pools.entries, 0);
+assert_eq!(engine.cpu_cache_stats().buffer_pool.entries, 0);
 ```
 
 `retained_bytes` in cache stats is tenferro's logical retained-payload estimate.

--- a/docs/performance/tt-inner-product-overhead.md
+++ b/docs/performance/tt-inner-product-overhead.md
@@ -21,6 +21,8 @@ inner-product overhead in `tenferro-rs`, compared with ITensors.jl.
   - Compares normal per-call execution with cached GEMM analysis.
 - `tenferro-tensor/benches/cpu_install_overhead.rs`
   - Measures `CpuContext::install` and the surrounding buffer-pool wrapper.
+    Current `install` runs inline; older results in this note measured a
+    tenferro-owned Rayon pool entry.
 - `tenferro-tensor/benches/openblas_direct_overhead.rs`
   - Measures direct `cblas_zgemm` calls for the same small pairwise shapes.
   - Requires the `cpu-blas` feature and is intended for `src-openblas` runs.
@@ -192,9 +194,9 @@ validation, GEMM analysis/cache lookup, output allocation through `BufferPool`,
 `TypedTensor` construction, and complex conjugation/materialization when BLAS
 cannot represent the requested conjugation as a transpose flag.
 
-## Install Overhead
+## Historical Install Overhead
 
-Measured on one thread:
+Measured on one thread before `CpuContext::install` was changed to run inline:
 
 | Case | Time |
 |---|---:|
@@ -204,8 +206,10 @@ Measured on one thread:
 | `ctx.install` + `BufferPool` take/restore | 5.71 us |
 | `ctx.install` + `BufferPool` + GEMM cache borrow | 5.97 us |
 
-The bottleneck is mostly `rayon::ThreadPool::install`. Buffer-pool movement is
-only about 0.2 us.
+The bottleneck was mostly `rayon::ThreadPool::install`. Buffer-pool movement is
+only about 0.2 us. Current CPU execution no longer owns or enters a Rayon pool
+in `CpuContext::install`; the benchmark is retained to measure the remaining
+caller-thread wrapper cost.
 
 For `site_update`, which performs two GEMMs, this adds roughly 11-12 us of
 fixed cost when each GEMM enters the backend separately.
@@ -232,20 +236,14 @@ pub enum Parallelism {
 ```
 
 Both APIs describe the requested thread count, not the thread pool that must run
-the work. faer and spindle rely on the current Rayon context through
+the work. faer and spindle rely on the current or global Rayon context through
 `rayon::current_num_threads`, `rayon::scope`, `into_par_iter`, and
-`spindle::for_each`. Therefore tenferro currently uses
-`CpuContext::install(...)` to make its owned Rayon pool the current execution
-context before calling faer.
+`spindle::for_each`.
 
-As an upper-bound experiment, the faer backend was run with an experimental
-switch that bypasses `CpuContext::install` and lets faer/spindle use the
-current or global Rayon pool directly:
-
-```bash
-TENFERRO_EXPERIMENTAL_FAER_GLOBAL_RAYON=1
-TENFERRO_PAIRWISE_THREADS=<1|2|4|8>
-```
+The faer backend is therefore run without a tenferro-owned Rayon pool.
+`CpuContext` stores the requested thread count, maps one thread to `Par::Seq`,
+and maps multi-threaded execution to `Par::rayon(n)`. faer/rayon then uses the
+current or global Rayon pool directly.
 
 The benchmark below is cached `site_update`, `Complex64`, `d = 2`, with all
 known BLAS/OpenMP thread pools set to one thread. Times are Criterion means in
@@ -267,19 +265,16 @@ increasing faer thread count does not help; it usually adds parallel dispatch
 overhead. The important optimization is removing per-GEMM `install`, not making
 each tiny GEMM parallel.
 
-The experiment should not be treated as a production backend policy. Bypassing
-`install` lets faer use the current/global Rayon pool, so `CpuContext` no longer
-fully controls pool isolation, thread count, or affinity. It is useful as a
-ceiling measurement and as evidence that coarse-grained pool entry is the main
-direction to pursue.
+The global-Rayon columns became the production policy. This removes the pool
+entry cost, but it also means `CpuContext` no longer provides pool isolation or
+affinity. Its `num_threads` value is a faer parallelism hint rather than a
+private worker-pool size.
 
 Design implications:
 
-- For one-thread faer, `Par::Seq` makes `install` unnecessary and a caller-thread
-  fast path is safe.
-- For multi-thread faer, keep tenferro pool semantics by entering the pool once
-  per larger unit of work, such as one TT contraction, one compiled graph, or
-  one linalg batch.
+- For one-thread faer, `Par::Seq` avoids Rayon dispatch.
+- For multi-thread faer, prefer process- or MPI-level workload partitioning when
+  pool isolation and CPU affinity matter.
 - Add a small-shape policy that keeps tiny faer GEMMs sequential even when the
   backend context has more than one thread.
 - A true pool-handle patch would need changes across faer, spindle, and the
@@ -315,8 +310,8 @@ This preserves Rayon pool semantics, but it is expensive for tiny GEMMs.
 - For the `cpu-blas` backend, LAPACK-backed linalg methods now use the same
   caller-thread pool wrapper. This covers `cholesky`, `triangular_solve`, `lu`,
   `full_piv_lu`, `full_piv_lu_solve`, `svd`, `qr`, `eigh`, and `eig`. The
-  `cpu-faer` backend still uses `install` because faer depends on the Rayon CPU
-  context for parallel policy.
+  `cpu-faer` backend now also avoids a tenferro-owned Rayon pool and passes the
+  `CpuContext` thread count to faer as `Par::Seq` or `Par::rayon(n)`.
 - The BLAS conjugation path now detects row-contiguous conjugated operands before
   acquiring an output buffer for a direct BLAS attempt that cannot succeed.
 
@@ -384,24 +379,22 @@ entry point without making normal eager contractions context-dependent.
 
 ## Optimization Candidates
 
-1. Keep `CpuContext::install` public semantics unchanged.
-2. Avoid broad "skip install when `num_threads == 1`" changes.
-3. Consider a private, narrow fast path for one-thread sequential GEMM only:
-   - `ctx.num_threads() == 1`
-   - faer parallel policy is `Par::Seq`
-   - operation is known GEMM-only
-4. Improve segmented execution so FFI GEMMs can run through an existing
+1. Keep `CpuContext` as the thread-count source for faer `Par`, not as an owned
+   worker-pool handle.
+2. Add a small-shape policy that keeps tiny faer GEMMs sequential even when the
+   backend context has more than one thread.
+3. Improve segmented execution so FFI GEMMs can run through an existing
    `TensorExec` session instead of returning to backend-level calls.
-5. Add scalar-like contraction fast paths for `nnz == 1`.
-6. Add tiny GEMM direct-loop fast paths for small `m`, `n`, `k`.
-7. Consider fixed-rank / tuple-based internal paths for common rank-2/rank-3
+4. Add scalar-like contraction fast paths for `nnz == 1`.
+5. Add tiny GEMM direct-loop fast paths for small `m`, `n`, `k`.
+6. Consider fixed-rank / tuple-based internal paths for common rank-2/rank-3
    contractions, while keeping the public `DotGeneralConfig` stable unless a
    broader API cleanup is desired.
-8. Further reduce BLAS conjugation fallback cost by going directly to a
+7. Further reduce BLAS conjugation fallback cost by going directly to a
    preconjugated or specialized contraction path when the stride pattern makes
    `CblasConjTrans` impossible. The obvious failed direct-BLAS/output-buffer
    attempt is already avoided.
-9. Add a direct tiny-complex contraction path for TT site updates, especially
+8. Add a direct tiny-complex contraction path for TT site updates, especially
    shapes equivalent to `(chi x chi)' * (chi x d*chi)` and
    `(chi*d x chi)' * (chi*d x chi)`.
 

--- a/tenferro-tensor/benches/cpu_install_overhead.rs
+++ b/tenferro-tensor/benches/cpu_install_overhead.rs
@@ -5,15 +5,15 @@ use tenferro_tensor::{
     TensorBackend,
 };
 
-fn bench_cpu_install_overhead(c: &mut Criterion) {
-    let mut group = c.benchmark_group("cpu_install_overhead/one_thread");
+fn bench_cpu_context_entry_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cpu_context_entry_overhead/one_thread");
 
-    group.bench_function("ctx_install_empty", |b| {
+    group.bench_function("ctx_install_inline_empty", |b| {
         let ctx = CpuContext::with_threads(1);
         b.iter(|| ctx.install(|| black_box(1usize)));
     });
 
-    group.bench_function("backend_install_empty", |b| {
+    group.bench_function("backend_install_inline_empty", |b| {
         let backend = CpuBackend::with_threads(1);
         b.iter(|| backend.install(|| black_box(1usize)));
     });
@@ -26,7 +26,7 @@ fn bench_cpu_install_overhead(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("ctx_install_with_buffer_pool", |b| {
+    group.bench_function("ctx_install_inline_with_buffer_pool", |b| {
         let ctx = CpuContext::with_threads(1);
         let mut buffers = BufferPool::new();
         b.iter(|| {
@@ -40,7 +40,7 @@ fn bench_cpu_install_overhead(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("ctx_install_with_buffer_pool_and_cache", |b| {
+    group.bench_function("ctx_install_inline_with_buffer_pool_and_cache", |b| {
         let ctx = CpuContext::with_threads(1);
         let mut buffers = BufferPool::new();
         let mut cache = <CpuBackend as TensorBackend>::RuntimeCache::default();
@@ -59,5 +59,5 @@ fn bench_cpu_install_overhead(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_cpu_install_overhead);
+criterion_group!(benches, bench_cpu_context_entry_overhead);
 criterion_main!(benches);

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -101,12 +101,6 @@ fn maybe_print_cpu_session_profile() {
     }
 }
 
-#[cfg(feature = "cpu-faer")]
-fn faer_global_rayon_bypass_enabled() -> bool {
-    static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| env::var("TENFERRO_EXPERIMENTAL_FAER_GLOBAL_RAYON").is_ok())
-}
-
 /// CPU execution backend.
 ///
 /// # Examples
@@ -354,7 +348,7 @@ impl CpuBackend {
         self.buffers.clear();
     }
 
-    /// Run a closure inside this backend's shared rayon thread pool.
+    /// Run a closure in this backend's CPU execution scope.
     ///
     /// # Examples
     ///
@@ -365,30 +359,13 @@ impl CpuBackend {
     /// let value = backend.install(|| 1 + 1);
     /// assert_eq!(value, 2);
     /// ```
-    pub fn install<R>(&self, op: impl FnOnce() -> R + Send) -> R
-    where
-        R: Send,
-    {
+    pub fn install<R>(&self, op: impl FnOnce() -> R) -> R {
         self.ctx.install(op)
     }
 
-    fn install_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R
-    where
-        R: Send,
-    {
-        #[cfg(feature = "cpu-faer")]
-        if faer_global_rayon_bypass_enabled() {
-            let mut buffers = std::mem::take(&mut self.buffers);
-            let result = op(&mut buffers);
-            self.buffers = buffers;
-            return result;
-        }
-
+    fn install_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R) -> R {
         let mut buffers = std::mem::take(&mut self.buffers);
-        let (result, buffers) = self.ctx.install(|| {
-            let result = op(&mut buffers);
-            (result, buffers)
-        });
+        let result = op(&mut buffers);
         self.buffers = buffers;
         result
     }
@@ -402,10 +379,7 @@ impl CpuBackend {
     }
 
     #[cfg(feature = "cpu-faer")]
-    fn linalg_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R
-    where
-        R: Send,
-    {
+    fn linalg_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R) -> R {
         self.install_with_pool(op)
     }
 
@@ -418,23 +392,10 @@ impl CpuBackend {
     fn install_with_pool_and_gemm_cache<R>(
         &mut self,
         gemm_analysis_cache: &mut gemm::GemmAnalysisCache,
-        op: impl FnOnce(&mut BufferPool, &mut gemm::GemmAnalysisCache) -> R + Send,
-    ) -> R
-    where
-        R: Send,
-    {
-        if faer_global_rayon_bypass_enabled() {
-            let mut buffers = std::mem::take(&mut self.buffers);
-            let result = op(&mut buffers, gemm_analysis_cache);
-            self.buffers = buffers;
-            return result;
-        }
-
+        op: impl FnOnce(&mut BufferPool, &mut gemm::GemmAnalysisCache) -> R,
+    ) -> R {
         let mut buffers = std::mem::take(&mut self.buffers);
-        let (result, buffers) = self.ctx.install(|| {
-            let result = op(&mut buffers, gemm_analysis_cache);
-            (result, buffers)
-        });
+        let result = op(&mut buffers, gemm_analysis_cache);
         self.buffers = buffers;
         result
     }
@@ -1341,15 +1302,12 @@ impl TensorBackend for CpuBackend {
         if !cpu_session_profile_enabled() {
             let mut buffers = std::mem::take(&mut self.buffers);
             let ctx = Arc::clone(&self.ctx);
-            let (result, buffers) = ctx.install(|| {
-                let mut session = CpuExecSession {
-                    ctx: ctx.as_ref(),
-                    buffers: &mut buffers,
-                    gemm_analysis_cache: cache,
-                };
-                let result = f(&mut session);
-                (result, buffers)
-            });
+            let mut session = CpuExecSession {
+                ctx: ctx.as_ref(),
+                buffers: &mut buffers,
+                gemm_analysis_cache: cache,
+            };
+            let result = f(&mut session);
             self.buffers = buffers;
             return result;
         }
@@ -1360,29 +1318,26 @@ impl TensorBackend for CpuBackend {
                 std::mem::take(&mut self.buffers)
             });
         let ctx = Arc::clone(&self.ctx);
-        let (result, buffers) =
-            profile_cpu_session_section("with_exec_session_cached.ctx_install", || {
-                ctx.install(|| {
-                    let session_started = Instant::now();
-                    let mut session = CpuExecSession {
-                        ctx: ctx.as_ref(),
-                        buffers: &mut buffers,
-                        gemm_analysis_cache: cache,
-                    };
-                    record_cpu_session_profile(
-                        "with_exec_session_cached.session_construct",
-                        session_started.elapsed(),
-                    );
+        let result = profile_cpu_session_section("with_exec_session_cached.exec_session", || {
+            let session_started = Instant::now();
+            let mut session = CpuExecSession {
+                ctx: ctx.as_ref(),
+                buffers: &mut buffers,
+                gemm_analysis_cache: cache,
+            };
+            record_cpu_session_profile(
+                "with_exec_session_cached.session_construct",
+                session_started.elapsed(),
+            );
 
-                    let exec_started = Instant::now();
-                    let result = f(&mut session);
-                    record_cpu_session_profile(
-                        "with_exec_session_cached.exec_body",
-                        exec_started.elapsed(),
-                    );
-                    (result, buffers)
-                })
-            });
+            let exec_started = Instant::now();
+            let result = f(&mut session);
+            record_cpu_session_profile(
+                "with_exec_session_cached.exec_body",
+                exec_started.elapsed(),
+            );
+            result
+        });
         profile_cpu_session_section("with_exec_session_cached.restore_buffers", || {
             self.buffers = buffers;
         });

--- a/tenferro-tensor/src/cpu/context.rs
+++ b/tenferro-tensor/src/cpu/context.rs
@@ -1,16 +1,12 @@
 use std::env;
-use std::mem::size_of;
-use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex, OnceLock};
 
-use lru::LruCache;
+use crate::{Error, Result};
 
-use crate::{CacheStats, Error, Result};
-
-/// Default number of distinct CPU thread-pool sizes retained process-wide.
-pub const DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY: usize = 16;
-
-/// Reusable CPU execution context backed by an owned rayon thread pool.
+/// Reusable CPU execution context carrying CPU parallelism policy.
+///
+/// `CpuContext` stores the requested thread count as a kernel-level
+/// parallelism hint. It does not own a Rayon thread pool; faer-backed kernels
+/// use Rayon through faer's global/current-pool integration.
 ///
 /// # Examples
 ///
@@ -18,89 +14,13 @@ pub const DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY: usize = 16;
 /// use tenferro_tensor::cpu::CpuContext;
 ///
 /// let ctx = CpuContext::with_threads(1);
-/// let seen = ctx.install(|| rayon::current_num_threads());
-/// assert_eq!(seen, 1);
+/// let value = ctx.install(|| 1 + 1);
+/// assert_eq!(value, 2);
+/// assert_eq!(ctx.num_threads(), 1);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CpuContext {
-    pool: Arc<rayon::ThreadPool>,
-}
-
-struct SharedThreadPoolCache {
-    pools: LruCache<usize, Arc<rayon::ThreadPool>>,
-}
-
-impl SharedThreadPoolCache {
-    fn new(capacity: NonZeroUsize) -> Self {
-        Self {
-            pools: LruCache::new(capacity),
-        }
-    }
-
-    fn clear(&mut self) {
-        self.pools.clear();
-    }
-
-    fn set_capacity(&mut self, capacity: NonZeroUsize) {
-        self.pools.resize(capacity);
-    }
-
-    fn stats(&self) -> CacheStats {
-        CacheStats {
-            entries: self.pools.len(),
-            retained_bytes: self.pools.len()
-                * (size_of::<usize>() + size_of::<Arc<rayon::ThreadPool>>()),
-        }
-    }
-}
-
-fn default_thread_pool_cache_capacity() -> NonZeroUsize {
-    NonZeroUsize::new(DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN)
-}
-
-fn shared_pools() -> &'static Mutex<SharedThreadPoolCache> {
-    static POOLS: OnceLock<Mutex<SharedThreadPoolCache>> = OnceLock::new();
-    POOLS.get_or_init(|| {
-        Mutex::new(SharedThreadPoolCache::new(
-            default_thread_pool_cache_capacity(),
-        ))
-    })
-}
-
-fn lock_shared_pools() -> std::sync::MutexGuard<'static, SharedThreadPoolCache> {
-    match shared_pools().lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => {
-            eprintln!("tenferro-tensor: CPU thread-pool cache mutex was poisoned; recovering");
-            poisoned.into_inner()
-        }
-    }
-}
-
-pub(crate) fn try_get_or_create_pool(num_threads: usize) -> Result<Arc<rayon::ThreadPool>> {
-    if num_threads == 0 {
-        return Err(Error::InvalidConfig {
-            op: "CpuContext::try_with_threads",
-            message: "thread count must be at least 1".into(),
-        });
-    }
-
-    let mut pools = lock_shared_pools();
-    if let Some(pool) = pools.pools.get(&num_threads) {
-        return Ok(Arc::clone(pool));
-    }
-
-    let pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_threads)
-            .build()
-            .map_err(|err| Error::BackendFailure {
-                op: "CpuContext::try_with_threads",
-                message: format!("failed to create rayon thread pool: {err}"),
-            })?,
-    );
-    pools.pools.put(num_threads, Arc::clone(&pool));
-    Ok(pool)
+    num_threads: usize,
 }
 
 impl CpuContext {
@@ -113,7 +33,7 @@ impl CpuContext {
     /// use tenferro_tensor::cpu::CpuContext;
     ///
     /// let ctx = CpuContext::from_env();
-    /// let _ = ctx.num_threads();
+    /// assert!(ctx.num_threads() >= 1);
     /// ```
     pub fn from_env() -> Self {
         Self::try_from_env()
@@ -129,7 +49,7 @@ impl CpuContext {
     ///
     /// let ctx = CpuContext::try_from_env()
     ///     .unwrap_or_else(|_| CpuContext::with_threads(1));
-    /// let _ = ctx.num_threads();
+    /// assert!(ctx.num_threads() >= 1);
     /// ```
     pub fn try_from_env() -> Result<Self> {
         match env::var("RAYON_NUM_THREADS") {
@@ -142,10 +62,6 @@ impl CpuContext {
                     Error::InvalidConfig { message, .. } => Error::InvalidConfig {
                         op: "CpuContext::try_from_env",
                         message: format!("invalid RAYON_NUM_THREADS value {value:?}: {message}"),
-                    },
-                    Error::BackendFailure { message, .. } => Error::BackendFailure {
-                        op: "CpuContext::try_from_env",
-                        message,
                     },
                     err => err,
                 })
@@ -160,7 +76,7 @@ impl CpuContext {
         }
     }
 
-    /// Create a CPU context with a fixed rayon thread-pool size.
+    /// Create a CPU context with a fixed parallelism hint.
     ///
     /// # Examples
     ///
@@ -177,7 +93,7 @@ impl CpuContext {
         }
     }
 
-    /// Try to create a CPU context with a fixed rayon thread-pool size.
+    /// Try to create a CPU context with a fixed parallelism hint.
     ///
     /// # Examples
     ///
@@ -188,82 +104,16 @@ impl CpuContext {
     /// assert_eq!(ctx.num_threads(), 1);
     /// ```
     pub fn try_with_threads(num_threads: usize) -> Result<Self> {
-        Ok(Self {
-            pool: try_get_or_create_pool(num_threads)?,
-        })
+        if num_threads == 0 {
+            return Err(Error::InvalidConfig {
+                op: "CpuContext::try_with_threads",
+                message: "thread count must be at least 1".into(),
+            });
+        }
+        Ok(Self { num_threads })
     }
 
-    /// Current process-wide CPU thread-pool cache capacity.
-    ///
-    /// The cache is keyed by requested thread count. Retained-byte stats only
-    /// count tenferro's cache handles, not OS thread stacks owned by live pools.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::cpu::CpuContext;
-    ///
-    /// assert!(CpuContext::shared_pool_cache_capacity().get() > 0);
-    /// ```
-    pub fn shared_pool_cache_capacity() -> NonZeroUsize {
-        lock_shared_pools().pools.cap()
-    }
-
-    /// Resize the process-wide CPU thread-pool cache.
-    ///
-    /// Shrinking evicts least-recently-used cached handles. Existing
-    /// [`CpuContext`] values keep their own `Arc` handles alive.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::num::NonZeroUsize;
-    /// use tenferro_tensor::cpu::CpuContext;
-    ///
-    /// CpuContext::set_shared_pool_cache_capacity(NonZeroUsize::new(1).unwrap());
-    /// assert_eq!(CpuContext::shared_pool_cache_capacity().get(), 1);
-    /// ```
-    pub fn set_shared_pool_cache_capacity(capacity: NonZeroUsize) {
-        lock_shared_pools().set_capacity(capacity);
-    }
-
-    /// Clear all cached process-wide CPU thread-pool handles.
-    ///
-    /// Existing [`CpuContext`] values remain usable because they own `Arc`
-    /// handles to their pools.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::cpu::CpuContext;
-    ///
-    /// CpuContext::clear_shared_pool_cache();
-    /// assert_eq!(CpuContext::shared_pool_cache_stats().entries, 0);
-    /// ```
-    pub fn clear_shared_pool_cache() {
-        lock_shared_pools().clear();
-    }
-
-    /// Return process-wide CPU thread-pool cache stats.
-    ///
-    /// `retained_bytes` reports tenferro's retained cache handles, not OS thread
-    /// stacks or rayon's internal allocations.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::cpu::CpuContext;
-    ///
-    /// CpuContext::clear_shared_pool_cache();
-    /// let stats = CpuContext::shared_pool_cache_stats();
-    /// assert_eq!(stats.entries, 0);
-    /// assert_eq!(stats.retained_bytes, 0);
-    /// ```
-    pub fn shared_pool_cache_stats() -> CacheStats {
-        lock_shared_pools().stats()
-    }
-
-    /// Return the number of threads in this context's owned rayon pool.
+    /// Return this context's CPU parallelism hint.
     ///
     /// # Examples
     ///
@@ -274,10 +124,13 @@ impl CpuContext {
     /// assert_eq!(ctx.num_threads(), 2);
     /// ```
     pub fn num_threads(&self) -> usize {
-        self.pool.current_num_threads()
+        self.num_threads
     }
 
-    /// Run a closure inside this context's owned rayon thread pool.
+    /// Run a closure on the caller thread.
+    ///
+    /// This method preserves the public execution-scope API without creating or
+    /// entering a tenferro-owned Rayon pool.
     ///
     /// # Examples
     ///
@@ -288,46 +141,27 @@ impl CpuContext {
     /// let value = ctx.install(|| 1 + 1);
     /// assert_eq!(value, 2);
     /// ```
-    pub fn install<R>(&self, op: impl FnOnce() -> R + Send) -> R
-    where
-        R: Send,
-    {
-        self.pool.install(op)
+    pub fn install<R>(&self, op: impl FnOnce() -> R) -> R {
+        op()
     }
 
     /// Return the faer parallelism policy for this context.
     #[cfg(feature = "cpu-faer")]
     pub(crate) fn faer_par(&self) -> faer::Par {
-        if self.num_threads() == 1 {
+        if self.num_threads == 1 {
             faer::Par::Seq
         } else {
-            faer::Par::rayon(0)
+            faer::Par::rayon(self.num_threads)
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroUsize;
-
-    use super::{CpuContext, DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY};
+    use super::CpuContext;
 
     #[test]
-    fn shared_pool_cache_is_bounded_and_clearable() {
-        CpuContext::clear_shared_pool_cache();
-        CpuContext::set_shared_pool_cache_capacity(NonZeroUsize::new(1).unwrap());
-
-        let _one = CpuContext::with_threads(1);
-        let _two = CpuContext::with_threads(2);
-
-        let stats = CpuContext::shared_pool_cache_stats();
-        assert_eq!(stats.entries, 1);
-        assert!(stats.retained_bytes > 0);
-
-        CpuContext::clear_shared_pool_cache();
-        assert_eq!(CpuContext::shared_pool_cache_stats().entries, 0);
-        CpuContext::set_shared_pool_cache_capacity(
-            NonZeroUsize::new(DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY).unwrap(),
-        );
+    fn try_with_threads_rejects_zero() {
+        assert!(CpuContext::try_with_threads(0).is_err());
     }
 }

--- a/tenferro-tensor/src/cpu/mod.rs
+++ b/tenferro-tensor/src/cpu/mod.rs
@@ -18,7 +18,7 @@ use crate::{Buffer, TypedTensor};
 
 pub use affinity::{available_parallelism, process_cpu_affinity_count};
 pub use backend::CpuBackend;
-pub use context::{CpuContext, DEFAULT_CPU_THREAD_POOL_CACHE_CAPACITY};
+pub use context::CpuContext;
 pub use elementwise::{
     abs, add, clamp, compare, conj, div, maximum, minimum, mul, neg, select, sign,
 };

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -1,3 +1,4 @@
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::{Mutex, OnceLock};
 use std::{ffi::OsString, sync::MutexGuard};
@@ -319,7 +320,7 @@ fn cpu_backend_try_new_propagates_invalid_rayon_num_threads() {
 }
 
 #[test]
-fn test_with_exec_session_runs_in_thread_pool() {
+fn test_with_exec_session_runs_compiled_ops() {
     let mut backend = CpuBackend::with_threads(2);
     let result = backend.with_exec_session(|session| {
         session
@@ -331,6 +332,35 @@ fn test_with_exec_session_runs_in_thread_pool() {
     });
     assert_eq!(get_f64(&result, &[0]), 4.0);
     assert_eq!(get_f64(&result, &[1]), 6.0);
+}
+
+#[test]
+fn cpu_context_install_runs_on_caller_thread() {
+    let ctx = CpuContext::with_threads(2);
+    let caller_thread = std::thread::current().id();
+    let seen_thread = ctx.install(|| std::thread::current().id());
+    assert_eq!(seen_thread, caller_thread);
+}
+
+#[test]
+fn cpu_install_accepts_non_send_state() {
+    let ctx = CpuContext::with_threads(2);
+    let state = Rc::new(41usize);
+    let seen = ctx.install(|| *state + 1);
+    assert_eq!(seen, 42);
+
+    let backend = CpuBackend::with_threads(2);
+    let state = Rc::new(20usize);
+    let seen = backend.install(|| *state + 2);
+    assert_eq!(seen, 22);
+}
+
+#[test]
+fn cpu_backend_exec_session_runs_on_caller_thread() {
+    let mut backend = CpuBackend::with_threads(2);
+    let caller_thread = std::thread::current().id();
+    let seen_thread = backend.with_exec_session(|_| std::thread::current().id());
+    assert_eq!(seen_thread, caller_thread);
 }
 
 #[test]
@@ -369,10 +399,10 @@ fn cpu_context_with_threads_reports_requested_size() {
 }
 
 #[test]
-fn cpu_context_install_uses_owned_pool() {
+fn cpu_context_install_executes_closure() {
     let ctx = CpuContext::with_threads(1);
-    let seen = ctx.install(|| rayon::current_num_threads());
-    assert_eq!(seen, 1);
+    let seen = ctx.install(|| 1 + 1);
+    assert_eq!(seen, 2);
 }
 
 fn env_lock() -> MutexGuard<'static, ()> {

--- a/tenferro/src/engine.rs
+++ b/tenferro/src/engine.rs
@@ -8,9 +8,8 @@ use super::exec::{ExecInstruction, ExecOp, ExecProgram};
 use tenferro_einsum::{ContractionTree, Subscripts};
 use tenferro_ops::std_tensor_op::EinsumSubscripts;
 use tenferro_tensor::{
-    buffer_pool::BufferPoolStats,
-    cpu::{CpuBackend, CpuContext},
-    CacheStats, RuntimeCacheControl, Tensor, TensorBackend,
+    buffer_pool::BufferPoolStats, cpu::CpuBackend, CacheStats, RuntimeCacheControl, Tensor,
+    TensorBackend,
 };
 
 /// Parsed einsum notation retained separately from shape-specific plans.
@@ -71,7 +70,6 @@ pub struct EngineCacheStats {
 ///
 /// The CPU buffer pool is reported with cache-style accounting: entries are
 /// retained buffers, and retained bytes are retained vector capacity.
-/// `thread_pools` reports the process-wide CPU thread-pool handle cache.
 ///
 /// # Examples
 ///
@@ -81,7 +79,6 @@ pub struct EngineCacheStats {
 /// let stats = CpuEngineCacheStats {
 ///     engine: EngineCacheStats::default(),
 ///     buffer_pool: CacheStats::empty(),
-///     thread_pools: CacheStats::empty(),
 /// };
 /// assert_eq!(stats.buffer_pool.retained_bytes, 0);
 /// ```
@@ -91,8 +88,6 @@ pub struct CpuEngineCacheStats {
     pub engine: EngineCacheStats,
     /// CPU backend buffer pool.
     pub buffer_pool: CacheStats,
-    /// Process-wide CPU thread-pool handle cache.
-    pub thread_pools: CacheStats,
 }
 
 /// Cache key derived from the compiled graph topology.
@@ -638,7 +633,6 @@ impl Engine<CpuBackend> {
         CpuEngineCacheStats {
             engine: self.cache_stats(),
             buffer_pool: self.backend.buffer_pool_cache_stats(),
-            thread_pools: CpuContext::shared_pool_cache_stats(),
         }
     }
 
@@ -656,7 +650,6 @@ impl Engine<CpuBackend> {
     pub fn clear_all_caches(&mut self) {
         self.clear_caches();
         self.reset_buffer_pool();
-        CpuContext::clear_shared_pool_cache();
     }
 
     /// Return the CPU GEMM analysis-cache slot capacity.

--- a/tenferro/tests/cache_management.rs
+++ b/tenferro/tests/cache_management.rs
@@ -78,6 +78,5 @@ fn cpu_cache_stats_include_buffer_pool_and_clear_all_caches() {
     assert_eq!(after.engine.einsum_parse.entries, 0);
     assert_eq!(after.engine.backend.entries, 0);
     assert_eq!(after.buffer_pool.entries, 0);
-    assert_eq!(after.thread_pools.entries, 0);
     assert_eq!(engine.buffer_pool_len(), 0);
 }


### PR DESCRIPTION
## Summary

- remove tenferro-owned Rayon thread-pool ownership and process-wide CPU thread-pool cache from `CpuContext`
- run CPU execution scopes on the caller thread while keeping `CpuContext` as the faer thread-count policy source
- update cache stats, tests, benchmarks, and performance/design docs to describe the new CPU threading model and configuration

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tenferro-tensor --release`
- `cargo test -p tenferro --test cache_management --release`
- `cargo test -p tenferro --doc --release`

## Notes

`cargo clippy -p tenferro-tensor -p tenferro --all-targets -- -D warnings` was attempted locally before publishing and fails on existing lint warnings such as `too_many_arguments` and `needless_range_loop` outside this change.