### PR TITLE
[codex] Overhaul user docs and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report incorrect behavior, a panic, or a supported path that does not work.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Precise, reproducible reports are easiest for maintainers and AI agents to verify.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the incorrect behavior, panic, error, or surprising result.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: Describe the behavior you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: Prefer a small Rust snippet, test case, command, or repository link.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area
+      description: Select every area that seems relevant.
+      multiple: true
+      options:
+        - TypedTensor
+        - Tensor
+        - EagerTensor
+        - TracedTensor
+        - CUDA/backend
+        - Automatic differentiation
+        - Documentation
+        - Performance
+        - Unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend-device
+    attributes:
+      label: Backend/device
+      options:
+        - CPU default backend
+        - CPU BLAS/LAPACK backend
+        - CUDA
+        - Not applicable
+        - Unsure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: tenferro-rs version or commit
+      placeholder: "crates.io version, git commit, or branch"
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Rust version, CUDA version, BLAS/LAPACK provider, and relevant feature flags if known.
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification hint
+      description: Optional. How should we know this is fixed?
+
+  - type: textarea
+    id: extra-context
+    attributes:
+      label: Additional context
+      description: Optional links, logs, screenshots, or related issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest a capability, documentation improvement, or workflow problem.
+title: "[Feature]: "
+labels: ["enhancement"]
+---
+
+## What are you trying to do?
+
+<!-- Describe the user goal or workflow. -->
+
+## What makes it hard today?
+
+<!-- Explain the current limitation, friction, or missing documentation. -->
+
+## Relevant area
+
+<!-- TypedTensor / Tensor / EagerTensor / TracedTensor / CUDA / AD / Docs / Performance / Unsure -->
+
+## Notes, examples, or related APIs
+
+<!-- Optional: code sketch, math notation, links, or similar APIs from PyTorch/JAX/Julia/etc. -->

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ General-purpose dense tensor computation in Rust, inspired by PyTorch and JAX.
 tenferro's complete default path is CPU: eager tensor operations with
 scalar-loss reverse-mode autodiff, lazy traced execution, einsum, linear
 algebra, and transform AD (VJP/JVP/HVP). CUDA execution is available through
-the feature-gated CubeCL backend with explicit CPU/GPU transfers.
+the feature-gated CUDA backend with explicit CPU/GPU transfers.
 
 AD shape and dtype metadata is owned by the live eager/traced tensor handles
 that need it. The backing lookup table is process-global, but entries are
@@ -20,12 +20,25 @@ eager execution, traced execution, einsum, linear algebra, autodiff, and backend
 selection. Internal workspace crates are documented through the API reference
 for contributors who need implementation details.
 
+## Development Model
+
+tenferro-rs uses agentic AI development: a small human-maintainer team develops
+the project with AI agents for implementation, documentation, review, issue
+triage, and verification. Human maintainers own design decisions, review
+outcomes, and merge decisions.
+
+Issues are easiest to handle when they describe the user problem clearly. Bug
+reports should include a minimal reproducer, expected behavior, actual
+behavior, and the backend/device involved. Feature requests can stay informal:
+describe what you are trying to do, what is hard today, and any examples or
+related APIs that help explain the desired workflow.
+
 ## Documentation
 
 **<https://tensor4all.org/tenferro-rs/>**
 
 - [Getting Started](https://tensor4all.org/tenferro-rs/getting-started/) — install and run the first checked CPU example
-- [Guides](https://tensor4all.org/tenferro-rs/guides/choosing-an-api.html) — API selection, tensor ops, einsum, linalg, autodiff, memory order, and CUDA
+- [Guides](https://tensor4all.org/tenferro-rs/guides/choosing-an-api.html) — tensor layers, execution models, tensor ops, einsum, linalg, autodiff, memory order, and CUDA
 - [API Reference](https://tensor4all.org/tenferro-rs/api/) — rustdoc links for every crate
 - [Internals](https://tensor4all.org/tenferro-rs/internals/) — architecture, specification, contributor pointers
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -31,7 +31,7 @@ website:
       - section: "Guides"
         contents:
           - guides/choosing-an-api.md
-          - guides/installation.md
+          - guides/execution-models.md
           - guides/eager-operations.md
           - guides/tensor-operations.md
           - guides/einsum.md
@@ -41,6 +41,7 @@ website:
           - guides/autodiff.md
           - guides/devices-and-gpu.md
           - guides/memory-order.md
+          - guides/installation.md
           - guides/performance.md
           - guides/troubleshooting.md
       - section: "API"

--- a/docs/assets/execution-models.svg
+++ b/docs/assets/execution-models.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 560" role="img" aria-labelledby="exec-models-title exec-models-desc">
+  <title id="exec-models-title">Eager CPU, Eager GPU, and Traced execution timelines</title>
+  <desc id="exec-models-desc">Three horizontal timelines compare CPU eager execution, GPU eager execution, and traced graph execution from left to right.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0 0 L 10 4 L 0 8 z" fill="#334155"/>
+    </marker>
+    <style>
+      .axis { stroke: #334155; stroke-width: 2; marker-end: url(#arrow); }
+      .lane { stroke: #94a3b8; stroke-width: 1.5; stroke-dasharray: 5 6; }
+      .label { font: 700 18px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+      .small { font: 14px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #334155; }
+      .tiny { font: 12px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+      .cpu { fill: #dbeafe; stroke: #2563eb; stroke-width: 1.5; }
+      .gpu { fill: #dcfce7; stroke: #16a34a; stroke-width: 1.5; }
+      .host { fill: #f8fafc; stroke: #64748b; stroke-width: 1.5; }
+      .trace { fill: #fae8ff; stroke: #a21caf; stroke-width: 1.5; }
+      .sync { stroke: #dc2626; stroke-width: 2; stroke-dasharray: 7 5; }
+      .syncText { font: 700 13px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #b91c1c; }
+    </style>
+  </defs>
+
+  <text x="120" y="42" class="small">time</text>
+  <line x1="165" y1="36" x2="1005" y2="36" class="axis"/>
+
+  <text x="36" y="108" class="label">Eager CPU</text>
+  <line x1="165" y1="104" x2="1005" y2="104" class="lane"/>
+  <rect x="190" y="72" width="105" height="54" rx="4" class="host"/>
+  <text x="212" y="102" class="small">call op</text>
+  <rect x="325" y="72" width="190" height="54" rx="4" class="cpu"/>
+  <text x="357" y="94" class="small">CPU compute</text>
+  <text x="354" y="114" class="tiny">host waits here</text>
+  <rect x="545" y="72" width="185" height="54" rx="4" class="host"/>
+  <text x="577" y="94" class="small">return Tensor</text>
+  <text x="580" y="114" class="tiny">host-readable</text>
+  <rect x="760" y="72" width="120" height="54" rx="4" class="host"/>
+  <text x="786" y="102" class="small">next op</text>
+
+  <text x="36" y="246" class="label">Eager GPU</text>
+  <line x1="165" y1="242" x2="1005" y2="242" class="lane"/>
+  <rect x="190" y="210" width="105" height="54" rx="4" class="host"/>
+  <text x="212" y="240" class="small">call op</text>
+  <rect x="325" y="210" width="150" height="54" rx="4" class="host"/>
+  <text x="356" y="232" class="small">enqueue</text>
+  <text x="344" y="252" class="tiny">host submits</text>
+  <rect x="505" y="210" width="205" height="54" rx="4" class="host"/>
+  <text x="532" y="232" class="small">return GPU Tensor</text>
+  <text x="552" y="252" class="tiny">handle, no ready flag</text>
+  <rect x="740" y="210" width="150" height="54" rx="4" class="host"/>
+  <text x="771" y="232" class="small">enqueue</text>
+  <text x="764" y="252" class="tiny">next GPU op</text>
+  <rect x="360" y="300" width="330" height="54" rx="4" class="gpu"/>
+  <text x="451" y="322" class="small">GPU compute</text>
+  <text x="421" y="342" class="tiny">ordered on backend stream</text>
+  <rect x="730" y="300" width="155" height="54" rx="4" class="gpu"/>
+  <text x="765" y="322" class="small">GPU op 2</text>
+  <text x="762" y="342" class="tiny">same stream</text>
+  <line x1="930" y1="190" x2="930" y2="375" class="sync"/>
+  <rect x="910" y="210" width="95" height="54" rx="4" class="host"/>
+  <text x="931" y="232" class="small">read</text>
+  <text x="920" y="252" class="tiny">download</text>
+  <text x="900" y="398" class="syncText">sync point</text>
+
+  <text x="36" y="450" class="label">Traced</text>
+  <line x1="165" y1="446" x2="1005" y2="446" class="lane"/>
+  <rect x="190" y="414" width="185" height="54" rx="4" class="trace"/>
+  <text x="220" y="436" class="small">build graph</text>
+  <text x="212" y="456" class="tiny">no kernels yet</text>
+  <rect x="405" y="414" width="185" height="54" rx="4" class="trace"/>
+  <text x="436" y="436" class="small">compile</text>
+  <text x="432" y="456" class="tiny">plan/optimize</text>
+  <rect x="620" y="414" width="185" height="54" rx="4" class="cpu"/>
+  <text x="650" y="436" class="small">execute graph</text>
+  <text x="640" y="456" class="tiny">CPU or CUDA backend</text>
+  <rect x="835" y="414" width="145" height="54" rx="4" class="host"/>
+  <text x="863" y="436" class="small">return</text>
+  <text x="853" y="456" class="tiny">or download</text>
+</svg>

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -1,31 +1,41 @@
 # Core Concepts
 
-## Data And Execution
+tenferro separates tensor data, execution timing, automatic differentiation,
+and device placement. That separation is the main design point: users can stay
+in no-AD typed tensor code for ordinary numeric work, move to eager AD for
+PyTorch-like training loops, or move to traced graphs for JAX-like transforms
+and compile/run reuse.
 
-tenferro keeps tensor values, eager AD state, graph compilation, and backend
-execution as separate pieces. That separation is intentional: it makes memory
-order, compilation reuse, and backend placement explicit.
+## The Three Axes
 
-| Piece | Use |
-| --- | --- |
-| `TypedTensor<T>` | Concrete tensor storage with a compile-time scalar type |
-| `Tensor` | Concrete tensor storage with a runtime dtype enum |
-| `EagerTensor` + `EagerRuntime` | PyTorch-style scalar-loss `backward()` |
-| `TracedTensor` | Lazy graph-building handle for transform AD and reuse |
-| `GraphCompiler` | Lowers traced outputs into reusable `GraphProgram`s |
-| `GraphExecutor<B>` | Runs compiled programs on a backend such as `CpuBackend` |
+| Axis | What it controls | User-facing choices |
+| --- | --- | --- |
+| Data layer | The value you pass around | `TypedTensor<T>`, `Tensor`, `EagerTensor`, `TracedTensor` |
+| Execution model | When operations run | Direct, eager AD, traced compile/run |
+| Backend/device | Where operations run | `CpuBackend` or `tenferro::cuda::CudaBackend` |
 
-Choose the smallest surface that matches the workflow:
+CUDA is not a separate tensor layer. The same concrete, eager, and traced
+surfaces can run supported operations on CUDA tensors when data is explicitly
+uploaded to a CUDA backend.
 
-- Direct numeric work -> `Tensor` or `TypedTensor<T>` with a backend.
-- Scalar-loss eager AD -> `EagerTensor` inside an `EagerRuntime`.
-- Transform AD, graph reuse, or symbolic inputs -> `TracedTensor` compiled by
-  `GraphCompiler` and run by `GraphExecutor`.
+## Tensor Layers
 
-## Memory Order
+| Layer | Role | Good fit |
+| --- | --- | --- |
+| `TypedTensor<T>` | Concrete no-AD tensor with compile-time scalar type | Most typed numeric code, typed host data, typed linalg/einsum |
+| `Tensor` | Concrete no-AD tensor with runtime dtype | Dynamic dtype workflows, backend dispatch, CPU/CUDA values |
+| `EagerTensor` | Concrete tensor plus eager gradient state | Scalar-loss reverse-mode AD with `backward()` |
+| `TracedTensor` | Symbolic graph-building tensor | Transform AD, graph optimization, repeated execution |
 
-tenferro stores dense tensors in column-major order. Constructors name the input
-order explicitly:
+Use the smallest layer that matches the job. AD is optional, and many projects
+should never leave the concrete tensor layers.
+
+## Memory Model
+
+tenferro stores dense tensors as contiguous column-major buffers. The leftmost
+dimension varies fastest in memory. This matches Fortran, Julia, MATLAB, and
+LAPACK-oriented workflows, and makes trailing batch axes natural for batched
+linear algebra and contractions.
 
 ```rust
 use tenferro::{Tensor, TypedTensor};
@@ -43,16 +53,17 @@ let dynamic = Tensor::from_vec_row_major(
 assert_eq!(dynamic.as_slice::<f64>().unwrap(), typed.as_slice());
 ```
 
-Use `from_vec_row_major` for data written in the conventional row-by-row style.
-Use `from_vec_col_major` when the buffer is already in tenferro's physical
-order.
+Use `from_vec_row_major` for data copied from PyTorch, NumPy, JAX, or C-style
+examples. Use `from_vec_col_major` when the flat buffer is already in tenferro's
+physical order.
 
 ## Direct Tensor Execution
 
-`Tensor` and `TypedTensor<T>` operations run immediately through a backend.
+`Tensor` operations run immediately through an explicit backend. Use this for
+ordinary no-AD computation when runtime dtype is useful.
 
 ```rust
-use tenferro::{CpuBackend, Tensor, TensorBackend};
+use tenferro::{CpuBackend, Tensor};
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
@@ -62,10 +73,27 @@ let c = a.matmul(&b, &mut backend).unwrap();
 assert_eq!(c.shape(), &[2, 2]);
 ```
 
+`TypedTensor<T>` is the compile-time scalar type layer. It is useful when the
+project already knows it is working with `f64`, `f32`, complex values, or
+another supported scalar type.
+
+```rust
+use tenferro::typed_tensor::einsum;
+use tenferro::{CpuBackend, TypedTensor};
+
+let mut backend = CpuBackend::new();
+let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+
+let c = einsum(&mut backend, &[&a, &b], "ij,jk->ik").unwrap();
+assert_eq!(c.shape.as_slice(), &[2, 2]);
+```
+
 ## Eager AD
 
 `EagerTensor` wraps concrete values in an `EagerRuntime` that owns gradient
-state. It is the right fit for scalar-loss reverse-mode workflows.
+state. It matches the PyTorch scalar-loss pattern: compute now, inspect now,
+call `backward()`, and clear gradients when you want a fresh accumulation.
 
 ```rust
 use tenferro::{EagerRuntime, Tensor};
@@ -80,8 +108,9 @@ assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
 
 ## Traced Graph Execution
 
-`TracedTensor` operations are lazy. Build a graph, compile it once, then run the
-compiled program through a backend executor.
+`TracedTensor` operations are lazy. They build a graph. A `GraphCompiler`
+lowers that graph into a reusable program, and a `GraphExecutor<B>` runs the
+program on a backend.
 
 ```rust
 use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
@@ -98,22 +127,5 @@ let result = executor.run(&program).unwrap();
 assert_eq!(result.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
 ```
 
-For symbolic placeholders, provide input specs at compile time and concrete
-bindings at run time:
-
-```rust
-use tenferro::{CpuBackend, DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
-
-let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-let y = &x + &x;
-
-let mut compiler = GraphCompiler::new();
-let program = compiler
-    .compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])
-    .unwrap();
-let bound = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let result = executor.run_with_inputs(&program, &[(&x, &bound)]).unwrap();
-
-assert_eq!(result.as_slice::<f64>().unwrap(), &[2.0, 4.0]);
-```
+Traced mode is the right layer for transform AD (`grad`, `vjp`, `jvp`, HVP),
+symbolic inputs, graph optimization, and repeated execution.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,8 +1,8 @@
 # Getting Started
 
-tenferro supports direct CPU tensor computation, eager scalar-loss AD, traced
+tenferro supports no-AD tensor computation, eager scalar-loss AD, traced
 execution, transform AD, einsum, linear algebra, and CUDA execution through the
-feature-gated CubeCL backend.
+feature-gated CUDA backend.
 
 ## Installation
 
@@ -62,9 +62,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Next Steps
 
-- [Choosing an API](../guides/choosing-an-api.md)
-- [Devices and GPU](../guides/devices-and-gpu.md)
 - [Core concepts](./core-concepts.md)
+- [Choosing a tensor layer](../guides/choosing-an-api.md)
+- [Execution models](../guides/execution-models.md)
+- [Memory order](../guides/memory-order.md)
+- [Devices and GPU](../guides/devices-and-gpu.md)
 - [PyTorch and JAX mapping](./pytorch-jax-mapping.md)
 - [Eager operations guide](../guides/eager-operations.md)
 - [Tensor operations guide](../guides/tensor-operations.md)

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -6,21 +6,23 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 
 | Concept | PyTorch | JAX | tenferro |
 |---|---|---|---|
-| Eager tensor | `numpy.ndarray` | — | `Tensor` + a backend |
-| Tensor handle | `torch.Tensor` | `jax.Array` / `jnp.ndarray` | `TracedTensor` |
+| Typed concrete tensor | `torch.Tensor` with fixed dtype | `jax.Array` with fixed dtype | `TypedTensor<T>` |
+| Dynamic concrete tensor | `torch.Tensor` | `jax.Array` / `jnp.ndarray` | `Tensor` + a backend |
+| Graph-building tensor handle | `torch.Tensor` under compiled/tracing tools | traced `jax.Array` values | `TracedTensor` |
 | Concrete result | `torch.Tensor` | `jax.Array` | `Tensor` returned by `GraphExecutor::run` |
 | Execution | Eager by default | Eager arrays, often staged with `jit` | Eager (`Tensor` / `EagerTensor`) or lazy traced (`TracedTensor` + `GraphCompiler` + `GraphExecutor`) |
 | Eager gradients | `loss.backward()` | — | `EagerTensor::backward()` with accumulation |
 | Transform AD | `torch.autograd.grad(...)` | `jax.grad`, `jax.vjp`, `jax.jvp`, `hvp` via composition | `loss.grad(&x)`, `.vjp()`, `.jvp()` |
 | Device/runtime | Device is attached to tensors | Device is attached to arrays | Backend lives in direct tensor calls, `EagerRuntime`, or `GraphExecutor` |
 | CUDA execution | `x.to("cuda")` | `jax.device_put(x)` | `tenferro::cuda::upload_tensor(...)` and `download_tensor(...)` |
-| Matrix contraction | `torch.einsum` | `jnp.einsum` | `tenferro::traced_tensor::einsum` |
+| Matrix contraction | `torch.einsum` | `jnp.einsum` | `typed_tensor::einsum`, `tensor::einsum`, `eager_tensor::einsum`, or `traced_tensor::einsum` |
 
 ## Function mapping
 
 | Task | PyTorch | JAX | tenferro (eager) | tenferro (lazy/AD) |
 |---|---|---|---|---|
-| Create tensor | `torch.tensor(data)` | `jnp.array(data)` | `Tensor::from_vec_col_major(shape, data)` | `TracedTensor::from_vec_col_major(shape, data)` |
+| Create typed tensor | `torch.tensor(data, dtype=...)` | `jnp.array(data, dtype=...)` | `TypedTensor::<T>::from_vec_col_major(shape, data)` | — |
+| Create dynamic tensor | `torch.tensor(data)` | `jnp.array(data)` | `Tensor::from_vec_col_major(shape, data)` | `TracedTensor::from_vec_col_major(shape, data)` |
 | Matrix multiply | `torch.matmul(a, b)` | `jnp.matmul(a, b)` | `a.matmul(&b, &mut ctx)` | `tenferro::traced_tensor::matmul(&a, &b)` |
 | Reshape | `x.reshape(shape)` | `jnp.reshape(x, shape)` | `x.reshape(&shape, &mut ctx)` | `x.reshape(&shape)` |
 | Transpose | `x.transpose(0, 1)` | `jnp.transpose(x, axes)` | `x.transpose(&perm, &mut ctx)` | `x.transpose(&perm)` |
@@ -61,7 +63,11 @@ between devices implicitly. Upload CPU tensors with
 `tenferro::cuda::upload_tensor` before CUDA backend operations, and download
 with `tenferro::cuda::download_tensor` before inspecting values on the host.
 
-CUDA support targets NVIDIA CUDA through the CubeCL backend. See
+For eager CUDA execution, operation calls submit work and return CUDA tensor
+handles. The host synchronizes at download/read boundaries or at operations
+that must inspect device-side status; there is no user-visible ready flag.
+
+CUDA support targets NVIDIA CUDA. See
 [Devices and GPU](../guides/devices-and-gpu.md) for the current coverage and
 setup commands.
 

--- a/docs/guides/autodiff.md
+++ b/docs/guides/autodiff.md
@@ -1,13 +1,21 @@
 # Autodiff
 
-tenferro exposes transform-oriented autodiff directly on `TracedTensor`.
-Eager tensors also support scalar-loss reverse-mode via `backward()`, but this
-page focuses on graph transforms that you compile and execute explicitly.
+tenferro supports two autodiff workflows on top of the same dense tensor stack:
+
+- PyTorch-like scalar-loss eager AD with `EagerTensor::backward()`,
+- JAX-like transform AD on `TracedTensor`.
+
+This page focuses on graph transforms that you compile and execute explicitly.
+For eager accumulation semantics, see [Eager Operations](eager-operations.md).
 
 - `grad` for scalar-loss reverse mode
 - `vjp` for vector-Jacobian products
 - `jvp` for Jacobian-vector products
 - Higher-order AD via composition, such as `jvp(grad(f))` for HVPs
+
+AD rules are extensible outside the core crate. Extension crates can register
+JVP/VJP rules for their operations; [`tenferro-fft`](tenferro-fft.md) is the
+current example.
 
 ## Reverse-mode gradient with `grad`
 
@@ -110,3 +118,14 @@ let mut executor = GraphExecutor::new(CpuBackend::new());
 let result = executor.run(&program).unwrap();
 assert_eq!(result.shape(), &[2, 2]);
 ```
+
+## Extension AD Rules
+
+External operations can participate in autodiff when the extension crate
+registers the corresponding rules. If an extension does not support a given AD
+path, tenferro reports that path as unsupported rather than silently returning
+an incorrect gradient.
+
+The `tenferro-fft` extension demonstrates this pattern for supported
+complex-to-complex FFT transforms. See [Custom Tensor Operations](custom-operations.md)
+for the extension model.

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -1,39 +1,85 @@
-# Choosing an API
+# Choosing a Tensor Layer
 
-Use the simplest tensor layer that matches the workflow.
+This page is about choosing a tensor layer, not choosing one monolithic API.
+tenferro has separate axes for data representation, execution timing, and
+backend/device placement.
 
-| Need | Use |
-| --- | --- |
-| Direct concrete computation on a selected backend | `Tensor` + a `TensorBackend` |
-| Compile-time scalar type while still owning dense data | `TypedTensor<T>` |
-| PyTorch-style scalar-loss `backward()` | `EagerTensor` + `EagerRuntime` |
-| `grad`, `vjp`, `jvp`, HVP, graph optimization | `TracedTensor` + `GraphCompiler` + `GraphExecutor<B>` |
-| Tensor operation not built into tenferro | an extension crate; see [Custom Tensor Operations](custom-operations.md) |
+## Start Here
 
-## Rule of Thumb
+| If your project needs | Start with | Why |
+| --- | --- | --- |
+| No autodiff, scalar type known at compile time | `TypedTensor<T>` | Static dtype, direct owned data, typed linalg/einsum |
+| No autodiff, dtype selected at runtime | `Tensor` | Dynamic dtype enum and broad concrete op surface |
+| PyTorch-like scalar-loss `backward()` | `EagerTensor` + `EagerRuntime` | Immediate execution with gradient accumulation |
+| JAX-like `grad`, `vjp`, `jvp`, HVP, graph reuse | `TracedTensor` + `GraphCompiler` + `GraphExecutor<B>` | Build graph, transform/compile it, run it repeatedly |
+| CPU or CUDA execution | A backend: `CpuBackend` or `tenferro::cuda::CudaBackend` | Device is orthogonal to tensor layer |
+| Operation outside the built-in surface | An extension crate | External ops can also register AD rules |
 
-Start with `Tensor` for direct concrete work. Move to `EagerTensor` when you need
-gradient accumulation, and move to `TracedTensor` when you need transform AD or
-graph reuse.
+For most non-AD projects, `TypedTensor<T>` or `Tensor` should come before any
+AD surface. Only move upward when the workflow needs gradient state or graph
+transforms.
 
-`Tensor` and `TypedTensor<T>` are concrete data containers. They represent CPU
-data by default, and under the `cuda` feature they can also represent
-explicitly uploaded CUDA-resident data. `EagerTensor` keeps PyTorch-style
-gradient state for immediate workflows inside an `EagerRuntime`. `TracedTensor`
-builds a lazy expression graph that a `GraphCompiler` lowers into a reusable
-program and a `GraphExecutor<B>` runs on a backend.
+## Data Layer
 
-Across concrete, eager, and traced workflows, use `stack(..., -1)` to create a
-trailing batch axis and `index_select(-1, positions)` to align entries along
-that axis.
+`TypedTensor<T>` owns dense tensor data with a compile-time scalar type. It is
+the simplest layer for fixed-dtype no-AD code and for applications that want
+ordinary Rust type checking around scalar values.
 
-CUDA support is provided by the feature-gated CubeCL backend for concrete,
-eager, and traced workflows. GPU tensors use explicit upload/download at
-backend boundaries; tenferro does not silently fall back to CPU when a GPU
-operation or dtype is unavailable. See [Devices and GPU](devices-and-gpu.md)
-for the current CUDA operation and dtype matrix.
+`Tensor` owns the same kind of dense data, but wraps supported scalar types in
+a runtime dtype enum. Use it when dtype must be selected dynamically, when you
+want the broad concrete tensor operation surface, or when you need to pass CPU
+or CUDA tensors through backend dispatch.
 
-When a project needs a tensor operation outside the built-in surface, prefer a
-focused extension crate over adding application-specific APIs to tenferro
-itself. The [tenferro-fft](tenferro-fft.md) package shows this pattern for
-Fourier transforms.
+`EagerTensor` is not a replacement for `Tensor`; it is `Tensor` plus eager AD
+state. Use it when the computation should run immediately and a scalar loss
+will call `backward()`.
+
+`TracedTensor` is a graph-building handle. It is the transform and compilation
+surface, not the default concrete tensor type.
+
+## Execution Model
+
+| Model | Similar to | What happens on each op |
+| --- | --- | --- |
+| Direct tensor execution | NumPy-style explicit backend calls | The backend runs the op immediately and returns a concrete `Tensor` |
+| Eager AD | PyTorch eager/autograd | The op runs immediately and records enough state for `backward()` |
+| Traced execution | JAX tracing/jit/grad | The op records graph structure; compute runs after compile/execute |
+
+See [Execution Models](execution-models.md) for the time-axis diagram,
+including the difference between Eager CPU, Eager GPU, and Traced mode.
+
+## Device And Backend
+
+CPU and CUDA are backend choices. They do not decide whether your program is
+typed, eager, or traced.
+
+CUDA support is provided by the feature-gated CUDA backend for concrete,
+eager, and traced workflows. CPU/GPU transfer is explicit:
+
+- upload CPU tensors before CUDA backend operations,
+- keep intermediate tensors on CUDA while doing CUDA work,
+- download only when the host must inspect values,
+- do not expect an unsupported CUDA operation to silently fall back to CPU.
+
+The current CUDA operation and dtype table is in
+[Devices and GPU](devices-and-gpu.md).
+
+## Operation Availability
+
+The operation guides describe each operation family across tensor layers:
+
+| Operation family | Concrete no-AD | Eager AD | Traced graph | CUDA |
+| --- | --- | --- | --- | --- |
+| Elementwise and shape ops | `Tensor` | `EagerTensor` | `TracedTensor` | Supported subset |
+| Einsum | `typed_tensor::einsum`, `tensor::einsum` | Through eager execution | `traced_tensor::einsum` | Supported through backend coverage |
+| Linear algebra | `Tensor` and selected `TypedTensor<T>` methods | Through eager execution | `traced_tensor` helpers | Supported subset |
+| Transform AD | Not applicable | Not the transform surface | `grad`, `vjp`, `jvp`, HVP | Backend-dependent execution |
+| Extension ops | Extension-provided eager hooks | If the extension provides eager hooks and AD | If the extension provides graph hooks and AD | Extension-dependent |
+
+## Extension Story
+
+Automatic differentiation is externally extensible. An extension crate can add
+operations, eager/traced execution hooks, and AD rules without forcing the core
+crate to grow application-specific APIs. [`tenferro-fft`](tenferro-fft.md) is
+the example extension package: it adds Fourier transform operations and
+registers AD rules for supported transforms.

--- a/docs/guides/custom-operations.md
+++ b/docs/guides/custom-operations.md
@@ -37,6 +37,36 @@ An extension crate is responsible for:
 - optional JVP/VJP rules for automatic differentiation,
 - clear errors when a dtype, shape, backend, or AD path is not supported.
 
+## Cache Ownership
+
+Keep semantic operation payloads and runtime caches separate.
+
+The `ExtensionOpTrait` payload is graph identity. It participates in hashing,
+equality, graph comparison, and AD rule lookup. Put parameters that change the
+meaning of the operation there: axes, normalization mode, algorithm choice, and
+similar values. Do not hide unbounded plan caches, vendor handles, or mutable
+global state inside the payload semantics.
+
+There is no monolithic core runtime owner for extension state, and the current
+`EagerRuntime`, `GraphCompiler`, and `GraphExecutor` do not provide a public
+slot where an extension can store arbitrary runtime cache entries. If an
+extension needs a cache, the extension crate should own an explicit runtime or
+cache object, for example `FftRuntime` or `FftPlanCache`, and expose
+clear/stat/capacity controls on that object. First-class extension cache slots
+are tracked in [issue #878](https://github.com/tensor4all/tenferro-rs/issues/878).
+
+An op payload may hold an `Arc` to such an extension-owned cache object only
+when the cache is a performance detail and is not part of semantic equality.
+Two extension ops that compare equal must remain interchangeable even if their
+caches are empty, warm, or independently owned.
+
+Compiled extension execution delegates to the extension's `eager_execute`, so
+eager and traced execution use the same extension-owned cache path.
+
+Avoid hidden process-global or thread-local caches in extension crates. If a
+cache lives longer than one call, make the owner explicit and bounded, and give
+users a way to clear it and inspect retained entries.
+
 ## Implementing An Extension Op
 
 Implement `tenferro::extension::ExtensionOpTrait` for the op payload. The

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -1,11 +1,40 @@
 # Devices and GPU
 
-tenferro follows the PyTorch convention: no implicit CPU/GPU transfer. Upload
-CPU tensors before CUDA backend operations and download results before host
-inspection.
+tenferro follows the PyTorch convention: no implicit CPU/GPU transfer. A tensor
+must already live on the device required by the backend operation.
 
-CUDA support targets NVIDIA CUDA through the CubeCL backend. AMD/ROCm is not a
+CUDA is a backend/device axis, not a separate tensor layer. The same concrete,
+eager, and traced surfaces can run supported CUDA operations when tensors are
+explicitly uploaded to CUDA memory and the executor/backend is CUDA-backed.
+
+CUDA support targets NVIDIA CUDA. AMD/ROCm is not a
 supported execution path yet.
+
+## Transfer Model
+
+| Boundary | What happens |
+| --- | --- |
+| CPU tensor to CUDA backend | Upload first with `tenferro::cuda::upload_tensor` |
+| CUDA tensor to CUDA backend | Runs on CUDA for supported op/dtype combinations |
+| CUDA tensor to CPU backend | Programming error or explicit failure; download first |
+| CUDA tensor to host inspection | Download with `tenferro::cuda::download_tensor` |
+| Unsupported CUDA op or dtype | Error, not silent CPU fallback |
+
+Keep tensors on CUDA across a CUDA workload. Download only when the host needs
+to inspect values or hand data to CPU-only code.
+
+## Eager GPU Synchronization
+
+Eager CUDA execution submits work immediately and returns a CUDA-resident
+`Tensor` handle. It does not expose a user-visible ready flag, and normal
+kernel launches do not imply host synchronization after every op. Subsequent
+CUDA ops can consume the returned handle on the same backend stream.
+
+The host waits when a value is downloaded or otherwise inspected on the host.
+Some library-backed operations also synchronize internally when they must read
+device-side status.
+
+For a time-axis diagram, see [Execution Models](execution-models.md).
 
 ## CUDA Quickstart
 
@@ -42,13 +71,23 @@ cargo check -p tenferro --features cuda --example cuda_quickstart
 Run it on a configured CUDA machine:
 
 ```bash
-CUBECL_DEBUG_LOG=0 \
 CUDA_PATH=/usr/local/cuda-12.0 \
 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:$LD_LIBRARY_PATH \
   cargo run -p tenferro --features cuda --example cuda_quickstart
 ```
 
 The example downloads the result back to CPU and asserts the expected values.
+
+## CUDA Across Tensor Layers
+
+| Tensor layer | CUDA model |
+| --- | --- |
+| `TypedTensor<T>` | Concrete CUDA storage is possible after upload; typed operation coverage depends on the operation family |
+| `Tensor` | Main concrete CUDA value for backend execution |
+| `EagerTensor` | Wraps CUDA-resident `Tensor` values when using an `EagerRuntime` with `CudaBackend` |
+| `TracedTensor` | Graphs can be executed by `GraphExecutor<CudaBackend>` for supported ops |
+
+CUDA coverage is about backend dispatch. It is not the same as AD coverage.
 
 ## Coverage
 

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -1,9 +1,9 @@
 # Eager Operations
 
-This guide covers using tenferro for direct computation with eager
-reverse-mode autodiff on scalar losses: the path you would choose for
-NumPy-like workflows where you control the computation explicitly and call
-`backward()` when you need gradients.
+This guide covers immediate execution: direct no-AD tensor computation and
+PyTorch-like eager reverse-mode autodiff on scalar losses. Start with
+`TypedTensor<T>` or `Tensor` for no-AD work. Use `EagerTensor` only when the
+workflow needs gradient accumulation and `backward()`.
 
 ## Setup
 
@@ -13,18 +13,24 @@ use tenferro::{CpuBackend, Tensor, TypedTensor};
 let mut ctx = CpuBackend::new();
 ```
 
-Every eager operation requires a backend context. `CpuBackend` is the standard
-CPU backend using the faer linear algebra library. With the `cuda` feature, the
-same concrete and eager APIs can execute supported operations on the CubeCL/CUDA
-backend when tensors are explicitly placed on the GPU.
+Every direct tensor operation requires a backend context. `CpuBackend` is the
+standard CPU backend using the faer linear algebra library. With the `cuda`
+feature, the same concrete and eager surfaces can execute supported operations
+on the CUDA backend when tensors are explicitly placed on the GPU.
 
 `EagerRuntime` is the gradient-owning wrapper for eager AD state. If you share
 one context across multiple tracked tensors, their gradients accumulate into
 the same state and you can reset them together with `clear_grads()`.
 
-Most eager operations are methods on `Tensor`. `TypedTensor<T>` is useful when
-you want compile-time dtype safety for construction or direct host-side data
-access.
+Most broad concrete operations are methods on `Tensor`. `TypedTensor<T>` is the
+first layer to consider when you want compile-time dtype safety, typed
+host-side data, or typed linalg/einsum wrappers.
+
+For CUDA, eager means the operation is submitted immediately. It does not mean
+the host waits after every GPU kernel. Host synchronization happens at
+download/read boundaries or inside operations that must inspect device-side
+status. See [Execution Models](execution-models.md) and
+[Devices and GPU](devices-and-gpu.md).
 
 ## Creating tensors
 
@@ -195,13 +201,15 @@ assert!(x.grad().is_none());
 assert!(y.grad().is_none());
 ```
 
-## When to use eager vs lazy
+## When To Use Each Immediate Layer
 
 | Scenario | Recommended |
 |----------|-------------|
-| Data preprocessing | Eager (`Tensor` + a backend) |
-| TCI inner loops | Eager |
-| Exploratory computation | Eager |
+| Fixed scalar type and no AD | `TypedTensor<T>` |
+| Dynamic dtype and no AD | `Tensor` + a backend |
+| Data preprocessing | `Tensor` + a backend |
+| TCI inner loops | Direct/eager execution |
+| Exploratory computation | Direct/eager execution |
 | Need scalar-loss reverse-mode gradients | Eager (`EagerTensor::backward()`) |
 | Need transform AD (`grad` / `vjp` / `jvp` / HVP) | Lazy traced (`TracedTensor` + `GraphCompiler` + `GraphExecutor<B>`) |
 | CUDA execution for supported operations | Eager (`Tensor` / `EagerTensor`) or lazy traced (`TracedTensor` + `GraphExecutor<B>`) with explicit upload/download |

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -1,14 +1,78 @@
 # Einsum
 
 If you already use `torch.einsum(...)` or `jnp.einsum(...)`, tenferro keeps
-the same subscript language. The traced API builds an einsum graph with a
-`GraphCompiler`; a `GraphExecutor` runs the compiled program.
+the same subscript language. Einsum is not a traced-only feature: tenferro has
+typed, concrete, eager, and traced routes.
 
 - PyTorch: `torch.einsum("ij,jk->ik", a, b)`
 - JAX: `jnp.einsum("ij,jk->ik", a, b)`
-- tenferro: `tenferro::traced_tensor::einsum(&mut compiler, &[&a, &b], "ij,jk->ik")`
+- tenferro typed: `tenferro::typed_tensor::einsum(&mut backend, &[&a, &b], "ij,jk->ik")`
+- tenferro concrete: `tenferro::tensor::einsum(&mut backend, &[&a, &b], "ij,jk->ik")`
+- tenferro eager AD: `tenferro::eager_tensor::einsum(&[&a, &b], "ij,jk->ik")`
+- tenferro traced: `tenferro::traced_tensor::einsum(&mut compiler, &[&a, &b], "ij,jk->ik")`
 
-## Matrix multiply
+## Layer Coverage
+
+| Layer | Einsum entry point |
+| --- | --- |
+| `TypedTensor<T>` | `tenferro::typed_tensor::einsum` |
+| `Tensor` | `tenferro::tensor::einsum` |
+| `EagerTensor` | `tenferro::eager_tensor::einsum` |
+| `TracedTensor` | `tenferro::traced_tensor::einsum` |
+| CUDA | Supported through the backend for CUDA-resident tensors |
+
+## Concrete Matrix Multiply
+
+Use the concrete route for no-AD backend execution.
+
+```rust
+use tenferro::tensor::einsum;
+use tenferro::{CpuBackend, Tensor};
+
+let mut backend = CpuBackend::new();
+let a = Tensor::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+);
+let b = Tensor::from_vec_col_major(
+    vec![3, 2],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+);
+
+let c = einsum(&mut backend, &[&a, &b], "ij,jk->ik").unwrap();
+
+assert_eq!(c.shape(), &[2, 2]);
+assert_eq!(c.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+```
+
+## Typed Matrix Multiply
+
+Use the typed route when all inputs share one compile-time scalar type.
+
+```rust
+use tenferro::typed_tensor::einsum;
+use tenferro::{CpuBackend, TypedTensor};
+
+let mut backend = CpuBackend::new();
+let a = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 2],
+    vec![1.0, 2.0, 3.0, 4.0],
+);
+let b = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 2],
+    vec![5.0, 6.0, 7.0, 8.0],
+);
+
+let c = einsum(&mut backend, &[&a, &b], "ij,jk->ik").unwrap();
+
+assert_eq!(c.shape.as_slice(), &[2, 2]);
+assert_eq!(c.host_data(), &[23.0, 34.0, 31.0, 46.0]);
+```
+
+## Traced Matrix Multiply
+
+Use the traced route when einsum should be part of a graph compiled by
+`GraphCompiler` and executed by `GraphExecutor`.
 
 ```rust
 use tenferro::traced_tensor::einsum;
@@ -40,46 +104,38 @@ Repeated labels select or reduce diagonals, matching the standard NumPy,
 PyTorch, and JAX idioms.
 
 ```rust
-use tenferro::traced_tensor::einsum;
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::tensor::einsum;
+use tenferro::{CpuBackend, Tensor};
 
-let matrix = TracedTensor::from_vec_col_major(
+let mut backend = CpuBackend::new();
+let matrix = Tensor::from_vec_col_major(
     vec![3, 3],
     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
 );
 
-let mut compiler = GraphCompiler::new();
-let trace = einsum(&mut compiler, &[&matrix], "ii->").unwrap();
-let diagonal = einsum(&mut compiler, &[&matrix], "ii->i").unwrap();
-let program = compiler.compile_many(&[&trace, &diagonal]).unwrap();
+let trace = einsum(&mut backend, &[&matrix], "ii->").unwrap();
+let diagonal = einsum(&mut backend, &[&matrix], "ii->i").unwrap();
 
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let outputs = executor.run_many(&program).unwrap();
-
-assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[15.0]);
-assert_eq!(outputs[1].as_slice::<f64>().unwrap(), &[1.0, 5.0, 9.0]);
+assert_eq!(trace.as_slice::<f64>().unwrap(), &[15.0]);
+assert_eq!(diagonal.as_slice::<f64>().unwrap(), &[1.0, 5.0, 9.0]);
 ```
 
 ## Outer product and diagonal embedding
 
 ```rust
-use tenferro::traced_tensor::einsum;
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::eager_tensor::einsum;
+use tenferro::{EagerRuntime, Tensor};
 
-let u = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-let v = TracedTensor::from_vec_col_major(vec![3], vec![3.0_f64, 4.0, 5.0]);
+let ctx = EagerRuntime::new();
+let u = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]));
+let v = ctx.variable_from(Tensor::from_vec_col_major(vec![3], vec![3.0_f64, 4.0, 5.0]));
 
-let mut compiler = GraphCompiler::new();
-let outer = einsum(&mut compiler, &[&u, &v], "i,j->ij").unwrap();
-let diag = einsum(&mut compiler, &[&v], "i->ii").unwrap();
-let program = compiler.compile_many(&[&outer, &diag]).unwrap();
+let outer = einsum(&[&u, &v], "i,j->ij").unwrap();
+let diag = einsum(&[&v], "i->ii").unwrap();
 
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let outputs = executor.run_many(&program).unwrap();
-
-assert_eq!(outputs[0].shape(), &[2, 3]);
-assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[3.0, 6.0, 4.0, 8.0, 5.0, 10.0]);
-assert_eq!(outputs[1].shape(), &[3, 3]);
+assert_eq!(outer.data().shape(), &[2, 3]);
+assert_eq!(outer.data().as_slice::<f64>().unwrap(), &[3.0, 6.0, 4.0, 8.0, 5.0, 10.0]);
+assert_eq!(diag.data().shape(), &[3, 3]);
 ```
 
 ## N-ary contraction
@@ -90,21 +146,17 @@ einsums are planned at runtime and cached by `GraphExecutor` for the observed
 input shapes.
 
 ```rust
-use tenferro::traced_tensor::einsum;
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::typed_tensor::einsum;
+use tenferro::{CpuBackend, TypedTensor};
 
-let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
-let b = TracedTensor::from_vec_col_major(vec![2, 2], vec![5.0_f64, 6.0, 7.0, 8.0]);
-let c = TracedTensor::from_vec_col_major(vec![2, 2], vec![9.0_f64, 10.0, 11.0, 12.0]);
+let mut backend = CpuBackend::new();
+let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+let c = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![9.0, 10.0, 11.0, 12.0]);
 
-let mut compiler = GraphCompiler::new();
-let out = einsum(&mut compiler, &[&a, &b, &c], "ij,jk,kl->il").unwrap();
-let program = compiler.compile(&out).unwrap();
+let out = einsum(&mut backend, &[&a, &b, &c], "ij,jk,kl->il").unwrap();
 
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let result = executor.run(&program).unwrap();
-
-assert_eq!(result.shape(), &[2, 2]);
+assert_eq!(out.shape.as_slice(), &[2, 2]);
 ```
 
 ## Concrete vs symbolic shapes
@@ -146,23 +198,20 @@ batch axes line up naturally with column-major storage, so this example keeps
 the batch dimension on the right.
 
 ```rust
-use tenferro::traced_tensor::einsum;
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::tensor::einsum;
+use tenferro::{CpuBackend, Tensor};
 
-let a = TracedTensor::from_vec_col_major(
+let mut backend = CpuBackend::new();
+let a = Tensor::from_vec_col_major(
     vec![2, 2, 2],
     vec![1.0_f64, 2.0, 3.0, 4.0, 9.0, 10.0, 11.0, 12.0],
 );
-let b = TracedTensor::from_vec_col_major(
+let b = Tensor::from_vec_col_major(
     vec![2, 2, 2],
     vec![5.0_f64, 6.0, 7.0, 8.0, 13.0, 14.0, 15.0, 16.0],
 );
 
-let mut compiler = GraphCompiler::new();
-let c = einsum(&mut compiler, &[&a, &b], "ijk,jlk->ilk").unwrap();
-let program = compiler.compile(&c).unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let result = executor.run(&program).unwrap();
+let result = einsum(&mut backend, &[&a, &b], "ijk,jlk->ilk").unwrap();
 
 assert_eq!(result.shape(), &[2, 2, 2]);
 ```

--- a/docs/guides/execution-models.md
+++ b/docs/guides/execution-models.md
@@ -1,0 +1,50 @@
+# Execution Models
+
+tenferro supports direct execution, PyTorch-like eager AD, and JAX-like traced
+execution on the same dense tensor stack. The key distinction is when work is
+submitted and when the host waits for results.
+
+![Eager CPU, Eager GPU, and Traced execution timelines](../assets/execution-models.svg)
+
+## Eager CPU
+
+Direct CPU tensor operations and eager CPU AD run immediately. A call enters
+the CPU backend, the CPU work completes, and the returned `Tensor` is
+host-readable.
+
+This is the easiest model for debugging and for ordinary no-AD numeric code.
+Use `TypedTensor<T>` or `Tensor` when no gradient state is needed. Use
+`EagerTensor` when you want PyTorch-style scalar-loss `backward()`.
+
+## Eager GPU
+
+Eager GPU work is immediate at the Rust API boundary, but it is not a ready
+flag API and it does not imply host synchronization after every kernel. An op
+submits work to the CUDA backend and returns a CUDA-resident `Tensor` handle.
+Subsequent CUDA ops can consume that handle on the same backend stream.
+
+The host waits when values are downloaded or otherwise need host inspection.
+Some library-backed operations also synchronize internally when they must read
+device-side status.
+
+## Traced Mode
+
+Traced mode records operations into a graph first. It is similar to JAX's
+tracing and `jit` workflow: build the expression, compile it, then run the
+compiled program through a `GraphExecutor<B>`.
+
+Use traced mode for transform AD (`grad`, `vjp`, `jvp`, HVP), symbolic inputs,
+graph optimization, and repeated execution. The executor backend decides
+whether the compiled program runs on CPU or CUDA for supported operations.
+
+## Why Support Both?
+
+Eager and traced serve different workflows on the same tensor stack.
+
+| Need | Better fit |
+| --- | --- |
+| Inspect intermediate values while developing | Eager CPU or eager GPU with explicit download |
+| Scalar-loss reverse-mode AD with gradient accumulation | `EagerTensor` |
+| Transform AD and higher-order AD | `TracedTensor` |
+| Reuse the same computation many times | `GraphCompiler` + `GraphExecutor<B>` |
+| Keep no-AD code simple | `TypedTensor<T>` or `Tensor` |

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -46,14 +46,13 @@ CUDA support is enabled with the `cuda` feature alias:
 tenferro = { path = "/path/to/tenferro-rs/tenferro", features = ["cuda"] }
 ```
 
-CUDA support targets NVIDIA CUDA through the CubeCL backend. See
+CUDA support targets NVIDIA CUDA. See
 [Devices and GPU](devices-and-gpu.md) for the transfer model and current
 coverage.
 
 Common CUDA runtime environment variables:
 
 ```bash
-CUBECL_DEBUG_LOG=0
 CUDA_PATH=/usr/local/cuda-12.0
 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:$LD_LIBRARY_PATH
 ```

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -1,27 +1,69 @@
 # Linear Algebra
 
-tenferro exposes traced linear algebra under `tenferro::traced_tensor`. The
-helpers return `TracedTensor` values, so multi-output decompositions are best
-compiled with `GraphCompiler::compile_many`.
+tenferro exposes linear algebra across the concrete and traced tensor layers.
+Use `Tensor` or `TypedTensor<T>` for no-AD direct execution. Use
+`TracedTensor` when the linear algebra operation should be part of a graph,
+transform AD pass, or repeated compile/run workflow.
+
+## Layer Coverage
+
+| Layer | Linear algebra style |
+| --- | --- |
+| `TypedTensor<T>` | Selected typed methods such as `svd`, `qr`, `cholesky`, and `eigh` |
+| `Tensor` | Dynamic dtype methods such as `svd`, `qr`, `cholesky`, `eigh`, and `solve` |
+| `EagerTensor` | Immediate execution with scalar-loss gradient recording where AD rules support the operation |
+| `TracedTensor` | `tenferro::traced_tensor` helpers for graph execution and transform AD |
+| CUDA | Supported subset through cuSOLVER/cuBLAS; see [Devices and GPU](devices-and-gpu.md) |
+
+## Concrete Solve
+
+```rust
+use tenferro::{CpuBackend, Tensor};
+
+let mut backend = CpuBackend::new();
+let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 0.0, 0.0, 9.0]);
+let b = Tensor::from_vec_col_major(vec![2, 1], vec![8.0_f64, 27.0]);
+
+let x = a.solve(&b, &mut backend).unwrap();
+
+assert_eq!(x.shape(), &[2, 1]);
+assert_eq!(x.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
+```
+
+## Typed Cholesky
+
+```rust
+use tenferro::{CpuBackend, TypedTensor};
+
+let mut backend = CpuBackend::new();
+let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![4.0, 0.0, 0.0, 9.0]);
+
+let factor = a.cholesky(&mut backend).unwrap();
+
+assert_eq!(factor.shape.as_slice(), &[2, 2]);
+assert_eq!(factor.host_data(), &[2.0, 0.0, 0.0, 3.0]);
+```
+
+## Direct Decompositions
+
+The same operation families are available outside traced graphs. Use concrete
+or typed tensors for direct no-AD execution, eager tensors when the result
+should remain connected to a scalar-loss AD tape, and traced helpers when the
+operation belongs in a reusable graph.
 
 ## Singular value decomposition
 
 ```rust
-use tenferro::traced_tensor::svd;
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::{CpuBackend, Tensor};
 
-let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]);
-let (u, s, vt) = svd(&a);
+let mut backend = CpuBackend::new();
+let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]);
+let (u, s, vt) = a.svd(&mut backend).unwrap();
 
-let mut compiler = GraphCompiler::new();
-let program = compiler.compile_many(&[&u, &s, &vt]).unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let outputs = executor.run_many(&program).unwrap();
+assert_eq!(u.shape(), &[2, 2]);
+assert_eq!(vt.shape(), &[2, 2]);
 
-assert_eq!(outputs[0].shape(), &[2, 2]);
-assert_eq!(outputs[2].shape(), &[2, 2]);
-
-let mut singular_values = outputs[1].as_slice::<f64>().unwrap().to_vec();
+let mut singular_values = s.as_slice::<f64>().unwrap().to_vec();
 singular_values.sort_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap());
 assert_eq!(singular_values, vec![1.0, 2.0]);
 ```
@@ -29,46 +71,36 @@ assert_eq!(singular_values, vec![1.0, 2.0]);
 ## QR decomposition
 
 ```rust
-use tenferro::traced_tensor::qr;
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::{CpuBackend, TypedTensor};
 
-let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]);
-let (q, r) = qr(&a);
+let mut backend = CpuBackend::new();
+let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0]);
+let (q, r) = a.qr(&mut backend).unwrap();
 
-let mut compiler = GraphCompiler::new();
-let program = compiler.compile_many(&[&q, &r]).unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let outputs = executor.run_many(&program).unwrap();
-
-assert_eq!(outputs[0].shape(), &[2, 2]);
-assert_eq!(outputs[1].shape(), &[2, 2]);
-assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[1.0, 0.0, 0.0, 1.0]);
-assert_eq!(outputs[1].as_slice::<f64>().unwrap(), &[1.0, 0.0, 0.0, 1.0]);
+assert_eq!(q.shape.as_slice(), &[2, 2]);
+assert_eq!(r.shape.as_slice(), &[2, 2]);
+assert_eq!(q.host_data(), &[1.0, 0.0, 0.0, 1.0]);
+assert_eq!(r.host_data(), &[1.0, 0.0, 0.0, 1.0]);
 ```
 
 ## Hermitian eigenvalue decomposition
 
 ```rust
-use tenferro::traced_tensor::eigh;
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::{EagerRuntime, Tensor};
 
-let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]);
-let (values, vectors) = eigh(&a);
+let ctx = EagerRuntime::new();
+let a = ctx.variable_from(Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
+let (values, vectors) = a.eigh().unwrap();
 
-let mut compiler = GraphCompiler::new();
-let program = compiler.compile_many(&[&values, &vectors]).unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let outputs = executor.run_many(&program).unwrap();
+assert_eq!(values.data().shape(), &[2]);
+assert_eq!(vectors.data().shape(), &[2, 2]);
 
-assert_eq!(outputs[0].shape(), &[2]);
-assert_eq!(outputs[1].shape(), &[2, 2]);
-
-let mut eigenvalues = outputs[0].as_slice::<f64>().unwrap().to_vec();
+let mut eigenvalues = values.data().as_slice::<f64>().unwrap().to_vec();
 eigenvalues.sort_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap());
 assert_eq!(eigenvalues, vec![1.0, 3.0]);
 ```
 
-## Cholesky factorization
+## Traced Cholesky Factorization
 
 ```rust
 use tenferro::traced_tensor::cholesky;
@@ -86,7 +118,7 @@ assert_eq!(result.shape(), &[2, 2]);
 assert_eq!(result.as_slice::<f64>().unwrap(), &[2.0, 0.0, 0.0, 3.0]);
 ```
 
-## Solve a linear system
+## Traced Solve In A Graph
 
 ```rust
 use tenferro::traced_tensor::solve;
@@ -105,27 +137,20 @@ assert_eq!(result.shape(), &[2, 1]);
 assert_eq!(result.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
 ```
 
-## Complete-pivot LU solve
+## Complete-Pivot LU Solve
 
 ```rust
-use tenferro::traced_tensor::{full_piv_lu, full_piv_lu_solve};
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::{CpuBackend, Tensor};
 
-let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]);
-let b = TracedTensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0]);
+let mut backend = CpuBackend::new();
+let a = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]);
+let b = Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0]);
 
-let (p, l, u, q, parity) = full_piv_lu(&a);
-let x = full_piv_lu_solve(&a, &b);
+let (p, _l, _u, _q, parity) = a.full_piv_lu(&mut backend).unwrap();
+let x = a.full_piv_lu_solve(&b, &mut backend).unwrap();
 
-let mut compiler = GraphCompiler::new();
-let program = compiler
-    .compile_many(&[&p, &l, &u, &q, &parity, &x])
-    .unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let outputs = executor.run_many(&program).unwrap();
-
-assert_eq!(outputs[0].shape(), &[2, 2]);
-assert_eq!(outputs[4].shape(), &[] as &[usize]);
-assert_eq!(outputs[5].shape(), &[2, 1]);
-assert_eq!(outputs[5].as_slice::<f64>().unwrap(), &[4.0, -1.0]);
+assert_eq!(p.shape(), &[2, 2]);
+assert_eq!(parity.shape(), &[] as &[usize]);
+assert_eq!(x.shape(), &[2, 1]);
+assert_eq!(x.as_slice::<f64>().unwrap(), &[4.0, -1.0]);
 ```

--- a/docs/guides/memory-order.md
+++ b/docs/guides/memory-order.md
@@ -1,12 +1,37 @@
 # Memory Order
 
-tenferro dense tensors use column-major flat buffers. The leftmost dimension
-varies fastest in memory.
+tenferro dense tensors use contiguous column-major storage. The leftmost
+dimension varies fastest in memory.
+
+This is intentional. tenferro is designed to feel natural for Fortran, Julia,
+MATLAB, Eigen/LAPACK-oriented, and scientific computing workflows where
+column-major arrays are common. It also gives a clear convention for batched
+linear algebra: keep compute dimensions on the left and batch dimensions on
+the right.
+
+## Shape And Flat Buffer
+
+For a logical `[2, 3]` matrix:
+
+```text
+[[1, 2, 3],
+ [4, 5, 6]]
+```
+
+the column-major flat buffer is:
+
+```text
+[1, 4, 2, 5, 3, 6]
+```
 
 ```rust
 use tenferro::Tensor;
 
-let tensor = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+let tensor = Tensor::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0],
+);
+
 assert_eq!(tensor.shape(), &[2, 3]);
 assert_eq!(
     tensor.as_slice::<f64>().unwrap(),
@@ -14,46 +39,40 @@ assert_eq!(
 );
 ```
 
-The logical matrix is:
-
-```text
-[[1, 2, 3],
- [4, 5, 6]]
-```
-
 ## Importing Row-Major Data
 
-PyTorch, NumPy, and JAX examples often show row-major flat buffers. Convert
-those buffers to column-major before constructing a tenferro tensor.
+PyTorch, NumPy, JAX, and many C-style examples present flat buffers in
+row-major order. Use `from_vec_row_major` at the boundary when the input buffer
+is written row by row.
 
 ```rust
 use tenferro::Tensor;
 
-fn row_major_to_column_major<T: Copy>(shape: &[usize], data: &[T]) -> Vec<T> {
-    assert_eq!(shape.len(), 2);
-    let rows = shape[0];
-    let cols = shape[1];
-    assert_eq!(data.len(), rows * cols);
-
-    let mut out = Vec::with_capacity(data.len());
-    for col in 0..cols {
-        for row in 0..rows {
-            out.push(data[row * cols + col]);
-        }
-    }
-    out
-}
-
-let shape = vec![2, 3];
-let row_major = vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
-let column_major = row_major_to_column_major(&shape, &row_major);
-let tensor = Tensor::from_vec_col_major(shape, column_major);
+let tensor = Tensor::from_vec_row_major(
+    vec![2, 3],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+);
 
 assert_eq!(
     tensor.as_slice::<f64>().unwrap(),
     &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
 );
 ```
+
+Use `from_vec_col_major` when the buffer already follows tenferro's physical
+order. Use `from_vec_row_major` when the buffer follows the order shown in most
+PyTorch, NumPy, and JAX snippets.
+
+## Batch Axes
+
+Because tenferro is column-major, trailing batch axes are natural for batched
+matrix operations and einsum. In a shape like `[m, k, batch]`, each batch slice
+contains a contiguous `[m, k]` matrix, so the backend can operate on each matrix
+without treating batch as the fastest-varying dimension.
+
+This differs from many PyTorch examples that place batch first. When porting
+code, prefer moving batch axes to the right if the tensor will feed repeated
+linear algebra or contraction kernels.
 
 ## Owned Export
 
@@ -63,7 +82,7 @@ Owned export returns the column-major host buffer:
 use tenferro::Tensor;
 
 let tensor = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
-let (shape, data) = tensor.try_into_vec::<f64>().unwrap();
+let (shape, data) = tensor.try_into_vec_col_major::<f64>().unwrap();
 
 assert_eq!(shape, vec![2, 2]);
 assert_eq!(data, vec![1.0, 3.0, 2.0, 4.0]);

--- a/docs/guides/tensor-operations.md
+++ b/docs/guides/tensor-operations.md
@@ -1,30 +1,57 @@
 # Tensor Operations
 
-This guide covers everyday traced tensor operations: creating graph inputs,
-applying elementwise math, changing shapes, broadcasting, and reducing over
-axes. Traced operations build a graph; `GraphCompiler` lowers the graph and
-`GraphExecutor` runs it on a backend.
+This guide covers everyday tensor operations: elementwise math, shape changes,
+broadcasting, reductions, and concrete backend execution. These operations are
+available through different tensor layers depending on whether you need no-AD
+computation, eager scalar-loss AD, or traced graph execution.
 
-## Create tensors from shape and data
+## Layer Coverage
+
+| Layer | Operation style |
+| --- | --- |
+| `TypedTensor<T>` | Typed storage and selected typed operation wrappers; convert to `Tensor` for the broad dynamic operation surface |
+| `Tensor` | Concrete no-AD operations through an explicit backend |
+| `EagerTensor` | Immediate operations that also record state for `backward()` |
+| `TracedTensor` | Lazy operations that build a graph for compile/run reuse |
+| CUDA | Supported operation/dtype combinations run on CUDA tensors with explicit upload/download |
+
+## Concrete Tensor Example
+
+Use `Tensor` with a backend when you want direct no-AD computation.
 
 ```rust
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::{CpuBackend, Tensor};
 
-let a = TracedTensor::from_vec_col_major(
-    vec![2, 3],
-    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-);
+let mut backend = CpuBackend::new();
+let a = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+let b = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]);
 
-let mut compiler = GraphCompiler::new();
-let program = compiler.compile(&a).unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let result = executor.run(&program).unwrap();
+let sum = a.add(&b, &mut backend).unwrap();
+let product = a.mul(&b, &mut backend).unwrap();
 
-assert_eq!(result.shape(), &[2, 3]);
-assert_eq!(result.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+assert_eq!(sum.as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
+assert_eq!(product.as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
 ```
 
-## Elementwise arithmetic
+## Eager AD Example
+
+Use `EagerTensor` when the same immediate computation should accumulate
+gradients for a scalar loss.
+
+```rust
+use tenferro::{EagerRuntime, Tensor};
+
+let ctx = EagerRuntime::new();
+let x = ctx.variable_from(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
+let y = (&x * &x).reduce_sum(&[0]).unwrap();
+
+y.backward().unwrap();
+assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
+```
+
+## Traced Tensor Example
+
+Use `TracedTensor` when operations should build a graph first and execute later.
 
 ```rust
 use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
@@ -43,84 +70,69 @@ assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
 assert_eq!(outputs[1].as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
 ```
 
-## Elementwise math functions
+## Elementwise Math Functions
 
 ```rust
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::{EagerRuntime, Tensor};
 
-let x = TracedTensor::from_vec_col_major(vec![3], vec![0.0_f64, 1.0, 2.0]);
-let y = x.exp();
+let ctx = EagerRuntime::new();
+let x = ctx.variable_from(Tensor::from_vec_col_major(vec![3], vec![0.0_f64, 1.0, 2.0]));
+let y = x.exp().unwrap();
 
-let mut compiler = GraphCompiler::new();
-let program = compiler.compile(&y).unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let result = executor.run(&program).unwrap();
-let data = result.as_slice::<f64>().unwrap();
+let data = y.data().as_slice::<f64>().unwrap();
 
 assert!((data[0] - 1.0).abs() < 1e-12);
 assert!((data[1] - std::f64::consts::E).abs() < 1e-12);
 assert!((data[2] - 7.38905609893065).abs() < 1e-12);
 ```
 
-## Reshape and transpose
+## Reshape And Transpose
 
 ```rust
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::{CpuBackend, Tensor};
 
-let a = TracedTensor::from_vec_col_major(
+let mut backend = CpuBackend::new();
+let a = Tensor::from_vec_col_major(
     vec![2, 3],
     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 );
-let reshaped = a.reshape(&[6]);
-let transposed = a.transpose(&[1, 0]);
+let reshaped = a.reshape(&[6], &mut backend).unwrap();
+let transposed = a.transpose(&[1, 0], &mut backend).unwrap();
 
-let mut compiler = GraphCompiler::new();
-let program = compiler.compile_many(&[&reshaped, &transposed]).unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let outputs = executor.run_many(&program).unwrap();
-
-assert_eq!(outputs[0].shape(), &[6]);
-assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-assert_eq!(outputs[1].shape(), &[3, 2]);
-assert_eq!(outputs[1].as_slice::<f64>().unwrap(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
+assert_eq!(reshaped.shape(), &[6]);
+assert_eq!(reshaped.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+assert_eq!(transposed.shape(), &[3, 2]);
+assert_eq!(transposed.as_slice::<f64>().unwrap(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
 ```
 
-## Explicit broadcast
+## Explicit Broadcast
 
 ```rust
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::{EagerRuntime, Tensor};
 
-let v = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-let repeated = v.broadcast(&[3, 2], &[0]);
+let ctx = EagerRuntime::new();
+let v = ctx.variable_from(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
+let repeated = v.broadcast_in_dim(&[3, 2], &[0]).unwrap();
 
-let mut compiler = GraphCompiler::new();
-let program = compiler.compile(&repeated).unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let result = executor.run(&program).unwrap();
-
-assert_eq!(result.shape(), &[3, 2]);
-assert_eq!(result.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 1.0, 2.0, 3.0]);
+assert_eq!(repeated.data().shape(), &[3, 2]);
+assert_eq!(repeated.data().as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 1.0, 2.0, 3.0]);
 ```
 
-## Reduce over axes
+## Reduce Over Axes
 
 ```rust
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro::{CpuBackend, Tensor};
 
-let a = TracedTensor::from_vec_col_major(
+let mut backend = CpuBackend::new();
+let a = Tensor::from_vec_col_major(
     vec![2, 3],
     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 );
-let row_sums = a.reduce_sum(&[1]);
-let total = a.reduce_sum(&[0, 1]);
+let row_sums = a.reduce_sum(&[1], &mut backend).unwrap();
+let total = a.reduce_sum(&[0, 1], &mut backend).unwrap();
 
-let mut compiler = GraphCompiler::new();
-let program = compiler.compile_many(&[&row_sums, &total]).unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let outputs = executor.run_many(&program).unwrap();
-
-assert_eq!(outputs[0].shape(), &[2]);
-assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[9.0, 12.0]);
-assert_eq!(outputs[1].shape(), &[] as &[usize]);
-assert_eq!(outputs[1].as_slice::<f64>().unwrap(), &[21.0]);
+assert_eq!(row_sums.shape(), &[2]);
+assert_eq!(row_sums.as_slice::<f64>().unwrap(), &[9.0, 12.0]);
+assert_eq!(total.shape(), &[] as &[usize]);
+assert_eq!(total.as_slice::<f64>().unwrap(), &[21.0]);
 ```

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -57,10 +57,12 @@ supported scalar type.
 
 ## Column-Major and Row-Major Confusion
 
-`Tensor::from_vec` reads flat data as column-major. When porting PyTorch,
-NumPy, or JAX examples that use row-major flat data, convert the data to
-column-major before construction. If another library expects row-major output,
-convert the exported `try_into_vec::<T>()` buffer at that boundary.
+`Tensor::from_vec_col_major` expects tenferro's physical column-major order.
+When porting PyTorch, NumPy, or JAX examples that use row-major flat data, use
+`Tensor::from_vec_row_major` at the import boundary. If another library expects
+row-major output, export with `try_into_vec_row_major::<T>()`; use
+`try_into_vec_col_major::<T>()` when the consumer expects tenferro's physical
+order.
 See [Memory Order](memory-order.md).
 
 ## CPU Backend Feature Conflicts

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,26 +1,26 @@
 # tenferro
 
-tenferro is a dense tensor computation library for Rust users who want
-PyTorch- and JAX-style tensor workflows with explicit Rust ownership and
-backend control.
+tenferro is a dense tensor computation stack for Rust users who want direct
+typed tensor computation, PyTorch-like eager autodiff, JAX-like traced graph
+transforms, einsum, linear algebra, and explicit CPU/CUDA backend control.
 
-It supports:
-
-- eager tensor operations with `Tensor`, `TypedTensor`, and a backend,
-- eager scalar-loss reverse-mode AD with `EagerTensor`,
-- lazy traced execution with `TracedTensor`, `GraphCompiler`, and
-  `GraphExecutor`,
-- transform AD with `grad`, `vjp`, `jvp`, and HVP composition,
-- einsum and linear algebra,
-- CUDA execution through the feature-gated CubeCL backend.
+The project covers both no-AD and AD workflows. Start with the lowest layer
+that solves your problem, then add autodiff, graph compilation, or CUDA only
+when the workflow needs them.
 
 ## Start Here
 
-- [Getting Started](getting-started/index.md)
-- [Choosing an API](guides/choosing-an-api.md)
-- [Custom Tensor Operations](guides/custom-operations.md)
+- [Core Concepts](getting-started/core-concepts.md)
+- [Choosing a Tensor Layer](guides/choosing-an-api.md)
+- [Execution Models](guides/execution-models.md)
+- [Memory Order](guides/memory-order.md)
 - [Devices and GPU](guides/devices-and-gpu.md)
 - [API Reference](api/index.md)
+
+Installation details live in the README and the short
+[Installation](guides/installation.md) guide. The online guides focus on the
+tensor stack, memory model, execution modes, operation coverage, and extension
+model.
 
 ## First CPU Example
 
@@ -46,9 +46,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Mental Model
 
-| Workflow | Use |
+tenferro has three independent axes. Do not read CUDA, eager AD, and traced
+graphs as competing APIs; they answer different questions.
+
+| Axis | Question | Choices |
+| --- | --- | --- |
+| Data layer | What kind of tensor value do I hold? | `TypedTensor<T>`, `Tensor`, `EagerTensor`, `TracedTensor` |
+| Execution model | When does computation run? | Direct backend call, eager AD, traced compile/run |
+| Device/backend | Where does computation run? | CPU backend or CUDA backend, with explicit transfer |
+
+Most no-AD code starts with `TypedTensor<T>` when the scalar type is known at
+compile time, or `Tensor` when dtype must be dynamic. `EagerTensor` adds
+PyTorch-style scalar-loss `backward()`. `TracedTensor` adds graph compilation,
+transform AD, symbolic inputs, and reuse.
+
+## Guides By Workflow
+
+| Workflow | Start with |
 | --- | --- |
-| Direct CPU computation | `Tensor` or `TypedTensor` with `CpuBackend` |
-| Scalar-loss eager AD | `EagerTensor` with `EagerRuntime` |
-| Transform AD and graph optimization | `TracedTensor` with `GraphCompiler` and `GraphExecutor` |
-| CUDA execution | `tenferro::cuda::CudaBackend` with the `cuda` feature and explicit upload/download |
+| No-AD computation with a fixed scalar type | [`TypedTensor<T>` and direct tensor workflows](guides/choosing-an-api.md) |
+| No-AD dynamic dtype computation | [`Tensor` with a backend](guides/eager-operations.md) |
+| PyTorch-like scalar-loss autodiff | [`EagerTensor` and `EagerRuntime`](guides/eager-operations.md) |
+| JAX-like graph transforms and repeated execution | [`TracedTensor`, `GraphCompiler`, and `GraphExecutor`](guides/execution-models.md) |
+| CUDA execution | [Explicit upload/download and CUDA backend coverage](guides/devices-and-gpu.md) |
+| External operations and AD rules | [Custom operations](guides/custom-operations.md) and [`tenferro-fft`](guides/tenferro-fft.md) |

--- a/docs/spec/extension-op.md
+++ b/docs/spec/extension-op.md
@@ -68,7 +68,7 @@ This document does **not** own:
 ## 3. Why a spec is needed before implementation
 
 A raw `StdTensorOp::Extension(Arc<dyn ExtensionOp>)` carrier is simple to add
-but underspecified on its own. This specification answers five questions that
+but underspecified on its own. This specification answers six questions that
 must be fixed for graph interning, AD caching, serialization boundaries, and
 runtime dispatch to remain deterministic:
 
@@ -84,6 +84,8 @@ runtime dispatch to remain deterministic:
 5. **How do caches stay stable across processes or versions?** Answered
    normatively in Section 11 (serialization compatibility) and
    Section 12 (failure modes).
+6. **Where may extension runtime caches live?** Answered normatively in
+   Section 4 under runtime cache ownership.
 
 This document is the normative answer for all five.
 
@@ -240,6 +242,32 @@ This design parallels how `std::any::Any`-style downcasts work in Rust:
 identity and equality are carried by a type-erased handle, and the
 concrete type is recovered only when the implementer explicitly chooses
 to compare.
+
+### Runtime cache ownership
+
+Extension payload identity and extension runtime caching are separate
+contracts.
+
+An `ExtensionOp` payload MUST describe operation semantics. Payload hashing and
+equality MUST NOT depend on cache warmth, vendor plan handles, allocated
+workspace, stream state, or other mutable runtime state. If such state changes
+the mathematical result or device placement contract, it is not a cache and
+MUST be represented as semantic payload instead.
+
+Extension crates that need plan caches or vendor handles MUST own them in an
+explicit runtime/cache object outside the semantic payload contract. That owner
+MUST be bounded by default and SHOULD expose clear, capacity, and stats APIs
+consistent with the workspace cache ownership rules. The op payload MAY hold an
+`Arc` to the extension-owned cache object only when that cache is a performance
+detail and two equal payloads remain interchangeable when their cache handles
+differ.
+
+There is no monolithic core runtime owner for extension cache state, and the
+current `EagerRuntime`, `GraphCompiler`, and `GraphExecutor` do not expose a
+general public extension cache slot. Compiled extension execution delegates to
+`ExtensionOp::eager_execute`, so eager and traced execution use the same
+extension-owned runtime cache path. First-class extension cache slots are
+tracked in [issue #878](https://github.com/tensor4all/tenferro-rs/issues/878).
 
 ### Rationale
 

--- a/tenferro/src/graph/program.rs
+++ b/tenferro/src/graph/program.rs
@@ -42,6 +42,7 @@ impl GraphProgram {
     /// let program = compiler.compile(&x.neg()).unwrap();
     /// assert_eq!(program.input_count(), 1);
     /// ```
+    #[inline(never)]
     pub fn input_count(&self) -> usize {
         self.inputs.len()
     }
@@ -58,6 +59,7 @@ impl GraphProgram {
     /// let program = compiler.compile(&x.neg()).unwrap();
     /// assert_eq!(program.output_count(), 1);
     /// ```
+    #[inline(never)]
     pub fn output_count(&self) -> usize {
         self.exec.output_slots.len()
     }
@@ -76,6 +78,7 @@ impl GraphProgram {
     ///     .unwrap();
     /// assert_eq!(program.input_specs()[0].shape(), &[4]);
     /// ```
+    #[inline(never)]
     pub fn input_specs(&self) -> &[GraphProgramInput] {
         &self.inputs
     }
@@ -135,6 +138,7 @@ impl GraphProgramInput {
     ///     .unwrap();
     /// assert_eq!(program.input_specs()[0].dtype(), DType::F64);
     /// ```
+    #[inline(never)]
     pub fn dtype(&self) -> DType {
         self.dtype
     }
@@ -151,6 +155,7 @@ impl GraphProgramInput {
     /// let program = compiler.compile(&x).unwrap();
     /// assert_eq!(program.input_specs()[0].shape(), &[2]);
     /// ```
+    #[inline(never)]
     pub fn shape(&self) -> &[usize] {
         &self.shape
     }


### PR DESCRIPTION
## Summary

- Reorganized the online docs around tensor layers, execution modes, device placement, and memory layout.
- Added an execution-model guide plus SVG diagram for Eager CPU, Eager GPU, and traced execution.
- Updated operation guides so `TypedTensor`, `Tensor`, `EagerTensor`, and `TracedTensor` are presented together instead of making traced mode look like the only path.
- Added README development-model guidance and simple issue templates for bug reports and feature requests.
- Documented the extension runtime-cache gap and linked the follow-up issue (#878).
- Marked `GraphProgram` accessor methods `#[inline(never)]` so release coverage continues to observe their doctested public contract.

## Validation

- `cargo fmt --all --check`
- `cargo test -p tenferro --test graph_compile graph_program_input_accessors_report_compiled_contract`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo test --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo test --doc --workspace --release`
- `python3 scripts/check-docs-site.py --root-dir .`
- `quarto render docs` (passed with existing output-dir warnings)
- `git diff --check`
- stale user-facing docs scan for old API/internal terms

Generated with Codex.
