### PR TITLE
[codex] Optimize CubeCL indexing and LU host transfers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-Before acting, read the vendored shared rules from `template-rs`:
+Before acting, read the latest shared Tensor4all agent rules from the
+`tensor4all-agent-rules` repository. If internet access is unavailable or the
+remote cannot be resolved, use the sibling checkout:
+
+- `../tensor4all-agent-rules/rules/index.md`
+
+Load only the common, Rust, performance, numerical, docs, or benchmark rule
+files relevant to the task.
+
+Then read the vendored `template-rs` baseline rules and the tenferro-specific
+rules:
 
 - `ai/vendor/template-rs/common-agent-rules.md`
 - `ai/vendor/template-rs/numerical-rust-rules.md`
@@ -18,6 +28,14 @@ Before touching AD rules, oracle replay, or linearized boundary code, review `RE
 ## Current Implementation Status
 
 The workspace contains active implementations alongside evolving APIs. Implementation work is allowed unless a task explicitly says otherwise.
+
+## Repository Rule Source
+
+Keep cross-repository implementation rules in `tensor4all-agent-rules`.
+Keep tenferro-specific durable rules in `REPOSITORY_RULES.md`. This
+`AGENTS.md` file is the entry point and tenferro-specific orientation; avoid
+duplicating the detailed performance, layout, CPU kernel, slicing, cache,
+threading, and GPU backend rules here.
 
 ### GPU Status
 
@@ -56,20 +74,21 @@ See [`docs/design/`](docs/design/) for architecture and design documents.
 
 **Note**: Files under `docs/plans/` are historical records of past design discussions and decisions. They may contradict the current API or design — do not update them to match the current state.
 
-## Performance-Critical Conventions
+## Performance, Layout, And Backend Rules
 
-### Column-Major Dimension Ordering
+See `REPOSITORY_RULES.md` for the authoritative performance and layout
+contracts, including column-major ordering, hidden materialization, range
+checks and slicing, CPU kernel ownership, anti-patterns, cache ownership, CPU
+threading, and GPU backend conventions.
 
-tenferro uses **column-major** (Fortran order) storage: the leftmost dimension has the smallest stride and varies fastest in memory. When designing internal layouts for multi-dimensional operations (einsum GEMM, linalg, etc.), dimension ordering must respect this:
-
-- **Batch dimensions go on the RIGHT (trailing)**: In col-major, rightmost dims have the largest stride. Placing batch dims on the right means each batch slice occupies a contiguous block of memory, giving good cache locality for the GEMM kernel operating within each slice.
-- **Contraction/compute dimensions go on the LEFT (leading)**: lo (M), sum (K), ro (N) dims should be leftmost so the GEMM kernel accesses contiguous memory.
-
-**Wrong** (batch on left in col-major): `A[batch..., m, k]` — batch has smallest stride, so elements within each `(m, k)` slice are scattered across memory.
-
-**Correct** (batch on right in col-major): `A[lo..., sum..., batch...]` — each batch slice is contiguous, matching strided-rs's convention and standard GEMM cache behavior.
-
-This applies to `target_a`, `target_b`, `c_gemm_shape` in einsum's `GemmPlan`, and to any future batched operation layout.
+Do not assume nearby existing implementation patterns are performance-correct.
+This repository still contains active optimization work and some legacy
+tradeoffs. Before copying patterns in tensor kernels, graph/compiler planning,
+caches, GPU kernels, benchmarks, or user-facing examples, check for hidden
+materialization, repeated per-element index work, avoidable large-state clones,
+repeated linear scans, accidental single-thread GPU execution, and weak
+shape-only validation. Prefer improving the pattern or documenting the residual
+risk rather than propagating it.
 
 ## Code Style
 
@@ -268,106 +287,6 @@ download single scalars.
 provided by any version of cuSOLVER. `CubeclBackend::eig` returns
 `BackendFailure`. Users must explicitly download the tensor to CPU and
 compute via `CpuBackend::eig`. This is a permanent cuSOLVER limitation.
-
-## CPU Kernel Implementation Rules
-
-**No naive CPU loop fallbacks.** All CPU tensor kernels must use optimized
-implementations. Hand-written element-by-element loops are prohibited in
-production code paths.
-
-Required backends by operation category:
-
-| Category | Required backend |
-|---|---|
-| Elementwise (add, mul, neg, exp, ...) | strided-kernel (`map_into`, `zip_map2_into`, etc.) |
-| Reduction (reduce_sum, reduce_prod, ...) | strided-kernel (`reduce`, `reduce_axis`) |
-| Structural (transpose, broadcast, extract_diag) | strided-kernel (`permute`+`copy_into`, `broadcast`, `diagonal_view`) |
-| GEMM (dot_general) | faer (`cpu-faer`) or BLAS (`cpu-blas`) |
-| Linalg (svd, qr, cholesky, eigh, solve) | faer (`cpu-faer`) or LAPACK (`cpu-blas`) |
-
-Exceptions (no strided-kernel API available):
-- `reshape`: metadata-only (contiguous memory, shape swap only)
-- `embed_diagonal`: dedicated implementation
-- Indexing ops (gather, scatter, slice, pad, concatenate, reverse): dedicated implementation
-
-Exactly one CPU backend must be enabled at build time (`cpu-faer` or `cpu-blas`).
-Both disabled or both enabled triggers `compile_error!`.
-
-## Common Performance Anti-Patterns
-
-When writing performance-sensitive code (GEMM, tensor operations, inner loops), avoid these mistakes:
-
-### 1. Duplicated f64/f32 functions instead of generic code
-
-**Bad:** Copy-pasting the same function body for `f64` and `f32` (e.g., `run_f64` / `run_f32`).
-
-**Good:** Use a trait (e.g., `FaerGemm`) or macro to share the logic. TypeId dispatch only at the outer boundary.
-
-### 2. Allocating dense buffers when strided access is available
-
-**Bad:** `vec![0.0; m*k]` + copy from strided source + GEMM + copy back to strided destination.
-
-**Good:** Use `faer::MatRef::from_raw_parts(ptr, m, k, row_stride, col_stride)` to access strided data directly — zero allocation, zero copy.
-
-### 3. Zero-initializing buffers that will be immediately overwritten
-
-**Bad:** `vec![0.0; n]` followed by a loop that overwrites every element.
-
-**Good:** `Vec::with_capacity(n)` + `unsafe { set_len(n) }` if you will write all elements, or avoid allocation entirely (see #2).
-
-### 4. Per-element index multiplication in inner loops
-
-**Bad:**
-```rust
-for j in 0..n {
-    for i in 0..m {
-        let off = i as isize * row_stride + j as isize * col_stride;
-        *ptr.offset(off) *= beta;
-    }
-}
-```
-
-**Good:** Use incremental pointer offsets:
-```rust
-let mut col_off = 0isize;
-for _ in 0..n {
-    let mut off = col_off;
-    for _ in 0..m {
-        *ptr.offset(off) *= beta;
-        off += row_stride;
-    }
-    col_off += col_stride;
-}
-```
-
-### 5. Allocating Vec inside hot loops
-
-**Bad:**
-```rust
-for_each_index(&dims, |idx| {
-    for i in 0..n {
-        let buf = vec![0usize; rank];  // ALLOCATION PER ITERATION
-        // ...
-    }
-});
-```
-
-**Good:** Pre-allocate outside and reuse with `.fill(0)`:
-```rust
-let mut buf = vec![0usize; rank];
-for_each_index(&dims, |idx| {
-    for i in 0..n {
-        buf.fill(0);
-        // ...
-    }
-});
-```
-
-### 6. Calling `Backend::plan()` inside hot loops
-
-**Bad:** Computing plans per-step inside the execution loop.
-
-**Good:** Pre-compute all plans before the loop and pass them in.
 
 ## Workspace Architecture
 

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -1,5 +1,8 @@
 # Repository Rules
 
+These are tenferro-specific rules. Apply them on top of the shared Tensor4all
+rules from `tensor4all-agent-rules`.
+
 ## Public Surface Drift
 
 - `README`, rustdoc, and examples must not claim capabilities beyond the current public surface.
@@ -56,7 +59,9 @@
 - Do not add ad hoc fixes that violate DRY, KISS, or layering.
 - Do not introduce compatibility shims, duplicated logic, or downstream reach-through into lower layers when the correct fix belongs in an existing seam or high-level API.
 
-## Complexity Budget
+## Performance And Layout Rules
+
+### Complexity Budget
 
 - Do not introduce accidental `O(n^2)` behavior in graph construction,
   metadata propagation, key hashing/equality, compilation, or execution
@@ -69,7 +74,132 @@
 - When optimizing compiler or graph-build overhead, measure scaling across
   increasing graph sizes, not only one fixed benchmark case.
 
-## Cache Ownership
+### Materialization And Copies
+
+- Production tensor paths must not silently materialize dense temporary buffers
+  whose memory or time scales with an unconstrained product of tensor
+  dimensions. Dense/reference implementations are allowed only when the API is
+  explicitly named and documented as dense, reference, or debug behavior.
+- Avoid dense copy-in/copy-out around operations that can consume strided
+  views, borrowed slices, backend-native buffers, or metadata-only layout
+  changes.
+- Do not introduce hidden CPU-GPU transfers. Follow the public device-transfer
+  policy: callers explicitly upload/download tensors, while execution pipeline
+  internals may move constants or scalar metadata only where the backend
+  contract documents that behavior.
+- When a copy or materialization is required by an output contiguity contract,
+  backend limitation, or external ABI boundary, make that boundary explicit in
+  the implementation and cover it with tests.
+
+### Dense Layout And Linear Algebra
+
+- tenferro uses column-major (Fortran order) dense storage: the leftmost
+  dimension has the smallest stride and varies fastest in memory.
+- Public flat-buffer constructors, exports, examples, FFI contracts, and docs
+  must state or preserve column-major semantics.
+- Do not add row-major compatibility shims or hidden row-major round-trips in
+  library code. If external data is naturally row-shaped, convert privately at
+  that explicit boundary.
+- For batched GEMM-style layouts, put contraction/compute dimensions on the
+  left and batch dimensions on the right. In column-major storage, this keeps
+  each batch slice contiguous for the GEMM kernel.
+- Use existing tensor/backend abstractions for GEMM, einsum, and dense linear
+  algebra. Do not reimplement linalg kernels locally in downstream layers when
+  the CPU/GPU backend already owns the operation.
+
+### Range Checks And Slicing
+
+- Public indexing and slicing APIs must validate rank, bounds, steps, output
+  shape, and empty/singleton boundary behavior at the API boundary or planning
+  boundary.
+- After validation, hot loops and kernels should not repeat the same range
+  checks per element. Carry validated shape/stride/offset metadata into the
+  inner implementation instead.
+- Prefer safe Rust patterns that help LLVM eliminate bounds checks: iterate
+  over slices directly, slice once before the loop, use `chunks_exact` when the
+  chunk size divides the length, and add explicit pre-loop assertions for
+  validated index ranges. Use unchecked indexing only as a last resort.
+- Prefer metadata-only slices, strided views, or backend-native slice kernels
+  over dense copies. If a slice must allocate, document and test the reason.
+- Slice, reshape, transpose, gather, scatter, pad, concatenate, and reverse
+  implementations must preserve column-major shape/stride/offset semantics.
+- If unchecked indexing or unsafe pointer access is used after validation, keep
+  the validation invariant close to the unsafe block and add tests for full
+  range, empty or singleton slices, lower and upper boundaries, out-of-range
+  errors, rank mismatch, and non-contiguous slices.
+
+### CPU Kernel Implementation
+
+- No naive CPU loop fallbacks. CPU tensor kernels must use optimized
+  implementations unless the operation is explicitly listed as an exception
+  below.
+- Required CPU implementations by operation category:
+
+  | Category | Required implementation |
+  |---|---|
+  | Elementwise (`add`, `mul`, `neg`, `exp`, ...) | `strided-kernel` (`map_into`, `zip_map2_into`, etc.) |
+  | Reduction (`reduce_sum`, `reduce_prod`, ...) | `strided-kernel` (`reduce`, `reduce_axis`) |
+  | Structural (`transpose`, `broadcast`, `extract_diag`) | `strided-kernel` (`permute` + `copy_into`, `broadcast`, `diagonal_view`) |
+  | GEMM (`dot_general`) | faer (`cpu-faer`) or BLAS (`cpu-blas`) |
+  | Linalg (`svd`, `qr`, `cholesky`, `eigh`, `solve`) | faer (`cpu-faer`) or LAPACK (`cpu-blas`) |
+
+- Exceptions with dedicated implementations are `reshape` (metadata-only),
+  `embed_diagonal`, and indexing ops such as gather, scatter, slice, pad,
+  concatenate, and reverse.
+- Exactly one CPU backend must be enabled at build time (`cpu-faer` or
+  `cpu-blas`). Both disabled or both enabled must fail at compile time.
+
+### Faer Integration
+
+- Prefer zero-copy `faer::MatRef` / `faer::MatMut` views over packing data into
+  temporary dense matrices. Validate shape, bounds, alignment, and aliasing
+  before constructing unsafe raw faer views.
+- Feed faer column-major-friendly layouts whenever possible. For faer dense
+  linalg, row stride `1` is the preferred contiguous layout; generic-stride
+  inputs that trigger faer performance warnings must be justified or converted
+  deliberately at an explicit boundary.
+- Pass faer parallelism through `CpuContext` only. Do not choose `Par::Rayon`
+  or thread counts independently inside operation helpers.
+- For linalg scratch space, compute scratch requirements before execution and
+  allocate reusable scratch once for the operation. Avoid repeated `Vec`
+  allocation in decomposition, solve, or batched inner loops.
+
+### Performance Anti-Patterns
+
+- Do not duplicate `f64`/`f32`/complex function bodies. Use generic helpers,
+  traits, or macros, and keep any unavoidable dtype dispatch isolated at the
+  outer boundary.
+- Do not allocate dense buffers when strided or backend-native access is
+  available.
+- Do not zero-initialize buffers that will be fully overwritten.
+- Avoid per-element index multiplication in hot loops; use incremental pointer
+  offsets or precomputed strides.
+- Do not allocate `Vec` or other heap buffers inside hot loops. Pre-allocate
+  and reuse scratch buffers.
+- Do not call `Backend::plan()` or equivalent planning APIs inside execution
+  loops. Pre-compute plans before the loop and pass them in.
+
+### Performance-Sensitive Tests And Benchmarks
+
+- Small reference tests may materialize dense tensors, but should materialize
+  each full result once and compare the whole result. Avoid per-element
+  re-contraction, re-evaluation, or repeated graph execution as the comparison
+  mechanism.
+- Long regression tests should be sized so accidental dense materialization,
+  accidental `O(n^2)` graph work, or unexpected copies fail quickly while the
+  intended algorithm remains cheap.
+- For approximate equality, report a useful residual such as an absolute max
+  error or relative norm error so performance-related failures remain
+  diagnosable.
+- Use release-mode benchmarks for performance claims. Prefer Criterion-style
+  benchmarks for microbenchmarks, wrap benchmark inputs and outputs with
+  `std::hint::black_box` where needed, and pin relevant thread counts when
+  comparing CPU behavior.
+- Benchmark scaling across representative tensor sizes, shapes, layouts, and
+  thread counts. A single fixed-size speedup is not enough evidence for a
+  performance-sensitive change.
+
+### Cache Ownership
 
 - Long-lived runtime/compiler caches must be owned by `Engine` or another
   explicit top-level runtime object, not hidden in thread-local/global state or
@@ -87,14 +217,14 @@
   capacity, memory behavior, entry/byte accounting, and
   clear/configuration/stats path.
 
-## CPU Threading Contract
+### CPU Threading Contract
 
 - For faer-backed CPU ops, `CpuContext` is the single source of truth for thread-pool policy.
 - Do not derive faer parallelism independently inside individual ops or helper functions.
 - Execute faer-backed work only inside `ctx.install(...)` so the owned rayon context is preserved.
 - Use `Par::Seq` for one-thread contexts and `Par::rayon(0)` for multi-thread contexts so faer follows the current `CpuContext`.
 
-## GPU Backend Contract
+### GPU Backend Contract
 
 - Before touching CubeCL/GPU backend code, read
   [`docs/design/gpu-backend-design.md`](docs/design/gpu-backend-design.md).

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -9,6 +9,7 @@
     "tenferro-cubecl/src/elementwise.rs",
     "tenferro-cubecl/src/helpers.rs",
     "tenferro-cubecl/src/indexing.rs",
+    "tenferro-cubecl/src/linalg.rs",
     "tenferro-cubecl/src/reduce/kernels.rs",
     "tenferro-cubecl/src/reduce/launch.rs",
     "tenferro-cubecl/src/structural.rs"

--- a/tenferro-cubecl/src/helpers.rs
+++ b/tenferro-cubecl/src/helpers.rs
@@ -6,39 +6,6 @@ pub(crate) fn zero_value<E: CubePrimitive>() -> E {
 }
 
 #[cube]
-pub(crate) fn flat_to_multi_index(
-    mut flat: usize,
-    #[comptime] shape: Sequence<usize>,
-) -> Array<usize> {
-    let rank = shape.len();
-    let mut indices = Array::<usize>::new(rank);
-    #[unroll]
-    for axis in 0..rank {
-        let dim = comptime! { *shape.index(axis) };
-        indices[axis] = flat % dim;
-        flat /= dim;
-    }
-    indices
-}
-
-#[cube]
-pub(crate) fn multi_to_flat_index(
-    indices: &Array<usize>,
-    #[comptime] shape: Sequence<usize>,
-) -> usize {
-    let rank = shape.len();
-    let mut offset = 0usize;
-    let mut stride = 1usize;
-    #[unroll]
-    for axis in 0..rank {
-        let dim = comptime! { *shape.index(axis) };
-        offset += indices[axis] * stride;
-        stride *= dim;
-    }
-    offset
-}
-
-#[cube]
 pub(crate) fn flat_to_tensor_index<E: CubePrimitive>(
     flat: usize,
     tensor: &Tensor<E>,
@@ -90,15 +57,4 @@ pub(crate) fn axis_position_in_sequence(#[comptime] axes: Sequence<usize>, axis:
         }
     }
     found
-}
-
-#[cube]
-pub(crate) fn shape_product(#[comptime] shape: Sequence<usize>) -> usize {
-    let mut total = 1usize;
-    let rank = shape.len();
-    #[unroll]
-    for axis in 0..rank {
-        total *= comptime! { *shape.index(axis) };
-    }
-    total
 }

--- a/tenferro-cubecl/src/indexing.rs
+++ b/tenferro-cubecl/src/indexing.rs
@@ -1,15 +1,19 @@
 use cubecl::prelude::*;
 
 use crate::helpers::{
-    axis_in_sequence, axis_position_in_sequence, flat_to_multi_index, flat_to_tensor_index,
-    multi_to_tensor_index, shape_product, zero_value,
+    axis_in_sequence, axis_position_in_sequence, flat_to_tensor_index, multi_to_tensor_index,
+    zero_value,
 };
 
 #[cube]
-pub(crate) fn clamp_window_start<I: Float>(start: I, dim_size: usize, window_size: usize) -> usize {
+pub(crate) fn clamp_window_start<I: Numeric + CubePrimitive>(
+    start: I,
+    dim_size: usize,
+    window_size: usize,
+) -> usize {
     let max_start = dim_size - window_size;
     let mut clamped = max_start;
-    if start <= I::new(0.0) {
+    if start <= I::from_int(0) {
         clamped = 0usize;
     } else {
         let raw = usize::cast_from(start);
@@ -21,7 +25,7 @@ pub(crate) fn clamp_window_start<I: Float>(start: I, dim_size: usize, window_siz
 }
 
 #[cube]
-pub(crate) fn index_component<I: Float>(
+pub(crate) fn index_component<I: Numeric + CubePrimitive>(
     indices: &Tensor<I>,
     batch_idx: &Array<usize>,
     #[comptime] index_vector_dim: usize,
@@ -46,6 +50,68 @@ pub(crate) fn index_component<I: Float>(
     }
 }
 
+#[cube]
+pub(crate) fn flat_to_index_batch_index<I: CubePrimitive>(
+    mut flat: usize,
+    indices: &Tensor<I>,
+    #[comptime] index_vector_dim: usize,
+    #[comptime] indices_rank: usize,
+) -> Array<usize> {
+    let batch_rank = comptime! {
+        if index_vector_dim < indices_rank {
+            indices_rank - 1
+        } else {
+            indices_rank
+        }
+    };
+    let batch_buf_len = if batch_rank == 0 { 1 } else { batch_rank };
+    let mut batch_idx = Array::<usize>::new(batch_buf_len);
+    let mut batch_axis = 0usize;
+    #[unroll]
+    for axis in 0..indices_rank {
+        if axis != index_vector_dim {
+            let dim = indices.shape(axis);
+            batch_idx[batch_axis] = flat % dim;
+            flat /= dim;
+            batch_axis += 1;
+        }
+    }
+    batch_idx
+}
+
+#[cube]
+pub(crate) fn flat_to_update_window_index<E: CubePrimitive>(
+    mut flat: usize,
+    updates: &Tensor<E>,
+    #[comptime] update_window_dims: Sequence<usize>,
+) -> Array<usize> {
+    let window_rank = update_window_dims.len();
+    let window_buf_len = if window_rank == 0 { 1 } else { window_rank };
+    let mut window_idx = Array::<usize>::new(window_buf_len);
+    #[unroll]
+    for pos in 0..window_rank {
+        let axis = comptime! { *update_window_dims.index(pos) };
+        let dim = updates.shape(axis);
+        window_idx[pos] = flat % dim;
+        flat /= dim;
+    }
+    window_idx
+}
+
+#[cube]
+pub(crate) fn update_window_len<E: CubePrimitive>(
+    updates: &Tensor<E>,
+    #[comptime] update_window_dims: Sequence<usize>,
+) -> usize {
+    let mut total = 1usize;
+    #[unroll]
+    for pos in 0..update_window_dims.len() {
+        let axis = comptime! { *update_window_dims.index(pos) };
+        total *= updates.shape(axis);
+    }
+    total
+}
+
 #[cube(launch_unchecked)]
 pub fn slice_kernel<E: CubePrimitive>(
     out: &mut Tensor<E>,
@@ -67,7 +133,7 @@ pub fn slice_kernel<E: CubePrimitive>(
 }
 
 #[cube(launch_unchecked)]
-pub fn dynamic_slice_kernel<E: CubePrimitive, I: Float>(
+pub fn dynamic_slice_kernel<E: CubePrimitive, I: Numeric + CubePrimitive>(
     out: &mut Tensor<E>,
     input: &Tensor<E>,
     starts: &Tensor<I>,
@@ -125,11 +191,10 @@ pub fn pad_kernel<E: CubePrimitive>(
 }
 
 #[cube(launch_unchecked)]
-pub fn gather_kernel<E: CubePrimitive, I: Float>(
+pub fn gather_kernel<E: CubePrimitive, I: Numeric + CubePrimitive>(
     out: &mut Tensor<E>,
     operand: &Tensor<E>,
     start_indices: &Tensor<I>,
-    #[comptime] batch_shape: Sequence<usize>,
     #[comptime] window_dims: Sequence<usize>,
     #[comptime] offset_dims: Sequence<usize>,
     #[comptime] start_index_map: Sequence<usize>,
@@ -141,8 +206,15 @@ pub fn gather_kernel<E: CubePrimitive, I: Float>(
 ) {
     if ABSOLUTE_POS < out.len() {
         let out_idx = flat_to_tensor_index(ABSOLUTE_POS, out, out_rank);
-        let batch_rank = batch_shape.len();
-        let mut batch_idx = Array::<usize>::new(batch_rank);
+        let batch_rank = comptime! {
+            if index_vector_dim < start_indices_rank {
+                start_indices_rank - 1
+            } else {
+                start_indices_rank
+            }
+        };
+        let batch_buf_len = if batch_rank == 0 { 1 } else { batch_rank };
+        let mut batch_idx = Array::<usize>::new(batch_buf_len);
         let mut window_offsets = Array::<usize>::new(operand_rank);
         #[unroll]
         for axis in 0..operand_rank {
@@ -204,52 +276,36 @@ pub fn scatter_copy_kernel<E: CubePrimitive>(out: &mut Tensor<E>, operand: &Tens
 }
 
 #[cube(launch_unchecked)]
-pub fn scatter_float_kernel<E: Float, I: Float>(
+pub fn scatter_float_kernel<E: Float, I: Numeric + CubePrimitive>(
     out: &mut Tensor<Atomic<E>>,
     operand: &Tensor<E>,
     scatter_indices: &Tensor<I>,
     updates: &Tensor<E>,
-    #[comptime] batch_shape: Sequence<usize>,
     #[comptime] window_dims: Sequence<usize>,
     #[comptime] update_window_dims: Sequence<usize>,
     #[comptime] scatter_dims_to_operand_dims: Sequence<usize>,
     #[comptime] index_vector_dim: usize,
-    #[comptime] window_shape_updates: Sequence<usize>,
     #[comptime] operand_rank: usize,
     #[comptime] updates_rank: usize,
     #[comptime] scatter_indices_rank: usize,
 ) {
-    let batch_iters = shape_product(batch_shape.clone());
-    let window_iters = shape_product(window_shape_updates.clone());
-    let update_iters = batch_iters * window_iters;
+    let window_iters = update_window_len(updates, update_window_dims.clone());
+    let update_iters = updates.len();
     if ABSOLUTE_POS < update_iters {
         let batch_flat = ABSOLUTE_POS / window_iters;
         let window_flat = ABSOLUTE_POS % window_iters;
-        let batch_rank = batch_shape.len();
-        let batch_buf_len = if batch_rank == 0 { 1 } else { batch_rank };
-        let window_rank = window_shape_updates.len();
-        let window_buf_len = if window_rank == 0 { 1 } else { window_rank };
-        let mut batch_idx = Array::<usize>::new(batch_buf_len);
-        let mut window_idx = Array::<usize>::new(window_buf_len);
+        let batch_idx = flat_to_index_batch_index(
+            batch_flat,
+            scatter_indices,
+            index_vector_dim,
+            scatter_indices_rank,
+        );
+        let window_idx =
+            flat_to_update_window_index(window_flat, updates, update_window_dims.clone());
         let mut update_idx = Array::<usize>::new(updates_rank);
         let mut operand_base = Array::<usize>::new(operand_rank);
         let mut operand_idx = Array::<usize>::new(operand_rank);
         let mut window_shape = Array::<usize>::new(operand_rank);
-
-        if batch_rank > 0 {
-            let next_batch_idx = flat_to_multi_index(batch_flat, batch_shape.clone());
-            #[unroll]
-            for axis in 0..batch_rank {
-                batch_idx[axis] = next_batch_idx[axis];
-            }
-        }
-        if window_rank > 0 {
-            let next_window_idx = flat_to_multi_index(window_flat, window_shape_updates.clone());
-            #[unroll]
-            for axis in 0..window_rank {
-                window_idx[axis] = next_window_idx[axis];
-            }
-        }
 
         #[unroll]
         for axis in 0..operand_rank {
@@ -260,7 +316,8 @@ pub fn scatter_float_kernel<E: Float, I: Float>(
         #[unroll]
         for pos in 0..window_dims.len() {
             let operand_axis = comptime! { *window_dims.index(pos) };
-            window_shape[operand_axis] = comptime! { *window_shape_updates.index(pos) };
+            let update_axis = comptime! { *update_window_dims.index(pos) };
+            window_shape[operand_axis] = updates.shape(update_axis);
         }
 
         let mut window_fits = true;
@@ -274,7 +331,7 @@ pub fn scatter_float_kernel<E: Float, I: Float>(
                 component,
                 scatter_indices_rank,
             );
-            if start < I::new(0.0) {
+            if start < I::from_int(0) {
                 window_fits = false;
             } else {
                 operand_base[operand_dim] = usize::cast_from(start);
@@ -320,53 +377,37 @@ pub fn scatter_float_kernel<E: Float, I: Float>(
 }
 
 #[cube(launch_unchecked)]
-pub fn scatter_complex_kernel<E: Complex, F: Float, I: Float>(
+pub fn scatter_complex_kernel<E: Complex, F: Float, I: Numeric + CubePrimitive>(
     out_parts: &mut Array<Atomic<F>>,
     operand: &Tensor<E>,
     scatter_indices: &Tensor<I>,
     updates: &Tensor<E>,
     update_parts: &Array<F>,
-    #[comptime] batch_shape: Sequence<usize>,
     #[comptime] window_dims: Sequence<usize>,
     #[comptime] update_window_dims: Sequence<usize>,
     #[comptime] scatter_dims_to_operand_dims: Sequence<usize>,
     #[comptime] index_vector_dim: usize,
-    #[comptime] window_shape_updates: Sequence<usize>,
     #[comptime] operand_rank: usize,
     #[comptime] updates_rank: usize,
     #[comptime] scatter_indices_rank: usize,
 ) {
-    let batch_iters = shape_product(batch_shape.clone());
-    let window_iters = shape_product(window_shape_updates.clone());
-    let update_iters = batch_iters * window_iters;
+    let window_iters = update_window_len(updates, update_window_dims.clone());
+    let update_iters = updates.len();
     if ABSOLUTE_POS < update_iters {
         let batch_flat = ABSOLUTE_POS / window_iters;
         let window_flat = ABSOLUTE_POS % window_iters;
-        let batch_rank = batch_shape.len();
-        let batch_buf_len = if batch_rank == 0 { 1 } else { batch_rank };
-        let window_rank = window_shape_updates.len();
-        let window_buf_len = if window_rank == 0 { 1 } else { window_rank };
-        let mut batch_idx = Array::<usize>::new(batch_buf_len);
-        let mut window_idx = Array::<usize>::new(window_buf_len);
+        let batch_idx = flat_to_index_batch_index(
+            batch_flat,
+            scatter_indices,
+            index_vector_dim,
+            scatter_indices_rank,
+        );
+        let window_idx =
+            flat_to_update_window_index(window_flat, updates, update_window_dims.clone());
         let mut update_idx = Array::<usize>::new(updates_rank);
         let mut operand_base = Array::<usize>::new(operand_rank);
         let mut operand_idx = Array::<usize>::new(operand_rank);
         let mut window_shape = Array::<usize>::new(operand_rank);
-
-        if batch_rank > 0 {
-            let next_batch_idx = flat_to_multi_index(batch_flat, batch_shape.clone());
-            #[unroll]
-            for axis in 0..batch_rank {
-                batch_idx[axis] = next_batch_idx[axis];
-            }
-        }
-        if window_rank > 0 {
-            let next_window_idx = flat_to_multi_index(window_flat, window_shape_updates.clone());
-            #[unroll]
-            for axis in 0..window_rank {
-                window_idx[axis] = next_window_idx[axis];
-            }
-        }
 
         #[unroll]
         for axis in 0..operand_rank {
@@ -377,7 +418,8 @@ pub fn scatter_complex_kernel<E: Complex, F: Float, I: Float>(
         #[unroll]
         for pos in 0..window_dims.len() {
             let operand_axis = comptime! { *window_dims.index(pos) };
-            window_shape[operand_axis] = comptime! { *window_shape_updates.index(pos) };
+            let update_axis = comptime! { *update_window_dims.index(pos) };
+            window_shape[operand_axis] = updates.shape(update_axis);
         }
 
         let mut window_fits = true;
@@ -391,7 +433,7 @@ pub fn scatter_complex_kernel<E: Complex, F: Float, I: Float>(
                 component,
                 scatter_indices_rank,
             );
-            if start < I::new(0.0) {
+            if start < I::from_int(0) {
                 window_fits = false;
             } else {
                 operand_base[operand_dim] = usize::cast_from(start);

--- a/tenferro-cubecl/src/lib.rs
+++ b/tenferro-cubecl/src/lib.rs
@@ -23,6 +23,8 @@ mod helpers;
 #[doc(hidden)]
 pub mod indexing;
 #[doc(hidden)]
+pub mod linalg;
+#[doc(hidden)]
 pub mod structural;
 
 pub use error::{CubeclKernelError, Result};

--- a/tenferro-cubecl/src/linalg.rs
+++ b/tenferro-cubecl/src/linalg.rs
@@ -1,0 +1,117 @@
+use cubecl::prelude::*;
+
+use crate::helpers::zero_value;
+
+#[cube]
+fn one_value<E: CubePrimitive>() -> E {
+    E::cast_from(1u32)
+}
+
+#[cube]
+fn batch_linear_index<E: CubePrimitive>(
+    tensor: &Tensor<E>,
+    flat: usize,
+    #[comptime] matrix_rank: usize,
+    #[comptime] rank: usize,
+) -> usize {
+    let mut batch = 0usize;
+    let mut stride = 1usize;
+    #[unroll]
+    for axis in matrix_rank..rank {
+        let coord = tensor.coordinate(flat, axis);
+        batch += coord * stride;
+        stride *= tensor.shape(axis);
+    }
+    batch
+}
+
+#[cube]
+fn matching_work_offset<Work: CubePrimitive, Out: CubePrimitive>(
+    work: &Tensor<Work>,
+    out: &Tensor<Out>,
+    flat: usize,
+    row: usize,
+    col: usize,
+    #[comptime] rank: usize,
+) -> usize {
+    let mut offset = row * work.stride(0usize) + col * work.stride(1usize);
+    #[unroll]
+    for axis in 2usize..rank {
+        let coord = out.coordinate(flat, axis);
+        offset += coord * work.stride(axis);
+    }
+    offset
+}
+
+#[cube(launch_unchecked)]
+pub fn lu_extract_outputs<E: CubePrimitive + core::ops::Neg<Output = E>>(
+    p_out: &mut Tensor<E>,
+    l_out: &mut Tensor<E>,
+    u_out: &mut Tensor<E>,
+    parity_out: &mut Tensor<E>,
+    work: &Tensor<E>,
+    pivots: &Array<u32>,
+    #[comptime] k: usize,
+    #[comptime] rank: usize,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < p_out.len() {
+        let row = p_out.coordinate(pos, 0usize);
+        let col = p_out.coordinate(pos, 1usize);
+        let batch = batch_linear_index(p_out, pos, 2usize, rank);
+        let mut final_row = col as u32;
+        #[unroll]
+        for step in 0usize..k {
+            let step_u32 = step as u32;
+            let pivot = pivots[step + batch * k] - 1u32;
+            if final_row == step_u32 {
+                final_row = pivot;
+            } else if final_row == pivot {
+                final_row = step_u32;
+            }
+        }
+        p_out[pos] = if final_row == row as u32 {
+            one_value::<E>()
+        } else {
+            zero_value::<E>()
+        };
+    }
+
+    if pos < l_out.len() {
+        let row = l_out.coordinate(pos, 0usize);
+        let col = l_out.coordinate(pos, 1usize);
+        l_out[pos] = if row < col {
+            zero_value::<E>()
+        } else if row == col {
+            one_value::<E>()
+        } else {
+            let work_offset = matching_work_offset(work, l_out, pos, row, col, rank);
+            work[work_offset]
+        };
+    }
+
+    if pos < u_out.len() {
+        let row = u_out.coordinate(pos, 0usize);
+        let col = u_out.coordinate(pos, 1usize);
+        u_out[pos] = if row <= col {
+            let work_offset = matching_work_offset(work, u_out, pos, row, col, rank);
+            work[work_offset]
+        } else {
+            zero_value::<E>()
+        };
+    }
+
+    if pos < parity_out.len() {
+        let batch = pos;
+        let mut sign = one_value::<E>();
+        #[unroll]
+        for step in 0usize..k {
+            let step_u32 = step as u32;
+            let pivot = pivots[step + batch * k] - 1u32;
+            if pivot != step_u32 {
+                sign = -sign;
+            }
+        }
+        parity_out[pos] = sign;
+    }
+}

--- a/tenferro-cubecl/tests/kernel_metadata_contract.rs
+++ b/tenferro-cubecl/tests/kernel_metadata_contract.rs
@@ -5,16 +5,19 @@ fn logical_kernels_do_not_take_tensor_shapes_as_comptime_parameters() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let files = [
         root.join("diagonal.rs"),
+        root.join("helpers.rs"),
         root.join("indexing.rs"),
         root.join("structural.rs"),
     ];
     let banned = [
+        "#[comptime] batch_shape",
         "#[comptime] input_shape",
         "#[comptime] output_shape",
         "#[comptime] operand_shape",
         "#[comptime] updates_shape",
         "#[comptime] scatter_indices_shape",
         "#[comptime] start_indices_shape",
+        "#[comptime] window_shape_updates",
         "#[comptime] shape: Sequence<usize>",
     ];
 
@@ -31,6 +34,41 @@ fn logical_kernels_do_not_take_tensor_shapes_as_comptime_parameters() {
     assert!(
         violations.is_empty(),
         "logical CubeCL kernels must receive tensor shape/stride through TensorBinding, not comptime shape parameters:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+#[ignore = "tracked in https://github.com/tensor4all/tenferro-rs/issues/881"]
+fn reduction_kernels_do_not_hide_unbounded_axis_work_in_one_worker() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let launch_source = fs::read_to_string(root.join("reduce").join("launch.rs"))
+        .expect("reduction launch source should be readable");
+    let kernels_source = fs::read_to_string(root.join("reduce").join("kernels.rs"))
+        .expect("reduction kernel source should be readable");
+    let checks = [
+        (
+            "reduce/launch.rs",
+            launch_source.as_str(),
+            "ReduceStrategy::Auto | ReduceStrategy::Unit",
+        ),
+        (
+            "reduce/kernels.rs",
+            kernels_source.as_str(),
+            "for reduce_index in 1..reduce_len",
+        ),
+    ];
+
+    let mut violations = Vec::new();
+    for (name, source, needle) in checks {
+        if source.contains(needle) {
+            violations.push(format!("{name} contains {needle}"));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "CubeCL reductions must not route Auto to a per-output worker with unbounded serial axis work; use a parallel reduction strategy or an explicitly bounded fallback:\n{}",
         violations.join("\n")
     );
 }

--- a/tenferro-tensor/src/cubecl/linalg.rs
+++ b/tenferro-tensor/src/cubecl/linalg.rs
@@ -3,11 +3,16 @@ use std::ops::Neg;
 use std::os::raw::c_char;
 
 use cubecl::prelude::{CubeElement, CubePrimitive};
+use cubecl_cuda::CudaRuntime;
 use cudarc::runtime::{result as cuda_result, sys::cudaStream_t};
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
+use tenferro_cubecl::linalg as cubecl_linalg;
 
-use super::dispatch::{alloc_output, cubecl_buffer, typed_from_cubecl};
+use super::dispatch::{
+    alloc_output, cube_count_for_len, cube_dim_1d, cubecl_buffer, typed_from_cubecl,
+    typed_tensor_array_arg, typed_tensor_binding,
+};
 use super::ffi::cusolver::{
     CublasDiagType, CublasFillMode, CublasOperation, CublasSideMode, CudaDataType, CudaStream,
     CusolverEigMode,
@@ -457,13 +462,18 @@ where
         .cusolver()
         .getrf_buffer_size(T::DATA_TYPE, m_i32, n_i32, a_ptr, lda, OP)?;
     let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
-    let pivots = alloc_workspace_bytes(backend.runtime(), k * std::mem::size_of::<i32>(), OP)?;
-    let info = alloc_workspace_bytes(backend.runtime(), std::mem::size_of::<i32>(), OP)?;
+    let mut pivot_shape = vec![k];
+    pivot_shape.extend_from_slice(&input.shape[2..]);
+    let pivots = alloc_output::<u32>(backend.runtime(), &pivot_shape);
+    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let pivots_ptr = typed_device_ptr(backend.runtime(), &pivots, OP)?;
+    let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let matrix_stride = m * n;
-    let mut all_pivots = vec![0_i32; k * batch_total];
 
     for batch in 0..batch_total {
         let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * matrix_stride) };
+        let batch_pivots = unsafe { batch_ptr::<u32>(pivots_ptr, batch * k) };
+        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch) };
         unsafe {
             handles.cusolver().getrf(
                 T::DATA_TYPE,
@@ -472,36 +482,27 @@ where
                 batch_a,
                 lda,
                 workspace.ptr,
-                pivots.ptr.cast::<i32>(),
-                info.ptr.cast::<i32>(),
+                batch_pivots.cast::<i32>(),
+                batch_info.cast::<i32>(),
                 OP,
             )?;
         }
+    }
 
-        let batch_pivots = &mut all_pivots[batch * k..(batch + 1) * k];
-        copy_device_to_host(backend.runtime(), batch_pivots, pivots.ptr.cast_const(), OP)?;
-        let mut host_info = [0_i32; 1];
-        copy_device_to_host(backend.runtime(), &mut host_info, info.ptr.cast_const(), OP)?;
-        if host_info[0] < 0 {
+    let host_info = download_device_tensor(backend.runtime(), &info, OP)?;
+    for &info_value in host_info.host_data() {
+        if info_value < 0 {
             return Err(crate::Error::BackendFailure {
                 op: OP,
                 message: format!(
                     "cusolverDn*getrf reported invalid parameter {}",
-                    -host_info[0]
+                    -info_value
                 ),
             });
         }
     }
 
-    sync_stream(backend.runtime(), OP)?;
-    let host_lu = download_device_tensor(backend.runtime(), &work, OP)?;
-    let (p, l, u, parity) = build_lu_outputs_host(&host_lu, &all_pivots)?;
-    Ok((
-        upload_host_tensor(backend.runtime(), p)?,
-        upload_host_tensor(backend.runtime(), l)?,
-        upload_host_tensor(backend.runtime(), u)?,
-        upload_host_tensor(backend.runtime(), parity)?,
-    ))
+    build_lu_outputs_device(backend.runtime(), &work, &pivots, m, n, &input.shape[2..])
 }
 
 fn svd_typed<T>(
@@ -782,9 +783,13 @@ where
     Ok((values, work))
 }
 
-fn build_lu_outputs_host<T>(
+fn build_lu_outputs_device<T>(
+    rt: &CubeclRuntime,
     lu: &TypedTensor<T>,
-    pivots: &[i32],
+    pivots: &TypedTensor<u32>,
+    m: usize,
+    n: usize,
+    batch_shape: &[usize],
 ) -> crate::Result<(
     TypedTensor<T>,
     TypedTensor<T>,
@@ -794,11 +799,7 @@ fn build_lu_outputs_host<T>(
 where
     T: LinalgScalar,
 {
-    let (m, n) = matrix_dims("lu", &lu.shape)?;
     let k = m.min(n);
-    let batch_shape = &lu.shape[2..];
-    let batch_total = batch_count(batch_shape);
-    let matrix_stride = m * n;
     let mut p_shape = vec![m, m];
     p_shape.extend_from_slice(batch_shape);
     let mut l_shape = vec![m, k];
@@ -806,72 +807,44 @@ where
     let mut u_shape = vec![k, n];
     u_shape.extend_from_slice(batch_shape);
     let parity_shape = batch_shape.to_vec();
-    let mut p_data = vec![T::zero(); m * m * batch_total];
-    let mut l_data = vec![T::zero(); m * k * batch_total];
-    let mut u_data = vec![T::zero(); k * n * batch_total];
-    let mut parity_data = vec![T::one(); batch_total.max(1)];
 
-    for batch in 0..batch_total {
-        let batch_lu = &lu.host_data()[batch * matrix_stride..(batch + 1) * matrix_stride];
-        let batch_pivots = &pivots[batch * k..(batch + 1) * k];
-        let mut perm = (0..m).collect::<Vec<_>>();
-        let mut parity = T::one();
-        for (step, &pivot_1indexed) in batch_pivots.iter().enumerate() {
-            let pivot =
-                usize::try_from(pivot_1indexed - 1).map_err(|_| crate::Error::BackendFailure {
-                    op: "lu",
-                    message: format!("cuSOLVER returned invalid pivot {pivot_1indexed}"),
-                })?;
-            if pivot >= m {
-                return Err(crate::Error::BackendFailure {
-                    op: "lu",
-                    message: format!(
-                        "cuSOLVER pivot {pivot_1indexed} is out of bounds for {m} rows"
-                    ),
-                });
-            }
-            if pivot != step {
-                perm.swap(step, pivot);
-                parity = -parity;
-            }
-        }
-
-        for row in 0..m {
-            let col = perm[row];
-            let idx = batch * m * m + col_major_index(m, row, col);
-            p_data[idx] = T::one();
-        }
-        for col in 0..k {
-            for row in 0..m {
-                let idx = batch * m * k + col_major_index(m, row, col);
-                l_data[idx] = if row < col {
-                    T::zero()
-                } else if row == col {
-                    T::one()
-                } else {
-                    batch_lu[col_major_index(m, row, col)]
-                };
-            }
-        }
-        for col in 0..n {
-            for row in 0..k {
-                let idx = batch * k * n + col_major_index(k, row, col);
-                u_data[idx] = if row <= col {
-                    batch_lu[col_major_index(m, row, col)]
-                } else {
-                    T::zero()
-                };
-            }
-        }
-        parity_data[if batch_shape.is_empty() { 0 } else { batch }] = parity;
+    let p = alloc_output::<T>(rt, &p_shape);
+    let l = alloc_output::<T>(rt, &l_shape);
+    let u = alloc_output::<T>(rt, &u_shape);
+    let parity = alloc_output::<T>(rt, &parity_shape);
+    let client = rt.client();
+    let launch_len = p
+        .n_elements()
+        .max(l.n_elements())
+        .max(u.n_elements())
+        .max(parity.n_elements());
+    let p_arg = typed_tensor_binding(&p, "lu")?;
+    let l_arg = typed_tensor_binding(&l, "lu")?;
+    let u_arg = typed_tensor_binding(&u, "lu")?;
+    let parity_arg = typed_tensor_binding(&parity, "lu")?;
+    let work_arg = typed_tensor_binding(lu, "lu")?;
+    let pivots_arg = typed_tensor_array_arg(pivots, "lu")?;
+    unsafe {
+        cubecl_linalg::lu_extract_outputs::launch_unchecked::<T, CudaRuntime>(
+            client,
+            cube_count_for_len(launch_len),
+            cube_dim_1d(),
+            p_arg.into_tensor_arg(),
+            l_arg.into_tensor_arg(),
+            u_arg.into_tensor_arg(),
+            parity_arg.into_tensor_arg(),
+            work_arg.into_tensor_arg(),
+            pivots_arg,
+            k,
+            lu.shape.len(),
+        );
     }
+    client.flush().map_err(|err| crate::Error::BackendFailure {
+        op: "lu",
+        message: format!("LU output extraction launch failed: {err:?}"),
+    })?;
 
-    Ok((
-        TypedTensor::from_vec_col_major(p_shape, p_data),
-        TypedTensor::from_vec_col_major(l_shape, l_data),
-        TypedTensor::from_vec_col_major(u_shape, u_data),
-        TypedTensor::from_vec_col_major(parity_shape, parity_data),
-    ))
+    Ok((p, l, u, parity))
 }
 
 fn zero_sized_lu_outputs<T>(
@@ -1178,10 +1151,6 @@ fn has_zero_dim(shape: &[usize]) -> bool {
 
 fn batch_count(batch_shape: &[usize]) -> usize {
     batch_shape.iter().product::<usize>().max(1)
-}
-
-fn col_major_index(rows: usize, row: usize, col: usize) -> usize {
-    row + col * rows
 }
 
 fn as_i32(value: usize, op: &'static str, label: &'static str) -> crate::Result<i32> {

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -80,6 +80,7 @@ use cubecl::client::ComputeClient;
 use cubecl::features::AtomicUsage;
 use cubecl::prelude::{
     ArrayArg, Complex as CubeComplex, CubeElement, CubePrimitive, Float as CubeFloat,
+    Numeric as CubeNumeric,
 };
 use cubecl::prelude::{Int as CubeInt, StorageType, TensorBinding, Type};
 use cubecl_cuda::CudaRuntime;
@@ -91,7 +92,7 @@ use crate::backend::TensorBackend;
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use crate::{Buffer, Tensor, TypedTensor};
+use crate::{Tensor, TypedTensor};
 
 mod dispatch;
 mod ffi;
@@ -212,39 +213,6 @@ impl CubeclBackend {
     /// ```
     pub fn runtime(&self) -> &CubeclRuntime {
         &self.rt
-    }
-
-    fn i64_indices_as_f64(&self, indices: &TypedTensor<i64>) -> crate::Result<TypedTensor<f64>> {
-        let host_values = match &indices.buffer {
-            Buffer::Host(data) => data.clone(),
-            Buffer::Cubecl(_) => {
-                let downloaded = download_tensor(self.runtime(), &Tensor::I64(indices.clone()))?;
-                downloaded
-                    .as_slice::<i64>()
-                    .expect("downloaded I64 tensor")
-                    .to_vec()
-            }
-            Buffer::Backend(_) => {
-                return Err(crate::Error::BackendFailure {
-                    op: "index_tensor",
-                    message: "backend buffers are not supported for CubeCL index conversion".into(),
-                })
-            }
-        };
-        let converted = Tensor::F64(TypedTensor::from_vec_col_major(
-            indices.shape.clone(),
-            host_values.into_iter().map(|value| value as f64).collect(),
-        ));
-        match &indices.buffer {
-            Buffer::Cubecl(_) => match upload_tensor(self.runtime(), &converted)? {
-                Tensor::F64(tensor) => Ok(tensor),
-                _ => unreachable!("upload preserves dtype"),
-            },
-            _ => match converted {
-                Tensor::F64(tensor) => Ok(tensor),
-                _ => unreachable!("constructed F64 tensor"),
-            },
-        }
     }
 
     fn cutensor_handle(&self) -> crate::Result<&ffi::cutensor::CutensorHandle> {
@@ -1002,7 +970,7 @@ impl CubeclBackend {
     ) -> crate::Result<TypedTensor<T>>
     where
         T: CubeElement + CubePrimitive + Clone,
-        I: CubeElement + CubeFloat + Clone,
+        I: CubeElement + CubePrimitive + CubeNumeric + Clone,
     {
         ensure_rank("dynamic_slice", input.shape.len(), slice_sizes.len())?;
         ensure_rank("dynamic_slice", 1, starts.shape.len())?;
@@ -1114,7 +1082,7 @@ impl CubeclBackend {
     ) -> crate::Result<TypedTensor<T>>
     where
         T: CubeElement + CubePrimitive + Clone,
-        I: CubeElement + CubeFloat + Clone,
+        I: CubeElement + CubePrimitive + CubeNumeric + Clone,
     {
         let meta = gather_launch_meta(&operand.shape, &start_indices.shape, config)?;
         launch_binary_tensor(
@@ -1131,7 +1099,6 @@ impl CubeclBackend {
                     out.into_tensor_arg(),
                     operand_arg.into_tensor_arg(),
                     indices_arg.into_tensor_arg(),
-                    comptime_sequence(&meta.batch_shape),
                     comptime_sequence(&meta.window_dims),
                     comptime_sequence(&config.offset_dims),
                     comptime_sequence(&config.start_index_map),
@@ -1154,7 +1121,7 @@ impl CubeclBackend {
     ) -> crate::Result<TypedTensor<T>>
     where
         T: CubeElement + CubeFloat + Clone,
-        I: CubeElement + CubeFloat + Clone,
+        I: CubeElement + CubePrimitive + CubeNumeric + Clone,
     {
         let meta = scatter_launch_meta(
             &operand.shape,
@@ -1209,12 +1176,10 @@ impl CubeclBackend {
                 operand_arg.into_tensor_arg(),
                 scatter_arg.into_tensor_arg(),
                 updates_arg.into_tensor_arg(),
-                comptime_sequence(&meta.batch_shape),
                 comptime_sequence(&meta.window_dims),
                 comptime_sequence(&config.update_window_dims),
                 comptime_sequence(&config.scatter_dims_to_operand_dims),
                 config.index_vector_dim,
-                comptime_sequence(&meta.window_shape_updates),
                 operand.shape.len(),
                 updates.shape.len(),
                 scatter_indices.shape.len(),
@@ -1233,7 +1198,7 @@ impl CubeclBackend {
     where
         T: CubeElement + CubeComplex + Clone,
         F: CubeElement + CubeFloat + Clone,
-        I: CubeElement + CubeFloat + Clone,
+        I: CubeElement + CubePrimitive + CubeNumeric + Clone,
     {
         let meta = scatter_launch_meta(
             &operand.shape,
@@ -1310,12 +1275,10 @@ impl CubeclBackend {
                 scatter_arg.into_tensor_arg(),
                 updates_arg.into_tensor_arg(),
                 update_parts,
-                comptime_sequence(&meta.batch_shape),
                 comptime_sequence(&meta.window_dims),
                 comptime_sequence(&config.update_window_dims),
                 comptime_sequence(&config.scatter_dims_to_operand_dims),
                 config.index_vector_dim,
-                comptime_sequence(&meta.window_shape_updates),
                 operand.shape.len(),
                 updates.shape.len(),
                 scatter_indices.shape.len(),
@@ -2460,24 +2423,16 @@ impl TensorBackend for CubeclBackend {
                 self.gather_typed(operand, indices, config).map(Tensor::C64)
             }
             (Tensor::F32(operand), Tensor::I64(indices)) => {
-                let indices = self.i64_indices_as_f64(indices)?;
-                self.gather_typed(operand, &indices, config)
-                    .map(Tensor::F32)
+                self.gather_typed(operand, indices, config).map(Tensor::F32)
             }
             (Tensor::F64(operand), Tensor::I64(indices)) => {
-                let indices = self.i64_indices_as_f64(indices)?;
-                self.gather_typed(operand, &indices, config)
-                    .map(Tensor::F64)
+                self.gather_typed(operand, indices, config).map(Tensor::F64)
             }
             (Tensor::C32(operand), Tensor::I64(indices)) => {
-                let indices = self.i64_indices_as_f64(indices)?;
-                self.gather_typed(operand, &indices, config)
-                    .map(Tensor::C32)
+                self.gather_typed(operand, indices, config).map(Tensor::C32)
             }
             (Tensor::C64(operand), Tensor::I64(indices)) => {
-                let indices = self.i64_indices_as_f64(indices)?;
-                self.gather_typed(operand, &indices, config)
-                    .map(Tensor::C64)
+                self.gather_typed(operand, indices, config).map(Tensor::C64)
             }
             (_, Tensor::C32(_) | Tensor::C64(_)) => Err(crate::Error::BackendFailure {
                 op: "gather",
@@ -2519,26 +2474,18 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(operand), Tensor::F64(indices), Tensor::C64(updates)) => self
                 .scatter_complex_typed::<_, f64, _>(operand, indices, updates, config)
                 .map(Tensor::C64),
-            (Tensor::F32(operand), Tensor::I64(indices), Tensor::F32(updates)) => {
-                let indices = self.i64_indices_as_f64(indices)?;
-                self.scatter_float_typed(operand, &indices, updates, config)
-                    .map(Tensor::F32)
-            }
-            (Tensor::F64(operand), Tensor::I64(indices), Tensor::F64(updates)) => {
-                let indices = self.i64_indices_as_f64(indices)?;
-                self.scatter_float_typed(operand, &indices, updates, config)
-                    .map(Tensor::F64)
-            }
-            (Tensor::C32(operand), Tensor::I64(indices), Tensor::C32(updates)) => {
-                let indices = self.i64_indices_as_f64(indices)?;
-                self.scatter_complex_typed::<_, f32, _>(operand, &indices, updates, config)
-                    .map(Tensor::C32)
-            }
-            (Tensor::C64(operand), Tensor::I64(indices), Tensor::C64(updates)) => {
-                let indices = self.i64_indices_as_f64(indices)?;
-                self.scatter_complex_typed::<_, f64, _>(operand, &indices, updates, config)
-                    .map(Tensor::C64)
-            }
+            (Tensor::F32(operand), Tensor::I64(indices), Tensor::F32(updates)) => self
+                .scatter_float_typed(operand, indices, updates, config)
+                .map(Tensor::F32),
+            (Tensor::F64(operand), Tensor::I64(indices), Tensor::F64(updates)) => self
+                .scatter_float_typed(operand, indices, updates, config)
+                .map(Tensor::F64),
+            (Tensor::C32(operand), Tensor::I64(indices), Tensor::C32(updates)) => self
+                .scatter_complex_typed::<_, f32, _>(operand, indices, updates, config)
+                .map(Tensor::C32),
+            (Tensor::C64(operand), Tensor::I64(indices), Tensor::C64(updates)) => self
+                .scatter_complex_typed::<_, f64, _>(operand, indices, updates, config)
+                .map(Tensor::C64),
             (_, Tensor::C32(_) | Tensor::C64(_), _) => Err(crate::Error::BackendFailure {
                 op: "scatter",
                 message: "complex index tensors are not supported".into(),
@@ -2593,26 +2540,18 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(input), Tensor::F64(starts)) => self
                 .dynamic_slice_typed(input, starts, slice_sizes)
                 .map(Tensor::C64),
-            (Tensor::F32(input), Tensor::I64(starts)) => {
-                let starts = self.i64_indices_as_f64(starts)?;
-                self.dynamic_slice_typed(input, &starts, slice_sizes)
-                    .map(Tensor::F32)
-            }
-            (Tensor::F64(input), Tensor::I64(starts)) => {
-                let starts = self.i64_indices_as_f64(starts)?;
-                self.dynamic_slice_typed(input, &starts, slice_sizes)
-                    .map(Tensor::F64)
-            }
-            (Tensor::C32(input), Tensor::I64(starts)) => {
-                let starts = self.i64_indices_as_f64(starts)?;
-                self.dynamic_slice_typed(input, &starts, slice_sizes)
-                    .map(Tensor::C32)
-            }
-            (Tensor::C64(input), Tensor::I64(starts)) => {
-                let starts = self.i64_indices_as_f64(starts)?;
-                self.dynamic_slice_typed(input, &starts, slice_sizes)
-                    .map(Tensor::C64)
-            }
+            (Tensor::F32(input), Tensor::I64(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::F32),
+            (Tensor::F64(input), Tensor::I64(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::F64),
+            (Tensor::C32(input), Tensor::I64(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::C32),
+            (Tensor::C64(input), Tensor::I64(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::C64),
             (_, Tensor::C32(_) | Tensor::C64(_)) => Err(crate::Error::BackendFailure {
                 op: "dynamic_slice",
                 message: "complex index tensors are not supported".into(),
@@ -3000,7 +2939,6 @@ fn operand_window_dims(rank: usize, collapsed_or_inserted: &[usize]) -> Vec<usiz
 
 struct GatherLaunchMeta {
     output_shape: Vec<usize>,
-    batch_shape: Vec<usize>,
     window_dims: Vec<usize>,
 }
 
@@ -3067,7 +3005,6 @@ fn gather_launch_meta(
     }
     Ok(GatherLaunchMeta {
         output_shape,
-        batch_shape,
         window_dims,
     })
 }

--- a/tenferro-tensor/src/cubecl/tests/linalg_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/linalg_tests.rs
@@ -129,6 +129,28 @@ fn assert_slice_close_f32(actual: &[f32], expected: &[f32], tol: f32) {
     }
 }
 
+fn assert_lu_batch_reconstructs_f32(
+    input: &[f32],
+    p: &[f32],
+    l: &[f32],
+    u: &[f32],
+    dims: (usize, usize, usize),
+    batch: usize,
+) {
+    let (m, k, n) = dims;
+    let a_start = batch * m * n;
+    let p_start = batch * m * m;
+    let l_start = batch * m * k;
+    let u_start = batch * k * n;
+    let a_batch = &input[a_start..a_start + m * n];
+    let p_batch = &p[p_start..p_start + m * m];
+    let l_batch = &l[l_start..l_start + m * k];
+    let u_batch = &u[u_start..u_start + k * n];
+    let pa = matmul_f32(p_batch, a_batch, m, m, n);
+    let lu = matmul_f32(l_batch, u_batch, m, k, n);
+    assert_slice_close_f32(&pa, &lu, 1e-4);
+}
+
 fn assert_slice_close_c32(actual: &[Complex32], expected: &[Complex32], tol: f32) {
     assert_eq!(actual.len(), expected.len());
     for (lhs, rhs) in actual.iter().zip(expected.iter()) {
@@ -216,6 +238,58 @@ fn test_cubecl_lu_f32_reconstructs_pa_equals_lu() {
     let lu = matmul_f32(&l_data, &u_data, 2, 2, 2);
     assert_slice_close_f32(&pa, &lu, 1e-4);
     assert_slice_close_f32(parity.as_slice::<f32>().unwrap(), &[-1.0], 1e-4);
+}
+
+#[test]
+#[ignore]
+fn test_cubecl_lu_f32_handles_rectangular_pivots() {
+    let rectangular = tensor_f32(vec![3, 2], vec![0.0, 2.0, 0.0, 1.0, 3.0, 0.0]);
+    let mut gpu = gpu_backend();
+    let outputs = gpu.lu(&upload(&gpu, &rectangular)).unwrap();
+    let p = download(&gpu, &outputs[0]);
+    let l = download(&gpu, &outputs[1]);
+    let u = download(&gpu, &outputs[2]);
+    let parity = download(&gpu, &outputs[3]);
+    assert_eq!(p.shape(), &[3, 3]);
+    assert_eq!(l.shape(), &[3, 2]);
+    assert_eq!(u.shape(), &[2, 2]);
+    assert_eq!(parity.shape(), &[] as &[usize]);
+    assert_lu_batch_reconstructs_f32(
+        rectangular.as_slice::<f32>().unwrap(),
+        p.as_slice::<f32>().unwrap(),
+        l.as_slice::<f32>().unwrap(),
+        u.as_slice::<f32>().unwrap(),
+        (3, 2, 2),
+        0,
+    );
+    assert_slice_close_f32(parity.as_slice::<f32>().unwrap(), &[-1.0], 1e-4);
+}
+
+#[test]
+#[ignore]
+fn test_cubecl_lu_f32_handles_batched_pivots() {
+    let batched = tensor_f32(vec![2, 2, 2], vec![0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0]);
+    let mut gpu = gpu_backend();
+    let outputs = gpu.lu(&upload(&gpu, &batched)).unwrap();
+    let p = download(&gpu, &outputs[0]);
+    let l = download(&gpu, &outputs[1]);
+    let u = download(&gpu, &outputs[2]);
+    let parity = download(&gpu, &outputs[3]);
+    assert_eq!(p.shape(), &[2, 2, 2]);
+    assert_eq!(l.shape(), &[2, 2, 2]);
+    assert_eq!(u.shape(), &[2, 2, 2]);
+    assert_eq!(parity.shape(), &[2]);
+    for batch in 0..2 {
+        assert_lu_batch_reconstructs_f32(
+            batched.as_slice::<f32>().unwrap(),
+            p.as_slice::<f32>().unwrap(),
+            l.as_slice::<f32>().unwrap(),
+            u.as_slice::<f32>().unwrap(),
+            (2, 2, 2),
+            batch,
+        );
+    }
+    assert_slice_close_f32(parity.as_slice::<f32>().unwrap(), &[-1.0, 1.0], 1e-4);
 }
 
 #[test]

--- a/tenferro-tensor/tests/cubecl_launch_contract.rs
+++ b/tenferro-tensor/tests/cubecl_launch_contract.rs
@@ -1,23 +1,32 @@
 use std::{fs, path::Path};
 
+fn cubecl_source(file: &str) -> String {
+    fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("cubecl")
+            .join(file),
+    )
+    .unwrap_or_else(|err| panic!("CubeCL source {file} should be readable: {err}"))
+}
+
+fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+    let start_idx = source
+        .find(start)
+        .unwrap_or_else(|| panic!("source should contain section start {start:?}"));
+    let remaining = &source[start_idx..];
+    let end_idx = remaining
+        .find(end)
+        .map(|offset| start_idx + offset)
+        .unwrap_or(source.len());
+    &source[start_idx..end_idx]
+}
+
 #[test]
 fn cubecl_scatter_does_not_use_single_thread_launch_fallback() {
-    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("src")
-        .join("cubecl");
-    let mod_source =
-        fs::read_to_string(root.join("mod.rs")).expect("CubeCL module source should be readable");
-    let scatter_start = mod_source
-        .find("    fn scatter(")
-        .expect("CubeCL backend should define scatter");
-    let scatter_end = mod_source[scatter_start..]
-        .find("    fn slice(")
-        .map(|offset| scatter_start + offset)
-        .expect("CubeCL backend should define slice after scatter");
-    let scatter_source = &mod_source[scatter_start..scatter_end];
-
-    let dispatch_source = fs::read_to_string(root.join("dispatch.rs"))
-        .expect("CubeCL dispatch source should be readable");
+    let mod_source = cubecl_source("mod.rs");
+    let scatter_source = source_section(&mod_source, "    fn scatter(", "    fn slice(");
+    let dispatch_source = cubecl_source("dispatch.rs");
     let sources = [
         ("cubecl/mod.rs scatter body", scatter_source),
         ("cubecl/dispatch.rs", dispatch_source.as_str()),
@@ -36,6 +45,56 @@ fn cubecl_scatter_does_not_use_single_thread_launch_fallback() {
     assert!(
         violations.is_empty(),
         "CubeCL scatter launch must not use a single-thread fallback:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn cubecl_i64_index_conversion_does_not_roundtrip_through_host() {
+    let mod_source = cubecl_source("mod.rs");
+    let banned = [
+        "fn i64_indices_as_f64",
+        "download_tensor(self.runtime(), &Tensor::I64",
+        "upload_tensor(self.runtime(), &converted",
+    ];
+
+    let mut violations = Vec::new();
+    for needle in banned {
+        if mod_source.contains(needle) {
+            violations.push(format!("cubecl/mod.rs contains {needle}"));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "CubeCL I64 index conversion must stay on device; host roundtrips in indexing paths are performance regressions:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn cubecl_lu_outputs_are_not_rebuilt_by_host_roundtrip() {
+    let linalg_source = cubecl_source("linalg.rs");
+    let lu_source = source_section(&linalg_source, "fn lu_typed", "fn svd_typed");
+    let banned = [
+        "download_device_tensor(backend.runtime(), &work, OP)",
+        "build_lu_outputs_host(&host_lu",
+        "upload_host_tensor(backend.runtime(), p)",
+        "upload_host_tensor(backend.runtime(), l)",
+        "upload_host_tensor(backend.runtime(), u)",
+        "upload_host_tensor(backend.runtime(), parity)",
+    ];
+
+    let mut violations = Vec::new();
+    for needle in banned {
+        if lu_source.contains(needle) {
+            violations.push(format!("cubecl/linalg.rs lu_typed contains {needle}"));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "CubeCL LU must not rebuild P/L/U/parity through a full device-to-host-to-device roundtrip:\n{}",
         violations.join("\n")
     );
 }


### PR DESCRIPTION
## Summary
- move shared Tensor4all performance rules into `REPOSITORY_RULES.md` and keep `AGENTS.md` as a lighter entry point
- keep CubeCL gather/scatter/dynamic-slice I64 indices on device instead of converting through host buffers
- rebuild CubeCL LU P/L/U/parity on GPU from cuSOLVER outputs instead of downloading full LU factors and uploading rebuilt outputs
- add contract tests for launch-shape regressions, I64 index host roundtrips, and LU host roundtrips

Closes #765
Closes #882

## Why
The local performance review found two avoidable GPU host-transfer patterns: indexing converted I64 index tensors through host-side f64 tensors, and LU downloaded full factor data to rebuild P/L/U/parity on CPU. These paths make small metadata work look cheap while hiding transfers that scale with tensor size.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p tenferro-cubecl --test kernel_metadata_contract`
- `cargo test -p tenferro-tensor --features cubecl --test cubecl_launch_contract`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-tensor --features cubecl test_cubecl_lu_f32 -- --ignored`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-tensor --features cubecl indexing_tests -- --ignored`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
