### PR TITLE
[codex] add direct solve and CPU benchmark baseline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ quote = "1"
 syn = "2"
 chainrules-core = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2d7662140d92f0dd73b2402aefc2272feafc9270", package = "chainrules" }
 chainrules = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2d7662140d92f0dd73b2402aefc2272feafc9270" }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "1351fa42cf98852d821963682e4fc5d0835ba6d4" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "1694275361d2f16abfb3f25ad7941407c88b7c09" }
 strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722", features = ["parallel"] }

--- a/benchmarks/torch-cpp/CMakeLists.txt
+++ b/benchmarks/torch-cpp/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.18)
+project(tenferro_torch_cpu_bench LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(Torch REQUIRED)
+
+add_executable(torch_cpu_bench torch_cpu_bench.cpp)
+target_link_libraries(torch_cpu_bench "${TORCH_LIBRARIES}")
+
+if(NOT MSVC)
+  target_compile_options(torch_cpu_bench PRIVATE -O3)
+endif()

--- a/benchmarks/torch-cpp/torch_cpu_bench.cpp
+++ b/benchmarks/torch-cpp/torch_cpu_bench.cpp
@@ -1,0 +1,533 @@
+#include <ATen/Parallel.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+using Tensor = torch::Tensor;
+
+constexpr int64_t kSmallMatmulSizes[] = {2, 4, 8, 16, 32};
+constexpr int64_t kLargeMatmulSizes[] = {128, 256, 512};
+constexpr int64_t kSmallLinalgSizes[] = {4, 8, 16, 32};
+constexpr int64_t kMediumLinalgSizes[] = {64, 128};
+constexpr int64_t kBatches[] = {16, 64, 256};
+constexpr int64_t kBatchedSmallSizes[] = {2, 4, 8, 16};
+
+struct BenchResult {
+  std::string suite;
+  std::string name;
+  std::string dtype;
+  std::string shape;
+  int threads = 1;
+  int iterations = 0;
+  double mean_us = 0.0;
+  double total_us = 0.0;
+};
+
+std::string shape_text(std::initializer_list<int64_t> dims) {
+  std::ostringstream out;
+  bool first = true;
+  for (auto dim : dims) {
+    if (!first) {
+      out << "x";
+    }
+    out << dim;
+    first = false;
+  }
+  return out.str();
+}
+
+Tensor f64_tensor(std::vector<int64_t> shape, int64_t seed) {
+  int64_t len = 1;
+  for (auto dim : shape) {
+    len *= dim;
+  }
+  std::vector<double> data(static_cast<size_t>(len));
+  for (int64_t idx = 0; idx < len; ++idx) {
+    data[static_cast<size_t>(idx)] =
+        static_cast<double>((idx * 17 + seed * 31 + 7) % 997) / 997.0 - 0.5;
+  }
+  auto options = torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCPU);
+  return torch::from_blob(data.data(), shape, options).clone();
+}
+
+Tensor c64_tensor(std::vector<int64_t> shape, int64_t seed) {
+  int64_t len = 1;
+  for (auto dim : shape) {
+    len *= dim;
+  }
+  std::vector<c10::complex<double>> data(static_cast<size_t>(len));
+  for (int64_t idx = 0; idx < len; ++idx) {
+    double re = static_cast<double>((idx * 17 + seed * 31 + 7) % 997) / 997.0 - 0.5;
+    double im = static_cast<double>((idx * 23 + seed * 19 + 11) % 991) / 991.0 - 0.5;
+    data[static_cast<size_t>(idx)] = c10::complex<double>(re, im);
+  }
+  auto options =
+      torch::TensorOptions().dtype(torch::kComplexDouble).device(torch::kCPU);
+  return torch::from_blob(data.data(), shape, options).clone();
+}
+
+Tensor f64_spd_tensor(int64_t n, int64_t seed) {
+  auto a = torch::empty({n, n}, torch::TensorOptions().dtype(torch::kFloat64));
+  auto acc = a.accessor<double, 2>();
+  for (int64_t row = 0; row < n; ++row) {
+    for (int64_t col = 0; col < n; ++col) {
+      if (row == col) {
+        acc[row][col] = static_cast<double>(n) + 2.0 + static_cast<double>(row + seed) * 0.001;
+      } else {
+        acc[row][col] = static_cast<double>((row + col + seed) % 7) * 0.01;
+      }
+    }
+  }
+  return a;
+}
+
+Tensor c64_hermitian_tensor(int64_t n, int64_t seed) {
+  auto a = torch::empty({n, n}, torch::TensorOptions().dtype(torch::kComplexDouble));
+  auto acc = a.accessor<c10::complex<double>, 2>();
+  for (int64_t row = 0; row < n; ++row) {
+    for (int64_t col = 0; col < n; ++col) {
+      acc[row][col] = c10::complex<double>(0.0, 0.0);
+    }
+  }
+  for (int64_t col = 0; col < n; ++col) {
+    for (int64_t row = 0; row <= col; ++row) {
+      c10::complex<double> value;
+      if (row == col) {
+        value = c10::complex<double>(
+            static_cast<double>(n) + 2.0 + static_cast<double>(row + seed) * 0.001,
+            0.0);
+      } else {
+        double re = static_cast<double>((row + col + seed) % 7) * 0.01;
+        double im = static_cast<double>((row * 3 + col + seed) % 5) * 0.01;
+        value = c10::complex<double>(re, im);
+      }
+      acc[row][col] = value;
+      acc[col][row] = c10::complex<double>(value.real(), -value.imag());
+    }
+  }
+  return a;
+}
+
+void consume(const Tensor& tensor) {
+  volatile double value = tensor.abs().sum().item<double>();
+  (void)value;
+}
+
+int iterations_for(const std::string& suite, int64_t scale) {
+  if (suite == "ad") {
+    return scale <= 16 ? 50 : 20;
+  }
+  if (scale <= 8) {
+    return 1000;
+  }
+  if (scale <= 32) {
+    return 300;
+  }
+  if (scale <= 128) {
+    return 80;
+  }
+  return 20;
+}
+
+BenchResult run_bench(
+    const std::string& suite,
+    const std::string& name,
+    const std::string& dtype,
+    const std::string& shape,
+    int threads,
+    int iterations,
+    const std::function<void()>& body) {
+  for (int i = 0; i < 5; ++i) {
+    body();
+  }
+
+  auto start = Clock::now();
+  for (int i = 0; i < iterations; ++i) {
+    body();
+  }
+  auto end = Clock::now();
+
+  double total_us =
+      static_cast<double>(
+          std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count()) /
+      1000.0;
+  return BenchResult{
+      suite,
+      name,
+      dtype,
+      shape,
+      threads,
+      iterations,
+      total_us / static_cast<double>(iterations),
+      total_us};
+}
+
+BenchResult run_ad_bench(
+    const std::string& name,
+    const std::string& shape,
+    int threads,
+    int iterations,
+    const std::function<std::pair<Tensor, Tensor>()>& setup,
+    const std::function<void(Tensor&, Tensor&)>& body) {
+  for (int i = 0; i < 5; ++i) {
+    auto inputs = setup();
+    body(inputs.first, inputs.second);
+  }
+
+  double total_us = 0.0;
+  for (int i = 0; i < iterations; ++i) {
+    auto inputs = setup();
+    auto start = Clock::now();
+    body(inputs.first, inputs.second);
+    auto end = Clock::now();
+    total_us += static_cast<double>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count()) /
+                1000.0;
+  }
+  return BenchResult{
+      "ad",
+      name,
+      "f64",
+      shape,
+      threads,
+      iterations,
+      total_us / static_cast<double>(iterations),
+      total_us};
+}
+
+void print_header() {
+  std::cout << "suite,name,dtype,threads,shape,iterations,mean_us,total_us\n";
+}
+
+void print_result(const BenchResult& result) {
+  std::cout << result.suite << "," << result.name << "," << result.dtype << ","
+            << result.threads << "," << result.shape << "," << result.iterations << ","
+            << std::fixed << std::setprecision(3) << result.mean_us << ","
+            << result.total_us << "\n";
+}
+
+void bench_matmul(int threads) {
+  for (auto n : kSmallMatmulSizes) {
+    auto a = f64_tensor({n, n}, 1);
+    auto b = f64_tensor({n, n}, 2);
+    print_result(run_bench(
+        "matmul",
+        "f64_square",
+        "f64",
+        shape_text({n, n}),
+        threads,
+        iterations_for("matmul", n),
+        [&]() { consume(torch::matmul(a, b)); }));
+
+    auto ac = c64_tensor({n, n}, 3);
+    auto bc = c64_tensor({n, n}, 4);
+    print_result(run_bench(
+        "matmul",
+        "c64_square",
+        "c64",
+        shape_text({n, n}),
+        threads,
+        iterations_for("matmul", n),
+        [&]() { consume(torch::matmul(ac, bc)); }));
+  }
+
+  for (auto n : kLargeMatmulSizes) {
+    auto a = f64_tensor({n, n}, 1);
+    auto b = f64_tensor({n, n}, 2);
+    print_result(run_bench(
+        "matmul",
+        "f64_square",
+        "f64",
+        shape_text({n, n}),
+        threads,
+        iterations_for("matmul", n),
+        [&]() { consume(torch::matmul(a, b)); }));
+  }
+}
+
+void bench_linalg(int threads) {
+  for (auto n : kSmallLinalgSizes) {
+    auto a = f64_spd_tensor(n, 1);
+    auto b_col = f64_tensor({n, 1}, 2);
+    auto b_mat = f64_tensor({n, 4}, 3);
+
+    print_result(run_bench(
+        "linalg",
+        "f64_svd",
+        "f64",
+        shape_text({n, n}),
+        threads,
+        iterations_for("linalg", n),
+        [&]() {
+          auto out = torch::linalg_svd(a, false);
+          consume(std::get<1>(out));
+        }));
+    print_result(run_bench(
+        "linalg",
+        "f64_qr",
+        "f64",
+        shape_text({n, n}),
+        threads,
+        iterations_for("linalg", n),
+        [&]() {
+          auto out = torch::linalg_qr(a);
+          consume(std::get<1>(out));
+        }));
+    print_result(run_bench(
+        "linalg",
+        "f64_eigh",
+        "f64",
+        shape_text({n, n}),
+        threads,
+        iterations_for("linalg", n),
+        [&]() {
+          auto out = torch::linalg_eigh(a);
+          consume(std::get<0>(out));
+        }));
+    print_result(run_bench(
+        "linalg",
+        "f64_solve_column_rhs1",
+        "f64",
+        shape_text({n, 1}),
+        threads,
+        iterations_for("linalg", n),
+        [&]() { consume(torch::linalg_solve(a, b_col)); }));
+    print_result(run_bench(
+        "linalg",
+        "f64_solve_matrix_rhs4",
+        "f64",
+        shape_text({n, 4}),
+        threads,
+        iterations_for("linalg", n),
+        [&]() { consume(torch::linalg_solve(a, b_mat)); }));
+
+    auto c = c64_hermitian_tensor(n, 5);
+    print_result(run_bench(
+        "linalg",
+        "c64_eigh",
+        "c64",
+        shape_text({n, n}),
+        threads,
+        iterations_for("linalg", n),
+        [&]() {
+          auto out = torch::linalg_eigh(c);
+          consume(std::get<0>(out));
+        }));
+  }
+
+  for (auto n : kMediumLinalgSizes) {
+    auto a = f64_spd_tensor(n, 1);
+    auto b_mat = f64_tensor({n, 4}, 3);
+    print_result(run_bench(
+        "linalg",
+        "f64_svd",
+        "f64",
+        shape_text({n, n}),
+        threads,
+        iterations_for("linalg", n),
+        [&]() {
+          auto out = torch::linalg_svd(a, false);
+          consume(std::get<1>(out));
+        }));
+    print_result(run_bench(
+        "linalg",
+        "f64_qr",
+        "f64",
+        shape_text({n, n}),
+        threads,
+        iterations_for("linalg", n),
+        [&]() {
+          auto out = torch::linalg_qr(a);
+          consume(std::get<1>(out));
+        }));
+    print_result(run_bench(
+        "linalg",
+        "f64_eigh",
+        "f64",
+        shape_text({n, n}),
+        threads,
+        iterations_for("linalg", n),
+        [&]() {
+          auto out = torch::linalg_eigh(a);
+          consume(std::get<0>(out));
+        }));
+    print_result(run_bench(
+        "linalg",
+        "f64_solve_matrix_rhs4",
+        "f64",
+        shape_text({n, 4}),
+        threads,
+        iterations_for("linalg", n),
+        [&]() { consume(torch::linalg_solve(a, b_mat)); }));
+  }
+}
+
+void bench_batched_einsum(int threads) {
+  for (auto batch : kBatches) {
+    for (auto n : kBatchedSmallSizes) {
+      auto a = f64_tensor({n, n, batch}, 1);
+      auto b = f64_tensor({n, n, batch}, 2);
+      print_result(run_bench(
+          "batched_einsum_rightmost_batch",
+          "f64_ikb_knb_to_inb",
+          "f64",
+          shape_text({n, n, batch}),
+          threads,
+          iterations_for("batched_einsum", n),
+          [&]() { consume(torch::einsum("ikb,knb->inb", {a, b})); }));
+    }
+  }
+}
+
+void bench_einsum_patterns(int threads) {
+  auto a = f64_tensor({64, 64}, 1);
+  auto b = f64_tensor({64, 64}, 2);
+  auto c = f64_tensor({64, 64}, 3);
+  print_result(run_bench(
+      "einsum_patterns",
+      "f64_binary_ij_jk_to_ik",
+      "f64",
+      shape_text({64, 64}),
+      threads,
+      iterations_for("einsum_patterns", 64),
+      [&]() { consume(torch::einsum("ij,jk->ik", {a, b})); }));
+  print_result(run_bench(
+      "einsum_patterns",
+      "f64_chain_ij_jk_kl_to_il",
+      "f64",
+      shape_text({64, 64}),
+      threads,
+      iterations_for("einsum_patterns", 64),
+      [&]() { consume(torch::einsum("ij,jk,kl->il", {a, b, c})); }));
+
+  auto x = f64_tensor({8, 16, 8}, 4);
+  auto y = f64_tensor({16, 8, 8}, 5);
+  print_result(run_bench(
+      "einsum_patterns",
+      "f64_multiedge_ijk_jkl_to_il",
+      "f64",
+      "8x16x8__16x8x8",
+      threads,
+      iterations_for("einsum_patterns", 16),
+      [&]() { consume(torch::einsum("ijk,jkl->il", {x, y})); }));
+
+  auto ac = c64_tensor({32, 32}, 6);
+  auto bc = c64_tensor({32, 32}, 7);
+  print_result(run_bench(
+      "einsum_patterns",
+      "c64_binary_ij_jk_to_ik",
+      "c64",
+      shape_text({32, 32}),
+      threads,
+      iterations_for("einsum_patterns", 32),
+      [&]() { consume(torch::einsum("ij,jk->ik", {ac, bc})); }));
+}
+
+void bench_ad(int threads) {
+  auto bench_svd_values = [&](int64_t n) {
+    auto base_svd = f64_spd_tensor(n, 3);
+    print_result(run_ad_bench(
+        "f64_grad_sum_svd_values",
+        shape_text({n, n}),
+        threads,
+        iterations_for("ad", n),
+        [&]() {
+          auto a = base_svd.detach().clone();
+          a.set_requires_grad(true);
+          return std::make_pair(a, Tensor());
+        },
+        [](Tensor& a, Tensor&) {
+          auto out = torch::linalg_svd(a, false);
+          auto loss = std::get<1>(out).sum();
+          loss.backward();
+          consume(a.grad());
+        }));
+  };
+
+  for (auto n : kSmallLinalgSizes) {
+    bench_svd_values(n);
+  }
+  for (auto n : kMediumLinalgSizes) {
+    bench_svd_values(n);
+  }
+
+  for (auto n : {4, 16, 64}) {
+    auto base_a = f64_tensor({n, n}, 1);
+    auto base_b = f64_tensor({n, n}, 2);
+    print_result(run_ad_bench(
+        "f64_grad_sum_matmul",
+        shape_text({n, n}),
+        threads,
+        iterations_for("ad", n),
+        [&]() {
+          auto a = base_a.detach().clone();
+          auto b = base_b.detach().clone();
+          a.set_requires_grad(true);
+          b.set_requires_grad(true);
+          return std::make_pair(a, b);
+        },
+        [](Tensor& a, Tensor& b) {
+          auto loss = torch::matmul(a, b).sum();
+          loss.backward();
+          consume(a.grad());
+          consume(b.grad());
+        }));
+
+    if (n <= 16) {
+      auto base_solve = f64_spd_tensor(n, 4);
+      auto base_rhs = f64_tensor({n, 1}, 5);
+      print_result(run_ad_bench(
+          "f64_grad_sum_solve",
+          shape_text({n, 1}),
+          threads,
+          iterations_for("ad", n),
+          [&]() {
+            auto a = base_solve.detach().clone();
+            auto b = base_rhs.detach().clone();
+            a.set_requires_grad(true);
+            b.set_requires_grad(true);
+            return std::make_pair(a, b);
+          },
+          [](Tensor& a, Tensor& b) {
+            auto loss = torch::linalg_solve(a, b).sum();
+            loss.backward();
+            consume(a.grad());
+            consume(b.grad());
+          }));
+    }
+  }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  int threads = 1;
+  if (argc >= 2) {
+    threads = std::max(1, std::atoi(argv[1]));
+  }
+
+  at::set_num_threads(threads);
+  at::set_num_interop_threads(1);
+  torch::manual_seed(0);
+
+  print_header();
+  bench_matmul(threads);
+  bench_linalg(threads);
+  bench_batched_einsum(threads);
+  bench_einsum_patterns(threads);
+  bench_ad(threads);
+  return 0;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ when the workflow needs them.
 - [Execution Models](guides/execution-models.md)
 - [Memory Order](guides/memory-order.md)
 - [Devices and GPU](guides/devices-and-gpu.md)
+- [CPU Benchmarks](performance/cpu-benchmarks.md)
 - [API Reference](api/index.md)
 
 Installation details live in the README. The online guides focus on the tensor

--- a/docs/performance/cpu-benchmark-results-2026-05-23.md
+++ b/docs/performance/cpu-benchmark-results-2026-05-23.md
@@ -1,0 +1,363 @@
+# CPU Benchmark Results - 2026-05-23
+
+This is a normal comparison benchmark run, not a publication gate. Times are
+mean wall-clock latency in microseconds (`us`); lower is better.
+
+## Run Metadata
+
+- Date: 2026-05-23
+- Host CPU: AMD EPYC 7713P 64-Core Processor
+- tenferro branch: `codex/cpu-benchmarks-libtorch`
+- tenferro HEAD during run: `c9a1a28b` with local working-tree changes
+- tidu code during run: local checkout equivalent to tidu-rs PR #25 merged commit `1694275361d2f16abfb3f25ad7941407c88b7c09`
+- Rust: `rustc 1.94.1 (e408947bf 2026-03-25)`
+- Cargo: `cargo 1.94.1 (29ea6fb6a 2026-03-24)`
+- Command: `TENFERRO_MAIN_REPO_DIR=$PWD bash scripts/bench-cpu.sh --kind all --threads 1,2,4 --no-download-libtorch -- --sample-size 10 --warm-up-time 0.2 --measurement-time 0.2`
+- Raw log: `target/bench-results/2026-05-23-cpu-all-svd-ad-sizes.log` (not committed)
+
+## SVD Focus
+
+The AD SVD-values benchmark now covers the same square sizes as the primal SVD
+benchmark: `4x4`, `8x8`, `16x16`, `32x32`, `64x64`, and `128x128`.
+
+| suite | benchmark | dtype | threads | shape | tenferro_us | torch_us | tenferro/torch | winner |
+|---|---|---:|---:|---|---:|---:|---:|---|
+| linalg | `f64_svd` | f64 | 1 | `4x4` | 4.661 | 20.170 | 0.23x | tenferro |
+| linalg | `f64_svd` | f64 | 1 | `8x8` | 13.383 | 32.586 | 0.41x | tenferro |
+| linalg | `f64_svd` | f64 | 1 | `16x16` | 39.607 | 68.808 | 0.58x | tenferro |
+| linalg | `f64_svd` | f64 | 1 | `32x32` | 190.525 | 202.919 | 0.94x | tenferro |
+| linalg | `f64_svd` | f64 | 1 | `64x64` | 1037.382 | 741.139 | 1.40x | torch |
+| linalg | `f64_svd` | f64 | 1 | `128x128` | 3116.023 | 3224.577 | 0.97x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `4x4` | 4.566 | 18.484 | 0.25x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `8x8` | 11.789 | 29.872 | 0.39x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `16x16` | 42.528 | 64.633 | 0.66x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `32x32` | 161.752 | 204.516 | 0.79x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `64x64` | 791.762 | 990.879 | 0.80x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `128x128` | 3637.459 | 3741.419 | 0.97x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `4x4` | 4.663 | 19.449 | 0.24x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `8x8` | 11.800 | 30.323 | 0.39x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `16x16` | 40.146 | 63.297 | 0.63x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `32x32` | 149.570 | 231.305 | 0.65x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `64x64` | 840.349 | 906.113 | 0.93x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `128x128` | 3244.179 | 3628.201 | 0.89x | tenferro |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `4x4` | 110.679 | 83.703 | 1.32x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `8x8` | 119.318 | 94.695 | 1.26x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `16x16` | 146.461 | 133.314 | 1.10x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `32x32` | 276.862 | 266.650 | 1.04x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `64x64` | 839.261 | 817.652 | 1.03x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `128x128` | 3796.990 | 3708.189 | 1.02x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `4x4` | 108.153 | 74.559 | 1.45x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `8x8` | 121.471 | 86.604 | 1.40x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `16x16` | 145.503 | 123.044 | 1.18x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `32x32` | 364.582 | 293.992 | 1.24x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `64x64` | 1393.896 | 1086.291 | 1.28x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `128x128` | 4159.568 | 4359.004 | 0.95x | tenferro |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `4x4` | 132.926 | 80.191 | 1.66x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `8x8` | 116.085 | 92.585 | 1.25x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `16x16` | 161.744 | 133.361 | 1.21x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `32x32` | 419.578 | 426.326 | 0.98x | tenferro |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `64x64` | 1053.240 | 1102.792 | 0.96x | tenferro |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `128x128` | 4051.628 | 4180.504 | 0.97x | tenferro |
+
+## Tenferro Slower Cases
+
+Rows where `tenferro/torch > 1.0`, sorted by ratio.
+
+| suite | benchmark | dtype | threads | shape | tenferro_us | torch_us | tenferro/torch | winner |
+|---|---|---:|---:|---|---:|---:|---:|---|
+| linalg | `f64_qr` | f64 | 4 | `32x32` | 226.392 | 43.647 | 5.19x | torch |
+| linalg | `f64_qr` | f64 | 4 | `64x64` | 1029.538 | 230.502 | 4.47x | torch |
+| linalg | `f64_qr` | f64 | 2 | `32x32` | 141.572 | 37.829 | 3.74x | torch |
+| linalg | `f64_qr` | f64 | 4 | `128x128` | 2775.310 | 751.851 | 3.69x | torch |
+| linalg | `f64_qr` | f64 | 2 | `64x64` | 732.766 | 231.035 | 3.17x | torch |
+| linalg | `f64_qr` | f64 | 2 | `128x128` | 1583.197 | 770.130 | 2.06x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `4x4` | 132.926 | 80.191 | 1.66x | torch |
+| matmul | `f64_square` | f64 | 1 | `256x256` | 2973.316 | 1807.628 | 1.64x | torch |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 2 | `128x4` | 310.386 | 201.601 | 1.54x | torch |
+| linalg | `f64_eigh` | f64 | 4 | `128x128` | 2122.134 | 1394.780 | 1.52x | torch |
+| linalg | `f64_eigh` | f64 | 4 | `64x64` | 515.723 | 346.952 | 1.49x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `4x4` | 108.153 | 74.559 | 1.45x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `8x8` | 121.471 | 86.604 | 1.40x | torch |
+| matmul | `f64_square` | f64 | 4 | `32x32` | 22.259 | 15.894 | 1.40x | torch |
+| linalg | `f64_svd` | f64 | 1 | `64x64` | 1037.382 | 741.139 | 1.40x | torch |
+| linalg | `f64_eigh` | f64 | 1 | `128x128` | 2201.138 | 1588.106 | 1.39x | torch |
+| linalg | `f64_eigh` | f64 | 2 | `128x128` | 2066.426 | 1526.433 | 1.35x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `4x4` | 110.679 | 83.703 | 1.32x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `64x64` | 1393.896 | 1086.291 | 1.28x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `8x8` | 119.318 | 94.695 | 1.26x | torch |
+| ad | `f64_grad_sum_matmul` | f64 | 2 | `64x64` | 254.021 | 202.251 | 1.26x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `8x8` | 116.085 | 92.585 | 1.25x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `32x32` | 364.582 | 293.992 | 1.24x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `16x16` | 161.744 | 133.361 | 1.21x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `16x16` | 145.503 | 123.044 | 1.18x | torch |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 4 | `128x4` | 233.449 | 201.381 | 1.16x | torch |
+| ad | `f64_grad_sum_matmul` | f64 | 4 | `64x64` | 231.322 | 199.666 | 1.16x | torch |
+| linalg | `f64_qr` | f64 | 1 | `32x32` | 45.060 | 39.460 | 1.14x | torch |
+| linalg | `f64_eigh` | f64 | 2 | `64x64` | 478.639 | 426.770 | 1.12x | torch |
+| ad | `f64_grad_sum_matmul` | f64 | 2 | `16x16` | 60.727 | 54.462 | 1.12x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `16x16` | 146.461 | 133.314 | 1.10x | torch |
+| matmul | `f64_square` | f64 | 2 | `32x32` | 15.237 | 14.024 | 1.09x | torch |
+| linalg | `f64_qr` | f64 | 2 | `16x16` | 17.576 | 16.340 | 1.08x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `32x32` | 276.862 | 266.650 | 1.04x | torch |
+| linalg | `f64_qr` | f64 | 1 | `64x64` | 157.708 | 152.176 | 1.04x | torch |
+| ad | `f64_grad_sum_matmul` | f64 | 2 | `4x4` | 49.490 | 48.083 | 1.03x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `64x64` | 839.261 | 817.652 | 1.03x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `128x128` | 3796.990 | 3708.189 | 1.02x | torch |
+| ad | `f64_grad_sum_matmul` | f64 | 4 | `4x4` | 53.243 | 52.372 | 1.02x | torch |
+
+## Full Paired Results
+
+| suite | benchmark | dtype | threads | shape | tenferro_us | torch_us | tenferro/torch | winner |
+|---|---|---:|---:|---|---:|---:|---:|---|
+| matmul | `f64_square` | f64 | 1 | `2x2` | 1.199 | 9.707 | 0.12x | tenferro |
+| matmul | `f64_square` | f64 | 1 | `4x4` | 1.576 | 8.985 | 0.18x | tenferro |
+| matmul | `f64_square` | f64 | 1 | `8x8` | 1.281 | 7.637 | 0.17x | tenferro |
+| matmul | `f64_square` | f64 | 1 | `16x16` | 1.617 | 8.386 | 0.19x | tenferro |
+| matmul | `f64_square` | f64 | 1 | `32x32` | 4.109 | 16.519 | 0.25x | tenferro |
+| matmul | `f64_square` | f64 | 1 | `128x128` | 203.068 | 340.270 | 0.60x | tenferro |
+| matmul | `f64_square` | f64 | 1 | `256x256` | 2973.316 | 1807.628 | 1.64x | torch |
+| matmul | `f64_square` | f64 | 1 | `512x512` | 11128.600 | 14721.812 | 0.76x | tenferro |
+| matmul | `f64_square` | f64 | 2 | `2x2` | 1.254 | 8.571 | 0.15x | tenferro |
+| matmul | `f64_square` | f64 | 2 | `4x4` | 1.206 | 7.947 | 0.15x | tenferro |
+| matmul | `f64_square` | f64 | 2 | `8x8` | 1.250 | 6.744 | 0.19x | tenferro |
+| matmul | `f64_square` | f64 | 2 | `16x16` | 2.646 | 8.846 | 0.30x | tenferro |
+| matmul | `f64_square` | f64 | 2 | `32x32` | 15.237 | 14.024 | 1.09x | torch |
+| matmul | `f64_square` | f64 | 2 | `128x128` | 118.188 | 277.935 | 0.43x | tenferro |
+| matmul | `f64_square` | f64 | 2 | `256x256` | 705.562 | 1982.694 | 0.36x | tenferro |
+| matmul | `f64_square` | f64 | 2 | `512x512` | 5282.173 | 7718.604 | 0.68x | tenferro |
+| matmul | `f64_square` | f64 | 4 | `2x2` | 1.192 | 5.112 | 0.23x | tenferro |
+| matmul | `f64_square` | f64 | 4 | `4x4` | 1.211 | 4.109 | 0.29x | tenferro |
+| matmul | `f64_square` | f64 | 4 | `8x8` | 1.272 | 4.306 | 0.30x | tenferro |
+| matmul | `f64_square` | f64 | 4 | `16x16` | 1.737 | 5.642 | 0.31x | tenferro |
+| matmul | `f64_square` | f64 | 4 | `32x32` | 22.259 | 15.894 | 1.40x | torch |
+| matmul | `f64_square` | f64 | 4 | `128x128` | 82.358 | 116.945 | 0.70x | tenferro |
+| matmul | `f64_square` | f64 | 4 | `256x256` | 475.553 | 1012.908 | 0.47x | tenferro |
+| matmul | `f64_square` | f64 | 4 | `512x512` | 2823.277 | 4768.127 | 0.59x | tenferro |
+| matmul | `c64_square` | c64 | 1 | `2x2` | 1.155 | 15.012 | 0.08x | tenferro |
+| matmul | `c64_square` | c64 | 1 | `4x4` | 1.208 | 12.634 | 0.10x | tenferro |
+| matmul | `c64_square` | c64 | 1 | `8x8` | 1.370 | 12.769 | 0.11x | tenferro |
+| matmul | `c64_square` | c64 | 1 | `16x16` | 2.671 | 16.730 | 0.16x | tenferro |
+| matmul | `c64_square` | c64 | 1 | `32x32` | 12.982 | 39.960 | 0.32x | tenferro |
+| matmul | `c64_square` | c64 | 2 | `2x2` | 1.254 | 13.140 | 0.10x | tenferro |
+| matmul | `c64_square` | c64 | 2 | `4x4` | 1.219 | 11.706 | 0.10x | tenferro |
+| matmul | `c64_square` | c64 | 2 | `8x8` | 1.409 | 11.890 | 0.12x | tenferro |
+| matmul | `c64_square` | c64 | 2 | `16x16` | 3.707 | 14.664 | 0.25x | tenferro |
+| matmul | `c64_square` | c64 | 2 | `32x32` | 15.602 | 35.431 | 0.44x | tenferro |
+| matmul | `c64_square` | c64 | 4 | `2x2` | 1.165 | 7.362 | 0.16x | tenferro |
+| matmul | `c64_square` | c64 | 4 | `4x4` | 1.369 | 6.803 | 0.20x | tenferro |
+| matmul | `c64_square` | c64 | 4 | `8x8` | 1.408 | 7.735 | 0.18x | tenferro |
+| matmul | `c64_square` | c64 | 4 | `16x16` | 4.599 | 11.402 | 0.40x | tenferro |
+| matmul | `c64_square` | c64 | 4 | `32x32` | 9.637 | 35.448 | 0.27x | tenferro |
+| linalg | `f64_svd` | f64 | 1 | `4x4` | 4.661 | 20.170 | 0.23x | tenferro |
+| linalg | `f64_svd` | f64 | 1 | `8x8` | 13.383 | 32.586 | 0.41x | tenferro |
+| linalg | `f64_svd` | f64 | 1 | `16x16` | 39.607 | 68.808 | 0.58x | tenferro |
+| linalg | `f64_svd` | f64 | 1 | `32x32` | 190.525 | 202.919 | 0.94x | tenferro |
+| linalg | `f64_svd` | f64 | 1 | `64x64` | 1037.382 | 741.139 | 1.40x | torch |
+| linalg | `f64_svd` | f64 | 1 | `128x128` | 3116.023 | 3224.577 | 0.97x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `4x4` | 4.566 | 18.484 | 0.25x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `8x8` | 11.789 | 29.872 | 0.39x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `16x16` | 42.528 | 64.633 | 0.66x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `32x32` | 161.752 | 204.516 | 0.79x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `64x64` | 791.762 | 990.879 | 0.80x | tenferro |
+| linalg | `f64_svd` | f64 | 2 | `128x128` | 3637.459 | 3741.419 | 0.97x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `4x4` | 4.663 | 19.449 | 0.24x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `8x8` | 11.800 | 30.323 | 0.39x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `16x16` | 40.146 | 63.297 | 0.63x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `32x32` | 149.570 | 231.305 | 0.65x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `64x64` | 840.349 | 906.113 | 0.93x | tenferro |
+| linalg | `f64_svd` | f64 | 4 | `128x128` | 3244.179 | 3628.201 | 0.89x | tenferro |
+| linalg | `f64_qr` | f64 | 1 | `4x4` | 2.009 | 10.157 | 0.20x | tenferro |
+| linalg | `f64_qr` | f64 | 1 | `8x8` | 3.575 | 10.908 | 0.33x | tenferro |
+| linalg | `f64_qr` | f64 | 1 | `16x16` | 9.884 | 16.043 | 0.62x | tenferro |
+| linalg | `f64_qr` | f64 | 1 | `32x32` | 45.060 | 39.460 | 1.14x | torch |
+| linalg | `f64_qr` | f64 | 1 | `64x64` | 157.708 | 152.176 | 1.04x | torch |
+| linalg | `f64_qr` | f64 | 1 | `128x128` | 579.450 | 759.769 | 0.76x | tenferro |
+| linalg | `f64_qr` | f64 | 2 | `4x4` | 2.569 | 10.749 | 0.24x | tenferro |
+| linalg | `f64_qr` | f64 | 2 | `8x8` | 3.301 | 11.303 | 0.29x | tenferro |
+| linalg | `f64_qr` | f64 | 2 | `16x16` | 17.576 | 16.340 | 1.08x | torch |
+| linalg | `f64_qr` | f64 | 2 | `32x32` | 141.572 | 37.829 | 3.74x | torch |
+| linalg | `f64_qr` | f64 | 2 | `64x64` | 732.766 | 231.035 | 3.17x | torch |
+| linalg | `f64_qr` | f64 | 2 | `128x128` | 1583.197 | 770.130 | 2.06x | torch |
+| linalg | `f64_qr` | f64 | 4 | `4x4` | 1.870 | 12.968 | 0.14x | tenferro |
+| linalg | `f64_qr` | f64 | 4 | `8x8` | 3.012 | 14.420 | 0.21x | tenferro |
+| linalg | `f64_qr` | f64 | 4 | `16x16` | 9.091 | 18.705 | 0.49x | tenferro |
+| linalg | `f64_qr` | f64 | 4 | `32x32` | 226.392 | 43.647 | 5.19x | torch |
+| linalg | `f64_qr` | f64 | 4 | `64x64` | 1029.538 | 230.502 | 4.47x | torch |
+| linalg | `f64_qr` | f64 | 4 | `128x128` | 2775.310 | 751.851 | 3.69x | torch |
+| linalg | `f64_eigh` | f64 | 1 | `4x4` | 3.153 | 13.852 | 0.23x | tenferro |
+| linalg | `f64_eigh` | f64 | 1 | `8x8` | 7.345 | 18.818 | 0.39x | tenferro |
+| linalg | `f64_eigh` | f64 | 1 | `16x16` | 23.127 | 34.511 | 0.67x | tenferro |
+| linalg | `f64_eigh` | f64 | 1 | `32x32` | 88.806 | 105.748 | 0.84x | tenferro |
+| linalg | `f64_eigh` | f64 | 1 | `64x64` | 344.060 | 364.886 | 0.94x | tenferro |
+| linalg | `f64_eigh` | f64 | 1 | `128x128` | 2201.138 | 1588.106 | 1.39x | torch |
+| linalg | `f64_eigh` | f64 | 2 | `4x4` | 3.211 | 12.516 | 0.26x | tenferro |
+| linalg | `f64_eigh` | f64 | 2 | `8x8` | 7.032 | 17.128 | 0.41x | tenferro |
+| linalg | `f64_eigh` | f64 | 2 | `16x16` | 26.233 | 32.678 | 0.80x | tenferro |
+| linalg | `f64_eigh` | f64 | 2 | `32x32` | 88.984 | 118.558 | 0.75x | tenferro |
+| linalg | `f64_eigh` | f64 | 2 | `64x64` | 478.639 | 426.770 | 1.12x | torch |
+| linalg | `f64_eigh` | f64 | 2 | `128x128` | 2066.426 | 1526.433 | 1.35x | torch |
+| linalg | `f64_eigh` | f64 | 4 | `4x4` | 3.083 | 12.821 | 0.24x | tenferro |
+| linalg | `f64_eigh` | f64 | 4 | `8x8` | 6.912 | 16.959 | 0.41x | tenferro |
+| linalg | `f64_eigh` | f64 | 4 | `16x16` | 22.281 | 31.451 | 0.71x | tenferro |
+| linalg | `f64_eigh` | f64 | 4 | `32x32` | 82.132 | 120.621 | 0.68x | tenferro |
+| linalg | `f64_eigh` | f64 | 4 | `64x64` | 515.723 | 346.952 | 1.49x | torch |
+| linalg | `f64_eigh` | f64 | 4 | `128x128` | 2122.134 | 1394.780 | 1.52x | torch |
+| linalg | `f64_solve_column_rhs1` | f64 | 1 | `4x1` | 1.253 | 23.431 | 0.05x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 1 | `8x1` | 1.588 | 23.435 | 0.07x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 1 | `16x1` | 3.858 | 26.128 | 0.15x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 1 | `32x1` | 8.490 | 35.631 | 0.24x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 2 | `4x1` | 1.301 | 20.956 | 0.06x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 2 | `8x1` | 1.608 | 21.534 | 0.07x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 2 | `16x1` | 3.573 | 23.317 | 0.15x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 2 | `32x1` | 7.655 | 34.099 | 0.22x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 4 | `4x1` | 1.182 | 21.176 | 0.06x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 4 | `8x1` | 1.486 | 21.486 | 0.07x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 4 | `16x1` | 3.223 | 24.149 | 0.13x | tenferro |
+| linalg | `f64_solve_column_rhs1` | f64 | 4 | `32x1` | 7.102 | 31.889 | 0.22x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 1 | `4x4` | 2.775 | 25.083 | 0.11x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 1 | `8x4` | 2.290 | 26.156 | 0.09x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 1 | `16x4` | 3.103 | 29.389 | 0.11x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 1 | `32x4` | 8.289 | 40.142 | 0.21x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 1 | `64x4` | 27.302 | 65.672 | 0.42x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 1 | `128x4` | 161.697 | 170.990 | 0.95x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 2 | `4x4` | 1.329 | 22.142 | 0.06x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 2 | `8x4` | 1.749 | 23.633 | 0.07x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 2 | `16x4` | 3.558 | 26.928 | 0.13x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 2 | `32x4` | 7.174 | 41.873 | 0.17x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 2 | `64x4` | 49.779 | 80.343 | 0.62x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 2 | `128x4` | 310.386 | 201.601 | 1.54x | torch |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 4 | `4x4` | 1.177 | 22.744 | 0.05x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 4 | `8x4` | 1.580 | 23.666 | 0.07x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 4 | `16x4` | 3.146 | 26.604 | 0.12x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 4 | `32x4` | 7.210 | 45.892 | 0.16x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 4 | `64x4` | 66.865 | 77.154 | 0.87x | tenferro |
+| linalg | `f64_solve_matrix_rhs4` | f64 | 4 | `128x4` | 233.449 | 201.381 | 1.16x | torch |
+| linalg | `c64_eigh` | c64 | 1 | `4x4` | 2.891 | 14.581 | 0.20x | tenferro |
+| linalg | `c64_eigh` | c64 | 1 | `8x8` | 8.208 | 20.035 | 0.41x | tenferro |
+| linalg | `c64_eigh` | c64 | 1 | `16x16` | 24.561 | 43.253 | 0.57x | tenferro |
+| linalg | `c64_eigh` | c64 | 1 | `32x32` | 112.024 | 149.170 | 0.75x | tenferro |
+| linalg | `c64_eigh` | c64 | 2 | `4x4` | 3.171 | 13.097 | 0.24x | tenferro |
+| linalg | `c64_eigh` | c64 | 2 | `8x8` | 7.987 | 18.141 | 0.44x | tenferro |
+| linalg | `c64_eigh` | c64 | 2 | `16x16` | 25.842 | 41.690 | 0.62x | tenferro |
+| linalg | `c64_eigh` | c64 | 2 | `32x32` | 114.903 | 158.444 | 0.73x | tenferro |
+| linalg | `c64_eigh` | c64 | 4 | `4x4` | 3.217 | 13.505 | 0.24x | tenferro |
+| linalg | `c64_eigh` | c64 | 4 | `8x8` | 7.541 | 18.311 | 0.41x | tenferro |
+| linalg | `c64_eigh` | c64 | 4 | `16x16` | 25.038 | 39.728 | 0.63x | tenferro |
+| linalg | `c64_eigh` | c64 | 4 | `32x32` | 113.260 | 155.682 | 0.73x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `2x2x16` | 4.656 | 19.640 | 0.24x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `2x2x64` | 5.142 | 22.054 | 0.23x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `2x2x256` | 12.760 | 26.282 | 0.49x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `4x4x16` | 3.255 | 21.380 | 0.15x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `4x4x64` | 6.558 | 27.481 | 0.24x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `4x4x256` | 31.671 | 50.638 | 0.63x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `8x8x16` | 8.522 | 107.073 | 0.08x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `8x8x64` | 9.903 | 364.840 | 0.03x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `8x8x256` | 40.896 | 1406.283 | 0.03x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `16x16x16` | 9.689 | 141.774 | 0.07x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `16x16x64` | 35.161 | 498.093 | 0.07x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 1 | `16x16x256` | 111.427 | 1950.126 | 0.06x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `2x2x16` | 3.004 | 19.684 | 0.15x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `2x2x64` | 5.072 | 20.896 | 0.24x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `2x2x256` | 12.478 | 24.924 | 0.50x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `4x4x16` | 3.319 | 21.205 | 0.16x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `4x4x64` | 5.863 | 25.191 | 0.23x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `4x4x256` | 16.926 | 47.033 | 0.36x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `8x8x16` | 4.023 | 103.589 | 0.04x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `8x8x64` | 8.717 | 335.369 | 0.03x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `8x8x256` | 27.583 | 1488.444 | 0.02x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `16x16x16` | 9.223 | 133.165 | 0.07x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `16x16x64` | 32.316 | 453.731 | 0.07x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 2 | `16x16x256` | 108.969 | 1860.461 | 0.06x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `2x2x16` | 2.985 | 19.231 | 0.16x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `2x2x64` | 7.220 | 20.941 | 0.34x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `2x2x256` | 14.531 | 23.133 | 0.63x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `4x4x16` | 3.309 | 20.784 | 0.16x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `4x4x64` | 6.292 | 25.828 | 0.24x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `4x4x256` | 19.661 | 44.584 | 0.44x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `8x8x16` | 5.455 | 102.489 | 0.05x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `8x8x64` | 9.712 | 346.916 | 0.03x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `8x8x256` | 27.386 | 1280.667 | 0.02x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `16x16x16` | 9.324 | 134.258 | 0.07x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `16x16x64` | 36.371 | 460.721 | 0.08x | tenferro |
+| batched_einsum_rightmost_batch | `f64_ikb_knb_to_inb` | f64 | 4 | `16x16x256` | 102.220 | 2113.694 | 0.05x | tenferro |
+| einsum_patterns | `f64_binary_ij_jk_to_ik` | f64 | 1 | `64x64` | 21.514 | 49.824 | 0.43x | tenferro |
+| einsum_patterns | `f64_binary_ij_jk_to_ik` | f64 | 2 | `64x64` | 40.110 | 66.289 | 0.61x | tenferro |
+| einsum_patterns | `f64_binary_ij_jk_to_ik` | f64 | 4 | `64x64` | 36.210 | 56.845 | 0.64x | tenferro |
+| einsum_patterns | `f64_chain_ij_jk_kl_to_il` | f64 | 1 | `64x64` | 49.646 | 87.487 | 0.57x | tenferro |
+| einsum_patterns | `f64_chain_ij_jk_kl_to_il` | f64 | 2 | `64x64` | 81.315 | 125.273 | 0.65x | tenferro |
+| einsum_patterns | `f64_chain_ij_jk_kl_to_il` | f64 | 4 | `64x64` | 100.516 | 106.778 | 0.94x | tenferro |
+| einsum_patterns | `f64_multiedge_ijk_jkl_to_il` | f64 | 1 | `8x16x8__16x8x8` | 3.149 | 17.545 | 0.18x | tenferro |
+| einsum_patterns | `f64_multiedge_ijk_jkl_to_il` | f64 | 2 | `8x16x8__16x8x8` | 3.319 | 21.011 | 0.16x | tenferro |
+| einsum_patterns | `f64_multiedge_ijk_jkl_to_il` | f64 | 4 | `8x16x8__16x8x8` | 4.539 | 22.159 | 0.20x | tenferro |
+| einsum_patterns | `c64_binary_ij_jk_to_ik` | c64 | 1 | `32x32` | 16.275 | 43.074 | 0.38x | tenferro |
+| einsum_patterns | `c64_binary_ij_jk_to_ik` | c64 | 2 | `32x32` | 10.837 | 50.269 | 0.22x | tenferro |
+| einsum_patterns | `c64_binary_ij_jk_to_ik` | c64 | 4 | `32x32` | 19.448 | 53.476 | 0.36x | tenferro |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `4x4` | 110.679 | 83.703 | 1.32x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `8x8` | 119.318 | 94.695 | 1.26x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `16x16` | 146.461 | 133.314 | 1.10x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `32x32` | 276.862 | 266.650 | 1.04x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `64x64` | 839.261 | 817.652 | 1.03x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 1 | `128x128` | 3796.990 | 3708.189 | 1.02x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `4x4` | 108.153 | 74.559 | 1.45x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `8x8` | 121.471 | 86.604 | 1.40x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `16x16` | 145.503 | 123.044 | 1.18x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `32x32` | 364.582 | 293.992 | 1.24x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `64x64` | 1393.896 | 1086.291 | 1.28x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 2 | `128x128` | 4159.568 | 4359.004 | 0.95x | tenferro |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `4x4` | 132.926 | 80.191 | 1.66x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `8x8` | 116.085 | 92.585 | 1.25x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `16x16` | 161.744 | 133.361 | 1.21x | torch |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `32x32` | 419.578 | 426.326 | 0.98x | tenferro |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `64x64` | 1053.240 | 1102.792 | 0.96x | tenferro |
+| ad | `f64_grad_sum_svd_values` | f64 | 4 | `128x128` | 4051.628 | 4180.504 | 0.97x | tenferro |
+| ad | `f64_grad_sum_matmul` | f64 | 1 | `4x4` | 52.688 | 58.551 | 0.90x | tenferro |
+| ad | `f64_grad_sum_matmul` | f64 | 1 | `16x16` | 59.181 | 61.138 | 0.97x | tenferro |
+| ad | `f64_grad_sum_matmul` | f64 | 1 | `64x64` | 132.613 | 146.561 | 0.90x | tenferro |
+| ad | `f64_grad_sum_matmul` | f64 | 2 | `4x4` | 49.490 | 48.083 | 1.03x | torch |
+| ad | `f64_grad_sum_matmul` | f64 | 2 | `16x16` | 60.727 | 54.462 | 1.12x | torch |
+| ad | `f64_grad_sum_matmul` | f64 | 2 | `64x64` | 254.021 | 202.251 | 1.26x | torch |
+| ad | `f64_grad_sum_matmul` | f64 | 4 | `4x4` | 53.243 | 52.372 | 1.02x | torch |
+| ad | `f64_grad_sum_matmul` | f64 | 4 | `16x16` | 56.500 | 59.314 | 0.95x | tenferro |
+| ad | `f64_grad_sum_matmul` | f64 | 4 | `64x64` | 231.322 | 199.666 | 1.16x | torch |
+| ad | `f64_grad_sum_solve` | f64 | 1 | `4x1` | 57.191 | 107.013 | 0.53x | tenferro |
+| ad | `f64_grad_sum_solve` | f64 | 1 | `16x1` | 69.958 | 111.985 | 0.62x | tenferro |
+| ad | `f64_grad_sum_solve` | f64 | 2 | `4x1` | 82.525 | 94.779 | 0.87x | tenferro |
+| ad | `f64_grad_sum_solve` | f64 | 2 | `16x1` | 101.421 | 103.210 | 0.98x | tenferro |
+| ad | `f64_grad_sum_solve` | f64 | 4 | `4x1` | 99.574 | 101.767 | 0.98x | tenferro |
+| ad | `f64_grad_sum_solve` | f64 | 4 | `16x1` | 99.551 | 105.708 | 0.94x | tenferro |
+
+## Tenferro-Only Results
+
+These are decomposition measurements without a Torch C++ counterpart in this
+benchmark file.
+
+| suite | benchmark | dtype | threads | shape | mean_us |
+|---|---|---:|---:|---|---:|
+| matmul | `c64_square` | c64 | 1 | `128x128` | 635.341 |
+| matmul | `c64_square` | c64 | 2 | `128x128` | 295.996 |
+| matmul | `c64_square` | c64 | 4 | `128x128` | 177.806 |
+| linalg | `f64_solve_column_rhs1` | f64 | 1 | `64x1` | 23.176 |
+| linalg | `f64_solve_column_rhs1` | f64 | 1 | `128x1` | 119.972 |
+| linalg | `f64_solve_column_rhs1` | f64 | 2 | `64x1` | 73.785 |
+| linalg | `f64_solve_column_rhs1` | f64 | 2 | `128x1` | 262.443 |
+| linalg | `f64_solve_column_rhs1` | f64 | 4 | `64x1` | 76.915 |
+| linalg | `f64_solve_column_rhs1` | f64 | 4 | `128x1` | 241.144 |
+| ad | `f64_backward_only_reduce_sum` | f64 | 1 | `64x64` | 16.919 |
+| ad | `f64_backward_only_reduce_sum` | f64 | 2 | `64x64` | 16.812 |
+| ad | `f64_backward_only_reduce_sum` | f64 | 4 | `64x64` | 17.059 |
+| ad | `f64_backward_only_sum_matmul` | f64 | 1 | `64x64` | 94.843 |
+| ad | `f64_backward_only_sum_matmul` | f64 | 2 | `64x64` | 162.973 |
+| ad | `f64_backward_only_sum_matmul` | f64 | 4 | `64x64` | 149.265 |
+| ad | `f64_forward_matmul_sum_tracked` | f64 | 1 | `64x64` | 41.368 |
+| ad | `f64_forward_matmul_sum_tracked` | f64 | 2 | `64x64` | 68.622 |
+| ad | `f64_forward_matmul_sum_tracked` | f64 | 4 | `64x64` | 55.194 |
+| ad | `f64_forward_matmul_sum_untracked` | f64 | 1 | `64x64` | 29.351 |
+| ad | `f64_forward_matmul_sum_untracked` | f64 | 2 | `64x64` | 44.449 |
+| ad | `f64_forward_matmul_sum_untracked` | f64 | 4 | `64x64` | 38.852 |
+| ad | `f64_manual_grad_sum_matmul_math` | f64 | 1 | `64x64` | 47.680 |
+| ad | `f64_manual_grad_sum_matmul_math` | f64 | 2 | `64x64` | 56.383 |
+| ad | `f64_manual_grad_sum_matmul_math` | f64 | 4 | `64x64` | 60.032 |
+
+## Torch-Only Results
+
+None.

--- a/docs/performance/cpu-benchmarks.md
+++ b/docs/performance/cpu-benchmarks.md
@@ -1,0 +1,82 @@
+# CPU Benchmarks
+
+The CPU benchmark suite is a normal reporting benchmark, not a publication
+gate. Use it to collect comparable timings before deciding which cases should
+become release or publication thresholds.
+
+Recent result snapshots:
+
+- [2026-05-23 CPU benchmark results](cpu-benchmark-results-2026-05-23.md)
+
+## Tenferro Benchmarks
+
+Run the Rust Criterion benchmarks through the wrapper script:
+
+```bash
+bash scripts/bench-cpu.sh --kind tenferro
+```
+
+The script runs thread counts `1,2,4` by default. Override them with:
+
+```bash
+bash scripts/bench-cpu.sh --kind tenferro --threads 1,4
+```
+
+The wrapper pins common CPU thread controls for each run:
+
+- `TENFERRO_BENCH_THREADS`
+- `RAYON_NUM_THREADS`
+- `OMP_NUM_THREADS`
+- `OPENBLAS_NUM_THREADS`
+- `MKL_NUM_THREADS`
+- `VECLIB_MAXIMUM_THREADS`
+
+Criterion setup creates input tensors outside the measured closure. AD cases
+use `iter_batched` so tensor data preparation happens in setup while the
+measured closure covers forward graph construction and backward execution.
+
+## LibTorch C++ Baseline
+
+The canonical Torch baseline is the LibTorch C++ benchmark:
+
+```bash
+bash scripts/bench-cpu.sh --kind torch-cpp
+```
+
+This avoids Python dispatch overhead in small-matrix latency cases. The script
+uses the official CPU-only LibTorch ZIP distribution and builds only the small
+benchmark binary locally. It does not build PyTorch from source.
+
+By default, the script stores downloaded LibTorch files under the main
+worktree, not under linked git worktrees:
+
+```text
+third_party/libtorch/
+```
+
+This avoids one LibTorch download per temporary worktree. Set
+`TENFERRO_BENCH_DEPS_DIR` to choose a different cache directory, or set
+`LIBTORCH_DIR` to point at an existing LibTorch installation.
+
+The default LibTorch URL can be overridden:
+
+```bash
+LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcpu.zip \
+  bash scripts/bench-cpu.sh --kind torch-cpp
+```
+
+## Scope
+
+The initial CPU suite covers:
+
+- matmul and matmul-like einsum for small and medium/large sizes
+- `svd`, `qr`, `eigh`, and `solve`
+- batched small einsum with the batch index on the right
+- representative N-ary einsum patterns
+- AD for `sum(matmul)`, `sum(svd(A).S)`, and `sum(solve(A, b))`
+- `f64` as the primary dtype, with selected `c64` cases
+
+The `sum(svd(A).S)` AD benchmark uses the same square sizes as the primal SVD
+benchmark: `4x4`, `8x8`, `16x16`, `32x32`, `64x64`, and `128x128`.
+
+GPU benchmarks and hard threshold comparisons are intentionally deferred.

--- a/scripts/bench-cpu.sh
+++ b/scripts/bench-cpu.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+DEFAULT_THREADS="1,2,4"
+THREADS_CSV="${TENFERRO_BENCH_THREADS_LIST:-$DEFAULT_THREADS}"
+KIND="all"
+DOWNLOAD_LIBTORCH=1
+CRITERION_ARGS=()
+
+DEFAULT_LIBTORCH_URL="https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcpu.zip"
+LIBTORCH_URL="${LIBTORCH_URL:-$DEFAULT_LIBTORCH_URL}"
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/bench-cpu.sh [options] [-- criterion-args...]
+
+Runs CPU benchmarks with thread counts pinned to 1, 2, and 4 by default.
+
+Options:
+  --kind tenferro|torch-cpp|all   Which benchmark to run (default: all)
+  --threads LIST                  Comma-separated thread counts (default: 1,2,4)
+  --no-download-libtorch          Require an existing LIBTORCH_DIR instead of downloading
+  --help                          Show this help text
+
+Environment:
+  TENFERRO_BENCH_THREADS_LIST     Default for --threads
+  TENFERRO_BENCH_DEPS_DIR         Repo-local dependency cache directory
+  TENFERRO_MAIN_REPO_DIR          Main worktree used for default dependency cache
+  LIBTORCH_DIR                    Existing LibTorch directory containing share/cmake/Torch
+  LIBTORCH_URL                    LibTorch ZIP URL to download when LIBTORCH_DIR is absent
+
+LibTorch cache policy:
+  By default, downloads go under the main worktree's third_party/libtorch
+  directory, not under linked git worktrees. This avoids one LibTorch copy per
+  temporary worktree.
+
+Examples:
+  bash scripts/bench-cpu.sh
+  bash scripts/bench-cpu.sh --kind tenferro --threads 1,4 -- --sample-size 10
+  LIBTORCH_DIR=/opt/libtorch bash scripts/bench-cpu.sh --kind torch-cpp
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kind)
+      KIND="${2:?missing value for --kind}"
+      shift 2
+      ;;
+    --threads)
+      THREADS_CSV="${2:?missing value for --threads}"
+      shift 2
+      ;;
+    --no-download-libtorch)
+      DOWNLOAD_LIBTORCH=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      CRITERION_ARGS=("$@")
+      break
+      ;;
+    *)
+      printf 'unknown argument: %s\n\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$KIND" in
+  tenferro|torch-cpp|all) ;;
+  *)
+    printf 'invalid --kind: %s\n' "$KIND" >&2
+    exit 2
+    ;;
+esac
+
+main_worktree() {
+  git -C "$ROOT_DIR" worktree list --porcelain | awk '
+    NR == 1 && $1 == "worktree" {
+      print $2
+      exit
+    }
+  '
+}
+
+MAIN_REPO_DIR="${TENFERRO_MAIN_REPO_DIR:-$(main_worktree)}"
+if [[ -z "$MAIN_REPO_DIR" ]]; then
+  MAIN_REPO_DIR="$ROOT_DIR"
+fi
+
+DEPS_DIR="${TENFERRO_BENCH_DEPS_DIR:-$MAIN_REPO_DIR/third_party/libtorch}"
+LIBTORCH_DIR="${LIBTORCH_DIR:-$DEPS_DIR/libtorch}"
+
+split_threads() {
+  local csv="$1"
+  local old_ifs="$IFS"
+  IFS=','
+  read -ra values <<< "$csv"
+  IFS="$old_ifs"
+  for value in "${values[@]}"; do
+    if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+      printf 'invalid thread count: %s\n' "$value" >&2
+      exit 2
+    fi
+    printf '%s\n' "$value"
+  done
+}
+
+pin_threads() {
+  local threads="$1"
+  export TENFERRO_BENCH_THREADS="$threads"
+  export RAYON_NUM_THREADS="$threads"
+  export OMP_NUM_THREADS="$threads"
+  export OPENBLAS_NUM_THREADS="$threads"
+  export MKL_NUM_THREADS="$threads"
+  export VECLIB_MAXIMUM_THREADS="$threads"
+  export NUMEXPR_NUM_THREADS="$threads"
+}
+
+ensure_libtorch() {
+  if [[ -f "$LIBTORCH_DIR/share/cmake/Torch/TorchConfig.cmake" ]]; then
+    return
+  fi
+
+  if [[ "$DOWNLOAD_LIBTORCH" -eq 0 ]]; then
+    cat >&2 <<EOF
+LibTorch was not found at:
+  $LIBTORCH_DIR
+
+Set LIBTORCH_DIR to an existing LibTorch install, or omit --no-download-libtorch.
+EOF
+    exit 1
+  fi
+
+  mkdir -p "$DEPS_DIR/archives"
+  local archive="$DEPS_DIR/archives/$(basename "${LIBTORCH_URL%%\?*}")"
+  if [[ ! -f "$archive" ]]; then
+    printf 'Downloading LibTorch to %s\n' "$archive" >&2
+    curl --fail --location --output "$archive" "$LIBTORCH_URL"
+  fi
+
+  local tmp_dir="$DEPS_DIR/.extract-$$"
+  rm -rf "$tmp_dir"
+  mkdir -p "$tmp_dir"
+  unzip -q "$archive" -d "$tmp_dir"
+  rm -rf "$LIBTORCH_DIR"
+  mv "$tmp_dir/libtorch" "$LIBTORCH_DIR"
+  rm -rf "$tmp_dir"
+}
+
+run_tenferro() {
+  local threads="$1"
+  pin_threads "$threads"
+  printf '==> tenferro Criterion CPU benchmarks, threads=%s\n' "$threads" >&2
+  cargo bench -p tenferro --bench cpu_bench -- "${CRITERION_ARGS[@]}"
+}
+
+build_torch_cpp() {
+  ensure_libtorch
+  local build_dir="$ROOT_DIR/target/torch-cpp-bench"
+  cmake -S "$ROOT_DIR/benchmarks/torch-cpp" \
+    -B "$build_dir" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH="$LIBTORCH_DIR"
+  cmake --build "$build_dir" --config Release --parallel
+}
+
+run_torch_cpp() {
+  local threads="$1"
+  pin_threads "$threads"
+  build_torch_cpp
+  export LD_LIBRARY_PATH="$LIBTORCH_DIR/lib:${LD_LIBRARY_PATH:-}"
+  printf '==> LibTorch C++ CPU baseline, threads=%s\n' "$threads" >&2
+  "$ROOT_DIR/target/torch-cpp-bench/torch_cpu_bench" "$threads"
+}
+
+mapfile -t THREADS < <(split_threads "$THREADS_CSV")
+
+for threads in "${THREADS[@]}"; do
+  case "$KIND" in
+    tenferro)
+      run_tenferro "$threads"
+      ;;
+    torch-cpp)
+      run_torch_cpp "$threads"
+      ;;
+    all)
+      run_tenferro "$threads"
+      run_torch_cpp "$threads"
+      ;;
+  esac
+done

--- a/tenferro-ops/src/ad/contraction.rs
+++ b/tenferro-ops/src/ad/contraction.rs
@@ -4,6 +4,7 @@ use computegraph::OpEmitter;
 use tenferro_tensor::{CompareDir, DotGeneralConfig};
 
 use crate::ad::context::ShapeGuardContext;
+use crate::ad::support::{conjugate_primal_if_complex, conjugate_primal_if_dtype_complex};
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::{EinsumSubscripts, StdTensorOp};
 use crate::sym_dim::SymDim;
@@ -286,15 +287,14 @@ pub fn transpose_dot_general(
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let rhs_conj =
-            emitter.add_op(StdTensorOp::Conj, vec![inputs[1].clone()], OpMode::Primal)[0];
+        let rhs_conj = conjugate_primal_if_complex(emitter, inputs[1].clone(), ctx);
         let (transpose_config, new_lhs_rank, new_rhs_rank, perm) =
             transpose_plan_for_lhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free);
         let out = emitter.add_op(
             StdTensorOp::DotGeneral {
                 config: transpose_config,
             },
-            vec![cotangent.clone(), ValRef::Local(rhs_conj)],
+            vec![cotangent.clone(), rhs_conj],
             OpMode::Linear {
                 active_mask: vec![true, false],
             },
@@ -304,15 +304,14 @@ pub fn transpose_dot_general(
     }
 
     if active_mask[1] {
-        let lhs_conj =
-            emitter.add_op(StdTensorOp::Conj, vec![inputs[0].clone()], OpMode::Primal)[0];
+        let lhs_conj = conjugate_primal_if_complex(emitter, inputs[0].clone(), ctx);
         let (transpose_config, new_lhs_rank, new_rhs_rank, perm) =
             transpose_plan_for_rhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free);
         let out = emitter.add_op(
             StdTensorOp::DotGeneral {
                 config: transpose_config,
             },
-            vec![ValRef::Local(lhs_conj), cotangent],
+            vec![lhs_conj, cotangent],
             OpMode::Linear {
                 active_mask: vec![false, true],
             },
@@ -330,6 +329,7 @@ pub fn transpose_nary_einsum(
     inputs: &[ValRef<StdTensorOp>],
     mode: &OpMode,
     subscripts: &EinsumSubscripts,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValId>> {
     let input_labels = &subscripts.inputs;
     let output_labels = &subscripts.output;
@@ -364,12 +364,11 @@ pub fn transpose_nary_einsum(
             }
 
             vjp_input_labels.push(input_labels[input_idx].clone());
-            let conjugated = emitter.add_op(
-                StdTensorOp::Conj,
-                vec![inputs[input_idx].clone()],
-                OpMode::Primal,
-            );
-            vjp_inputs.push(ValRef::Local(conjugated[0]));
+            vjp_inputs.push(conjugate_primal_if_complex(
+                emitter,
+                inputs[input_idx].clone(),
+                ctx,
+            ));
         }
 
         let out = emitter.add_op(
@@ -488,14 +487,12 @@ pub fn transpose_reduce_prod(
                 vec![ValRef::Local(prod_broadcast), inputs[0].clone()],
                 OpMode::Primal,
             )[0];
-            let coeff_conj = emitter.add_op(
-                StdTensorOp::Conj,
-                vec![ValRef::Local(coeff)],
-                OpMode::Primal,
-            )[0];
+            let input_dtype = ctx.dtype_of(&inputs[0]);
+            let coeff_conj =
+                conjugate_primal_if_dtype_complex(emitter, ValRef::Local(coeff), input_dtype);
             let out = emitter.add_op(
                 StdTensorOp::Mul,
-                vec![ValRef::Local(coeff_conj), ValRef::Local(cotangent)],
+                vec![coeff_conj, ValRef::Local(cotangent)],
                 OpMode::Linear {
                     active_mask: vec![false, true],
                 },
@@ -565,14 +562,12 @@ pub fn transpose_reduce_chooser(
                 vec![ValRef::Local(indicators), ValRef::Local(counts_broadcast)],
                 OpMode::Primal,
             )[0];
-            let weights_conj = emitter.add_op(
-                StdTensorOp::Conj,
-                vec![ValRef::Local(weights)],
-                OpMode::Primal,
-            )[0];
+            let input_dtype = ctx.dtype_of(&inputs[0]);
+            let weights_conj =
+                conjugate_primal_if_dtype_complex(emitter, ValRef::Local(weights), input_dtype);
             let out = emitter.add_op(
                 StdTensorOp::Mul,
-                vec![ValRef::Local(weights_conj), ValRef::Local(cotangent)],
+                vec![weights_conj, ValRef::Local(cotangent)],
                 OpMode::Linear {
                     active_mask: vec![false, true],
                 },

--- a/tenferro-ops/src/ad/linalg.rs
+++ b/tenferro-ops/src/ad/linalg.rs
@@ -4,6 +4,7 @@ use computegraph::OpEmitter;
 use tenferro_tensor::{DType, DotGeneralConfig, PadConfig};
 
 use super::context::{resolve_and_guard, ShapeGuardContext};
+use super::support::{conjugate_linear_if_dtype_complex, conjugate_primal_if_dtype_complex};
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 
@@ -325,23 +326,45 @@ pub fn linearize_triangular_solve(
     vec![Some(out[0])]
 }
 
-pub fn linearize_full_piv_lu_solve(
+#[derive(Clone, Copy)]
+enum LinearSolveOp {
+    Solve,
+    FullPivLuSolve,
+}
+
+fn linear_solve_op(kind: LinearSolveOp, transpose_a: bool) -> StdTensorOp {
+    match kind {
+        LinearSolveOp::Solve => StdTensorOp::Solve { transpose_a },
+        LinearSolveOp::FullPivLuSolve => StdTensorOp::FullPivLuSolve { transpose_a },
+    }
+}
+
+fn linear_solve_op_name(kind: LinearSolveOp) -> &'static str {
+    match kind {
+        LinearSolveOp::Solve => "linearize_solve",
+        LinearSolveOp::FullPivLuSolve => "linearize_full_piv_lu_solve",
+    }
+}
+
+fn linearize_linear_solve(
     builder: &mut FragmentBuilder<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
+    kind: LinearSolveOp,
 ) -> Vec<Option<LocalValId>> {
     let lhs_rank = ctx.shape_of(&ValRef::External(primal_in[0].clone())).len();
     let rhs_rank = ctx.shape_of(&ValRef::External(primal_in[1].clone())).len();
+    let op_name = linear_solve_op_name(kind);
     assert!(
         lhs_rank >= 2 && rhs_rank >= 2,
-        "linearize_full_piv_lu_solve: expected matrix operands"
+        "{op_name}: expected matrix operands"
     );
     assert_eq!(
         lhs_rank, rhs_rank,
-        "linearize_full_piv_lu_solve: rank mismatch between lhs and rhs"
+        "{op_name}: rank mismatch between lhs and rhs"
     );
     let rank = lhs_rank;
     let mut rhs_tangent = tangent_in[1];
@@ -366,7 +389,7 @@ pub fn linearize_full_piv_lu_solve(
     };
 
     let out = builder.add_op(
-        StdTensorOp::FullPivLuSolve { transpose_a },
+        linear_solve_op(kind, transpose_a),
         vec![
             ValRef::External(primal_in[0].clone()),
             ValRef::Local(rhs_tangent),
@@ -376,6 +399,44 @@ pub fn linearize_full_piv_lu_solve(
         },
     );
     vec![Some(out[0])]
+}
+
+pub fn linearize_solve(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    primal_out: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    transpose_a: bool,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    linearize_linear_solve(
+        builder,
+        primal_in,
+        primal_out,
+        tangent_in,
+        transpose_a,
+        ctx,
+        LinearSolveOp::Solve,
+    )
+}
+
+pub fn linearize_full_piv_lu_solve(
+    builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    primal_out: &[GlobalValKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValId>],
+    transpose_a: bool,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    linearize_linear_solve(
+        builder,
+        primal_in,
+        primal_out,
+        tangent_in,
+        transpose_a,
+        ctx,
+        LinearSolveOp::FullPivLuSolve,
+    )
 }
 
 fn triangular_solve_rhs_tangent(
@@ -433,13 +494,14 @@ pub fn linearize_svd(
     let (m, n, batch_shape) = matrix_shape_parts(input_shape, "linearize_svd");
     let (m_size, n_size) = resolve_and_guard(m, n, ctx);
     let matrix_rank = input_shape.len();
+    let dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
     let k = DimExpr::min(m.clone(), n.clone());
     let u = ValRef::External(primal_out[0].clone());
     let s = ValRef::External(primal_out[1].clone());
     let vt = ValRef::External(primal_out[2].clone());
 
-    let uh = adjoint_matrix_fixed(builder, u.clone(), matrix_rank);
-    let v = adjoint_matrix_fixed(builder, vt.clone(), matrix_rank);
+    let uh = adjoint_matrix_fixed(builder, u.clone(), matrix_rank, dtype);
+    let v = adjoint_matrix_fixed(builder, vt.clone(), matrix_rank, dtype);
     let tmp = matmul_linear(
         builder,
         ValRef::Local(uh),
@@ -485,14 +547,14 @@ pub fn linearize_svd(
     let s_inv = fixed_div(builder, s.clone(), ValRef::Local(safe_s_sq));
     let s_inv_mat = embed_diag_fixed(builder, ValRef::Local(s_inv));
 
-    let ds_h = adjoint_matrix_linear(builder, ds_mat, matrix_rank);
+    let ds_h = adjoint_matrix_linear(builder, ds_mat, matrix_rank, dtype);
     let anti_hermitian = linear_sub(builder, ds_mat, ds_h);
     // Matches JAX's complex gauge correction: 0.5 * (dS - dS^H) * diag(1 / s).
     let d_udv_diag = hadamard_fixed_linear(builder, ValRef::Local(s_inv_mat), anti_hermitian);
     let d_udv_diag = linear_scale(builder, d_udv_diag, 0.5);
 
     let dss = hadamard_fixed_linear(builder, ValRef::Local(s_dim), ds_mat);
-    let dss_h = adjoint_matrix_linear(builder, dss, matrix_rank);
+    let dss_h = adjoint_matrix_linear(builder, dss, matrix_rank, dtype);
     let du_inner_sum = linear_add(builder, dss, dss_h);
     let du_inner = hadamard_fixed_linear(builder, ValRef::Local(f), du_inner_sum);
     let du_inner = linear_add(builder, du_inner, d_udv_diag);
@@ -505,7 +567,7 @@ pub fn linearize_svd(
     );
 
     let sds = hadamard_fixed_linear(builder, ValRef::Local(s_dim_t), ds_mat);
-    let sds_h = adjoint_matrix_linear(builder, sds, matrix_rank);
+    let sds_h = adjoint_matrix_linear(builder, sds, matrix_rank, dtype);
     let dv_inner_sum = linear_add(builder, sds, sds_h);
     let dv_inner = hadamard_fixed_linear(builder, ValRef::Local(f), dv_inner_sum);
     let mut dv = matmul_linear(
@@ -550,7 +612,7 @@ pub fn linearize_svd(
     }
 
     if n_size > m_size {
-        let da_h = adjoint_matrix_linear(builder, da, matrix_rank);
+        let da_h = adjoint_matrix_linear(builder, da, matrix_rank, dtype);
         let d_ahu = matmul_linear(
             builder,
             ValRef::Local(da_h),
@@ -583,7 +645,7 @@ pub fn linearize_svd(
         dv = linear_add(builder, dv, correction);
     }
 
-    let dvt = adjoint_matrix_linear(builder, dv, matrix_rank);
+    let dvt = adjoint_matrix_linear(builder, dv, matrix_rank, dtype);
 
     vec![Some(du), Some(ds), Some(dvt)]
 }
@@ -603,11 +665,12 @@ pub fn linearize_eigh(
     let input_shape = primal_input_shape(ctx, primal_in);
     let input_shape = input_shape.as_slice();
     let matrix_rank = input_shape.len();
+    let dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
     let w = ValRef::External(primal_out[0].clone());
     let v = ValRef::External(primal_out[1].clone());
-    let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank);
+    let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
 
-    let vh = adjoint_matrix_fixed(builder, v.clone(), matrix_rank);
+    let vh = adjoint_matrix_fixed(builder, v.clone(), matrix_rank, dtype);
     let tmp = matmul_linear(
         builder,
         ValRef::Local(vh),
@@ -669,9 +732,10 @@ pub fn linearize_cholesky(
     let input_shape = primal_input_shape(ctx, primal_in);
     let input_shape = input_shape.as_slice();
     let matrix_rank = input_shape.len();
+    let dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
     let l = ValRef::External(primal_out[0].clone());
-    let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank);
-    let l_conj = fixed_unary(builder, StdTensorOp::Conj, l.clone());
+    let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
+    let l_conj = conjugate_primal_if_dtype_complex(builder, l.clone(), dtype);
 
     let tmp = builder.add_op(
         StdTensorOp::TriangularSolve {
@@ -680,7 +744,7 @@ pub fn linearize_cholesky(
             transpose_a: true,
             unit_diagonal: false,
         },
-        vec![ValRef::Local(l_conj), ValRef::Local(da_self_adjoint)],
+        vec![l_conj, ValRef::Local(da_self_adjoint)],
         OpMode::Linear {
             active_mask: vec![false, true],
         },
@@ -736,11 +800,12 @@ pub fn linearize_qr(
     let (m, n, batch_shape) = matrix_shape_parts(input_shape, "linearize_qr");
     let (m_size, n_size) = resolve_and_guard(m, n, ctx);
     let matrix_rank = input_shape.len();
+    let dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
     let q = ValRef::External(primal_out[0].clone());
     let r = ValRef::External(primal_out[1].clone());
 
     if n_size > m_size {
-        let qh = adjoint_matrix_fixed(builder, q.clone(), matrix_rank);
+        let qh = adjoint_matrix_fixed(builder, q.clone(), matrix_rank, dtype);
         let leading_selector = leading_column_selector_fixed(
             builder,
             m_size,
@@ -764,8 +829,9 @@ pub fn linearize_qr(
             ValRef::Local(leading_selector_t),
             matrix_rank,
         );
-        let r_leading_h = adjoint_matrix_fixed(builder, ValRef::Local(r_leading), matrix_rank);
-        let da_leading_h = adjoint_matrix_linear(builder, da_leading, matrix_rank);
+        let r_leading_h =
+            adjoint_matrix_fixed(builder, ValRef::Local(r_leading), matrix_rank, dtype);
+        let da_leading_h = adjoint_matrix_linear(builder, da_leading, matrix_rank, dtype);
         let dx_rinv_h = builder.add_op(
             StdTensorOp::TriangularSolve {
                 left_side: true,
@@ -778,7 +844,7 @@ pub fn linearize_qr(
                 active_mask: vec![false, true],
             },
         )[0];
-        let dx_rinv = adjoint_matrix_linear(builder, dx_rinv_h, matrix_rank);
+        let dx_rinv = adjoint_matrix_linear(builder, dx_rinv_h, matrix_rank, dtype);
         let qt_dx_rinv = matmul_linear(
             builder,
             ValRef::Local(qh),
@@ -786,7 +852,7 @@ pub fn linearize_qr(
             vec![false, true],
             matrix_rank,
         );
-        let qt_dx_rinv_h = adjoint_matrix_linear(builder, qt_dx_rinv, matrix_rank);
+        let qt_dx_rinv_h = adjoint_matrix_linear(builder, qt_dx_rinv, matrix_rank, dtype);
         let sym = linear_add(builder, qt_dx_rinv, qt_dx_rinv_h);
         let upper = builder.add_op(
             StdTensorOp::Triu { k: 1 },
@@ -877,8 +943,8 @@ pub fn linearize_qr(
         return vec![Some(dq), Some(dr)];
     }
 
-    let r_h = adjoint_matrix_fixed(builder, r.clone(), matrix_rank);
-    let da_h = adjoint_matrix_linear(builder, da, matrix_rank);
+    let r_h = adjoint_matrix_fixed(builder, r.clone(), matrix_rank, dtype);
+    let da_h = adjoint_matrix_linear(builder, da, matrix_rank, dtype);
     let dx_rinv_h = builder.add_op(
         StdTensorOp::TriangularSolve {
             left_side: true,
@@ -891,8 +957,8 @@ pub fn linearize_qr(
             active_mask: vec![false, true],
         },
     )[0];
-    let dx_rinv = adjoint_matrix_linear(builder, dx_rinv_h, matrix_rank);
-    let qh = adjoint_matrix_fixed(builder, q.clone(), matrix_rank);
+    let dx_rinv = adjoint_matrix_linear(builder, dx_rinv_h, matrix_rank, dtype);
+    let qh = adjoint_matrix_fixed(builder, q.clone(), matrix_rank, dtype);
     let qt_dx_rinv = matmul_linear(
         builder,
         ValRef::Local(qh),
@@ -900,7 +966,7 @@ pub fn linearize_qr(
         vec![false, true],
         matrix_rank,
     );
-    let qt_dx_rinv_h = adjoint_matrix_linear(builder, qt_dx_rinv, matrix_rank);
+    let qt_dx_rinv_h = adjoint_matrix_linear(builder, qt_dx_rinv, matrix_rank, dtype);
     let sym = linear_add(builder, qt_dx_rinv, qt_dx_rinv_h);
     let upper = builder.add_op(
         StdTensorOp::Triu { k: 1 },
@@ -953,8 +1019,8 @@ pub fn transpose_triangular_solve(
 
     let mut result = vec![None, None];
     if active_mask[0] || active_mask[1] {
-        let conjugated_a =
-            emitter.add_op(StdTensorOp::Conj, vec![inputs[0].clone()], OpMode::Primal)[0];
+        let dtype = ctx.dtype_of(&inputs[0]);
+        let conjugated_a = conjugate_primal_if_dtype_complex(emitter, inputs[0].clone(), dtype);
         let out = emitter.add_op(
             StdTensorOp::TriangularSolve {
                 left_side,
@@ -962,7 +1028,7 @@ pub fn transpose_triangular_solve(
                 transpose_a: !transpose_a,
                 unit_diagonal,
             },
-            vec![ValRef::Local(conjugated_a), ValRef::Local(ct)],
+            vec![conjugated_a, ValRef::Local(ct)],
             OpMode::Linear {
                 active_mask: vec![false, true],
             },
@@ -987,6 +1053,7 @@ pub fn transpose_triangular_solve(
                 left_side,
                 transpose_a,
                 rank,
+                dtype,
             );
             let matrix_cotangent =
                 project_triangular_operand_linear(emitter, matrix_cotangent, lower, unit_diagonal);
@@ -1000,13 +1067,14 @@ pub fn transpose_triangular_solve(
     result
 }
 
-pub fn transpose_full_piv_lu_solve(
+fn transpose_linear_solve(
     emitter: &mut impl OpEmitter<StdTensorOp>,
     cotangent_out: &[Option<LocalValId>],
     inputs: &[ValRef<StdTensorOp>],
     mode: &OpMode,
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
+    kind: LinearSolveOp,
 ) -> Vec<Option<LocalValId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None, None];
@@ -1017,13 +1085,11 @@ pub fn transpose_full_piv_lu_solve(
 
     let mut result = vec![None, None];
     if active_mask[0] || active_mask[1] {
-        let conjugated_a =
-            emitter.add_op(StdTensorOp::Conj, vec![inputs[0].clone()], OpMode::Primal)[0];
+        let dtype = ctx.dtype_of(&inputs[0]);
+        let conjugated_a = conjugate_primal_if_dtype_complex(emitter, inputs[0].clone(), dtype);
         let out = emitter.add_op(
-            StdTensorOp::FullPivLuSolve {
-                transpose_a: !transpose_a,
-            },
-            vec![ValRef::Local(conjugated_a), ValRef::Local(ct)],
+            linear_solve_op(kind, !transpose_a),
+            vec![conjugated_a, ValRef::Local(ct)],
             OpMode::Linear {
                 active_mask: vec![false, true],
             },
@@ -1032,7 +1098,7 @@ pub fn transpose_full_piv_lu_solve(
         if active_mask[0] {
             let rank = ctx.shape_of(&inputs[0]).len();
             let solution = emitter.add_op(
-                StdTensorOp::FullPivLuSolve { transpose_a },
+                linear_solve_op(kind, transpose_a),
                 inputs.to_vec(),
                 OpMode::Primal,
             )[0];
@@ -1043,6 +1109,7 @@ pub fn transpose_full_piv_lu_solve(
                 true,
                 transpose_a,
                 rank,
+                dtype,
             ));
         }
         if active_mask[1] {
@@ -1053,6 +1120,44 @@ pub fn transpose_full_piv_lu_solve(
     result
 }
 
+pub fn transpose_solve(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+    transpose_a: bool,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    transpose_linear_solve(
+        emitter,
+        cotangent_out,
+        inputs,
+        mode,
+        transpose_a,
+        ctx,
+        LinearSolveOp::Solve,
+    )
+}
+
+pub fn transpose_full_piv_lu_solve(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    mode: &OpMode,
+    transpose_a: bool,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValId>> {
+    transpose_linear_solve(
+        emitter,
+        cotangent_out,
+        inputs,
+        mode,
+        transpose_a,
+        ctx,
+        LinearSolveOp::FullPivLuSolve,
+    )
+}
+
 fn solve_matrix_cotangent(
     emitter: &mut impl OpEmitter<StdTensorOp>,
     rhs_cotangent: LocalValId,
@@ -1060,9 +1165,10 @@ fn solve_matrix_cotangent(
     left_side: bool,
     transpose_a: bool,
     rank: usize,
+    dtype: DType,
 ) -> LocalValId {
     let negative_rhs_cotangent = linear_neg(emitter, rhs_cotangent);
-    let solution_h = adjoint_matrix_fixed(emitter, solution, rank);
+    let solution_h = adjoint_matrix_fixed(emitter, solution, rank, dtype);
     let op_matrix_cotangent = if left_side {
         matmul_linear(
             emitter,
@@ -1384,17 +1490,19 @@ fn adjoint_matrix_fixed(
     builder: &mut impl OpEmitter<StdTensorOp>,
     input: ValRef<StdTensorOp>,
     rank: usize,
+    dtype: DType,
 ) -> LocalValId {
-    let conjugated = fixed_unary(builder, StdTensorOp::Conj, input);
-    transpose_matrix_fixed(builder, ValRef::Local(conjugated), rank)
+    let input = conjugate_primal_if_dtype_complex(builder, input, dtype);
+    transpose_matrix_fixed(builder, input, rank)
 }
 
 fn adjoint_matrix_linear(
     builder: &mut FragmentBuilder<StdTensorOp>,
     input: LocalValId,
     rank: usize,
+    dtype: DType,
 ) -> LocalValId {
-    let conjugated = linear_unary(builder, StdTensorOp::Conj, input);
+    let conjugated = conjugate_linear_if_dtype_complex(builder, input, dtype);
     builder.add_op(
         StdTensorOp::Transpose {
             perm: matrix_transpose_perm(rank),
@@ -1444,6 +1552,7 @@ fn self_adjoint_from_lower_linear(
     builder: &mut FragmentBuilder<StdTensorOp>,
     input: LocalValId,
     rank: usize,
+    dtype: DType,
 ) -> LocalValId {
     let strict_lower = builder.add_op(
         StdTensorOp::Tril { k: -1 },
@@ -1452,14 +1561,18 @@ fn self_adjoint_from_lower_linear(
             active_mask: vec![true],
         },
     )[0];
-    let strict_lower_h = adjoint_matrix_linear(builder, strict_lower, rank);
+    let strict_lower_h = adjoint_matrix_linear(builder, strict_lower, rank, dtype);
     let offdiag = linear_add(builder, strict_lower, strict_lower_h);
 
     let diag = extract_diag_linear(builder, input);
-    let diag_h = linear_unary(builder, StdTensorOp::Conj, diag);
-    let diag_sum = linear_add(builder, diag, diag_h);
-    let real_diag = linear_scale(builder, diag_sum, 0.5);
-    let diag_mat = embed_diag_linear(builder, real_diag);
+    let diag = if matches!(dtype, DType::F32 | DType::F64) {
+        diag
+    } else {
+        let diag_h = conjugate_linear_if_dtype_complex(builder, diag, dtype);
+        let diag_sum = linear_add(builder, diag, diag_h);
+        linear_scale(builder, diag_sum, 0.5)
+    };
+    let diag_mat = embed_diag_linear(builder, diag);
     linear_add(builder, offdiag, diag_mat)
 }
 

--- a/tenferro-ops/src/ad/mod.rs
+++ b/tenferro-ops/src/ad/mod.rs
@@ -79,7 +79,7 @@ pub fn try_linearize(
         StdTensorOp::Add => semiring::linearize_add(builder, tangent_in),
         StdTensorOp::Mul => semiring::linearize_mul(builder, primal_in, tangent_in),
         StdTensorOp::Neg => semiring::linearize_neg(builder, tangent_in),
-        StdTensorOp::Conj => semiring::linearize_conj(builder, tangent_in),
+        StdTensorOp::Conj => semiring::linearize_conj(builder, primal_in, tangent_in, ctx),
 
         // Elementwise (non-semiring) family.
         StdTensorOp::Div => elementwise::linearize_div(builder, primal_in, primal_out, tangent_in),
@@ -128,10 +128,10 @@ pub fn try_linearize(
             structural::linearize_transpose(builder, tangent_in, perm)
         }
         StdTensorOp::Reshape { .. } => {
-            structural::linearize_reshape(builder, primal_in, tangent_in, op)
+            structural::linearize_reshape(builder, primal_in, tangent_in, op, ctx)
         }
         StdTensorOp::BroadcastInDim { shape, dims } => {
-            structural::linearize_broadcast_in_dim(builder, primal_in, tangent_in, shape, dims)
+            structural::linearize_broadcast_in_dim(builder, primal_in, tangent_in, shape, dims, ctx)
         }
         StdTensorOp::Convert { from, to } => {
             structural::linearize_convert(builder, tangent_in, *from, *to)
@@ -197,6 +197,14 @@ pub fn try_linearize(
         StdTensorOp::FullPivLu => {
             linalg::linearize_full_piv_lu(builder, primal_in, primal_out, tangent_in, ctx)
         }
+        StdTensorOp::Solve { transpose_a } => linalg::linearize_solve(
+            builder,
+            primal_in,
+            primal_out,
+            tangent_in,
+            *transpose_a,
+            ctx,
+        ),
         StdTensorOp::FullPivLuSolve { transpose_a } => linalg::linearize_full_piv_lu_solve(
             builder,
             primal_in,
@@ -288,9 +296,9 @@ pub fn try_transpose_rule(
     let cotangents = match op {
         // Semiring-arithmetic family.
         StdTensorOp::Add => semiring::transpose_add(cotangent_out),
-        StdTensorOp::Mul => semiring::transpose_mul(emitter, cotangent_out, inputs, mode),
+        StdTensorOp::Mul => semiring::transpose_mul(emitter, cotangent_out, inputs, mode, ctx),
         StdTensorOp::Neg => semiring::transpose_neg(emitter, cotangent_out),
-        StdTensorOp::Conj => semiring::transpose_conj(emitter, cotangent_out),
+        StdTensorOp::Conj => semiring::transpose_conj(emitter, cotangent_out, inputs, ctx),
 
         // Elementwise (non-semiring) family.
         StdTensorOp::Div => elementwise::transpose_div(emitter, cotangent_out, inputs, mode),
@@ -323,9 +331,14 @@ pub fn try_transpose_rule(
         StdTensorOp::DotGeneral { config } => {
             contraction::transpose_dot_general(emitter, cotangent_out, inputs, mode, config, ctx)
         }
-        StdTensorOp::NaryEinsum { subscripts } => {
-            contraction::transpose_nary_einsum(emitter, cotangent_out, inputs, mode, subscripts)
-        }
+        StdTensorOp::NaryEinsum { subscripts } => contraction::transpose_nary_einsum(
+            emitter,
+            cotangent_out,
+            inputs,
+            mode,
+            subscripts,
+            ctx,
+        ),
         StdTensorOp::ReduceSum { .. } => {
             contraction::transpose_reduce_sum(emitter, cotangent_out, op, inputs, ctx)
         }
@@ -435,6 +448,9 @@ pub fn try_transpose_rule(
             *unit_diagonal,
             ctx,
         ),
+        StdTensorOp::Solve { transpose_a } => {
+            linalg::transpose_solve(emitter, cotangent_out, inputs, mode, *transpose_a, ctx)
+        }
         StdTensorOp::FullPivLuSolve { transpose_a } => linalg::transpose_full_piv_lu_solve(
             emitter,
             cotangent_out,

--- a/tenferro-ops/src/ad/semiring.rs
+++ b/tenferro-ops/src/ad/semiring.rs
@@ -2,6 +2,8 @@ use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 
+use crate::ad::context::ShapeGuardContext;
+use crate::ad::support::{conjugate_linear_if_dtype_complex, conjugate_primal_if_complex};
 use crate::std_tensor_op::StdTensorOp;
 
 pub fn linearize_add(
@@ -92,18 +94,14 @@ pub fn linearize_neg(
 
 pub fn linearize_conj(
     builder: &mut FragmentBuilder<StdTensorOp>,
+    primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
-                StdTensorOp::Conj,
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
-                    active_mask: vec![true],
-                },
-            );
-            vec![Some(out[0])]
+            let dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
+            vec![Some(conjugate_linear_if_dtype_complex(builder, dx, dtype))]
         }
         None => vec![None],
     }
@@ -121,6 +119,7 @@ pub fn transpose_mul(
     cotangent_out: &[Option<LocalValId>],
     inputs: &[ValRef<StdTensorOp>],
     mode: &OpMode,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
@@ -135,11 +134,10 @@ pub fn transpose_mul(
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let rhs_conj =
-            emitter.add_op(StdTensorOp::Conj, vec![inputs[1].clone()], OpMode::Primal)[0];
+        let rhs_conj = conjugate_primal_if_complex(emitter, inputs[1].clone(), ctx);
         let out = emitter.add_op(
             StdTensorOp::Mul,
-            vec![ValRef::Local(rhs_conj), ValRef::Local(ct)],
+            vec![rhs_conj, ValRef::Local(ct)],
             OpMode::Linear {
                 active_mask: vec![false, true],
             },
@@ -148,11 +146,10 @@ pub fn transpose_mul(
     }
 
     if active_mask[1] {
-        let lhs_conj =
-            emitter.add_op(StdTensorOp::Conj, vec![inputs[0].clone()], OpMode::Primal)[0];
+        let lhs_conj = conjugate_primal_if_complex(emitter, inputs[0].clone(), ctx);
         let out = emitter.add_op(
             StdTensorOp::Mul,
-            vec![ValRef::Local(lhs_conj), ValRef::Local(ct)],
+            vec![lhs_conj, ValRef::Local(ct)],
             OpMode::Linear {
                 active_mask: vec![false, true],
             },
@@ -185,17 +182,13 @@ pub fn transpose_neg(
 pub fn transpose_conj(
     emitter: &mut impl OpEmitter<StdTensorOp>,
     cotangent_out: &[Option<LocalValId>],
+    inputs: &[ValRef<StdTensorOp>],
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValId>> {
     match cotangent_out[0] {
         Some(ct) => {
-            let out = emitter.add_op(
-                StdTensorOp::Conj,
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
-                    active_mask: vec![true],
-                },
-            );
-            vec![Some(out[0])]
+            let dtype = ctx.dtype_of(&inputs[0]);
+            vec![Some(conjugate_linear_if_dtype_complex(emitter, ct, dtype))]
         }
         None => vec![None],
     }

--- a/tenferro-ops/src/ad/structural.rs
+++ b/tenferro-ops/src/ad/structural.rs
@@ -9,6 +9,35 @@ use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
 
+fn is_identity_perm(perm: &[usize]) -> bool {
+    perm.iter()
+        .enumerate()
+        .all(|(index, &value)| index == value)
+}
+
+fn shape_exprs_match_primal_input(
+    ctx: &mut ShapeGuardContext,
+    primal_in: &[GlobalValKey<StdTensorOp>],
+    shape: &[DimExpr],
+) -> bool {
+    if primal_in.is_empty() || DimExpr::max_input_idx_all(shape).is_some_and(|idx| idx > 0) {
+        return false;
+    }
+
+    let input_shape = ctx
+        .shape_of(&ValRef::External(primal_in[0].clone()))
+        .to_vec();
+    if input_shape.len() != shape.len() {
+        return false;
+    }
+
+    let input_shapes = [input_shape.as_slice()];
+    shape
+        .iter()
+        .zip(input_shape.iter())
+        .all(|(expr, dim)| SymDim::from_dim_expr(expr, &input_shapes) == dim.clone())
+}
+
 pub fn linearize_transpose(
     builder: &mut FragmentBuilder<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
@@ -16,6 +45,9 @@ pub fn linearize_transpose(
 ) -> Vec<Option<LocalValId>> {
     match tangent_in[0] {
         Some(dx) => {
+            if is_identity_perm(perm) {
+                return vec![Some(dx)];
+            }
             let out = builder.add_op(
                 StdTensorOp::Transpose {
                     perm: perm.to_vec(),
@@ -36,6 +68,7 @@ pub fn linearize_reshape(
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     op: &StdTensorOp,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValId>> {
     let StdTensorOp::Reshape { to_shape } = op else {
         unreachable!("linearize_reshape expects Reshape");
@@ -43,6 +76,9 @@ pub fn linearize_reshape(
 
     match tangent_in[0] {
         Some(dx) => {
+            if shape_exprs_match_primal_input(ctx, primal_in, to_shape) {
+                return vec![Some(dx)];
+            }
             let needs_shape_source =
                 DimExpr::max_input_idx_all(to_shape).is_some_and(|idx| idx > 0);
             let mut op_inputs = vec![ValRef::Local(dx)];
@@ -71,9 +107,15 @@ pub fn linearize_broadcast_in_dim(
     tangent_in: &[Option<LocalValId>],
     shape: &[DimExpr],
     dims: &[usize],
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValId>> {
     match tangent_in[0] {
         Some(dx) => {
+            if dims.iter().copied().eq(0..dims.len())
+                && shape_exprs_match_primal_input(ctx, primal_in, shape)
+            {
+                return vec![Some(dx)];
+            }
             let needs_shape_source = DimExpr::max_input_idx_all(shape).is_some_and(|idx| idx > 0);
             let mut op_inputs = vec![ValRef::Local(dx)];
             let active_mask = if needs_shape_source {
@@ -272,6 +314,9 @@ pub fn transpose_transpose(
 
     match cotangent_out[0] {
         Some(ct) => {
+            if is_identity_perm(&inv) {
+                return vec![Some(ct)];
+            }
             let out = emitter.add_op(
                 StdTensorOp::Transpose { perm: inv },
                 vec![ValRef::Local(ct)],

--- a/tenferro-ops/src/ad/support.rs
+++ b/tenferro-ops/src/ad/support.rs
@@ -1,3 +1,8 @@
+use computegraph::types::{LocalValId, OpMode, ValRef};
+use computegraph::OpEmitter;
+use tenferro_tensor::DType;
+
+use crate::ad::context::ShapeGuardContext;
 use crate::std_tensor_op::StdTensorOp;
 
 /// Describes how a core [`StdTensorOp`] participates in AD.
@@ -78,8 +83,52 @@ pub(crate) fn ad_rule_support(op: &StdTensorOp) -> AdRuleSupport {
         | StdTensorOp::ReduceProd { .. }
         | StdTensorOp::ReduceMax { .. }
         | StdTensorOp::ReduceMin { .. }
+        | StdTensorOp::Solve { .. }
         | StdTensorOp::FullPivLuSolve { .. }
         | StdTensorOp::TriangularSolve { .. }
         | StdTensorOp::ValidateNonsingular => AdRuleSupport::DirectTranspose,
+    }
+}
+
+pub(crate) fn is_real_dtype(dtype: DType) -> bool {
+    matches!(dtype, DType::F32 | DType::F64)
+}
+
+pub(crate) fn conjugate_primal_if_complex(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    input: ValRef<StdTensorOp>,
+    ctx: &mut ShapeGuardContext,
+) -> ValRef<StdTensorOp> {
+    let dtype = ctx.dtype_of(&input);
+    conjugate_primal_if_dtype_complex(emitter, input, dtype)
+}
+
+pub(crate) fn conjugate_primal_if_dtype_complex(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    input: ValRef<StdTensorOp>,
+    dtype: DType,
+) -> ValRef<StdTensorOp> {
+    if is_real_dtype(dtype) {
+        input
+    } else {
+        ValRef::Local(emitter.add_op(StdTensorOp::Conj, vec![input], OpMode::Primal)[0])
+    }
+}
+
+pub(crate) fn conjugate_linear_if_dtype_complex(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    input: LocalValId,
+    dtype: DType,
+) -> LocalValId {
+    if is_real_dtype(dtype) {
+        input
+    } else {
+        emitter.add_op(
+            StdTensorOp::Conj,
+            vec![ValRef::Local(input)],
+            OpMode::Linear {
+                active_mask: vec![true],
+            },
+        )[0]
     }
 }

--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -186,6 +186,9 @@ pub enum StdTensorOp {
     Cholesky,
     Lu,
     FullPivLu,
+    Solve {
+        transpose_a: bool,
+    },
     FullPivLuSolve {
         transpose_a: bool,
     },
@@ -442,7 +445,8 @@ impl PartialEq for StdTensorOp {
             (Self::Svd { eps: a }, Self::Svd { eps: b })
             | (Self::Eigh { eps: a }, Self::Eigh { eps: b }) => a.to_bits() == b.to_bits(),
             (Self::Eig { input_dtype: a }, Self::Eig { input_dtype: b }) => a == b,
-            (Self::FullPivLuSolve { transpose_a: a }, Self::FullPivLuSolve { transpose_a: b }) => {
+            (Self::Solve { transpose_a: a }, Self::Solve { transpose_a: b })
+            | (Self::FullPivLuSolve { transpose_a: a }, Self::FullPivLuSolve { transpose_a: b }) => {
                 a == b
             }
             (
@@ -496,6 +500,9 @@ impl Hash for StdTensorOp {
                 hash_f64(*eps, state);
             }
             Self::Qr | Self::Cholesky | Self::Lu | Self::FullPivLu => {}
+            Self::Solve { transpose_a } => {
+                transpose_a.hash(state);
+            }
             Self::FullPivLuSolve { transpose_a } => {
                 transpose_a.hash(state);
             }
@@ -654,7 +661,7 @@ impl GraphOp for StdTensorOp {
             | Self::Eigh { .. }
             | Self::Eig { .. }
             | Self::ValidateNonsingular => 1,
-            Self::TriangularSolve { .. } | Self::FullPivLuSolve { .. } => 2,
+            Self::TriangularSolve { .. } | Self::Solve { .. } | Self::FullPivLuSolve { .. } => 2,
             Self::Extension(op) => ExtensionOp::n_inputs(op.as_ref()),
         }
     }
@@ -711,6 +718,7 @@ impl GraphOp for StdTensorOp {
             | Self::ReduceMin { .. } => 1,
             Self::Cholesky
             | Self::TriangularSolve { .. }
+            | Self::Solve { .. }
             | Self::FullPivLuSolve { .. }
             | Self::ValidateNonsingular => 1,
             Self::Lu => 4,

--- a/tenferro-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-ops/src/tests/std_tensor_op_tests.rs
@@ -23,6 +23,10 @@ macro_rules! shape {
     };
 }
 
+fn sym_shape(dims: &[usize]) -> Vec<SymDim> {
+    dims.iter().copied().map(SymDim::from).collect()
+}
+
 fn subs_ij_jk_ik() -> EinsumSubscripts {
     EinsumSubscripts::new(
         &[&[b'i' as u32, b'j' as u32], &[b'j' as u32, b'k' as u32]],
@@ -116,6 +120,15 @@ fn seed_uniform_ref_metadata(
     inputs: &[ValRef<StdTensorOp>],
     shape: Vec<SymDim>,
 ) {
+    seed_uniform_ref_metadata_with_dtype(ctx, inputs, DType::F64, shape);
+}
+
+fn seed_uniform_ref_metadata_with_dtype(
+    ctx: &mut ShapeGuardContext,
+    inputs: &[ValRef<StdTensorOp>],
+    dtype: DType,
+    shape: Vec<SymDim>,
+) {
     for input in inputs {
         let key = match input {
             ValRef::External(key) => key.clone(),
@@ -123,7 +136,7 @@ fn seed_uniform_ref_metadata(
                 panic!("expected external input in test helper, got local {local_id}")
             }
         };
-        ctx.insert_metadata(key, TensorMeta::exact(DType::F64, shape.clone()));
+        ctx.insert_metadata(key, TensorMeta::exact(dtype, shape.clone()));
     }
 }
 
@@ -552,6 +565,124 @@ fn test_std_tensor_op_transpose_rule_add_fans_out_cotangent() {
 }
 
 #[test]
+fn test_std_tensor_op_mul_transpose_skips_real_conjugates_and_keeps_complex_conjugates() {
+    let (real_result, _, real_fragment) = run_transpose_case_with_input_shape(
+        StdTensorOp::Mul,
+        2,
+        &[true, true],
+        true,
+        Some(sym_shape(&[2])),
+    );
+
+    assert!(real_result.iter().all(Option::is_some));
+    assert!(
+        real_fragment
+            .ops()
+            .iter()
+            .all(|op| op.op != StdTensorOp::Conj),
+        "real mul transpose should not emit no-op Conj nodes"
+    );
+
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ad_ctx = ShapeGuardContext::default();
+    let cotangent = builder.add_input(tensor_input_key(401));
+    let inputs = external_inputs(510, 2);
+    seed_uniform_ref_metadata_with_dtype(&mut ad_ctx, &inputs, DType::C64, sym_shape(&[2]));
+    let complex_result = StdTensorOp::Mul.transpose_rule(
+        &mut builder,
+        &[Some(cotangent)],
+        &inputs,
+        &linear_mode(&[true, true]),
+        &mut ad_ctx,
+    );
+    let complex_fragment = builder.build();
+
+    assert!(complex_result.iter().all(Option::is_some));
+    assert!(
+        complex_fragment
+            .ops()
+            .iter()
+            .any(|op| op.op == StdTensorOp::Conj),
+        "complex mul transpose must still conjugate inactive primal factors"
+    );
+}
+
+#[test]
+fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ad_ctx = ShapeGuardContext::default();
+    let primal_in = add_input_keys(&mut builder, 530, 1);
+    ad_ctx.insert_metadata(
+        primal_in[0].clone(),
+        TensorMeta::exact(DType::F64, sym_shape(&[2])),
+    );
+    let tangent = builder.add_input(tensor_input_key(540));
+    let real_linearized =
+        StdTensorOp::Conj.linearize(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+    let real_linear_fragment = builder.build();
+    assert_eq!(real_linearized, vec![Some(tangent)]);
+    assert!(real_linear_fragment.ops().is_empty());
+
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ad_ctx = ShapeGuardContext::default();
+    let input = ValRef::External(GlobalValKey::Input(tensor_input_key(541)));
+    seed_uniform_ref_metadata_with_dtype(
+        &mut ad_ctx,
+        std::slice::from_ref(&input),
+        DType::F64,
+        sym_shape(&[2]),
+    );
+    let cotangent = builder.add_input(tensor_input_key(542));
+    let real_transposed = StdTensorOp::Conj.transpose_rule(
+        &mut builder,
+        &[Some(cotangent)],
+        &[input],
+        &linear_mode(&[true]),
+        &mut ad_ctx,
+    );
+    let real_transpose_fragment = builder.build();
+    assert_eq!(real_transposed, vec![Some(cotangent)]);
+    assert!(real_transpose_fragment.ops().is_empty());
+
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ad_ctx = ShapeGuardContext::default();
+    let primal_in = add_input_keys(&mut builder, 550, 1);
+    ad_ctx.insert_metadata(
+        primal_in[0].clone(),
+        TensorMeta::exact(DType::C64, sym_shape(&[2])),
+    );
+    let tangent = builder.add_input(tensor_input_key(560));
+    let complex_linearized =
+        StdTensorOp::Conj.linearize(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+    let complex_linear_fragment = builder.build();
+    assert!(complex_linearized[0].is_some());
+    assert_eq!(complex_linear_fragment.ops().len(), 1);
+    assert_eq!(complex_linear_fragment.ops()[0].op, StdTensorOp::Conj);
+
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ad_ctx = ShapeGuardContext::default();
+    let input = ValRef::External(GlobalValKey::Input(tensor_input_key(561)));
+    seed_uniform_ref_metadata_with_dtype(
+        &mut ad_ctx,
+        std::slice::from_ref(&input),
+        DType::C64,
+        sym_shape(&[2]),
+    );
+    let cotangent = builder.add_input(tensor_input_key(562));
+    let complex_transposed = StdTensorOp::Conj.transpose_rule(
+        &mut builder,
+        &[Some(cotangent)],
+        &[input],
+        &linear_mode(&[true]),
+        &mut ad_ctx,
+    );
+    let complex_transpose_fragment = builder.build();
+    assert!(complex_transposed[0].is_some());
+    assert_eq!(complex_transpose_fragment.ops().len(), 1);
+    assert_eq!(complex_transpose_fragment.ops()[0].op, StdTensorOp::Conj);
+}
+
+#[test]
 fn test_std_tensor_op_hash_covers_remaining_variants() {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
@@ -647,11 +778,55 @@ fn test_std_tensor_op_nary_einsum_linearize_emits_term_sum() {
 }
 
 #[test]
-fn test_std_tensor_op_nary_einsum_transpose_emits_conjugates_and_vjp_term() {
+fn test_std_tensor_op_nary_einsum_transpose_skips_real_conjugates_and_emits_vjp_term() {
     let op = StdTensorOp::NaryEinsum {
         subscripts: subs_ij_jk_kl_il(),
     };
-    let (result, _, fragment) = run_transpose_case(op, 3, &[false, true, false], true);
+    let (result, _, fragment) = run_transpose_case_with_input_shape(
+        op,
+        3,
+        &[false, true, false],
+        true,
+        Some(sym_shape(&[2, 3])),
+    );
+
+    assert_eq!(result[0], None);
+    assert!(result[1].is_some());
+    assert_eq!(result[2], None);
+    assert_eq!(fragment.ops().len(), 1);
+    assert_eq!(
+        fragment.ops()[0].op,
+        StdTensorOp::NaryEinsum {
+            subscripts: subs_il_ij_kl_jk(),
+        }
+    );
+    assert_eq!(
+        fragment.ops()[0].mode,
+        OpMode::Linear {
+            active_mask: vec![true, false, false],
+        }
+    );
+}
+
+#[test]
+fn test_std_tensor_op_nary_einsum_transpose_keeps_complex_conjugates() {
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ad_ctx = ShapeGuardContext::default();
+    let cotangent = builder.add_input(tensor_input_key(420));
+    let inputs = external_inputs(520, 3);
+    seed_uniform_ref_metadata_with_dtype(&mut ad_ctx, &inputs, DType::C64, sym_shape(&[2, 3]));
+    let op = StdTensorOp::NaryEinsum {
+        subscripts: subs_ij_jk_kl_il(),
+    };
+
+    let result = op.transpose_rule(
+        &mut builder,
+        &[Some(cotangent)],
+        &inputs,
+        &linear_mode(&[false, true, false]),
+        &mut ad_ctx,
+    );
+    let fragment = builder.build();
 
     assert_eq!(result[0], None);
     assert!(result[1].is_some());
@@ -663,12 +838,6 @@ fn test_std_tensor_op_nary_einsum_transpose_emits_conjugates_and_vjp_term() {
         fragment.ops()[2].op,
         StdTensorOp::NaryEinsum {
             subscripts: subs_il_ij_kl_jk(),
-        }
-    );
-    assert_eq!(
-        fragment.ops()[2].mode,
-        OpMode::Linear {
-            active_mask: vec![true, false, false],
         }
     );
 }
@@ -1019,6 +1188,11 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
     assert_eq!(transpose_none_result, vec![None]);
     assert!(transpose_none_fragment.ops().is_empty());
 
+    let (identity_transpose_result, identity_transpose_fragment) =
+        run_linearize_case(StdTensorOp::Transpose { perm: vec![0, 1] }, 0, 0, &[true]);
+    assert!(identity_transpose_result[0].is_some());
+    assert!(identity_transpose_fragment.ops().is_empty());
+
     let reshape = StdTensorOp::Reshape {
         to_shape: shape![2, 2],
     };
@@ -1028,6 +1202,23 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
     assert_eq!(reshape_linear_fragment.ops().len(), 1);
     assert_eq!(reshape_linear_fragment.ops()[0].op, reshape);
 
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ad_ctx = ShapeGuardContext::default();
+    let primal_in = add_input_keys(&mut builder, 904, 1);
+    ad_ctx.insert_metadata(
+        primal_in[0].clone(),
+        TensorMeta::exact(DType::F64, sym_shape(&[2, 2])),
+    );
+    let tangent = builder.add_input(tensor_input_key(905));
+    let identity_reshape = StdTensorOp::Reshape {
+        to_shape: shape![2, 2],
+    };
+    let identity_reshape_result =
+        identity_reshape.linearize(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+    let identity_reshape_fragment = builder.build();
+    assert_eq!(identity_reshape_result, vec![Some(tangent)]);
+    assert!(identity_reshape_fragment.ops().is_empty());
+
     let (transpose_result, _, transpose_fragment) = run_transpose_case(
         StdTensorOp::Transpose { perm: vec![0, 1] },
         1,
@@ -1035,11 +1226,7 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         true,
     );
     assert!(transpose_result[0].is_some());
-    assert_eq!(transpose_fragment.ops().len(), 1);
-    assert_eq!(
-        transpose_fragment.ops()[0].op,
-        StdTensorOp::Transpose { perm: vec![0, 1] }
-    );
+    assert!(transpose_fragment.ops().is_empty());
 
     let (broadcast_linear_result, broadcast_linear_fragment) = run_linearize_case(
         StdTensorOp::BroadcastInDim {
@@ -1058,6 +1245,24 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
             dims: vec![0, 2],
         }
     );
+
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ad_ctx = ShapeGuardContext::default();
+    let primal_in = add_input_keys(&mut builder, 906, 1);
+    ad_ctx.insert_metadata(
+        primal_in[0].clone(),
+        TensorMeta::exact(DType::F64, sym_shape(&[2, 3])),
+    );
+    let tangent = builder.add_input(tensor_input_key(907));
+    let identity_broadcast = StdTensorOp::BroadcastInDim {
+        shape: shape![2, 3],
+        dims: vec![0, 1],
+    };
+    let identity_broadcast_result =
+        identity_broadcast.linearize(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+    let identity_broadcast_fragment = builder.build();
+    assert_eq!(identity_broadcast_result, vec![Some(tangent)]);
+    assert!(identity_broadcast_fragment.ops().is_empty());
 
     let (broadcast_none_result, broadcast_none_fragment) = run_linearize_case(
         StdTensorOp::BroadcastInDim {
@@ -1349,18 +1554,56 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
         },
     };
     let (scalar_transpose_result, _, scalar_transpose_fragment) =
-        run_transpose_case(scalar_contract, 2, &[true, false], true);
+        run_transpose_case(scalar_contract.clone(), 2, &[true, false], true);
     assert!(scalar_transpose_result[0].is_some());
     assert_eq!(scalar_transpose_result[1], None);
     assert_eq!(
         scalar_transpose_fragment.ops()[0].op,
         StdTensorOp::Reshape { to_shape: shape![] }
     );
-    assert_eq!(scalar_transpose_fragment.ops()[1].op, StdTensorOp::Conj);
+    assert!(scalar_transpose_fragment
+        .ops()
+        .iter()
+        .all(|node| node.op != StdTensorOp::Conj));
+    assert!(matches!(
+        scalar_transpose_fragment.ops()[1].op,
+        StdTensorOp::DotGeneral { .. }
+    ));
     assert_eq!(
         scalar_transpose_fragment.ops().last().unwrap().op,
         StdTensorOp::Transpose { perm: vec![1, 0] }
     );
+
+    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut ad_ctx = ShapeGuardContext::default();
+    let cotangent = builder.add_input(tensor_input_key(990));
+    let inputs = external_inputs(991, 2);
+    for (input, shape) in inputs.iter().zip([&[2, 3][..], &[3, 2][..]]) {
+        let ValRef::External(key) = input else {
+            unreachable!("external_inputs returns external refs")
+        };
+        ad_ctx.insert_metadata(
+            key.clone(),
+            TensorMeta::exact(
+                DType::C64,
+                shape.iter().copied().map(SymDim::from).collect(),
+            ),
+        );
+    }
+    let complex_transpose_result = scalar_contract.transpose_rule(
+        &mut builder,
+        &[Some(cotangent)],
+        &inputs,
+        &linear_mode(&[true, false]),
+        &mut ad_ctx,
+    );
+    let complex_transpose_fragment = builder.build();
+    assert!(complex_transpose_result[0].is_some());
+    assert_eq!(complex_transpose_result[1], None);
+    assert!(complex_transpose_fragment
+        .ops()
+        .iter()
+        .any(|node| node.op == StdTensorOp::Conj));
 }
 
 #[test]

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -9,7 +9,6 @@ use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use crate::validate::validate_nonsingular_u;
 use crate::{Buffer, CacheStats, Tensor, TensorRead, TypedTensor};
 
 use super::exec_session::CpuExecSession;
@@ -1271,19 +1270,58 @@ impl TensorBackend for CpuBackend {
             (b.clone(), None)
         };
 
-        let outputs = self.lu(a)?;
-        let p = &outputs[0];
-        let l = &outputs[1];
-        let u = &outputs[2];
-        validate_nonsingular_u(u)?;
+        #[cfg(feature = "cpu-faer")]
+        let ctx = Arc::clone(&self.ctx);
+        let result = self.linalg_with_pool(|buffers| match (a, &rhs) {
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::F32(a), Tensor::F32(b)) => {
+                linalg::solve(ctx.as_ref(), buffers, a, b, false).map(Tensor::F32)
+            }
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::F64(a), Tensor::F64(b)) => {
+                linalg::solve(ctx.as_ref(), buffers, a, b, false).map(Tensor::F64)
+            }
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::F32(a), Tensor::F32(b)) => {
+                linalg::solve(buffers, a, b, false).map(Tensor::F32)
+            }
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::F64(a), Tensor::F64(b)) => {
+                linalg::solve(buffers, a, b, false).map(Tensor::F64)
+            }
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::C32(a), Tensor::C32(b)) => {
+                linalg::solve(buffers, a, b, false).map(Tensor::C32)
+            }
+            #[cfg(feature = "cpu-blas")]
+            (Tensor::C64(a), Tensor::C64(b)) => {
+                linalg::solve(buffers, a, b, false).map(Tensor::C64)
+            }
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::C32(a), Tensor::C32(b)) => {
+                linalg::solve(ctx.as_ref(), buffers, a, b, false).map(Tensor::C32)
+            }
+            #[cfg(feature = "cpu-faer")]
+            (Tensor::C64(a), Tensor::C64(b)) => {
+                linalg::solve(ctx.as_ref(), buffers, a, b, false).map(Tensor::C64)
+            }
+            _ => {
+                if a.dtype() != rhs.dtype() {
+                    Err(crate::Error::DTypeMismatch {
+                        op: "solve",
+                        lhs: a.dtype(),
+                        rhs: rhs.dtype(),
+                    })
+                } else {
+                    Err(unsupported_dtype("solve", a.dtype()))
+                }
+            }
+        })?;
 
-        let pb = matmul_preserve_trailing_batch(self, p, &rhs)?;
-        let z = self.triangular_solve(l, &pb, true, true, false, true)?;
-        let x = self.triangular_solve(u, &z, true, false, false, false)?;
         if let Some(shape) = restore_shape {
-            self.reshape(&x, &shape)
+            self.reshape(&result, &shape)
         } else {
-            Ok(x)
+            Ok(result)
         }
     }
 
@@ -1377,25 +1415,6 @@ fn batched_vector_rhs_shape(a: &Tensor, b: &Tensor) -> Option<Vec<usize>> {
     let mut rhs_shape = vec![b.shape()[0], 1];
     rhs_shape.extend_from_slice(&b.shape()[1..]);
     Some(rhs_shape)
-}
-
-fn matmul_preserve_trailing_batch(
-    backend: &mut CpuBackend,
-    lhs: &Tensor,
-    rhs: &Tensor,
-) -> crate::Result<Tensor> {
-    let rank = lhs.shape().len();
-    let batch_dims: Vec<usize> = (2..rank).collect();
-    backend.dot_general(
-        lhs,
-        rhs,
-        &DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: batch_dims.clone(),
-            rhs_batch_dims: batch_dims,
-        },
-    )
 }
 
 pub(crate) fn reclaim_typed<T: PoolScalar>(pool: &mut BufferPool, typed: TypedTensor<T>) {

--- a/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/faer_linalg.rs
@@ -34,6 +34,13 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         b: &TypedTensor<Self>,
         transpose_a: bool,
     ) -> crate::Result<TypedTensor<Self>>;
+    fn solve_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        a: &TypedTensor<Self>,
+        b: &TypedTensor<Self>,
+        transpose_a: bool,
+    ) -> crate::Result<TypedTensor<Self>>;
     fn triangular_solve_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -1000,6 +1007,91 @@ macro_rules! impl_faer_linalg_for_real {
         Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
     }
 
+    fn solve_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        a: &TypedTensor<Self>,
+        b: &TypedTensor<Self>,
+        transpose_a: bool,
+    ) -> crate::Result<TypedTensor<Self>> {
+        let n = square_matrix_dim(a, "solve")?;
+        let (b_rows, b_cols) = matrix_dims(b, "solve")?;
+        if b_rows != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "solve",
+                lhs: vec![n],
+                rhs: vec![b_rows],
+            });
+        }
+
+        let mut lu = Mat::zeros(n, n);
+        lu.copy_from(MatRef::from_column_major_slice(a.host_data(), n, n));
+        let mut row_perm = vec![0usize; n];
+        let mut row_perm_inv = vec![0usize; n];
+        let mut mem = MemBuffer::new(
+            faer::linalg::lu::partial_pivoting::factor::lu_in_place_scratch::<usize, Self>(
+                n,
+                n,
+                ctx.faer_par(),
+                Default::default(),
+            ),
+        );
+        let stack = MemStack::new(&mut mem);
+        let (_, row_perm_ref) = faer::linalg::lu::partial_pivoting::factor::lu_in_place(
+            lu.as_mut(),
+            &mut row_perm,
+            &mut row_perm_inv,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        );
+        for i in 0..n {
+            if lu[(i, i)] == 0.0 {
+                return Err(crate::Error::BackendFailure {
+                    op: "solve",
+                    message: "matrix is singular".into(),
+                });
+            }
+        }
+
+        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
+        rhs_data.extend_from_slice(b.host_data());
+        let rhs = MatMut::from_column_major_slice_mut(&mut rhs_data, n, b_cols);
+        let mut mem = MemBuffer::new(if transpose_a {
+            faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place_scratch::<
+                usize,
+                Self,
+            >(n, b_cols, ctx.faer_par())
+        } else {
+            faer::linalg::lu::partial_pivoting::solve::solve_in_place_scratch::<usize, Self>(
+                n,
+                b_cols,
+                ctx.faer_par(),
+            )
+        });
+        let stack = MemStack::new(&mut mem);
+        if transpose_a {
+            faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place(
+                lu.as_ref(),
+                lu.as_ref(),
+                row_perm_ref,
+                rhs,
+                ctx.faer_par(),
+                stack,
+            );
+        } else {
+            faer::linalg::lu::partial_pivoting::solve::solve_in_place(
+                lu.as_ref(),
+                lu.as_ref(),
+                row_perm_ref,
+                rhs,
+                ctx.faer_par(),
+                stack,
+            );
+        }
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
+    }
+
     fn triangular_solve_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -1575,6 +1667,96 @@ macro_rules! impl_faer_linalg_for_complex {
         Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
     }
 
+    fn solve_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        a: &TypedTensor<Self>,
+        b: &TypedTensor<Self>,
+        transpose_a: bool,
+    ) -> crate::Result<TypedTensor<Self>> {
+        let n = square_matrix_dim(a, "solve")?;
+        let (b_rows, b_cols) = matrix_dims(b, "solve")?;
+        if b_rows != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "solve",
+                lhs: vec![n],
+                rhs: vec![b_rows],
+            });
+        }
+
+        let mut lu = Mat::zeros(n, n);
+        lu.copy_from(MatRef::from_column_major_slice(
+            $to_faer_slice(a.host_data()),
+            n,
+            n,
+        ));
+        let mut row_perm = vec![0usize; n];
+        let mut row_perm_inv = vec![0usize; n];
+        let mut mem = MemBuffer::new(
+            faer::linalg::lu::partial_pivoting::factor::lu_in_place_scratch::<usize, $faer_complex>(
+                n,
+                n,
+                ctx.faer_par(),
+                Default::default(),
+            ),
+        );
+        let stack = MemStack::new(&mut mem);
+        let (_, row_perm_ref) = faer::linalg::lu::partial_pivoting::factor::lu_in_place(
+            lu.as_mut(),
+            &mut row_perm,
+            &mut row_perm_inv,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        );
+        for i in 0..n {
+            let value = lu[(i, i)];
+            if value.re == 0.0 && value.im == 0.0 {
+                return Err(crate::Error::BackendFailure {
+                    op: "solve",
+                    message: "matrix is singular".into(),
+                });
+            }
+        }
+
+        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
+        rhs_data.extend_from_slice(b.host_data());
+        let rhs =
+            MatMut::from_column_major_slice_mut($to_faer_slice_mut(&mut rhs_data), n, b_cols);
+        let mut mem = MemBuffer::new(if transpose_a {
+            faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place_scratch::<
+                usize,
+                $faer_complex,
+            >(n, b_cols, ctx.faer_par())
+        } else {
+            faer::linalg::lu::partial_pivoting::solve::solve_in_place_scratch::<
+                usize,
+                $faer_complex,
+            >(n, b_cols, ctx.faer_par())
+        });
+        let stack = MemStack::new(&mut mem);
+        if transpose_a {
+            faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place(
+                lu.as_ref(),
+                lu.as_ref(),
+                row_perm_ref,
+                rhs,
+                ctx.faer_par(),
+                stack,
+            );
+        } else {
+            faer::linalg::lu::partial_pivoting::solve::solve_in_place(
+                lu.as_ref(),
+                lu.as_ref(),
+                row_perm_ref,
+                rhs,
+                ctx.faer_par(),
+                stack,
+            );
+        }
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
+    }
+
     fn triangular_solve_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -2047,6 +2229,41 @@ pub(crate) fn full_piv_lu_solve<T: FaerLinalg>(
     }
     batched_binary_result("full_piv_lu_solve", buffers, a, b, 2, 2, |buffers, a, b| {
         T::full_piv_lu_solve_2d(ctx, buffers, a, b, transpose_a)
+    })
+}
+
+pub(crate) fn solve<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    a: &TypedTensor<T>,
+    b: &TypedTensor<T>,
+    transpose_a: bool,
+) -> crate::Result<TypedTensor<T>> {
+    if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
+        let (n, a_batch_shape) = square_core_and_batch(a, "solve")?;
+        let (b_rows, _, b_batch_shape) = matrix_core_and_batch(b, "solve")?;
+        if b_rows != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "solve",
+                lhs: vec![n],
+                rhs: vec![b_rows],
+            });
+        }
+        if a_batch_shape != b_batch_shape {
+            return Err(crate::Error::ShapeMismatch {
+                op: "solve",
+                lhs: a_batch_shape.to_vec(),
+                rhs: b_batch_shape.to_vec(),
+            });
+        }
+        return Ok(tensor_from_vec_with_template(
+            b.shape.clone(),
+            Vec::new(),
+            b,
+        ));
+    }
+    batched_binary_result("solve", buffers, a, b, 2, 2, |buffers, a, b| {
+        T::solve_2d(ctx, buffers, a, b, transpose_a)
     })
 }
 

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg.rs
@@ -5,6 +5,7 @@ mod full_piv_lu;
 mod helpers;
 mod lu;
 mod qr;
+mod solve;
 mod svd;
 mod triangular_solve;
 
@@ -14,5 +15,6 @@ pub(crate) use eigh::eigh;
 pub(crate) use full_piv_lu::{full_piv_lu, full_piv_lu_solve};
 pub(crate) use lu::lu;
 pub(crate) use qr::qr;
+pub(crate) use solve::solve;
 pub(crate) use svd::svd;
 pub(crate) use triangular_solve::triangular_solve;

--- a/tenferro-tensor/src/cpu/linalg/lapack_linalg/solve.rs
+++ b/tenferro-tensor/src/cpu/linalg/lapack_linalg/solve.rs
@@ -1,0 +1,203 @@
+use num_complex::{Complex32, Complex64};
+
+use crate::buffer_pool::BufferPool;
+use crate::TypedTensor;
+
+use super::helpers::{
+    batched_binary_result, check_lapack_info, dim_i32, has_zero_dim, matrix_core_and_batch_result,
+    matrix_dims, square_core_and_batch_result, square_matrix_dim, tensor_from_vec_with_template,
+};
+
+pub(crate) trait LapackSolve: Clone + Copy {
+    fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32);
+    fn getrs(
+        trans: u8,
+        n: i32,
+        nrhs: i32,
+        a: &[Self],
+        lda: i32,
+        ipiv: &[i32],
+        b: &mut [Self],
+        ldb: i32,
+        info: &mut i32,
+    );
+}
+
+impl LapackSolve for f64 {
+    fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        unsafe {
+            lapack::dgetrf(m, n, data, lda, ipiv, info);
+        }
+    }
+
+    fn getrs(
+        trans: u8,
+        n: i32,
+        nrhs: i32,
+        a: &[Self],
+        lda: i32,
+        ipiv: &[i32],
+        b: &mut [Self],
+        ldb: i32,
+        info: &mut i32,
+    ) {
+        unsafe {
+            lapack::dgetrs(trans, n, nrhs, a, lda, ipiv, b, ldb, info);
+        }
+    }
+}
+
+impl LapackSolve for f32 {
+    fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        unsafe {
+            lapack::sgetrf(m, n, data, lda, ipiv, info);
+        }
+    }
+
+    fn getrs(
+        trans: u8,
+        n: i32,
+        nrhs: i32,
+        a: &[Self],
+        lda: i32,
+        ipiv: &[i32],
+        b: &mut [Self],
+        ldb: i32,
+        info: &mut i32,
+    ) {
+        unsafe {
+            lapack::sgetrs(trans, n, nrhs, a, lda, ipiv, b, ldb, info);
+        }
+    }
+}
+
+impl LapackSolve for Complex32 {
+    fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        unsafe {
+            lapack::cgetrf(m, n, data, lda, ipiv, info);
+        }
+    }
+
+    fn getrs(
+        trans: u8,
+        n: i32,
+        nrhs: i32,
+        a: &[Self],
+        lda: i32,
+        ipiv: &[i32],
+        b: &mut [Self],
+        ldb: i32,
+        info: &mut i32,
+    ) {
+        unsafe {
+            lapack::cgetrs(trans, n, nrhs, a, lda, ipiv, b, ldb, info);
+        }
+    }
+}
+
+impl LapackSolve for Complex64 {
+    fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        unsafe {
+            lapack::zgetrf(m, n, data, lda, ipiv, info);
+        }
+    }
+
+    fn getrs(
+        trans: u8,
+        n: i32,
+        nrhs: i32,
+        a: &[Self],
+        lda: i32,
+        ipiv: &[i32],
+        b: &mut [Self],
+        ldb: i32,
+        info: &mut i32,
+    ) {
+        unsafe {
+            lapack::zgetrs(trans, n, nrhs, a, lda, ipiv, b, ldb, info);
+        }
+    }
+}
+
+fn solve_2d<T: LapackSolve>(
+    _buffers: &mut BufferPool,
+    a: &TypedTensor<T>,
+    b: &TypedTensor<T>,
+    transpose_a: bool,
+) -> crate::Result<TypedTensor<T>> {
+    let n = square_matrix_dim(a, "solve")?;
+    let (b_rows, b_cols) = matrix_dims(b, "solve")?;
+    if b_rows != n {
+        return Err(crate::Error::ShapeMismatch {
+            op: "solve",
+            lhs: vec![n],
+            rhs: vec![b_rows],
+        });
+    }
+
+    let n_i32 = dim_i32(n, "solve")?;
+    let b_cols_i32 = dim_i32(b_cols, "solve")?;
+    let mut lu = a.host_data().to_vec();
+    let mut ipiv = vec![0_i32; n];
+    let mut info = 0;
+    T::getrf(n_i32, n_i32, &mut lu, n_i32, &mut ipiv, &mut info);
+    check_lapack_info("solve", "getrf", info.min(0))?;
+    if info > 0 {
+        return Err(crate::Error::BackendFailure {
+            op: "solve",
+            message: "matrix is singular".into(),
+        });
+    }
+
+    let mut rhs = b.host_data().to_vec();
+    let mut info = 0;
+    T::getrs(
+        if transpose_a { b'T' } else { b'N' },
+        n_i32,
+        b_cols_i32,
+        &lu,
+        n_i32,
+        &ipiv,
+        &mut rhs,
+        n_i32,
+        &mut info,
+    );
+    check_lapack_info("solve", "getrs", info)?;
+
+    Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs, b))
+}
+
+pub(crate) fn solve<T: LapackSolve>(
+    buffers: &mut BufferPool,
+    a: &TypedTensor<T>,
+    b: &TypedTensor<T>,
+    transpose_a: bool,
+) -> crate::Result<TypedTensor<T>> {
+    if has_zero_dim(&a.shape) || has_zero_dim(&b.shape) {
+        let (n, a_batch_shape) = square_core_and_batch_result(a, "solve")?;
+        let (b_rows, _, b_batch_shape) = matrix_core_and_batch_result(b, "solve")?;
+        if b_rows != n {
+            return Err(crate::Error::ShapeMismatch {
+                op: "solve",
+                lhs: vec![n],
+                rhs: vec![b_rows],
+            });
+        }
+        if a_batch_shape != b_batch_shape {
+            return Err(crate::Error::ShapeMismatch {
+                op: "solve",
+                lhs: a_batch_shape.to_vec(),
+                rhs: b_batch_shape.to_vec(),
+            });
+        }
+        return Ok(tensor_from_vec_with_template(
+            b.shape.clone(),
+            Vec::new(),
+            b,
+        ));
+    }
+
+    batched_binary_result("solve", buffers, a, b, |buffers, a, b| {
+        solve_2d(buffers, a, b, transpose_a)
+    })
+}

--- a/tenferro-tensor/src/cpu/linalg/mod.rs
+++ b/tenferro-tensor/src/cpu/linalg/mod.rs
@@ -5,11 +5,11 @@ pub mod faer_linalg;
 pub mod lapack_linalg;
 
 #[cfg(feature = "cpu-faer")]
-pub(crate) use faer_linalg::{cholesky, eig, eigh, lu, qr, svd, triangular_solve};
+pub(crate) use faer_linalg::{cholesky, eig, eigh, lu, qr, solve, svd, triangular_solve};
 #[cfg(feature = "cpu-faer")]
 pub(crate) use faer_linalg::{full_piv_lu, full_piv_lu_solve};
 
 #[cfg(feature = "cpu-blas")]
-pub(crate) use lapack_linalg::{cholesky, eig, eigh, lu, qr, svd, triangular_solve};
+pub(crate) use lapack_linalg::{cholesky, eig, eigh, lu, qr, solve, svd, triangular_solve};
 #[cfg(feature = "cpu-blas")]
 pub(crate) use lapack_linalg::{full_piv_lu, full_piv_lu_solve};

--- a/tenferro-tensor/src/cubecl/ffi/cutensor.rs
+++ b/tenferro-tensor/src/cubecl/ffi/cutensor.rs
@@ -36,6 +36,7 @@ pub(crate) enum CudaDataType {
 #[derive(Clone, Copy)]
 pub(crate) enum CutensorOperator {
     Identity = 1,
+    Conj = 9,
 }
 
 #[repr(i32)]
@@ -395,12 +396,14 @@ pub(crate) struct OperationDescriptor {
 }
 
 impl OperationDescriptor {
-    pub(crate) fn new_contraction(
+    pub(crate) fn new_contraction_with_ops(
         handle: &CutensorHandle,
         desc_a: &TensorDescriptor,
         mode_a: &[i32],
+        op_a: CutensorOperator,
         desc_b: &TensorDescriptor,
         mode_b: &[i32],
+        op_b: CutensorOperator,
         desc_c: &TensorDescriptor,
         mode_c: &[i32],
         desc_d: &TensorDescriptor,
@@ -415,10 +418,10 @@ impl OperationDescriptor {
                 &mut raw,
                 desc_a.as_raw(),
                 mode_a.as_ptr(),
-                CutensorOperator::Identity,
+                op_a,
                 desc_b.as_raw(),
                 mode_b.as_ptr(),
-                CutensorOperator::Identity,
+                op_b,
                 desc_c.as_raw(),
                 mode_c.as_ptr(),
                 CutensorOperator::Identity,

--- a/tenferro-tensor/src/cubecl/gemm.rs
+++ b/tenferro-tensor/src/cubecl/gemm.rs
@@ -6,7 +6,7 @@ use num_traits::{One, Zero};
 
 use super::dispatch::{alloc_output, cubecl_buffer, dtype_mismatch, typed_from_cubecl};
 use super::ffi::cutensor::{
-    CudaDataType, CutensorComputeDescriptor, CutensorCudaStream, CutensorHandle,
+    CudaDataType, CutensorComputeDescriptor, CutensorCudaStream, CutensorHandle, CutensorOperator,
     CutensorWorksizePreference, OperationDescriptor, Plan, PlanPreference, TensorDescriptor,
 };
 use super::{CubeclBackend, CubeclRuntime};
@@ -18,12 +18,14 @@ const CUDA_ALLOCATION_ALIGNMENT: u32 = 256;
 
 trait CutensorScalar: CubeElement + CubePrimitive + Clone + One + Zero {
     const DATA_TYPE: CudaDataType;
+    const IS_COMPLEX: bool;
 
     fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor;
 }
 
 impl CutensorScalar for f32 {
     const DATA_TYPE: CudaDataType = CudaDataType::R32F;
+    const IS_COMPLEX: bool = false;
 
     fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
         handle.compute_desc_32f()
@@ -32,6 +34,7 @@ impl CutensorScalar for f32 {
 
 impl CutensorScalar for f64 {
     const DATA_TYPE: CudaDataType = CudaDataType::R64F;
+    const IS_COMPLEX: bool = false;
 
     fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
         handle.compute_desc_64f()
@@ -40,6 +43,7 @@ impl CutensorScalar for f64 {
 
 impl CutensorScalar for Complex32 {
     const DATA_TYPE: CudaDataType = CudaDataType::C32F;
+    const IS_COMPLEX: bool = true;
 
     fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
         handle.compute_desc_32f()
@@ -48,6 +52,7 @@ impl CutensorScalar for Complex32 {
 
 impl CutensorScalar for Complex64 {
     const DATA_TYPE: CudaDataType = CudaDataType::C64F;
+    const IS_COMPLEX: bool = true;
 
     fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
         handle.compute_desc_64f()
@@ -107,11 +112,54 @@ pub(super) fn dot_general(
     }
 }
 
+pub(super) fn dot_general_with_conj(
+    backend: &CubeclBackend,
+    lhs: &Tensor,
+    rhs: &Tensor,
+    config: &DotGeneralConfig,
+    lhs_conj: bool,
+    rhs_conj: bool,
+) -> crate::Result<Tensor> {
+    match (lhs, rhs) {
+        (Tensor::F32(lhs), Tensor::F32(rhs)) => {
+            dot_general_typed_with_conj(backend, lhs, rhs, config, lhs_conj, rhs_conj)
+                .map(Tensor::F32)
+        }
+        (Tensor::F64(lhs), Tensor::F64(rhs)) => {
+            dot_general_typed_with_conj(backend, lhs, rhs, config, lhs_conj, rhs_conj)
+                .map(Tensor::F64)
+        }
+        (Tensor::C32(lhs), Tensor::C32(rhs)) => {
+            dot_general_typed_with_conj(backend, lhs, rhs, config, lhs_conj, rhs_conj)
+                .map(Tensor::C32)
+        }
+        (Tensor::C64(lhs), Tensor::C64(rhs)) => {
+            dot_general_typed_with_conj(backend, lhs, rhs, config, lhs_conj, rhs_conj)
+                .map(Tensor::C64)
+        }
+        _ => Err(dtype_mismatch(OP, lhs, rhs)),
+    }
+}
+
 fn dot_general_typed<T>(
     backend: &CubeclBackend,
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     config: &DotGeneralConfig,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: CutensorScalar,
+{
+    dot_general_typed_with_conj(backend, lhs, rhs, config, false, false)
+}
+
+fn dot_general_typed_with_conj<T>(
+    backend: &CubeclBackend,
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+    config: &DotGeneralConfig,
+    lhs_conj: bool,
+    rhs_conj: bool,
 ) -> crate::Result<TypedTensor<T>>
 where
     T: CutensorScalar,
@@ -152,12 +200,14 @@ where
         CUDA_ALLOCATION_ALIGNMENT,
         OP,
     )?;
-    let op_desc = OperationDescriptor::new_contraction(
+    let op_desc = OperationDescriptor::new_contraction_with_ops(
         cutensor,
         &desc_a,
         &layout.lhs_modes,
+        cutensor_conj_op::<T>(lhs_conj),
         &desc_b,
         &layout.rhs_modes,
+        cutensor_conj_op::<T>(rhs_conj),
         &desc_out,
         &layout.output_modes,
         &desc_out,
@@ -202,6 +252,14 @@ where
     }
 
     Ok(output)
+}
+
+fn cutensor_conj_op<T: CutensorScalar>(conj: bool) -> CutensorOperator {
+    if conj && T::IS_COMPLEX {
+        CutensorOperator::Conj
+    } else {
+        CutensorOperator::Identity
+    }
 }
 
 fn raw_stream(rt: &CubeclRuntime) -> crate::Result<CutensorCudaStream> {

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -2391,6 +2391,17 @@ impl TensorBackend for CubeclBackend {
         gemm::dot_general(self, lhs, rhs, config)
     }
 
+    fn dot_general_with_conj(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+        lhs_conj: bool,
+        rhs_conj: bool,
+    ) -> crate::Result<Tensor> {
+        gemm::dot_general_with_conj(self, lhs, rhs, config, lhs_conj, rhs_conj)
+    }
+
     fn gather(
         &mut self,
         operand: &Tensor,

--- a/tenferro-tensor/src/inject.rs
+++ b/tenferro-tensor/src/inject.rs
@@ -192,12 +192,20 @@ pub struct LapackProviderPtrSet {
     pub zpotrf: Option<*const c_void>,
     /// Fortran `sgetrf` raw function pointer.
     pub sgetrf: Option<*const c_void>,
+    /// Fortran `sgetrs` raw function pointer.
+    pub sgetrs: Option<*const c_void>,
     /// Fortran `dgetrf` raw function pointer.
     pub dgetrf: Option<*const c_void>,
+    /// Fortran `dgetrs` raw function pointer.
+    pub dgetrs: Option<*const c_void>,
     /// Fortran `cgetrf` raw function pointer.
     pub cgetrf: Option<*const c_void>,
+    /// Fortran `cgetrs` raw function pointer.
+    pub cgetrs: Option<*const c_void>,
     /// Fortran `zgetrf` raw function pointer.
     pub zgetrf: Option<*const c_void>,
+    /// Fortran `zgetrs` raw function pointer.
+    pub zgetrs: Option<*const c_void>,
     /// Fortran `ssyev` raw function pointer.
     pub ssyev: Option<*const c_void>,
     /// Fortran `dsyev` raw function pointer.
@@ -266,9 +274,13 @@ impl LapackProviderPtrSet {
             cpotrf: None,
             zpotrf: None,
             sgetrf: None,
+            sgetrs: None,
             dgetrf: None,
+            dgetrs: None,
             cgetrf: None,
+            cgetrs: None,
             zgetrf: None,
+            zgetrs: None,
             ssyev: None,
             dsyev: None,
             cheev: None,
@@ -863,12 +875,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_sgetrf_ilp64
     );
     register_field!(
+        sgetrs,
+        "sgetrs",
+        SgetrsLp64FnPtr,
+        SgetrsIlp64FnPtr,
+        register_sgetrs_lp64,
+        register_sgetrs_ilp64
+    );
+    register_field!(
         dgetrf,
         "dgetrf",
         DgetrfLp64FnPtr,
         DgetrfIlp64FnPtr,
         register_dgetrf_lp64,
         register_dgetrf_ilp64
+    );
+    register_field!(
+        dgetrs,
+        "dgetrs",
+        DgetrsLp64FnPtr,
+        DgetrsIlp64FnPtr,
+        register_dgetrs_lp64,
+        register_dgetrs_ilp64
     );
     register_field!(
         cgetrf,
@@ -879,12 +907,28 @@ pub unsafe fn register_lapack_provider_ptrs(
         register_cgetrf_ilp64
     );
     register_field!(
+        cgetrs,
+        "cgetrs",
+        CgetrsLp64FnPtr,
+        CgetrsIlp64FnPtr,
+        register_cgetrs_lp64,
+        register_cgetrs_ilp64
+    );
+    register_field!(
         zgetrf,
         "zgetrf",
         ZgetrfLp64FnPtr,
         ZgetrfIlp64FnPtr,
         register_zgetrf_lp64,
         register_zgetrf_ilp64
+    );
+    register_field!(
+        zgetrs,
+        "zgetrs",
+        ZgetrsLp64FnPtr,
+        ZgetrsIlp64FnPtr,
+        register_zgetrs_lp64,
+        register_zgetrs_ilp64
     );
     register_field!(
         ssyev,

--- a/tenferro-tensor/tests/inject_tests.rs
+++ b/tenferro-tensor/tests/inject_tests.rs
@@ -1,13 +1,13 @@
 #![cfg(all(feature = "cpu-blas", feature = "provider-inject"))]
 
-use std::ffi::c_char;
+use std::ffi::{c_char, c_void};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, Once};
 
 use tenferro_tensor::cpu::CpuBackend;
 use tenferro_tensor::inject::{
-    register_blas_gemm_fn_ptrs, register_lapack_full_piv_lu_fn_ptrs, BlasGemmFnPtrSet,
-    LapackFullPivLuFnPtrSet,
+    register_blas_gemm_fn_ptrs, register_lapack_full_piv_lu_fn_ptrs, register_lapack_provider_ptrs,
+    BlasGemmFnPtrSet, LapackFullPivLuFnPtrSet, LapackProviderPtrSet, ProviderAbi,
 };
 use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
 
@@ -16,6 +16,8 @@ static TEST_LOCK: Mutex<()> = Mutex::new(());
 static DGEMM_CALLS: AtomicUsize = AtomicUsize::new(0);
 static DGETC2_CALLS: AtomicUsize = AtomicUsize::new(0);
 static DGESC2_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DGETRF_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DGETRS_CALLS: AtomicUsize = AtomicUsize::new(0);
 
 fn register_test_ptrs_once() {
     REGISTER_ONCE.call_once(|| unsafe {
@@ -28,6 +30,15 @@ fn register_test_ptrs_once() {
             dgesc2: Some(test_dgesc2),
             ..LapackFullPivLuFnPtrSet::new()
         });
+        register_lapack_provider_ptrs(
+            ProviderAbi::Lp64,
+            LapackProviderPtrSet {
+                dgetrf: Some(test_dgetrf as *const c_void),
+                dgetrs: Some(test_dgetrs as *const c_void),
+                ..LapackProviderPtrSet::new()
+            },
+        )
+        .expect("test dgetrf/dgetrs registration should succeed");
     });
 }
 
@@ -116,6 +127,43 @@ unsafe extern "C" fn test_dgesc2(
     DGESC2_CALLS.fetch_add(1, Ordering::SeqCst);
     unsafe {
         *scale = 1.0;
+    }
+}
+
+unsafe extern "C" fn test_dgetrf(
+    m: *const lapack_inject::lapackint,
+    n: *const lapack_inject::lapackint,
+    _a: *mut f64,
+    _lda: *const lapack_inject::lapackint,
+    ipiv: *mut lapack_inject::lapackint,
+    info: *mut lapack_inject::lapackint,
+) {
+    DGETRF_CALLS.fetch_add(1, Ordering::SeqCst);
+    let k = unsafe { (*m).min(*n) as usize };
+    for index in 0..k {
+        unsafe {
+            *ipiv.add(index) = (index + 1) as lapack_inject::lapackint;
+        }
+    }
+    unsafe {
+        *info = 0;
+    }
+}
+
+unsafe extern "C" fn test_dgetrs(
+    _trans: *const c_char,
+    _n: *const lapack_inject::lapackint,
+    _nrhs: *const lapack_inject::lapackint,
+    _a: *const f64,
+    _lda: *const lapack_inject::lapackint,
+    _ipiv: *const lapack_inject::lapackint,
+    _b: *mut f64,
+    _ldb: *const lapack_inject::lapackint,
+    info: *mut lapack_inject::lapackint,
+) {
+    DGETRS_CALLS.fetch_add(1, Ordering::SeqCst);
+    unsafe {
+        *info = 0;
     }
 }
 
@@ -238,6 +286,32 @@ fn provider_inject_full_piv_lu_solve_uses_registered_lapack() {
 
     assert_eq!(DGETC2_CALLS.load(Ordering::SeqCst), 1);
     assert_eq!(DGESC2_CALLS.load(Ordering::SeqCst), 1);
+    match x {
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[4.0, 8.0]),
+        _ => panic!("expected f64 tensor"),
+    }
+}
+
+#[test]
+fn provider_inject_solve_uses_registered_lapack_getrf_getrs() {
+    let _guard = TEST_LOCK
+        .lock()
+        .expect("provider-inject test lock poisoned");
+    register_test_ptrs_once();
+    DGETRF_CALLS.store(0, Ordering::SeqCst);
+    DGETRS_CALLS.store(0, Ordering::SeqCst);
+
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(
+        vec![2, 2],
+        vec![1.0, 0.0, 0.0, 1.0],
+    ));
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![4.0, 8.0]));
+
+    let mut backend = CpuBackend::new();
+    let x = backend.solve(&a, &b);
+
+    assert_eq!(DGETRF_CALLS.load(Ordering::SeqCst), 1);
+    assert_eq!(DGETRS_CALLS.load(Ordering::SeqCst), 1);
     match x {
         Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[4.0, 8.0]),
         _ => panic!("expected f64 tensor"),

--- a/tenferro/Cargo.toml
+++ b/tenferro/Cargo.toml
@@ -69,3 +69,7 @@ harness = false
 [[bench]]
 name = "mps_inner_product_eager"
 harness = false
+
+[[bench]]
+name = "cpu_bench"
+harness = false

--- a/tenferro/benches/cpu_bench.rs
+++ b/tenferro/benches/cpu_bench.rs
@@ -1,0 +1,485 @@
+use std::env;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use criterion::{black_box, criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
+use num_complex::{Complex32, Complex64};
+use tenferro::eager_tensor::einsum;
+use tenferro::{CpuBackend, DType, EagerRuntime, EagerTensor, Tensor};
+
+const SMALL_MATMUL_SIZES: &[usize] = &[2, 4, 8, 16, 32];
+const LARGE_MATMUL_SIZES: &[usize] = &[128, 256, 512];
+const SMALL_LINALG_SIZES: &[usize] = &[4, 8, 16, 32];
+const MEDIUM_LINALG_SIZES: &[usize] = &[64, 128];
+const BATCHES: &[usize] = &[16, 64, 256];
+const BATCHED_SMALL_SIZES: &[usize] = &[2, 4, 8, 16];
+
+fn bench_threads() -> usize {
+    env::var("TENFERRO_BENCH_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&threads| threads > 0)
+        .unwrap_or(1)
+}
+
+fn cpu_ctx(threads: usize) -> Arc<EagerRuntime> {
+    EagerRuntime::with_cpu_backend(CpuBackend::with_threads(threads))
+}
+
+fn f64_tensor(shape: Vec<usize>, seed: usize) -> Tensor {
+    let len = shape.iter().product();
+    let data = (0..len)
+        .map(|idx| ((idx * 17 + seed * 31 + 7) % 997) as f64 / 997.0 - 0.5)
+        .collect();
+    Tensor::from_vec_col_major(shape, data)
+}
+
+fn c64_tensor(shape: Vec<usize>, seed: usize) -> Tensor {
+    let len = shape.iter().product();
+    let data = (0..len)
+        .map(|idx| {
+            let re = ((idx * 17 + seed * 31 + 7) % 997) as f64 / 997.0 - 0.5;
+            let im = ((idx * 23 + seed * 19 + 11) % 991) as f64 / 991.0 - 0.5;
+            Complex64::new(re, im)
+        })
+        .collect();
+    Tensor::from_vec_col_major(shape, data)
+}
+
+fn f64_spd_tensor(n: usize, seed: usize) -> Tensor {
+    let mut data = vec![0.0; n * n];
+    for col in 0..n {
+        for row in 0..n {
+            let value = if row == col {
+                n as f64 + 2.0 + (row + seed) as f64 * 0.001
+            } else {
+                ((row + col + seed) % 7) as f64 * 0.01
+            };
+            data[row + col * n] = value;
+        }
+    }
+    Tensor::from_vec_col_major(vec![n, n], data)
+}
+
+fn c64_hermitian_tensor(n: usize, seed: usize) -> Tensor {
+    let mut data = vec![Complex64::new(0.0, 0.0); n * n];
+    for col in 0..n {
+        for row in 0..=col {
+            let value = if row == col {
+                Complex64::new(n as f64 + 2.0 + (row + seed) as f64 * 0.001, 0.0)
+            } else {
+                let re = ((row + col + seed) % 7) as f64 * 0.01;
+                let im = ((row * 3 + col + seed) % 5) as f64 * 0.01;
+                Complex64::new(re, im)
+            };
+            data[row + col * n] = value;
+            data[col + row * n] = value.conj();
+        }
+    }
+    Tensor::from_vec_col_major(vec![n, n], data)
+}
+
+fn eager(ctx: &Arc<EagerRuntime>, tensor: Tensor) -> EagerTensor {
+    EagerTensor::from_tensor_in(tensor, Arc::clone(ctx))
+}
+
+fn tracked(ctx: &Arc<EagerRuntime>, tensor: Tensor) -> EagerTensor {
+    EagerTensor::requires_grad_in(tensor, Arc::clone(ctx))
+}
+
+fn iter_excluding_setup_and_input_drop<I>(
+    bench: &mut Bencher<'_>,
+    mut setup: impl FnMut() -> I,
+    mut routine: impl FnMut(&I),
+) {
+    bench.iter_custom(|iters| {
+        let mut total = Duration::ZERO;
+        for _ in 0..iters {
+            let input = setup();
+            let started = Instant::now();
+            routine(&input);
+            total += started.elapsed();
+            black_box(&input);
+            drop(input);
+        }
+        total
+    });
+}
+
+fn consume_f64(tensor: &EagerTensor) {
+    let data = tensor.data();
+    black_box(data.shape());
+    black_box(data.as_slice::<f64>().expect("f64 tensor")[0]);
+}
+
+fn consume_c64(tensor: &EagerTensor) {
+    let data = tensor.data();
+    black_box(data.shape());
+    black_box(data.as_slice::<Complex64>().expect("c64 tensor")[0]);
+}
+
+fn consume_numeric(tensor: &EagerTensor) {
+    let data = tensor.data();
+    black_box(data.shape());
+    match data.dtype() {
+        DType::F32 => {
+            black_box(data.as_slice::<f32>().expect("f32 tensor")[0]);
+        }
+        DType::F64 => {
+            black_box(data.as_slice::<f64>().expect("f64 tensor")[0]);
+        }
+        DType::I64 => {
+            black_box(data.as_slice::<i64>().expect("i64 tensor")[0]);
+        }
+        DType::C32 => {
+            black_box(data.as_slice::<Complex32>().expect("c32 tensor")[0]);
+        }
+        DType::C64 => {
+            black_box(data.as_slice::<Complex64>().expect("c64 tensor")[0]);
+        }
+    }
+}
+
+fn bench_matmul(c: &mut Criterion) {
+    let threads = bench_threads();
+    let ctx = cpu_ctx(threads);
+    let mut group = c.benchmark_group(format!("tenferro_cpu/matmul/threads_{threads}"));
+
+    for &n in SMALL_MATMUL_SIZES.iter().chain(LARGE_MATMUL_SIZES) {
+        let a = eager(&ctx, f64_tensor(vec![n, n], 1));
+        let b = eager(&ctx, f64_tensor(vec![n, n], 2));
+        group.bench_function(BenchmarkId::new("f64_square", n), |bench| {
+            bench.iter(|| {
+                let out = black_box(&a)
+                    .matmul(black_box(&b))
+                    .expect("f64 matmul should succeed");
+                consume_f64(&out);
+            });
+        });
+
+        if n <= 128 {
+            let a = eager(&ctx, c64_tensor(vec![n, n], 3));
+            let b = eager(&ctx, c64_tensor(vec![n, n], 4));
+            group.bench_function(BenchmarkId::new("c64_square", n), |bench| {
+                bench.iter(|| {
+                    let out = black_box(&a)
+                        .matmul(black_box(&b))
+                        .expect("c64 matmul should succeed");
+                    consume_c64(&out);
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_linalg(c: &mut Criterion) {
+    let threads = bench_threads();
+    let ctx = cpu_ctx(threads);
+    let mut group = c.benchmark_group(format!("tenferro_cpu/linalg/threads_{threads}"));
+
+    for &n in SMALL_LINALG_SIZES.iter().chain(MEDIUM_LINALG_SIZES) {
+        let a = eager(&ctx, f64_spd_tensor(n, 1));
+        let b_col = eager(&ctx, f64_tensor(vec![n, 1], 2));
+        let b_mat = eager(&ctx, f64_tensor(vec![n, 4], 3));
+
+        group.bench_function(BenchmarkId::new("f64_svd", n), |bench| {
+            bench.iter(|| {
+                let (_, s, _) = black_box(&a).svd().expect("svd should succeed");
+                consume_f64(&s);
+            });
+        });
+        group.bench_function(BenchmarkId::new("f64_qr", n), |bench| {
+            bench.iter(|| {
+                let (_, r) = black_box(&a).qr().expect("qr should succeed");
+                consume_f64(&r);
+            });
+        });
+        group.bench_function(BenchmarkId::new("f64_eigh", n), |bench| {
+            bench.iter(|| {
+                let (values, _) = black_box(&a).eigh().expect("eigh should succeed");
+                consume_f64(&values);
+            });
+        });
+        group.bench_function(BenchmarkId::new("f64_solve_column_rhs1", n), |bench| {
+            bench.iter(|| {
+                let out = black_box(&a)
+                    .solve(black_box(&b_col))
+                    .expect("solve column RHS should succeed");
+                consume_f64(&out);
+            });
+        });
+        group.bench_function(BenchmarkId::new("f64_solve_matrix_rhs4", n), |bench| {
+            bench.iter(|| {
+                let out = black_box(&a)
+                    .solve(black_box(&b_mat))
+                    .expect("solve matrix RHS should succeed");
+                consume_f64(&out);
+            });
+        });
+
+        if n <= 32 {
+            let a = eager(&ctx, c64_hermitian_tensor(n, 5));
+            group.bench_function(BenchmarkId::new("c64_eigh", n), |bench| {
+                bench.iter(|| {
+                    let (values, _) = black_box(&a).eigh().expect("c64 eigh should succeed");
+                    consume_numeric(&values);
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_batched_einsum(c: &mut Criterion) {
+    let threads = bench_threads();
+    let ctx = cpu_ctx(threads);
+    let mut group = c.benchmark_group(format!(
+        "tenferro_cpu/batched_einsum_rightmost_batch/threads_{threads}"
+    ));
+
+    for &batch in BATCHES {
+        for &n in BATCHED_SMALL_SIZES {
+            let a = eager(&ctx, f64_tensor(vec![n, n, batch], 1));
+            let b = eager(&ctx, f64_tensor(vec![n, n, batch], 2));
+            let params = format!("n_{n}_batch_{batch}");
+            group.bench_function(BenchmarkId::new("f64_ikb_knb_to_inb", params), |bench| {
+                bench.iter(|| {
+                    let out = einsum(&[black_box(&a), black_box(&b)], "ikb,knb->inb")
+                        .expect("batched einsum should succeed");
+                    consume_f64(&out);
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_einsum_patterns(c: &mut Criterion) {
+    let threads = bench_threads();
+    let ctx = cpu_ctx(threads);
+    let mut group = c.benchmark_group(format!("tenferro_cpu/einsum_patterns/threads_{threads}"));
+
+    let a = eager(&ctx, f64_tensor(vec![64, 64], 1));
+    let b = eager(&ctx, f64_tensor(vec![64, 64], 2));
+    let c_tensor = eager(&ctx, f64_tensor(vec![64, 64], 3));
+    group.bench_function("f64_binary_ij_jk_to_ik", |bench| {
+        bench.iter(|| {
+            let out = einsum(&[black_box(&a), black_box(&b)], "ij,jk->ik")
+                .expect("binary einsum should succeed");
+            consume_f64(&out);
+        });
+    });
+    group.bench_function("f64_chain_ij_jk_kl_to_il", |bench| {
+        bench.iter(|| {
+            let out = einsum(
+                &[black_box(&a), black_box(&b), black_box(&c_tensor)],
+                "ij,jk,kl->il",
+            )
+            .expect("chain einsum should succeed");
+            consume_f64(&out);
+        });
+    });
+
+    let x = eager(&ctx, f64_tensor(vec![8, 16, 8], 4));
+    let y = eager(&ctx, f64_tensor(vec![16, 8, 8], 5));
+    group.bench_function("f64_multiedge_ijk_jkl_to_il", |bench| {
+        bench.iter(|| {
+            let out = einsum(&[black_box(&x), black_box(&y)], "ijk,jkl->il")
+                .expect("multi-edge einsum should succeed");
+            consume_f64(&out);
+        });
+    });
+
+    let a = eager(&ctx, c64_tensor(vec![32, 32], 6));
+    let b = eager(&ctx, c64_tensor(vec![32, 32], 7));
+    group.bench_function("c64_binary_ij_jk_to_ik", |bench| {
+        bench.iter(|| {
+            let out = einsum(&[black_box(&a), black_box(&b)], "ij,jk->ik")
+                .expect("c64 binary einsum should succeed");
+            consume_c64(&out);
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_ad(c: &mut Criterion) {
+    let threads = bench_threads();
+    let mut group = c.benchmark_group(format!("tenferro_cpu/ad/threads_{threads}"));
+
+    for &n in SMALL_LINALG_SIZES.iter().chain(MEDIUM_LINALG_SIZES) {
+        group.bench_function(BenchmarkId::new("f64_grad_sum_svd_values", n), |bench| {
+            iter_excluding_setup_and_input_drop(
+                bench,
+                || {
+                    let ctx = cpu_ctx(threads);
+                    tracked(&ctx, f64_spd_tensor(n, 3))
+                },
+                |a| {
+                    let (_, s, _) = a.svd().expect("svd should succeed");
+                    let loss = s.reduce_sum(&[0]).expect("sum should succeed");
+                    black_box(loss.backward().expect("backward should succeed"));
+                    black_box(a.grad());
+                },
+            );
+        });
+    }
+
+    for &n in &[4, 16, 64] {
+        group.bench_function(BenchmarkId::new("f64_grad_sum_matmul", n), |bench| {
+            iter_excluding_setup_and_input_drop(
+                bench,
+                || {
+                    let ctx = cpu_ctx(threads);
+                    let a = tracked(&ctx, f64_tensor(vec![n, n], 1));
+                    let b = tracked(&ctx, f64_tensor(vec![n, n], 2));
+                    (a, b)
+                },
+                |(a, b)| {
+                    let out = a.matmul(&b).expect("matmul should succeed");
+                    let loss = out.reduce_sum(&[0, 1]).expect("sum should succeed");
+                    black_box(loss.backward().expect("backward should succeed"));
+                    black_box(a.grad());
+                    black_box(b.grad());
+                },
+            );
+        });
+
+        if n <= 16 {
+            group.bench_function(BenchmarkId::new("f64_grad_sum_solve", n), |bench| {
+                iter_excluding_setup_and_input_drop(
+                    bench,
+                    || {
+                        let ctx = cpu_ctx(threads);
+                        let a = tracked(&ctx, f64_spd_tensor(n, 4));
+                        let b = tracked(&ctx, f64_tensor(vec![n, 1], 5));
+                        (a, b)
+                    },
+                    |(a, b)| {
+                        let x = a.solve(&b).expect("solve should succeed");
+                        let loss = x.reduce_sum(&[0, 1]).expect("sum should succeed");
+                        black_box(loss.backward().expect("backward should succeed"));
+                        black_box(a.grad());
+                        black_box(b.grad());
+                    },
+                );
+            });
+        }
+    }
+
+    let n = 64;
+    group.bench_function("f64_forward_matmul_sum_untracked/64", |bench| {
+        let ctx = cpu_ctx(threads);
+        let a = eager(&ctx, f64_tensor(vec![n, n], 1));
+        let b = eager(&ctx, f64_tensor(vec![n, n], 2));
+        bench.iter(|| {
+            let out = black_box(&a)
+                .matmul(black_box(&b))
+                .expect("matmul should succeed");
+            let loss = out.reduce_sum(&[0, 1]).expect("sum should succeed");
+            consume_f64(&loss);
+        });
+    });
+
+    group.bench_function("f64_forward_matmul_sum_tracked/64", |bench| {
+        iter_excluding_setup_and_input_drop(
+            bench,
+            || {
+                let ctx = cpu_ctx(threads);
+                let a = tracked(&ctx, f64_tensor(vec![n, n], 1));
+                let b = tracked(&ctx, f64_tensor(vec![n, n], 2));
+                (a, b)
+            },
+            |(a, b)| {
+                let out = black_box(&a)
+                    .matmul(black_box(&b))
+                    .expect("matmul should succeed");
+                let loss = out.reduce_sum(&[0, 1]).expect("sum should succeed");
+                consume_f64(&loss);
+            },
+        );
+    });
+
+    group.bench_function("f64_backward_only_sum_matmul/64", |bench| {
+        iter_excluding_setup_and_input_drop(
+            bench,
+            || {
+                let ctx = cpu_ctx(threads);
+                let a = tracked(&ctx, f64_tensor(vec![n, n], 1));
+                let b = tracked(&ctx, f64_tensor(vec![n, n], 2));
+                let out = a.matmul(&b).expect("matmul should succeed");
+                let loss = out.reduce_sum(&[0, 1]).expect("sum should succeed");
+                (a, b, loss)
+            },
+            |(a, b, loss)| {
+                black_box(loss.backward().expect("backward should succeed"));
+                black_box(a.grad());
+                black_box(b.grad());
+            },
+        );
+    });
+
+    group.bench_function("f64_backward_only_reduce_sum/64", |bench| {
+        iter_excluding_setup_and_input_drop(
+            bench,
+            || {
+                let ctx = cpu_ctx(threads);
+                let a = tracked(&ctx, f64_tensor(vec![n, n], 1));
+                let loss = a.reduce_sum(&[0, 1]).expect("sum should succeed");
+                (a, loss)
+            },
+            |(a, loss)| {
+                black_box(loss.backward().expect("backward should succeed"));
+                black_box(a.grad());
+            },
+        );
+    });
+
+    group.bench_function("f64_manual_grad_sum_matmul_math/64", |bench| {
+        let ctx = cpu_ctx(threads);
+        let a = eager(&ctx, f64_tensor(vec![n, n], 1));
+        let b = eager(&ctx, f64_tensor(vec![n, n], 2));
+        let ct = eager(
+            &ctx,
+            Tensor::from_vec_col_major(vec![n, n], vec![1.0_f64; n * n]),
+        );
+        let grad_a_config = tenferro::DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![1],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        };
+        let grad_b_config = tenferro::DotGeneralConfig {
+            lhs_contracting_dims: vec![0],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        };
+        bench.iter(|| {
+            let grad_a = black_box(&ct)
+                .dot_general(black_box(&b), grad_a_config.clone())
+                .expect("grad A dot_general should succeed");
+            let grad_b = black_box(&a)
+                .dot_general(black_box(&ct), grad_b_config.clone())
+                .expect("grad B dot_general should succeed");
+            consume_f64(&grad_a);
+            consume_f64(&grad_b);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_matmul,
+    bench_linalg,
+    bench_batched_einsum,
+    bench_einsum_patterns,
+    bench_ad
+);
+criterion_main!(benches);

--- a/tenferro/src/compiler/mod.rs
+++ b/tenferro/src/compiler/mod.rs
@@ -395,6 +395,9 @@ fn std_to_exec_op(op: &StdTensorOp) -> ExecOp {
         StdTensorOp::Cholesky { .. } => ExecOp::Cholesky,
         StdTensorOp::Lu { .. } => ExecOp::Lu,
         StdTensorOp::FullPivLu { .. } => ExecOp::FullPivLu,
+        StdTensorOp::Solve { transpose_a } => ExecOp::Solve {
+            transpose_a: *transpose_a,
+        },
         StdTensorOp::FullPivLuSolve { transpose_a } => ExecOp::FullPivLuSolve {
             transpose_a: *transpose_a,
         },

--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -1,12 +1,12 @@
 use std::cell::RefCell;
 use std::cmp::Reverse;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 use computegraph::fragment::Fragment;
-use computegraph::{GlobalValKey, ValRef};
+use computegraph::{GlobalValKey, LocalValId, OpMode, ValRef};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
@@ -24,11 +24,12 @@ use crate::eager_emitter::EagerEmitter;
 use crate::eager_exec::exec_op_on_tensors;
 use crate::error::{ContextId, Error, Result};
 use crate::metadata::{
-    metadata_scopes_for_scope, push_metadata_scope, register_scoped_fragment_metadata,
+    metadata_scopes_for_scope, push_metadata_scope, register_scoped_live_fragment_metadata,
     register_scoped_metadata_batch, register_scoped_value_metadata, tensor_meta_from_tensor,
     MetadataScope,
 };
 use crate::traced::next_input_key;
+use tenferro_ops::TensorMeta;
 
 pub(crate) type GradSlot = Arc<Mutex<Option<Arc<Tensor>>>>;
 pub(crate) type WeakGradSlot = Weak<Mutex<Option<Arc<Tensor>>>>;
@@ -450,13 +451,31 @@ impl EagerTensor {
         grad_node: Option<Arc<GradNode<StdTensorOp>>>,
         metadata_scopes: Vec<Arc<MetadataScope>>,
     ) -> Self {
+        Self::new_result_arc(
+            ctx,
+            key,
+            Arc::new(tensor),
+            requires_grad,
+            grad_node,
+            metadata_scopes,
+        )
+    }
+
+    pub(crate) fn new_result_arc(
+        ctx: Arc<EagerRuntime>,
+        key: GlobalValKey<StdTensorOp>,
+        tensor: Arc<Tensor>,
+        requires_grad: bool,
+        grad_node: Option<Arc<GradNode<StdTensorOp>>>,
+        metadata_scopes: Vec<Arc<MetadataScope>>,
+    ) -> Self {
         let grad_slot = Arc::new(Mutex::new(None));
         if requires_grad {
             ctx.register_grad_slot(&key, &grad_slot);
         }
 
         Self {
-            data: Arc::new(tensor),
+            data: tensor,
             key,
             grad_node,
             requires_grad,
@@ -676,6 +695,83 @@ pub(crate) struct TenferroBackwardCallbacks<'a, B: TensorBackend> {
     metadata_scopes: Vec<Arc<MetadataScope>>,
 }
 
+fn missing_tangent_base_key(key: &GlobalValKey<StdTensorOp>) -> Option<GlobalValKey<StdTensorOp>> {
+    let GlobalValKey::Input(tangent_key) = key else {
+        return None;
+    };
+    let TensorInputKey::Tangent { of, .. } = tangent_key else {
+        return None;
+    };
+    Some(GlobalValKey::Input((**of).clone()))
+}
+
+fn eager_forward_input_metadata(
+    key: &GlobalValKey<StdTensorOp>,
+    initial_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
+) -> TensorMeta {
+    if let Some(value) = initial_data.get(key) {
+        return tensor_meta_from_tensor(value.as_ref());
+    }
+
+    let base_key = missing_tangent_base_key(key)
+        .unwrap_or_else(|| panic!("missing concrete eager value for {:?}", key));
+    let base = initial_data
+        .get(&base_key)
+        .unwrap_or_else(|| panic!("missing base eager value for {:?}", base_key));
+    tensor_meta_from_tensor(base.as_ref())
+}
+
+fn eager_forward_value<B: TensorBackend>(
+    all_values: &mut HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
+    key: &GlobalValKey<StdTensorOp>,
+    initial_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
+    backend: &mut B,
+) -> Arc<Tensor> {
+    if let Some(value) = all_values.get(key) {
+        return Arc::clone(value);
+    }
+
+    let base_key = missing_tangent_base_key(key)
+        .unwrap_or_else(|| panic!("missing concrete eager value for {:?}", key));
+    let base = initial_data
+        .get(&base_key)
+        .unwrap_or_else(|| panic!("missing base eager value for {:?}", base_key));
+    let value = Arc::new(zero_like_tensor(base.as_ref(), backend));
+    all_values.insert(key.clone(), Arc::clone(&value));
+    value
+}
+
+fn live_fragment_values(fragment: &Fragment<StdTensorOp>) -> HashSet<LocalValId> {
+    let mut producers = HashMap::new();
+    for (op_index, op_node) in fragment.ops().iter().enumerate() {
+        for &output_id in &op_node.outputs {
+            producers.insert(output_id, op_index);
+        }
+    }
+
+    let mut live = HashSet::new();
+    let mut stack = fragment.outputs().to_vec();
+    while let Some(local_id) = stack.pop() {
+        if !live.insert(local_id) {
+            continue;
+        }
+        let Some(&op_index) = producers.get(&local_id) else {
+            continue;
+        };
+        for input in &fragment.ops()[op_index].inputs {
+            if let ValRef::Local(input_id) = input {
+                stack.push(*input_id);
+            }
+        }
+    }
+
+    live
+}
+
+fn linear_op_depends_on_tangents(mode: &OpMode) -> bool {
+    matches!(mode, OpMode::Linear { active_mask } if active_mask.iter().any(|is_active| *is_active))
+}
+
 impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallbacks<'_, B> {
     fn execute_forward(
         &mut self,
@@ -683,43 +779,44 @@ impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallba
         initial_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
     ) -> HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>> {
         let mut all_values = initial_data.clone();
-
-        for &input_id in fragment.inputs() {
-            let key = fragment.vals()[input_id].key.clone();
-            all_values.entry(key.clone()).or_insert_with(|| {
-                let GlobalValKey::Input(tangent_key) = &key else {
-                    panic!("expected input key for eager forward: {:?}", key);
-                };
-                let tenferro_ops::input_key::TensorInputKey::Tangent { of, .. } = tangent_key
-                else {
-                    panic!("missing concrete eager value for {:?}", key);
-                };
-                let base_key = GlobalValKey::Input((**of).clone());
-                let base = initial_data
-                    .get(&base_key)
-                    .unwrap_or_else(|| panic!("missing base eager value for {:?}", base_key));
-                Arc::new(zero_like_tensor(base.as_ref(), self.backend))
-            });
-        }
+        let live_values = live_fragment_values(fragment);
+        let input_metadata = fragment
+            .inputs()
+            .iter()
+            .map(|&input_id| {
+                let key = fragment.vals()[input_id].key.clone();
+                let meta = eager_forward_input_metadata(&key, initial_data);
+                (key, meta)
+            })
+            .collect::<Vec<_>>();
 
         for op_node in fragment.ops() {
-            let resolved_inputs: Vec<&Tensor> = op_node
+            if linear_op_depends_on_tangents(&op_node.mode) {
+                continue;
+            }
+            if !op_node
+                .outputs
+                .iter()
+                .any(|output_id| live_values.contains(output_id))
+            {
+                continue;
+            }
+
+            let resolved_values: Vec<Arc<Tensor>> = op_node
                 .inputs
                 .iter()
                 .map(|input| match input {
                     ValRef::Local(local_id) => {
                         let key = &fragment.vals()[*local_id].key;
-                        all_values
-                            .get(key)
-                            .unwrap_or_else(|| panic!("missing eager value for local {:?}", key))
-                            .as_ref()
+                        eager_forward_value(&mut all_values, key, initial_data, self.backend)
                     }
-                    ValRef::External(key) => all_values
-                        .get(key)
-                        .unwrap_or_else(|| panic!("missing eager value for external {:?}", key))
-                        .as_ref(),
+                    ValRef::External(key) => {
+                        eager_forward_value(&mut all_values, key, initial_data, self.backend)
+                    }
                 })
                 .collect();
+            let resolved_inputs: Vec<&Tensor> =
+                resolved_values.iter().map(|value| value.as_ref()).collect();
             let outputs = exec_op_on_tensors(&op_node.op, &resolved_inputs, self.backend)
                 .unwrap_or_else(|err| {
                     panic!("eager forward exec failed for {:?}: {}", op_node.op, err)
@@ -731,21 +828,8 @@ impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallba
             }
         }
 
-        let metadata_scope = register_scoped_fragment_metadata(
-            fragment,
-            fragment.inputs().iter().map(|input_id| {
-                let key = fragment.vals()[*input_id].key.clone();
-                let meta = tensor_meta_from_tensor(
-                    all_values
-                        .get(&key)
-                        .unwrap_or_else(|| {
-                            panic!("missing eager value for fragment input {:?}", key)
-                        })
-                        .as_ref(),
-                );
-                (key, meta)
-            }),
-        );
+        let metadata_scope =
+            register_scoped_live_fragment_metadata(fragment, &live_values, input_metadata);
         push_metadata_scope(&mut self.metadata_scopes, Arc::new(metadata_scope));
 
         all_values

--- a/tenferro/src/eager_emitter.rs
+++ b/tenferro/src/eager_emitter.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use computegraph::{GlobalValKey, LocalValId, OpEmitter, OpMode, ValRef};
+use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_tensor::{Tensor, TensorBackend};
+use tenferro_tensor::{Tensor, TensorBackend, TypedTensor};
 
 use crate::eager_exec::exec_op_on_tensors;
 
@@ -31,6 +32,22 @@ impl<'a, B: TensorBackend> EagerEmitter<'a, B> {
     pub fn tensor(&self, id: LocalValId) -> Arc<Tensor> {
         Arc::clone(&self.results[id])
     }
+
+    fn external_tensor(&mut self, key: &GlobalValKey<StdTensorOp>) -> Arc<Tensor> {
+        if let Some(tensor) = self.external_data.get(key) {
+            return Arc::clone(tensor);
+        }
+
+        let base_key = missing_tangent_base_key(key)
+            .unwrap_or_else(|| panic!("EagerEmitter: missing external {:?}", key));
+        let base = self
+            .external_data
+            .get(&base_key)
+            .unwrap_or_else(|| panic!("EagerEmitter: missing tangent base {:?}", base_key));
+        let zero = Arc::new(zero_like_tensor(base.as_ref()));
+        self.external_data.insert(key.clone(), Arc::clone(&zero));
+        zero
+    }
 }
 
 impl<B: TensorBackend> OpEmitter<StdTensorOp> for EagerEmitter<'_, B> {
@@ -40,16 +57,16 @@ impl<B: TensorBackend> OpEmitter<StdTensorOp> for EagerEmitter<'_, B> {
         inputs: Vec<ValRef<StdTensorOp>>,
         _mode: OpMode,
     ) -> Vec<LocalValId> {
-        let concrete: Vec<&Tensor> = inputs
+        let concrete_values: Vec<Arc<Tensor>> = inputs
             .iter()
             .map(|value| match value {
-                ValRef::Local(id) => self.results[*id].as_ref(),
-                ValRef::External(key) => self
-                    .external_data
-                    .get(key)
-                    .unwrap_or_else(|| panic!("EagerEmitter: missing external {:?}", key))
-                    .as_ref(),
+                ValRef::Local(id) => Arc::clone(&self.results[*id]),
+                ValRef::External(key) => self.external_tensor(key),
             })
+            .collect();
+        let concrete: Vec<&Tensor> = concrete_values
+            .iter()
+            .map(|tensor| tensor.as_ref())
             .collect();
 
         let outputs = exec_op_on_tensors(&op, &concrete, self.backend)
@@ -60,5 +77,25 @@ impl<B: TensorBackend> OpEmitter<StdTensorOp> for EagerEmitter<'_, B> {
             self.results.push(Arc::new(output));
         }
         (base..self.results.len()).collect()
+    }
+}
+
+fn missing_tangent_base_key(key: &GlobalValKey<StdTensorOp>) -> Option<GlobalValKey<StdTensorOp>> {
+    let GlobalValKey::Input(tangent_key) = key else {
+        return None;
+    };
+    let TensorInputKey::Tangent { of, .. } = tangent_key else {
+        return None;
+    };
+    Some(GlobalValKey::Input((**of).clone()))
+}
+
+fn zero_like_tensor(input: &Tensor) -> Tensor {
+    match input {
+        Tensor::F32(tensor) => Tensor::F32(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::F64(tensor) => Tensor::F64(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::I64(tensor) => Tensor::I64(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::C32(tensor) => Tensor::C32(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::C64(tensor) => Tensor::C64(TypedTensor::zeros(tensor.shape.clone())),
     }
 }

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -11,34 +11,54 @@ use crate::error::{Error, Result};
 use crate::scalar_semantics::dynamic_truncate_size;
 use crate::shape_infer::promote_dtype_for_binary_op;
 
+enum PromotedTensor<'a> {
+    Borrowed(&'a Tensor),
+    Owned(Tensor),
+}
+
+impl<'a> PromotedTensor<'a> {
+    fn tensor(&'a self) -> &'a Tensor {
+        match self {
+            Self::Borrowed(tensor) => tensor,
+            Self::Owned(tensor) => tensor,
+        }
+    }
+}
+
+fn promote_to_dtype<'a>(
+    exec: &mut dyn TensorExec,
+    tensor: &'a Tensor,
+    promoted: DType,
+) -> Result<PromotedTensor<'a>> {
+    if tensor.dtype() == promoted {
+        Ok(PromotedTensor::Borrowed(tensor))
+    } else {
+        Ok(PromotedTensor::Owned(
+            exec.convert(tensor, promoted).map_err(Error::from)?,
+        ))
+    }
+}
+
 /// If the two tensors have different dtypes, insert Convert ops so they
 /// both match the promoted result dtype. Returns the (possibly converted)
 /// tensors.
-fn promote_binary_to_dtype(
+fn promote_binary_to_dtype<'a>(
     exec: &mut dyn TensorExec,
-    a: &Tensor,
-    b: &Tensor,
+    a: &'a Tensor,
+    b: &'a Tensor,
     promoted: DType,
-) -> Result<(Tensor, Tensor)> {
-    let a = if a.dtype() != promoted {
-        exec.convert(a, promoted).map_err(Error::from)?
-    } else {
-        a.clone()
-    };
-    let b = if b.dtype() != promoted {
-        exec.convert(b, promoted).map_err(Error::from)?
-    } else {
-        b.clone()
-    };
+) -> Result<(PromotedTensor<'a>, PromotedTensor<'a>)> {
+    let a = promote_to_dtype(exec, a, promoted)?;
+    let b = promote_to_dtype(exec, b, promoted)?;
     Ok((a, b))
 }
 
-fn promote_binary(
+fn promote_binary<'a>(
     exec: &mut dyn TensorExec,
-    a: &Tensor,
-    b: &Tensor,
+    a: &'a Tensor,
+    b: &'a Tensor,
     op: &StdTensorOp,
-) -> Result<(Tensor, Tensor)> {
+) -> Result<(PromotedTensor<'a>, PromotedTensor<'a>)> {
     let promoted = promote_dtype_for_binary_op(op, a.dtype(), b.dtype());
     promote_binary_to_dtype(exec, a, b, promoted)
 }
@@ -54,7 +74,7 @@ pub(crate) fn exec_dot_general_with_conj_on_tensors<B: TensorBackend>(
     let promoted = crate::shape_infer::promote_dtype(lhs.dtype(), rhs.dtype());
     backend.with_exec_session(|exec| {
         let (lhs, rhs) = promote_binary_to_dtype(exec, lhs, rhs, promoted)?;
-        exec.dot_general_with_conj(&lhs, &rhs, config, lhs_conj, rhs_conj)
+        exec.dot_general_with_conj(lhs.tensor(), rhs.tensor(), config, lhs_conj, rhs_conj)
             .map_err(Error::from)
     })
 }
@@ -88,20 +108,49 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
         });
     }
 
+    if let StdTensorOp::Solve { transpose_a } = op {
+        let promoted = promote_dtype_for_binary_op(op, inputs[0].dtype(), inputs[1].dtype());
+        let a_converted;
+        let b_converted;
+        let a = if inputs[0].dtype() == promoted {
+            inputs[0]
+        } else {
+            a_converted = backend.convert(inputs[0], promoted)?;
+            &a_converted
+        };
+        let b = if inputs[1].dtype() == promoted {
+            inputs[1]
+        } else {
+            b_converted = backend.convert(inputs[1], promoted)?;
+            &b_converted
+        };
+        let a_transposed;
+        let a_ref = if *transpose_a {
+            let rank = a.shape().len();
+            let mut perm: Vec<usize> = (0..rank).collect();
+            perm.swap(0, 1);
+            a_transposed = backend.transpose(a, &perm)?;
+            &a_transposed
+        } else {
+            a
+        };
+        return Ok(vec![backend.solve(a_ref, b)?]);
+    }
+
     backend.with_exec_session(|exec| {
         let result = match op {
             StdTensorOp::Add => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.add(&a, &b)?]
+                vec![exec.add(a.tensor(), b.tensor())?]
             }
             StdTensorOp::Mul => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.mul(&a, &b)?]
+                vec![exec.mul(a.tensor(), b.tensor())?]
             }
             StdTensorOp::Neg => vec![exec.neg(inputs[0])?],
             StdTensorOp::Div => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.div(&a, &b)?]
+                vec![exec.div(a.tensor(), b.tensor())?]
             }
             StdTensorOp::Exp => vec![exec.exp(inputs[0])?],
             StdTensorOp::Log => vec![exec.log(inputs[0])?],
@@ -112,28 +161,28 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
             StdTensorOp::Rsqrt => vec![exec.rsqrt(inputs[0])?],
             StdTensorOp::Pow => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.pow(&a, &b)?]
+                vec![exec.pow(a.tensor(), b.tensor())?]
             }
             StdTensorOp::Abs => vec![exec.abs(inputs[0])?],
             StdTensorOp::Sign => vec![exec.sign(inputs[0])?],
             StdTensorOp::Conj => vec![exec.conj(inputs[0])?],
             StdTensorOp::Maximum => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.maximum(&a, &b)?]
+                vec![exec.maximum(a.tensor(), b.tensor())?]
             }
             StdTensorOp::Minimum => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.minimum(&a, &b)?]
+                vec![exec.minimum(a.tensor(), b.tensor())?]
             }
             StdTensorOp::Compare(dir) => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.compare(&a, &b, dir)?]
+                vec![exec.compare(a.tensor(), b.tensor(), dir)?]
             }
             StdTensorOp::Transpose { perm } => vec![exec.transpose(inputs[0], perm)?],
             StdTensorOp::ReduceSum { axes, .. } => vec![exec.reduce_sum(inputs[0], axes)?],
             StdTensorOp::DotGeneral { config, .. } => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.dot_general(&a, &b, config)?]
+                vec![exec.dot_general(a.tensor(), b.tensor(), config)?]
             }
             StdTensorOp::Reshape { to_shape, .. } => {
                 let shape = resolve_tensor_shape_exprs(inputs, to_shape);
@@ -163,25 +212,22 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
             StdTensorOp::Constant { dtype, bytes } => vec![constant_tensor(*dtype, bytes)],
             StdTensorOp::Select => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                let (a, c) = promote_binary(exec, &a, inputs[2], op)?;
-                vec![exec.select(&a, &b, &c)?]
+                let (a, c) = promote_binary(exec, a.tensor(), inputs[2], op)?;
+                vec![exec.select(a.tensor(), b.tensor(), c.tensor())?]
             }
             StdTensorOp::Clamp => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                let (a, c) = promote_binary(exec, &a, inputs[2], op)?;
-                vec![exec.clamp(&a, &b, &c)?]
+                let (a, c) = promote_binary(exec, a.tensor(), inputs[2], op)?;
+                vec![exec.clamp(a.tensor(), b.tensor(), c.tensor())?]
             }
             StdTensorOp::Concatenate { axis, .. } => {
                 let promoted = crate::shape_infer::promote_dtypes(inputs.iter().map(|t| t.dtype()));
-                let mut promoted_inputs: Vec<Tensor> = Vec::with_capacity(inputs.len());
+                let mut promoted_inputs = Vec::with_capacity(inputs.len());
                 for t in inputs {
-                    if t.dtype() != promoted {
-                        promoted_inputs.push(exec.convert(t, promoted).map_err(Error::from)?);
-                    } else {
-                        promoted_inputs.push((*t).clone());
-                    }
+                    promoted_inputs.push(promote_to_dtype(exec, t, promoted)?);
                 }
-                let promoted_refs: Vec<&Tensor> = promoted_inputs.iter().collect();
+                let promoted_refs: Vec<&Tensor> =
+                    promoted_inputs.iter().map(PromotedTensor::tensor).collect();
                 vec![exec.concatenate(&promoted_refs, *axis)?]
             }
             StdTensorOp::NaryEinsum { .. } => {
@@ -209,14 +255,14 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
             }
             StdTensorOp::Scatter(config) => {
                 let (operand, updates) = promote_binary(exec, inputs[0], inputs[2], op)?;
-                vec![exec.scatter(&operand, inputs[1], &updates, config)?]
+                vec![exec.scatter(operand.tensor(), inputs[1], updates.tensor(), config)?]
             }
             StdTensorOp::DynamicSlice { slice_sizes } => {
                 vec![exec.dynamic_slice(inputs[0], inputs[1], slice_sizes)?]
             }
             StdTensorOp::DynamicUpdateSlice => {
                 let (operand, update) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.dynamic_update_slice(&operand, &update, inputs[2])?]
+                vec![exec.dynamic_update_slice(operand.tensor(), update.tensor(), inputs[2])?]
             }
             StdTensorOp::Cholesky { .. } => vec![exec.cholesky(inputs[0])?],
             StdTensorOp::TriangularSolve {
@@ -228,8 +274,8 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
             } => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
                 vec![exec.triangular_solve(
-                    &a,
-                    &b,
+                    a.tensor(),
+                    b.tensor(),
                     *left_side,
                     *lower,
                     *transpose_a,
@@ -240,9 +286,12 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
             StdTensorOp::Qr { .. } => exec.qr(inputs[0])?,
             StdTensorOp::Lu { .. } => exec.lu(inputs[0])?,
             StdTensorOp::FullPivLu { .. } => exec.full_piv_lu(inputs[0])?,
+            StdTensorOp::Solve { .. } => {
+                unreachable!("Solve is handled before opening an exec session")
+            }
             StdTensorOp::FullPivLuSolve { transpose_a } => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                vec![exec.full_piv_lu_solve(&a, &b, *transpose_a)?]
+                vec![exec.full_piv_lu_solve(a.tensor(), b.tensor(), *transpose_a)?]
             }
             StdTensorOp::Eigh { .. } => exec.eigh(inputs[0])?,
             StdTensorOp::Eig { .. } => exec.eig(inputs[0])?,

--- a/tenferro/src/eager_ops.rs
+++ b/tenferro/src/eager_ops.rs
@@ -684,10 +684,10 @@ impl EagerTensor {
             .into_iter()
             .zip(outputs)
             .map(|(trace, output)| {
-                Self::new_result(
+                Self::new_result_arc(
                     Arc::clone(&self.ctx),
                     trace.key,
-                    output.as_ref().clone(),
+                    output,
                     trace.requires_grad,
                     trace.node,
                     metadata_scopes.clone(),
@@ -755,10 +755,10 @@ impl EagerTensor {
         }
 
         let result = profile_eager_op_section("nary_op.new_tracked_result", || {
-            Self::new_result(
+            Self::new_result_arc(
                 ctx,
                 trace.key,
-                output.as_ref().clone(),
+                output,
                 trace.requires_grad,
                 trace.node,
                 metadata_scopes,

--- a/tenferro/src/eager_ops_linalg.rs
+++ b/tenferro/src/eager_ops_linalg.rs
@@ -147,9 +147,7 @@ impl EagerTensor {
         self.binary_op(b, StdTensorOp::FullPivLuSolve { transpose_a: false })
     }
 
-    /// Solve `A x = rhs` using complete-pivoting LU factorization.
-    ///
-    /// This is a shorter alias for [`Self::full_piv_lu_solve`].
+    /// Solve `A x = rhs` using LU factorization and triangular solves.
     ///
     /// # Examples
     ///
@@ -164,7 +162,7 @@ impl EagerTensor {
     /// assert_eq!(x.data().as_slice::<f64>().unwrap(), &[2.0, 2.0]);
     /// ```
     pub fn solve(&self, rhs: &Self) -> Result<Self> {
-        self.full_piv_lu_solve(rhs)
+        self.binary_op(rhs, StdTensorOp::Solve { transpose_a: false })
     }
 
     /// Solve `x A = rhs`, returning `rhs * A^{-1}` without forming an inverse.
@@ -214,7 +212,7 @@ impl EagerTensor {
         }
         let a_t = self.transpose(&[1, 0])?;
         let rhs_t = rhs.transpose(&[1, 0])?;
-        a_t.full_piv_lu_solve(&rhs_t)?.transpose(&[1, 0])
+        a_t.solve(&rhs_t)?.transpose(&[1, 0])
     }
 
     /// Cholesky factorization: `A = L L^T` for real inputs.

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -135,6 +135,9 @@ pub enum ExecOp {
     Qr,
     Lu,
     FullPivLu,
+    Solve {
+        transpose_a: bool,
+    },
     FullPivLuSolve {
         transpose_a: bool,
     },
@@ -245,6 +248,7 @@ pub(crate) fn is_ffi_instruction(inst: &ExecInstruction) -> bool {
             | ExecOp::Qr
             | ExecOp::Lu
             | ExecOp::FullPivLu
+            | ExecOp::Solve { .. }
             | ExecOp::FullPivLuSolve { .. }
             | ExecOp::Eigh
             | ExecOp::Eig
@@ -692,6 +696,22 @@ pub(crate) fn execute_ffi_instruction<B: TensorBackend>(
         ExecOp::FullPivLu => {
             let results = backend.full_piv_lu(get(slots, &inst.input_slots, 0)?)?;
             assign_multi_output(slots, inst, results, "full_piv_lu")?;
+        }
+        ExecOp::Solve { transpose_a } => {
+            let a = get(slots, &inst.input_slots, 0)?;
+            let b = get(slots, &inst.input_slots, 1)?;
+            let a_transposed;
+            let a_ref = if *transpose_a {
+                let rank = a.shape().len();
+                let mut perm: Vec<usize> = (0..rank).collect();
+                perm.swap(0, 1);
+                a_transposed = backend.transpose(a, &perm)?;
+                &a_transposed
+            } else {
+                a
+            };
+            let result = backend.solve(a_ref, b)?;
+            slots[inst.output_slots[0]] = Some(result);
         }
         ExecOp::FullPivLuSolve { transpose_a } => {
             let result = backend.full_piv_lu_solve(

--- a/tenferro/src/graph/compiler.rs
+++ b/tenferro/src/graph/compiler.rs
@@ -501,6 +501,17 @@ fn descriptor_for_input(
     }
     if !matches!(key, TensorInputKey::User { .. }) {
         let root = tangent_primal_root(key);
+        if let Some(tensor) = default_inputs.get(root) {
+            return Ok(InputDescriptor {
+                key: key.clone(),
+                dtype: tensor.dtype(),
+                shape: tensor.shape().to_vec(),
+                default_tensor: Some(Arc::new(zeros_tensor(
+                    tensor.dtype(),
+                    tensor.shape().to_vec(),
+                ))),
+            });
+        }
         if let Some(spec) = binding_specs.get(root) {
             return Ok(InputDescriptor {
                 key: key.clone(),

--- a/tenferro/src/graph/executor.rs
+++ b/tenferro/src/graph/executor.rs
@@ -548,6 +548,16 @@ fn resolve_inputs(
         .map(|input| input.key.clone())
         .collect();
     let tangent_root_specs = tangent_root_specs(&program.inputs);
+    let default_map: HashMap<_, _> = program
+        .inputs
+        .iter()
+        .filter_map(|input| {
+            input
+                .default_tensor
+                .as_ref()
+                .map(|tensor| (input.key.clone(), tensor.as_ref()))
+        })
+        .collect();
     let mut binding_map = HashMap::new();
     for (index, (placeholder, tensor)) in bindings.iter().enumerate() {
         if placeholder.data.is_some() {
@@ -575,7 +585,7 @@ fn resolve_inputs(
     program
         .inputs
         .iter()
-        .map(|input| resolve_input(input, &binding_map))
+        .map(|input| resolve_input(input, &binding_map, &default_map))
         .collect()
 }
 
@@ -594,12 +604,13 @@ fn tangent_root_specs(inputs: &[GraphProgramInput]) -> HashMap<TensorInputKey, &
 fn resolve_input(
     input: &GraphProgramInput,
     bindings: &HashMap<TensorInputKey, &Tensor>,
+    defaults: &HashMap<TensorInputKey, &Tensor>,
 ) -> Result<Tensor> {
     let tensor = if let Some(bound) = bindings.get(&input.key) {
         (*bound).clone()
     } else if let Some(default) = &input.default_tensor {
         default.as_ref().clone()
-    } else if let Some(zero) = deferred_zero_for_tangent_key(&input.key, bindings) {
+    } else if let Some(zero) = deferred_zero_for_tangent_key(&input.key, bindings, defaults) {
         zero
     } else {
         return Err(Error::UnboundPlaceholder {
@@ -666,12 +677,13 @@ fn validate_input_tensor(input: &GraphProgramInput, tensor: &Tensor) -> Result<(
 fn deferred_zero_for_tangent_key(
     key: &TensorInputKey,
     bindings: &HashMap<TensorInputKey, &Tensor>,
+    defaults: &HashMap<TensorInputKey, &Tensor>,
 ) -> Option<Tensor> {
     if matches!(key, TensorInputKey::User { .. }) {
         return None;
     }
     let root = tangent_primal_root(key);
-    let primal = bindings.get(root)?;
+    let primal = bindings.get(root).or_else(|| defaults.get(root))?;
     Some(zeros_tensor(primal.dtype(), primal.shape().to_vec()))
 }
 

--- a/tenferro/src/metadata.rs
+++ b/tenferro/src/metadata.rs
@@ -1,5 +1,5 @@
 use computegraph::fragment::Fragment;
-use computegraph::types::{GlobalValKey, ValRef};
+use computegraph::types::{GlobalValKey, LocalValId, ValRef};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -58,7 +58,19 @@ pub(crate) fn register_scoped_fragment_metadata(
     fragment: &Fragment<StdTensorOp>,
     seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
 ) -> MetadataScope {
-    register_scoped_global_metadata_batch(fragment_metadata_registrations(fragment, seeded))
+    register_scoped_global_metadata_batch(fragment_metadata_registrations(fragment, None, seeded))
+}
+
+pub(crate) fn register_scoped_live_fragment_metadata(
+    fragment: &Fragment<StdTensorOp>,
+    live_values: &HashSet<LocalValId>,
+    seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
+) -> MetadataScope {
+    register_scoped_global_metadata_batch(fragment_metadata_registrations(
+        fragment,
+        Some(live_values),
+        seeded,
+    ))
 }
 
 pub(crate) fn metadata_scopes_with_new<'a>(
@@ -114,6 +126,7 @@ fn extend_metadata_scopes<'a>(
 
 fn fragment_metadata_registrations(
     fragment: &Fragment<StdTensorOp>,
+    live_values: Option<&HashSet<LocalValId>>,
     seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
 ) -> Vec<(GlobalValKey<StdTensorOp>, TensorMeta)> {
     let seeded: Vec<_> = seeded.into_iter().collect();
@@ -128,6 +141,16 @@ fn fragment_metadata_registrations(
 
     let mut registrations = seeded;
     for op_node in fragment.ops() {
+        if let Some(live_values) = live_values {
+            if !op_node
+                .outputs
+                .iter()
+                .any(|output_id| live_values.contains(output_id))
+            {
+                continue;
+            }
+        }
+
         let input_metas: Vec<_> = op_node
             .inputs
             .iter()

--- a/tenferro/src/shape_infer.rs
+++ b/tenferro/src/shape_infer.rs
@@ -114,6 +114,7 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         | StdTensorOp::DotGeneral { .. }
         | StdTensorOp::NaryEinsum { .. }
         | StdTensorOp::TriangularSolve { .. }
+        | StdTensorOp::Solve { .. }
         | StdTensorOp::FullPivLuSolve { .. }
         | StdTensorOp::Concatenate { .. }
         | StdTensorOp::PadToMatch { .. }
@@ -298,7 +299,9 @@ pub fn infer_output_shapes(op: &StdTensorOp, input_shapes: &[&[DimExpr]]) -> Vec
         StdTensorOp::Eigh { .. } | StdTensorOp::Eig { .. } => {
             eig_like_shapes(require_input(op, input_shapes, 0))
         }
-        StdTensorOp::TriangularSolve { .. } | StdTensorOp::FullPivLuSolve { .. } => {
+        StdTensorOp::TriangularSolve { .. }
+        | StdTensorOp::Solve { .. }
+        | StdTensorOp::FullPivLuSolve { .. } => {
             vec![require_input(op, input_shapes, 1).to_vec()]
         }
         StdTensorOp::Extension(ext) => {

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -815,11 +815,6 @@ impl TracedTensor {
             )],
         );
         ad_ctx.refresh_global_metadata();
-        let linear_tangent_input_ids: Vec<LocalValId> = linear
-            .tangent_inputs
-            .iter()
-            .map(|(_, local_id)| *local_id)
-            .collect();
         let transposed = try_transpose(&linear, &mut ad_ctx)?;
         let cotangent_input_key =
             linear_input_key(&transposed.fragment, transposed.tangent_inputs[0].1);
@@ -852,31 +847,10 @@ impl TracedTensor {
                 .clone()
                 .unwrap_or_else(|| panic!("vjp cotangent must have concrete tensor data")),
         );
-        // Build the zero-cotangent for inactive tangent inputs.
-        //
-        // When `wrt` has a concrete shape we materialise the zero tensor
-        // eagerly and store it in `inputs_map`. When `wrt` is symbolic
-        // (shape_hint == None) we leave those tangent input keys absent from
-        // `inputs_map`; `GraphExecutor::run_with_inputs` synthesises the
-        // zeros once the concrete shape is known from the caller's binding.
-        // This is the deferred zero-tangent policy used for
-        // symbolic-shape placeholder gradients.
-        if let Some(concrete_shape) = try_concrete_shape(wrt) {
-            let zero_tangent = Arc::new(zeros_tensor(wrt.dtype, concrete_shape));
-            for (_, local_id) in &transposed.tangent_inputs {
-                let tangent_input_key = linear_input_key(&transposed.fragment, *local_id);
-                if tangent_input_key != cotangent_input_key {
-                    inputs_map.insert(tangent_input_key, Arc::clone(&zero_tangent));
-                }
-            }
-            for local_id in linear_tangent_input_ids {
-                let tangent_input_key = linear_input_key(&linear_fragment, local_id);
-                inputs_map.insert(tangent_input_key, Arc::clone(&zero_tangent));
-            }
-        }
-        // Symbolic case: tangent keys are intentionally absent from
-        // inputs_map; GraphExecutor::run_with_inputs resolves them via deferred-zero
-        // synthesis keyed on the primal binding.
+        // Inactive tangent keys are intentionally absent from `inputs_map`.
+        // Graph execution resolves them through deferred-zero synthesis keyed
+        // on the primal binding, avoiding dense zero tensors during VJP graph
+        // construction.
 
         let mut extra_roots = vec![self.fragment.clone(), linear_fragment];
         extra_roots.extend(checkpoint_fragments);
@@ -2228,15 +2202,5 @@ fn ones_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
         DType::I64 => Tensor::I64(TypedTensor::ones(shape)),
         DType::C32 => Tensor::C32(TypedTensor::ones(shape)),
         DType::C64 => Tensor::C64(TypedTensor::ones(shape)),
-    }
-}
-
-fn zeros_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
-    match dtype {
-        DType::F32 => Tensor::F32(TypedTensor::zeros(shape)),
-        DType::F64 => Tensor::F64(TypedTensor::zeros(shape)),
-        DType::I64 => Tensor::I64(TypedTensor::zeros(shape)),
-        DType::C32 => Tensor::C32(TypedTensor::zeros(shape)),
-        DType::C64 => Tensor::C64(TypedTensor::zeros(shape)),
     }
 }

--- a/third_party/libtorch/.gitignore
+++ b/third_party/libtorch/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/third_party/libtorch/README.md
+++ b/third_party/libtorch/README.md
@@ -1,0 +1,13 @@
+# LibTorch Benchmark Cache
+
+This directory is the default repo-local cache for the optional LibTorch C++
+CPU benchmark baseline.
+
+The benchmark script stores downloaded LibTorch ZIP files and extracted
+libraries here by default. These files are intentionally ignored by git because
+they are large binary artifacts. When running from a linked git worktree, the
+script resolves the main worktree with `git worktree list` and uses this
+directory there, so each temporary worktree does not download its own copy.
+
+Override the location with `TENFERRO_BENCH_DEPS_DIR` or point directly at an
+existing LibTorch install with `LIBTORCH_DIR`.


### PR DESCRIPTION
## Summary

- Add `StdTensorOp::Solve` and direct CPU solve dispatch for faer and LAPACK/BLAS paths.
- Update eager backward replay to prune seeded/live output work while still replaying fixed linear helper ops needed by gradients.
- Add a repo-local LibTorch cache location, Torch C++ CPU baseline, Criterion CPU benchmark harness, and `scripts/bench-cpu.sh` thread control.
- Record fresh CPU benchmark results in `docs/performance/cpu-benchmark-results-2026-05-23.md`; AD SVD-values now uses the same matrix sizes as primal SVD.

Closes #862

## Notes

This adds the benchmark as a normal benchmark suite, not a publication gate. The benchmark command excludes LibTorch download/build/data preparation from measured timing and runs thread counts 1, 2, and 4.

The tenferro dependency on `tidu` is pinned to merged tidu PR #25 (`1694275361d2f16abfb3f25ad7941407c88b7c09`) for the eager backward pruning behavior.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p tenferro --benches`
- `cmake --build target/torch-cpp-bench --config Release --parallel`
- `TENFERRO_MAIN_REPO_DIR=$PWD bash scripts/bench-cpu.sh --kind all --threads 1,2,4 --no-download-libtorch -- --sample-size 10 --warm-up-time 0.2 --measurement-time 0.2`
- `cargo test -p tenferro --test eager_linalg --release`
- `cargo test -p tenferro-tensor --release solve`
- `cargo test -p tenferro-tensor --no-default-features --features cpu-blas,provider-inject --release --test inject_tests`
- `cargo test -p tenferro-ops --release`
- `cargo test -p tenferro --release`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Full workspace coverage was not rerun locally; CI should cover the required full gate.
