### PR TITLE
[codex] Add strided tensor views and dtype coverage

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -181,9 +181,9 @@ rules from `tensor4all-agent-rules`.
 
 ### Performance Anti-Patterns
 
-- Do not duplicate `f64`/`f32`/complex function bodies. Use generic helpers,
-  traits, or macros, and keep any unavoidable dtype dispatch isolated at the
-  outer boundary.
+- Do not hand-copy near-identical dtype-specific operation bodies. Prefer
+  generic helpers, sealed traits, or macros, and keep any unavoidable dtype
+  dispatch isolated at the outer boundary.
 - Do not allocate dense buffers when strided or backend-native access is
   available.
 - Do not zero-initialize buffers that will be fully overwritten.
@@ -296,7 +296,13 @@ rules from `tensor4all-agent-rules`.
 - Use generic constructors with sealed traits instead of per-type functions.
 - Bad: `TracedTensor::from_f64(...)`, `TracedTensor::from_f32(...)`, etc.
 - Good: `TracedTensor::new<T: TensorScalar>(shape, data)` — type inference selects the variant.
-- Sealed traits (`TensorScalar`, `PoolScalar`, etc.) restrict to supported dtypes (f64, f32, Complex64, Complex32).
+- For dtype-polymorphic tensor operations, prefer one typed generic
+  implementation plus outer dtype dispatch over per-dtype copy-pasted
+  implementations.
+- If Rust generics cannot express the shared structure cleanly, use a local
+  macro to generate the repetitive dispatch or variant plumbing.
+- Sealed traits (`TensorScalar`, `PoolScalar`, etc.) restrict APIs to the
+  currently supported dtype set.
 
 ## Public API Convention
 

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -697,7 +697,7 @@ fn conjugate_primal_if_complex(
     ctx: &mut ShapeGuardContext,
 ) -> ValRef<StdTensorOp> {
     match ctx.dtype_of(&input) {
-        DType::F32 | DType::F64 | DType::I64 => input,
+        DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => input,
         DType::C32 | DType::C64 => {
             ValRef::Local(emitter.add_op(StdTensorOp::Conj, vec![input], OpMode::Primal)[0])
         }
@@ -722,8 +722,10 @@ fn promote_dtype(lhs: DType, rhs: DType) -> DType {
         (rhs, lhs)
     };
     match (a, b) {
-        (I64, F32 | F64) => F64,
-        (I64, C32 | C64) => C64,
+        (Bool, other) => other,
+        (I32, I64) => I64,
+        (I32 | I64, F32 | F64) => F64,
+        (I32 | I64, C32 | C64) => C64,
         (F32, F64) => F64,
         (F32, C32) => C32,
         (F32, C64) => C64,
@@ -736,11 +738,13 @@ fn promote_dtype(lhs: DType, rhs: DType) -> DType {
 
 fn promotion_rank(dt: DType) -> u8 {
     match dt {
-        DType::I64 => 0,
-        DType::F32 => 1,
-        DType::F64 => 2,
-        DType::C32 => 3,
-        DType::C64 => 4,
+        DType::Bool => 0,
+        DType::I32 => 1,
+        DType::I64 => 2,
+        DType::F32 => 3,
+        DType::F64 => 4,
+        DType::C32 => 5,
+        DType::C64 => 6,
     }
 }
 

--- a/tenferro-fft/src/lib.rs
+++ b/tenferro-fft/src/lib.rs
@@ -427,7 +427,12 @@ pub fn fft(input: &TracedTensor, n: Option<usize>, axis: isize, norm: FftNorm) -
     let kind = match input.dtype {
         DType::C32 | DType::C64 => FftKind::C2C { forward: true },
         DType::F32 | DType::F64 => FftKind::R2C { onesided: false },
-        DType::I64 => panic!("fft expects real or complex floating input, got I64"),
+        DType::I32 | DType::I64 | DType::Bool => {
+            panic!(
+                "fft expects real or complex floating input, got {:?}",
+                input.dtype
+            )
+        }
     };
     apply_unary_fft(input, kind, n, axis, norm)
 }

--- a/tenferro-linalg/src/ad/mod.rs
+++ b/tenferro-linalg/src/ad/mod.rs
@@ -297,7 +297,7 @@ pub(crate) fn linearize_eig(
             },
         )[0],
         DType::C64 | DType::C32 => da,
-        DType::I64 => return vec![None, None],
+        DType::I32 | DType::I64 | DType::Bool => return vec![None, None],
     };
 
     let dav = matmul_linear(

--- a/tenferro-linalg/src/extension.rs
+++ b/tenferro-linalg/src/extension.rs
@@ -529,7 +529,7 @@ fn eig_output_dtype(dtype: DType) -> DType {
     match dtype {
         DType::F64 | DType::C64 => DType::C64,
         DType::F32 | DType::C32 => DType::C32,
-        DType::I64 => DType::C64,
+        DType::I32 | DType::I64 | DType::Bool => DType::C64,
     }
 }
 
@@ -552,8 +552,10 @@ fn promote_dtype(lhs: DType, rhs: DType) -> DType {
         (rhs, lhs)
     };
     match (a, b) {
-        (I64, F32 | F64) => F64,
-        (I64, C32 | C64) => C64,
+        (Bool, other) => other,
+        (I32, I64) => I64,
+        (I32 | I64, F32 | F64) => F64,
+        (I32 | I64, C32 | C64) => C64,
         (F32, F64) => F64,
         (F32, C32) => C32,
         (F32, C64) => C64,
@@ -566,11 +568,13 @@ fn promote_dtype(lhs: DType, rhs: DType) -> DType {
 
 fn promotion_rank(dtype: DType) -> u8 {
     match dtype {
-        DType::I64 => 0,
-        DType::F32 => 1,
-        DType::F64 => 2,
-        DType::C32 => 3,
-        DType::C64 => 4,
+        DType::Bool => 0,
+        DType::I32 => 1,
+        DType::I64 => 2,
+        DType::F32 => 3,
+        DType::F64 => 4,
+        DType::C32 => 5,
+        DType::C64 => 6,
     }
 }
 
@@ -581,6 +585,8 @@ fn hash_dtype(hasher: &mut dyn Hasher, dtype: DType) {
         DType::I64 => 2,
         DType::C64 => 3,
         DType::C32 => 4,
+        DType::I32 => 5,
+        DType::Bool => 6,
     };
     hasher.write_u8(tag);
 }

--- a/tenferro-linalg/src/traced.rs
+++ b/tenferro-linalg/src/traced.rs
@@ -276,7 +276,9 @@ fn scalar_real(dtype: DType, value: f64) -> TracedTensor {
     match dtype {
         DType::F64 => TracedTensor::from_vec_col_major(vec![], vec![value]),
         DType::F32 => TracedTensor::from_vec_col_major(vec![], vec![value as f32]),
+        DType::I32 => TracedTensor::from_vec_col_major(vec![], vec![value.round() as i32]),
         DType::I64 => TracedTensor::from_vec_col_major(vec![], vec![value.round() as i64]),
+        DType::Bool => TracedTensor::from_vec_col_major(vec![], vec![value != 0.0]),
         DType::C64 => TracedTensor::from_vec_col_major(vec![], vec![Complex64::new(value, 0.0)]),
         DType::C32 => {
             TracedTensor::from_vec_col_major(vec![], vec![Complex32::new(value as f32, 0.0)])
@@ -357,7 +359,7 @@ fn default_pinv_rtol(dtype: DType, max_dim: usize) -> f64 {
     let eps = match dtype {
         DType::F32 | DType::C32 => f32::EPSILON as f64,
         DType::F64 | DType::C64 => f64::EPSILON,
-        DType::I64 => 0.0,
+        DType::I32 | DType::I64 | DType::Bool => 0.0,
     };
     eps * max_dim as f64
 }

--- a/tenferro-linalg/tests/traced_extension.rs
+++ b/tenferro-linalg/tests/traced_extension.rs
@@ -1,4 +1,42 @@
-use tenferro::{CpuBackend, DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use num_complex::{Complex32, Complex64};
+use tenferro::{
+    CpuBackend, DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor, TypedTensor,
+};
+
+fn traced_with_dtype(dtype: DType, shape: Vec<usize>) -> TracedTensor {
+    let n_elements = shape.iter().product();
+    let tensor = match dtype {
+        DType::F32 => Tensor::F32(TypedTensor::from_vec_col_major(
+            shape,
+            vec![1.0_f32; n_elements],
+        )),
+        DType::F64 => Tensor::F64(TypedTensor::from_vec_col_major(
+            shape,
+            vec![1.0_f64; n_elements],
+        )),
+        DType::I32 => Tensor::I32(TypedTensor::from_vec_col_major(
+            shape,
+            vec![1_i32; n_elements],
+        )),
+        DType::I64 => Tensor::I64(TypedTensor::from_vec_col_major(
+            shape,
+            vec![1_i64; n_elements],
+        )),
+        DType::Bool => Tensor::Bool(TypedTensor::from_vec_col_major(
+            shape,
+            vec![true; n_elements],
+        )),
+        DType::C32 => Tensor::C32(TypedTensor::from_vec_col_major(
+            shape,
+            vec![Complex32::new(1.0, 0.5); n_elements],
+        )),
+        DType::C64 => Tensor::C64(TypedTensor::from_vec_col_major(
+            shape,
+            vec![Complex64::new(1.0, 0.5); n_elements],
+        )),
+    };
+    TracedTensor::from_tensor_concrete_shape(tensor)
+}
 
 #[test]
 fn svd_executes_after_runtime_registration() {
@@ -94,4 +132,58 @@ fn traced_metadata_matches_linalg_extension_shapes_and_dtypes() {
     let (eigh_values, eigh_vectors) = tenferro_linalg::eigh(&square);
     assert_eq!(eigh_values.concrete_shape(), vec![3, 2]);
     assert_eq!(eigh_vectors.concrete_shape(), vec![3, 3, 2]);
+}
+
+#[test]
+fn traced_metadata_promotes_linalg_dtypes_broadly() {
+    let promotion_cases = [
+        (DType::Bool, DType::I32, DType::I32),
+        (DType::I32, DType::I64, DType::I64),
+        (DType::I32, DType::F32, DType::F64),
+        (DType::I64, DType::C32, DType::C64),
+        (DType::F32, DType::F64, DType::F64),
+        (DType::F32, DType::C32, DType::C32),
+        (DType::F32, DType::C64, DType::C64),
+        (DType::F64, DType::C32, DType::C64),
+        (DType::C32, DType::C64, DType::C64),
+    ];
+
+    for (a_dtype, b_dtype, expected_dtype) in promotion_cases {
+        let a = traced_with_dtype(a_dtype, vec![2, 2]);
+        let b = traced_with_dtype(b_dtype, vec![2, 1]);
+        let solved = tenferro_linalg::solve(&a, &b);
+        assert_eq!(solved.dtype, expected_dtype);
+        assert_eq!(solved.concrete_shape(), vec![2, 1]);
+    }
+
+    let triangular = tenferro_linalg::triangular_solve(
+        &traced_with_dtype(DType::Bool, vec![2, 2]),
+        &traced_with_dtype(DType::F32, vec![2, 1]),
+        true,
+        false,
+        true,
+        true,
+    );
+    assert_eq!(triangular.dtype, DType::F32);
+    assert_eq!(triangular.concrete_shape(), vec![2, 1]);
+}
+
+#[test]
+fn traced_metadata_covers_eig_output_dtype_rules() {
+    for (input_dtype, expected_dtype) in [
+        (DType::F64, DType::C64),
+        (DType::C64, DType::C64),
+        (DType::F32, DType::C32),
+        (DType::C32, DType::C32),
+        (DType::I32, DType::C64),
+        (DType::I64, DType::C64),
+        (DType::Bool, DType::C64),
+    ] {
+        let a = traced_with_dtype(input_dtype, vec![2, 2]);
+        let (values, vectors) = tenferro_linalg::eig(&a);
+        assert_eq!(values.dtype, expected_dtype);
+        assert_eq!(vectors.dtype, expected_dtype);
+        assert_eq!(values.concrete_shape(), vec![2]);
+        assert_eq!(vectors.concrete_shape(), vec![2, 2]);
+    }
 }

--- a/tenferro-ops/src/ad/zeros.rs
+++ b/tenferro-ops/src/ad/zeros.rs
@@ -41,7 +41,9 @@ fn zero_bytes(dtype: DType) -> Vec<u8> {
     match dtype {
         DType::F32 => 0.0_f32.to_le_bytes().to_vec(),
         DType::F64 => 0.0_f64.to_le_bytes().to_vec(),
+        DType::I32 => 0_i32.to_le_bytes().to_vec(),
         DType::I64 => 0_i64.to_le_bytes().to_vec(),
+        DType::Bool => vec![0],
         DType::C32 => {
             let mut bytes = Vec::with_capacity(8);
             bytes.extend_from_slice(&0.0_f32.to_le_bytes());

--- a/tenferro-ops/src/std_tensor_op.rs
+++ b/tenferro-ops/src/std_tensor_op.rs
@@ -190,6 +190,38 @@ impl StdTensorOp {
         }
     }
 
+    /// Create an `i32` scalar constant op.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ops::std_tensor_op::StdTensorOp;
+    ///
+    /// let op = StdTensorOp::constant_i32(7);
+    /// ```
+    pub fn constant_i32(value: i32) -> Self {
+        Self::Constant {
+            dtype: DType::I32,
+            bytes: value.to_le_bytes().to_vec(),
+        }
+    }
+
+    /// Create a `bool` scalar constant op.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ops::std_tensor_op::StdTensorOp;
+    ///
+    /// let op = StdTensorOp::constant_bool(true);
+    /// ```
+    pub fn constant_bool(value: bool) -> Self {
+        Self::Constant {
+            dtype: DType::Bool,
+            bytes: vec![u8::from(value)],
+        }
+    }
+
     /// Create a `Complex64` scalar constant op.
     ///
     /// # Examples

--- a/tenferro-tensor/src/buffer_pool.rs
+++ b/tenferro-tensor/src/buffer_pool.rs
@@ -66,7 +66,9 @@ pub struct BufferPoolStats {
 pub struct BufferPool {
     f64_pool: BTreeMap<usize, Vec<Vec<f64>>>,
     f32_pool: BTreeMap<usize, Vec<Vec<f32>>>,
+    i32_pool: BTreeMap<usize, Vec<Vec<i32>>>,
     i64_pool: BTreeMap<usize, Vec<Vec<i64>>>,
+    bool_pool: BTreeMap<usize, Vec<Vec<bool>>>,
     c64_pool: BTreeMap<usize, Vec<Vec<Complex64>>>,
     c32_pool: BTreeMap<usize, Vec<Vec<Complex32>>>,
     retained_capacity_bytes: usize,
@@ -133,7 +135,9 @@ mod private {
 
     impl Sealed for f64 {}
     impl Sealed for f32 {}
+    impl Sealed for i32 {}
     impl Sealed for i64 {}
+    impl Sealed for bool {}
     impl Sealed for num_complex::Complex64 {}
     impl Sealed for num_complex::Complex32 {}
 }
@@ -168,7 +172,9 @@ fn evict_one_from_pool<T>(pool: &mut BTreeMap<usize, Vec<Vec<T>>>) -> Option<usi
 enum TypedPoolKind {
     F64,
     F32,
+    I32,
     I64,
+    Bool,
     C64,
     C32,
 }
@@ -223,7 +229,9 @@ macro_rules! impl_pool_scalar {
 
 impl_pool_scalar!(f64, f64_pool);
 impl_pool_scalar!(f32, f32_pool);
+impl_pool_scalar!(i32, i32_pool);
 impl_pool_scalar!(i64, i64_pool);
+impl_pool_scalar!(bool, bool_pool);
 impl_pool_scalar!(Complex64, c64_pool);
 impl_pool_scalar!(Complex32, c32_pool);
 
@@ -259,7 +267,9 @@ impl BufferPool {
         Self {
             f64_pool: BTreeMap::new(),
             f32_pool: BTreeMap::new(),
+            i32_pool: BTreeMap::new(),
             i64_pool: BTreeMap::new(),
+            bool_pool: BTreeMap::new(),
             c64_pool: BTreeMap::new(),
             c32_pool: BTreeMap::new(),
             retained_capacity_bytes: 0,
@@ -371,7 +381,9 @@ impl BufferPool {
         BufferPoolStats {
             buffers: pool_len(&self.f64_pool)
                 + pool_len(&self.f32_pool)
+                + pool_len(&self.i32_pool)
                 + pool_len(&self.i64_pool)
+                + pool_len(&self.bool_pool)
                 + pool_len(&self.c64_pool)
                 + pool_len(&self.c32_pool),
             capacity_bytes: self.retained_capacity_bytes,
@@ -443,7 +455,9 @@ impl BufferPool {
     pub fn is_empty(&self) -> bool {
         self.f64_pool.is_empty()
             && self.f32_pool.is_empty()
+            && self.i32_pool.is_empty()
             && self.i64_pool.is_empty()
+            && self.bool_pool.is_empty()
             && self.c64_pool.is_empty()
             && self.c32_pool.is_empty()
     }
@@ -467,7 +481,9 @@ impl BufferPool {
     pub fn clear(&mut self) {
         self.f64_pool.clear();
         self.f32_pool.clear();
+        self.i32_pool.clear();
         self.i64_pool.clear();
+        self.bool_pool.clear();
         self.c64_pool.clear();
         self.c32_pool.clear();
         self.retained_capacity_bytes = 0;
@@ -488,7 +504,9 @@ impl BufferPool {
         let candidates = [
             smallest_pool_candidate(&self.f64_pool, TypedPoolKind::F64),
             smallest_pool_candidate(&self.f32_pool, TypedPoolKind::F32),
+            smallest_pool_candidate(&self.i32_pool, TypedPoolKind::I32),
             smallest_pool_candidate(&self.i64_pool, TypedPoolKind::I64),
+            smallest_pool_candidate(&self.bool_pool, TypedPoolKind::Bool),
             smallest_pool_candidate(&self.c64_pool, TypedPoolKind::C64),
             smallest_pool_candidate(&self.c32_pool, TypedPoolKind::C32),
         ];
@@ -499,7 +517,9 @@ impl BufferPool {
         match kind {
             TypedPoolKind::F64 => evict_one_from_pool(&mut self.f64_pool),
             TypedPoolKind::F32 => evict_one_from_pool(&mut self.f32_pool),
+            TypedPoolKind::I32 => evict_one_from_pool(&mut self.i32_pool),
             TypedPoolKind::I64 => evict_one_from_pool(&mut self.i64_pool),
+            TypedPoolKind::Bool => evict_one_from_pool(&mut self.bool_pool),
             TypedPoolKind::C64 => evict_one_from_pool(&mut self.c64_pool),
             TypedPoolKind::C32 => evict_one_from_pool(&mut self.c32_pool),
         }

--- a/tenferro-tensor/src/cpu/analytic.rs
+++ b/tenferro-tensor/src/cpu/analytic.rs
@@ -148,10 +148,12 @@ macro_rules! define_unary_analytic_op {
             match input {
                 Tensor::F32(t) => Ok(Tensor::F32($typed_with_pool_fn(buffers, t)?)),
                 Tensor::F64(t) => Ok(Tensor::F64($typed_with_pool_fn(buffers, t)?)),
-                Tensor::I64(_) => Err(crate::Error::BackendFailure {
-                    op: stringify!($dispatch_fn),
-                    message: "unsupported dtype I64".into(),
-                }),
+                Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+                    Err(crate::Error::BackendFailure {
+                        op: stringify!($dispatch_fn),
+                        message: format!("unsupported dtype {:?}", input.dtype()),
+                    })
+                }
                 Tensor::C32(t) => Ok(Tensor::C32($typed_with_pool_fn(buffers, t)?)),
                 Tensor::C64(t) => Ok(Tensor::C64($typed_with_pool_fn(buffers, t)?)),
             }

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -1388,7 +1388,9 @@ impl TensorBackend for CpuBackend {
         match tensor {
             Tensor::F32(t) => reclaim_typed(&mut self.buffers, t),
             Tensor::F64(t) => reclaim_typed(&mut self.buffers, t),
+            Tensor::I32(t) => reclaim_typed(&mut self.buffers, t),
             Tensor::I64(t) => reclaim_typed(&mut self.buffers, t),
+            Tensor::Bool(t) => reclaim_typed(&mut self.buffers, t),
             Tensor::C32(t) => reclaim_typed(&mut self.buffers, t),
             Tensor::C64(t) => reclaim_typed(&mut self.buffers, t),
         }
@@ -1430,7 +1432,12 @@ fn zeros_like_tensor(input: &Tensor) -> Tensor {
     match input {
         Tensor::F32(t) => Tensor::F32(TypedTensor::zeros(t.shape.clone())),
         Tensor::F64(t) => Tensor::F64(TypedTensor::zeros(t.shape.clone())),
+        Tensor::I32(t) => Tensor::I32(TypedTensor::zeros(t.shape.clone())),
         Tensor::I64(t) => Tensor::I64(TypedTensor::zeros(t.shape.clone())),
+        Tensor::Bool(t) => Tensor::Bool(TypedTensor::from_vec_col_major(
+            t.shape.clone(),
+            vec![false; t.n_elements()],
+        )),
         Tensor::C32(t) => Tensor::C32(TypedTensor::zeros(t.shape.clone())),
         Tensor::C64(t) => Tensor::C64(TypedTensor::zeros(t.shape.clone())),
     }

--- a/tenferro-tensor/src/cpu/elementwise.rs
+++ b/tenferro-tensor/src/cpu/elementwise.rs
@@ -178,6 +178,7 @@ pub(crate) fn add_with_pool(
     match (lhs, rhs) {
         (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_add_with_pool(buffers, a, b)?)),
         (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_add_with_pool(buffers, a, b)?)),
+        (Tensor::I32(a), Tensor::I32(b)) => Ok(Tensor::I32(typed_add_with_pool(buffers, a, b)?)),
         (Tensor::I64(a), Tensor::I64(b)) => Ok(Tensor::I64(typed_add_with_pool(buffers, a, b)?)),
         (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_add_with_pool(buffers, a, b)?)),
         (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_add_with_pool(buffers, a, b)?)),
@@ -217,6 +218,7 @@ pub(crate) fn mul_with_pool(
     match (lhs, rhs) {
         (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::F32(typed_mul_with_pool(buffers, a, b)?)),
         (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::F64(typed_mul_with_pool(buffers, a, b)?)),
+        (Tensor::I32(a), Tensor::I32(b)) => Ok(Tensor::I32(typed_mul_with_pool(buffers, a, b)?)),
         (Tensor::I64(a), Tensor::I64(b)) => Ok(Tensor::I64(typed_mul_with_pool(buffers, a, b)?)),
         (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_mul_with_pool(buffers, a, b)?)),
         (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_mul_with_pool(buffers, a, b)?)),
@@ -290,9 +292,9 @@ pub(crate) fn neg_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_neg_with_pool(buffers, t)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_neg_with_pool(buffers, t)?)),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(crate::Error::BackendFailure {
             op: "neg",
-            message: "unsupported dtype I64".into(),
+            message: format!("unsupported dtype {:?}", input.dtype()),
         }),
         Tensor::C32(t) => Ok(Tensor::C32(typed_neg_with_pool(buffers, t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_neg_with_pool(buffers, t)?)),
@@ -307,9 +309,9 @@ pub(crate) fn conj_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate:
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_conj_with_pool(buffers, t)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_conj_with_pool(buffers, t)?)),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(crate::Error::BackendFailure {
             op: "conj",
-            message: "unsupported dtype I64".into(),
+            message: format!("unsupported dtype {:?}", input.dtype()),
         }),
         Tensor::C32(t) => Ok(Tensor::C32(typed_conj_with_pool(buffers, t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_conj_with_pool(buffers, t)?)),
@@ -324,9 +326,9 @@ pub(crate) fn abs_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_abs_with_pool(buffers, t)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_abs_with_pool(buffers, t)?)),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(crate::Error::BackendFailure {
             op: "abs",
-            message: "unsupported dtype I64".into(),
+            message: format!("unsupported dtype {:?}", input.dtype()),
         }),
         Tensor::C32(t) => Ok(Tensor::C32(typed_abs_with_pool(buffers, t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_abs_with_pool(buffers, t)?)),
@@ -341,9 +343,9 @@ pub(crate) fn sign_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate:
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_sign_with_pool(buffers, t)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_sign_with_pool(buffers, t)?)),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(crate::Error::BackendFailure {
             op: "sign",
-            message: "unsupported dtype I64".into(),
+            message: format!("unsupported dtype {:?}", input.dtype()),
         }),
         Tensor::C32(t) => Ok(Tensor::C32(typed_sign_with_pool(buffers, t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_sign_with_pool(buffers, t)?)),

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -669,7 +669,9 @@ impl TensorExec for CpuExecSession<'_> {
         match tensor {
             Tensor::F32(t) => reclaim_typed(self.buffers, t),
             Tensor::F64(t) => reclaim_typed(self.buffers, t),
+            Tensor::I32(t) => reclaim_typed(self.buffers, t),
             Tensor::I64(t) => reclaim_typed(self.buffers, t),
+            Tensor::Bool(t) => reclaim_typed(self.buffers, t),
             Tensor::C32(t) => reclaim_typed(self.buffers, t),
             Tensor::C64(t) => reclaim_typed(self.buffers, t),
         }

--- a/tenferro-tensor/src/cpu/indexing.rs
+++ b/tenferro-tensor/src/cpu/indexing.rs
@@ -11,49 +11,98 @@ trait TensorAsTyped<T> {
     fn as_typed(&self) -> Option<&TypedTensor<T>>;
 }
 
-impl TensorAsTyped<f32> for Tensor {
-    fn as_typed(&self) -> Option<&TypedTensor<f32>> {
-        match self {
-            Tensor::F32(tensor) => Some(tensor),
-            _ => None,
-        }
-    }
+macro_rules! impl_tensor_as_typed {
+    ($(($ty:ty, $variant:ident)),+ $(,)?) => {
+        $(
+            impl TensorAsTyped<$ty> for Tensor {
+                fn as_typed(&self) -> Option<&TypedTensor<$ty>> {
+                    match self {
+                        Tensor::$variant(tensor) => Some(tensor),
+                        _ => None,
+                    }
+                }
+            }
+        )+
+    };
 }
 
-impl TensorAsTyped<f64> for Tensor {
-    fn as_typed(&self) -> Option<&TypedTensor<f64>> {
-        match self {
-            Tensor::F64(tensor) => Some(tensor),
-            _ => None,
+impl_tensor_as_typed!(
+    (f32, F32),
+    (f64, F64),
+    (i32, I32),
+    (i64, I64),
+    (bool, Bool),
+    (num_complex::Complex<f32>, C32),
+    (num_complex::Complex<f64>, C64),
+);
+
+macro_rules! dispatch_tensor_unary_result {
+    ($input:expr, |$tensor:ident| $body:expr) => {
+        match $input {
+            Tensor::F32($tensor) => Ok(Tensor::F32($body?)),
+            Tensor::F64($tensor) => Ok(Tensor::F64($body?)),
+            Tensor::I32($tensor) => Ok(Tensor::I32($body?)),
+            Tensor::I64($tensor) => Ok(Tensor::I64($body?)),
+            Tensor::Bool($tensor) => Ok(Tensor::Bool($body?)),
+            Tensor::C32($tensor) => Ok(Tensor::C32($body?)),
+            Tensor::C64($tensor) => Ok(Tensor::C64($body?)),
         }
-    }
+    };
 }
 
-impl TensorAsTyped<i64> for Tensor {
-    fn as_typed(&self) -> Option<&TypedTensor<i64>> {
-        match self {
-            Tensor::I64(tensor) => Some(tensor),
-            _ => None,
+macro_rules! dispatch_tensor_unary_with_bool_special_result {
+    ($input:expr, |$tensor:ident| $body:expr, bool |$bool_tensor:ident| $bool_body:expr) => {
+        match $input {
+            Tensor::F32($tensor) => Ok(Tensor::F32($body?)),
+            Tensor::F64($tensor) => Ok(Tensor::F64($body?)),
+            Tensor::I32($tensor) => Ok(Tensor::I32($body?)),
+            Tensor::I64($tensor) => Ok(Tensor::I64($body?)),
+            Tensor::Bool($bool_tensor) => Ok(Tensor::Bool($bool_body?)),
+            Tensor::C32($tensor) => Ok(Tensor::C32($body?)),
+            Tensor::C64($tensor) => Ok(Tensor::C64($body?)),
         }
-    }
+    };
 }
 
-impl TensorAsTyped<num_complex::Complex<f32>> for Tensor {
-    fn as_typed(&self) -> Option<&TypedTensor<num_complex::Complex<f32>>> {
-        match self {
-            Tensor::C32(tensor) => Some(tensor),
-            _ => None,
+macro_rules! dispatch_same_dtype_result {
+    ($op:literal, $lhs:expr, $rhs:expr, |$lhs_t:ident, $rhs_t:ident| $body:expr) => {
+        match ($lhs, $rhs) {
+            (Tensor::F32($lhs_t), Tensor::F32($rhs_t)) => Ok(Tensor::F32($body?)),
+            (Tensor::F64($lhs_t), Tensor::F64($rhs_t)) => Ok(Tensor::F64($body?)),
+            (Tensor::I32($lhs_t), Tensor::I32($rhs_t)) => Ok(Tensor::I32($body?)),
+            (Tensor::I64($lhs_t), Tensor::I64($rhs_t)) => Ok(Tensor::I64($body?)),
+            (Tensor::Bool($lhs_t), Tensor::Bool($rhs_t)) => Ok(Tensor::Bool($body?)),
+            (Tensor::C32($lhs_t), Tensor::C32($rhs_t)) => Ok(Tensor::C32($body?)),
+            (Tensor::C64($lhs_t), Tensor::C64($rhs_t)) => Ok(Tensor::C64($body?)),
+            _ => Err(crate::Error::DTypeMismatch {
+                op: $op,
+                lhs: $lhs.dtype(),
+                rhs: $rhs.dtype(),
+            }),
         }
-    }
+    };
 }
 
-impl TensorAsTyped<num_complex::Complex<f64>> for Tensor {
-    fn as_typed(&self) -> Option<&TypedTensor<num_complex::Complex<f64>>> {
-        match self {
-            Tensor::C64(tensor) => Some(tensor),
-            _ => None,
+macro_rules! dispatch_same_dtype_without_bool_result {
+    ($op:literal, $lhs:expr, $rhs:expr, $bool_message:literal, |$lhs_t:ident, $rhs_t:ident| $body:expr) => {
+        match ($lhs, $rhs) {
+            (Tensor::F32($lhs_t), Tensor::F32($rhs_t)) => Ok(Tensor::F32($body?)),
+            (Tensor::F64($lhs_t), Tensor::F64($rhs_t)) => Ok(Tensor::F64($body?)),
+            (Tensor::I32($lhs_t), Tensor::I32($rhs_t)) => Ok(Tensor::I32($body?)),
+            (Tensor::I64($lhs_t), Tensor::I64($rhs_t)) => Ok(Tensor::I64($body?)),
+            (Tensor::C32($lhs_t), Tensor::C32($rhs_t)) => Ok(Tensor::C32($body?)),
+            (Tensor::C64($lhs_t), Tensor::C64($rhs_t)) => Ok(Tensor::C64($body?)),
+            (Tensor::Bool(_), Tensor::Bool(_)) => Err(crate::Error::BackendFailure {
+                op: $op,
+                message: $bool_message.into(),
+            }),
+            _ => Err(crate::Error::DTypeMismatch {
+                op: $op,
+                lhs: $lhs.dtype(),
+                rhs: $rhs.dtype(),
+            }),
         }
-    }
+    };
 }
 
 fn with_local_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
@@ -61,12 +110,12 @@ fn with_local_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
     f(&mut buffers)
 }
 
-fn pooled_zeroed_tensor<T>(buffers: &mut BufferPool, shape: Vec<usize>) -> TypedTensor<T>
+fn pooled_filled_tensor<T>(buffers: &mut BufferPool, shape: Vec<usize>, fill: T) -> TypedTensor<T>
 where
-    T: Clone + Zero + PoolScalar,
+    T: Copy + Clone + PoolScalar,
 {
     let mut out = pooled_uninit_tensor(buffers, shape);
-    out.host_data_mut().fill(T::zero());
+    out.host_data_mut().fill(fill);
     out
 }
 
@@ -97,16 +146,12 @@ pub(crate) fn gather_with_pool(
     config: &GatherConfig,
 ) -> crate::Result<Tensor> {
     let start_indices = try_index_tensor(start_indices)?;
-    match operand {
-        Tensor::F32(t) => typed_gather(buffers, t, &start_indices, config).map(Tensor::F32),
-        Tensor::F64(t) => typed_gather(buffers, t, &start_indices, config).map(Tensor::F64),
-        Tensor::C32(t) => typed_gather(buffers, t, &start_indices, config).map(Tensor::C32),
-        Tensor::C64(t) => typed_gather(buffers, t, &start_indices, config).map(Tensor::C64),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
-            op: "gather",
-            message: "I64 data tensors are not supported by this operation".into(),
-        }),
-    }
+    dispatch_tensor_unary_result!(operand, |t| typed_gather(
+        buffers,
+        t,
+        &start_indices,
+        config
+    ))
 }
 
 pub fn scatter(
@@ -126,29 +171,13 @@ pub(crate) fn scatter_with_pool(
     config: &ScatterConfig,
 ) -> crate::Result<Tensor> {
     let scatter_indices = try_index_tensor(scatter_indices)?;
-    match (operand, updates) {
-        (Tensor::F32(op), Tensor::F32(upd)) => {
-            typed_scatter(buffers, op, &scatter_indices, upd, config).map(Tensor::F32)
-        }
-        (Tensor::F64(op), Tensor::F64(upd)) => {
-            typed_scatter(buffers, op, &scatter_indices, upd, config).map(Tensor::F64)
-        }
-        (Tensor::C32(op), Tensor::C32(upd)) => {
-            typed_scatter(buffers, op, &scatter_indices, upd, config).map(Tensor::C32)
-        }
-        (Tensor::C64(op), Tensor::C64(upd)) => {
-            typed_scatter(buffers, op, &scatter_indices, upd, config).map(Tensor::C64)
-        }
-        (Tensor::I64(_), Tensor::I64(_)) => Err(crate::Error::BackendFailure {
-            op: "scatter",
-            message: "I64 data tensors are not supported by this operation".into(),
-        }),
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "scatter",
-            lhs: operand.dtype(),
-            rhs: updates.dtype(),
-        }),
-    }
+    dispatch_same_dtype_without_bool_result!(
+        "scatter",
+        operand,
+        updates,
+        "Bool data tensors are not supported by additive scatter",
+        |op, upd| typed_scatter(buffers, op, &scatter_indices, upd, config)
+    )
 }
 
 pub fn slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> {
@@ -164,13 +193,7 @@ pub(crate) fn try_slice_with_pool(
     input: &Tensor,
     config: &SliceConfig,
 ) -> crate::Result<Tensor> {
-    match input {
-        Tensor::F32(tensor) => Ok(Tensor::F32(typed_slice(buffers, tensor, config)?)),
-        Tensor::F64(tensor) => Ok(Tensor::F64(typed_slice(buffers, tensor, config)?)),
-        Tensor::I64(tensor) => Ok(Tensor::I64(typed_slice(buffers, tensor, config)?)),
-        Tensor::C32(tensor) => Ok(Tensor::C32(typed_slice(buffers, tensor, config)?)),
-        Tensor::C64(tensor) => Ok(Tensor::C64(typed_slice(buffers, tensor, config)?)),
-    }
+    dispatch_tensor_unary_result!(input, |t| typed_slice(buffers, t, config))
 }
 
 pub fn dynamic_slice(
@@ -188,16 +211,12 @@ pub(crate) fn dynamic_slice_with_pool(
     slice_sizes: &[usize],
 ) -> crate::Result<Tensor> {
     let starts = try_index_tensor(starts)?;
-    match input {
-        Tensor::F32(t) => typed_dynamic_slice(buffers, t, &starts, slice_sizes).map(Tensor::F32),
-        Tensor::F64(t) => typed_dynamic_slice(buffers, t, &starts, slice_sizes).map(Tensor::F64),
-        Tensor::C32(t) => typed_dynamic_slice(buffers, t, &starts, slice_sizes).map(Tensor::C32),
-        Tensor::C64(t) => typed_dynamic_slice(buffers, t, &starts, slice_sizes).map(Tensor::C64),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
-            op: "dynamic_slice",
-            message: "I64 data tensors are not supported by this operation".into(),
-        }),
-    }
+    dispatch_tensor_unary_result!(input, |t| typed_dynamic_slice(
+        buffers,
+        t,
+        &starts,
+        slice_sizes
+    ))
 }
 
 /// Return `operand` with `update` written at dynamic `starts`.
@@ -232,28 +251,9 @@ pub(crate) fn dynamic_update_slice_with_pool(
     starts: &Tensor,
 ) -> crate::Result<Tensor> {
     let starts = try_index_tensor(starts)?;
-    match (operand, update) {
-        (Tensor::F32(op), Tensor::F32(upd)) => {
-            typed_dynamic_update_slice(buffers, op, upd, &starts).map(Tensor::F32)
-        }
-        (Tensor::F64(op), Tensor::F64(upd)) => {
-            typed_dynamic_update_slice(buffers, op, upd, &starts).map(Tensor::F64)
-        }
-        (Tensor::I64(op), Tensor::I64(upd)) => {
-            typed_dynamic_update_slice(buffers, op, upd, &starts).map(Tensor::I64)
-        }
-        (Tensor::C32(op), Tensor::C32(upd)) => {
-            typed_dynamic_update_slice(buffers, op, upd, &starts).map(Tensor::C32)
-        }
-        (Tensor::C64(op), Tensor::C64(upd)) => {
-            typed_dynamic_update_slice(buffers, op, upd, &starts).map(Tensor::C64)
-        }
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "dynamic_update_slice",
-            lhs: operand.dtype(),
-            rhs: update.dtype(),
-        }),
-    }
+    dispatch_same_dtype_result!("dynamic_update_slice", operand, update, |op, upd| {
+        typed_dynamic_update_slice(buffers, op, upd, &starts)
+    })
 }
 
 pub fn pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
@@ -269,13 +269,11 @@ pub(crate) fn try_pad_with_pool(
     input: &Tensor,
     config: &PadConfig,
 ) -> crate::Result<Tensor> {
-    match input {
-        Tensor::F32(tensor) => Ok(Tensor::F32(typed_pad(buffers, tensor, config)?)),
-        Tensor::F64(tensor) => Ok(Tensor::F64(typed_pad(buffers, tensor, config)?)),
-        Tensor::I64(tensor) => Ok(Tensor::I64(typed_pad(buffers, tensor, config)?)),
-        Tensor::C32(tensor) => Ok(Tensor::C32(typed_pad(buffers, tensor, config)?)),
-        Tensor::C64(tensor) => Ok(Tensor::C64(typed_pad(buffers, tensor, config)?)),
-    }
+    dispatch_tensor_unary_with_bool_special_result!(
+        input,
+        |t| typed_pad(buffers, t, config),
+        bool | t | typed_pad_with_fill(buffers, t, config, false)
+    )
 }
 
 pub fn concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
@@ -298,23 +296,9 @@ pub(crate) fn try_concatenate_with_pool(
             op: "concatenate",
             message: "concatenate requires at least one input".into(),
         })?;
-    match first {
-        Tensor::F32(t) => Ok(Tensor::F32(typed_concatenate_from_dyn_inputs(
-            buffers, t, inputs, axis,
-        )?)),
-        Tensor::F64(t) => Ok(Tensor::F64(typed_concatenate_from_dyn_inputs(
-            buffers, t, inputs, axis,
-        )?)),
-        Tensor::I64(t) => Ok(Tensor::I64(typed_concatenate_from_dyn_inputs(
-            buffers, t, inputs, axis,
-        )?)),
-        Tensor::C32(t) => Ok(Tensor::C32(typed_concatenate_from_dyn_inputs(
-            buffers, t, inputs, axis,
-        )?)),
-        Tensor::C64(t) => Ok(Tensor::C64(typed_concatenate_from_dyn_inputs(
-            buffers, t, inputs, axis,
-        )?)),
-    }
+    dispatch_tensor_unary_result!(first, |t| typed_concatenate_from_dyn_inputs(
+        buffers, t, inputs, axis
+    ))
 }
 
 pub fn reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
@@ -326,13 +310,7 @@ pub(crate) fn reverse_with_pool(
     input: &Tensor,
     axes: &[usize],
 ) -> crate::Result<Tensor> {
-    match input {
-        Tensor::F32(t) => typed_reverse(buffers, t, axes).map(Tensor::F32),
-        Tensor::F64(t) => typed_reverse(buffers, t, axes).map(Tensor::F64),
-        Tensor::I64(t) => typed_reverse(buffers, t, axes).map(Tensor::I64),
-        Tensor::C32(t) => typed_reverse(buffers, t, axes).map(Tensor::C32),
-        Tensor::C64(t) => typed_reverse(buffers, t, axes).map(Tensor::C64),
-    }
+    dispatch_tensor_unary_result!(input, |t| typed_reverse(buffers, t, axes))
 }
 
 fn typed_slice<T: Copy + Clone + PoolScalar>(
@@ -589,6 +567,10 @@ fn f64_index_to_i64(value: f64) -> crate::Result<i64> {
 
 fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor> {
     match tensor {
+        Tensor::I32(t) => Ok(IndexTensor {
+            shape: t.shape.clone(),
+            values: t.host_data().iter().map(|&value| value as i64).collect(),
+        }),
         Tensor::I64(t) => Ok(IndexTensor {
             shape: t.shape.clone(),
             values: t.host_data().to_vec(),
@@ -615,6 +597,10 @@ fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor> {
                 values: values?,
             })
         }
+        Tensor::Bool(_) => Err(crate::Error::InvalidConfig {
+            op: "index_tensor",
+            message: "bool index tensors are not supported".into(),
+        }),
         Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::InvalidConfig {
             op: "index_tensor",
             message: "complex index tensors are not supported".into(),
@@ -751,7 +737,7 @@ fn operand_window_dims(rank: usize, collapsed_or_inserted: &[usize]) -> Vec<usiz
         .collect()
 }
 
-fn typed_gather<T: Copy + Clone + Zero + PoolScalar>(
+fn typed_gather<T: Copy + Clone + PoolScalar>(
     buffers: &mut BufferPool,
     operand: &TypedTensor<T>,
     start_indices: &IndexTensor,
@@ -1174,7 +1160,7 @@ where
     Ok(out)
 }
 
-fn typed_dynamic_slice<T: Copy + Clone + Zero + PoolScalar>(
+fn typed_dynamic_slice<T: Copy + Clone + PoolScalar>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
     starts: &IndexTensor,
@@ -1290,6 +1276,15 @@ fn typed_pad<T: Copy + Clone + Zero + PoolScalar>(
     input: &TypedTensor<T>,
     config: &PadConfig,
 ) -> crate::Result<TypedTensor<T>> {
+    typed_pad_with_fill(buffers, input, config, T::zero())
+}
+
+fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+    config: &PadConfig,
+    fill: T,
+) -> crate::Result<TypedTensor<T>> {
     let rank = input.shape.len();
     if config.edge_padding_low.len() != rank {
         return Err(crate::Error::RankMismatch {
@@ -1335,7 +1330,7 @@ fn typed_pad<T: Copy + Clone + Zero + PoolScalar>(
         );
     }
 
-    let mut out = pooled_zeroed_tensor(buffers, out_shape.clone());
+    let mut out = pooled_filled_tensor(buffers, out_shape.clone(), fill);
     let mut input_idx = vec![0usize; input.shape.len()];
     let mut out_idx = vec![0usize; input.shape.len()];
 

--- a/tenferro-tensor/src/cpu/reduction.rs
+++ b/tenferro-tensor/src/cpu/reduction.rs
@@ -35,7 +35,12 @@ pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_sum(t, axes)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_sum(t, axes)?)),
+        Tensor::I32(t) => Ok(Tensor::I32(typed_reduce_sum(t, axes)?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_reduce_sum(t, axes)?)),
+        Tensor::Bool(_) => Err(crate::Error::BackendFailure {
+            op: "reduce_sum",
+            message: "unsupported dtype Bool".into(),
+        }),
         Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_sum(t, axes)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_sum(t, axes)?)),
     }
@@ -45,7 +50,12 @@ pub fn reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_prod(t, axes)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_prod(t, axes)?)),
+        Tensor::I32(t) => Ok(Tensor::I32(typed_reduce_prod(t, axes)?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_reduce_prod(t, axes)?)),
+        Tensor::Bool(_) => Err(crate::Error::BackendFailure {
+            op: "reduce_prod",
+            message: "unsupported dtype Bool".into(),
+        }),
         Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_prod(t, axes)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_prod(t, axes)?)),
     }
@@ -59,10 +69,12 @@ pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(tensor) => Ok(Tensor::F32(typed_reduce_max(tensor, axes)?)),
         Tensor::F64(tensor) => Ok(Tensor::F64(typed_reduce_max(tensor, axes)?)),
-        Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-            op: "reduce_max",
-            message: format!("unsupported dtype {:?}", input.dtype()),
-        }),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => {
+            Err(crate::Error::BackendFailure {
+                op: "reduce_max",
+                message: format!("unsupported dtype {:?}", input.dtype()),
+            })
+        }
     }
 }
 
@@ -74,10 +86,12 @@ pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(tensor) => Ok(Tensor::F32(typed_reduce_min(tensor, axes)?)),
         Tensor::F64(tensor) => Ok(Tensor::F64(typed_reduce_min(tensor, axes)?)),
-        Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-            op: "reduce_min",
-            message: format!("unsupported dtype {:?}", input.dtype()),
-        }),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => {
+            Err(crate::Error::BackendFailure {
+                op: "reduce_min",
+                message: format!("unsupported dtype {:?}", input.dtype()),
+            })
+        }
     }
 }
 

--- a/tenferro-tensor/src/cpu/structural.rs
+++ b/tenferro-tensor/src/cpu/structural.rs
@@ -68,6 +68,34 @@ fn validate_permutation(op: &'static str, perm: &[usize], rank: usize) -> crate:
     Ok(())
 }
 
+macro_rules! dispatch_tensor_unary_result {
+    ($input:expr, |$tensor:ident| $body:expr) => {
+        match $input {
+            Tensor::F32($tensor) => Ok(Tensor::F32($body?)),
+            Tensor::F64($tensor) => Ok(Tensor::F64($body?)),
+            Tensor::I32($tensor) => Ok(Tensor::I32($body?)),
+            Tensor::I64($tensor) => Ok(Tensor::I64($body?)),
+            Tensor::Bool($tensor) => Ok(Tensor::Bool($body?)),
+            Tensor::C32($tensor) => Ok(Tensor::C32($body?)),
+            Tensor::C64($tensor) => Ok(Tensor::C64($body?)),
+        }
+    };
+}
+
+macro_rules! dispatch_tensor_unary_with_bool_special_result {
+    ($input:expr, |$tensor:ident| $body:expr, bool |$bool_tensor:ident| $bool_body:expr) => {
+        match $input {
+            Tensor::F32($tensor) => Ok(Tensor::F32($body?)),
+            Tensor::F64($tensor) => Ok(Tensor::F64($body?)),
+            Tensor::I32($tensor) => Ok(Tensor::I32($body?)),
+            Tensor::I64($tensor) => Ok(Tensor::I64($body?)),
+            Tensor::Bool($bool_tensor) => Ok(Tensor::Bool($bool_body?)),
+            Tensor::C32($tensor) => Ok(Tensor::C32($body?)),
+            Tensor::C64($tensor) => Ok(Tensor::C64($body?)),
+        }
+    };
+}
+
 fn host_view<T: Copy>(tensor: &TypedTensor<T>) -> crate::Result<StridedView<'_, T, Identity>> {
     match &tensor.buffer {
         crate::Buffer::Host(data) => {
@@ -97,10 +125,21 @@ fn zeroed_tensor_from_pool<T>(buffers: &mut BufferPool, shape: Vec<usize>) -> Ty
 where
     T: Zero + Clone + PoolScalar,
 {
+    filled_tensor_from_pool(buffers, shape, T::zero())
+}
+
+fn filled_tensor_from_pool<T>(
+    buffers: &mut BufferPool,
+    shape: Vec<usize>,
+    fill: T,
+) -> TypedTensor<T>
+where
+    T: Copy + Clone + PoolScalar,
+{
     let len = shape.iter().product();
-    // SAFETY: every element is initialized with zero before returning.
+    // SAFETY: every element is initialized with `fill` before returning.
     let mut data = unsafe { T::pool_acquire(buffers, len) };
-    data.fill(T::zero());
+    data.fill(fill);
     TypedTensor::from_vec_col_major(shape, data)
 }
 
@@ -142,23 +181,11 @@ pub(crate) fn transpose_with_pool(
     input: &Tensor,
     perm: &[usize],
 ) -> crate::Result<Tensor> {
-    match input {
-        Tensor::F32(t) => Ok(Tensor::F32(typed_transpose_with_pool(buffers, t, perm)?)),
-        Tensor::F64(t) => Ok(Tensor::F64(typed_transpose_with_pool(buffers, t, perm)?)),
-        Tensor::I64(t) => Ok(Tensor::I64(typed_transpose_with_pool(buffers, t, perm)?)),
-        Tensor::C32(t) => Ok(Tensor::C32(typed_transpose_with_pool(buffers, t, perm)?)),
-        Tensor::C64(t) => Ok(Tensor::C64(typed_transpose_with_pool(buffers, t, perm)?)),
-    }
+    dispatch_tensor_unary_result!(input, |t| typed_transpose_with_pool(buffers, t, perm))
 }
 
 pub fn reshape(input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
-    match input {
-        Tensor::F32(t) => Ok(Tensor::F32(typed_reshape(t, shape)?)),
-        Tensor::F64(t) => Ok(Tensor::F64(typed_reshape(t, shape)?)),
-        Tensor::I64(t) => Ok(Tensor::I64(typed_reshape(t, shape)?)),
-        Tensor::C32(t) => Ok(Tensor::C32(typed_reshape(t, shape)?)),
-        Tensor::C64(t) => Ok(Tensor::C64(typed_reshape(t, shape)?)),
-    }
+    dispatch_tensor_unary_result!(input, |t| typed_reshape(t, shape))
 }
 
 pub fn broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> crate::Result<Tensor> {
@@ -171,23 +198,9 @@ pub(crate) fn broadcast_in_dim_with_pool(
     shape: &[usize],
     dims: &[usize],
 ) -> crate::Result<Tensor> {
-    match input {
-        Tensor::F32(t) => Ok(Tensor::F32(typed_broadcast_in_dim_with_pool(
-            buffers, t, shape, dims,
-        )?)),
-        Tensor::F64(t) => Ok(Tensor::F64(typed_broadcast_in_dim_with_pool(
-            buffers, t, shape, dims,
-        )?)),
-        Tensor::I64(t) => Ok(Tensor::I64(typed_broadcast_in_dim_with_pool(
-            buffers, t, shape, dims,
-        )?)),
-        Tensor::C32(t) => Ok(Tensor::C32(typed_broadcast_in_dim_with_pool(
-            buffers, t, shape, dims,
-        )?)),
-        Tensor::C64(t) => Ok(Tensor::C64(typed_broadcast_in_dim_with_pool(
-            buffers, t, shape, dims,
-        )?)),
-    }
+    dispatch_tensor_unary_result!(input, |t| typed_broadcast_in_dim_with_pool(
+        buffers, t, shape, dims
+    ))
 }
 
 pub fn convert(input: &Tensor, to: DType) -> crate::Result<Tensor> {
@@ -204,8 +217,14 @@ pub(crate) fn convert_with_pool(
         (Tensor::F32(t), DType::F64) => {
             Tensor::F64(typed_convert_with_pool(buffers, t, |x| x as f64))
         }
+        (Tensor::F32(t), DType::I32) => {
+            Tensor::I32(typed_convert_with_pool(buffers, t, |x| x as i32))
+        }
         (Tensor::F32(t), DType::I64) => {
             Tensor::I64(typed_convert_with_pool(buffers, t, |x| x as i64))
+        }
+        (Tensor::F32(t), DType::Bool) => {
+            Tensor::Bool(typed_convert_with_pool(buffers, t, |x| x != 0.0))
         }
         (Tensor::F32(t), DType::C32) => Tensor::C32(typed_convert_with_pool(buffers, t, |x| {
             Complex32::new(x, 0.0)
@@ -217,8 +236,14 @@ pub(crate) fn convert_with_pool(
             Tensor::F32(typed_convert_with_pool(buffers, t, |x| x as f32))
         }
         (Tensor::F64(t), DType::F64) => Tensor::F64(t.clone()),
+        (Tensor::F64(t), DType::I32) => {
+            Tensor::I32(typed_convert_with_pool(buffers, t, |x| x as i32))
+        }
         (Tensor::F64(t), DType::I64) => {
             Tensor::I64(typed_convert_with_pool(buffers, t, |x| x as i64))
+        }
+        (Tensor::F64(t), DType::Bool) => {
+            Tensor::Bool(typed_convert_with_pool(buffers, t, |x| x != 0.0))
         }
         (Tensor::F64(t), DType::C32) => Tensor::C32(typed_convert_with_pool(buffers, t, |x| {
             Complex32::new(x as f32, 0.0)
@@ -226,26 +251,92 @@ pub(crate) fn convert_with_pool(
         (Tensor::F64(t), DType::C64) => Tensor::C64(typed_convert_with_pool(buffers, t, |x| {
             Complex64::new(x, 0.0)
         })),
+        (Tensor::I32(t), DType::F32) => {
+            Tensor::F32(typed_convert_with_pool(buffers, t, |x| x as f32))
+        }
+        (Tensor::I32(t), DType::F64) => {
+            Tensor::F64(typed_convert_with_pool(buffers, t, |x| x as f64))
+        }
+        (Tensor::I32(t), DType::I32) => Tensor::I32(t.clone()),
+        (Tensor::I32(t), DType::I64) => {
+            Tensor::I64(typed_convert_with_pool(buffers, t, |x| x as i64))
+        }
+        (Tensor::I32(t), DType::Bool) => {
+            Tensor::Bool(typed_convert_with_pool(buffers, t, |x| x != 0))
+        }
+        (Tensor::I32(t), DType::C32) => Tensor::C32(typed_convert_with_pool(buffers, t, |x| {
+            Complex32::new(x as f32, 0.0)
+        })),
+        (Tensor::I32(t), DType::C64) => Tensor::C64(typed_convert_with_pool(buffers, t, |x| {
+            Complex64::new(x as f64, 0.0)
+        })),
         (Tensor::I64(t), DType::F32) => {
             Tensor::F32(typed_convert_with_pool(buffers, t, |x| x as f32))
         }
         (Tensor::I64(t), DType::F64) => {
             Tensor::F64(typed_convert_with_pool(buffers, t, |x| x as f64))
         }
+        (Tensor::I64(t), DType::I32) => {
+            Tensor::I32(typed_convert_with_pool(buffers, t, |x| x as i32))
+        }
         (Tensor::I64(t), DType::I64) => Tensor::I64(t.clone()),
+        (Tensor::I64(t), DType::Bool) => {
+            Tensor::Bool(typed_convert_with_pool(buffers, t, |x| x != 0))
+        }
         (Tensor::I64(t), DType::C32) => Tensor::C32(typed_convert_with_pool(buffers, t, |x| {
             Complex32::new(x as f32, 0.0)
         })),
         (Tensor::I64(t), DType::C64) => Tensor::C64(typed_convert_with_pool(buffers, t, |x| {
             Complex64::new(x as f64, 0.0)
         })),
+        (Tensor::Bool(t), DType::F32) => Tensor::F32(typed_convert_with_pool(buffers, t, |x| {
+            if x {
+                1.0
+            } else {
+                0.0
+            }
+        })),
+        (Tensor::Bool(t), DType::F64) => Tensor::F64(typed_convert_with_pool(buffers, t, |x| {
+            if x {
+                1.0
+            } else {
+                0.0
+            }
+        })),
+        (Tensor::Bool(t), DType::I32) => {
+            Tensor::I32(typed_convert_with_pool(
+                buffers,
+                t,
+                |x| if x { 1 } else { 0 },
+            ))
+        }
+        (Tensor::Bool(t), DType::I64) => {
+            Tensor::I64(typed_convert_with_pool(
+                buffers,
+                t,
+                |x| if x { 1 } else { 0 },
+            ))
+        }
+        (Tensor::Bool(t), DType::Bool) => Tensor::Bool(t.clone()),
+        (Tensor::Bool(t), DType::C32) => Tensor::C32(typed_convert_with_pool(buffers, t, |x| {
+            Complex32::new(if x { 1.0 } else { 0.0 }, 0.0)
+        })),
+        (Tensor::Bool(t), DType::C64) => Tensor::C64(typed_convert_with_pool(buffers, t, |x| {
+            Complex64::new(if x { 1.0 } else { 0.0 }, 0.0)
+        })),
         (Tensor::C32(t), DType::F32) => Tensor::F32(typed_convert_with_pool(buffers, t, |z| z.re)),
         (Tensor::C32(t), DType::F64) => {
             Tensor::F64(typed_convert_with_pool(buffers, t, |z| z.re as f64))
         }
+        (Tensor::C32(t), DType::I32) => {
+            Tensor::I32(typed_convert_with_pool(buffers, t, |z| z.re as i32))
+        }
         (Tensor::C32(t), DType::I64) => {
             Tensor::I64(typed_convert_with_pool(buffers, t, |z| z.re as i64))
         }
+        (Tensor::C32(t), DType::Bool) => Tensor::Bool(typed_convert_with_pool(buffers, t, |z| {
+            z.re != 0.0 || z.im != 0.0
+        })),
         (Tensor::C32(t), DType::C32) => Tensor::C32(t.clone()),
         (Tensor::C32(t), DType::C64) => Tensor::C64(typed_convert_with_pool(buffers, t, |z| {
             Complex64::new(z.re as f64, z.im as f64)
@@ -254,9 +345,15 @@ pub(crate) fn convert_with_pool(
             Tensor::F32(typed_convert_with_pool(buffers, t, |z| z.re as f32))
         }
         (Tensor::C64(t), DType::F64) => Tensor::F64(typed_convert_with_pool(buffers, t, |z| z.re)),
+        (Tensor::C64(t), DType::I32) => {
+            Tensor::I32(typed_convert_with_pool(buffers, t, |z| z.re as i32))
+        }
         (Tensor::C64(t), DType::I64) => {
             Tensor::I64(typed_convert_with_pool(buffers, t, |z| z.re as i64))
         }
+        (Tensor::C64(t), DType::Bool) => Tensor::Bool(typed_convert_with_pool(buffers, t, |z| {
+            z.re != 0.0 || z.im != 0.0
+        })),
         (Tensor::C64(t), DType::C32) => Tensor::C32(typed_convert_with_pool(buffers, t, |z| {
             Complex32::new(z.re as f32, z.im as f32)
         })),
@@ -275,23 +372,9 @@ pub(crate) fn extract_diagonal_with_pool(
     axis_a: usize,
     axis_b: usize,
 ) -> crate::Result<Tensor> {
-    match input {
-        Tensor::F32(t) => Ok(Tensor::F32(typed_extract_diagonal_with_pool(
-            buffers, t, axis_a, axis_b,
-        )?)),
-        Tensor::F64(t) => Ok(Tensor::F64(typed_extract_diagonal_with_pool(
-            buffers, t, axis_a, axis_b,
-        )?)),
-        Tensor::I64(t) => Ok(Tensor::I64(typed_extract_diagonal_with_pool(
-            buffers, t, axis_a, axis_b,
-        )?)),
-        Tensor::C32(t) => Ok(Tensor::C32(typed_extract_diagonal_with_pool(
-            buffers, t, axis_a, axis_b,
-        )?)),
-        Tensor::C64(t) => Ok(Tensor::C64(typed_extract_diagonal_with_pool(
-            buffers, t, axis_a, axis_b,
-        )?)),
-    }
+    dispatch_tensor_unary_result!(input, |t| typed_extract_diagonal_with_pool(
+        buffers, t, axis_a, axis_b
+    ))
 }
 
 pub fn embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor> {
@@ -304,23 +387,14 @@ pub(crate) fn embed_diagonal_with_pool(
     axis_a: usize,
     axis_b: usize,
 ) -> crate::Result<Tensor> {
-    match input {
-        Tensor::F32(t) => Ok(Tensor::F32(typed_embed_diagonal_with_pool(
-            buffers, t, axis_a, axis_b,
-        )?)),
-        Tensor::F64(t) => Ok(Tensor::F64(typed_embed_diagonal_with_pool(
-            buffers, t, axis_a, axis_b,
-        )?)),
-        Tensor::I64(t) => Ok(Tensor::I64(typed_embed_diagonal_with_pool(
-            buffers, t, axis_a, axis_b,
-        )?)),
-        Tensor::C32(t) => Ok(Tensor::C32(typed_embed_diagonal_with_pool(
-            buffers, t, axis_a, axis_b,
-        )?)),
-        Tensor::C64(t) => Ok(Tensor::C64(typed_embed_diagonal_with_pool(
-            buffers, t, axis_a, axis_b,
-        )?)),
-    }
+    dispatch_tensor_unary_with_bool_special_result!(
+        input,
+        |t| typed_embed_diagonal_with_pool(buffers, t, axis_a, axis_b),
+        bool | t
+            | typed_embed_diagonal_impl(t, axis_a, axis_b, |shape| {
+                filled_tensor_from_pool(buffers, shape, false)
+            })
+    )
 }
 
 pub fn tril(input: &Tensor, k: i64) -> crate::Result<Tensor> {
@@ -332,13 +406,11 @@ pub(crate) fn tril_with_pool(
     input: &Tensor,
     k: i64,
 ) -> crate::Result<Tensor> {
-    match input {
-        Tensor::F32(t) => Ok(Tensor::F32(typed_tril_with_pool(buffers, t, k)?)),
-        Tensor::F64(t) => Ok(Tensor::F64(typed_tril_with_pool(buffers, t, k)?)),
-        Tensor::I64(t) => Ok(Tensor::I64(typed_tril_with_pool(buffers, t, k)?)),
-        Tensor::C32(t) => Ok(Tensor::C32(typed_tril_with_pool(buffers, t, k)?)),
-        Tensor::C64(t) => Ok(Tensor::C64(typed_tril_with_pool(buffers, t, k)?)),
-    }
+    dispatch_tensor_unary_with_bool_special_result!(
+        input,
+        |t| typed_tril_with_pool(buffers, t, k),
+        bool | t | typed_triangular_mask_with_fill_pool(buffers, t, k, false, false)
+    )
 }
 
 pub fn triu(input: &Tensor, k: i64) -> crate::Result<Tensor> {
@@ -350,16 +422,14 @@ pub(crate) fn triu_with_pool(
     input: &Tensor,
     k: i64,
 ) -> crate::Result<Tensor> {
-    match input {
-        Tensor::F32(t) => Ok(Tensor::F32(typed_triu_with_pool(buffers, t, k)?)),
-        Tensor::F64(t) => Ok(Tensor::F64(typed_triu_with_pool(buffers, t, k)?)),
-        Tensor::I64(t) => Ok(Tensor::I64(typed_triu_with_pool(buffers, t, k)?)),
-        Tensor::C32(t) => Ok(Tensor::C32(typed_triu_with_pool(buffers, t, k)?)),
-        Tensor::C64(t) => Ok(Tensor::C64(typed_triu_with_pool(buffers, t, k)?)),
-    }
+    dispatch_tensor_unary_with_bool_special_result!(
+        input,
+        |t| typed_triu_with_pool(buffers, t, k),
+        bool | t | typed_triangular_mask_with_fill_pool(buffers, t, k, true, false)
+    )
 }
 
-pub fn typed_transpose<T: Copy + Zero + Clone>(
+pub fn typed_transpose<T: Copy + Clone>(
     tensor: &TypedTensor<T>,
     perm: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
@@ -379,7 +449,7 @@ pub(crate) fn typed_transpose_with_pool<T>(
     perm: &[usize],
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Zero + Clone + PoolScalar,
+    T: Copy + Clone + PoolScalar,
 {
     validate_permutation("transpose", perm, tensor.shape.len())?;
     let src = host_view(tensor)?;
@@ -411,7 +481,7 @@ pub fn typed_reshape<T: Clone>(
     })
 }
 
-pub fn typed_broadcast_in_dim<T: Copy + Zero + Clone>(
+pub fn typed_broadcast_in_dim<T: Copy + Clone>(
     tensor: &TypedTensor<T>,
     shape: &[usize],
     dims: &[usize],
@@ -428,7 +498,7 @@ pub(crate) fn typed_broadcast_in_dim_with_pool<T>(
     dims: &[usize],
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Zero + Clone + PoolScalar,
+    T: Copy + Clone + PoolScalar,
 {
     typed_broadcast_in_dim_impl(tensor, shape, dims, |shape| unsafe {
         typed_array_uninit_from_pool(buffers, shape)
@@ -442,7 +512,7 @@ fn typed_broadcast_in_dim_impl<T>(
     make_out: impl FnOnce(&[usize]) -> strided_kernel::StridedArray<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Zero + Clone,
+    T: Copy + Clone,
 {
     validate_rank("broadcast_in_dim", tensor.shape.len(), dims.len())?;
     let mut seen = vec![false; shape.len()];
@@ -500,7 +570,7 @@ fn typed_convert_with_pool<S, T>(
 ) -> TypedTensor<T>
 where
     S: Copy,
-    T: Copy + Clone + Zero + PoolScalar,
+    T: Copy + Clone + PoolScalar,
 {
     // SAFETY: map_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, &tensor.shape) };
@@ -508,7 +578,7 @@ where
     tensor_from_array(out)
 }
 
-pub fn typed_extract_diagonal<T: Copy + Zero + Clone>(
+pub fn typed_extract_diagonal<T: Copy + Clone>(
     tensor: &TypedTensor<T>,
     axis_a: usize,
     axis_b: usize,
@@ -534,7 +604,7 @@ pub(crate) fn typed_extract_diagonal_with_pool<T>(
     axis_b: usize,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Zero + Clone + PoolScalar,
+    T: Copy + Clone + PoolScalar,
 {
     validate_axis("extract_diagonal", axis_a, tensor.shape.len())?;
     validate_axis("extract_diagonal", axis_b, tensor.shape.len())?;
@@ -579,7 +649,7 @@ fn typed_embed_diagonal_impl<T>(
     make_zeroed: impl FnOnce(Vec<usize>) -> TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Zero + Clone,
+    T: Copy + Clone,
 {
     validate_axis("embed_diagonal", axis_a, tensor.shape.len())?;
     if axis_b > tensor.shape.len() {
@@ -644,7 +714,7 @@ pub(crate) fn typed_tril_with_pool<T>(
 where
     T: Copy + Zero + Clone + PoolScalar,
 {
-    typed_triangular_mask_with_pool(buffers, tensor, k, false)
+    typed_triangular_mask_with_fill_pool(buffers, tensor, k, false, T::zero())
 }
 
 pub fn typed_triu<T: Copy + Zero + Clone>(
@@ -662,7 +732,7 @@ pub(crate) fn typed_triu_with_pool<T>(
 where
     T: Copy + Zero + Clone + PoolScalar,
 {
-    typed_triangular_mask_with_pool(buffers, tensor, k, true)
+    typed_triangular_mask_with_fill_pool(buffers, tensor, k, true, T::zero())
 }
 
 fn typed_triangular_mask<T: Copy + Zero + Clone>(
@@ -720,14 +790,15 @@ fn typed_triangular_mask<T: Copy + Zero + Clone>(
     Ok(out)
 }
 
-fn typed_triangular_mask_with_pool<T>(
+fn typed_triangular_mask_with_fill_pool<T>(
     buffers: &mut BufferPool,
     tensor: &TypedTensor<T>,
     k: i64,
     upper: bool,
+    fill: T,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Zero + Clone + PoolScalar,
+    T: Copy + Clone + PoolScalar,
 {
     if tensor.shape.len() < 2 {
         return Err(crate::Error::RankMismatch {
@@ -766,7 +837,7 @@ where
                     row >= boundary
                 };
                 if !keep {
-                    data[base + row as usize + col * rows] = T::zero();
+                    data[base + row as usize + col * rows] = fill;
                 }
             }
         }

--- a/tenferro-tensor/src/tests/cpu_indexing_coverage_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_indexing_coverage_tests.rs
@@ -107,11 +107,29 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2]
     );
 
+    let i32_operand = Tensor::from_vec_col_major(vec![3], vec![1_i32, 2, 3]);
+    assert_eq!(
+        gather(&i32_operand, &indices, &simple_gather_config())
+            .unwrap()
+            .shape(),
+        &[2]
+    );
+
     let i64_operand = Tensor::from_vec_col_major(vec![3], vec![1_i64, 2, 3]);
-    assert!(matches!(
-        gather(&i64_operand, &indices, &simple_gather_config()),
-        Err(crate::Error::BackendFailure { op: "gather", .. })
-    ));
+    assert_eq!(
+        gather(&i64_operand, &indices, &simple_gather_config())
+            .unwrap()
+            .shape(),
+        &[2]
+    );
+
+    let bool_operand = Tensor::from_vec_col_major(vec![3], vec![true, false, true]);
+    assert_eq!(
+        gather(&bool_operand, &indices, &simple_gather_config())
+            .unwrap()
+            .shape(),
+        &[2]
+    );
 
     let scatter_indices = Tensor::from_vec_col_major(vec![2, 2], vec![0_i64, 1, 0, 1]);
 
@@ -160,11 +178,22 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2, 2]
     );
 
-    assert!(matches!(
+    assert_eq!(
         scatter(
             &Tensor::from_vec_col_major(vec![2, 2], vec![0_i64; 4]),
             &scatter_indices,
             &Tensor::from_vec_col_major(vec![2], vec![1_i64, 2]),
+            &diagonal_scatter_config(),
+        )
+        .unwrap()
+        .shape(),
+        &[2, 2]
+    );
+    assert!(matches!(
+        scatter(
+            &Tensor::from_vec_col_major(vec![2, 2], vec![false; 4]),
+            &scatter_indices,
+            &Tensor::from_vec_col_major(vec![2], vec![true, false]),
             &diagonal_scatter_config(),
         ),
         Err(crate::Error::BackendFailure { op: "scatter", .. })
@@ -197,6 +226,12 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2]
     );
     assert_eq!(
+        crate::cpu::indexing::slice(&bool_operand, &slice_cfg)
+            .unwrap()
+            .shape(),
+        &[2]
+    );
+    assert_eq!(
         crate::cpu::indexing::slice(&c32_operand, &slice_cfg)
             .unwrap()
             .shape(),
@@ -222,13 +257,14 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         dynamic_slice(&c64_operand, &starts, &[2]).unwrap().shape(),
         &[2]
     );
-    assert!(matches!(
-        dynamic_slice(&i64_operand, &starts, &[2]),
-        Err(crate::Error::BackendFailure {
-            op: "dynamic_slice",
-            ..
-        })
-    ));
+    assert_eq!(
+        dynamic_slice(&i64_operand, &starts, &[2]).unwrap().shape(),
+        &[2]
+    );
+    assert_eq!(
+        dynamic_slice(&bool_operand, &starts, &[2]).unwrap().shape(),
+        &[2]
+    );
 
     let pad_cfg = PadConfig {
         edge_padding_low: vec![1],
@@ -237,6 +273,7 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
     };
     assert_eq!(pad(&f32_operand, &pad_cfg).unwrap().shape(), &[5]);
     assert_eq!(pad(&i64_operand, &pad_cfg).unwrap().shape(), &[5]);
+    assert_eq!(pad(&bool_operand, &pad_cfg).unwrap().shape(), &[5]);
     assert_eq!(pad(&c32_operand, &pad_cfg).unwrap().shape(), &[5]);
     assert_eq!(pad(&c64_operand, &pad_cfg).unwrap().shape(), &[5]);
 
@@ -271,6 +308,8 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
     );
 
     assert_eq!(backend.reverse(&f32_operand, &[0]).unwrap().shape(), &[3]);
+    assert_eq!(backend.reverse(&i64_operand, &[0]).unwrap().shape(), &[3]);
+    assert_eq!(backend.reverse(&bool_operand, &[0]).unwrap().shape(), &[3]);
     assert_eq!(backend.reverse(&c32_operand, &[0]).unwrap().shape(), &[3]);
     assert_eq!(backend.reverse(&c64_operand, &[0]).unwrap().shape(), &[3]);
 }

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -3310,8 +3310,71 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
                 inner.host_data(),
                 &[Complex64::new(1.25, -0.5), Complex64::new(-2.5, 4.0)]
             ),
+            _ => unreachable!("unexpected conversion case"),
         }
     }
+}
+
+#[test]
+fn test_cpu_supports_i32_and_bool_structural_paths() {
+    let mut backend = CpuBackend::new();
+
+    let i32_tensor = Tensor::from_vec_col_major(vec![2], vec![-1_i32, 0]);
+    let i32_as_bool = backend.convert(&i32_tensor, DType::Bool).unwrap();
+    assert_eq!(i32_as_bool.as_slice::<bool>().unwrap(), &[true, false]);
+
+    let bool_tensor = Tensor::from_vec_col_major(vec![2], vec![true, false]);
+    let bool_as_i64 = backend.convert(&bool_tensor, DType::I64).unwrap();
+    assert_eq!(bool_as_i64.as_slice::<i64>().unwrap(), &[1, 0]);
+
+    let bool_matrix =
+        Tensor::from_vec_col_major(vec![2, 3], vec![true, false, false, true, true, false]);
+    let transposed = transpose(&bool_matrix, &[1, 0]).unwrap();
+    assert_eq!(transposed.shape(), &[3, 2]);
+    assert_eq!(
+        transposed.as_slice::<bool>().unwrap(),
+        &[true, false, true, false, true, false]
+    );
+
+    let padded = pad(
+        &bool_tensor,
+        &PadConfig {
+            edge_padding_low: vec![1],
+            edge_padding_high: vec![1],
+            interior_padding: vec![0],
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        padded.as_slice::<bool>().unwrap(),
+        &[false, true, false, false]
+    );
+
+    let starts = Tensor::from_vec_col_major(vec![1], vec![1_i32]);
+    let sliced = dynamic_slice(
+        &Tensor::from_vec_col_major(vec![3], vec![true, false, true]),
+        &starts,
+        &[2],
+    )
+    .unwrap();
+    assert_eq!(sliced.as_slice::<bool>().unwrap(), &[false, true]);
+
+    let upper = triu(
+        &Tensor::from_vec_col_major(vec![2, 2], vec![true, true, false, true]),
+        0,
+    )
+    .unwrap();
+    assert_eq!(
+        upper.as_slice::<bool>().unwrap(),
+        &[true, false, false, true]
+    );
+
+    let i32_sum = reduce_sum(
+        &Tensor::from_vec_col_major(vec![2, 2], vec![1_i32, 2, 3, 4]),
+        &[0],
+    )
+    .unwrap();
+    assert_eq!(i32_sum.as_slice::<i32>().unwrap(), &[3, 7]);
 }
 
 #[test]

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -563,6 +563,400 @@ fn dynamic_strided_tensor_view_mut_multi_slice_returns_option() {
 }
 
 #[test]
+fn strided_tensor_view_validation_covers_error_edges() {
+    let data = [1_i32, 2, 3];
+
+    let empty = TypedStridedTensorView::new(&[0, 3], &[1, 0], 3, &data).unwrap();
+    assert_eq!(empty.n_elements(), 0);
+    assert_eq!(
+        empty.materialize_col_major().unwrap().as_slice(),
+        &[] as &[i32]
+    );
+    assert_eq!(empty.get(&[0, 0]), None);
+    assert!(matches!(
+        TypedStridedTensorView::<i32>::new(&[0], &[1], 4, &data),
+        Err(Error::InvalidConfig { .. })
+    ));
+
+    assert!(matches!(
+        TypedStridedTensorView::<i32>::new(&[2], &[1, 1], 0, &data),
+        Err(Error::RankMismatch { .. })
+    ));
+    assert!(matches!(
+        TypedStridedTensorView::<i32>::new(&[2], &[-1], 0, &data[..1]),
+        Err(Error::InvalidConfig { .. })
+    ));
+    assert!(matches!(
+        TypedStridedTensorView::<i32>::new(&[2], &[2], 0, &data[..1]),
+        Err(Error::InvalidConfig { .. })
+    ));
+
+    let view = TypedStridedTensorView::new(&[3], &[1], 0, &data).unwrap();
+    assert_eq!(view.try_get(&[1]), Some(&2));
+    assert_eq!(view.try_linear_offset(&[0, 0]), None);
+    assert_eq!(view.try_linear_offset(&[3]), None);
+
+    assert!(matches!(
+        TypedStridedTensorView::<i32>::new(&[usize::MAX, 2], &[1, 1], 0, &[]),
+        Err(Error::InvalidConfig { .. })
+    ));
+    assert!(matches!(
+        TypedStridedTensorView::<i32>::new(&[3], &[isize::MAX], 0, &[]),
+        Err(Error::InvalidConfig { .. })
+    ));
+    assert!(matches!(
+        TypedStridedTensorView::<i32>::new(&[2, 2], &[isize::MAX, 1], 0, &[]),
+        Err(Error::InvalidConfig { .. })
+    ));
+}
+
+#[test]
+fn strided_tensor_view_slice_permute_and_reshape_cover_boundaries() {
+    let data = [1_i32, 2, 3, 4, 5, 6];
+    let view = TypedStridedTensorView::new(&[2, 3], &[3, 1], 0, &data).unwrap();
+
+    assert!(matches!(
+        view.try_permute_axes(&[0]),
+        Err(Error::RankMismatch { .. })
+    ));
+    assert!(matches!(
+        view.try_permute_axes(&[2, 0]),
+        Err(Error::AxisOutOfBounds { .. })
+    ));
+    assert!(matches!(
+        view.try_permute_axes(&[0, 0]),
+        Err(Error::DuplicateAxis { .. })
+    ));
+
+    assert!(matches!(
+        view.try_slice(&[StridedSliceSpec::all()]),
+        Err(Error::RankMismatch { .. })
+    ));
+    assert!(matches!(
+        view.try_slice_axis(2, StridedSliceSpec::all()),
+        Err(Error::AxisOutOfBounds { .. })
+    ));
+    assert!(matches!(
+        view.try_slice(&[StridedSliceSpec::all(), StridedSliceSpec::new(0, None, 0)]),
+        Err(Error::InvalidConfig { .. })
+    ));
+    assert!(matches!(
+        view.try_slice(&[StridedSliceSpec::all(), StridedSliceSpec::new(-4, None, 1)]),
+        Err(Error::InvalidConfig { .. })
+    ));
+    assert!(matches!(
+        view.try_slice(&[
+            StridedSliceSpec::all(),
+            StridedSliceSpec::new(0, Some(4), 1)
+        ]),
+        Err(Error::InvalidConfig { .. })
+    ));
+
+    let empty = view
+        .try_slice_axis(1, StridedSliceSpec::new(2, Some(1), 1))
+        .unwrap();
+    assert_eq!(empty.shape(), &[2, 0]);
+    assert_eq!(
+        empty.materialize_col_major().unwrap().as_slice(),
+        &[] as &[i32]
+    );
+
+    assert!(matches!(
+        view.try_reshape(&[5]),
+        Err(Error::InvalidConfig { .. })
+    ));
+    assert!(matches!(
+        TypedStridedTensorView::<i32>::from_col_major(&[isize::MAX as usize, 2, 2], &[]),
+        Err(Error::InvalidConfig { .. })
+    ));
+
+    let scalar = TypedStridedTensorView::from_col_major(&[], &data[..1]).unwrap();
+    assert_eq!(scalar.shape(), &[] as &[usize]);
+    assert_eq!(scalar.strides(), &[] as &[isize]);
+    assert_eq!(scalar.get(&[]), Some(&1));
+
+    let singleton_axis = TypedStridedTensorView::new(&[1, 3], &[99, 1], 0, &data).unwrap();
+    assert_eq!(singleton_axis.try_reshape(&[3]).unwrap().strides(), &[1]);
+}
+
+#[test]
+fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cases() {
+    let mut data = [0_i32, 1, 2, 3, 4, 5];
+    let mut view = TypedStridedTensorViewMut::new(&[6], &[1], 0, &mut data).unwrap();
+    {
+        let (mut high, mut low) = view
+            .try_multi_slice_mut(
+                &[StridedSliceSpec::new(4, Some(6), 1)],
+                &[StridedSliceSpec::new(1, Some(3), 1)],
+            )
+            .unwrap();
+        *high.get_mut(&[0]).unwrap() = 40;
+        *low.get_mut(&[1]).unwrap() = 20;
+    }
+    assert_eq!(view.as_physical_slice(), &[0, 1, 20, 3, 40, 5]);
+
+    let mut data = [0_i32, 1, 2, 3];
+    let mut view = TypedStridedTensorViewMut::new(&[4], &[1], 0, &mut data).unwrap();
+    {
+        let (empty, mut right) = view
+            .try_multi_slice_mut(
+                &[StridedSliceSpec::new(0, Some(0), 1)],
+                &[StridedSliceSpec::new(2, Some(4), 1)],
+            )
+            .unwrap();
+        assert_eq!(empty.n_elements(), 0);
+        *right.get_mut(&[0]).unwrap() = 20;
+    }
+    assert_eq!(view.as_physical_slice(), &[0, 1, 20, 3]);
+
+    let mut data = [0_i32, 1, 2, 3];
+    let mut view = TypedStridedTensorViewMut::new(&[4], &[1], 0, &mut data).unwrap();
+    {
+        let (mut left, empty) = view
+            .try_multi_slice_mut(
+                &[StridedSliceSpec::new(0, Some(2), 1)],
+                &[StridedSliceSpec::new(4, Some(4), 1)],
+            )
+            .unwrap();
+        assert_eq!(empty.n_elements(), 0);
+        *left.get_mut(&[1]).unwrap() = 10;
+    }
+    assert_eq!(view.as_physical_slice(), &[0, 10, 2, 3]);
+
+    let mut data = [0_i32, 1, 2, 3];
+    let mut view = TypedStridedTensorViewMut::new(&[4], &[1], 0, &mut data).unwrap();
+    let (empty_left, empty_right) = view
+        .try_multi_slice_mut(
+            &[StridedSliceSpec::new(0, Some(0), 1)],
+            &[StridedSliceSpec::new(4, Some(4), 1)],
+        )
+        .unwrap();
+    assert_eq!(empty_left.n_elements(), 0);
+    assert_eq!(empty_right.n_elements(), 0);
+
+    let mut data = [0_i32, 1, 2, 3, 4, 5];
+    let mut view = TypedStridedTensorViewMut::new(&[6], &[1], 0, &mut data).unwrap();
+    {
+        let (mut reversed_high, mut low) = view
+            .try_multi_slice_mut(
+                &[StridedSliceSpec::new(3, Some(6), -1)],
+                &[StridedSliceSpec::new(0, Some(3), 1)],
+            )
+            .unwrap();
+        assert_eq!(reversed_high.get(&[0]), Some(&5));
+        *reversed_high.get_mut(&[2]).unwrap() = 30;
+        *low.get_mut(&[2]).unwrap() = 20;
+    }
+    assert_eq!(view.as_physical_slice(), &[0, 1, 20, 30, 4, 5]);
+
+    let mut data = [0_i32, 1, 2, 3, 4, 5];
+    let mut view = TypedStridedTensorViewMut::new(&[6], &[1], 0, &mut data).unwrap();
+    assert!(view
+        .try_multi_slice_mut(
+            &[StridedSliceSpec::new(0, Some(6), 2)],
+            &[StridedSliceSpec::new(1, Some(6), 2)],
+        )
+        .is_none());
+}
+
+#[test]
+fn dynamic_strided_tensor_view_covers_all_dtype_variants() {
+    macro_rules! assert_read_variant {
+        ($ctor:ident, $ty:ty, $dtype:expr, [$a:expr, $b:expr, $c:expr, $d:expr]) => {{
+            let data: [$ty; 4] = [$a, $b, $c, $d];
+            let view = StridedTensorView::$ctor(&[2, 2], &[2, 1], 0, &data).unwrap();
+            assert_eq!(view.dtype(), $dtype);
+            assert_eq!(view.shape(), &[2, 2]);
+            assert_eq!(view.strides(), &[2, 1]);
+            assert_eq!(view.offset(), 0);
+            assert_eq!(
+                view.to_tensor().unwrap().as_slice::<$ty>().unwrap(),
+                &[$a, $c, $b, $d]
+            );
+        }};
+    }
+
+    assert_read_variant!(f32, f32, DType::F32, [1.0_f32, 2.0, 3.0, 4.0]);
+    assert_read_variant!(f64, f64, DType::F64, [1.0_f64, 2.0, 3.0, 4.0]);
+    assert_read_variant!(i32, i32, DType::I32, [1_i32, 2, 3, 4]);
+    assert_read_variant!(i64, i64, DType::I64, [1_i64, 2, 3, 4]);
+    assert_read_variant!(bool, bool, DType::Bool, [false, true, true, false]);
+    assert_read_variant!(
+        c32,
+        Complex32,
+        DType::C32,
+        [
+            Complex32::new(1.0, 1.0),
+            Complex32::new(2.0, 2.0),
+            Complex32::new(3.0, 3.0),
+            Complex32::new(4.0, 4.0)
+        ]
+    );
+    assert_read_variant!(
+        c64,
+        Complex64,
+        DType::C64,
+        [
+            Complex64::new(1.0, 1.0),
+            Complex64::new(2.0, 2.0),
+            Complex64::new(3.0, 3.0),
+            Complex64::new(4.0, 4.0)
+        ]
+    );
+}
+
+#[test]
+fn dynamic_strided_tensor_view_mut_covers_all_dtype_variants() {
+    macro_rules! assert_mut_variant {
+        (
+            $ctor:ident,
+            $variant:ident,
+            $ty:ty,
+            $dtype:expr,
+            [$a:expr, $b:expr, $c:expr, $d:expr],
+            $replacement:expr
+        ) => {{
+            let mut data: [$ty; 4] = [$a, $b, $c, $d];
+            let mut view = StridedTensorViewMut::$ctor(&[2, 2], &[2, 1], 0, &mut data).unwrap();
+            assert_eq!(view.dtype(), $dtype);
+            assert_eq!(view.shape(), &[2, 2]);
+            assert_eq!(view.strides(), &[2, 1]);
+            assert_eq!(view.offset(), 0);
+            match &mut view {
+                StridedTensorViewMut::$variant(typed) => {
+                    *typed.try_get_mut(&[1, 1]).unwrap() = $replacement;
+                }
+                _ => unreachable!(),
+            }
+            assert_eq!(
+                view.as_read_only()
+                    .to_tensor()
+                    .unwrap()
+                    .as_slice::<$ty>()
+                    .unwrap(),
+                &[$a, $c, $b, $replacement]
+            );
+            assert_eq!(
+                view.to_tensor().unwrap().as_slice::<$ty>().unwrap(),
+                &[$a, $c, $b, $replacement]
+            );
+        }};
+    }
+
+    assert_mut_variant!(f32, F32, f32, DType::F32, [1.0_f32, 2.0, 3.0, 4.0], 40.0);
+    assert_mut_variant!(f64, F64, f64, DType::F64, [1.0_f64, 2.0, 3.0, 4.0], 40.0);
+    assert_mut_variant!(i32, I32, i32, DType::I32, [1_i32, 2, 3, 4], 40);
+    assert_mut_variant!(i64, I64, i64, DType::I64, [1_i64, 2, 3, 4], 40);
+    assert_mut_variant!(
+        bool,
+        Bool,
+        bool,
+        DType::Bool,
+        [false, true, true, false],
+        true
+    );
+    assert_mut_variant!(
+        c32,
+        C32,
+        Complex32,
+        DType::C32,
+        [
+            Complex32::new(1.0, 1.0),
+            Complex32::new(2.0, 2.0),
+            Complex32::new(3.0, 3.0),
+            Complex32::new(4.0, 4.0)
+        ],
+        Complex32::new(40.0, -1.0)
+    );
+    assert_mut_variant!(
+        c64,
+        C64,
+        Complex64,
+        DType::C64,
+        [
+            Complex64::new(1.0, 1.0),
+            Complex64::new(2.0, 2.0),
+            Complex64::new(3.0, 3.0),
+            Complex64::new(4.0, 4.0)
+        ],
+        Complex64::new(40.0, -1.0)
+    );
+}
+
+#[test]
+fn dynamic_strided_tensor_view_mut_multi_slice_covers_all_dtype_variants() {
+    macro_rules! assert_dynamic_multi_slice {
+        (
+            $ctor:ident,
+            $variant:ident,
+            $ty:ty,
+            [$a:expr, $b:expr, $c:expr, $d:expr],
+            $left:expr,
+            $right:expr
+        ) => {{
+            let mut data: [$ty; 4] = [$a, $b, $c, $d];
+            let mut view = StridedTensorViewMut::$ctor(&[4], &[1], 0, &mut data).unwrap();
+            {
+                let (mut lhs, mut rhs) = view
+                    .try_multi_slice_mut(
+                        &[StridedSliceSpec::new(0, Some(2), 1)],
+                        &[StridedSliceSpec::new(2, Some(4), 1)],
+                    )
+                    .unwrap();
+                match &mut lhs {
+                    StridedTensorViewMut::$variant(typed) => {
+                        *typed.get_mut(&[1]).unwrap() = $left;
+                    }
+                    _ => unreachable!(),
+                }
+                match &mut rhs {
+                    StridedTensorViewMut::$variant(typed) => {
+                        *typed.get_mut(&[0]).unwrap() = $right;
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            assert_eq!(
+                view.to_tensor().unwrap().as_slice::<$ty>().unwrap(),
+                &[$a, $left, $right, $d]
+            );
+        }};
+    }
+
+    assert_dynamic_multi_slice!(f32, F32, f32, [1.0_f32, 2.0, 3.0, 4.0], 20.0, 30.0);
+    assert_dynamic_multi_slice!(f64, F64, f64, [1.0_f64, 2.0, 3.0, 4.0], 20.0, 30.0);
+    assert_dynamic_multi_slice!(i32, I32, i32, [1_i32, 2, 3, 4], 20, 30);
+    assert_dynamic_multi_slice!(i64, I64, i64, [1_i64, 2, 3, 4], 20, 30);
+    assert_dynamic_multi_slice!(bool, Bool, bool, [false, false, false, true], true, true);
+    assert_dynamic_multi_slice!(
+        c32,
+        C32,
+        Complex32,
+        [
+            Complex32::new(1.0, 1.0),
+            Complex32::new(2.0, 2.0),
+            Complex32::new(3.0, 3.0),
+            Complex32::new(4.0, 4.0)
+        ],
+        Complex32::new(20.0, -1.0),
+        Complex32::new(30.0, -1.0)
+    );
+    assert_dynamic_multi_slice!(
+        c64,
+        C64,
+        Complex64,
+        [
+            Complex64::new(1.0, 1.0),
+            Complex64::new(2.0, 2.0),
+            Complex64::new(3.0, 3.0),
+            Complex64::new(4.0, 4.0)
+        ],
+        Complex64::new(20.0, -1.0),
+        Complex64::new(30.0, -1.0)
+    );
+}
+
+#[test]
 fn tensor_read_wraps_owned_tensor_or_borrowed_view() {
     let tensor = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
     let read_tensor = TensorRead::from_tensor(&tensor);

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -4,8 +4,9 @@ use num_complex::{Complex32, Complex64};
 
 use crate::types::{
     col_major_strides, flat_to_multi, Buffer, BufferHandle, ComputeDevice, ConjElem, DType,
-    MemoryKind, Placement, Tensor, TensorRead, TensorScalar, TensorView, TypedTensor,
-    TypedTensorView,
+    MemoryKind, Placement, StridedSliceSpec, StridedTensorView, StridedTensorViewMut, Tensor,
+    TensorRead, TensorScalar, TensorView, TypedStridedTensorView, TypedStridedTensorViewMut,
+    TypedTensor, TypedTensorView,
 };
 use crate::Error;
 
@@ -290,6 +291,7 @@ fn backend_buffers_panic_when_host_access_is_requested() {
 fn tensor_shape_and_dtype_cover_all_variants() {
     let f32_tensor = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]));
     let f64_tensor = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![3.0_f64]));
+    let i32_tensor = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1_i32, -2]));
     let c32_tensor = Tensor::C32(TypedTensor::from_vec_col_major(
         vec![1],
         vec![Complex32::new(1.0, -2.0)],
@@ -298,11 +300,16 @@ fn tensor_shape_and_dtype_cover_all_variants() {
         vec![1, 1],
         vec![Complex64::new(-3.0, 4.0)],
     ));
+    let bool_tensor = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]));
 
     assert_eq!(f32_tensor.shape(), &[2]);
     assert_eq!(f32_tensor.dtype(), DType::F32);
     assert_eq!(f64_tensor.shape(), &[] as &[usize]);
     assert_eq!(f64_tensor.dtype(), DType::F64);
+    assert_eq!(i32_tensor.shape(), &[2]);
+    assert_eq!(i32_tensor.dtype(), DType::I32);
+    assert_eq!(bool_tensor.shape(), &[2]);
+    assert_eq!(bool_tensor.dtype(), DType::Bool);
     assert_eq!(c32_tensor.shape(), &[1]);
     assert_eq!(c32_tensor.dtype(), DType::C32);
     assert_eq!(c64_tensor.shape(), &[1, 1]);
@@ -326,7 +333,9 @@ fn typed_tensor_view_validates_shape_and_exposes_slice() {
 fn tensor_view_covers_dtype_shape_and_materialization() {
     let f32_data = [1.0_f32, 2.0];
     let f64_data = [1.0_f64, 2.0];
+    let i32_data = [1_i32, 2];
     let i64_data = [1_i64, 2];
+    let bool_data = [true, false];
     let c32_data = [Complex32::new(1.0, -1.0), Complex32::new(2.0, 0.5)];
     let c64_data = [Complex64::new(1.0, -1.0), Complex64::new(2.0, 0.5)];
     let shape = [2usize];
@@ -334,11 +343,21 @@ fn tensor_view_covers_dtype_shape_and_materialization() {
     let views = [
         TensorView::f32(&shape, &f32_data).unwrap(),
         TensorView::f64(&shape, &f64_data).unwrap(),
+        TensorView::i32(&shape, &i32_data).unwrap(),
         TensorView::i64(&shape, &i64_data).unwrap(),
+        TensorView::bool(&shape, &bool_data).unwrap(),
         TensorView::c32(&shape, &c32_data).unwrap(),
         TensorView::c64(&shape, &c64_data).unwrap(),
     ];
-    let dtypes = [DType::F32, DType::F64, DType::I64, DType::C32, DType::C64];
+    let dtypes = [
+        DType::F32,
+        DType::F64,
+        DType::I32,
+        DType::I64,
+        DType::Bool,
+        DType::C32,
+        DType::C64,
+    ];
 
     for (view, dtype) in views.iter().zip(dtypes) {
         assert_eq!(view.dtype(), dtype);
@@ -347,6 +366,200 @@ fn tensor_view_covers_dtype_shape_and_materialization() {
         assert_eq!(tensor.dtype(), dtype);
         assert_eq!(tensor.shape(), &[2]);
     }
+}
+
+#[test]
+fn strided_tensor_view_materializes_sliced_host_layouts() {
+    let row_major = [1_i32, 2, 3, 4, 5, 6];
+    let view = TypedStridedTensorView::new(&[2, 3], &[3, 1], 0, &row_major).unwrap();
+
+    assert_eq!(view.shape(), &[2, 3]);
+    assert_eq!(view.strides(), &[3, 1]);
+    assert_eq!(view.get(&[1, 2]), Some(&6));
+    assert_eq!(
+        view.materialize_col_major().unwrap().as_slice(),
+        &[1, 4, 2, 5, 3, 6]
+    );
+
+    let transposed = view.try_permute_axes(&[1, 0]).unwrap();
+    assert_eq!(transposed.shape(), &[3, 2]);
+    assert_eq!(
+        transposed.materialize_col_major().unwrap().as_slice(),
+        &[1, 2, 3, 4, 5, 6]
+    );
+
+    let reversed_cols = view.try_slice_axis(1, StridedSliceSpec::reverse()).unwrap();
+    assert_eq!(reversed_cols.strides(), &[3, -1]);
+    assert_eq!(
+        reversed_cols.materialize_col_major().unwrap().as_slice(),
+        &[3, 6, 2, 5, 1, 4]
+    );
+
+    let every_other_col = view
+        .try_slice(&[StridedSliceSpec::all(), StridedSliceSpec::new(0, None, 2)])
+        .unwrap();
+    assert_eq!(
+        every_other_col.materialize_col_major().unwrap().as_slice(),
+        &[1, 4, 3, 6]
+    );
+    assert!(view.try_reshape(&[6]).is_err());
+
+    let col_major = [1_i32, 4, 2, 5, 3, 6];
+    let contiguous = TypedStridedTensorView::from_col_major(&[2, 3], &col_major).unwrap();
+    assert_eq!(contiguous.try_reshape(&[6]).unwrap().strides(), &[1]);
+}
+
+#[test]
+fn dynamic_strided_tensor_view_covers_i32_and_bool() {
+    let i32_data = [1_i32, 2, 3, 4];
+    let i32_view = StridedTensorView::i32(&[2, 2], &[2, 1], 0, &i32_data).unwrap();
+    assert_eq!(i32_view.dtype(), DType::I32);
+    assert_eq!(
+        i32_view.to_tensor().unwrap().as_slice::<i32>().unwrap(),
+        &[1, 3, 2, 4]
+    );
+
+    let bool_data = [false, true, true];
+    let bool_view = StridedTensorView::bool(&[3], &[-1], 2, &bool_data).unwrap();
+    assert_eq!(bool_view.dtype(), DType::Bool);
+    assert_eq!(
+        bool_view.to_tensor().unwrap().as_slice::<bool>().unwrap(),
+        &[true, true, false]
+    );
+}
+
+#[test]
+fn strided_tensor_view_mut_updates_sliced_host_layouts() {
+    let mut row_major = [1_i32, 2, 3, 4, 5, 6];
+    let mut view = TypedStridedTensorViewMut::new(&[2, 3], &[3, 1], 0, &mut row_major).unwrap();
+
+    assert_eq!(view.shape(), &[2, 3]);
+    assert_eq!(view.strides(), &[3, 1]);
+    assert_eq!(view.get(&[1, 2]), Some(&6));
+
+    *view.get_mut(&[1, 2]).unwrap() = 60;
+    assert_eq!(view.get(&[1, 2]), Some(&60));
+
+    {
+        let mut transposed = view.try_permute_axes(&[1, 0]).unwrap();
+        *transposed.get_mut(&[2, 1]).unwrap() = 600;
+    }
+    assert_eq!(view.get(&[1, 2]), Some(&600));
+
+    {
+        let mut reversed_cols = view.try_slice_axis(1, StridedSliceSpec::reverse()).unwrap();
+        assert_eq!(reversed_cols.strides(), &[3, -1]);
+        *reversed_cols.get_mut(&[0, 0]).unwrap() = 30;
+    }
+    assert_eq!(view.get(&[0, 2]), Some(&30));
+
+    let materialized = view.materialize_col_major().unwrap();
+    assert_eq!(materialized.as_slice(), &[1, 4, 2, 5, 30, 600]);
+}
+
+#[test]
+fn strided_tensor_view_mut_rejects_aliasing_layouts() {
+    let data = [1_i32, 2, 3, 4];
+    assert!(TypedStridedTensorView::new(&[2, 2], &[1, 1], 0, &data).is_ok());
+
+    let mut data = [1_i32, 2, 3, 4];
+    let err = TypedStridedTensorViewMut::new(&[2, 2], &[1, 1], 0, &mut data).unwrap_err();
+    assert!(matches!(err, Error::InvalidConfig { .. }));
+
+    let mut data = [1_i32, 2];
+    assert!(TypedStridedTensorViewMut::new(&[2], &[0], 0, &mut data).is_err());
+
+    let mut data = [1_i32, 2, 3];
+    let mut reversed = TypedStridedTensorViewMut::new(&[3], &[-1], 2, &mut data).unwrap();
+    *reversed.get_mut(&[2]).unwrap() = 10;
+    assert_eq!(reversed.as_physical_slice(), &[10, 2, 3]);
+
+    let mut data = [1_i32, 2];
+    let singleton_zero_stride =
+        TypedStridedTensorViewMut::new(&[1, 2], &[0, 1], 0, &mut data).unwrap();
+    assert_eq!(singleton_zero_stride.shape(), &[1, 2]);
+}
+
+#[test]
+fn strided_tensor_view_mut_multi_slice_returns_option() {
+    let mut data = [1_i32, 2, 3, 4, 5, 6];
+    let mut view = TypedStridedTensorViewMut::new(&[6], &[1], 0, &mut data).unwrap();
+
+    {
+        let (mut left, mut right) = view
+            .try_multi_slice_mut(
+                &[StridedSliceSpec::new(0, Some(3), 1)],
+                &[StridedSliceSpec::new(3, Some(6), 1)],
+            )
+            .unwrap();
+        *left.get_mut(&[2]).unwrap() = 30;
+        *right.get_mut(&[0]).unwrap() = 40;
+    }
+    assert_eq!(view.as_physical_slice(), &[1, 2, 30, 40, 5, 6]);
+
+    assert!(view
+        .try_multi_slice_mut(
+            &[StridedSliceSpec::new(0, Some(4), 1)],
+            &[StridedSliceSpec::new(3, Some(6), 1)],
+        )
+        .is_none());
+
+    assert!(view
+        .try_multi_slice_mut(
+            &[StridedSliceSpec::new(0, Some(2), 0)],
+            &[StridedSliceSpec::new(3, Some(6), 1)],
+        )
+        .is_none());
+}
+
+#[test]
+fn dynamic_strided_tensor_view_mut_covers_i32_and_bool() {
+    let mut i32_data = [1_i32, 2, 3, 4];
+    let mut i32_view = StridedTensorViewMut::i32(&[2, 2], &[2, 1], 0, &mut i32_data).unwrap();
+    assert_eq!(i32_view.dtype(), DType::I32);
+    match &mut i32_view {
+        StridedTensorViewMut::I32(view) => *view.get_mut(&[1, 1]).unwrap() = 40,
+        _ => unreachable!(),
+    }
+    assert_eq!(
+        i32_view.to_tensor().unwrap().as_slice::<i32>().unwrap(),
+        &[1, 3, 2, 40]
+    );
+
+    let mut bool_data = [false, true, true];
+    let mut bool_view = StridedTensorViewMut::bool(&[3], &[-1], 2, &mut bool_data).unwrap();
+    assert_eq!(bool_view.dtype(), DType::Bool);
+    match &mut bool_view {
+        StridedTensorViewMut::Bool(view) => *view.get_mut(&[2]).unwrap() = true,
+        _ => unreachable!(),
+    }
+    assert_eq!(
+        bool_view.to_tensor().unwrap().as_slice::<bool>().unwrap(),
+        &[true, true, true]
+    );
+}
+
+#[test]
+fn dynamic_strided_tensor_view_mut_multi_slice_returns_option() {
+    let mut data = [1_i32, 2, 3, 4];
+    let mut view = StridedTensorViewMut::i32(&[4], &[1], 0, &mut data).unwrap();
+    {
+        let (left, right) = view
+            .try_multi_slice_mut(
+                &[StridedSliceSpec::new(0, Some(2), 1)],
+                &[StridedSliceSpec::new(2, Some(4), 1)],
+            )
+            .unwrap();
+        assert_eq!(left.shape(), &[2]);
+        assert_eq!(right.shape(), &[2]);
+    }
+
+    assert!(view
+        .try_multi_slice_mut(
+            &[StridedSliceSpec::new(0, Some(3), 1)],
+            &[StridedSliceSpec::new(2, Some(4), 1)],
+        )
+        .is_none());
 }
 
 #[test]
@@ -387,6 +600,27 @@ tensor_scalar_roundtrip_test!(
     f64,
     vec![2, 1],
     vec![1.25_f64, -2.5_f64]
+);
+
+tensor_scalar_roundtrip_test!(
+    tensor_scalar_roundtrip_i32,
+    i32,
+    vec![2],
+    vec![1_i32, -2_i32]
+);
+
+tensor_scalar_roundtrip_test!(
+    tensor_scalar_roundtrip_i64,
+    i64,
+    vec![2],
+    vec![1_i64, -2_i64]
+);
+
+tensor_scalar_roundtrip_test!(
+    tensor_scalar_roundtrip_bool,
+    bool,
+    vec![2],
+    vec![true, false]
 );
 
 tensor_scalar_roundtrip_test!(

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -5,6 +5,12 @@ use crate::{DotGeneralConfig, TensorBackend};
 
 mod accessors;
 mod shape_packing;
+mod strided_view;
+
+pub use strided_view::{
+    StridedSliceSpec, StridedTensorView, StridedTensorViewMut, TypedStridedTensorView,
+    TypedStridedTensorViewMut,
+};
 
 /// Memory location for tensor storage.
 ///
@@ -209,15 +215,17 @@ impl<'a, T> TypedTensorView<'a, T> {
 pub enum DType {
     F32,
     F64,
+    I32,
     I64,
+    Bool,
     C32,
     C64,
 }
 
 /// Sealed trait for scalar types that can be stored in a [`Tensor`].
 ///
-/// This trait is implemented for `f64`, `f32`, `i64`, [`Complex64`], and
-/// [`Complex32`].
+/// This trait is implemented for `f64`, `f32`, `i32`, `i64`, `bool`,
+/// [`Complex64`], and [`Complex32`].
 ///
 /// # Examples
 ///
@@ -285,7 +293,9 @@ mod private {
 
     impl Sealed for f64 {}
     impl Sealed for f32 {}
+    impl Sealed for i32 {}
     impl Sealed for i64 {}
+    impl Sealed for bool {}
     impl Sealed for num_complex::Complex64 {}
     impl Sealed for num_complex::Complex32 {}
 }
@@ -389,6 +399,72 @@ impl TensorScalar for i64 {
     }
 }
 
+impl TensorScalar for i32 {
+    type Real = i32;
+
+    fn dtype() -> DType {
+        DType::I32
+    }
+
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::I32(TypedTensor::from_vec_col_major(shape, data))
+    }
+
+    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
+        match tensor {
+            Tensor::I32(t) => Some(t.host_data()),
+            _ => None,
+        }
+    }
+
+    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
+        match tensor {
+            Tensor::I32(t) => Some(t.host_data_mut()),
+            _ => None,
+        }
+    }
+
+    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
+        match tensor {
+            Tensor::I32(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
+impl TensorScalar for bool {
+    type Real = bool;
+
+    fn dtype() -> DType {
+        DType::Bool
+    }
+
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
+        Tensor::Bool(TypedTensor::from_vec_col_major(shape, data))
+    }
+
+    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
+        match tensor {
+            Tensor::Bool(t) => Some(t.host_data()),
+            _ => None,
+        }
+    }
+
+    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
+        match tensor {
+            Tensor::Bool(t) => Some(t.host_data_mut()),
+            _ => None,
+        }
+    }
+
+    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
+        match tensor {
+            Tensor::Bool(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
 impl TensorScalar for Complex64 {
     type Real = f64;
 
@@ -469,7 +545,9 @@ impl TensorScalar for Complex32 {
 pub enum Tensor {
     F32(TypedTensor<f32>),
     F64(TypedTensor<f64>),
+    I32(TypedTensor<i32>),
     I64(TypedTensor<i64>),
+    Bool(TypedTensor<bool>),
     C32(TypedTensor<Complex<f32>>),
     C64(TypedTensor<Complex<f64>>),
 }
@@ -479,7 +557,9 @@ pub enum Tensor {
 pub enum TensorView<'a> {
     F32(TypedTensorView<'a, f32>),
     F64(TypedTensorView<'a, f64>),
+    I32(TypedTensorView<'a, i32>),
     I64(TypedTensorView<'a, i64>),
+    Bool(TypedTensorView<'a, bool>),
     C32(TypedTensorView<'a, Complex<f32>>),
     C64(TypedTensorView<'a, Complex<f64>>),
 }
@@ -543,6 +623,42 @@ impl From<TypedTensor<i64>> for Tensor {
     }
 }
 
+/// Wrap an `i32` [`TypedTensor`] into the corresponding [`Tensor`] variant.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{DType, Tensor, TypedTensor};
+///
+/// let typed = TypedTensor::from_vec_col_major(vec![2], vec![1_i32, 2]);
+/// let tensor: Tensor = typed.into();
+/// assert_eq!(tensor.dtype(), DType::I32);
+/// assert_eq!(tensor.shape(), &[2]);
+/// ```
+impl From<TypedTensor<i32>> for Tensor {
+    fn from(t: TypedTensor<i32>) -> Self {
+        Tensor::I32(t)
+    }
+}
+
+/// Wrap a `bool` [`TypedTensor`] into the corresponding [`Tensor`] variant.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{DType, Tensor, TypedTensor};
+///
+/// let typed = TypedTensor::from_vec_col_major(vec![2], vec![true, false]);
+/// let tensor: Tensor = typed.into();
+/// assert_eq!(tensor.dtype(), DType::Bool);
+/// assert_eq!(tensor.shape(), &[2]);
+/// ```
+impl From<TypedTensor<bool>> for Tensor {
+    fn from(t: TypedTensor<bool>) -> Self {
+        Tensor::Bool(t)
+    }
+}
+
 /// Wrap a [`Complex64`] [`TypedTensor`] into the corresponding [`Tensor`]
 /// variant.
 ///
@@ -600,6 +716,14 @@ impl<'a> TensorView<'a> {
         Ok(Self::I64(TypedTensorView::new(shape, data)?))
     }
 
+    pub fn i32(shape: &'a [usize], data: &'a [i32]) -> crate::Result<Self> {
+        Ok(Self::I32(TypedTensorView::new(shape, data)?))
+    }
+
+    pub fn bool(shape: &'a [usize], data: &'a [bool]) -> crate::Result<Self> {
+        Ok(Self::Bool(TypedTensorView::new(shape, data)?))
+    }
+
     pub fn c32(shape: &'a [usize], data: &'a [Complex32]) -> crate::Result<Self> {
         Ok(Self::C32(TypedTensorView::new(shape, data)?))
     }
@@ -612,7 +736,9 @@ impl<'a> TensorView<'a> {
         match self {
             Self::F32(_) => DType::F32,
             Self::F64(_) => DType::F64,
+            Self::I32(_) => DType::I32,
             Self::I64(_) => DType::I64,
+            Self::Bool(_) => DType::Bool,
             Self::C32(_) => DType::C32,
             Self::C64(_) => DType::C64,
         }
@@ -622,7 +748,9 @@ impl<'a> TensorView<'a> {
         match self {
             Self::F32(t) => t.shape,
             Self::F64(t) => t.shape,
+            Self::I32(t) => t.shape,
             Self::I64(t) => t.shape,
+            Self::Bool(t) => t.shape,
             Self::C32(t) => t.shape,
             Self::C64(t) => t.shape,
         }
@@ -632,7 +760,9 @@ impl<'a> TensorView<'a> {
         match self {
             Self::F32(t) => Tensor::from_vec_col_major(t.shape.to_vec(), t.data.to_vec()),
             Self::F64(t) => Tensor::from_vec_col_major(t.shape.to_vec(), t.data.to_vec()),
+            Self::I32(t) => Tensor::from_vec_col_major(t.shape.to_vec(), t.data.to_vec()),
             Self::I64(t) => Tensor::from_vec_col_major(t.shape.to_vec(), t.data.to_vec()),
+            Self::Bool(t) => Tensor::from_vec_col_major(t.shape.to_vec(), t.data.to_vec()),
             Self::C32(t) => Tensor::from_vec_col_major(t.shape.to_vec(), t.data.to_vec()),
             Self::C64(t) => Tensor::from_vec_col_major(t.shape.to_vec(), t.data.to_vec()),
         }
@@ -1151,7 +1281,9 @@ impl Tensor {
         match self {
             Tensor::F32(t) => &t.shape,
             Tensor::F64(t) => &t.shape,
+            Tensor::I32(t) => &t.shape,
             Tensor::I64(t) => &t.shape,
+            Tensor::Bool(t) => &t.shape,
             Tensor::C32(t) => &t.shape,
             Tensor::C64(t) => &t.shape,
         }
@@ -1171,7 +1303,9 @@ impl Tensor {
         match self {
             Tensor::F32(_) => DType::F32,
             Tensor::F64(_) => DType::F64,
+            Tensor::I32(_) => DType::I32,
             Tensor::I64(_) => DType::I64,
+            Tensor::Bool(_) => DType::Bool,
             Tensor::C32(_) => DType::C32,
             Tensor::C64(_) => DType::C64,
         }

--- a/tenferro-tensor/src/types/strided_view.rs
+++ b/tenferro-tensor/src/types/strided_view.rs
@@ -1,0 +1,1800 @@
+use num_complex::{Complex32, Complex64};
+use smallvec::SmallVec;
+
+use super::{for_each_index, DType, Tensor, TypedTensor};
+use crate::{Error, Result};
+
+type ShapeVec = SmallVec<[usize; 8]>;
+type StrideVec = SmallVec<[isize; 8]>;
+
+const NEW_OP: &str = "TypedStridedTensorView::new";
+const MUT_NEW_OP: &str = "TypedStridedTensorViewMut::new";
+
+fn invalid_config(op: &'static str, message: impl Into<String>) -> Error {
+    Error::InvalidConfig {
+        op,
+        message: message.into(),
+    }
+}
+
+fn checked_element_count(shape: &[usize], op: &'static str) -> Result<usize> {
+    let mut product = 1usize;
+    for &dim in shape {
+        if dim == 0 {
+            return Ok(0);
+        }
+        product = product.checked_mul(dim).ok_or_else(|| {
+            invalid_config(op, format!("shape product overflows for shape {shape:?}"))
+        })?;
+    }
+    Ok(product)
+}
+
+fn checked_isize(value: usize, op: &'static str, role: &'static str) -> Result<isize> {
+    isize::try_from(value)
+        .map_err(|_| invalid_config(op, format!("{role} value {value} does not fit in isize")))
+}
+
+fn checked_col_major_strides(shape: &[usize], op: &'static str) -> Result<StrideVec> {
+    let mut strides = StrideVec::with_capacity(shape.len());
+    if shape.is_empty() {
+        return Ok(strides);
+    }
+
+    strides.push(1);
+    let mut stride = 1isize;
+    for axis in 1..shape.len() {
+        let prev_extent = checked_isize(shape[axis - 1], op, "shape")?;
+        stride = stride.checked_mul(prev_extent).ok_or_else(|| {
+            invalid_config(
+                op,
+                format!("column-major stride overflows for shape {shape:?}"),
+            )
+        })?;
+        strides.push(stride);
+    }
+    Ok(strides)
+}
+
+fn validate_parts(
+    data_len: usize,
+    shape: &[usize],
+    strides: &[isize],
+    offset: isize,
+    op: &'static str,
+) -> Result<usize> {
+    if shape.len() != strides.len() {
+        return Err(Error::RankMismatch {
+            op,
+            expected: shape.len(),
+            actual: strides.len(),
+        });
+    }
+
+    let element_count = checked_element_count(shape, op)?;
+    let data_bound = checked_isize(data_len, op, "data length")?;
+
+    if element_count == 0 {
+        if (0..=data_bound).contains(&offset) {
+            return Ok(0);
+        }
+        return Err(invalid_config(
+            op,
+            format!("empty view offset {offset} is outside 0..={data_len}"),
+        ));
+    }
+
+    let mut min_offset = offset;
+    let mut max_offset = offset;
+    for (&extent, &stride) in shape.iter().zip(strides) {
+        let steps = checked_isize(extent - 1, op, "shape")?;
+        let end = stride.checked_mul(steps).ok_or_else(|| {
+            invalid_config(
+                op,
+                format!("stride span overflows for extent {extent} and stride {stride}"),
+            )
+        })?;
+        let (axis_min, axis_max) = if end < 0 { (end, 0) } else { (0, end) };
+        min_offset = min_offset
+            .checked_add(axis_min)
+            .ok_or_else(|| invalid_config(op, "minimum reachable offset overflows"))?;
+        max_offset = max_offset
+            .checked_add(axis_max)
+            .ok_or_else(|| invalid_config(op, "maximum reachable offset overflows"))?;
+    }
+
+    if min_offset < 0 || max_offset >= data_bound {
+        return Err(invalid_config(
+            op,
+            format!(
+                "reachable offsets {min_offset}..={max_offset} are outside data length {data_len}"
+            ),
+        ));
+    }
+
+    Ok(element_count)
+}
+
+fn reachable_offset_span(
+    shape: &[usize],
+    strides: &[isize],
+    offset: isize,
+    op: &'static str,
+) -> Result<Option<(usize, usize)>> {
+    let element_count = checked_element_count(shape, op)?;
+    if element_count == 0 {
+        return Ok(None);
+    }
+
+    let mut min_offset = offset;
+    let mut max_offset = offset;
+    for (&extent, &stride) in shape.iter().zip(strides) {
+        let steps = checked_isize(extent - 1, op, "shape")?;
+        let end = stride.checked_mul(steps).ok_or_else(|| {
+            invalid_config(
+                op,
+                format!("stride span overflows for extent {extent} and stride {stride}"),
+            )
+        })?;
+        let (axis_min, axis_max) = if end < 0 { (end, 0) } else { (0, end) };
+        min_offset = min_offset
+            .checked_add(axis_min)
+            .ok_or_else(|| invalid_config(op, "minimum reachable offset overflows"))?;
+        max_offset = max_offset
+            .checked_add(axis_max)
+            .ok_or_else(|| invalid_config(op, "maximum reachable offset overflows"))?;
+    }
+
+    let min_offset = usize::try_from(min_offset)
+        .map_err(|_| invalid_config(op, "minimum reachable offset is negative"))?;
+    let max_offset = usize::try_from(max_offset)
+        .map_err(|_| invalid_config(op, "maximum reachable offset is negative"))?;
+    Ok(Some((min_offset, max_offset)))
+}
+
+fn split_two_mut_ranges<T>(
+    data: &mut [T],
+    first: (usize, usize),
+    second: (usize, usize),
+) -> Option<(&mut [T], &mut [T])> {
+    if first.1 < second.0 {
+        let (_, after_first_start) = data.split_at_mut(first.0);
+        let (first_slice, after_first) = after_first_start.split_at_mut(first.1 - first.0 + 1);
+        let (_, after_gap) = after_first.split_at_mut(second.0 - first.1 - 1);
+        let (second_slice, _) = after_gap.split_at_mut(second.1 - second.0 + 1);
+        Some((first_slice, second_slice))
+    } else if second.1 < first.0 {
+        let (_, after_second_start) = data.split_at_mut(second.0);
+        let (second_slice, after_second) = after_second_start.split_at_mut(second.1 - second.0 + 1);
+        let (_, after_gap) = after_second.split_at_mut(first.0 - second.1 - 1);
+        let (first_slice, _) = after_gap.split_at_mut(first.1 - first.0 + 1);
+        Some((first_slice, second_slice))
+    } else {
+        None
+    }
+}
+
+fn adjusted_offset(offset: isize, span_start: usize, op: &'static str) -> Option<isize> {
+    let span_start = checked_isize(span_start, op, "span start").ok()?;
+    offset.checked_sub(span_start)
+}
+
+fn strides_overlap(shape: &[usize], strides: &[isize]) -> bool {
+    let mut axes = SmallVec::<[usize; 8]>::from_iter(0..shape.len());
+    axes.sort_by_key(|&axis| strides[axis].unsigned_abs());
+
+    let mut sum_prev_offsets = 0usize;
+    for axis in axes {
+        let extent = shape[axis];
+        if extent == 0 {
+            return false;
+        }
+        if extent <= 1 {
+            continue;
+        }
+
+        let stride = strides[axis].unsigned_abs();
+        if stride <= sum_prev_offsets {
+            return true;
+        }
+
+        let Some(axis_span) = (extent - 1).checked_mul(stride) else {
+            return true;
+        };
+        let Some(next_sum) = sum_prev_offsets.checked_add(axis_span) else {
+            return true;
+        };
+        sum_prev_offsets = next_sum;
+    }
+
+    false
+}
+
+fn validate_mut_parts(
+    data_len: usize,
+    shape: &[usize],
+    strides: &[isize],
+    offset: isize,
+    op: &'static str,
+) -> Result<usize> {
+    let element_count = validate_parts(data_len, shape, strides, offset, op)?;
+    if element_count > 0 && strides_overlap(shape, strides) {
+        return Err(invalid_config(
+            op,
+            "mutable strided views must not alias logical elements",
+        ));
+    }
+    Ok(element_count)
+}
+
+fn checked_strided_offset(
+    shape: &[usize],
+    strides: &[isize],
+    base_offset: isize,
+    indices: &[usize],
+) -> Option<usize> {
+    if indices.len() != shape.len() {
+        return None;
+    }
+
+    let mut offset = base_offset;
+    for ((&idx, &extent), &stride) in indices.iter().zip(shape).zip(strides) {
+        if idx >= extent {
+            return None;
+        }
+        let idx = isize::try_from(idx).ok()?;
+        let delta = stride.checked_mul(idx)?;
+        offset = offset.checked_add(delta)?;
+    }
+
+    usize::try_from(offset).ok()
+}
+
+fn validate_permutation(axes: &[usize], rank: usize, op: &'static str) -> Result<()> {
+    if axes.len() != rank {
+        return Err(Error::RankMismatch {
+            op,
+            expected: rank,
+            actual: axes.len(),
+        });
+    }
+
+    let mut seen = SmallVec::<[bool; 8]>::from_elem(false, rank);
+    for &axis in axes {
+        if axis >= rank {
+            return Err(Error::AxisOutOfBounds { op, axis, rank });
+        }
+        if seen[axis] {
+            return Err(Error::DuplicateAxis {
+                op,
+                axis,
+                role: "permutation",
+            });
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn is_col_major_contiguous(shape: &[usize], strides: &[isize], op: &'static str) -> Result<bool> {
+    let mut expected = 1isize;
+    for (&extent, &stride) in shape.iter().zip(strides) {
+        if extent == 0 {
+            return Ok(true);
+        }
+        if extent == 1 {
+            continue;
+        }
+        if stride != expected {
+            return Ok(false);
+        }
+        let extent = checked_isize(extent, op, "shape")?;
+        expected = expected.checked_mul(extent).ok_or_else(|| {
+            invalid_config(
+                op,
+                format!("column-major stride overflows for shape {shape:?}"),
+            )
+        })?;
+    }
+    Ok(true)
+}
+
+fn normalize_bound(
+    bound: isize,
+    extent: usize,
+    op: &'static str,
+    role: &'static str,
+) -> Result<isize> {
+    let extent = checked_isize(extent, op, "shape")?;
+    let bound = if bound < 0 {
+        extent
+            .checked_add(bound)
+            .ok_or_else(|| invalid_config(op, format!("{role} {bound} overflows")))?
+    } else {
+        bound
+    };
+    if !(0..=extent).contains(&bound) {
+        return Err(invalid_config(
+            op,
+            format!("{role} {bound} is outside 0..={extent}"),
+        ));
+    }
+    Ok(bound)
+}
+
+fn normalized_slice(
+    slice: StridedSliceSpec,
+    extent: usize,
+    op: &'static str,
+) -> Result<(usize, isize, isize)> {
+    if slice.step == 0 {
+        return Err(invalid_config(op, "slice step must not be zero"));
+    }
+
+    let start = normalize_bound(slice.start, extent, op, "slice start")?;
+    let end = match slice.end {
+        Some(end) => normalize_bound(end, extent, op, "slice end")?,
+        None => checked_isize(extent, op, "shape")?,
+    };
+    if start >= end {
+        return Ok((0, start, slice.step));
+    }
+
+    let range_len = usize::try_from(end - start)
+        .map_err(|_| invalid_config(op, "slice range length overflows"))?;
+    let step_abs = slice.step.unsigned_abs();
+    let out_extent = range_len.div_ceil(step_abs);
+    let first = if slice.step < 0 { end - 1 } else { start };
+    Ok((out_extent, first, slice.step))
+}
+
+fn permuted_parts(
+    shape: &[usize],
+    strides: &[isize],
+    offset: isize,
+    axes: &[usize],
+    op: &'static str,
+) -> Result<(ShapeVec, StrideVec, isize)> {
+    validate_permutation(axes, shape.len(), op)?;
+
+    let mut next_shape = ShapeVec::with_capacity(axes.len());
+    let mut next_strides = StrideVec::with_capacity(axes.len());
+    for &axis in axes {
+        next_shape.push(shape[axis]);
+        next_strides.push(strides[axis]);
+    }
+    Ok((next_shape, next_strides, offset))
+}
+
+fn sliced_parts(
+    shape: &[usize],
+    strides: &[isize],
+    base_offset: isize,
+    slices: &[StridedSliceSpec],
+    op: &'static str,
+) -> Result<(ShapeVec, StrideVec, isize)> {
+    let rank = shape.len();
+    if slices.len() != rank {
+        return Err(Error::RankMismatch {
+            op,
+            expected: rank,
+            actual: slices.len(),
+        });
+    }
+
+    let mut offset = base_offset;
+    let mut next_shape = ShapeVec::with_capacity(rank);
+    let mut next_strides = StrideVec::with_capacity(rank);
+    for (axis, slice) in slices.iter().copied().enumerate() {
+        let (out_extent, first, step) = normalized_slice(slice, shape[axis], op)?;
+        let start_delta = strides[axis]
+            .checked_mul(first)
+            .ok_or_else(|| invalid_config(op, "slice offset delta overflows"))?;
+        offset = offset
+            .checked_add(start_delta)
+            .ok_or_else(|| invalid_config(op, "slice offset overflows"))?;
+        let stride = strides[axis]
+            .checked_mul(step)
+            .ok_or_else(|| invalid_config(op, "slice stride overflows"))?;
+        next_shape.push(out_extent);
+        next_strides.push(stride);
+    }
+
+    Ok((next_shape, next_strides, offset))
+}
+
+fn slice_axis_specs(
+    rank: usize,
+    axis: usize,
+    slice: StridedSliceSpec,
+    op: &'static str,
+) -> Result<SmallVec<[StridedSliceSpec; 8]>> {
+    if axis >= rank {
+        return Err(Error::AxisOutOfBounds { op, axis, rank });
+    }
+
+    let mut slices = SmallVec::<[StridedSliceSpec; 8]>::from_elem(StridedSliceSpec::all(), rank);
+    slices[axis] = slice;
+    Ok(slices)
+}
+
+fn reshaped_strides(
+    current_shape: &[usize],
+    current_strides: &[isize],
+    current_n_elements: usize,
+    next_shape: &[usize],
+    op: &'static str,
+) -> Result<StrideVec> {
+    let next_count = checked_element_count(next_shape, op)?;
+    if current_n_elements != next_count {
+        return Err(invalid_config(
+            op,
+            format!(
+                "element count mismatch: current shape {:?} has {}, requested shape {:?} has {}",
+                current_shape, current_n_elements, next_shape, next_count
+            ),
+        ));
+    }
+    if current_n_elements > 1 && !is_col_major_contiguous(current_shape, current_strides, op)? {
+        return Err(invalid_config(
+            op,
+            "reshape without materialization requires a contiguous column-major view",
+        ));
+    }
+
+    checked_col_major_strides(next_shape, op)
+}
+
+/// One-axis slice specification for [`TypedStridedTensorView::try_slice`].
+///
+/// This follows ndarray's range-with-step model: negative `start` or `end`
+/// values count from the end of the axis, `end` is exclusive, and negative
+/// `step` reverses the selected range before stepping.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::StridedSliceSpec;
+///
+/// let every_other_reversed = StridedSliceSpec::new(0, None, -2);
+/// assert_eq!(every_other_reversed.step(), -2);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StridedSliceSpec {
+    start: isize,
+    end: Option<isize>,
+    step: isize,
+}
+
+impl StridedSliceSpec {
+    /// Create a slice from a signed start, optional exclusive end, and step.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedSliceSpec;
+    ///
+    /// let slice = StridedSliceSpec::new(1, Some(-1), 1);
+    /// assert_eq!(slice.start(), 1);
+    /// assert_eq!(slice.end(), Some(-1));
+    /// ```
+    pub fn new(start: isize, end: Option<isize>, step: isize) -> Self {
+        Self { start, end, step }
+    }
+
+    /// Select the full axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedSliceSpec;
+    ///
+    /// assert_eq!(StridedSliceSpec::all(), StridedSliceSpec::new(0, None, 1));
+    /// ```
+    pub fn all() -> Self {
+        Self::new(0, None, 1)
+    }
+
+    /// Select the full axis in reverse order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedSliceSpec;
+    ///
+    /// assert_eq!(StridedSliceSpec::reverse(), StridedSliceSpec::new(0, None, -1));
+    /// ```
+    pub fn reverse() -> Self {
+        Self::new(0, None, -1)
+    }
+
+    /// Return the signed start bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedSliceSpec;
+    ///
+    /// assert_eq!(StridedSliceSpec::new(-3, None, 1).start(), -3);
+    /// ```
+    pub fn start(&self) -> isize {
+        self.start
+    }
+
+    /// Return the optional signed exclusive end bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedSliceSpec;
+    ///
+    /// assert_eq!(StridedSliceSpec::new(0, Some(2), 1).end(), Some(2));
+    /// ```
+    pub fn end(&self) -> Option<isize> {
+        self.end
+    }
+
+    /// Return the signed step.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedSliceSpec;
+    ///
+    /// assert_eq!(StridedSliceSpec::reverse().step(), -1);
+    /// ```
+    pub fn step(&self) -> isize {
+        self.step
+    }
+}
+
+/// Borrowed read-only view of host tensor data with arbitrary logical strides.
+///
+/// This is an adapter type for external host layouts such as row-major,
+/// sliced, transposed, or reversed arrays. It does not change tenferro's
+/// canonical compute representation: owned [`TypedTensor`] values and
+/// [`super::TypedTensorView`] remain contiguous column-major.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::TypedStridedTensorView;
+///
+/// let row_major = [1.0_f64, 2.0, 3.0, 4.0];
+/// let view = TypedStridedTensorView::new(&[2, 2], &[2, 1], 0, &row_major).unwrap();
+///
+/// assert_eq!(view.get(&[1, 0]), Some(&3.0));
+/// ```
+#[derive(Clone, Debug)]
+pub struct TypedStridedTensorView<'a, T> {
+    data: &'a [T],
+    shape: ShapeVec,
+    strides: StrideVec,
+    offset: isize,
+    n_elements: usize,
+}
+
+impl<'a, T> TypedStridedTensorView<'a, T> {
+    /// Create a borrowed strided host view.
+    ///
+    /// `offset` and `strides` are measured in elements, not bytes. Negative
+    /// strides are supported when every reachable element remains inside
+    /// `data`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [1_i32, 2, 3, 4, 5, 6];
+    /// let view = TypedStridedTensorView::new(&[2, 3], &[3, 1], 0, &data).unwrap();
+    ///
+    /// assert_eq!(view.get(&[1, 2]), Some(&6));
+    /// ```
+    pub fn new(shape: &[usize], strides: &[isize], offset: isize, data: &'a [T]) -> Result<Self> {
+        let n_elements = validate_parts(data.len(), shape, strides, offset, NEW_OP)?;
+        Ok(Self {
+            data,
+            shape: ShapeVec::from_slice(shape),
+            strides: StrideVec::from_slice(strides),
+            offset,
+            n_elements,
+        })
+    }
+
+    /// Create a strided view over contiguous column-major data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [1.0_f64, 2.0, 3.0, 4.0];
+    /// let view = TypedStridedTensorView::from_col_major(&[2, 2], &data).unwrap();
+    ///
+    /// assert_eq!(view.strides(), &[1, 2]);
+    /// ```
+    pub fn from_col_major(shape: &[usize], data: &'a [T]) -> Result<Self> {
+        let strides = checked_col_major_strides(shape, "TypedStridedTensorView::from_col_major")?;
+        Self::new(shape, &strides, 0, data)
+    }
+
+    /// Return the logical shape.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [true, false];
+    /// let view = TypedStridedTensorView::new(&[2], &[1], 0, &data).unwrap();
+    /// assert_eq!(view.shape(), &[2]);
+    /// ```
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Return the logical strides measured in elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [1, 2, 3];
+    /// let view = TypedStridedTensorView::new(&[3], &[-1], 2, &data).unwrap();
+    /// assert_eq!(view.strides(), &[-1]);
+    /// ```
+    pub fn strides(&self) -> &[isize] {
+        &self.strides
+    }
+
+    /// Return the physical starting offset measured in elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [1, 2, 3];
+    /// let view = TypedStridedTensorView::new(&[2], &[1], 1, &data).unwrap();
+    /// assert_eq!(view.offset(), 1);
+    /// ```
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+
+    /// Return the borrowed physical host slice backing this view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [1, 2];
+    /// let view = TypedStridedTensorView::new(&[2], &[1], 0, &data).unwrap();
+    /// assert_eq!(view.as_physical_slice(), &[1, 2]);
+    /// ```
+    pub fn as_physical_slice(&self) -> &'a [T] {
+        self.data
+    }
+
+    /// Return the number of logical elements in the view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [0; 6];
+    /// let view = TypedStridedTensorView::new(&[2, 3], &[1, 2], 0, &data).unwrap();
+    /// assert_eq!(view.n_elements(), 6);
+    /// ```
+    pub fn n_elements(&self) -> usize {
+        self.n_elements
+    }
+
+    /// Compute the physical element offset for a logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [1, 2, 3];
+    /// let view = TypedStridedTensorView::new(&[3], &[-1], 2, &data).unwrap();
+    /// assert_eq!(view.try_linear_offset(&[2]), Some(0));
+    /// ```
+    pub fn try_linear_offset(&self, indices: &[usize]) -> Option<usize> {
+        checked_strided_offset(&self.shape, &self.strides, self.offset, indices)
+    }
+
+    /// Borrow one element by logical multi-index.
+    ///
+    /// Returns `None` when the rank or any index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [1, 2, 3];
+    /// let view = TypedStridedTensorView::new(&[3], &[1], 0, &data).unwrap();
+    /// assert_eq!(view.get(&[1]), Some(&2));
+    /// assert_eq!(view.get(&[3]), None);
+    /// ```
+    pub fn get(&self, indices: &[usize]) -> Option<&T> {
+        let offset = self.try_linear_offset(indices)?;
+        self.data.get(offset)
+    }
+
+    /// Explicit alias for [`TypedStridedTensorView::get`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [1, 2];
+    /// let view = TypedStridedTensorView::new(&[2], &[1], 0, &data).unwrap();
+    /// assert_eq!(view.try_get(&[0]), Some(&1));
+    /// ```
+    pub fn try_get(&self, indices: &[usize]) -> Option<&T> {
+        self.get(indices)
+    }
+
+    /// Return a metadata-only view with axes permuted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [1, 2, 3, 4, 5, 6];
+    /// let view = TypedStridedTensorView::new(&[2, 3], &[3, 1], 0, &data).unwrap();
+    /// let transposed = view.try_permute_axes(&[1, 0]).unwrap();
+    ///
+    /// assert_eq!(transposed.shape(), &[3, 2]);
+    /// assert_eq!(transposed.get(&[2, 1]), Some(&6));
+    /// ```
+    pub fn try_permute_axes(&self, axes: &[usize]) -> Result<Self> {
+        const OP: &str = "TypedStridedTensorView::try_permute_axes";
+        let (shape, strides, offset) =
+            permuted_parts(&self.shape, &self.strides, self.offset, axes, OP)?;
+        Self::new(&shape, &strides, offset, self.data)
+    }
+
+    /// Return a metadata-only slice using one [`StridedSliceSpec`] per axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{StridedSliceSpec, TypedStridedTensorView};
+    ///
+    /// let data = [0, 1, 2, 3];
+    /// let view = TypedStridedTensorView::new(&[4], &[1], 0, &data).unwrap();
+    /// let sliced = view.try_slice(&[StridedSliceSpec::new(0, None, -2)]).unwrap();
+    ///
+    /// assert_eq!(sliced.shape(), &[2]);
+    /// assert_eq!(sliced.materialize_col_major().unwrap().as_slice(), &[3, 1]);
+    /// ```
+    pub fn try_slice(&self, slices: &[StridedSliceSpec]) -> Result<Self> {
+        const OP: &str = "TypedStridedTensorView::try_slice";
+        let (shape, strides, offset) =
+            sliced_parts(&self.shape, &self.strides, self.offset, slices, OP)?;
+        Self::new(&shape, &strides, offset, self.data)
+    }
+
+    /// Return a metadata-only slice along a single axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{StridedSliceSpec, TypedStridedTensorView};
+    ///
+    /// let data = [1, 2, 3, 4];
+    /// let view = TypedStridedTensorView::new(&[2, 2], &[1, 2], 0, &data).unwrap();
+    /// let sliced = view.try_slice_axis(1, StridedSliceSpec::reverse()).unwrap();
+    ///
+    /// assert_eq!(sliced.get(&[0, 0]), Some(&3));
+    /// ```
+    pub fn try_slice_axis(&self, axis: usize, slice: StridedSliceSpec) -> Result<Self> {
+        const OP: &str = "TypedStridedTensorView::try_slice_axis";
+        let slices = slice_axis_specs(self.shape.len(), axis, slice, OP)?;
+        self.try_slice(&slices)
+    }
+
+    /// Return a metadata-only reshape when the current view is representable
+    /// as contiguous column-major logical storage.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let data = [1, 2, 3, 4];
+    /// let view = TypedStridedTensorView::from_col_major(&[2, 2], &data).unwrap();
+    /// let reshaped = view.try_reshape(&[4]).unwrap();
+    ///
+    /// assert_eq!(reshaped.shape(), &[4]);
+    /// ```
+    pub fn try_reshape(&self, shape: &[usize]) -> Result<Self> {
+        const OP: &str = "TypedStridedTensorView::try_reshape";
+        let strides = reshaped_strides(&self.shape, &self.strides, self.n_elements, shape, OP)?;
+        Self::new(shape, &strides, self.offset, self.data)
+    }
+}
+
+impl<T: Clone> TypedStridedTensorView<'_, T> {
+    /// Materialize this adapter view into tenferro's canonical column-major
+    /// owned tensor representation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorView;
+    ///
+    /// let row_major = [1.0_f64, 2.0, 3.0, 4.0];
+    /// let view = TypedStridedTensorView::new(&[2, 2], &[2, 1], 0, &row_major).unwrap();
+    /// let tensor = view.materialize_col_major().unwrap();
+    ///
+    /// assert_eq!(tensor.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
+    /// ```
+    pub fn materialize_col_major(&self) -> Result<TypedTensor<T>> {
+        let mut data = Vec::with_capacity(self.n_elements);
+        let mut error = None;
+        for_each_index(&self.shape, |index| match self.get(index) {
+            Some(value) => data.push(value.clone()),
+            None => {
+                if error.is_none() {
+                    error = Some(invalid_config(
+                        "TypedStridedTensorView::materialize_col_major",
+                        format!("validated index {index:?} was not reachable"),
+                    ));
+                }
+            }
+        });
+        if let Some(error) = error {
+            return Err(error);
+        }
+        Ok(TypedTensor::from_vec_col_major(self.shape.to_vec(), data))
+    }
+}
+
+/// Borrowed mutable view of host tensor data with arbitrary logical strides.
+///
+/// Mutable strided views reject layouts where two logical indices can refer to
+/// the same backing element. This mirrors ndarray's mutable view invariant:
+/// read-only views may alias, but mutable views must not expose overlapping
+/// logical elements.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::TypedStridedTensorViewMut;
+///
+/// let mut row_major = [1_i32, 2, 3, 4];
+/// let mut view = TypedStridedTensorViewMut::new(&[2, 2], &[2, 1], 0, &mut row_major).unwrap();
+///
+/// *view.get_mut(&[1, 0]).unwrap() = 40;
+/// assert_eq!(view.as_physical_slice(), &[1, 2, 40, 4]);
+/// ```
+#[derive(Debug)]
+pub struct TypedStridedTensorViewMut<'a, T> {
+    data: &'a mut [T],
+    shape: ShapeVec,
+    strides: StrideVec,
+    offset: isize,
+    n_elements: usize,
+}
+
+impl<'a, T> TypedStridedTensorViewMut<'a, T> {
+    /// Create a borrowed mutable strided host view.
+    ///
+    /// `offset` and `strides` are measured in elements, not bytes. Negative
+    /// strides are supported when every reachable element remains inside
+    /// `data`. Layouts with overlapping logical elements are rejected.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1_i32, 2, 3];
+    /// let mut view = TypedStridedTensorViewMut::new(&[3], &[-1], 2, &mut data).unwrap();
+    ///
+    /// *view.get_mut(&[2]).unwrap() = 10;
+    /// assert_eq!(view.as_physical_slice(), &[10, 2, 3]);
+    /// ```
+    pub fn new(
+        shape: &[usize],
+        strides: &[isize],
+        offset: isize,
+        data: &'a mut [T],
+    ) -> Result<Self> {
+        let n_elements = validate_mut_parts(data.len(), shape, strides, offset, MUT_NEW_OP)?;
+        Ok(Self {
+            data,
+            shape: ShapeVec::from_slice(shape),
+            strides: StrideVec::from_slice(strides),
+            offset,
+            n_elements,
+        })
+    }
+
+    /// Create a mutable view over contiguous column-major data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1.0_f64, 2.0, 3.0, 4.0];
+    /// let view = TypedStridedTensorViewMut::from_col_major(&[2, 2], &mut data).unwrap();
+    ///
+    /// assert_eq!(view.strides(), &[1, 2]);
+    /// ```
+    pub fn from_col_major(shape: &[usize], data: &'a mut [T]) -> Result<Self> {
+        let strides =
+            checked_col_major_strides(shape, "TypedStridedTensorViewMut::from_col_major")?;
+        Self::new(shape, &strides, 0, data)
+    }
+
+    /// Return the logical shape.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [true, false];
+    /// let view = TypedStridedTensorViewMut::new(&[2], &[1], 0, &mut data).unwrap();
+    /// assert_eq!(view.shape(), &[2]);
+    /// ```
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Return the logical strides measured in elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2, 3];
+    /// let view = TypedStridedTensorViewMut::new(&[3], &[-1], 2, &mut data).unwrap();
+    /// assert_eq!(view.strides(), &[-1]);
+    /// ```
+    pub fn strides(&self) -> &[isize] {
+        &self.strides
+    }
+
+    /// Return the physical starting offset measured in elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2, 3];
+    /// let view = TypedStridedTensorViewMut::new(&[2], &[1], 1, &mut data).unwrap();
+    /// assert_eq!(view.offset(), 1);
+    /// ```
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+
+    /// Return the borrowed physical host slice backing this view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2];
+    /// let view = TypedStridedTensorViewMut::new(&[2], &[1], 0, &mut data).unwrap();
+    /// assert_eq!(view.as_physical_slice(), &[1, 2]);
+    /// ```
+    pub fn as_physical_slice(&self) -> &[T] {
+        self.data
+    }
+
+    /// Mutably borrow the physical host slice backing this view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2];
+    /// let mut view = TypedStridedTensorViewMut::new(&[2], &[1], 0, &mut data).unwrap();
+    /// view.as_physical_slice_mut()[0] = 3;
+    /// assert_eq!(view.get(&[0]), Some(&3));
+    /// ```
+    pub fn as_physical_slice_mut(&mut self) -> &mut [T] {
+        self.data
+    }
+
+    /// Return the number of logical elements in the view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [0; 6];
+    /// let view = TypedStridedTensorViewMut::new(&[2, 3], &[1, 2], 0, &mut data).unwrap();
+    /// assert_eq!(view.n_elements(), 6);
+    /// ```
+    pub fn n_elements(&self) -> usize {
+        self.n_elements
+    }
+
+    /// Compute the physical element offset for a logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2, 3];
+    /// let view = TypedStridedTensorViewMut::new(&[3], &[-1], 2, &mut data).unwrap();
+    /// assert_eq!(view.try_linear_offset(&[2]), Some(0));
+    /// ```
+    pub fn try_linear_offset(&self, indices: &[usize]) -> Option<usize> {
+        checked_strided_offset(&self.shape, &self.strides, self.offset, indices)
+    }
+
+    /// Borrow one element by logical multi-index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2, 3];
+    /// let view = TypedStridedTensorViewMut::new(&[3], &[1], 0, &mut data).unwrap();
+    /// assert_eq!(view.get(&[1]), Some(&2));
+    /// ```
+    pub fn get(&self, indices: &[usize]) -> Option<&T> {
+        let offset = self.try_linear_offset(indices)?;
+        self.data.get(offset)
+    }
+
+    /// Mutably borrow one element by logical multi-index.
+    ///
+    /// Returns `None` when the rank or any index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2, 3];
+    /// let mut view = TypedStridedTensorViewMut::new(&[3], &[1], 0, &mut data).unwrap();
+    /// *view.get_mut(&[1]).unwrap() = 20;
+    /// assert_eq!(view.as_physical_slice(), &[1, 20, 3]);
+    /// ```
+    pub fn get_mut(&mut self, indices: &[usize]) -> Option<&mut T> {
+        let offset = self.try_linear_offset(indices)?;
+        self.data.get_mut(offset)
+    }
+
+    /// Explicit alias for [`TypedStridedTensorViewMut::get`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2];
+    /// let view = TypedStridedTensorViewMut::new(&[2], &[1], 0, &mut data).unwrap();
+    /// assert_eq!(view.try_get(&[0]), Some(&1));
+    /// ```
+    pub fn try_get(&self, indices: &[usize]) -> Option<&T> {
+        self.get(indices)
+    }
+
+    /// Explicit alias for [`TypedStridedTensorViewMut::get_mut`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2];
+    /// let mut view = TypedStridedTensorViewMut::new(&[2], &[1], 0, &mut data).unwrap();
+    /// *view.try_get_mut(&[0]).unwrap() = 3;
+    /// assert_eq!(view.as_physical_slice(), &[3, 2]);
+    /// ```
+    pub fn try_get_mut(&mut self, indices: &[usize]) -> Option<&mut T> {
+        self.get_mut(indices)
+    }
+
+    /// Borrow this mutable view as a read-only strided view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2];
+    /// let view = TypedStridedTensorViewMut::new(&[2], &[1], 0, &mut data).unwrap();
+    /// assert_eq!(view.as_read_only().get(&[1]), Some(&2));
+    /// ```
+    pub fn as_read_only(&self) -> TypedStridedTensorView<'_, T> {
+        TypedStridedTensorView {
+            data: self.data,
+            shape: self.shape.clone(),
+            strides: self.strides.clone(),
+            offset: self.offset,
+            n_elements: self.n_elements,
+        }
+    }
+
+    /// Convert this mutable view into a read-only strided view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2];
+    /// let view = TypedStridedTensorViewMut::new(&[2], &[1], 0, &mut data).unwrap();
+    /// let read_only = view.into_read_only();
+    /// assert_eq!(read_only.get(&[0]), Some(&1));
+    /// ```
+    pub fn into_read_only(self) -> TypedStridedTensorView<'a, T> {
+        TypedStridedTensorView {
+            data: self.data,
+            shape: self.shape,
+            strides: self.strides,
+            offset: self.offset,
+            n_elements: self.n_elements,
+        }
+    }
+
+    /// Return a mutable metadata-only view with axes permuted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2, 3, 4, 5, 6];
+    /// let mut view = TypedStridedTensorViewMut::new(&[2, 3], &[3, 1], 0, &mut data).unwrap();
+    /// {
+    ///     let mut transposed = view.try_permute_axes(&[1, 0]).unwrap();
+    ///     *transposed.get_mut(&[2, 1]).unwrap() = 60;
+    /// }
+    /// assert_eq!(view.get(&[1, 2]), Some(&60));
+    /// ```
+    pub fn try_permute_axes(&mut self, axes: &[usize]) -> Result<TypedStridedTensorViewMut<'_, T>> {
+        const OP: &str = "TypedStridedTensorViewMut::try_permute_axes";
+        let (shape, strides, offset) =
+            permuted_parts(&self.shape, &self.strides, self.offset, axes, OP)?;
+        TypedStridedTensorViewMut::new(&shape, &strides, offset, &mut *self.data)
+    }
+
+    /// Return a mutable metadata-only slice using one [`StridedSliceSpec`] per axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{StridedSliceSpec, TypedStridedTensorViewMut};
+    ///
+    /// let mut data = [0, 1, 2, 3];
+    /// let mut view = TypedStridedTensorViewMut::new(&[4], &[1], 0, &mut data).unwrap();
+    /// {
+    ///     let mut sliced = view.try_slice(&[StridedSliceSpec::new(0, None, -2)]).unwrap();
+    ///     *sliced.get_mut(&[0]).unwrap() = 30;
+    /// }
+    /// assert_eq!(view.as_physical_slice(), &[0, 1, 2, 30]);
+    /// ```
+    pub fn try_slice(
+        &mut self,
+        slices: &[StridedSliceSpec],
+    ) -> Result<TypedStridedTensorViewMut<'_, T>> {
+        const OP: &str = "TypedStridedTensorViewMut::try_slice";
+        let (shape, strides, offset) =
+            sliced_parts(&self.shape, &self.strides, self.offset, slices, OP)?;
+        TypedStridedTensorViewMut::new(&shape, &strides, offset, &mut *self.data)
+    }
+
+    /// Return two mutable metadata-only slices when their physical offset
+    /// ranges are disjoint.
+    ///
+    /// This returns `None` instead of panicking when either slice spec is
+    /// invalid or the selected physical ranges overlap.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{StridedSliceSpec, TypedStridedTensorViewMut};
+    ///
+    /// let mut data = [1, 2, 3, 4];
+    /// let mut view = TypedStridedTensorViewMut::new(&[4], &[1], 0, &mut data).unwrap();
+    /// {
+    ///     let (mut left, mut right) = view
+    ///         .try_multi_slice_mut(
+    ///             &[StridedSliceSpec::new(0, Some(2), 1)],
+    ///             &[StridedSliceSpec::new(2, Some(4), 1)],
+    ///         )
+    ///         .unwrap();
+    ///     *left.get_mut(&[1]).unwrap() = 20;
+    ///     *right.get_mut(&[0]).unwrap() = 30;
+    /// }
+    /// assert_eq!(view.as_physical_slice(), &[1, 20, 30, 4]);
+    /// ```
+    pub fn try_multi_slice_mut(
+        &mut self,
+        first: &[StridedSliceSpec],
+        second: &[StridedSliceSpec],
+    ) -> Option<(
+        TypedStridedTensorViewMut<'_, T>,
+        TypedStridedTensorViewMut<'_, T>,
+    )> {
+        const OP: &str = "TypedStridedTensorViewMut::try_multi_slice_mut";
+        let (first_shape, first_strides, first_offset) =
+            sliced_parts(&self.shape, &self.strides, self.offset, first, OP).ok()?;
+        let (second_shape, second_strides, second_offset) =
+            sliced_parts(&self.shape, &self.strides, self.offset, second, OP).ok()?;
+
+        validate_mut_parts(
+            self.data.len(),
+            &first_shape,
+            &first_strides,
+            first_offset,
+            OP,
+        )
+        .ok()?;
+        validate_mut_parts(
+            self.data.len(),
+            &second_shape,
+            &second_strides,
+            second_offset,
+            OP,
+        )
+        .ok()?;
+
+        match (
+            reachable_offset_span(&first_shape, &first_strides, first_offset, OP).ok()?,
+            reachable_offset_span(&second_shape, &second_strides, second_offset, OP).ok()?,
+        ) {
+            (Some(first_span), Some(second_span)) => {
+                let first_offset = adjusted_offset(first_offset, first_span.0, OP)?;
+                let second_offset = adjusted_offset(second_offset, second_span.0, OP)?;
+                let (first_data, second_data) =
+                    split_two_mut_ranges(&mut *self.data, first_span, second_span)?;
+                let first_view = TypedStridedTensorViewMut::new(
+                    &first_shape,
+                    &first_strides,
+                    first_offset,
+                    first_data,
+                )
+                .ok()?;
+                let second_view = TypedStridedTensorViewMut::new(
+                    &second_shape,
+                    &second_strides,
+                    second_offset,
+                    second_data,
+                )
+                .ok()?;
+                Some((first_view, second_view))
+            }
+            (None, Some(second_span)) => {
+                let (_, after_second_start) = self.data.split_at_mut(second_span.0);
+                let (second_data, _) =
+                    after_second_start.split_at_mut(second_span.1 - second_span.0 + 1);
+                let second_offset = adjusted_offset(second_offset, second_span.0, OP)?;
+                let first_view =
+                    TypedStridedTensorViewMut::new(&first_shape, &first_strides, 0, &mut [])
+                        .ok()?;
+                let second_view = TypedStridedTensorViewMut::new(
+                    &second_shape,
+                    &second_strides,
+                    second_offset,
+                    second_data,
+                )
+                .ok()?;
+                Some((first_view, second_view))
+            }
+            (Some(first_span), None) => {
+                let (_, after_first_start) = self.data.split_at_mut(first_span.0);
+                let (first_data, _) =
+                    after_first_start.split_at_mut(first_span.1 - first_span.0 + 1);
+                let first_offset = adjusted_offset(first_offset, first_span.0, OP)?;
+                let first_view = TypedStridedTensorViewMut::new(
+                    &first_shape,
+                    &first_strides,
+                    first_offset,
+                    first_data,
+                )
+                .ok()?;
+                let second_view =
+                    TypedStridedTensorViewMut::new(&second_shape, &second_strides, 0, &mut [])
+                        .ok()?;
+                Some((first_view, second_view))
+            }
+            (None, None) => {
+                let first_view =
+                    TypedStridedTensorViewMut::new(&first_shape, &first_strides, 0, &mut [])
+                        .ok()?;
+                let second_view =
+                    TypedStridedTensorViewMut::new(&second_shape, &second_strides, 0, &mut [])
+                        .ok()?;
+                Some((first_view, second_view))
+            }
+        }
+    }
+
+    /// Return a mutable metadata-only slice along a single axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{StridedSliceSpec, TypedStridedTensorViewMut};
+    ///
+    /// let mut data = [1, 2, 3, 4];
+    /// let mut view = TypedStridedTensorViewMut::new(&[2, 2], &[1, 2], 0, &mut data).unwrap();
+    /// {
+    ///     let mut sliced = view.try_slice_axis(1, StridedSliceSpec::reverse()).unwrap();
+    ///     *sliced.get_mut(&[0, 0]).unwrap() = 30;
+    /// }
+    /// assert_eq!(view.get(&[0, 1]), Some(&30));
+    /// ```
+    pub fn try_slice_axis(
+        &mut self,
+        axis: usize,
+        slice: StridedSliceSpec,
+    ) -> Result<TypedStridedTensorViewMut<'_, T>> {
+        const OP: &str = "TypedStridedTensorViewMut::try_slice_axis";
+        let slices = slice_axis_specs(self.shape.len(), axis, slice, OP)?;
+        self.try_slice(&slices)
+    }
+
+    /// Return a mutable metadata-only reshape for contiguous column-major views.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut data = [1, 2, 3, 4];
+    /// let mut view = TypedStridedTensorViewMut::from_col_major(&[2, 2], &mut data).unwrap();
+    /// let reshaped = view.try_reshape(&[4]).unwrap();
+    ///
+    /// assert_eq!(reshaped.shape(), &[4]);
+    /// ```
+    pub fn try_reshape(&mut self, shape: &[usize]) -> Result<TypedStridedTensorViewMut<'_, T>> {
+        const OP: &str = "TypedStridedTensorViewMut::try_reshape";
+        let strides = reshaped_strides(&self.shape, &self.strides, self.n_elements, shape, OP)?;
+        TypedStridedTensorViewMut::new(shape, &strides, self.offset, &mut *self.data)
+    }
+}
+
+impl<T: Clone> TypedStridedTensorViewMut<'_, T> {
+    /// Materialize this mutable adapter view into tenferro's canonical
+    /// column-major owned tensor representation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::TypedStridedTensorViewMut;
+    ///
+    /// let mut row_major = [1.0_f64, 2.0, 3.0, 4.0];
+    /// let view = TypedStridedTensorViewMut::new(&[2, 2], &[2, 1], 0, &mut row_major).unwrap();
+    /// let tensor = view.materialize_col_major().unwrap();
+    ///
+    /// assert_eq!(tensor.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
+    /// ```
+    pub fn materialize_col_major(&self) -> Result<TypedTensor<T>> {
+        self.as_read_only().materialize_col_major()
+    }
+}
+
+/// Dynamic borrowed strided host tensor view.
+///
+/// The dynamic view supports all dtypes represented by tenferro's compute
+/// [`Tensor`], including `bool` and `i32`.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{DType, StridedTensorView};
+///
+/// let data = [true, false];
+/// let view = StridedTensorView::bool(&[2], &[1], 0, &data).unwrap();
+///
+/// assert_eq!(view.dtype(), DType::Bool);
+/// ```
+#[derive(Clone, Debug)]
+pub enum StridedTensorView<'a> {
+    F32(TypedStridedTensorView<'a, f32>),
+    F64(TypedStridedTensorView<'a, f64>),
+    I32(TypedStridedTensorView<'a, i32>),
+    I64(TypedStridedTensorView<'a, i64>),
+    Bool(TypedStridedTensorView<'a, bool>),
+    C32(TypedStridedTensorView<'a, Complex32>),
+    C64(TypedStridedTensorView<'a, Complex64>),
+}
+
+macro_rules! strided_view_ctor {
+    ($name:ident, $variant:ident, $ty:ty, $dtype:ident) => {
+        #[doc = concat!("Create a dynamic `", stringify!($dtype), "` strided view.")]
+        pub fn $name(
+            shape: &[usize],
+            strides: &[isize],
+            offset: isize,
+            data: &'a [$ty],
+        ) -> Result<Self> {
+            Ok(Self::$variant(TypedStridedTensorView::new(
+                shape, strides, offset, data,
+            )?))
+        }
+    };
+}
+
+impl<'a> StridedTensorView<'a> {
+    strided_view_ctor!(f32, F32, f32, F32);
+    strided_view_ctor!(f64, F64, f64, F64);
+    strided_view_ctor!(i32, I32, i32, I32);
+    strided_view_ctor!(i64, I64, i64, I64);
+    strided_view_ctor!(bool, Bool, bool, Bool);
+    strided_view_ctor!(c32, C32, Complex32, C32);
+    strided_view_ctor!(c64, C64, Complex64, C64);
+
+    /// Return the view dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{DType, StridedTensorView};
+    ///
+    /// let data = [1_i32, 2];
+    /// let view = StridedTensorView::i32(&[2], &[1], 0, &data).unwrap();
+    /// assert_eq!(view.dtype(), DType::I32);
+    /// ```
+    pub fn dtype(&self) -> DType {
+        match self {
+            Self::F32(_) => DType::F32,
+            Self::F64(_) => DType::F64,
+            Self::I32(_) => DType::I32,
+            Self::I64(_) => DType::I64,
+            Self::Bool(_) => DType::Bool,
+            Self::C32(_) => DType::C32,
+            Self::C64(_) => DType::C64,
+        }
+    }
+
+    /// Return the logical shape.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedTensorView;
+    ///
+    /// let data = [1.0_f64, 2.0];
+    /// let view = StridedTensorView::f64(&[2], &[1], 0, &data).unwrap();
+    /// assert_eq!(view.shape(), &[2]);
+    /// ```
+    pub fn shape(&self) -> &[usize] {
+        match self {
+            Self::F32(t) => t.shape(),
+            Self::F64(t) => t.shape(),
+            Self::I32(t) => t.shape(),
+            Self::I64(t) => t.shape(),
+            Self::Bool(t) => t.shape(),
+            Self::C32(t) => t.shape(),
+            Self::C64(t) => t.shape(),
+        }
+    }
+
+    /// Return the logical strides measured in elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedTensorView;
+    ///
+    /// let data = [1_i64, 2];
+    /// let view = StridedTensorView::i64(&[2], &[1], 0, &data).unwrap();
+    /// assert_eq!(view.strides(), &[1]);
+    /// ```
+    pub fn strides(&self) -> &[isize] {
+        match self {
+            Self::F32(t) => t.strides(),
+            Self::F64(t) => t.strides(),
+            Self::I32(t) => t.strides(),
+            Self::I64(t) => t.strides(),
+            Self::Bool(t) => t.strides(),
+            Self::C32(t) => t.strides(),
+            Self::C64(t) => t.strides(),
+        }
+    }
+
+    /// Return the physical starting offset measured in elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedTensorView;
+    ///
+    /// let data = [1.0_f32, 2.0];
+    /// let view = StridedTensorView::f32(&[1], &[1], 1, &data).unwrap();
+    /// assert_eq!(view.offset(), 1);
+    /// ```
+    pub fn offset(&self) -> isize {
+        match self {
+            Self::F32(t) => t.offset(),
+            Self::F64(t) => t.offset(),
+            Self::I32(t) => t.offset(),
+            Self::I64(t) => t.offset(),
+            Self::Bool(t) => t.offset(),
+            Self::C32(t) => t.offset(),
+            Self::C64(t) => t.offset(),
+        }
+    }
+
+    /// Materialize this dynamic view into tenferro's compute [`Tensor`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedTensorView;
+    ///
+    /// let data = [1.0_f64, 2.0];
+    /// let view = StridedTensorView::f64(&[2], &[1], 0, &data).unwrap();
+    /// let tensor = view.to_tensor().unwrap();
+    ///
+    /// assert_eq!(tensor.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    pub fn to_tensor(&self) -> Result<Tensor> {
+        match self {
+            Self::F32(t) => Ok(Tensor::F32(t.materialize_col_major()?)),
+            Self::F64(t) => Ok(Tensor::F64(t.materialize_col_major()?)),
+            Self::I32(t) => Ok(Tensor::I32(t.materialize_col_major()?)),
+            Self::I64(t) => Ok(Tensor::I64(t.materialize_col_major()?)),
+            Self::Bool(t) => Ok(Tensor::Bool(t.materialize_col_major()?)),
+            Self::C32(t) => Ok(Tensor::C32(t.materialize_col_major()?)),
+            Self::C64(t) => Ok(Tensor::C64(t.materialize_col_major()?)),
+        }
+    }
+}
+
+/// Dynamic borrowed mutable strided host tensor view.
+///
+/// The dynamic mutable view supports all dtypes represented by tenferro's
+/// compute [`Tensor`]. Like [`TypedStridedTensorViewMut`], constructors reject
+/// layouts where two logical indices can refer to the same backing element.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{DType, StridedTensorViewMut};
+///
+/// let mut data = [true, false];
+/// let view = StridedTensorViewMut::bool(&[2], &[1], 0, &mut data).unwrap();
+///
+/// assert_eq!(view.dtype(), DType::Bool);
+/// ```
+#[derive(Debug)]
+pub enum StridedTensorViewMut<'a> {
+    F32(TypedStridedTensorViewMut<'a, f32>),
+    F64(TypedStridedTensorViewMut<'a, f64>),
+    I32(TypedStridedTensorViewMut<'a, i32>),
+    I64(TypedStridedTensorViewMut<'a, i64>),
+    Bool(TypedStridedTensorViewMut<'a, bool>),
+    C32(TypedStridedTensorViewMut<'a, Complex32>),
+    C64(TypedStridedTensorViewMut<'a, Complex64>),
+}
+
+macro_rules! strided_view_mut_ctor {
+    ($name:ident, $variant:ident, $ty:ty, $dtype:ident) => {
+        #[doc = concat!("Create a dynamic mutable `", stringify!($dtype), "` strided view.")]
+        pub fn $name(
+            shape: &[usize],
+            strides: &[isize],
+            offset: isize,
+            data: &'a mut [$ty],
+        ) -> Result<Self> {
+            Ok(Self::$variant(TypedStridedTensorViewMut::new(
+                shape, strides, offset, data,
+            )?))
+        }
+    };
+}
+
+impl<'a> StridedTensorViewMut<'a> {
+    strided_view_mut_ctor!(f32, F32, f32, F32);
+    strided_view_mut_ctor!(f64, F64, f64, F64);
+    strided_view_mut_ctor!(i32, I32, i32, I32);
+    strided_view_mut_ctor!(i64, I64, i64, I64);
+    strided_view_mut_ctor!(bool, Bool, bool, Bool);
+    strided_view_mut_ctor!(c32, C32, Complex32, C32);
+    strided_view_mut_ctor!(c64, C64, Complex64, C64);
+
+    /// Return the view dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{DType, StridedTensorViewMut};
+    ///
+    /// let mut data = [1_i32, 2];
+    /// let view = StridedTensorViewMut::i32(&[2], &[1], 0, &mut data).unwrap();
+    /// assert_eq!(view.dtype(), DType::I32);
+    /// ```
+    pub fn dtype(&self) -> DType {
+        match self {
+            Self::F32(_) => DType::F32,
+            Self::F64(_) => DType::F64,
+            Self::I32(_) => DType::I32,
+            Self::I64(_) => DType::I64,
+            Self::Bool(_) => DType::Bool,
+            Self::C32(_) => DType::C32,
+            Self::C64(_) => DType::C64,
+        }
+    }
+
+    /// Return the logical shape.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedTensorViewMut;
+    ///
+    /// let mut data = [1.0_f64, 2.0];
+    /// let view = StridedTensorViewMut::f64(&[2], &[1], 0, &mut data).unwrap();
+    /// assert_eq!(view.shape(), &[2]);
+    /// ```
+    pub fn shape(&self) -> &[usize] {
+        match self {
+            Self::F32(t) => t.shape(),
+            Self::F64(t) => t.shape(),
+            Self::I32(t) => t.shape(),
+            Self::I64(t) => t.shape(),
+            Self::Bool(t) => t.shape(),
+            Self::C32(t) => t.shape(),
+            Self::C64(t) => t.shape(),
+        }
+    }
+
+    /// Return the logical strides measured in elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedTensorViewMut;
+    ///
+    /// let mut data = [1_i64, 2];
+    /// let view = StridedTensorViewMut::i64(&[2], &[1], 0, &mut data).unwrap();
+    /// assert_eq!(view.strides(), &[1]);
+    /// ```
+    pub fn strides(&self) -> &[isize] {
+        match self {
+            Self::F32(t) => t.strides(),
+            Self::F64(t) => t.strides(),
+            Self::I32(t) => t.strides(),
+            Self::I64(t) => t.strides(),
+            Self::Bool(t) => t.strides(),
+            Self::C32(t) => t.strides(),
+            Self::C64(t) => t.strides(),
+        }
+    }
+
+    /// Return the physical starting offset measured in elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedTensorViewMut;
+    ///
+    /// let mut data = [1.0_f32, 2.0];
+    /// let view = StridedTensorViewMut::f32(&[1], &[1], 1, &mut data).unwrap();
+    /// assert_eq!(view.offset(), 1);
+    /// ```
+    pub fn offset(&self) -> isize {
+        match self {
+            Self::F32(t) => t.offset(),
+            Self::F64(t) => t.offset(),
+            Self::I32(t) => t.offset(),
+            Self::I64(t) => t.offset(),
+            Self::Bool(t) => t.offset(),
+            Self::C32(t) => t.offset(),
+            Self::C64(t) => t.offset(),
+        }
+    }
+
+    /// Borrow this mutable dynamic view as a read-only dynamic view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedTensorViewMut;
+    ///
+    /// let mut data = [1.0_f64, 2.0];
+    /// let view = StridedTensorViewMut::f64(&[2], &[1], 0, &mut data).unwrap();
+    /// assert_eq!(view.as_read_only().to_tensor().unwrap().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    pub fn as_read_only(&self) -> StridedTensorView<'_> {
+        match self {
+            Self::F32(t) => StridedTensorView::F32(t.as_read_only()),
+            Self::F64(t) => StridedTensorView::F64(t.as_read_only()),
+            Self::I32(t) => StridedTensorView::I32(t.as_read_only()),
+            Self::I64(t) => StridedTensorView::I64(t.as_read_only()),
+            Self::Bool(t) => StridedTensorView::Bool(t.as_read_only()),
+            Self::C32(t) => StridedTensorView::C32(t.as_read_only()),
+            Self::C64(t) => StridedTensorView::C64(t.as_read_only()),
+        }
+    }
+
+    /// Return two mutable dynamic slices when their physical offset ranges are disjoint.
+    ///
+    /// This returns `None` instead of panicking when either slice spec is
+    /// invalid or the selected physical ranges overlap.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{StridedSliceSpec, StridedTensorViewMut};
+    ///
+    /// let mut data = [1_i32, 2, 3, 4];
+    /// let mut view = StridedTensorViewMut::i32(&[4], &[1], 0, &mut data).unwrap();
+    /// let (left, right) = view
+    ///     .try_multi_slice_mut(
+    ///         &[StridedSliceSpec::new(0, Some(2), 1)],
+    ///         &[StridedSliceSpec::new(2, Some(4), 1)],
+    ///     )
+    ///     .unwrap();
+    /// assert_eq!(left.shape(), &[2]);
+    /// assert_eq!(right.shape(), &[2]);
+    /// ```
+    pub fn try_multi_slice_mut(
+        &mut self,
+        first: &[StridedSliceSpec],
+        second: &[StridedSliceSpec],
+    ) -> Option<(StridedTensorViewMut<'_>, StridedTensorViewMut<'_>)> {
+        match self {
+            Self::F32(t) => t
+                .try_multi_slice_mut(first, second)
+                .map(|(a, b)| (StridedTensorViewMut::F32(a), StridedTensorViewMut::F32(b))),
+            Self::F64(t) => t
+                .try_multi_slice_mut(first, second)
+                .map(|(a, b)| (StridedTensorViewMut::F64(a), StridedTensorViewMut::F64(b))),
+            Self::I32(t) => t
+                .try_multi_slice_mut(first, second)
+                .map(|(a, b)| (StridedTensorViewMut::I32(a), StridedTensorViewMut::I32(b))),
+            Self::I64(t) => t
+                .try_multi_slice_mut(first, second)
+                .map(|(a, b)| (StridedTensorViewMut::I64(a), StridedTensorViewMut::I64(b))),
+            Self::Bool(t) => t
+                .try_multi_slice_mut(first, second)
+                .map(|(a, b)| (StridedTensorViewMut::Bool(a), StridedTensorViewMut::Bool(b))),
+            Self::C32(t) => t
+                .try_multi_slice_mut(first, second)
+                .map(|(a, b)| (StridedTensorViewMut::C32(a), StridedTensorViewMut::C32(b))),
+            Self::C64(t) => t
+                .try_multi_slice_mut(first, second)
+                .map(|(a, b)| (StridedTensorViewMut::C64(a), StridedTensorViewMut::C64(b))),
+        }
+    }
+
+    /// Materialize this dynamic mutable view into tenferro's compute [`Tensor`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::StridedTensorViewMut;
+    ///
+    /// let mut data = [1.0_f64, 2.0];
+    /// let view = StridedTensorViewMut::f64(&[2], &[1], 0, &mut data).unwrap();
+    /// let tensor = view.to_tensor().unwrap();
+    ///
+    /// assert_eq!(tensor.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    pub fn to_tensor(&self) -> Result<Tensor> {
+        self.as_read_only().to_tensor()
+    }
+}

--- a/tenferro-tensor/src/validate/mod.rs
+++ b/tenferro-tensor/src/validate/mod.rs
@@ -131,9 +131,9 @@ pub fn validate_nonsingular_u(u: &Tensor) -> Result<()> {
         Tensor::F32(t) => check_singular_diagonal(t),
         Tensor::C64(t) => check_singular_diagonal(t),
         Tensor::C32(t) => check_singular_diagonal(t),
-        Tensor::I64(_) => Err(Error::BackendFailure {
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(Error::BackendFailure {
             op: "solve",
-            message: "unsupported dtype I64".into(),
+            message: format!("unsupported dtype {:?}", u.dtype()),
         }),
     }
 }

--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -980,7 +980,12 @@ pub(crate) fn zero_like_tensor<B: TensorBackend>(input: &Tensor, _backend: &mut 
     match input {
         Tensor::F32(tensor) => Tensor::F32(TypedTensor::zeros(tensor.shape.clone())),
         Tensor::F64(tensor) => Tensor::F64(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::I32(tensor) => Tensor::I32(TypedTensor::zeros(tensor.shape.clone())),
         Tensor::I64(tensor) => Tensor::I64(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::Bool(tensor) => Tensor::Bool(TypedTensor::from_vec_col_major(
+            tensor.shape.clone(),
+            vec![false; tensor.n_elements()],
+        )),
         Tensor::C32(tensor) => Tensor::C32(TypedTensor::zeros(tensor.shape.clone())),
         Tensor::C64(tensor) => Tensor::C64(TypedTensor::zeros(tensor.shape.clone())),
     }

--- a/tenferro/src/eager_emitter.rs
+++ b/tenferro/src/eager_emitter.rs
@@ -94,7 +94,12 @@ fn zero_like_tensor(input: &Tensor) -> Tensor {
     match input {
         Tensor::F32(tensor) => Tensor::F32(TypedTensor::zeros(tensor.shape.clone())),
         Tensor::F64(tensor) => Tensor::F64(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::I32(tensor) => Tensor::I32(TypedTensor::zeros(tensor.shape.clone())),
         Tensor::I64(tensor) => Tensor::I64(TypedTensor::zeros(tensor.shape.clone())),
+        Tensor::Bool(tensor) => Tensor::Bool(TypedTensor::from_vec_col_major(
+            tensor.shape.clone(),
+            vec![false; tensor.n_elements()],
+        )),
         Tensor::C32(tensor) => Tensor::C32(TypedTensor::zeros(tensor.shape.clone())),
         Tensor::C64(tensor) => Tensor::C64(TypedTensor::zeros(tensor.shape.clone())),
     }

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -312,9 +312,17 @@ fn constant_tensor(dtype: DType, bytes: &[u8]) -> Tensor {
             vec![],
             vec![f32::from_le_bytes(exact_bytes::<4>(dtype, bytes))],
         )),
+        DType::I32 => Tensor::I32(TypedTensor::from_vec_col_major(
+            vec![],
+            vec![i32::from_le_bytes(exact_bytes::<4>(dtype, bytes))],
+        )),
         DType::I64 => Tensor::I64(TypedTensor::from_vec_col_major(
             vec![],
             vec![i64::from_le_bytes(exact_bytes::<8>(dtype, bytes))],
+        )),
+        DType::Bool => Tensor::Bool(TypedTensor::from_vec_col_major(
+            vec![],
+            vec![exact_bytes::<1>(dtype, bytes)[0] != 0],
         )),
         DType::C64 => {
             let data = exact_bytes::<16>(dtype, bytes);

--- a/tenferro/src/exec.rs
+++ b/tenferro/src/exec.rs
@@ -768,9 +768,17 @@ pub(crate) fn constant_tensor(dtype: DType, bytes: &[u8]) -> Tensor {
             vec![],
             vec![f32::from_le_bytes(exact_bytes::<4>(dtype, bytes))],
         )),
+        DType::I32 => Tensor::I32(TypedTensor::from_vec_col_major(
+            vec![],
+            vec![i32::from_le_bytes(exact_bytes::<4>(dtype, bytes))],
+        )),
         DType::I64 => Tensor::I64(TypedTensor::from_vec_col_major(
             vec![],
             vec![i64::from_le_bytes(exact_bytes::<8>(dtype, bytes))],
+        )),
+        DType::Bool => Tensor::Bool(TypedTensor::from_vec_col_major(
+            vec![],
+            vec![exact_bytes::<1>(dtype, bytes)[0] != 0],
         )),
         DType::C64 => {
             let data = exact_bytes::<16>(dtype, bytes);

--- a/tenferro/src/graph/compiler.rs
+++ b/tenferro/src/graph/compiler.rs
@@ -458,7 +458,15 @@ fn zeros_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
     match dtype {
         DType::F32 => Tensor::F32(tenferro_tensor::TypedTensor::zeros(shape)),
         DType::F64 => Tensor::F64(tenferro_tensor::TypedTensor::zeros(shape)),
+        DType::I32 => Tensor::I32(tenferro_tensor::TypedTensor::zeros(shape)),
         DType::I64 => Tensor::I64(tenferro_tensor::TypedTensor::zeros(shape)),
+        DType::Bool => {
+            let len = shape.iter().product();
+            Tensor::Bool(tenferro_tensor::TypedTensor::from_vec_col_major(
+                shape,
+                vec![false; len],
+            ))
+        }
         DType::C32 => Tensor::C32(tenferro_tensor::TypedTensor::zeros(shape)),
         DType::C64 => Tensor::C64(tenferro_tensor::TypedTensor::zeros(shape)),
     }

--- a/tenferro/src/graph/executor.rs
+++ b/tenferro/src/graph/executor.rs
@@ -664,7 +664,12 @@ fn zeros_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
     match dtype {
         DType::F32 => Tensor::F32(TypedTensor::zeros(shape)),
         DType::F64 => Tensor::F64(TypedTensor::zeros(shape)),
+        DType::I32 => Tensor::I32(TypedTensor::zeros(shape)),
         DType::I64 => Tensor::I64(TypedTensor::zeros(shape)),
+        DType::Bool => {
+            let len = shape.iter().product();
+            Tensor::Bool(TypedTensor::from_vec_col_major(shape, vec![false; len]))
+        }
         DType::C32 => Tensor::C32(TypedTensor::zeros(shape)),
         DType::C64 => Tensor::C64(TypedTensor::zeros(shape)),
     }

--- a/tenferro/src/shape_infer.rs
+++ b/tenferro/src/shape_infer.rs
@@ -14,9 +14,12 @@ use tenferro_tensor::{DType, DotGeneralConfig, GatherConfig, PadConfig, SliceCon
 /// precision loss, following the policy defined in [#811].
 ///
 /// Rules:
+/// - Bool + T -> T
+/// - I32 + I32 -> I32
+/// - I32 + I64 -> I64
 /// - I64 + I64 → I64 (integer-preserving; Div/Pow use [`promote_dtype_div_like`])
-/// - I64 + F32/F64 → F64 (F32 does not have enough mantissa bits for arbitrary I64)
-/// - I64 + C32/C64 → C64
+/// - I32/I64 + F32/F64 → F64 (F32 does not have enough mantissa bits for arbitrary integers)
+/// - I32/I64 + C32/C64 → C64
 /// - F32 + F64 → F64
 /// - F32 + C32 → C32
 /// - F32/C32 + C64 → C64
@@ -35,14 +38,16 @@ pub fn promote_dtype(lhs: DType, rhs: DType) -> DType {
         (rhs, lhs)
     };
     match (a, b) {
-        (I64, F32 | F64) => F64, // I64 → F64 (F32 can't represent all I64)
-        (I64, C32 | C64) => C64, // I64 → C64
-        (F32, F64) => F64,       // F32 → F64
-        (F32, C32) => C32,       // F32 + C32 → C32
-        (F32, C64) => C64,       // F32 + C64 → C64
-        (F64, C32) => C64,       // F64 + C32 → C64
-        (F64, C64) => C64,       // F64 + C64 → C64
-        (C32, C64) => C64,       // C32 → C64
+        (Bool, other) => other,
+        (I32, I64) => I64,
+        (I32 | I64, F32 | F64) => F64,
+        (I32 | I64, C32 | C64) => C64,
+        (F32, F64) => F64,
+        (F32, C32) => C32,
+        (F32, C64) => C64,
+        (F64, C32) => C64,
+        (F64, C64) => C64,
+        (C32, C64) => C64,
         _ => unreachable!("promote_dtype: unhandled pair {:?} {:?}", lhs, rhs),
     }
 }
@@ -65,21 +70,23 @@ pub fn promote_dtype_for_binary_op(op: &StdTensorOp, lhs: DType, rhs: DType) -> 
     }
 }
 
-/// Internal promotion ordering: I64 < F32 < F64 < C32 < C64.
+/// Internal promotion ordering: Bool < I32 < I64 < F32 < F64 < C32 < C64.
 fn promotion_rank(dt: DType) -> u8 {
     match dt {
-        DType::I64 => 0,
-        DType::F32 => 1,
-        DType::F64 => 2,
-        DType::C32 => 3,
-        DType::C64 => 4,
+        DType::Bool => 0,
+        DType::I32 => 1,
+        DType::I64 => 2,
+        DType::F32 => 3,
+        DType::F64 => 4,
+        DType::C32 => 5,
+        DType::C64 => 6,
     }
 }
 
 /// Like [`promote_dtype`], but for division-like ops where I64 / I64
 /// should produce F64 to avoid integer truncation.
 pub fn promote_dtype_div_like(lhs: DType, rhs: DType) -> DType {
-    if lhs == DType::I64 && rhs == DType::I64 {
+    if matches!(lhs, DType::I32 | DType::I64) && matches!(rhs, DType::I32 | DType::I64) {
         return DType::F64;
     }
     promote_dtype(lhs, rhs)

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -1060,7 +1060,9 @@ impl TracedTensor {
         let op = match self.dtype {
             DType::F64 => StdTensorOp::constant_f64(factor),
             DType::F32 => StdTensorOp::constant_f32(factor as f32),
+            DType::I32 => StdTensorOp::constant_i32(round_real_to_i64(factor) as i32),
             DType::I64 => StdTensorOp::constant_i64(round_real_to_i64(factor)),
+            DType::Bool => StdTensorOp::constant_bool(factor != 0.0),
             DType::C64 => StdTensorOp::constant_c64(Complex64::new(factor, 0.0)),
             DType::C32 => StdTensorOp::constant_c32(Complex32::new(factor as f32, 0.0)),
         };
@@ -1090,7 +1092,7 @@ impl TracedTensor {
                 self,
                 StdTensorOp::constant_c32(Complex32::new(factor.re as f32, factor.im as f32)),
             ),
-            DType::F32 | DType::F64 | DType::I64 => {
+            DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => {
                 panic!(
                     "scale_complex only supports complex tensors; use scale_real for real tensors"
                 )
@@ -2186,7 +2188,12 @@ fn ones_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
     match dtype {
         DType::F32 => Tensor::F32(TypedTensor::ones(shape)),
         DType::F64 => Tensor::F64(TypedTensor::ones(shape)),
+        DType::I32 => Tensor::I32(TypedTensor::ones(shape)),
         DType::I64 => Tensor::I64(TypedTensor::ones(shape)),
+        DType::Bool => {
+            let len = shape.iter().product();
+            Tensor::Bool(TypedTensor::from_vec_col_major(shape, vec![true; len]))
+        }
         DType::C32 => Tensor::C32(TypedTensor::ones(shape)),
         DType::C64 => Tensor::C64(TypedTensor::ones(shape)),
     }

--- a/tenferro/tests/ad.rs
+++ b/tenferro/tests/ad.rs
@@ -341,7 +341,15 @@ fn zeros_by_dtype(dtype: DType, shape: Vec<usize>) -> Tensor {
     match dtype {
         DType::F32 => Tensor::F32(TypedTensor::zeros(shape)),
         DType::F64 => Tensor::F64(TypedTensor::zeros(shape)),
+        DType::I32 => Tensor::I32(TypedTensor::zeros(shape)),
         DType::I64 => Tensor::I64(TypedTensor::zeros(shape)),
+        DType::Bool => {
+            let n_elements = shape.iter().product();
+            Tensor::Bool(TypedTensor::from_vec_col_major(
+                shape,
+                vec![false; n_elements],
+            ))
+        }
         DType::C32 => Tensor::C32(TypedTensor::zeros(shape)),
         DType::C64 => Tensor::C64(TypedTensor::zeros(shape)),
     }

--- a/tenferro/tests/oracle_replay/main.rs
+++ b/tenferro/tests/oracle_replay/main.rs
@@ -740,7 +740,7 @@ fn cotangent_scalar(
         let aligned_cotangent = match output.tensor.dtype {
             DType::C32 | DType::C64 => aligned_cotangent.conj(),
             DType::F32 | DType::F64 => aligned_cotangent,
-            DType::I64 => continue,
+            DType::I32 | DType::I64 | DType::Bool => continue,
         };
         let axes: Vec<usize> = (0..output.tensor.rank).collect();
         scalar_terms.push((&output.tensor * &aligned_cotangent).reduce_sum(&axes));
@@ -872,7 +872,15 @@ fn zero_traced_tensor(dtype: DType, shape: Vec<usize>) -> TracedTensor {
     let tensor = match dtype {
         DType::F32 => Tensor::F32(TypedTensor::<f32>::zeros(shape)),
         DType::F64 => Tensor::F64(TypedTensor::<f64>::zeros(shape)),
+        DType::I32 => Tensor::I32(TypedTensor::<i32>::zeros(shape)),
         DType::I64 => Tensor::I64(TypedTensor::<i64>::zeros(shape)),
+        DType::Bool => {
+            let n_elements = shape.iter().product();
+            Tensor::Bool(TypedTensor::from_vec_col_major(
+                shape,
+                vec![false; n_elements],
+            ))
+        }
         DType::C32 => Tensor::C32(TypedTensor::<Complex32>::zeros(shape)),
         DType::C64 => Tensor::C64(TypedTensor::<Complex64>::zeros(shape)),
     };


### PR DESCRIPTION
## Summary

- Add borrowed read-only and mutable strided tensor views for host tensor inputs, including slicing, axis slicing, reshaping, materialization, and dynamic dtype wrappers.
- Extend tensor dtype coverage with `i32` and `bool` across tensor types, buffer pools, CPU structural/indexing paths, constants, promotion, and extension crates.
- Refactor structural and indexing dtype dispatch toward generic helpers/macros, and document that rule in `REPOSITORY_RULES.md`.
- Add coverage-oriented tests for strided-view validation, mutable aliasing/multi-slice behavior, dynamic dtype variants, and linalg extension dtype metadata.

## Notes

- Mutable strided views reject overlapping logical layouts. `try_multi_slice_mut` returns `None` for invalid or overlapping slice selections instead of panicking.
- Read-only strided views allow overlapping layouts and materialize into tenferro's column-major owned tensors when needed.
- `try_multi_slice_mut` is intentionally conservative: it returns mutable pairs for disjoint physical spans, while interleaved selections with overlapping physical ranges return `None`.

Fixes #886

## Validation

- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo test -p tenferro-tensor`
- `cargo test --no-run --workspace --release`
- `ORACLE_REPLAY_CASE_LIMIT=100 cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- Local coverage after the follow-up: `tenferro-tensor/src/types/strided_view.rs` 91.3%, `tenferro-linalg/src/extension.rs` 81.7%
- GitHub Actions: `rustfmt`, `cargo test (blas inject)`, `coverage`, `docs-site`, `CI (same-repo PR / self-hosted heavy / cpu-faer)`, `CI (same-repo PR / self-hosted heavy / cpu-blas)`, and `CI gate (PR workspace tests)` passed