### PR TITLE
[codex] Fix eager einsum cache ownership and GPU reductions

### DIFF
--- a/docs/design/einsum-extension-migration-audit.md
+++ b/docs/design/einsum-extension-migration-audit.md
@@ -1,0 +1,191 @@
+# Einsum Extension Migration Audit
+
+This is the working audit table for moving the current einsum experiment into a
+real external extension crate. Implementation should start from `origin/main`,
+but the current branch is the source inventory. The goal is to reuse the
+existing code deliberately, not to regenerate an einsum implementation from
+scratch.
+
+## Rules
+
+- Treat this document as the migration checklist.
+- Move or adapt the listed source items before inventing replacement code.
+- If an item is intentionally not moved, record the reason in the implementation
+  PR.
+- The owning agent may implement, but this thread must verify each step against
+  this table before moving on.
+- `tenferro-einsum` owns einsum implementation. `tenferro` owns only generic
+  extension runtime surface.
+
+Status values:
+
+```text
+pending       not started
+ported        code moved/adapted
+verified      verification command passed
+not-needed    intentionally replaced or removed with reason
+```
+
+## Pre-Migration Setup
+
+| Source item | Current path | Target | Verification | Status |
+|-------------|--------------|--------|--------------|--------|
+| Clean implementation base | git branch/worktree | Start implementation from `origin/main`, using this experimental branch only as source inventory | `git merge-base --is-ancestor origin/main HEAD` on the implementation branch, or record the worktree base explicitly | pending |
+| GPU feature naming | `Cargo.toml`, crate manifests | Use `gpu` as shared capability feature, `cuda` as first vendor backend, and reserve `rocm` | `rg -n "gpu|cuda|rocm|cubecl" Cargo.toml tenferro*/Cargo.toml` | pending |
+| GPU implementation crate rename | `tenferro-cubecl` | Rename to `tenferro-gpubackend` in this restructure | `rg -n "tenferro-cubecl|tenferro-gpubackend" Cargo.toml tenferro*/Cargo.toml` | pending |
+| AD feature naming | crate manifests | Use `autodiff`; do not expose stable `ad` feature | `rg -n "\\bad\\b|autodiff|tidu|chainrules" Cargo.toml tenferro*/Cargo.toml` | pending |
+
+## Existing Assets To Reuse
+
+| Source item | Current path | Target | Verification | Status |
+|-------------|--------------|--------|--------------|--------|
+| String/integer subscript parser core | `tenferro-einsum/src/syntax/subscripts.rs`, `syntax/notation.rs` | Keep in `tenferro-einsum`; do not duplicate parser in `tenferro` | `cargo test -p tenferro-einsum subscripts` | pending |
+| Nested contraction syntax | `tenferro-einsum/src/syntax/nested.rs` | Keep in `tenferro-einsum`; reuse for `EinsumOptimize::Nested` | `cargo test -p tenferro-einsum nested` | pending |
+| Contraction planning and optimizer options | `tenferro-einsum/src/planning/*` | Keep in `tenferro-einsum`; expose through traced API as needed | `cargo test -p tenferro-einsum planning` | pending |
+| Fragment lowering | `tenferro-einsum/src/builder.rs` | Reuse from extension executor/runtime path | `rg -n "build_einsum_fragment" tenferro-einsum/src` | pending |
+| Standalone eager tensor execution | `tenferro-einsum/src/eager.rs` | Keep as direct `tenferro_einsum::eager_*` APIs | `cargo test -p tenferro-einsum eager` | pending |
+| Typed eager facade | `tenferro-einsum/src/typed_eager.rs` | Keep in `tenferro-einsum`; remove `tenferro::typed_tensor::einsum*` facade | `cargo test -p tenferro-einsum typed_eager` | pending |
+| Eager runtime plan cache | `tenferro/src/eager.rs`, `tenferro-runtime/src/extension_runtime.rs` | Owned by `EagerRuntime` through `ExtensionExecutor<EagerBackend>`; direct `tenferro-einsum` eager APIs do not retain a hidden cache | `cargo test -p tenferro-einsum --test traced_graph_cache eager_einsum` | done |
+
+## Move From `tenferro` To `tenferro-einsum`
+
+| Source item | Current path | Target | Verification | Status |
+|-------------|--------------|--------|--------------|--------|
+| Integer-label public API wrapper `EinsumSubscripts` | `tenferro/src/einsum_subscripts.rs` | `tenferro-einsum/src/api/subscripts.rs` or folded into `Subscripts` API | `rg -n "EinsumSubscripts|parse_einsum_subscripts" tenferro-einsum/src tenferro-einsum/tests` | pending |
+| Traced public API `einsum`, `einsum_with`, `einsum_subscripts`, `einsum_subscripts_with` | `tenferro/src/einsum.rs` | `tenferro-einsum/src/traced.rs`; exported as `tenferro_einsum::einsum*` | `rg -n "pub fn einsum" tenferro-einsum/src && ! rg -n "pub fn einsum" tenferro/src` | pending |
+| `EinsumOptimize` and strategy conversion | `tenferro/src/einsum.rs` | `tenferro-einsum/src/traced.rs` or `src/optimize.rs` | `rg -n "EinsumOptimize|resolve_strategy|nested_to_v1_pairs" tenferro-einsum/src` | pending |
+| Symbolic optimization validation | `tenferro/src/einsum.rs` | `tenferro-einsum` traced API, preserving current symbolic restrictions | `rg -n "symbolic einsum supports only default automatic optimization" tenferro-einsum` | pending |
+| Traced extension payload construction | `tenferro/src/einsum.rs`, `build_einsum_extension_tensor` | `tenferro-einsum` traced API using generic `tenferro::extension::apply` | `rg -n "build_einsum_extension_tensor|ExtensionOp" tenferro-einsum/src` | pending |
+| Eager AD-facing API for `EagerTensor` | `tenferro/src/eager_einsum.rs` | `tenferro-einsum/src/eager_tensor.rs`, under `autodiff` where needed | `rg -n "EagerTensor|requires_grad|StdTensorOp::Extension" tenferro-einsum/src` | pending |
+| Tensor facade eager APIs | `tenferro/src/tensor.rs` | Remove from `tenferro`; direct users call `tenferro_einsum::eager_*` | `! rg -n "einsum" tenferro/src/tensor.rs` | pending |
+| TypedTensor facade eager APIs | `tenferro/src/typed_tensor.rs` | Remove from `tenferro`; direct users call `tenferro_einsum::typed_eager_*` | `! rg -n "einsum" tenferro/src/typed_tensor.rs` | pending |
+| EagerTensor facade APIs | `tenferro/src/eager_tensor.rs` | Remove from `tenferro`; direct users call `tenferro_einsum` | `! rg -n "einsum" tenferro/src/eager_tensor.rs` | pending |
+
+## Move Extension Payload, Execution, And Caches
+
+| Source item | Current path | Target | Verification | Status |
+|-------------|--------------|--------|--------------|--------|
+| Family identity | `tenferro/src/einsum_extension.rs`, `EINSUM_EXTENSION_FAMILY_ID` | `tenferro-einsum/src/extension.rs`, family `tenferro.einsum` plus schema version | `rg -n "tenferro\\.einsum|schema" tenferro-einsum/src` | pending |
+| Cache IDs: static plans, parse, runtime plans | `tenferro/src/einsum_extension.rs`, `EINSUM_*_CACHE_ID` | `tenferro-einsum` cache module with typed IDs | `rg -n "STATIC.*PLAN|PARSE|RUNTIME.*PLAN|ExtensionCache" tenferro-einsum/src` | pending |
+| Default cache capacity | `tenferro/src/einsum_extension.rs`, `DEFAULT_EINSUM_CACHE_CAPACITY` | `tenferro-einsum` cache module | `rg -n "DEFAULT_EINSUM_CACHE_CAPACITY|DEFAULT_.*CACHE" tenferro-einsum/src` | pending |
+| Parsed-subscript compile cache | `GraphCompilerExtensionCaches::cached_subscripts` | Extension compile cache through generic `ExtensionCacheStore` | `rg -n "cached_subscripts|ParsedEinsum" tenferro-einsum/src tenferro/src` | pending |
+| Static contraction-tree compile cache | `GraphCompilerExtensionCaches::cached_static_einsum_tree` | Extension compile cache through generic `ExtensionCacheStore` | `rg -n "cached_static_einsum_tree|static.*einsum" tenferro-einsum/src tenferro/src` | pending |
+| Runtime contraction-plan cache | `GraphExecutorExtensionCaches::runtime_einsum_plans` | Extension runtime cache through generic `ExtensionCacheStore` | `rg -n "runtime_einsum_plans|runtime.*plan" tenferro-einsum/src tenferro/src` | pending |
+| Cache stats retained-byte helpers | `einsum_subscripts_retained_bytes`, `einsum_plan_cache_stats`, `einsum_parse_cache_stats` | `tenferro-einsum` cache module | `rg -n "retained_bytes|cache_stats" tenferro-einsum/src` | pending |
+| Extension payload `EinsumExtensionOp` | `tenferro/src/einsum_extension.rs` | `tenferro-einsum/src/extension.rs` | `rg -n "struct EinsumExtensionOp|impl ExtensionOp for EinsumExtensionOp" tenferro-einsum/src` | pending |
+| Payload hashing/equality/clone | `impl ExtensionOp for EinsumExtensionOp` | Preserve in `tenferro-einsum` with structural hash; avoid pointer identity for cached tree | `rg -n "payload_hash|payload_eq|clone_arc" tenferro-einsum/src` | pending |
+| Shape and dtype inference | `EinsumExtensionOp::infer_output_meta` | Preserve in `tenferro-einsum`; tests move with symbolic cases | `rg -n "infer_output_meta" tenferro-einsum/src && cargo test -p tenferro-einsum symbolic` | pending |
+| Eager compatibility fallback | `EinsumExtensionOp::eager_execute` | Keep only as context-free compatibility fallback; `EagerRuntime` execution routes through `ExtensionExecutor` | `rg -n "exec_op_on_tensors_with_extension_executor|register_extension" tenferro/src tenferro-einsum/src` | done |
+| Context-aware execution | `execute_einsum_extension`, `execute_einsum_extension_op`, `execute_einsum_tree` | `tenferro-einsum` runtime implementing `ExtensionRuntime<B>` | `rg -n "impl .*ExtensionRuntime|execute_einsum" tenferro-einsum/src` | done |
+| Runtime builder execution bridge | `execute_einsum_tree` using `build_einsum_fragment` and exec IR | Reuse in `tenferro-einsum`; expose any missing generic runtime helpers from `tenferro` | `rg -n "build_einsum_fragment|eval_exec" tenferro-einsum/src tenferro/src` | pending |
+
+## Generic Runtime Work Remaining In `tenferro`
+
+| Source item | Current path | Target | Verification | Status |
+|-------------|--------------|--------|--------------|--------|
+| Primal extension carrier | `tenferro-ops/src/ext_op.rs` | Keep in `tenferro-ops`; add schema version and remove long-term `eager_execute` dependency | `cargo test -p tenferro-ops ext_op` | pending |
+| AD split for extension rules | `tenferro-ops/src/ext_op.rs` | Split primal `ext_op` from `autodiff`-gated `ext_ad` | `cargo check -p tenferro-ops --no-default-features` | pending |
+| Backend-typed executor registry | new generic runtime surface | `tenferro` or `tenferro-ops` depending on dependency needs; no einsum names | `rg -n "ExtensionRegistry|ExtensionExecutor" tenferro tenferro-ops` | pending |
+| Runtime execution context | new generic runtime surface | `tenferro`, with `BackendRuntimeState<B>` external to backend `B` | `rg -n "ExtensionExecutionContext|BackendRuntimeState" tenferro` | pending |
+| Generic cache store | current `tenferro/src/graph/cache.rs` plus experiment cache API | `tenferro` generic cache module; no hard-coded einsum fields | `rg -n "ExtensionCacheKey|ExtensionCacheStore|ExtensionCacheSelector" tenferro/src` | pending |
+| Graph compiler cache stats | `GraphCompilerCacheStats` currently has `static_einsum_plans`, `einsum_parse` | Replace hard-coded fields with generic extension cache stats | `! rg -n "static_einsum_plans|einsum_parse" tenferro/src` | pending |
+| Graph executor cache stats | `GraphExecutorCacheStats` currently has `runtime_einsum_plans` | Replace hard-coded field with generic extension cache stats | `! rg -n "runtime_einsum_plans" tenferro/src` | pending |
+| Compiler cache key extension fingerprint | `tenferro/src/graph/cache.rs` | Keep generic extension payload fingerprinting | `cargo test -p tenferro graph_compile` | pending |
+| `extension::apply` traced helper | `tenferro/src/extension.rs` | Keep generic application API; no einsum knowledge | `cargo test -p tenferro extension_op` | pending |
+| `extension::apply_eager` | `tenferro/src/extension.rs` | Route through `EagerRuntime`'s registry/cache context | `rg -n "ctx\\.exec_outputs" tenferro/src/extension.rs` | done |
+| Multi-output extension graph support | `shape_infer`, `compiler/mod.rs`, `exec.rs`, `segment.rs` | Make N-output and mixed-dtype extension execution generic | `cargo test -p tenferro extension_op shape_inference exec_dispatch` | pending |
+
+## Remove From `tenferro-ops`
+
+| Source item | Current path | Target | Verification | Status |
+|-------------|--------------|--------|--------------|--------|
+| Built-in `StdTensorOp::NaryEinsum` variant | `tenferro-ops/src/std_tensor_op.rs` | Remove; use `StdTensorOp::Extension(EinsumExtensionOp)` from `tenferro-einsum` | `! rg -n "NaryEinsum" tenferro-ops/src` | pending |
+| N-ary einsum AD registration | `tenferro-ops/src/ad/mod.rs`, `ad/contraction.rs` | Move/replace with `tenferro-einsum` extension AD rule under `autodiff` | `! rg -n "einsum|NaryEinsum" tenferro-ops/src/ad` | pending |
+| Einsum AD support manifest | `tenferro-ops/src/ad/support.rs` | Remove from core support manifest; extension crate owns support reporting | `! rg -n "einsum|NaryEinsum" tenferro-ops/src/ad/support.rs` | pending |
+| Std op tests for `NaryEinsum` | `tenferro-ops/src/tests/std_tensor_op_tests.rs` | Move relevant behavior to `tenferro-einsum` tests or extension tests | `! rg -n "NaryEinsum|einsum" tenferro-ops/src/tests` | pending |
+
+## AD Migration
+
+| Source item | Current path | Target | Verification | Status |
+|-------------|--------------|--------|--------------|--------|
+| Einsum extension AD rule type | `EinsumExtensionAdRule` in `tenferro/src/einsum_extension.rs` | `tenferro-einsum/src/ad.rs`, gated by `autodiff` | `rg -n "EinsumExtensionAdRule|ExtensionAdRule" tenferro-einsum/src` | pending |
+| Rule registration | `ensure_einsum_extension_rule_registered` | `tenferro-einsum` registration helper, gated by `autodiff` | `rg -n "ensure_.*rule_registered|register_extension" tenferro-einsum/src` | pending |
+| Linearize rule | `linearize_einsum_extension` | `tenferro-einsum/src/ad.rs`; preserve output-shape hints | `rg -n "linearize_einsum_extension|linearize" tenferro-einsum/src` | pending |
+| Transpose rule | `transpose_einsum_extension` | `tenferro-einsum/src/ad.rs`; preserve repeated/new label behavior | `rg -n "transpose_einsum_extension|transpose" tenferro-einsum/src` | pending |
+| AD tests for traced einsum | `tenferro/tests/einsum_ad.rs` | `tenferro-einsum/tests/ad.rs`, gated by `autodiff` | `cargo test -p tenferro-einsum --features autodiff --test ad` | pending |
+| No-AD build boundary | `tenferro`, `tenferro-ops`, `tenferro-einsum` Cargo features | Gate `tidu`, `chainrules-core`, `chainrules` behind `autodiff` | `cargo check --no-default-features && cargo tree --no-default-features -e normal -p tenferro` | pending |
+
+## Runtime Wiring To Preserve Or Generalize
+
+| Source item | Current path | Target | Verification | Status |
+|-------------|--------------|--------|--------------|--------|
+| Compiler symbolic/static path | `tenferro/src/einsum.rs`, `GraphCompiler::cached_*` | `tenferro-einsum` uses generic compiler extension cache | `cargo test -p tenferro-einsum symbolic` | pending |
+| Compiled extension dispatch special case | `tenferro/src/exec.rs` downcasts `EinsumExtensionOp` | Replace with generic `ExtensionExecutor<B>` dispatch; no einsum downcast in `tenferro` | `! rg -n "EinsumExtensionOp|execute_einsum" tenferro/src/exec.rs tenferro/src/eager_exec.rs` | pending |
+| Eager extension dispatch special case | `tenferro/src/eager_exec.rs` downcasts `EinsumExtensionOp` | Replace with generic context-aware extension execution | `! rg -n "EinsumExtensionOp|execute_einsum" tenferro/src/eager_exec.rs` | pending |
+| Segment helper cache threading | `tenferro/src/segment.rs` uses `EinsumPlanCache` | Replace with generic extension cache/context threading | `! rg -n "EinsumPlanCache|einsum" tenferro/src/segment.rs` | pending |
+| Compiler lowering from std op to exec op | `tenferro/src/compiler/mod.rs` | Keep generic `StdTensorOp::Extension` lowering | `cargo test -p tenferro compiler_wiring` | pending |
+| Shape inference for extensions | `tenferro/src/shape_infer.rs` | Keep generic `infer_output_meta`; ensure multi-output metadata is used | `cargo test -p tenferro shape_inference` | pending |
+| `TracedTensor` symbolic shape comments and behavior | `tenferro/src/traced.rs` | Remove einsum-specific comments from `tenferro`; keep generic symbolic extension behavior | `! rg -n "einsum" tenferro/src/traced.rs` | pending |
+
+## Tests To Move Or Rewrite
+
+| Source test | Current path | Target | Verification | Status |
+|-------------|--------------|--------|--------------|--------|
+| Graph einsum static/runtime cache tests | `tenferro/tests/graph_einsum.rs` | `tenferro-einsum/tests/graph.rs` or `tests/cache.rs` | `cargo test -p tenferro-einsum --test graph` | pending |
+| Extension cache management tests | `tenferro/tests/einsum_extension_cache.rs`, `tenferro/tests/cache_management.rs` | Split generic cache tests in `tenferro`, einsum cache behavior in `tenferro-einsum` | `cargo test -p tenferro cache_management && cargo test -p tenferro-einsum cache` | pending |
+| Symbolic einsum tests | `tenferro/tests/einsum_extension_symbolic.rs`, deleted `nary_einsum_symbolic.rs` | `tenferro-einsum/tests/symbolic.rs` | `cargo test -p tenferro-einsum symbolic` | pending |
+| Tensor eager facade tests | `tenferro/tests/tensor_einsum.rs`, `eager_tensor_einsum.rs` | Move to `tenferro-einsum/tests/eager_tensor.rs` or delete if facade removed | `cargo test -p tenferro-einsum eager_tensor` | pending |
+| Legacy einsum tests | `tenferro/tests/einsum.rs` | Move remaining API behavior to `tenferro-einsum/tests/traced.rs` | `cargo test -p tenferro-einsum traced` | pending |
+| CPU backend einsum reuse tests | `tenferro/tests/cpu_backend.rs` | Keep only generic backend/buffer-pool tests in `tenferro`; move einsum-specific cases | `! rg -n "einsum" tenferro/tests/cpu_backend.rs` | pending |
+| Compiler/executor cache capacity tests | `tenferro/tests/graph_compile.rs`, `graph_executor.rs` | Replace einsum-specific capacity assertions with generic extension cache tests | `! rg -n "einsum_cache|runtime_einsum" tenferro/tests/graph_compile.rs tenferro/tests/graph_executor.rs` | pending |
+| Extension op smoke tests | `tenferro/tests/extension_op.rs`, `tenferro-ops/src/tests/ext_op_tests.rs` | Keep and update for new executor registry/context | `cargo test -p tenferro extension_op && cargo test -p tenferro-ops ext_op` | pending |
+
+## Cleanup Acceptance Checks
+
+Run these before declaring the migration complete:
+
+```sh
+# tenferro must not own or export einsum implementation.
+! rg -n "pub .*einsum|EinsumSubscripts|EinsumOptimize|EinsumExtensionOp|execute_einsum" tenferro/src
+
+# tenferro must not normally depend on tenferro-einsum.
+! rg -n 'tenferro-einsum' tenferro/Cargo.toml
+
+# tenferro-ops must not contain the old built-in op or AD rule.
+! rg -n "NaryEinsum|einsum" tenferro-ops/src/ad tenferro-ops/src/std_tensor_op.rs
+
+# Generic runtime may mention extension caches, but not hard-coded einsum cache fields.
+! rg -n "static_einsum_plans|einsum_parse|runtime_einsum_plans|einsum_cache" tenferro/src
+
+# The implementation must live in tenferro-einsum.
+rg -n "EinsumExtensionOp|ExtensionExecutor|tenferro\\.einsum|einsum" tenferro-einsum/src tenferro-einsum/tests
+```
+
+Run these build checks:
+
+```sh
+cargo check --workspace
+cargo test -p tenferro-einsum
+cargo test -p tenferro
+cargo test -p tenferro-ops
+cargo check --no-default-features
+cargo check --no-default-features --features cpu-faer
+cargo tree --no-default-features -e normal -p tenferro
+```
+
+The `cargo tree` output must not contain `tidu`, `chainrules-core`, or
+`chainrules` for primal-only builds.
+
+## Step-By-Step Review Gates
+
+1. Inventory gate: every source item above is marked `ported` or `not-needed`
+   with a reason.
+2. Runtime gate: `tenferro` has generic extension registry/cache APIs and no
+   einsum downcasts.
+3. Crate gate: `tenferro-einsum` owns traced, eager, AD, extension payload,
+   execution, and cache behavior.
+4. Cache gate: parse, static-plan, and runtime-plan caches exist in explicit
+   compiler/runtime owners; context-free direct eager caches are removed.
+5. AD gate: einsum AD tests pass with `autodiff`; primal-only builds exclude AD
+   dependencies.
+6. Cleanup gate: all acceptance commands above pass.

--- a/docs/design/extension-runtime-restructure.md
+++ b/docs/design/extension-runtime-restructure.md
@@ -1,0 +1,957 @@
+# Extension Runtime Restructure
+
+This note sketches a post-`origin/main` restructure for making tenferro a lean
+tensor graph runtime while moving domain-heavy operation families into
+extension crates. The immediate motivation is einsum, but the design must also
+cover linalg, FFT, future random/sparse/special packages, and non-AD builds.
+
+The key decision is to treat crate boundaries and feature boundaries
+separately:
+
+- crate boundaries split operation domains,
+- feature boundaries split optional capabilities such as automatic
+  differentiation and CUDA.
+
+## Goals
+
+- Keep `tenferro` small enough to be the runtime/foundation crate.
+- Keep `tenferro-ops` focused on the minimal IR, primitive ops, and extension
+  carrier.
+- Move domain-specific APIs and implementation ownership into extension crates.
+- Make extension crates usable directly, Rust-style, without requiring
+  `tenferro` to re-export every domain.
+- Let automatic differentiation be controlled by an `autodiff` feature rather
+  than by separate AD crates.
+- Make primal-only builds possible without `tidu`, `chainrules-core`, or
+  `chainrules` dependencies, per issue #861.
+- Support multi-output, mixed-dtype, backend-aware extension execution well
+  enough for linalg.
+
+## Non-Goals
+
+- Do not make `tenferro` an ndarray replacement.
+- Do not require Python/NumPy-style discoverability through one flat facade.
+- Do not split AD into separate crates unless feature gates prove
+  unmanageable.
+- Do not optimize partial-output execution in the first migration. Correctness
+  and a stable contract come first.
+
+## Target Crate Shape
+
+```text
+tenferro
+  Runtime/foundation crate:
+  - TracedTensor / EagerTensor
+  - GraphCompiler / GraphExecutor
+  - generic ExtensionOp carrier and execution runtime
+  - minimal primitive ops and wrappers
+  - backend dispatch infrastructure
+
+tenferro-ops
+  Minimal operation IR:
+  - primitive StdTensorOp variants
+  - StdTensorOp::Extension
+  - primal ExtensionOp trait
+  - autodiff-gated AD traits/registry/builders
+
+tenferro-einsum
+  Directly used extension crate:
+  - tenferro_einsum::einsum / einsum_with / integer-label APIs
+  - EinsumExtensionOp
+  - parser, optimizer, lowering, eager/runtime implementation
+  - extension-owned caches
+  - autodiff-gated einsum AD rule
+
+tenferro-linalg
+  Future extension crate:
+  - svd, qr, eig, eigh, cholesky, lu, solve, triangular_solve, ...
+  - linalg extension ops and backend dispatch
+  - linalg-specific AD rules under autodiff
+
+tenferro-fft
+  Existing external extension crate shape:
+  - fft, ifft, rfft, irfft
+  - should move AD registration behind autodiff
+
+future:
+  tenferro-random, tenferro-sparse, tenferro-special, tenferro-signal
+```
+
+Usage should be explicit:
+
+```rust
+use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro_einsum::einsum;
+use tenferro_fft::{fft, FftNorm};
+use tenferro_linalg::svd;
+```
+
+`tenferro` does not need to provide `tenferro::fft` or `tenferro::linalg`.
+Discoverability should come from crate names, docs, examples, and catalog pages
+rather than from a flat facade.
+
+## Dependency Direction
+
+Domain extension crates should be ordinary downstream crates of `tenferro`.
+That keeps extension APIs close to the user-facing tensor types and matches
+`tenferro-fft`:
+
+```text
+tenferro-einsum -> tenferro -> tenferro-ops -> tenferro-tensor
+tenferro-fft    -> tenferro -> tenferro-ops -> tenferro-tensor
+tenferro-linalg -> tenferro -> tenferro-ops -> tenferro-tensor
+```
+
+`tenferro` must not depend on `tenferro-einsum`, `tenferro-fft`, or
+`tenferro-linalg`, otherwise extension crates cannot own their implementation
+without creating facade cycles. If a batteries-included experience is useful
+later, add a separate `tenferro-full` or `tenferro-prelude` crate rather than
+making the foundation crate re-export every domain.
+
+## Feature Naming
+
+Public feature names should describe capabilities, not implementation details:
+
+```toml
+[features]
+default = ["cpu-faer", "autodiff"]
+autodiff = ["dep:tidu", "dep:chainrules-core", "dep:chainrules"]
+cpu-faer = [...]
+cpu-blas = [...]
+gpu = [...]
+cuda = ["gpu", ...]
+rocm = ["gpu", ...] # planned
+```
+
+If an `ad` feature exists during migration, rename it to `autodiff` rather than
+keeping both names long term. A temporary `ad = ["autodiff"]` alias is acceptable
+inside the workspace during transition, but it should not be documented as a
+stable public feature.
+
+`gpu` should be the public capability feature for GPU infrastructure. Concrete
+vendor backends should use vendor feature names: `cuda` now, `rocm` later.
+`cubecl` may remain an internal module or private implementation detail, but
+users should not need to select it directly. Because the current workspace
+contains a visible `tenferro-cubecl` crate, a feature rename alone does not make
+CubeCL invisible to workspace users. Rename the implementation crate to the
+technology-neutral `tenferro-gpubackend` as part of this restructure. That crate
+can use CubeCL internally today and still leave room for CUDA, ROCm, or a
+non-CubeCL implementation later. Step 1 of the migration should introduce `gpu`
+as the shared capability feature, `cuda` as the first concrete vendor backend,
+and update workspace/package paths from `tenferro-cubecl` to
+`tenferro-gpubackend`.
+
+Feature semantics:
+
+```text
+gpu
+  Enables GPU-facing abstractions and extension plumbing. It does not by itself
+  promise a usable vendor backend.
+
+cuda
+  Enables the CUDA backend and implies gpu.
+
+rocm
+  Planned. Enables the ROCm backend and implies gpu.
+```
+
+## Extension Primal Contract
+
+The primal extension contract must remain available without `autodiff`.
+
+Required surface:
+
+- stable `family_id`,
+- deterministic `payload_hash`,
+- structural `payload_eq`,
+- fixed `n_inputs` and `n_outputs`,
+- per-output shape and dtype inference,
+- forward execution through a registered family executor.
+
+Forward execution should receive an execution context. A context-free
+`eager_execute(&[&Tensor])` method should not be part of the long-term primary
+contract. Even host implementations may need context for planner caches,
+workspace, profiling, determinism settings, or CPU buffer pools.
+
+## Backend-Aware Extension Execution
+
+Use one context-aware execution contract for eager and compiled execution. Do
+not put a generic method such as `fn execute<B: TensorBackend>(...)` directly
+on `dyn ExtensionOp`; generic trait methods are not object-safe.
+
+The selected design is a backend-typed, object-safe executor registry:
+
+```rust
+pub trait ExtensionExecutor<B: TensorBackend>: Send + Sync + 'static {
+    fn family_id(&self) -> ExtensionFamilyId;
+    fn accepts_schema_version(&self, version: ExtensionSchemaVersion) -> bool;
+
+    fn execute(
+        &self,
+        ctx: &mut ExtensionExecutionContext<'_, B>,
+        op: &dyn ExtensionOp,
+        inputs: &[&Tensor],
+    ) -> tenferro_tensor::Result<Vec<Tensor>>;
+}
+
+pub struct ExtensionRegistry<B: TensorBackend> {
+    executors: HashMap<ExtensionFamilyId, Arc<dyn ExtensionExecutor<B>>>,
+}
+```
+
+`dyn ExtensionExecutor<B>` is object-safe because `B` is fixed at the registry
+type. This avoids an erased-context downcast protocol. A `GraphExecutor<B>` or
+`EagerRuntime<B>` executes extensions through the registry for its own backend
+type. Extension crates may provide one executor that is generic over many
+backends, or separate CPU/CUDA executors when backend-specific kernels or
+planner caches are required.
+
+The concrete shape should be:
+
+```text
+ExtensionOp
+  object-safe payload and metadata:
+  - family_id
+  - schema_version
+  - payload_hash / payload_eq
+  - n_inputs / n_outputs
+  - infer_output_meta
+
+ExtensionExecutor
+  object-safe family executor registered by family_id for one backend type B:
+  - accepts_schema_version(schema_version)
+  - execute(ctx, op, inputs) -> Vec<Tensor>
+  - may downcast op payload after checking family_id and schema_version
+
+ExtensionRegistry<B>
+  runtime-owned mapping:
+  - family_id -> ExtensionExecutor<B>
+  - registration rejects duplicate family IDs for the same backend registry
+  - execution rejects ops whose schema_version is not accepted by the executor
+```
+
+The executor context should provide enough information for:
+
+- backend-specific execution,
+- backend runtime caches,
+- CPU buffer pools,
+- GPU streams/sessions,
+- dispatch mode,
+- extension-owned runtime caches,
+- temporary workspace management.
+
+Conceptually, this is the typed shape each concrete backend implementation may
+use internally:
+
+```rust
+pub struct ExtensionExecutionContext<'a, B: TensorBackend> {
+    pub backend: &'a mut B,
+    pub backend_runtime: &'a mut BackendRuntimeState<B>,
+    pub extension_caches: &'a mut dyn ExtensionCacheStore,
+    pub dispatch_mode: DispatchMode,
+}
+```
+
+`BackendRuntimeState<B>` is owned by the runtime/session, not borrowed out of
+`B`. This avoids aliasing `&mut B` and `&mut B::RuntimeCache` when a backend
+implementation stores cache-like state internally. Backend implementations may
+still delegate from `BackendRuntimeState<B>` into `B` if that is their local
+implementation strategy, but the extension runtime contract treats backend
+runtime state as an external execution resource.
+
+The object-safe call exposed by the runtime is typed by the surrounding backend
+registry:
+
+```text
+GraphExecutor<B>
+  -> ExtensionRegistry<B>
+  -> dyn ExtensionExecutor<B>
+  -> ExtensionExecutionContext<'_, B>
+```
+
+Simple host-only extensions can ignore unused context fields; they should not
+need a separate no-context method. The existing
+`eager_execute(&[&Tensor]) -> Vec<Tensor>` method is a transitional API only.
+After the registry lands, remove it from the primary trait and route eager and
+compiled execution through the same context-aware executor surface.
+
+Registration should be explicit and non-global. A runtime/session builder owns
+the registry and hands immutable executor registrations plus mutable cache
+storage to eager and compiled execution:
+
+```rust
+let extensions = ExtensionRegistry::<CpuBackend>::new()
+    .with(tenferro_einsum::executor::<CpuBackend>())
+    .with(tenferro_fft::executor::<CpuBackend>());
+
+let executor = GraphExecutor::builder(cpu_backend)
+    .extensions(extensions)
+    .build();
+```
+
+Registries are per backend type and per runtime/session. A process using CPU
+and CUDA/ROCm in the same run constructs one `ExtensionRegistry<CpuBackend>` and
+one registry for each GPU backend type. There is no global cross-backend
+registry in the first design; a future convenience layer may build multiple
+typed registries from one extension catalog.
+
+Convenience constructors may install standard extension crates in examples or a
+future `tenferro-full` crate, but `tenferro` itself should not globally register
+or depend on domain executors.
+
+The public runtime surface needed by external extension crates is:
+
+- construct a traced/eager extension application from an `Arc<dyn ExtensionOp>`,
+- register an `ExtensionExecutor<B>` with an `ExtensionRegistry<B>`,
+- access typed extension runtime caches by family-owned cache IDs,
+- report per-output metadata and validation errors,
+- return multiple output tensors from one extension execution,
+- attach `autodiff` rules when the feature is enabled.
+
+Einsum should not need private `tenferro` helpers once these APIs exist.
+
+## Multi-Output Semantics
+
+Multi-output extensions are first-class.
+
+Rules:
+
+- `n_outputs()` declares the number of output slots.
+- `infer_output_meta()` returns exactly one `(DType, Vec<SymDim>)` per output.
+- mixed output dtypes are legal.
+- each output slot has independent metadata.
+- the graph compiler and executor allocate, track, and reclaim output slots
+  independently.
+- output metadata is part of graph validation and compile-cache safety.
+
+Linalg needs this immediately:
+
+```text
+svd(C64[m,n])  -> U: C64[m,k], S: F64[k], Vh: C64[k,n]
+eigh(C64[n,n]) -> W: F64[n], V: C64[n,n]
+eig(F64[n,n])  -> W: C64[n], V: C64[n,n]
+lu(A)          -> multiple factor/pivot outputs
+```
+
+Before moving linalg, add tests for a synthetic extension returning mixed-dtype
+multi-output values, for example `(C64 matrix, F64 vector)`.
+
+## Partial Output Use
+
+A graph may consume only some outputs of a multi-output extension:
+
+```rust
+let (_u, s, _vh) = svd(&x);
+loss(&s)
+```
+
+Initial rule:
+
+```text
+The executor may materialize all outputs declared by an extension op.
+Unused downstream values may be removed by graph DCE, but the runtime is not
+required to split one extension execution into independently computed outputs.
+Per-output lazy execution is future work.
+```
+
+This is conservative and fits linalg, where backend kernels often compute all
+outputs together or expose separate modes only for some operations. It also
+keeps the first migration focused on correctness.
+
+Future extension metadata may describe output computability:
+
+```text
+AllOrNothing
+IndependentlyComputable
+SubsetModes([...])
+```
+
+but that should not block the first extension-runtime contract.
+
+## Autodiff Feature Boundary
+
+Use `autodiff`, not `ad`, as the public feature name.
+
+Primal pieces available without `autodiff`:
+
+- `ExtensionOp`,
+- `StdTensorOp::Extension`,
+- graph compilation and execution,
+- eager forward execution,
+- domain extension forward APIs.
+
+Autodiff-gated pieces:
+
+- `ExtensionAdRule`,
+- `ExtensionChainRule`,
+- `AdValue`,
+- `FruleBuilder`,
+- `RRuleBuilder`,
+- extension AD registry,
+- `PrimitiveOp` impls that depend on `chainrules-core`,
+- `TensorInputKey` AD keying,
+- `TracedTensor::{grad, jvp, vjp, ...}`,
+- `EagerTensor::{requires_grad_in, grad, backward, ...}`,
+- `tidu` integration,
+- Cargo dependencies on `tidu`, `chainrules-core`, and `chainrules`.
+
+Concrete current items to gate or move during implementation:
+
+```text
+tenferro-ops/src/std_tensor_op.rs
+  impl PrimitiveOp for StdTensorOp
+
+tenferro-ops/src/input_key.rs
+  impl ADKey for TensorInputKey
+
+tenferro-ops/src/ext_op.rs
+  ExtensionAdRule, ExtensionChainRule, AdValue,
+  FruleBuilder, RRuleBuilder, AD support reporting
+
+tenferro/src/error.rs
+  Error variants that directly expose AD rule failures
+
+tenferro/src/traced.rs and traced tensor API modules
+  grad, try_grad, jvp, try_jvp, vjp, try_vjp, hvp-style helpers
+
+tenferro/src/eager.rs and eager tensor API modules
+  requires_grad_in, grad, clear_grad, tracks_grad, backward,
+  eager tape/tidu integration
+```
+
+The feature introduction step is only naming. Issue #861 is not satisfied until
+these impls and APIs are actually `#[cfg(feature = "autodiff")]` and
+`cargo check --no-default-features` no longer builds `tidu`,
+`chainrules-core`, or `chainrules`. `chainrules-rs` is the repository name;
+`chainrules-core` and `chainrules` are the Cargo dependency names that need to
+disappear from primal-only builds.
+
+The current `tenferro-ops/src/ext_op.rs` mixes primal extension and extension
+AD. It should be split into an always-available primal module and an
+`autodiff`-gated module, for example:
+
+```text
+tenferro_ops::ext_op      // primal ExtensionOp
+tenferro_ops::ext_ad      // ExtensionAdRule, builders, registry
+tenferro::extension       // primal facade
+tenferro::extension::ad   // autodiff facade
+```
+
+This split is a prerequisite for no-AD builds that still support extension
+forward execution.
+
+## Multi-Output VJP Contract
+
+The transpose rule for a multi-output extension receives one optional cotangent
+per output:
+
+```text
+cotangent_out: Vec<Option<Cotangent>>
+```
+
+Semantics:
+
+- `None` means that output is inactive in the differentiated scalar.
+- `None` is not the same as a materialized zero tensor unless the rule chooses
+  to treat it that way.
+- a rule may support only some active-output subsets and return
+  `Unsupported` for others.
+- support should eventually be finer than one boolean per op.
+
+Examples:
+
+```text
+svd:
+  only S active      -> relatively common and useful
+  U/S/Vh active      -> full rule, more complex
+  only U or only Vh  -> may be unsupported initially
+
+eigh:
+  only eigenvalues active  -> simpler
+  eigenvectors active      -> more complex, degeneracy-sensitive
+
+eig:
+  eigenvalues active       -> complex-valued even for real inputs
+  eigenvectors active      -> more complex, degeneracy-sensitive
+
+qr/lu:
+  selected outputs may be active depending on downstream use
+```
+
+AD APIs should also allow callers or wrapper APIs to declare which outputs are
+intended to participate in autodiff. This is separate from ordinary graph DCE:
+an output may be computed for primal use while explicitly excluded from
+autodiff.
+
+The contract should distinguish three concepts:
+
+```text
+produced outputs
+  All outputs the primal extension op returns.
+
+used outputs
+  Outputs consumed by the primal graph after ordinary DCE.
+
+autodiff-active outputs
+  Outputs whose cotangents are allowed to flow into the extension's VJP rule.
+```
+
+For linalg this matters because partial rules are common and useful. A wrapper
+can expose an explicit active-output policy:
+
+```rust
+let (u, s, vh) = svd(&x);
+let s = s.autodiff_active();
+let u = u.stop_gradient();
+let vh = vh.stop_gradient();
+```
+
+or, more ergonomically, operation-specific wrappers can encode the intended
+policy:
+
+```rust
+let s = svd_values(&x);        // only singular values are autodiff-active
+let (w, v) = eigh(&x);         // wrapper may mark both active
+let w = eigvalsh(&x);          // only eigenvalues are autodiff-active
+```
+
+The lower-level extension rule should receive an active-output mask in addition
+to the optional cotangents:
+
+```rust
+pub struct ExtensionVjpRequest<'a> {
+    pub op: &'a dyn ExtensionOp,
+    pub inputs: &'a [AdValue],
+    pub outputs: &'a [AdValue],
+    pub active_outputs: &'a [bool],
+    pub cotangent_out: &'a [Option<Cotangent>],
+}
+
+pub trait ExtensionAdRule {
+    fn vjp(&self, request: ExtensionVjpRequest<'_>) -> Result<Vec<Option<Cotangent>>>;
+    fn jvp(&self, request: ExtensionJvpRequest<'_>) -> Result<Vec<Option<Tangent>>>;
+}
+```
+
+These two fields are intentionally not the same. `cotangent_out[i]` describes
+what the transformed graph currently needs. `active_outputs[i]` describes the
+AD contract selected by the API, wrapper, or explicit stop-gradient boundary.
+`active_outputs[i] == false` means output `i` is outside the requested autodiff
+contract even if the primal value is produced and used. If a cotangent is
+nevertheless present for an inactive output, the AD transform must treat the
+inactive marker as a stop-gradient boundary and pass `None` to the extension
+rule for that slot. It should not reject the graph merely because a primal user
+kept the value alive; wrappers such as `svd_values` should compose predictably
+with ordinary graph use.
+
+This allows a rule to be precise:
+
+```text
+svd full rule:
+  supports active outputs {S}
+  may later support {U, S, Vh}
+  rejects {U}, {Vh}, {U, Vh}, etc. until implemented
+
+eigh:
+  supports {W}
+  may later support {W, V}
+```
+
+For the first implementation, the active-output mask can be derived from
+ordinary graph activity plus explicit `stop_gradient` boundaries. Later, public
+operation wrappers can expose more intentional APIs for common subsets.
+
+The wrapper or API records the intended active-output policy; the AD transform
+combines that policy with graph activity and `stop_gradient` boundaries before
+invoking `ExtensionAdRule::vjp`.
+
+The AD rule API already passes output cotangent options in spirit. The
+restructure should preserve that, make the active-output meaning explicit, and
+add tests for partial-output VJP behavior.
+
+## Extension Cache Model
+
+Cache identity should be typed, not string-mutation based.
+
+Rules:
+
+- extension families own cache semantics and cache IDs,
+- `tenferro` owns generic storage/control/reporting infrastructure,
+- public cache mutation uses `ExtensionCacheId`,
+- no `*_by_name` or family-string mutation APIs,
+- compiler-side and executor-side caches remain distinct,
+- family IDs are globally namespaced strings, for example
+  `tenferro.einsum`, `tenferro.fft`, and `tenferro.linalg`,
+- schema versions are explicit and participate in executor/cache
+  compatibility checks.
+
+`family_id` identifies the operation family, not a single cache. Versioning
+should be monotonic within a family. A new schema version may reuse old cache
+entries only if the family executor declares compatibility; otherwise the
+runtime treats caches as separate. Two crates must not register different
+executors for the same `(family_id, schema_version)` unless they are the same
+implementation version.
+For the first implementation, `ExtensionExecutor::accepts_schema_version`
+governs both op payload compatibility and cache-entry compatibility. If a
+future family needs finer-grained cache compatibility, add a separate
+`accepts_cache_from_schema_version` hook.
+
+The selected ownership model is:
+
+```text
+GraphCompiler
+  owns compile-time extension caches:
+  - parser caches
+  - symbolic/static planning caches
+  - metadata inference caches
+
+GraphExecutor<B> / EagerRuntime<B>
+  owns backend runtime extension caches:
+  - runtime contraction plans
+  - FFT plans
+  - backend workspace pools
+  - backend-specific analysis caches
+```
+
+The storage object is a type map keyed by a typed cache key:
+
+```rust
+pub struct ExtensionCacheKey {
+    pub family_id: ExtensionFamilyId,
+    pub schema_version: ExtensionSchemaVersion,
+    pub cache_id: ExtensionCacheId,
+    pub backend: Option<BackendCacheKey>,
+}
+
+pub enum BackendCacheKey {
+    BackendType(&'static str),
+    Device { backend: &'static str, device_id: String },
+    RuntimeInstance(u64),
+}
+
+pub enum ExtensionCacheSelector {
+    All,
+    Family(ExtensionFamilyId),
+    Cache(ExtensionCacheKey),
+}
+
+pub enum ExtensionCacheLimit {
+    Entries(usize),
+    Bytes(usize),
+    Unlimited,
+}
+
+pub trait ExtensionCacheStore {
+    fn get_or_insert_any(
+        &mut self,
+        key: ExtensionCacheKey,
+        init: &mut dyn FnMut() -> Box<dyn Any + Send + Sync>,
+    ) -> &mut dyn Any;
+
+    fn clear(&mut self, selector: ExtensionCacheSelector);
+    fn stats(&self, selector: ExtensionCacheSelector) -> ExtensionCacheStats;
+    fn set_limit(&mut self, key: ExtensionCacheKey, limit: ExtensionCacheLimit);
+}
+
+pub trait ExtensionCacheStoreExt {
+    fn get_or_insert<T: Any + Send + Sync>(
+        &mut self,
+        key: ExtensionCacheKey,
+        init: impl FnOnce() -> T,
+    ) -> tenferro_tensor::Result<&mut T>;
+}
+```
+
+`ExtensionCacheStore` is object-safe for runtime contexts. The generic
+`ExtensionCacheStoreExt::get_or_insert<T>` helper can live as an extension trait
+implemented for `dyn ExtensionCacheStore`, performing downcast checks and
+returning a typed cache entry to extension crates. Public controls use selectors
+such as `Family(family_id)`, `Cache(key)`, or `All`; they do not expose string
+mutation APIs.
+
+Use two distinct stores, not one store discriminated only by key: one
+compile-time store owned by `GraphCompiler`, and one runtime store owned by each
+`GraphExecutor<B>` or `EagerRuntime<B>`. Runtime stores are per runtime/session
+instance and externally serialized through `&mut self` execution APIs in the
+first design. Sharing one cache store across concurrent executors requires an
+explicit synchronization wrapper and is future work.
+
+`BackendCacheKey` should be omitted for compile-time caches and present for
+backend runtime caches. Prefer `Device` for GPU planner caches that depend on a
+specific device, `BackendType` for backend-wide CPU planner state, and
+`RuntimeInstance` only for state that cannot be shared safely across runtime
+instances.
+
+Einsum likely needs:
+
+```text
+parse cache                 compiler or extension build side
+static contraction plans     compiler/build side
+runtime contraction plans    executor/runtime side
+```
+
+FFT may need planner caches later.
+
+Linalg may need backend analysis or factorization plan caches later.
+
+The important design point is that `GraphCompiler` and `GraphExecutor` should
+not contain hard-coded `einsum_*` fields once `tenferro-einsum` is a true
+extension crate.
+
+## Domain Migration Notes
+
+### Einsum
+
+Einsum should be the first migrated domain because it is mostly single-output
+and the current experimental branch already exposes the right failure modes.
+
+Move into `tenferro-einsum`:
+
+- `EinsumSubscripts` or an equivalent integer-label API,
+- `EinsumExtensionOp`,
+- `tenferro.einsum` family identity and schema versions,
+- cache IDs and cache semantics,
+- traced API `tenferro_einsum::einsum`,
+- eager/runtime execution,
+- `autodiff`-gated AD rule.
+
+`tenferro-einsum` should own all implementation details: parsing, integer-label
+normalization, path planning, static contraction tree construction, lowering,
+runtime execution, and cache policy. `tenferro` should provide only the generic
+extension application API, executor registry, runtime context, and cache storage.
+Any helper currently required by the prototype but private to `tenferro` should
+be promoted to a domain-neutral public API or removed from the extension path.
+`tenferro-einsum` is an implementation crate, not a facade-only crate, so unit
+tests may live there.
+
+Remove from `tenferro-ops`:
+
+- `StdTensorOp::NaryEinsum`,
+- einsum-specific AD rules,
+- einsum-specific support manifest entries.
+
+Remove from `tenferro`:
+
+- dependency on `tenferro-einsum`,
+- `tenferro::einsum` facade unless a separate batteries-included crate is
+  created,
+- hard-coded einsum compiler/executor cache fields,
+- all einsum-named implementation files and tests.
+
+Concrete files from the current branch/prototype to move or delete include:
+
+```text
+tenferro/src/einsum.rs
+tenferro/src/eager_einsum.rs
+tenferro/src/einsum_subscripts.rs
+tenferro/src/einsum_extension.rs
+tenferro/src/tensor.rs einsum facade functions
+tenferro/src/typed_tensor.rs einsum facade functions
+tenferro/src/eager_tensor.rs einsum facade functions
+tenferro/tests/graph_einsum.rs
+tenferro/tests/tensor_einsum.rs
+tenferro/tests/einsum_ad.rs
+tenferro/tests/einsum_extension_cache.rs
+tenferro/tests/einsum_extension_symbolic.rs
+tenferro/tests/nary_einsum_cache.rs
+tenferro/tests/nary_einsum_symbolic.rs
+```
+
+Post-migration acceptance criterion:
+
+- `tenferro/Cargo.toml` has no normal dependency on `tenferro-einsum`,
+- `tenferro/src/**/*.rs` contains no public item named `einsum*`,
+- `tenferro` exports nothing named `einsum*`,
+- `tenferro` has no hard-coded einsum cache fields or cache APIs,
+- no `pub` item in `tenferro` exists solely to support `tenferro-einsum`,
+- implementation and AD tests for einsum live in `tenferro-einsum/tests`.
+
+A `dev-dependency` from `tenferro` tests to `tenferro-einsum` is allowed only
+for runtime/extension integration coverage. It must not leak into normal
+dependencies or public API.
+
+### Linalg
+
+Linalg should not be the first full migration. It is the stress test for the
+extension runtime.
+
+Before migrating linalg, solve:
+
+- backend-aware extension execution,
+- mixed-dtype multi-output metadata,
+- partial output use,
+- multi-output VJP support,
+- extension AD behind `autodiff`,
+- public graph-building helpers needed by an external crate.
+
+Linalg candidates for `tenferro-linalg`:
+
+- `svd`, `qr`, `eig`, `eigh`,
+- `cholesky`, `lu`, `full_piv_lu`,
+- `solve`, `full_piv_lu_solve`, `triangular_solve`,
+- derived wrappers such as `det`, `inv`, `pinv`, `norm`.
+
+Core may keep `dot_general` and minimal primitives used by linalg lowering.
+
+Concrete phase-1 boundary:
+
+- keep existing linalg backend kernels and low-level backend traits in
+  `tenferro-tensor` until extension backend dispatch is proven,
+- keep direct `StdTensorOp` linalg variants in `tenferro-ops` until the
+  multi-output extension executor supports mixed dtypes and AD-active output
+  masks,
+- move only public wrappers that can be expressed through the generic extension
+  surface after that surface exists,
+- remove direct linalg variants only after parity tests cover eager, compiled,
+  shape inference, AD support reporting, and GPU/backend paths.
+
+The variants to account for are:
+
+```text
+Cholesky, Lu, FullPivLu, Solve, FullPivLuSolve,
+Svd, Qr, Eigh, Eig, TriangularSolve, ValidateNonsingular
+```
+
+### FFT
+
+`tenferro-fft` is already close to the desired external extension-crate shape.
+
+Needed adjustments:
+
+- put AD registration behind `autodiff`,
+- consider backend-aware execution before adding GPU/cuFFT support,
+- add planner caches through the generic extension cache model when needed.
+
+### Random
+
+Random is a good future extension because it differentiates tenferro from
+plain ndarray-style helpers if it is graph/backend aware:
+
+- explicit keys/seeds,
+- CPU/GPU reproducibility policy,
+- graph random ops,
+- non-differentiability or reparameterization rules under `autodiff`.
+
+## Alternatives Considered
+
+### One Domain Crate With Features
+
+An alternative is a single `tenferro-domains` crate:
+
+```toml
+tenferro-domains = { features = ["einsum", "fft", "linalg", "random"] }
+```
+
+This improves discoverability and reduces dependency-list noise, but it makes
+independent release cadence, compile parallelism, optional heavy dependencies,
+and domain ownership worse. It also recreates a broad facade under a different
+name.
+
+Prefer separate crates for now:
+
+```text
+tenferro-einsum
+tenferro-fft
+tenferro-linalg
+tenferro-random
+```
+
+A later `tenferro-full` can re-export common crates if users want a bundled
+experience.
+
+## Migration Plan
+
+Start from `origin/main`, not from the current einsum experiment branch.
+
+1. Stabilize names and direction.
+   - introduce `autodiff` as the stable public AD feature,
+   - remove or temporarily alias any existing `ad` feature to `autodiff`,
+   - expose `gpu` as the shared public GPU capability feature,
+   - expose `cuda` as the first concrete vendor backend feature and make it
+     imply `gpu`,
+   - reserve `rocm` as the future ROCm backend feature, also implying `gpu`,
+   - stop requiring users to select implementation-facing `cubecl`,
+   - rename the implementation crate from `tenferro-cubecl` to
+     `tenferro-gpubackend` in this restructure,
+   - document that domain crates are imported directly rather than re-exported
+     from `tenferro`,
+   - keep existing defaults initially unless publish constraints require a
+     lean default.
+
+2. Redesign primal extension execution.
+   - introduce `ExtensionRegistry<B>` and object-safe `ExtensionExecutor<B>`,
+   - add `accepts_schema_version` to the executor contract,
+   - make context-aware execution the primary forward contract,
+   - remove context-free `eager_execute` from the long-term trait,
+   - ensure eager and compiled execution use the same semantic surface,
+   - let simple host-only extensions ignore context fields,
+   - make registration explicit through runtime/session builders, not global
+     initialization,
+   - expose the public runtime helpers external extension crates need,
+   - add object-safety tests for `dyn ExtensionExecutor<B>`.
+
+3. Split primal extension from extension AD.
+   - keep `ExtensionOp` always available,
+   - gate AD registry/builders/rules behind `autodiff`,
+   - gate `PrimitiveOp`/`ADKey` impls and tensor AD APIs behind `autodiff`,
+   - add no-AD compile checks,
+   - add CI for `cargo check --no-default-features`,
+   - add CI for `cargo check --no-default-features --features cpu-faer`,
+   - add a dependency assertion such as
+     `cargo tree --no-default-features -e normal -p tenferro` and equivalent
+     per-crate checks that fail if `tidu`, `chainrules-core`, or `chainrules`
+     appear.
+
+4. Lift extension graph/runtime support to multi-output.
+   - ensure graph nodes can represent N extension outputs,
+   - ensure per-output dtype and shape metadata flows through shape inference,
+     compiler validation, segmenting, and execution,
+   - ensure `GraphExecutor<B>` returns and stores all extension outputs without
+     assuming a single output tensor,
+   - ensure mixed-dtype outputs are accepted before linalg migration.
+
+5. Add multi-output and mixed-dtype extension tests.
+   - synthetic extension returning multiple outputs,
+   - partial output use,
+   - explicit autodiff-active output masks,
+   - inactive outputs behave as stop-gradient when cotangents would otherwise
+     flow,
+   - compile cache correctness,
+   - eager and compiled execution.
+
+6. Move einsum to `tenferro-einsum`.
+   - remove direct `NaryEinsum` from `tenferro-ops`,
+   - expose `tenferro_einsum::einsum`,
+   - move parser/subscripts/path planning/lowering/runtime/cache ownership out
+     of `tenferro`,
+   - remove all public `tenferro::einsum` and
+     `tenferro::{tensor,typed_tensor,eager_tensor}` einsum facade functions
+     unless a compatibility crate is created,
+   - remove all hard-coded einsum cache APIs from `GraphCompiler` and
+     `GraphExecutor`,
+   - move tests into `tenferro-einsum/tests`,
+   - keep AD under `autodiff`,
+   - verify the structured acceptance criteria from the Einsum section,
+     including no normal `tenferro -> tenferro-einsum` dependency and no
+     `tenferro` public `einsum*` exports.
+
+7. Revisit linalg.
+   - first make linalg work as extensions while backend kernels may still live
+     in `tenferro-tensor`,
+   - later decide whether kernel ownership should also move.
+
+8. Update docs and examples.
+   - document extension crate catalog,
+   - stop implying all domains live under `tenferro::*`,
+   - explain `autodiff`, `gpu`, `cuda`, and planned `rocm` features.
+
+## Open Questions
+
+- Should `tenferro` default to `autodiff`, or should the crates.io foundation
+  pass default to primal-only?
+- Should a future `tenferro-full` or `tenferro-prelude` crate re-export common
+  domain crates, or should all domain crates remain explicit?
+- How much of linalg backend kernel ownership belongs in `tenferro-tensor`
+  versus `tenferro-linalg`?
+- How fine-grained should AD support reporting become for partial multi-output
+  rules?

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -161,6 +161,13 @@ Elementwise, structural, indexing, and reduction kernels should launch enough
 parallel work items to cover the output or update domain. Single-thread launch
 is not an acceptable correctness fallback for new or modified kernels.
 
+Reduction `Auto` strategy may use one unit per keepdims output element only
+when the reduce-axis length is bounded by the hardware plane width. Larger
+reduce axes must use a parallel plane/subgroup reduction strategy, or return an
+unsupported-strategy error when the runtime cannot provide plane operations.
+The explicit `Unit` strategy remains available as a requested serial strategy,
+but `Auto` must not silently route unbounded reduce-axis work to one worker.
+
 Scatter uses a two-phase launch: first a parallel copy initializes `out` from
 `operand`, then a parallel update kernel covers the scatter update domain.
 Overlapping add-scatter updates use CubeCL atomic add for supported real scalar

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -13,9 +13,9 @@ allocation, explicit CPU/GPU transfer, broad structural/elementwise/reduction
 kernels, cuTENSOR contractions, and cuSOLVER/cuBLAS linear algebra paths.
 Performance optimization is still active work. The remaining unsupported CUDA
 cases are operation-specific: `eig`, `full_piv_lu`, `full_piv_lu_solve`,
-`dynamic_update_slice`, `I64` numeric/linalg gaps, and selected complex
-analytic or ordering operations. HIP/ROCm is still a feature stub rather than
-a supported execution path.
+`dynamic_update_slice`, integer numeric/linalg gaps, `Bool` kernel gaps beyond
+transfer and reshape, and selected complex analytic or ordering operations.
+HIP/ROCm is still a feature stub rather than a supported execution path.
 
 See also:
 
@@ -218,11 +218,11 @@ CUDA library calls:
 
 | Category | Current status |
 | --- | --- |
-| Allocation/transfer | CUDA allocation, upload, download, raw pointer bridge |
+| Allocation/transfer | CUDA allocation, upload, download, raw pointer bridge for all public tensor dtypes |
 | Elementwise | `F32`/`F64` arithmetic, comparison, selection, clamp, and analytic unary ops; `C32`/`C64` add/mul/div/neg/conj |
-| Reductions | sum/prod for all tensor dtypes; min/max for `F32`/`F64` |
-| Structural | transpose, reshape, broadcast, reverse, concatenate, diagonal extraction/embedding, triangular masks for all tensor dtypes |
-| Indexing | slice/pad/concatenate/reverse for all tensor dtypes; gather/scatter/dynamic_slice for floating and complex data with numeric index tensors |
+| Reductions | sum/prod for `F32`, `F64`, `I32`, `I64`, `C32`, and `C64`; min/max for `F32`/`F64` |
+| Structural | reshape for all public tensor dtypes; transpose, broadcast, reverse, concatenate, diagonal extraction/embedding, and triangular masks for non-`Bool` dtypes with CubeCL element storage |
+| Indexing | slice/pad/concatenate/reverse for `F32`, `F64`, `I32`, `I64`, `C32`, and `C64`; gather/dynamic_slice for `F32`, `F64`, `I32`, `C32`, and `C64` data with `F32`, `F64`, `I32`, or `I64` start/index tensors; scatter for floating and complex data with those numeric index tensors |
 | Contraction | cuTENSOR-backed paths for supported real and complex floating dtypes |
 | Linalg | cuSOLVER/cuBLAS-backed SVD, QR, Cholesky, LU, Eigh, LU solve, and triangular solve for supported real and complex floating dtypes |
 
@@ -245,7 +245,9 @@ The following are intentionally outside the current batch:
 - selected complex analytic kernels and ordering operations,
 - CUDA implementations for `full_piv_lu`, `full_piv_lu_solve`, and
   `dynamic_update_slice`,
-- `I64` numeric/linalg CUDA kernels beyond structural and reduction paths,
+- integer numeric/linalg CUDA kernels beyond structural and reduction paths,
+- `Bool` CUDA kernels beyond allocation, upload/download, and metadata-only
+  reshape,
 - changing the public placement contract.
 
 ## Tests

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -17,6 +17,8 @@ architecture see [Architecture](../architecture/). For normative specs see
 | [contraction-pipeline.md](./contraction-pipeline.md) | Binary contraction pipeline, copy elision |
 | [dot-general-overhead.md](./dot-general-overhead.md) | Fixed-cost analysis for many small `dot_general` contractions |
 | [dynamic-symbolic-shapes.md](./dynamic-symbolic-shapes.md) | Dynamic and symbolic shape metadata contract |
+| [extension-runtime-restructure.md](./extension-runtime-restructure.md) | Current restructure direction for extension crates, backend-aware execution, multi-output, linalg migration boundaries, and autodiff feature gates |
+| [einsum-extension-migration-audit.md](./einsum-extension-migration-audit.md) | Source-to-target migration checklist for moving einsum into tenferro-einsum without regenerating the implementation |
 | [einsum-dyadtensor.md](./einsum-dyadtensor.md) | AD integration for einsum + frontend |
 | [gpu-backend-design.md](./gpu-backend-design.md) | GPU backend architecture |
 | [inplace-indexing.md](./inplace-indexing.md) | Partial in-place updates design |

--- a/docs/guides/custom-operations.md
+++ b/docs/guides/custom-operations.md
@@ -47,21 +47,22 @@ meaning of the operation there: axes, normalization mode, algorithm choice, and
 similar values. Do not hide unbounded plan caches, vendor handles, or mutable
 global state inside the payload semantics.
 
-There is no monolithic core runtime owner for extension state, and the current
-`EagerRuntime`, `GraphCompiler`, and `GraphExecutor` do not provide a public
-slot where an extension can store arbitrary runtime cache entries. If an
-extension needs a cache, the extension crate should own an explicit runtime or
-cache object, for example `FftRuntime` or `FftPlanCache`, and expose
-clear/stat/capacity controls on that object. First-class extension cache slots
-are tracked in [issue #878](https://github.com/tensor4all/tenferro-rs/issues/878).
+There is no monolithic process-global owner for arbitrary extension state.
+`EagerRuntime`, `GraphCompiler`, and `GraphExecutor` own explicit generic
+extension cache stores. Extension runtimes put entries in those stores with
+`ExtensionCacheKey`, so retained plans are tied to the compiler, eager context,
+or executor that uses them.
 
 An op payload may hold an `Arc` to such an extension-owned cache object only
 when the cache is a performance detail and is not part of semantic equality.
 Two extension ops that compare equal must remain interchangeable even if their
 caches are empty, warm, or independently owned.
 
-Compiled extension execution delegates to the extension's `eager_execute`, so
-eager and traced execution use the same extension-owned cache path.
+For einsum, `GraphCompiler` owns parse and static-plan caches, while
+`GraphExecutor` and `EagerRuntime` own runtime contraction-plan caches through
+their extension executors. These caches default to bounded LRU capacity 256 and
+expose capacity, clear, entry count, and retained-byte stats through the owning
+runtime.
 
 Avoid hidden process-global or thread-local caches in extension crates. If a
 cache lives longer than one call, make the owner explicit and bounded, and give

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -97,32 +97,33 @@ coverage for CUDA-resident `Tensor` values. It is not an autodiff coverage table
 
 Legend:
 
-- `F32`, `F64`, `I64`, `C32`, and `C64` are the current public `Tensor` dtypes.
+- `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, and `C64` are the current public `Tensor` dtypes.
 - Listed dtypes have CUDA implementations for that operation.
 - Missing dtypes or rows marked "No CUDA implementation" return an error
   rather than silently falling back to CPU.
 
 | Operation or family | CUDA dtype support | Notes |
 | --- | --- | --- |
-| Allocation, upload, download | `F32`, `F64`, `I64`, `C32`, `C64` | Explicit CPU/GPU transfer only |
-| `add`, `mul`, `div` | `F32`, `F64`, `C32`, `C64` | Same dtype inputs only; `I64` arithmetic is not implemented |
-| `neg` | `F32`, `F64`, `C32`, `C64` | `I64` is not implemented |
-| `conj` | `F32`, `F64`, `C32`, `C64` | Real dtypes are identity; `I64` is not implemented |
-| `abs`, `sign` | `F32`, `F64` | Complex and `I64` inputs are not implemented |
+| Allocation, upload, download | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Explicit CPU/GPU transfer only |
+| `add`, `mul`, `div` | `F32`, `F64`, `C32`, `C64` | Same dtype inputs only; integer and `Bool` arithmetic are not implemented |
+| `neg` | `F32`, `F64`, `C32`, `C64` | Integer and `Bool` negation are not implemented |
+| `conj` | `F32`, `F64`, `C32`, `C64` | Real floating dtypes are identity; integer and `Bool` inputs are not implemented |
+| `abs`, `sign` | `F32`, `F64` | Complex, integer, and `Bool` inputs are not implemented |
 | `maximum`, `minimum`, `compare`, `select`, `clamp` | `F32`, `F64` | Complex ordering is not defined; `compare` returns a numeric 0/1 tensor |
 | `exp`, `log`, `sin`, `cos`, `tanh`, `sqrt`, `rsqrt`, `expm1`, `log1p` | `F32`, `F64` | Complex analytic kernels are not implemented |
 | `pow` | `F32`, `F64` | Same dtype inputs only |
-| `transpose`, `reshape`, `broadcast_in_dim`, `extract_diagonal`, `embed_diagonal`, `tril`, `triu` | `F32`, `F64`, `I64`, `C32`, `C64` | Structural tensor operations |
-| `convert` | `F32`, `F64`, `C32`, `C64` among those dtypes; `I64` identity only | Conversion to or from `I64` is not implemented except `I64 -> I64` |
-| `reduce_sum`, `reduce_prod` | `F32`, `F64`, `I64`, `C32`, `C64` | Multi-axis reductions are composed from single-axis kernels |
-| `reduce_max`, `reduce_min` | `F32`, `F64` | Complex ordering is not defined; `I64` min/max is not implemented |
+| `reshape` | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Metadata-only shape change |
+| `transpose`, `broadcast_in_dim`, `extract_diagonal`, `embed_diagonal`, `tril`, `triu` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | Structural tensor operations; `Bool` is not implemented |
+| `convert` | `F32`, `F64`, `C32`, `C64` among those dtypes; `I32`, `I64`, and `Bool` identity only | Conversion to or from integer or `Bool` dtypes is not implemented except identity |
+| `reduce_sum`, `reduce_prod` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | Multi-axis reductions are composed from single-axis kernels; `Bool` is not implemented |
+| `reduce_max`, `reduce_min` | `F32`, `F64` | Complex ordering is not defined; integer and `Bool` min/max are not implemented |
 | `dot_general` | `F32`, `F64`, `C32`, `C64` | cuTENSOR-backed contraction; same dtype inputs only |
-| `gather` | operand `F32`, `F64`, `C32`, `C64`; indices `F32`, `F64`, or `I64` | Complex index tensors and `I64` operands are not implemented |
-| `scatter` | operand/update `F32`, `F64`, `C32`, `C64`; indices `F32`, `F64`, or `I64` | Add-scatter semantics; complex index tensors and `I64` operands are not implemented |
-| `slice`, `pad`, `concatenate`, `reverse` | `F32`, `F64`, `I64`, `C32`, `C64` | Dense structural/indexing operations |
-| `dynamic_slice` | input `F32`, `F64`, `C32`, `C64`; starts `F32`, `F64`, or `I64` | Complex start tensors and `I64` inputs are not implemented |
+| `gather` | operand `F32`, `F64`, `I32`, `C32`, `C64`; indices `F32`, `F64`, `I32`, or `I64` | Complex and `Bool` index tensors; `I64` and `Bool` operands are not implemented |
+| `scatter` | operand/update `F32`, `F64`, `C32`, `C64`; indices `F32`, `F64`, `I32`, or `I64` | Add-scatter semantics; complex and `Bool` index tensors and integer/`Bool` operands are not implemented |
+| `slice`, `pad`, `concatenate`, `reverse` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | Dense structural/indexing operations; `Bool` is not implemented |
+| `dynamic_slice` | input `F32`, `F64`, `I32`, `C32`, `C64`; starts `F32`, `F64`, `I32`, or `I64` | Complex and `Bool` start tensors; `I64` and `Bool` inputs are not implemented |
 | `dynamic_update_slice` | No CUDA implementation | Returns an error |
-| `cholesky`, `triangular_solve`, `lu`, `svd`, `qr`, `eigh`, `solve` | `F32`, `F64`, `C32`, `C64` | cuSOLVER/cuBLAS-backed; `svd` and `eigh` return real singular/eigenvalue tensors for complex inputs |
+| `cholesky`, `triangular_solve`, `lu`, `svd`, `qr`, `eigh`, `solve` | `F32`, `F64`, `C32`, `C64` | cuSOLVER/cuBLAS-backed; integer and `Bool` dtypes are not implemented |
 | `full_piv_lu`, `full_piv_lu_solve` | No CUDA implementation | Returns an error |
 | General `eig` | No CUDA implementation | cuSOLVER does not provide LAPACK `dgeev`-style general eigendecomposition; download to CPU explicitly |
 | AMD/ROCm | No supported backend | ROCm remains a feature stub |

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -87,8 +87,9 @@ assert_eq!(c.shape, vec![2, 2]);
 ## Cache Management
 
 Einsum uses the shared extension cache infrastructure from
-`tenferro-runtime`, re-exported by `tenferro`. Runtime caches live on
-`GraphExecutor`; compile-time extension caches live on `GraphCompiler`.
+`tenferro-runtime`, re-exported by `tenferro`. Compile-time extension caches
+live on `GraphCompiler`; runtime contraction-plan caches live on
+`GraphExecutor` and `EagerRuntime`.
 
 Use `tenferro_einsum::EINSUM_EXTENSION_FAMILY_ID` with
 `ExtensionCacheSelector` when you need to inspect or clear only einsum cache

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -60,10 +60,11 @@ VECLIB_MAXIMUM_THREADS=4 \
 
 ## Reuse compiler and executor state
 
-Use one `GraphCompiler` per traced workload when you want to retain graph
-lowering and static einsum planning caches. Use one `GraphExecutor<B>` per
-backend execution context when you want to retain runtime einsum plans, backend
-analysis, and reusable CPU buffers.
+Use one `EagerRuntime` per eager backend context when you want to retain eager
+einsum plans across immediate operations. Use one `GraphCompiler` per traced
+workload when you want to retain graph lowering and static einsum planning
+caches. Use one `GraphExecutor<B>` per backend execution context when you want
+to retain runtime einsum plans, backend analysis, and reusable CPU buffers.
 
 ## Cache management
 
@@ -72,21 +73,31 @@ or cleared independently.
 
 ```rust
 use std::num::NonZeroUsize;
-use tenferro::{CpuBackend, GraphCompiler, GraphExecutor};
+use tenferro::extension::ExtensionCacheLimits;
+use tenferro::{CpuBackend, EagerRuntime, GraphCompiler, GraphExecutor};
+
+let eager = EagerRuntime::with_cpu_backend(CpuBackend::new());
+eager.set_extension_cache_limits(ExtensionCacheLimits::new(NonZeroUsize::new(128).unwrap()));
+assert_eq!(eager.cache_stats().extensions.entries, 0);
 
 let mut compiler = GraphCompiler::new();
 compiler.set_compile_cache_capacity(NonZeroUsize::new(128).unwrap());
-compiler.set_einsum_cache_capacity(NonZeroUsize::new(128).unwrap());
+compiler
+    .extension_caches_mut()
+    .set_limits(ExtensionCacheLimits::new(NonZeroUsize::new(128).unwrap()));
 assert_eq!(compiler.cache_stats().compile.entries, 0);
 
 let mut executor = GraphExecutor::new(CpuBackend::new());
-executor.set_einsum_cache_capacity(NonZeroUsize::new(128).unwrap());
+executor
+    .extension_executor_mut()
+    .set_cache_limits(ExtensionCacheLimits::new(NonZeroUsize::new(128).unwrap()));
 executor.set_gemm_analysis_cache_capacity(512);
-assert_eq!(executor.cache_stats().runtime_einsum_plans.entries, 0);
+assert_eq!(executor.cache_stats().extensions.entries, 0);
 assert_eq!(executor.cache_stats().backend.entries, 0);
 
 compiler.clear_caches();
 executor.clear_caches();
+eager.clear_caches();
 ```
 
 For CPU executors, `cpu_cache_stats()` also reports the CPU buffer pool.
@@ -123,7 +134,7 @@ For multi-input traced contractions, `GraphCompiler` plans concrete-shape
 einsums and `GraphExecutor` caches runtime plans for symbolic-shape einsums.
 Reuse both objects for repeated shapes and subscripts.
 
-Direct, typed, and eager einsum routes execute immediately and use bounded
-planning internally. If you need explicit long-lived planning and runtime cache
-ownership, use the traced route and reuse `GraphCompiler` and
-`GraphExecutor<B>`.
+Direct and typed einsum routes execute immediately without retaining a hidden
+plan cache. `EagerTensor` einsum uses the owning `EagerRuntime` extension cache.
+For traced workloads, reuse `GraphCompiler` and `GraphExecutor<B>` to retain
+compile-time and runtime extension plans.

--- a/docs/spec/extension-op.md
+++ b/docs/spec/extension-op.md
@@ -262,12 +262,11 @@ consistent with the workspace cache ownership rules. The op payload MAY hold an
 detail and two equal payloads remain interchangeable when their cache handles
 differ.
 
-There is no monolithic core runtime owner for extension cache state, and the
-current `EagerRuntime`, `GraphCompiler`, and `GraphExecutor` do not expose a
-general public extension cache slot. Compiled extension execution delegates to
-`ExtensionOp::eager_execute`, so eager and traced execution use the same
-extension-owned runtime cache path. First-class extension cache slots are
-tracked in [issue #878](https://github.com/tensor4all/tenferro-rs/issues/878).
+There is no monolithic core runtime owner for arbitrary extension cache state.
+`EagerRuntime`, `GraphCompiler`, and `GraphExecutor` own explicit generic
+extension cache stores. Extension crates may use those stores only through the
+owning compiler/runtime/executor context; they MUST NOT hide long-lived caches
+inside semantic payloads, process globals, or thread-local state.
 
 ### Rationale
 
@@ -507,20 +506,24 @@ both, with a normatively-split responsibility.
 
 ### Eager path
 
-The eager path runs through `tenferro/src/eager_exec.rs::exec_op_on_tensors`
-and `tenferro/src/eager_emitter.rs::EagerEmitter::add_op`. The implementation
-MUST include a single match arm in `exec_op_on_tensors` that routes
-`StdTensorOp::Extension(op)` to `op.eager_execute(inputs)`:
+The eager path runs through `EagerRuntime` and
+`tenferro/src/eager_exec.rs::exec_op_on_tensors_with_extension_executor`.
+When execution is attached to an `EagerRuntime` and a runtime is registered for
+the extension family, the implementation MUST route `StdTensorOp::Extension(op)`
+through that runtime's `ExtensionExecutor`:
 
 ```rust
 // Conceptual:
-StdTensorOp::Extension(ext) => ext.eager_execute(inputs)?,
+StdTensorOp::Extension(ext) => extension_executor.execute(backend, ext, inputs)?,
 ```
 
 The eager path MUST NOT open a backend execution session for extension
-ops (i.e. MUST NOT wrap `eager_execute` in
-`backend.with_exec_session`); the extension owns its execution model
-and may choose to open its own session internally if needed.
+ops before handing control to the extension runtime; the extension runtime owns
+its execution model and receives the backend plus its runtime-owned cache store.
+The context-free `ExtensionOp::eager_execute` method is a compatibility
+fallback for direct execution helpers and for unregistered eager extension
+families. Built-in extensions with long-lived caches MUST register a runtime so
+`EagerRuntime`-attached execution uses the runtime-owned cache store.
 
 ### Compiled path
 
@@ -535,8 +538,7 @@ The compiled path runs through
    `op.infer_output_meta(...)` to populate
    `ExecInstruction::dtype` and `ExecInstruction::output_shapes`.
 3. An `execute_extension_op` dispatcher in `tenferro/src/exec.rs` that,
-   at runtime, calls `ext.eager_execute(inputs)` (the same method used
-   by the eager path).
+   at runtime, calls the registered `ExtensionExecutor<B>`.
 4. A single-instruction-boundary category for extensions in
    `tenferro/src/segment.rs` (similar to `DotGeneral` / `NaryEinsum`).
    Extensions MUST NOT participate in elementwise fusion planning
@@ -549,20 +551,17 @@ The compiled path runs through
   `infer_output_meta` for metadata population, and assigning
   `last_use` markers. It does not invoke backend kernels.
 - **`eager_exec` / `eager_emitter`** are responsible for: resolving
-  inputs from the emitter's tensor cache and calling
-  `eager_execute`.
-- **Extension impl (`eager_execute`)** is responsible for: actual
-  forward computation, backend selection, and device placement of
-  outputs. The core pipeline MUST NOT second-guess these choices.
+  inputs from the emitter's tensor cache and calling the runtime-owned
+  extension executor when one is available.
+- **Extension runtime (`ExtensionRuntime<B>`)** is responsible for: actual
+  forward computation, backend use, runtime cache entries, and device placement
+  of outputs. The core pipeline MUST NOT second-guess these choices.
 
 ### Rationale
 
-Keeping one `eager_execute` method (rather than separate eager/compiled
-APIs) avoids a second virtual-function surface and matches how
-non-extension linalg ops work today: they flow through the same
-`TensorBackend` trait regardless of compiled vs. eager entry. Extensions
-are lighter-weight than linalg ops (no backend trait to satisfy), but
-the single-method design keeps the two paths congruent.
+Using one `ExtensionRuntime<B>` contract for eager and compiled execution keeps
+runtime caches tied to explicit owners (`EagerRuntime` or `GraphExecutor`) and
+avoids hidden thread-local or process-global state in extension crates.
 
 ### Failure signature
 
@@ -808,15 +807,15 @@ these error types / behaviours in the listed scenarios.
 
 | Scenario | Required behaviour |
 |---|---|
-| `eager_execute` returns `Err` | Propagate to caller as `Error::BackendFailure { op: "extension", message }` with `family_id` included in `message`. MUST NOT retry, MUST NOT swallow. |
-| Backend lacks a capability the extension needs | The extension's `eager_execute` SHOULD return `Error::BackendFailure` with a descriptive message that includes `family_id` and the missing capability name. The core pipeline MUST NOT fall back to a different backend. |
-| Graph references an unregistered `family_id` at eager-execute time | Return `Error::Unsupported { op: "extension", message: "<family_id>: not registered" }`. |
+| Extension runtime execution returns `Err` | Propagate to caller as `Error::BackendFailure { op: "extension", message }` with `family_id` included in `message`. MUST NOT retry, MUST NOT swallow. |
+| Backend lacks a capability the extension needs | The extension runtime SHOULD return `Error::BackendFailure` with a descriptive message that includes `family_id` and the missing capability name. The core pipeline MUST NOT fall back to a different backend. |
+| Graph references an unregistered `family_id` at eager or graph runtime execution time | Return a backend/config error with `family_id` and registration guidance. |
 | Graph references an unregistered `family_id` at compile time | Return `Error::Unsupported` from `compile_std_to_exec`. |
 | AD rules (`frule` / `rrule`, or low-level `linearize` / `transpose_rule`) encounter an `Extension` with no registered AD rule | Return `ADRuleError::Unsupported` with `family_id` and rule kind; traced `grad` / eager `backward` propagate it through `tenferro::Error`. |
 | Hash collision on `family_id` (second registration attempt) | Registry MUST reject with `RegistrationError::Duplicate`. |
 | Arity mismatch: `n_inputs()` disagrees with the `primal_in.len()` the dispatcher passed | `Error::InvalidConfig { op: "extension", message: "family_id=<id>: expected N inputs, got M" }`. |
 | Output shape disagrees with `infer_output_meta` result length | `Error::InvalidConfig` with `family_id` and the mismatched counts. |
-| `eager_execute` returns a tensor on the wrong device | Propagate to the caller as `Error::BackendFailure` (the core pipeline does not re-locate tensors). |
+| Extension runtime returns a tensor on the wrong device | Propagate to the caller as `Error::BackendFailure` (the core pipeline does not re-locate tensors). |
 | Registration with malformed `family_id` | `RegistrationError::MalformedFamilyId`. |
 
 ### Constants for `op` field

--- a/tenferro-einsum/src/eager.rs
+++ b/tenferro-einsum/src/eager.rs
@@ -3,15 +3,9 @@ use std::cell::RefCell;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::num::NonZeroUsize;
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
-use lru::LruCache;
-#[cfg(test)]
-use std::mem::size_of;
-#[cfg(test)]
-use tenferro_tensor::CacheStats;
 use tenferro_tensor::{
     DotGeneralConfig, Error, Result, Tensor, TensorBackend, TensorExec, TensorRead, TensorView,
 };
@@ -19,8 +13,6 @@ use tenferro_tensor::{
 use crate::{ContractionTree, Subscripts};
 
 const EAGER_EINSUM_OP: &str = "eager_einsum";
-/// Default number of eager einsum contraction plans retained per thread.
-pub(crate) const DEFAULT_EAGER_EINSUM_CACHE_CAPACITY: usize = 256;
 
 #[derive(Debug, Default, Clone)]
 struct EagerEinsumProfileEntry {
@@ -31,97 +23,6 @@ struct EagerEinsumProfileEntry {
 thread_local! {
     static EAGER_EINSUM_PROFILE_STATE: RefCell<HashMap<&'static str, EagerEinsumProfileEntry>> =
         RefCell::new(HashMap::new());
-    static EAGER_EINSUM_PLAN_CACHE: RefCell<EagerEinsumPlanCache> =
-        RefCell::new(EagerEinsumPlanCache::new(default_eager_einsum_cache_capacity()));
-}
-
-type EagerEinsumPlanCacheKey = (Subscripts, Vec<Vec<usize>>);
-
-struct EagerEinsumPlanCache {
-    plans: LruCache<EagerEinsumPlanCacheKey, Arc<ContractionTree>>,
-}
-
-impl EagerEinsumPlanCache {
-    fn new(capacity: NonZeroUsize) -> Self {
-        Self {
-            plans: LruCache::new(capacity),
-        }
-    }
-
-    #[cfg(test)]
-    fn capacity(&self) -> NonZeroUsize {
-        self.plans.cap()
-    }
-
-    #[cfg(test)]
-    fn set_capacity(&mut self, capacity: NonZeroUsize) {
-        self.plans.resize(capacity);
-    }
-
-    #[cfg(test)]
-    fn clear(&mut self) {
-        self.plans.clear();
-    }
-
-    #[cfg(test)]
-    fn stats(&self) -> CacheStats {
-        let mut retained_bytes = 0usize;
-        for (key, tree) in self.plans.iter() {
-            retained_bytes += eager_plan_key_retained_bytes(key)
-                + size_of::<Arc<ContractionTree>>()
-                + tree.retained_bytes_for_cache_stats();
-        }
-        CacheStats {
-            entries: self.plans.len(),
-            retained_bytes,
-        }
-    }
-}
-
-fn default_eager_einsum_cache_capacity() -> NonZeroUsize {
-    NonZeroUsize::new(DEFAULT_EAGER_EINSUM_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN)
-}
-
-#[cfg(test)]
-fn vec_retained_bytes<T>(values: &Vec<T>) -> usize {
-    values.capacity() * size_of::<T>()
-}
-
-#[cfg(test)]
-fn vec_of_vec_retained_bytes<T>(values: &[Vec<T>]) -> usize {
-    values.iter().map(vec_retained_bytes).sum()
-}
-
-#[cfg(test)]
-fn subscripts_retained_bytes(subscripts: &Subscripts) -> usize {
-    vec_of_vec_retained_bytes(&subscripts.inputs) + vec_retained_bytes(&subscripts.output)
-}
-
-#[cfg(test)]
-fn eager_plan_key_retained_bytes(key: &EagerEinsumPlanCacheKey) -> usize {
-    subscripts_retained_bytes(&key.0) + vec_of_vec_retained_bytes(&key.1)
-}
-
-#[must_use]
-#[cfg(test)]
-pub(crate) fn eager_einsum_cache_capacity() -> NonZeroUsize {
-    EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow().capacity())
-}
-
-#[cfg(test)]
-pub(crate) fn set_eager_einsum_cache_capacity(capacity: NonZeroUsize) {
-    EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow_mut().set_capacity(capacity));
-}
-
-#[cfg(test)]
-pub(crate) fn clear_eager_einsum_cache() {
-    EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow_mut().clear());
-}
-
-#[must_use]
-#[cfg(test)]
-pub(crate) fn eager_einsum_cache_stats() -> CacheStats {
-    EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow().stats())
 }
 
 fn eager_einsum_profile_enabled() -> bool {
@@ -132,11 +33,6 @@ fn eager_einsum_profile_enabled() -> bool {
 fn eager_einsum_trace_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| env::var("TENFERRO_PROFILE_EAGER_EINSUM").is_ok())
-}
-
-fn eager_einsum_cache_disabled() -> bool {
-    static DISABLED: OnceLock<bool> = OnceLock::new();
-    *DISABLED.get_or_init(|| env::var("TENFERRO_DISABLE_EAGER_EINSUM_CACHE").is_ok())
 }
 
 fn record_eager_einsum_profile(section: &'static str, elapsed: Duration) {
@@ -426,40 +322,6 @@ fn plan_subscripts(subs: &Subscripts, input_shapes: &[&[usize]]) -> Result<Contr
 
     ContractionTree::optimize(subs, input_shapes)
         .map_err(|err| eager_invalid_config(format!("failed to optimize contraction tree: {err}")))
-}
-
-fn cached_plan_subscripts(
-    subs: &Subscripts,
-    input_shapes: &[&[usize]],
-) -> Result<Arc<ContractionTree>> {
-    if eager_einsum_cache_disabled() {
-        return Ok(Arc::new(plan_subscripts(subs, input_shapes)?));
-    }
-
-    let key = profile_eager_einsum_section("plan_cache_key", || {
-        (
-            subs.clone(),
-            input_shapes
-                .iter()
-                .map(|shape| shape.to_vec())
-                .collect::<Vec<_>>(),
-        )
-    });
-
-    if let Some(tree) = profile_eager_einsum_section("plan_cache_lookup", || {
-        EAGER_EINSUM_PLAN_CACHE.with(|cache| cache.borrow_mut().plans.get(&key).cloned())
-    }) {
-        return Ok(tree);
-    }
-
-    let tree = profile_eager_einsum_section("plan_cache_miss_optimize", || {
-        plan_subscripts(subs, input_shapes)
-    })?;
-    let tree = Arc::new(tree);
-    EAGER_EINSUM_PLAN_CACHE.with(|cache| {
-        cache.borrow_mut().plans.put(key, Arc::clone(&tree));
-    });
-    Ok(tree)
 }
 
 fn take_labeled<'a>(
@@ -1056,10 +918,10 @@ pub(crate) fn eager_einsum_subscripts(
                 .collect::<Vec<_>>()
         });
         let tree = profile_eager_einsum_section("plan_subscripts", || {
-            cached_plan_subscripts(subscripts, &shapes)
+            plan_subscripts(subscripts, &shapes)
         })?;
         let result = profile_eager_einsum_section("with_exec_session", || {
-            ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, tree.as_ref()))
+            ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, &tree))
         });
         record_eager_einsum_profile("total", total_started.elapsed());
         maybe_print_eager_einsum_profile();
@@ -1073,11 +935,11 @@ pub(crate) fn eager_einsum_subscripts(
         let shape_us = started.elapsed().as_secs_f64() * 1.0e6;
 
         let started = Instant::now();
-        let tree = cached_plan_subscripts(subscripts, &shapes)?;
+        let tree = plan_subscripts(subscripts, &shapes)?;
         let plan_us = started.elapsed().as_secs_f64() * 1.0e6;
 
         let started = Instant::now();
-        let result = ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, tree.as_ref()));
+        let result = ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, &tree));
         let exec_us = started.elapsed().as_secs_f64() * 1.0e6;
         let total_us = total_started.elapsed().as_secs_f64() * 1.0e6;
 
@@ -1091,8 +953,8 @@ pub(crate) fn eager_einsum_subscripts(
     }
 
     let shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
-    let tree = cached_plan_subscripts(subscripts, &shapes)?;
-    ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, tree.as_ref()))
+    let tree = plan_subscripts(subscripts, &shapes)?;
+    ctx.with_exec_session(|exec| eager_einsum_exec(exec, inputs, &tree))
 }
 
 /// Eager N-ary einsum on read-only tensor inputs.
@@ -1111,8 +973,8 @@ pub(crate) fn eager_einsum_read_subscripts(
     }
 
     let shapes: Vec<&[usize]> = inputs.iter().map(TensorRead::shape).collect();
-    let tree = cached_plan_subscripts(subscripts, &shapes)?;
-    ctx.with_exec_session(|exec| eager_einsum_exec_read(exec, inputs, tree.as_ref()))
+    let tree = plan_subscripts(subscripts, &shapes)?;
+    ctx.with_exec_session(|exec| eager_einsum_exec_read(exec, inputs, &tree))
 }
 
 /// Eager N-ary einsum that consumes concrete [`Tensor`] inputs.
@@ -1144,9 +1006,9 @@ pub(crate) fn eager_einsum_owned_subscripts(
     subscripts: &Subscripts,
 ) -> Result<Tensor> {
     let shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
-    let tree = cached_plan_subscripts(subscripts, &shapes)?;
+    let tree = plan_subscripts(subscripts, &shapes)?;
     let values = inputs.into_iter().map(TensorValue::Owned).collect();
-    ctx.with_exec_session(|exec| eager_einsum_exec_values(exec, values, tree.as_ref()))
+    ctx.with_exec_session(|exec| eager_einsum_exec_values(exec, values, &tree))
 }
 
 #[cfg(test)]

--- a/tenferro-einsum/src/eager/tests.rs
+++ b/tenferro-einsum/src/eager/tests.rs
@@ -1,13 +1,10 @@
 use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend, TensorRead, TensorView};
 
 use super::{
-    binary_contract, clear_eager_einsum_cache, eager_einsum, eager_einsum_cache_capacity,
-    eager_einsum_cache_stats, eager_einsum_exec_read, set_eager_einsum_cache_capacity,
-    try_eager_einsum_binary_read_fast, LabeledTensor, TensorValue,
-    DEFAULT_EAGER_EINSUM_CACHE_CAPACITY,
+    binary_contract, eager_einsum_exec_read, try_eager_einsum_binary_read_fast, LabeledTensor,
+    TensorValue,
 };
 use crate::{ContractionTree, Subscripts};
-use std::num::NonZeroUsize;
 
 #[test]
 fn tensor_value_view_paths_materialize_and_read() {
@@ -128,29 +125,4 @@ fn binary_read_fast_path_rejects_non_fast_shapes_and_labels() {
     let duplicate_labels = Subscripts::parse("ii,jk->ik").unwrap();
     let inputs = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
     assert!(try_eager_einsum_binary_read_fast(&mut ctx, &inputs, &duplicate_labels).is_none());
-}
-
-#[test]
-fn eager_einsum_cache_is_bounded_and_reports_stats() {
-    clear_eager_einsum_cache();
-    set_eager_einsum_cache_capacity(NonZeroUsize::new(1).unwrap());
-    let mut ctx = CpuBackend::new();
-
-    for mid in [3, 4] {
-        let a = Tensor::from_vec_col_major(vec![2, mid], vec![1.0_f64; 2 * mid]);
-        let b = Tensor::from_vec_col_major(vec![mid, 3], vec![1.0_f64; mid * 3]);
-        let c = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
-        let out = eager_einsum(&mut ctx, &[&a, &b, &c], "ij,jk,kl->il").unwrap();
-        assert_eq!(out.shape(), &[2, 2]);
-    }
-
-    assert_eq!(eager_einsum_cache_capacity().get(), 1);
-    let stats = eager_einsum_cache_stats();
-    assert_eq!(stats.entries, 1);
-    assert!(stats.retained_bytes > 0);
-
-    clear_eager_einsum_cache();
-    set_eager_einsum_cache_capacity(
-        NonZeroUsize::new(DEFAULT_EAGER_EINSUM_CACHE_CAPACITY).unwrap(),
-    );
 }

--- a/tenferro-einsum/src/eager_tensor.rs
+++ b/tenferro-einsum/src/eager_tensor.rs
@@ -6,7 +6,9 @@ use tenferro::error::{Error, Result};
 use tenferro::extension::apply_eager;
 use tenferro::EagerTensor;
 
-use crate::extension::{ensure_einsum_extension_rule_registered, EinsumExtensionOp};
+use crate::extension::{
+    ensure_einsum_extension_rule_registered, register_runtime, EinsumExtensionOp,
+};
 use crate::{parse_einsum_subscripts, EinsumSubscripts};
 
 /// Execute an einsum eagerly on [`EagerTensor`] values.
@@ -22,6 +24,12 @@ pub fn einsum_subscripts(
     subscripts: &EinsumSubscripts,
 ) -> Result<EagerTensor> {
     ensure_einsum_extension_rule_registered().map_err(|err| Error::Internal(err.to_string()))?;
+    if let Some(first) = inputs.first() {
+        first
+            .runtime()
+            .register_extension(register_runtime)
+            .map_err(|err| Error::Internal(err.to_string()))?;
+    }
 
     let op = Arc::new(EinsumExtensionOp::new(subscripts.clone()));
     let mut outputs = apply_eager(op, inputs)?;

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -42,10 +42,9 @@ use crate::{ContractionTree, EinsumSubscripts, Subscripts};
 
 /// Standard einsum extension payload.
 ///
-/// This mirrors the current `tenferro.einsum.v1` payload shape without pulling
-/// in the facade/runtime crate. Execution still requires the future generic
-/// runtime to provide backend and cache context, so [`ExtensionOp::eager_execute`]
-/// intentionally returns an error for now.
+/// This mirrors the current `tenferro.einsum.v1` payload shape. Runtime-owned
+/// execution goes through [`EinsumRuntime`]; [`ExtensionOp::eager_execute`] is
+/// kept only as a context-free compatibility fallback.
 #[derive(Clone)]
 pub(crate) struct EinsumExtensionOp {
     subscripts: EinsumSubscripts,

--- a/tenferro-einsum/tests/traced_graph_cache.rs
+++ b/tenferro-einsum/tests/traced_graph_cache.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "autodiff")]
+
 use std::num::NonZeroUsize;
 
 use tenferro::extension::ExtensionCacheLimits;

--- a/tenferro-einsum/tests/traced_graph_cache.rs
+++ b/tenferro-einsum/tests/traced_graph_cache.rs
@@ -1,9 +1,12 @@
 use std::num::NonZeroUsize;
 
 use tenferro::extension::ExtensionCacheLimits;
-use tenferro::{CpuBackend, DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use tenferro::{
+    CpuBackend, DType, EagerRuntime, GraphCompiler, GraphExecutor, Tensor, TracedTensor,
+};
 use tenferro_einsum::{
-    einsum, einsum_with, parse_einsum_subscripts, ContractionOptimizerOptions, EinsumOptimize,
+    eager_tensor::einsum as eager_einsum, einsum, einsum_with, parse_einsum_subscripts,
+    ContractionOptimizerOptions, EinsumOptimize,
 };
 
 fn register_runtime(executor: &mut GraphExecutor<CpuBackend>) {
@@ -80,6 +83,26 @@ fn run_runtime_planned_matmul(
         .expect("run")
 }
 
+fn run_eager_matmul(
+    ctx: &std::sync::Arc<EagerRuntime>,
+    rows: usize,
+    cols: usize,
+    mid: usize,
+) -> Tensor {
+    let a = ctx.constant_from(Tensor::from_vec_col_major(
+        vec![rows, mid],
+        (0..rows * mid).map(|i| i as f64).collect::<Vec<_>>(),
+    ));
+    let b = ctx.constant_from(Tensor::from_vec_col_major(
+        vec![mid, cols],
+        (0..mid * cols).map(|i| i as f64).collect::<Vec<_>>(),
+    ));
+    eager_einsum(&[&a, &b], "ij,jk->ik")
+        .expect("eager einsum")
+        .data()
+        .clone()
+}
+
 fn extension_cache_entries(compiler: &GraphCompiler) -> usize {
     compiler.cache_stats().extensions.entries
 }
@@ -141,6 +164,44 @@ fn extension_compile_cache_limits_bound_static_einsum_entries() {
         compiler.extension_caches().limits().max_entries(),
         NonZeroUsize::new(3).unwrap()
     );
+}
+
+#[test]
+fn eager_einsum_runtime_plan_cache_is_owned_by_context() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+
+    let out = run_eager_matmul(&ctx, 2, 4, 3);
+    assert_eq!(out.shape(), &[2, 4]);
+    assert_eq!(ctx.cache_stats().extensions.entries, 1);
+
+    let _ = run_eager_matmul(&ctx, 2, 4, 3);
+    assert_eq!(ctx.cache_stats().extensions.entries, 1);
+
+    let other_ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let _ = run_eager_matmul(&other_ctx, 2, 4, 3);
+    assert_eq!(ctx.cache_stats().extensions.entries, 1);
+    assert_eq!(other_ctx.cache_stats().extensions.entries, 1);
+}
+
+#[test]
+fn eager_extension_cache_limits_bound_runtime_planned_einsum_entries() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    ctx.set_extension_cache_limits(ExtensionCacheLimits::new(NonZeroUsize::new(3).unwrap()));
+
+    for mid in 1..=5 {
+        let _ = run_eager_matmul(&ctx, 2, 2, mid);
+    }
+
+    let stats = ctx.cache_stats();
+    assert_eq!(stats.extensions.entries, 3);
+    assert!(stats.extensions.retained_bytes > 0);
+    assert_eq!(
+        ctx.extension_cache_limits().max_entries(),
+        NonZeroUsize::new(3).unwrap()
+    );
+
+    ctx.clear_caches();
+    assert_eq!(ctx.cache_stats().extensions.entries, 0);
 }
 
 #[test]

--- a/tenferro-gpubackend/src/reduce/kernels.rs
+++ b/tenferro-gpubackend/src/reduce/kernels.rs
@@ -32,10 +32,10 @@ macro_rules! reduce_binary_kernel {
                 }
 
                 let axis_stride = input.stride(axis);
-                let reduce_len = input.shape(axis);
+                let axis_len = input.shape(axis);
                 let mut acc = input[input_base_offset];
 
-                for reduce_index in 1..reduce_len {
+                for reduce_index in 1..axis_len {
                     let input_offset = input_base_offset + reduce_index * axis_stride;
                     acc = acc $op input[input_offset];
                 }
@@ -52,6 +52,59 @@ reduce_binary_kernel!(reduce_sum_complex, Complex, +);
 reduce_binary_kernel!(reduce_prod_float, Float, *);
 reduce_binary_kernel!(reduce_prod_int, Int, *);
 reduce_binary_kernel!(reduce_prod_complex, Complex, *);
+
+macro_rules! reduce_binary_plane_kernel {
+    ($name:ident, $bound:ident, $op:tt, $plane_reduce:ident) => {
+        #[cube(launch_unchecked)]
+        pub(crate) fn $name<T: $bound>(
+            input: &Tensor<T>,
+            output: &mut Tensor<T>,
+            axis: usize,
+            output_len: usize,
+        ) {
+            let output_index = CUBE_POS_X as usize;
+            if output_index < output_len {
+                let rank = output.rank();
+                let mut remaining = output_index;
+                let mut input_base_offset = 0usize;
+                let mut output_offset = 0usize;
+
+                for dim in 0..rank {
+                    let dim_len = output.shape(dim);
+                    let coord = remaining % dim_len;
+                    remaining /= dim_len;
+                    input_base_offset += coord * input.stride(dim);
+                    output_offset += coord * output.stride(dim);
+                }
+
+                let axis_stride = input.stride(axis);
+                let axis_len = input.shape(axis);
+                let plane_width = PLANE_DIM as usize;
+                let mut reduce_index = UNIT_POS as usize;
+                let mut acc = input[input_base_offset + reduce_index * axis_stride];
+
+                reduce_index += plane_width;
+                while reduce_index < axis_len {
+                    let input_offset = input_base_offset + reduce_index * axis_stride;
+                    acc = acc $op input[input_offset];
+                    reduce_index += plane_width;
+                }
+
+                let reduced = $plane_reduce(acc);
+                if UNIT_POS == 0 {
+                    output[output_offset] = reduced;
+                }
+            }
+        }
+    };
+}
+
+reduce_binary_plane_kernel!(reduce_sum_float_plane, Float, +, plane_sum);
+reduce_binary_plane_kernel!(reduce_sum_int_plane, Int, +, plane_sum);
+reduce_binary_plane_kernel!(reduce_sum_complex_plane, Complex, +, plane_sum);
+reduce_binary_plane_kernel!(reduce_prod_float_plane, Float, *, plane_prod);
+reduce_binary_plane_kernel!(reduce_prod_int_plane, Int, *, plane_prod);
+reduce_binary_plane_kernel!(reduce_prod_complex_plane, Complex, *, plane_prod);
 
 #[cube(launch_unchecked)]
 pub(crate) fn reduce_max_float<F: Float>(
@@ -76,15 +129,57 @@ pub(crate) fn reduce_max_float<F: Float>(
         }
 
         let axis_stride = input.stride(axis);
-        let reduce_len = input.shape(axis);
+        let axis_len = input.shape(axis);
         let mut acc = input[input_base_offset];
 
-        for reduce_index in 1..reduce_len {
+        for reduce_index in 1..axis_len {
             let input_offset = input_base_offset + reduce_index * axis_stride;
             acc = acc.max(input[input_offset]);
         }
 
         output[output_offset] = acc;
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn reduce_max_float_plane<F: Float>(
+    input: &Tensor<F>,
+    output: &mut Tensor<F>,
+    axis: usize,
+    output_len: usize,
+) {
+    let output_index = CUBE_POS_X as usize;
+    if output_index < output_len {
+        let rank = output.rank();
+        let mut remaining = output_index;
+        let mut input_base_offset = 0usize;
+        let mut output_offset = 0usize;
+
+        for dim in 0..rank {
+            let dim_len = output.shape(dim);
+            let coord = remaining % dim_len;
+            remaining /= dim_len;
+            input_base_offset += coord * input.stride(dim);
+            output_offset += coord * output.stride(dim);
+        }
+
+        let axis_stride = input.stride(axis);
+        let axis_len = input.shape(axis);
+        let plane_width = PLANE_DIM as usize;
+        let mut reduce_index = UNIT_POS as usize;
+        let mut acc = input[input_base_offset + reduce_index * axis_stride];
+
+        reduce_index += plane_width;
+        while reduce_index < axis_len {
+            let input_offset = input_base_offset + reduce_index * axis_stride;
+            acc = acc.max(input[input_offset]);
+            reduce_index += plane_width;
+        }
+
+        let reduced = plane_max(acc);
+        if UNIT_POS == 0 {
+            output[output_offset] = reduced;
+        }
     }
 }
 
@@ -111,14 +206,56 @@ pub(crate) fn reduce_min_float<F: Float>(
         }
 
         let axis_stride = input.stride(axis);
-        let reduce_len = input.shape(axis);
+        let axis_len = input.shape(axis);
         let mut acc = input[input_base_offset];
 
-        for reduce_index in 1..reduce_len {
+        for reduce_index in 1..axis_len {
             let input_offset = input_base_offset + reduce_index * axis_stride;
             acc = acc.min(input[input_offset]);
         }
 
         output[output_offset] = acc;
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn reduce_min_float_plane<F: Float>(
+    input: &Tensor<F>,
+    output: &mut Tensor<F>,
+    axis: usize,
+    output_len: usize,
+) {
+    let output_index = CUBE_POS_X as usize;
+    if output_index < output_len {
+        let rank = output.rank();
+        let mut remaining = output_index;
+        let mut input_base_offset = 0usize;
+        let mut output_offset = 0usize;
+
+        for dim in 0..rank {
+            let dim_len = output.shape(dim);
+            let coord = remaining % dim_len;
+            remaining /= dim_len;
+            input_base_offset += coord * input.stride(dim);
+            output_offset += coord * output.stride(dim);
+        }
+
+        let axis_stride = input.stride(axis);
+        let axis_len = input.shape(axis);
+        let plane_width = PLANE_DIM as usize;
+        let mut reduce_index = UNIT_POS as usize;
+        let mut acc = input[input_base_offset + reduce_index * axis_stride];
+
+        reduce_index += plane_width;
+        while reduce_index < axis_len {
+            let input_offset = input_base_offset + reduce_index * axis_stride;
+            acc = acc.min(input[input_offset]);
+            reduce_index += plane_width;
+        }
+
+        let reduced = plane_min(acc);
+        if UNIT_POS == 0 {
+            output[output_offset] = reduced;
+        }
     }
 }

--- a/tenferro-gpubackend/src/reduce/launch.rs
+++ b/tenferro-gpubackend/src/reduce/launch.rs
@@ -15,7 +15,7 @@
 // Tenferro changes: narrowed to tenferro reduction ops, current CubeCL fork,
 // single-axis keepdims output, and explicit tenferro column-major bindings.
 
-use cubecl::prelude::*;
+use cubecl::{features::Plane, prelude::*};
 
 use super::{
     kernels,
@@ -43,6 +43,23 @@ pub enum ReduceStrategy {
     Auto,
     /// Use one worker per keepdims output element.
     Unit,
+    /// Use one hardware plane/subgroup per keepdims output element.
+    Plane,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResolvedReduceStrategy {
+    Unit,
+    Plane,
+}
+
+#[derive(Clone, Debug)]
+struct ResolvedReduceLaunch {
+    kind: ResolvedReduceStrategy,
+    cube_count: CubeCount,
+    cube_dim: CubeDim,
+    axis: usize,
+    output_len: usize,
 }
 
 fn validate_launch<R: Runtime>(
@@ -80,19 +97,111 @@ fn validate_reduce_problem(
 fn launch_with_unit_settings<R: Runtime>(
     client: &ComputeClient<R>,
     problem: ReduceProblem,
-    strategy: ReduceStrategy,
-) -> (CubeCount, CubeDim, usize, usize) {
-    match strategy {
-        ReduceStrategy::Auto | ReduceStrategy::Unit => {
-            let settings = unit_launch_settings(client, problem);
-            let _has_idle_units = settings.blueprint.idle_units;
-            (
-                settings.cube_count,
-                settings.cube_dim,
-                problem.axis,
-                problem.reduce_count,
-            )
+) -> ResolvedReduceLaunch {
+    let settings = unit_launch_settings(client, problem);
+    let _has_idle_units = settings.blueprint.idle_units;
+    ResolvedReduceLaunch {
+        kind: ResolvedReduceStrategy::Unit,
+        cube_count: settings.cube_count,
+        cube_dim: settings.cube_dim,
+        axis: problem.axis,
+        output_len: problem.reduce_count,
+    }
+}
+
+fn launch_with_plane_settings<R: Runtime>(
+    client: &ComputeClient<R>,
+    problem: ReduceProblem,
+) -> Result<ResolvedReduceLaunch> {
+    let plane_width = client.properties().hardware.plane_size_max.max(1);
+    validate_plane_strategy(
+        problem,
+        plane_width,
+        client.features().plane.contains(Plane::Ops),
+    )?;
+
+    let cubes = u32::try_from(problem.reduce_count.max(1)).map_err(|_| {
+        CubeclKernelError::InvalidStrategy {
+            reason: format!(
+                "reduction output element count {} exceeds static CubeCL launch limit",
+                problem.reduce_count
+            ),
         }
+    })?;
+    Ok(ResolvedReduceLaunch {
+        kind: ResolvedReduceStrategy::Plane,
+        cube_count: CubeCount::Static(cubes, 1, 1),
+        cube_dim: CubeDim::new_1d(plane_width),
+        axis: problem.axis,
+        output_len: problem.reduce_count,
+    })
+}
+
+fn validate_plane_strategy(
+    problem: ReduceProblem,
+    plane_width: u32,
+    has_plane_ops: bool,
+) -> Result<()> {
+    if !has_plane_ops {
+        return Err(CubeclKernelError::InvalidStrategy {
+            reason: "plane reduction requires backend plane operations".to_owned(),
+        });
+    }
+    if problem.reduce_len < plane_width as usize {
+        return Err(CubeclKernelError::InvalidStrategy {
+            reason: format!(
+                "plane reduction requires reduce axis length {} to be at least plane width {}",
+                problem.reduce_len, plane_width
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn auto_reduce_strategy<R: Runtime>(
+    client: &ComputeClient<R>,
+    problem: ReduceProblem,
+) -> Result<ResolvedReduceStrategy> {
+    let unit_axis_limit = client.properties().hardware.plane_size_max.max(1) as usize;
+    auto_reduce_strategy_for_capabilities(
+        problem.reduce_len,
+        unit_axis_limit,
+        client.features().plane.contains(Plane::Ops),
+    )
+}
+
+fn auto_reduce_strategy_for_capabilities(
+    reduce_len: usize,
+    unit_axis_limit: usize,
+    has_plane_ops: bool,
+) -> Result<ResolvedReduceStrategy> {
+    if reduce_len <= unit_axis_limit {
+        return Ok(ResolvedReduceStrategy::Unit);
+    }
+    if has_plane_ops {
+        Ok(ResolvedReduceStrategy::Plane)
+    } else {
+        Err(CubeclKernelError::InvalidStrategy {
+            reason: format!(
+                "Auto reduction cannot reduce axis length {} without plane operations",
+                reduce_len
+            ),
+        })
+    }
+}
+
+fn resolve_launch_settings<R: Runtime>(
+    client: &ComputeClient<R>,
+    problem: ReduceProblem,
+    strategy: ReduceStrategy,
+) -> Result<ResolvedReduceLaunch> {
+    match strategy {
+        ReduceStrategy::Unit => Ok(launch_with_unit_settings(client, problem)),
+        ReduceStrategy::Plane => launch_with_plane_settings(client, problem),
+        ReduceStrategy::Auto => match auto_reduce_strategy(client, problem)? {
+            ResolvedReduceStrategy::Unit => Ok(launch_with_unit_settings(client, problem)),
+            ResolvedReduceStrategy::Plane => launch_with_plane_settings(client, problem),
+        },
     }
 }
 
@@ -119,24 +228,36 @@ pub fn launch_sum_float<R: Runtime, F: Float + CubeElement>(
     strategy: ReduceStrategy,
 ) -> Result<()> {
     let problem = validate_launch(&input, &output, axis)?;
-    let (cube_count, cube_dim, axis, output_len) =
-        launch_with_unit_settings(client, problem, strategy);
+    let launch = resolve_launch_settings(client, problem, strategy)?;
 
     unsafe {
         // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
         // and keepdims output shapes are compatible and the reduce axis is
-        // non-empty. `launch_with_unit_settings` derives the launched output
+        // non-empty. `resolve_launch_settings` derives the launched output
         // domain from that validated problem; the reduction kernel uses
         // `output_len == problem.reduce_count` to guard output indexing.
-        kernels::reduce_sum_float::launch_unchecked::<F, R>(
-            client,
-            cube_count,
-            cube_dim,
-            input.into_tensor_arg(),
-            output.into_tensor_arg(),
-            axis,
-            output_len,
-        );
+        match launch.kind {
+            ResolvedReduceStrategy::Unit => kernels::reduce_sum_float::launch_unchecked::<F, R>(
+                client,
+                launch.cube_count,
+                launch.cube_dim,
+                input.into_tensor_arg(),
+                output.into_tensor_arg(),
+                launch.axis,
+                launch.output_len,
+            ),
+            ResolvedReduceStrategy::Plane => {
+                kernels::reduce_sum_float_plane::launch_unchecked::<F, R>(
+                    client,
+                    launch.cube_count,
+                    launch.cube_dim,
+                    input.into_tensor_arg(),
+                    output.into_tensor_arg(),
+                    launch.axis,
+                    launch.output_len,
+                )
+            }
+        }
     }
 
     Ok(())
@@ -165,24 +286,36 @@ pub fn launch_sum_int<R: Runtime, I: Int + CubeElement>(
     strategy: ReduceStrategy,
 ) -> Result<()> {
     let problem = validate_launch(&input, &output, axis)?;
-    let (cube_count, cube_dim, axis, output_len) =
-        launch_with_unit_settings(client, problem, strategy);
+    let launch = resolve_launch_settings(client, problem, strategy)?;
 
     unsafe {
         // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
         // and keepdims output shapes are compatible and the reduce axis is
-        // non-empty. `launch_with_unit_settings` derives the launched output
+        // non-empty. `resolve_launch_settings` derives the launched output
         // domain from that validated problem; the reduction kernel uses
         // `output_len == problem.reduce_count` to guard output indexing.
-        kernels::reduce_sum_int::launch_unchecked::<I, R>(
-            client,
-            cube_count,
-            cube_dim,
-            input.into_tensor_arg(),
-            output.into_tensor_arg(),
-            axis,
-            output_len,
-        );
+        match launch.kind {
+            ResolvedReduceStrategy::Unit => kernels::reduce_sum_int::launch_unchecked::<I, R>(
+                client,
+                launch.cube_count,
+                launch.cube_dim,
+                input.into_tensor_arg(),
+                output.into_tensor_arg(),
+                launch.axis,
+                launch.output_len,
+            ),
+            ResolvedReduceStrategy::Plane => {
+                kernels::reduce_sum_int_plane::launch_unchecked::<I, R>(
+                    client,
+                    launch.cube_count,
+                    launch.cube_dim,
+                    input.into_tensor_arg(),
+                    output.into_tensor_arg(),
+                    launch.axis,
+                    launch.output_len,
+                )
+            }
+        }
     }
 
     Ok(())
@@ -212,24 +345,36 @@ pub fn launch_sum_complex<R: Runtime, C: Complex + CubeElement>(
     strategy: ReduceStrategy,
 ) -> Result<()> {
     let problem = validate_launch(&input, &output, axis)?;
-    let (cube_count, cube_dim, axis, output_len) =
-        launch_with_unit_settings(client, problem, strategy);
+    let launch = resolve_launch_settings(client, problem, strategy)?;
 
     unsafe {
         // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
         // and keepdims output shapes are compatible and the reduce axis is
-        // non-empty. `launch_with_unit_settings` derives the launched output
+        // non-empty. `resolve_launch_settings` derives the launched output
         // domain from that validated problem; the reduction kernel uses
         // `output_len == problem.reduce_count` to guard output indexing.
-        kernels::reduce_sum_complex::launch_unchecked::<C, R>(
-            client,
-            cube_count,
-            cube_dim,
-            input.into_tensor_arg(),
-            output.into_tensor_arg(),
-            axis,
-            output_len,
-        );
+        match launch.kind {
+            ResolvedReduceStrategy::Unit => kernels::reduce_sum_complex::launch_unchecked::<C, R>(
+                client,
+                launch.cube_count,
+                launch.cube_dim,
+                input.into_tensor_arg(),
+                output.into_tensor_arg(),
+                launch.axis,
+                launch.output_len,
+            ),
+            ResolvedReduceStrategy::Plane => {
+                kernels::reduce_sum_complex_plane::launch_unchecked::<C, R>(
+                    client,
+                    launch.cube_count,
+                    launch.cube_dim,
+                    input.into_tensor_arg(),
+                    output.into_tensor_arg(),
+                    launch.axis,
+                    launch.output_len,
+                )
+            }
+        }
     }
 
     Ok(())
@@ -258,24 +403,36 @@ pub fn launch_prod_float<R: Runtime, F: Float + CubeElement>(
     strategy: ReduceStrategy,
 ) -> Result<()> {
     let problem = validate_launch(&input, &output, axis)?;
-    let (cube_count, cube_dim, axis, output_len) =
-        launch_with_unit_settings(client, problem, strategy);
+    let launch = resolve_launch_settings(client, problem, strategy)?;
 
     unsafe {
         // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
         // and keepdims output shapes are compatible and the reduce axis is
-        // non-empty. `launch_with_unit_settings` derives the launched output
+        // non-empty. `resolve_launch_settings` derives the launched output
         // domain from that validated problem; the reduction kernel uses
         // `output_len == problem.reduce_count` to guard output indexing.
-        kernels::reduce_prod_float::launch_unchecked::<F, R>(
-            client,
-            cube_count,
-            cube_dim,
-            input.into_tensor_arg(),
-            output.into_tensor_arg(),
-            axis,
-            output_len,
-        );
+        match launch.kind {
+            ResolvedReduceStrategy::Unit => kernels::reduce_prod_float::launch_unchecked::<F, R>(
+                client,
+                launch.cube_count,
+                launch.cube_dim,
+                input.into_tensor_arg(),
+                output.into_tensor_arg(),
+                launch.axis,
+                launch.output_len,
+            ),
+            ResolvedReduceStrategy::Plane => {
+                kernels::reduce_prod_float_plane::launch_unchecked::<F, R>(
+                    client,
+                    launch.cube_count,
+                    launch.cube_dim,
+                    input.into_tensor_arg(),
+                    output.into_tensor_arg(),
+                    launch.axis,
+                    launch.output_len,
+                )
+            }
+        }
     }
 
     Ok(())
@@ -304,24 +461,36 @@ pub fn launch_prod_int<R: Runtime, I: Int + CubeElement>(
     strategy: ReduceStrategy,
 ) -> Result<()> {
     let problem = validate_launch(&input, &output, axis)?;
-    let (cube_count, cube_dim, axis, output_len) =
-        launch_with_unit_settings(client, problem, strategy);
+    let launch = resolve_launch_settings(client, problem, strategy)?;
 
     unsafe {
         // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
         // and keepdims output shapes are compatible and the reduce axis is
-        // non-empty. `launch_with_unit_settings` derives the launched output
+        // non-empty. `resolve_launch_settings` derives the launched output
         // domain from that validated problem; the reduction kernel uses
         // `output_len == problem.reduce_count` to guard output indexing.
-        kernels::reduce_prod_int::launch_unchecked::<I, R>(
-            client,
-            cube_count,
-            cube_dim,
-            input.into_tensor_arg(),
-            output.into_tensor_arg(),
-            axis,
-            output_len,
-        );
+        match launch.kind {
+            ResolvedReduceStrategy::Unit => kernels::reduce_prod_int::launch_unchecked::<I, R>(
+                client,
+                launch.cube_count,
+                launch.cube_dim,
+                input.into_tensor_arg(),
+                output.into_tensor_arg(),
+                launch.axis,
+                launch.output_len,
+            ),
+            ResolvedReduceStrategy::Plane => {
+                kernels::reduce_prod_int_plane::launch_unchecked::<I, R>(
+                    client,
+                    launch.cube_count,
+                    launch.cube_dim,
+                    input.into_tensor_arg(),
+                    output.into_tensor_arg(),
+                    launch.axis,
+                    launch.output_len,
+                )
+            }
+        }
     }
 
     Ok(())
@@ -351,24 +520,36 @@ pub fn launch_prod_complex<R: Runtime, C: Complex + CubeElement>(
     strategy: ReduceStrategy,
 ) -> Result<()> {
     let problem = validate_launch(&input, &output, axis)?;
-    let (cube_count, cube_dim, axis, output_len) =
-        launch_with_unit_settings(client, problem, strategy);
+    let launch = resolve_launch_settings(client, problem, strategy)?;
 
     unsafe {
         // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
         // and keepdims output shapes are compatible and the reduce axis is
-        // non-empty. `launch_with_unit_settings` derives the launched output
+        // non-empty. `resolve_launch_settings` derives the launched output
         // domain from that validated problem; the reduction kernel uses
         // `output_len == problem.reduce_count` to guard output indexing.
-        kernels::reduce_prod_complex::launch_unchecked::<C, R>(
-            client,
-            cube_count,
-            cube_dim,
-            input.into_tensor_arg(),
-            output.into_tensor_arg(),
-            axis,
-            output_len,
-        );
+        match launch.kind {
+            ResolvedReduceStrategy::Unit => kernels::reduce_prod_complex::launch_unchecked::<C, R>(
+                client,
+                launch.cube_count,
+                launch.cube_dim,
+                input.into_tensor_arg(),
+                output.into_tensor_arg(),
+                launch.axis,
+                launch.output_len,
+            ),
+            ResolvedReduceStrategy::Plane => {
+                kernels::reduce_prod_complex_plane::launch_unchecked::<C, R>(
+                    client,
+                    launch.cube_count,
+                    launch.cube_dim,
+                    input.into_tensor_arg(),
+                    output.into_tensor_arg(),
+                    launch.axis,
+                    launch.output_len,
+                )
+            }
+        }
     }
 
     Ok(())
@@ -397,24 +578,36 @@ pub fn launch_max_float<R: Runtime, F: Float + CubeElement>(
     strategy: ReduceStrategy,
 ) -> Result<()> {
     let problem = validate_launch(&input, &output, axis)?;
-    let (cube_count, cube_dim, axis, output_len) =
-        launch_with_unit_settings(client, problem, strategy);
+    let launch = resolve_launch_settings(client, problem, strategy)?;
 
     unsafe {
         // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
         // and keepdims output shapes are compatible and the reduce axis is
-        // non-empty. `launch_with_unit_settings` derives the launched output
+        // non-empty. `resolve_launch_settings` derives the launched output
         // domain from that validated problem; the reduction kernel uses
         // `output_len == problem.reduce_count` to guard output indexing.
-        kernels::reduce_max_float::launch_unchecked::<F, R>(
-            client,
-            cube_count,
-            cube_dim,
-            input.into_tensor_arg(),
-            output.into_tensor_arg(),
-            axis,
-            output_len,
-        );
+        match launch.kind {
+            ResolvedReduceStrategy::Unit => kernels::reduce_max_float::launch_unchecked::<F, R>(
+                client,
+                launch.cube_count,
+                launch.cube_dim,
+                input.into_tensor_arg(),
+                output.into_tensor_arg(),
+                launch.axis,
+                launch.output_len,
+            ),
+            ResolvedReduceStrategy::Plane => {
+                kernels::reduce_max_float_plane::launch_unchecked::<F, R>(
+                    client,
+                    launch.cube_count,
+                    launch.cube_dim,
+                    input.into_tensor_arg(),
+                    output.into_tensor_arg(),
+                    launch.axis,
+                    launch.output_len,
+                )
+            }
+        }
     }
 
     Ok(())
@@ -443,24 +636,36 @@ pub fn launch_min_float<R: Runtime, F: Float + CubeElement>(
     strategy: ReduceStrategy,
 ) -> Result<()> {
     let problem = validate_launch(&input, &output, axis)?;
-    let (cube_count, cube_dim, axis, output_len) =
-        launch_with_unit_settings(client, problem, strategy);
+    let launch = resolve_launch_settings(client, problem, strategy)?;
 
     unsafe {
         // SAFETY: `validate_launch` produced a `ReduceProblem` proving input
         // and keepdims output shapes are compatible and the reduce axis is
-        // non-empty. `launch_with_unit_settings` derives the launched output
+        // non-empty. `resolve_launch_settings` derives the launched output
         // domain from that validated problem; the reduction kernel uses
         // `output_len == problem.reduce_count` to guard output indexing.
-        kernels::reduce_min_float::launch_unchecked::<F, R>(
-            client,
-            cube_count,
-            cube_dim,
-            input.into_tensor_arg(),
-            output.into_tensor_arg(),
-            axis,
-            output_len,
-        );
+        match launch.kind {
+            ResolvedReduceStrategy::Unit => kernels::reduce_min_float::launch_unchecked::<F, R>(
+                client,
+                launch.cube_count,
+                launch.cube_dim,
+                input.into_tensor_arg(),
+                output.into_tensor_arg(),
+                launch.axis,
+                launch.output_len,
+            ),
+            ResolvedReduceStrategy::Plane => {
+                kernels::reduce_min_float_plane::launch_unchecked::<F, R>(
+                    client,
+                    launch.cube_count,
+                    launch.cube_dim,
+                    input.into_tensor_arg(),
+                    output.into_tensor_arg(),
+                    launch.axis,
+                    launch.output_len,
+                )
+            }
+        }
     }
 
     Ok(())

--- a/tenferro-gpubackend/src/reduce/launch/tests.rs
+++ b/tenferro-gpubackend/src/reduce/launch/tests.rs
@@ -33,3 +33,51 @@ fn validate_reduce_problem_rejects_non_keepdims_output_shape() {
         }
     );
 }
+
+#[test]
+fn auto_strategy_uses_unit_only_within_bounded_axis_limit() {
+    assert_eq!(
+        super::auto_reduce_strategy_for_capabilities(32, 32, false).unwrap(),
+        super::ResolvedReduceStrategy::Unit
+    );
+    assert_eq!(
+        super::auto_reduce_strategy_for_capabilities(33, 32, true).unwrap(),
+        super::ResolvedReduceStrategy::Plane
+    );
+}
+
+#[test]
+fn auto_strategy_rejects_large_axis_without_plane_ops() {
+    let err = super::auto_reduce_strategy_for_capabilities(33, 32, false).unwrap_err();
+
+    assert_eq!(
+        err,
+        CubeclKernelError::InvalidStrategy {
+            reason: "Auto reduction cannot reduce axis length 33 without plane operations"
+                .to_owned(),
+        }
+    );
+}
+
+#[test]
+fn explicit_plane_strategy_requires_full_plane_and_plane_ops() {
+    let problem = super::ReduceProblem {
+        reduce_len: 31,
+        reduce_count: 4,
+        axis: 0,
+    };
+
+    assert_eq!(
+        super::validate_plane_strategy(problem, 32, false).unwrap_err(),
+        CubeclKernelError::InvalidStrategy {
+            reason: "plane reduction requires backend plane operations".to_owned(),
+        }
+    );
+    assert_eq!(
+        super::validate_plane_strategy(problem, 32, true).unwrap_err(),
+        CubeclKernelError::InvalidStrategy {
+            reason: "plane reduction requires reduce axis length 31 to be at least plane width 32"
+                .to_owned(),
+        }
+    );
+}

--- a/tenferro-gpubackend/tests/kernel_metadata_contract.rs
+++ b/tenferro-gpubackend/tests/kernel_metadata_contract.rs
@@ -39,7 +39,6 @@ fn logical_kernels_do_not_take_tensor_shapes_as_comptime_parameters() {
 }
 
 #[test]
-#[ignore = "tracked in https://github.com/tensor4all/tenferro-rs/issues/881"]
 fn reduction_kernels_do_not_hide_unbounded_axis_work_in_one_worker() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let launch_source = fs::read_to_string(root.join("reduce").join("launch.rs"))

--- a/tenferro-runtime/src/extension_runtime.rs
+++ b/tenferro-runtime/src/extension_runtime.rs
@@ -208,7 +208,7 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
             return Err(tenferro_tensor::Error::InvalidConfig {
                 op: "extension",
                 message: format!(
-                    "missing runtime for family_id {:?}; register the extension on this GraphExecutor, for example `executor.register_extension(<extension_crate>::register_runtime)`",
+                    "missing runtime for family_id {:?}; register the extension on this runtime owner, for example `executor.register_extension(<extension_crate>::register_runtime)` or `eager_runtime.register_extension(<extension_crate>::register_runtime)`",
                     op.family_id()
                 ),
             });

--- a/tenferro-tensor/src/cpu/gemm/tests.rs
+++ b/tenferro-tensor/src/cpu/gemm/tests.rs
@@ -11,6 +11,7 @@ use super::dot_general;
 use super::faer_gemm::FaerGemm;
 #[cfg(feature = "cpu-blas")]
 use crate::buffer_pool::BufferPool;
+use crate::cache::RuntimeCacheControl;
 use crate::config::DotGeneralConfig;
 #[cfg(feature = "cpu-faer")]
 use crate::cpu::CpuContext;
@@ -107,6 +108,50 @@ fn gemm_analysis_cache_keeps_direct_and_canonical_candidates_separate() {
         .canonical
         .as_ref()
         .is_some_and(|plan| plan.dims.is_some()));
+}
+
+#[test]
+fn gemm_analysis_cache_reuses_matching_direct_plan_and_reports_stats() {
+    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]);
+    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.0; 6]);
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let mut cache = GemmAnalysisCache::default();
+
+    let first = analyse_gemm_cached(
+        &mut cache,
+        Some(3),
+        GemmAnalysisCacheKind::Direct,
+        &lhs,
+        &rhs,
+        &config,
+    )
+    .expect("first analysis should validate")
+    .expect("first analysis should be representable");
+    assert_eq!((first.m, first.n, first.k, first.batch_total), (2, 2, 3, 1));
+
+    let cached = analyse_gemm_cached(
+        &mut cache,
+        Some(3),
+        GemmAnalysisCacheKind::Direct,
+        &lhs,
+        &rhs,
+        &config,
+    )
+    .expect("cached analysis should validate")
+    .expect("cached analysis should be present");
+    assert_eq!(
+        (cached.m, cached.n, cached.k, cached.batch_total),
+        (2, 2, 3, 1)
+    );
+
+    let stats = cache.stats();
+    assert_eq!(stats.entries, 1);
+    assert!(stats.retained_bytes > 0);
 }
 
 #[cfg(feature = "cpu-blas")]

--- a/tenferro-tensor/src/cubecl/fusion/mod.rs
+++ b/tenferro-tensor/src/cubecl/fusion/mod.rs
@@ -42,6 +42,6 @@ pub(crate) fn execute_elementwise_fusion(
             let outputs = launch::launch(backend.runtime(), classified)?;
             Ok(Some(outputs.into_iter().map(Tensor::C64).collect()))
         }
-        crate::DType::I64 => Ok(None),
+        crate::DType::I32 | crate::DType::I64 | crate::DType::Bool => Ok(None),
     }
 }

--- a/tenferro-tensor/src/cubecl/linalg.rs
+++ b/tenferro-tensor/src/cubecl/linalg.rs
@@ -60,6 +60,13 @@ impl LinalgScalar for Complex64 {
     const NEEDS_RWORK: bool = true;
 }
 
+fn unsupported_linalg_dtype(op: &'static str, input: &Tensor) -> crate::Error {
+    crate::Error::BackendFailure {
+        op,
+        message: format!("unsupported dtype {:?}", input.dtype()),
+    }
+}
+
 struct Workspace {
     _handle: Option<cubecl::server::Handle>,
     ptr: *mut c_void,
@@ -80,10 +87,9 @@ pub(super) fn cholesky(backend: &mut CubeclBackend, input: &Tensor) -> crate::Re
         Tensor::F64(t) => cholesky_typed(backend, t).map(Tensor::F64),
         Tensor::C32(t) => cholesky_typed(backend, t).map(Tensor::C32),
         Tensor::C64(t) => cholesky_typed(backend, t).map(Tensor::C64),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
-            op: "cholesky",
-            message: "unsupported dtype I64".into(),
-        }),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_linalg_dtype("cholesky", input))
+        }
     }
 }
 
@@ -159,10 +165,9 @@ pub(super) fn lu(backend: &mut CubeclBackend, input: &Tensor) -> crate::Result<V
                 Tensor::C64(parity),
             ]
         }),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
-            op: "lu",
-            message: "unsupported dtype I64".into(),
-        }),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_linalg_dtype("lu", input))
+        }
     }
 }
 
@@ -198,10 +203,9 @@ pub(super) fn svd(backend: &mut CubeclBackend, input: &Tensor) -> crate::Result<
             .map(|(u, s, vt)| vec![Tensor::C32(u), Tensor::F32(s), Tensor::C32(vt)]),
         Tensor::C64(t) => svd_typed(backend, t)
             .map(|(u, s, vt)| vec![Tensor::C64(u), Tensor::F64(s), Tensor::C64(vt)]),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
-            op: "svd",
-            message: "unsupported dtype I64".into(),
-        }),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_linalg_dtype("svd", input))
+        }
     }
 }
 
@@ -211,10 +215,9 @@ pub(super) fn qr(backend: &mut CubeclBackend, input: &Tensor) -> crate::Result<V
         Tensor::F64(t) => qr_typed(backend, t).map(|(q, r)| vec![Tensor::F64(q), Tensor::F64(r)]),
         Tensor::C32(t) => qr_typed(backend, t).map(|(q, r)| vec![Tensor::C32(q), Tensor::C32(r)]),
         Tensor::C64(t) => qr_typed(backend, t).map(|(q, r)| vec![Tensor::C64(q), Tensor::C64(r)]),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
-            op: "qr",
-            message: "unsupported dtype I64".into(),
-        }),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_linalg_dtype("qr", input))
+        }
     }
 }
 
@@ -224,10 +227,9 @@ pub(super) fn eigh(backend: &mut CubeclBackend, input: &Tensor) -> crate::Result
         Tensor::F64(t) => eigh_typed(backend, t).map(|(w, v)| vec![Tensor::F64(w), Tensor::F64(v)]),
         Tensor::C32(t) => eigh_typed(backend, t).map(|(w, v)| vec![Tensor::F32(w), Tensor::C32(v)]),
         Tensor::C64(t) => eigh_typed(backend, t).map(|(w, v)| vec![Tensor::F64(w), Tensor::C64(v)]),
-        Tensor::I64(_) => Err(crate::Error::BackendFailure {
-            op: "eigh",
-            message: "unsupported dtype I64".into(),
-        }),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_linalg_dtype("eigh", input))
+        }
     }
 }
 
@@ -1187,7 +1189,12 @@ fn zeros_like_tensor(input: &Tensor) -> Tensor {
     match input {
         Tensor::F32(t) => Tensor::F32(TypedTensor::zeros(t.shape.clone())),
         Tensor::F64(t) => Tensor::F64(TypedTensor::zeros(t.shape.clone())),
+        Tensor::I32(t) => Tensor::I32(TypedTensor::zeros(t.shape.clone())),
         Tensor::I64(t) => Tensor::I64(TypedTensor::zeros(t.shape.clone())),
+        Tensor::Bool(t) => Tensor::Bool(TypedTensor::from_vec_col_major(
+            t.shape.clone(),
+            vec![false; t.n_elements()],
+        )),
         Tensor::C32(t) => Tensor::C32(TypedTensor::zeros(t.shape.clone())),
         Tensor::C64(t) => Tensor::C64(TypedTensor::zeros(t.shape.clone())),
     }

--- a/tenferro-tensor/src/cubecl/memory.rs
+++ b/tenferro-tensor/src/cubecl/memory.rs
@@ -25,7 +25,9 @@ pub fn upload_tensor(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<Tenso
     match tensor {
         Tensor::F64(t) => upload_typed::<f64>(client, rt.device_ordinal(), t).map(Tensor::F64),
         Tensor::F32(t) => upload_typed::<f32>(client, rt.device_ordinal(), t).map(Tensor::F32),
+        Tensor::I32(t) => upload_typed::<i32>(client, rt.device_ordinal(), t).map(Tensor::I32),
         Tensor::I64(t) => upload_typed::<i64>(client, rt.device_ordinal(), t).map(Tensor::I64),
+        Tensor::Bool(t) => upload_bool(client, rt.device_ordinal(), t).map(Tensor::Bool),
         Tensor::C64(t) => {
             upload_typed::<Complex64>(client, rt.device_ordinal(), t).map(Tensor::C64)
         }
@@ -50,7 +52,9 @@ pub fn download_tensor(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<Ten
     match tensor {
         Tensor::F64(t) => download_typed::<f64>(client, t).map(Tensor::F64),
         Tensor::F32(t) => download_typed::<f32>(client, t).map(Tensor::F32),
+        Tensor::I32(t) => download_typed::<i32>(client, t).map(Tensor::I32),
         Tensor::I64(t) => download_typed::<i64>(client, t).map(Tensor::I64),
+        Tensor::Bool(t) => download_bool(client, t).map(Tensor::Bool),
         Tensor::C64(t) => download_typed::<Complex64>(client, t).map(Tensor::C64),
         Tensor::C32(t) => download_typed::<Complex32>(client, t).map(Tensor::C32),
     }
@@ -143,11 +147,79 @@ fn download_typed<T: CubeElement + Clone>(
     Ok(TypedTensor::from_vec_col_major(typed.shape.clone(), data))
 }
 
+fn upload_bool(
+    client: &ComputeClient<CudaRuntime>,
+    device_ordinal: usize,
+    typed: &TypedTensor<bool>,
+) -> crate::Result<TypedTensor<bool>> {
+    let host_data = match &typed.buffer {
+        Buffer::Host(data) => data,
+        Buffer::Backend(_) => {
+            return Err(crate::Error::BackendFailure {
+                op: "upload",
+                message: "expected host buffer".into(),
+            });
+        }
+        Buffer::Cubecl(_) => {
+            return Err(crate::Error::BackendFailure {
+                op: "upload",
+                message: "tensor is already backed by CubeCL storage".into(),
+            });
+        }
+    };
+
+    let bytes: Vec<u8> = host_data.iter().map(|&value| u8::from(value)).collect();
+    let handle = client.create_from_slice(&bytes);
+    Ok(TypedTensor {
+        buffer: Buffer::Cubecl(CubeclBuffer::new(handle, host_data.len())),
+        shape: typed.shape.clone(),
+        placement: Placement {
+            memory_kind: MemoryKind::Device,
+            resident_device: Some(ComputeDevice {
+                kind: "cuda".into(),
+                ordinal: device_ordinal,
+            }),
+        },
+    })
+}
+
+fn download_bool(
+    client: &ComputeClient<CudaRuntime>,
+    typed: &TypedTensor<bool>,
+) -> crate::Result<TypedTensor<bool>> {
+    let handle = match &typed.buffer {
+        Buffer::Host(_) => {
+            return Err(crate::Error::BackendFailure {
+                op: "download",
+                message: "expected CubeCL buffer".into(),
+            });
+        }
+        Buffer::Backend(_) => {
+            return Err(crate::Error::BackendFailure {
+                op: "download",
+                message: "expected CubeCL buffer".into(),
+            });
+        }
+        Buffer::Cubecl(buffer) => buffer.handle.clone(),
+    };
+
+    let bytes = client
+        .read_one(handle)
+        .map_err(|err| crate::Error::BackendFailure {
+            op: "download",
+            message: format!("{err:?}"),
+        })?;
+    let data = bytes.iter().map(|&byte| byte != 0).collect();
+    Ok(TypedTensor::from_vec_col_major(typed.shape.clone(), data))
+}
+
 fn cubecl_handle(tensor: &Tensor) -> crate::Result<cubecl::server::Handle> {
     match tensor {
         Tensor::F64(t) => cubecl_handle_from_buffer(&t.buffer),
         Tensor::F32(t) => cubecl_handle_from_buffer(&t.buffer),
+        Tensor::I32(t) => cubecl_handle_from_buffer(&t.buffer),
         Tensor::I64(t) => cubecl_handle_from_buffer(&t.buffer),
+        Tensor::Bool(t) => cubecl_handle_from_buffer(&t.buffer),
         Tensor::C64(t) => cubecl_handle_from_buffer(&t.buffer),
         Tensor::C32(t) => cubecl_handle_from_buffer(&t.buffer),
     }

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -1457,7 +1457,9 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::C64),
-            Tensor::I64(_) => Err(unsupported_dtype("neg", input.dtype())),
+            Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+                Err(unsupported_dtype("neg", input.dtype()))
+            }
         }
     }
 
@@ -1471,7 +1473,9 @@ impl TensorBackend for CubeclBackend {
                 ensure_resident_on_runtime(self.runtime(), tensor, "conj")?;
                 Ok(Tensor::F64(tensor.clone()))
             }
-            Tensor::I64(_) => Err(unsupported_dtype("conj", input.dtype())),
+            Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+                Err(unsupported_dtype("conj", input.dtype()))
+            }
             Tensor::C32(tensor) => launch_unary(
                 self.runtime(),
                 tensor,
@@ -1583,10 +1587,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "abs",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("abs", input.dtype())),
         }
     }
 
@@ -1616,10 +1617,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "sign",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("sign", input.dtype())),
         }
     }
 
@@ -1862,10 +1860,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "exp",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("exp", input.dtype())),
         }
     }
 
@@ -1895,10 +1890,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "log",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("log", input.dtype())),
         }
     }
 
@@ -1928,10 +1920,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "sin",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("sin", input.dtype())),
         }
     }
 
@@ -1961,10 +1950,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "cos",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("cos", input.dtype())),
         }
     }
 
@@ -1994,10 +1980,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "tanh",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("tanh", input.dtype())),
         }
     }
 
@@ -2027,10 +2010,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "sqrt",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("sqrt", input.dtype())),
         }
     }
 
@@ -2060,10 +2040,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "rsqrt",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("rsqrt", input.dtype())),
         }
     }
 
@@ -2131,10 +2108,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "expm1",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("expm1", input.dtype())),
         }
     }
 
@@ -2164,10 +2138,7 @@ impl TensorBackend for CubeclBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "log1p",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            _ => Err(unsupported_dtype("log1p", input.dtype())),
         }
     }
 
@@ -2175,7 +2146,9 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.transpose_typed(t, perm).map(Tensor::F32),
             Tensor::F64(t) => self.transpose_typed(t, perm).map(Tensor::F64),
+            Tensor::I32(t) => self.transpose_typed(t, perm).map(Tensor::I32),
             Tensor::I64(t) => self.transpose_typed(t, perm).map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("transpose", input.dtype())),
             Tensor::C32(t) => self.transpose_typed(t, perm).map(Tensor::C32),
             Tensor::C64(t) => self.transpose_typed(t, perm).map(Tensor::C64),
         }
@@ -2202,7 +2175,17 @@ impl TensorBackend for CubeclBackend {
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
             })),
+            Tensor::I32(t) => Ok(Tensor::I32(TypedTensor {
+                buffer: t.buffer.clone(),
+                shape: shape.to_vec(),
+                placement: t.placement.clone(),
+            })),
             Tensor::I64(t) => Ok(Tensor::I64(TypedTensor {
+                buffer: t.buffer.clone(),
+                shape: shape.to_vec(),
+                placement: t.placement.clone(),
+            })),
+            Tensor::Bool(t) => Ok(Tensor::Bool(TypedTensor {
                 buffer: t.buffer.clone(),
                 shape: shape.to_vec(),
                 placement: t.placement.clone(),
@@ -2229,7 +2212,9 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.broadcast_typed(t, shape, dims).map(Tensor::F32),
             Tensor::F64(t) => self.broadcast_typed(t, shape, dims).map(Tensor::F64),
+            Tensor::I32(t) => self.broadcast_typed(t, shape, dims).map(Tensor::I32),
             Tensor::I64(t) => self.broadcast_typed(t, shape, dims).map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("broadcast_in_dim", input.dtype())),
             Tensor::C32(t) => self.broadcast_typed(t, shape, dims).map(Tensor::C32),
             Tensor::C64(t) => self.broadcast_typed(t, shape, dims).map(Tensor::C64),
         }
@@ -2241,6 +2226,9 @@ impl TensorBackend for CubeclBackend {
             (Tensor::F32(t), crate::DType::F64) => {
                 self.convert_float_to_float::<f32, f64>(t).map(Tensor::F64)
             }
+            (Tensor::F32(_), crate::DType::I32 | crate::DType::Bool) => {
+                Err(unsupported_dtype("convert", to))
+            }
             (Tensor::F32(_), crate::DType::I64) => Err(unsupported_dtype("convert", to)),
             (Tensor::F32(t), crate::DType::C32) => self.convert_f32_to_c32(t).map(Tensor::C32),
             (Tensor::F32(t), crate::DType::C64) => self.convert_f32_to_c64(t).map(Tensor::C64),
@@ -2248,13 +2236,23 @@ impl TensorBackend for CubeclBackend {
                 self.convert_float_to_float::<f64, f32>(t).map(Tensor::F32)
             }
             (Tensor::F64(t), crate::DType::F64) => Ok(Tensor::F64(t.clone())),
+            (Tensor::F64(_), crate::DType::I32 | crate::DType::Bool) => {
+                Err(unsupported_dtype("convert", to))
+            }
             (Tensor::F64(_), crate::DType::I64) => Err(unsupported_dtype("convert", to)),
             (Tensor::F64(t), crate::DType::C32) => self.convert_f64_to_c32(t).map(Tensor::C32),
             (Tensor::F64(t), crate::DType::C64) => self.convert_f64_to_c64(t).map(Tensor::C64),
+            (Tensor::I32(t), crate::DType::I32) => Ok(Tensor::I32(t.clone())),
+            (Tensor::I32(_), _) => Err(unsupported_dtype("convert", input.dtype())),
             (Tensor::I64(_), crate::DType::I64) => Ok(input.clone()),
             (Tensor::I64(_), _) => Err(unsupported_dtype("convert", input.dtype())),
+            (Tensor::Bool(t), crate::DType::Bool) => Ok(Tensor::Bool(t.clone())),
+            (Tensor::Bool(_), _) => Err(unsupported_dtype("convert", input.dtype())),
             (Tensor::C32(t), crate::DType::F32) => self.convert_c32_to_f32(t).map(Tensor::F32),
             (Tensor::C32(t), crate::DType::F64) => self.convert_c32_to_f64(t).map(Tensor::F64),
+            (Tensor::C32(_), crate::DType::I32 | crate::DType::Bool) => {
+                Err(unsupported_dtype("convert", to))
+            }
             (Tensor::C32(_), crate::DType::I64) => Err(unsupported_dtype("convert", to)),
             (Tensor::C32(t), crate::DType::C32) => Ok(Tensor::C32(t.clone())),
             (Tensor::C32(t), crate::DType::C64) => self
@@ -2262,6 +2260,9 @@ impl TensorBackend for CubeclBackend {
                 .map(Tensor::C64),
             (Tensor::C64(t), crate::DType::F32) => self.convert_c64_to_f32(t).map(Tensor::F32),
             (Tensor::C64(t), crate::DType::F64) => self.convert_c64_to_f64(t).map(Tensor::F64),
+            (Tensor::C64(_), crate::DType::I32 | crate::DType::Bool) => {
+                Err(unsupported_dtype("convert", to))
+            }
             (Tensor::C64(_), crate::DType::I64) => Err(unsupported_dtype("convert", to)),
             (Tensor::C64(t), crate::DType::C32) => self
                 .convert_complex_to_complex::<Complex64, Complex32>(t)
@@ -2283,9 +2284,13 @@ impl TensorBackend for CubeclBackend {
             Tensor::F64(t) => self
                 .extract_diagonal_typed(t, axis_a, axis_b)
                 .map(Tensor::F64),
+            Tensor::I32(t) => self
+                .extract_diagonal_typed(t, axis_a, axis_b)
+                .map(Tensor::I32),
             Tensor::I64(t) => self
                 .extract_diagonal_typed(t, axis_a, axis_b)
                 .map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("extract_diagonal", input.dtype())),
             Tensor::C32(t) => self
                 .extract_diagonal_typed(t, axis_a, axis_b)
                 .map(Tensor::C32),
@@ -2308,9 +2313,13 @@ impl TensorBackend for CubeclBackend {
             Tensor::F64(t) => self
                 .embed_diagonal_typed(t, axis_a, axis_b)
                 .map(Tensor::F64),
+            Tensor::I32(t) => self
+                .embed_diagonal_typed(t, axis_a, axis_b)
+                .map(Tensor::I32),
             Tensor::I64(t) => self
                 .embed_diagonal_typed(t, axis_a, axis_b)
                 .map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("embed_diagonal", input.dtype())),
             Tensor::C32(t) => self
                 .embed_diagonal_typed(t, axis_a, axis_b)
                 .map(Tensor::C32),
@@ -2324,7 +2333,9 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.tril_typed(t, k).map(Tensor::F32),
             Tensor::F64(t) => self.tril_typed(t, k).map(Tensor::F64),
+            Tensor::I32(t) => self.tril_typed(t, k).map(Tensor::I32),
             Tensor::I64(t) => self.tril_typed(t, k).map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("tril", input.dtype())),
             Tensor::C32(t) => self.tril_typed(t, k).map(Tensor::C32),
             Tensor::C64(t) => self.tril_typed(t, k).map(Tensor::C64),
         }
@@ -2334,7 +2345,9 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.triu_typed(t, k).map(Tensor::F32),
             Tensor::F64(t) => self.triu_typed(t, k).map(Tensor::F64),
+            Tensor::I32(t) => self.triu_typed(t, k).map(Tensor::I32),
             Tensor::I64(t) => self.triu_typed(t, k).map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("triu", input.dtype())),
             Tensor::C32(t) => self.triu_typed(t, k).map(Tensor::C32),
             Tensor::C64(t) => self.triu_typed(t, k).map(Tensor::C64),
         }
@@ -2344,7 +2357,9 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.reduce_sum_float_typed(t, axes).map(Tensor::F32),
             Tensor::F64(t) => self.reduce_sum_float_typed(t, axes).map(Tensor::F64),
+            Tensor::I32(t) => self.reduce_sum_int_typed(t, axes).map(Tensor::I32),
             Tensor::I64(t) => self.reduce_sum_int_typed(t, axes).map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("reduce_sum", input.dtype())),
             Tensor::C32(t) => self.reduce_sum_complex_typed(t, axes).map(Tensor::C32),
             Tensor::C64(t) => self.reduce_sum_complex_typed(t, axes).map(Tensor::C64),
         }
@@ -2354,7 +2369,9 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.reduce_prod_float_typed(t, axes).map(Tensor::F32),
             Tensor::F64(t) => self.reduce_prod_float_typed(t, axes).map(Tensor::F64),
+            Tensor::I32(t) => self.reduce_prod_int_typed(t, axes).map(Tensor::I32),
             Tensor::I64(t) => self.reduce_prod_int_typed(t, axes).map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("reduce_prod", input.dtype())),
             Tensor::C32(t) => self.reduce_prod_complex_typed(t, axes).map(Tensor::C32),
             Tensor::C64(t) => self.reduce_prod_complex_typed(t, axes).map(Tensor::C64),
         }
@@ -2364,10 +2381,12 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.reduce_max_typed(t, axes).map(Tensor::F32),
             Tensor::F64(t) => self.reduce_max_typed(t, axes).map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "reduce_max",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => {
+                Err(crate::Error::BackendFailure {
+                    op: "reduce_max",
+                    message: format!("unsupported dtype {:?}", input.dtype()),
+                })
+            }
         }
     }
 
@@ -2375,10 +2394,12 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.reduce_min_typed(t, axes).map(Tensor::F32),
             Tensor::F64(t) => self.reduce_min_typed(t, axes).map(Tensor::F64),
-            Tensor::I64(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::BackendFailure {
-                op: "reduce_min",
-                message: format!("unsupported dtype {:?}", input.dtype()),
-            }),
+            Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => {
+                Err(crate::Error::BackendFailure {
+                    op: "reduce_min",
+                    message: format!("unsupported dtype {:?}", input.dtype()),
+                })
+            }
         }
     }
 
@@ -2421,6 +2442,9 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(operand), Tensor::F32(indices)) => {
                 self.gather_typed(operand, indices, config).map(Tensor::C64)
             }
+            (Tensor::I32(operand), Tensor::F32(indices)) => {
+                self.gather_typed(operand, indices, config).map(Tensor::I32)
+            }
             (Tensor::F32(operand), Tensor::F64(indices)) => {
                 self.gather_typed(operand, indices, config).map(Tensor::F32)
             }
@@ -2432,6 +2456,24 @@ impl TensorBackend for CubeclBackend {
             }
             (Tensor::C64(operand), Tensor::F64(indices)) => {
                 self.gather_typed(operand, indices, config).map(Tensor::C64)
+            }
+            (Tensor::I32(operand), Tensor::F64(indices)) => {
+                self.gather_typed(operand, indices, config).map(Tensor::I32)
+            }
+            (Tensor::F32(operand), Tensor::I32(indices)) => {
+                self.gather_typed(operand, indices, config).map(Tensor::F32)
+            }
+            (Tensor::F64(operand), Tensor::I32(indices)) => {
+                self.gather_typed(operand, indices, config).map(Tensor::F64)
+            }
+            (Tensor::C32(operand), Tensor::I32(indices)) => {
+                self.gather_typed(operand, indices, config).map(Tensor::C32)
+            }
+            (Tensor::C64(operand), Tensor::I32(indices)) => {
+                self.gather_typed(operand, indices, config).map(Tensor::C64)
+            }
+            (Tensor::I32(operand), Tensor::I32(indices)) => {
+                self.gather_typed(operand, indices, config).map(Tensor::I32)
             }
             (Tensor::F32(operand), Tensor::I64(indices)) => {
                 self.gather_typed(operand, indices, config).map(Tensor::F32)
@@ -2445,11 +2487,17 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(operand), Tensor::I64(indices)) => {
                 self.gather_typed(operand, indices, config).map(Tensor::C64)
             }
+            (Tensor::I32(operand), Tensor::I64(indices)) => {
+                self.gather_typed(operand, indices, config).map(Tensor::I32)
+            }
+            (_, Tensor::Bool(_)) => Err(unsupported_dtype("gather", start_indices.dtype())),
             (_, Tensor::C32(_) | Tensor::C64(_)) => Err(crate::Error::BackendFailure {
                 op: "gather",
                 message: "complex index tensors are not supported".into(),
             }),
-            (Tensor::I64(_), _) => Err(unsupported_dtype("gather", operand.dtype())),
+            (Tensor::I64(_) | Tensor::Bool(_), _) => {
+                Err(unsupported_dtype("gather", operand.dtype()))
+            }
         }
     }
 
@@ -2485,6 +2533,18 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(operand), Tensor::F64(indices), Tensor::C64(updates)) => self
                 .scatter_complex_typed::<_, f64, _>(operand, indices, updates, config)
                 .map(Tensor::C64),
+            (Tensor::F32(operand), Tensor::I32(indices), Tensor::F32(updates)) => self
+                .scatter_float_typed(operand, indices, updates, config)
+                .map(Tensor::F32),
+            (Tensor::F64(operand), Tensor::I32(indices), Tensor::F64(updates)) => self
+                .scatter_float_typed(operand, indices, updates, config)
+                .map(Tensor::F64),
+            (Tensor::C32(operand), Tensor::I32(indices), Tensor::C32(updates)) => self
+                .scatter_complex_typed::<_, f32, _>(operand, indices, updates, config)
+                .map(Tensor::C32),
+            (Tensor::C64(operand), Tensor::I32(indices), Tensor::C64(updates)) => self
+                .scatter_complex_typed::<_, f64, _>(operand, indices, updates, config)
+                .map(Tensor::C64),
             (Tensor::F32(operand), Tensor::I64(indices), Tensor::F32(updates)) => self
                 .scatter_float_typed(operand, indices, updates, config)
                 .map(Tensor::F32),
@@ -2497,6 +2557,7 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(operand), Tensor::I64(indices), Tensor::C64(updates)) => self
                 .scatter_complex_typed::<_, f64, _>(operand, indices, updates, config)
                 .map(Tensor::C64),
+            (_, Tensor::Bool(_), _) => Err(unsupported_dtype("scatter", scatter_indices.dtype())),
             (_, Tensor::C32(_) | Tensor::C64(_), _) => Err(crate::Error::BackendFailure {
                 op: "scatter",
                 message: "complex index tensors are not supported".into(),
@@ -2514,7 +2575,9 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.slice_typed(t, config).map(Tensor::F32),
             Tensor::F64(t) => self.slice_typed(t, config).map(Tensor::F64),
+            Tensor::I32(t) => self.slice_typed(t, config).map(Tensor::I32),
             Tensor::I64(t) => self.slice_typed(t, config).map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("slice", input.dtype())),
             Tensor::C32(t) => self.slice_typed(t, config).map(Tensor::C32),
             Tensor::C64(t) => self.slice_typed(t, config).map(Tensor::C64),
         }
@@ -2539,6 +2602,9 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(input), Tensor::F32(starts)) => self
                 .dynamic_slice_typed(input, starts, slice_sizes)
                 .map(Tensor::C64),
+            (Tensor::I32(input), Tensor::F32(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::I32),
             (Tensor::F32(input), Tensor::F64(starts)) => self
                 .dynamic_slice_typed(input, starts, slice_sizes)
                 .map(Tensor::F32),
@@ -2551,6 +2617,24 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(input), Tensor::F64(starts)) => self
                 .dynamic_slice_typed(input, starts, slice_sizes)
                 .map(Tensor::C64),
+            (Tensor::I32(input), Tensor::F64(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::I32),
+            (Tensor::F32(input), Tensor::I32(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::F32),
+            (Tensor::F64(input), Tensor::I32(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::F64),
+            (Tensor::C32(input), Tensor::I32(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::C32),
+            (Tensor::C64(input), Tensor::I32(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::C64),
+            (Tensor::I32(input), Tensor::I32(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::I32),
             (Tensor::F32(input), Tensor::I64(starts)) => self
                 .dynamic_slice_typed(input, starts, slice_sizes)
                 .map(Tensor::F32),
@@ -2563,11 +2647,17 @@ impl TensorBackend for CubeclBackend {
             (Tensor::C64(input), Tensor::I64(starts)) => self
                 .dynamic_slice_typed(input, starts, slice_sizes)
                 .map(Tensor::C64),
+            (Tensor::I32(input), Tensor::I64(starts)) => self
+                .dynamic_slice_typed(input, starts, slice_sizes)
+                .map(Tensor::I32),
+            (_, Tensor::Bool(_)) => Err(unsupported_dtype("dynamic_slice", starts.dtype())),
             (_, Tensor::C32(_) | Tensor::C64(_)) => Err(crate::Error::BackendFailure {
                 op: "dynamic_slice",
                 message: "complex index tensors are not supported".into(),
             }),
-            (Tensor::I64(_), _) => Err(unsupported_dtype("dynamic_slice", input.dtype())),
+            (Tensor::I64(_) | Tensor::Bool(_), _) => {
+                Err(unsupported_dtype("dynamic_slice", input.dtype()))
+            }
         }
     }
 
@@ -2587,7 +2677,9 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.pad_typed(t, config).map(Tensor::F32),
             Tensor::F64(t) => self.pad_typed(t, config).map(Tensor::F64),
+            Tensor::I32(t) => self.pad_typed(t, config).map(Tensor::I32),
             Tensor::I64(t) => self.pad_typed(t, config).map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("pad", input.dtype())),
             Tensor::C32(t) => self.pad_typed(t, config).map(Tensor::C32),
             Tensor::C64(t) => self.pad_typed(t, config).map(Tensor::C64),
         }
@@ -2622,6 +2714,16 @@ impl TensorBackend for CubeclBackend {
                     .collect();
                 self.concatenate_typed(&typed?, axis).map(Tensor::F64)
             }
+            Tensor::I32(_) => {
+                let typed: crate::Result<Vec<&TypedTensor<i32>>> = inputs
+                    .iter()
+                    .map(|tensor| match tensor {
+                        Tensor::I32(t) => Ok(t),
+                        _ => Err(dtype_mismatch("concatenate", first, tensor)),
+                    })
+                    .collect();
+                self.concatenate_typed(&typed?, axis).map(Tensor::I32)
+            }
             Tensor::I64(_) => {
                 let typed: crate::Result<Vec<&TypedTensor<i64>>> = inputs
                     .iter()
@@ -2632,6 +2734,7 @@ impl TensorBackend for CubeclBackend {
                     .collect();
                 self.concatenate_typed(&typed?, axis).map(Tensor::I64)
             }
+            Tensor::Bool(_) => Err(unsupported_dtype("concatenate", first.dtype())),
             Tensor::C32(_) => {
                 let typed: crate::Result<Vec<&TypedTensor<Complex32>>> = inputs
                     .iter()
@@ -2659,7 +2762,9 @@ impl TensorBackend for CubeclBackend {
         match input {
             Tensor::F32(t) => self.reverse_typed(t, axes).map(Tensor::F32),
             Tensor::F64(t) => self.reverse_typed(t, axes).map(Tensor::F64),
+            Tensor::I32(t) => self.reverse_typed(t, axes).map(Tensor::I32),
             Tensor::I64(t) => self.reverse_typed(t, axes).map(Tensor::I64),
+            Tensor::Bool(_) => Err(unsupported_dtype("reverse", input.dtype())),
             Tensor::C32(t) => self.reverse_typed(t, axes).map(Tensor::C32),
             Tensor::C64(t) => self.reverse_typed(t, axes).map(Tensor::C64),
         }

--- a/tenferro-tensor/src/cubecl/tests/mod.rs
+++ b/tenferro-tensor/src/cubecl/tests/mod.rs
@@ -43,6 +43,14 @@ fn tensor_i64(shape: Vec<usize>, data: Vec<i64>) -> Tensor {
     Tensor::I64(TypedTensor::from_vec_col_major(shape, data))
 }
 
+fn tensor_i32(shape: Vec<usize>, data: Vec<i32>) -> Tensor {
+    Tensor::I32(TypedTensor::from_vec_col_major(shape, data))
+}
+
+fn tensor_bool(shape: Vec<usize>, data: Vec<bool>) -> Tensor {
+    Tensor::Bool(TypedTensor::from_vec_col_major(shape, data))
+}
+
 fn tensor_c32(shape: Vec<usize>, data: Vec<Complex32>) -> Tensor {
     Tensor::C32(TypedTensor::from_vec_col_major(shape, data))
 }
@@ -79,6 +87,16 @@ fn assert_tensor_close(actual: &Tensor, expected: &Tensor, tol: f64) {
         (Tensor::I64(_), Tensor::I64(_)) => {
             let actual = actual.as_slice::<i64>().unwrap();
             let expected = expected.as_slice::<i64>().unwrap();
+            assert_eq!(actual, expected);
+        }
+        (Tensor::I32(_), Tensor::I32(_)) => {
+            let actual = actual.as_slice::<i32>().unwrap();
+            let expected = expected.as_slice::<i32>().unwrap();
+            assert_eq!(actual, expected);
+        }
+        (Tensor::Bool(_), Tensor::Bool(_)) => {
+            let actual = actual.as_slice::<bool>().unwrap();
+            let expected = expected.as_slice::<bool>().unwrap();
             assert_eq!(actual, expected);
         }
         (Tensor::C32(_), Tensor::C32(_)) => {

--- a/tenferro-tensor/src/cubecl/tests/reduction_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/reduction_tests.rs
@@ -2,8 +2,8 @@
 use crate::TensorBackend;
 
 use super::{
-    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c64, tensor_f64, tensor_i64,
-    upload,
+    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_bool, tensor_c64, tensor_f64,
+    tensor_i32, tensor_i64, upload,
 };
 
 #[test]
@@ -100,6 +100,53 @@ fn test_cubecl_i64_sum_and_prod_match_cpu() {
     let gpu_out = gpu.reduce_prod(&gpu_input, &[2]).unwrap();
     let actual = download(&gpu, &gpu_out);
     assert_tensor_close(&actual, &expected, 0.0);
+}
+
+#[test]
+#[ignore]
+fn test_cubecl_i32_sum_and_prod_match_cpu() {
+    let input = tensor_i32(vec![2, 3, 2], vec![1, 2, 3, 4, 5, 6, -1, -2, 2, 3, -3, 4]);
+
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+
+    let expected = cpu.reduce_sum(&input, &[0]).unwrap();
+    let gpu_out = gpu.reduce_sum(&gpu_input, &[0]).unwrap();
+    let actual = download(&gpu, &gpu_out);
+    assert_tensor_close(&actual, &expected, 0.0);
+
+    let expected = cpu.reduce_prod(&input, &[2]).unwrap();
+    let gpu_out = gpu.reduce_prod(&gpu_input, &[2]).unwrap();
+    let actual = download(&gpu, &gpu_out);
+    assert_tensor_close(&actual, &expected, 0.0);
+}
+
+#[test]
+#[ignore]
+fn test_cubecl_bool_reductions_are_unsupported() {
+    let input = tensor_bool(vec![2, 3], vec![true, false, true, true, false, false]);
+
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+
+    let err = gpu.reduce_sum(&gpu_input, &[0]).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::BackendFailure {
+            op: "reduce_sum",
+            ..
+        }
+    ));
+
+    let err = gpu.reduce_prod(&gpu_input, &[1]).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::BackendFailure {
+            op: "reduce_prod",
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/tenferro-tensor/src/cubecl/tests/runtime_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/runtime_tests.rs
@@ -69,6 +69,36 @@ gpu_test!(test_upload_download_i64, {
     );
 });
 
+gpu_test!(test_upload_download_i32, {
+    let rt = CubeclRuntime::new(0).unwrap();
+    let host = Tensor::from_vec_col_major(vec![2, 3], vec![1_i32, -2, 3, -4, 5, -6]);
+    let gpu = upload_tensor(&rt, &host).unwrap();
+
+    assert_eq!(gpu.dtype(), crate::DType::I32);
+
+    let back = download_tensor(&rt, &gpu).unwrap();
+    assert_eq!(back.shape(), host.shape());
+    assert_eq!(
+        back.as_slice::<i32>().unwrap(),
+        host.as_slice::<i32>().unwrap()
+    );
+});
+
+gpu_test!(test_upload_download_bool, {
+    let rt = CubeclRuntime::new(0).unwrap();
+    let host = Tensor::from_vec_col_major(vec![2, 3], vec![true, false, true, true, false, false]);
+    let gpu = upload_tensor(&rt, &host).unwrap();
+
+    assert_eq!(gpu.dtype(), crate::DType::Bool);
+
+    let back = download_tensor(&rt, &gpu).unwrap();
+    assert_eq!(back.shape(), host.shape());
+    assert_eq!(
+        back.as_slice::<bool>().unwrap(),
+        host.as_slice::<bool>().unwrap()
+    );
+});
+
 gpu_test!(test_upload_download_c64, {
     use num_complex::Complex64;
 
@@ -165,6 +195,22 @@ gpu_test!(test_full_round_trip_all_dtypes, {
     assert_eq!(
         back.as_slice::<i64>().unwrap(),
         t.as_slice::<i64>().unwrap()
+    );
+
+    let t = Tensor::from_vec_col_major(vec![3], vec![1_i32, -2, 3]);
+    let gpu = upload_tensor(&rt, &t).unwrap();
+    let back = download_tensor(&rt, &gpu).unwrap();
+    assert_eq!(
+        back.as_slice::<i32>().unwrap(),
+        t.as_slice::<i32>().unwrap()
+    );
+
+    let t = Tensor::from_vec_col_major(vec![4], vec![true, false, false, true]);
+    let gpu = upload_tensor(&rt, &t).unwrap();
+    let back = download_tensor(&rt, &gpu).unwrap();
+    assert_eq!(
+        back.as_slice::<bool>().unwrap(),
+        t.as_slice::<bool>().unwrap()
     );
 
     let t = Tensor::from_vec_col_major(

--- a/tenferro-tensor/src/cubecl/tests/structural_tests.rs
+++ b/tenferro-tensor/src/cubecl/tests/structural_tests.rs
@@ -3,8 +3,8 @@ use crate::DType;
 use crate::TensorBackend;
 
 use super::{
-    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c64, tensor_f64, tensor_i64,
-    upload,
+    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_bool, tensor_c64, tensor_f64,
+    tensor_i32, tensor_i64, upload,
 };
 
 #[test]
@@ -120,6 +120,72 @@ fn test_cubecl_i64_structural_ops_match_cpu() {
 
     let expected = cpu.triu(&matrix, -1).unwrap();
     let gpu_out = gpu.triu(&gpu_matrix, -1).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+}
+
+#[test]
+#[ignore]
+fn test_cubecl_i32_structural_ops_match_cpu() {
+    let input = tensor_i32(vec![2, 3], vec![1, -2, 3, -4, 5, -6]);
+    let scalar = tensor_i32(vec![], vec![7]);
+    let vector = tensor_i32(vec![3], vec![10, -20, 30]);
+    let matrix = tensor_i32(vec![3, 3], vec![1, -2, 3, -4, 5, -6, 7, -8, 9]);
+
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+    let gpu_scalar = upload(&gpu, &scalar);
+    let gpu_vector = upload(&gpu, &vector);
+
+    let expected = cpu.transpose(&input, &[1, 0]).unwrap();
+    let gpu_out = gpu.transpose(&gpu_input, &[1, 0]).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.reshape(&input, &[3, 2]).unwrap();
+    let gpu_out = gpu.reshape(&gpu_input, &[3, 2]).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.broadcast_in_dim(&scalar, &[2, 3], &[]).unwrap();
+    let gpu_out = gpu.broadcast_in_dim(&gpu_scalar, &[2, 3], &[]).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.reverse(&input, &[1]).unwrap();
+    let gpu_out = gpu.reverse(&gpu_input, &[1]).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.concatenate(&[&input, &input], 1).unwrap();
+    let gpu_out = gpu.concatenate(&[&gpu_input, &gpu_input], 1).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let gpu_matrix = upload(&gpu, &matrix);
+    let expected = cpu.extract_diagonal(&matrix, 0, 1).unwrap();
+    let gpu_out = gpu.extract_diagonal(&gpu_matrix, 0, 1).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.embed_diagonal(&vector, 0, 1).unwrap();
+    let gpu_out = gpu.embed_diagonal(&gpu_vector, 0, 1).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.tril(&matrix, 0).unwrap();
+    let gpu_out = gpu.tril(&gpu_matrix, 0).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+
+    let expected = cpu.triu(&matrix, -1).unwrap();
+    let gpu_out = gpu.triu(&gpu_matrix, -1).unwrap();
+    assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
+}
+
+#[test]
+#[ignore]
+fn test_cubecl_bool_reshape_round_trips() {
+    let input = tensor_bool(vec![2, 3], vec![true, false, true, true, false, false]);
+
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+
+    let expected = cpu.reshape(&input, &[3, 2]).unwrap();
+    let gpu_out = gpu.reshape(&gpu_input, &[3, 2]).unwrap();
     assert_tensor_close(&download(&gpu, &gpu_out), &expected, 0.0);
 }
 

--- a/tenferro/src/eager.rs
+++ b/tenferro/src/eager.rs
@@ -10,10 +10,12 @@ use computegraph::{GlobalValKey, LocalValId, OpMode, ValRef};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
+use tenferro_runtime::extension_cache::ExtensionCacheLimits;
+use tenferro_runtime::extension_runtime::{ExtensionExecutor, ExtensionRuntimeRegistryError};
 use tenferro_tensor::cpu::CpuBackend;
 #[cfg(feature = "cuda")]
 use tenferro_tensor::cubecl::CubeclBackend;
-use tenferro_tensor::{Tensor, TensorBackend, TypedTensor};
+use tenferro_tensor::{CacheStats, Tensor, TensorBackend, TypedTensor};
 use tidu::{
     topo_sort_grad_dag, try_backward_dag, BackwardCallbacks, EagerOutput, EagerValue, GradNode,
     LinearFragment,
@@ -21,7 +23,7 @@ use tidu::{
 
 use crate::eager_backend::EagerBackend;
 use crate::eager_emitter::EagerEmitter;
-use crate::eager_exec::exec_op_on_tensors;
+use crate::eager_exec::{exec_op_on_tensors, exec_op_on_tensors_with_extension_executor};
 use crate::error::{ContextId, Error, Result};
 use crate::metadata::{
     metadata_scopes_for_scope, push_metadata_scope, register_scoped_live_fragment_metadata,
@@ -119,10 +121,19 @@ pub(crate) fn print_and_reset_eager_op_profile() {
     });
 }
 
+/// Stats for caches owned by an [`EagerRuntime`].
+///
+/// `retained_bytes` fields are logical payload estimates, not process RSS.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EagerRuntimeCacheStats {
+    /// Generic extension runtime caches.
+    pub extensions: CacheStats,
+}
+
 /// Shared eager execution context for tensors on a backend.
 ///
-/// Reusing one context lets eager tensors share backend state and gradient
-/// storage across a computation.
+/// Reusing one context lets eager tensors share backend state, extension
+/// runtime caches, and gradient storage across a computation.
 ///
 /// # Examples
 ///
@@ -138,6 +149,7 @@ pub(crate) fn print_and_reset_eager_op_profile() {
 /// ```
 pub struct EagerRuntime {
     pub(crate) backend: Mutex<EagerBackend>,
+    pub(crate) extension_executor: Mutex<ExtensionExecutor<EagerBackend>>,
     grad_slots: Mutex<HashMap<GlobalValKey<StdTensorOp>, WeakGradSlot>>,
 }
 
@@ -145,6 +157,7 @@ impl EagerRuntime {
     fn from_backend(backend: EagerBackend) -> Self {
         Self {
             backend: Mutex::new(backend),
+            extension_executor: Mutex::new(ExtensionExecutor::new()),
             grad_slots: Mutex::new(HashMap::new()),
         }
     }
@@ -205,6 +218,93 @@ impl EagerRuntime {
     /// ```
     pub fn id(&self) -> ContextId {
         ContextId::from_ptr(self)
+    }
+
+    /// Register one extension runtime on this eager context.
+    pub fn register_extension(
+        &self,
+        register: impl FnOnce(
+            &mut ExtensionExecutor<EagerBackend>,
+        ) -> std::result::Result<(), ExtensionRuntimeRegistryError>,
+    ) -> std::result::Result<(), ExtensionRuntimeRegistryError> {
+        register(&mut self.extension_executor.lock().unwrap())
+    }
+
+    /// Clear generic extension runtime cache entries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerRuntime};
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// ctx.clear_extension_caches();
+    /// assert_eq!(ctx.cache_stats().extensions.entries, 0);
+    /// ```
+    pub fn clear_extension_caches(&self) {
+        self.extension_executor.lock().unwrap().clear_caches();
+    }
+
+    /// Clear every cache owned by this eager context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerRuntime};
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// ctx.clear_caches();
+    /// assert_eq!(ctx.cache_stats().extensions.entries, 0);
+    /// ```
+    pub fn clear_caches(&self) {
+        self.clear_extension_caches();
+    }
+
+    /// Return eager runtime cache-entry and retained-byte stats.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::{CpuBackend, EagerRuntime};
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// let stats = ctx.cache_stats();
+    /// assert_eq!(stats.extensions.entries, 0);
+    /// ```
+    pub fn cache_stats(&self) -> EagerRuntimeCacheStats {
+        EagerRuntimeCacheStats {
+            extensions: self.extension_executor.lock().unwrap().cache_stats(),
+        }
+    }
+
+    /// Return the extension cache retention limits.
+    pub fn extension_cache_limits(&self) -> ExtensionCacheLimits {
+        self.extension_executor.lock().unwrap().cache_limits()
+    }
+
+    /// Replace extension cache retention limits.
+    pub fn set_extension_cache_limits(&self, limits: ExtensionCacheLimits) {
+        self.extension_executor
+            .lock()
+            .unwrap()
+            .set_cache_limits(limits);
+    }
+
+    pub(crate) fn exec_outputs(&self, op: &StdTensorOp, inputs: &[&Tensor]) -> Result<Vec<Tensor>> {
+        let mut backend =
+            profile_eager_op_section("exec_outputs.lock_backend", || self.backend.lock().unwrap());
+        let mut extension_executor =
+            profile_eager_op_section("exec_outputs.lock_extensions", || {
+                self.extension_executor.lock().unwrap()
+            });
+        profile_eager_op_section("exec_outputs.exec_op", || {
+            exec_op_on_tensors_with_extension_executor(
+                op,
+                inputs,
+                &mut *backend,
+                Some(&mut *extension_executor),
+            )
+        })
     }
 
     pub(crate) fn register_grad_slot(&self, key: &GlobalValKey<StdTensorOp>, slot: &GradSlot) {
@@ -632,6 +732,11 @@ impl EagerTensor {
         self.ctx.id()
     }
 
+    /// Borrow the eager runtime context that owns this tensor.
+    pub fn runtime(&self) -> &Arc<EagerRuntime> {
+        &self.ctx
+    }
+
     /// Check whether two tensors belong to the same eager context.
     ///
     /// # Examples
@@ -678,20 +783,24 @@ impl EagerTensor {
 
         let sorted = topo_sort_grad_dag(&self.grad_node);
         let mut backend = self.ctx.backend.lock().unwrap();
+        let mut extension_executor = self.ctx.extension_executor.lock().unwrap();
         let seed = Arc::new(one_like_tensor(self.data.as_ref(), &mut *backend));
         let mut callbacks = TenferroBackwardCallbacks {
             backend: &mut *backend,
+            extension_executor: Some(&mut *extension_executor),
             metadata_scopes: self.metadata_scopes.clone(),
         };
         let mut ad_ctx = ShapeGuardContext::with_global_metadata();
         let cotangents = try_backward_dag(&sorted, &self.key, seed, &mut callbacks, &mut ad_ctx)?;
+        drop(callbacks);
         self.ctx.store_grads(&cotangents, &mut *backend)?;
         Ok(cotangents)
     }
 }
 
-pub(crate) struct TenferroBackwardCallbacks<'a, B: TensorBackend> {
+pub(crate) struct TenferroBackwardCallbacks<'a, B: TensorBackend + 'static> {
     backend: &'a mut B,
+    extension_executor: Option<&'a mut ExtensionExecutor<B>>,
     metadata_scopes: Vec<Arc<MetadataScope>>,
 }
 
@@ -772,7 +881,9 @@ fn linear_op_depends_on_tangents(mode: &OpMode) -> bool {
     matches!(mode, OpMode::Linear { active_mask } if active_mask.iter().any(|is_active| *is_active))
 }
 
-impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallbacks<'_, B> {
+impl<B: TensorBackend + 'static> BackwardCallbacks<StdTensorOp>
+    for TenferroBackwardCallbacks<'_, B>
+{
     fn execute_forward(
         &mut self,
         fragment: &Fragment<StdTensorOp>,
@@ -817,7 +928,17 @@ impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallba
                 .collect();
             let resolved_inputs: Vec<&Tensor> =
                 resolved_values.iter().map(|value| value.as_ref()).collect();
-            let outputs = exec_op_on_tensors(&op_node.op, &resolved_inputs, self.backend)
+            let outputs =
+                if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
+                    exec_op_on_tensors_with_extension_executor(
+                        &op_node.op,
+                        &resolved_inputs,
+                        self.backend,
+                        Some(extension_executor),
+                    )
+                } else {
+                    exec_op_on_tensors(&op_node.op, &resolved_inputs, self.backend)
+                }
                 .unwrap_or_else(|err| {
                     panic!("eager forward exec failed for {:?}: {}", op_node.op, err)
                 });
@@ -842,7 +963,11 @@ impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallba
         external_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
         ctx: &mut ShapeGuardContext,
     ) -> Vec<Option<Arc<Tensor>>> {
-        let mut emitter = EagerEmitter::new(self.backend);
+        let mut emitter = if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
+            EagerEmitter::with_extension_executor(self.backend, extension_executor)
+        } else {
+            EagerEmitter::new(self.backend)
+        };
         emitter.external_data = external_data.clone();
         let cotangent_seed_ids = cotangent_out
             .iter()
@@ -867,7 +992,11 @@ impl<B: TensorBackend> BackwardCallbacks<StdTensorOp> for TenferroBackwardCallba
         external_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
         ctx: &mut ShapeGuardContext,
     ) -> chainrules_core::ADRuleResult<Vec<Option<Arc<Tensor>>>> {
-        let mut emitter = EagerEmitter::new(self.backend);
+        let mut emitter = if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
+            EagerEmitter::with_extension_executor(self.backend, extension_executor)
+        } else {
+            EagerEmitter::new(self.backend)
+        };
         emitter.external_data = external_data.clone();
         let cotangent_seed_ids = cotangent_out
             .iter()
@@ -957,12 +1086,7 @@ pub(crate) fn exec_single_output(
     inputs: &[&Tensor],
     ctx: &EagerRuntime,
 ) -> Result<Tensor> {
-    let mut backend = profile_eager_op_section("exec_single_output.lock_backend", || {
-        ctx.backend.lock().unwrap()
-    });
-    let mut outputs = profile_eager_op_section("exec_single_output.exec_op", || {
-        exec_op_on_tensors(op, inputs, &mut *backend)
-    })?;
+    let mut outputs = ctx.exec_outputs(op, inputs)?;
     if outputs.len() != 1 {
         return Err(Error::Internal(format!(
             "expected one eager output for {:?}, got {}",

--- a/tenferro/src/eager_backend.rs
+++ b/tenferro/src/eager_backend.rs
@@ -7,7 +7,7 @@ use tenferro_tensor::{
     TensorRead,
 };
 
-pub(crate) enum EagerBackend {
+pub enum EagerBackend {
     Cpu(CpuBackend),
     #[cfg(feature = "cuda")]
     Cuda(CubeclBackend),

--- a/tenferro/src/eager_emitter.rs
+++ b/tenferro/src/eager_emitter.rs
@@ -4,20 +4,35 @@ use std::sync::Arc;
 use computegraph::{GlobalValKey, LocalValId, OpEmitter, OpMode, ValRef};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_runtime::extension_runtime::ExtensionExecutor;
 use tenferro_tensor::{Tensor, TensorBackend, TypedTensor};
 
-use crate::eager_exec::exec_op_on_tensors;
+use crate::eager_exec::{exec_op_on_tensors, exec_op_on_tensors_with_extension_executor};
 
-pub struct EagerEmitter<'a, B: TensorBackend> {
+pub struct EagerEmitter<'a, B: TensorBackend + 'static> {
     pub backend: &'a mut B,
+    pub extension_executor: Option<&'a mut ExtensionExecutor<B>>,
     pub external_data: HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
     pub results: Vec<Arc<Tensor>>,
 }
 
-impl<'a, B: TensorBackend> EagerEmitter<'a, B> {
+impl<'a, B: TensorBackend + 'static> EagerEmitter<'a, B> {
     pub fn new(backend: &'a mut B) -> Self {
         Self {
             backend,
+            extension_executor: None,
+            external_data: HashMap::new(),
+            results: Vec::new(),
+        }
+    }
+
+    pub fn with_extension_executor(
+        backend: &'a mut B,
+        extension_executor: &'a mut ExtensionExecutor<B>,
+    ) -> Self {
+        Self {
+            backend,
+            extension_executor: Some(extension_executor),
             external_data: HashMap::new(),
             results: Vec::new(),
         }
@@ -50,7 +65,7 @@ impl<'a, B: TensorBackend> EagerEmitter<'a, B> {
     }
 }
 
-impl<B: TensorBackend> OpEmitter<StdTensorOp> for EagerEmitter<'_, B> {
+impl<B: TensorBackend + 'static> OpEmitter<StdTensorOp> for EagerEmitter<'_, B> {
     fn add_op(
         &mut self,
         op: StdTensorOp,
@@ -69,8 +84,17 @@ impl<B: TensorBackend> OpEmitter<StdTensorOp> for EagerEmitter<'_, B> {
             .map(|tensor| tensor.as_ref())
             .collect();
 
-        let outputs = exec_op_on_tensors(&op, &concrete, self.backend)
-            .unwrap_or_else(|err| panic!("eager exec failed for {:?}: {}", op, err));
+        let outputs = if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
+            exec_op_on_tensors_with_extension_executor(
+                &op,
+                &concrete,
+                self.backend,
+                Some(extension_executor),
+            )
+        } else {
+            exec_op_on_tensors(&op, &concrete, self.backend)
+        }
+        .unwrap_or_else(|err| panic!("eager exec failed for {:?}: {}", op, err));
 
         let base = self.results.len();
         for output in outputs {

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -10,6 +10,7 @@ use tenferro_tensor::{
 use crate::error::{Error, Result};
 use crate::scalar_semantics::dynamic_truncate_size;
 use crate::shape_infer::promote_dtype_for_binary_op;
+use tenferro_runtime::extension_runtime::ExtensionExecutor;
 
 enum PromotedTensor<'a> {
     Borrowed(&'a Tensor),
@@ -90,18 +91,48 @@ pub fn exec_op_on_tensors<B: TensorBackend>(
     backend: &mut B,
 ) -> Result<Vec<Tensor>> {
     if let StdTensorOp::Extension(ext) = op {
-        // Per spec Section 8 the eager path MUST NOT open a backend exec
-        // session for extension ops; the extension owns its execution
-        // model. Route errors through the standard tensor error channel
-        // so callers see consistent error types.
-        return ext.eager_execute(inputs).map_err(|err| {
-            Error::TensorRuntime(tenferro_tensor::Error::BackendFailure {
-                op: "extension",
-                message: format!("family_id={:?}: {err}", ext.family_id()),
-            })
-        });
+        return ext
+            .eager_execute(inputs)
+            .map_err(|err| extension_error(ext.as_ref(), err));
     }
 
+    exec_standard_op_on_tensors(op, inputs, backend)
+}
+
+pub(crate) fn exec_op_on_tensors_with_extension_executor<B: TensorBackend + 'static>(
+    op: &StdTensorOp,
+    inputs: &[&Tensor],
+    backend: &mut B,
+    extension_executor: Option<&mut ExtensionExecutor<B>>,
+) -> Result<Vec<Tensor>> {
+    if let StdTensorOp::Extension(ext) = op {
+        let outputs = match extension_executor {
+            Some(extension_executor) if extension_executor.registry().contains(ext.family_id()) => {
+                extension_executor.execute(backend, ext.as_ref(), inputs)
+            }
+            _ => ext.eager_execute(inputs),
+        };
+        return outputs.map_err(|err| extension_error(ext.as_ref(), err));
+    }
+
+    exec_standard_op_on_tensors(op, inputs, backend)
+}
+
+fn extension_error(
+    ext: &dyn tenferro_ops::ext_op::ExtensionOp,
+    err: tenferro_tensor::Error,
+) -> Error {
+    Error::TensorRuntime(tenferro_tensor::Error::BackendFailure {
+        op: "extension",
+        message: format!("family_id={:?}: {err}", ext.family_id()),
+    })
+}
+
+fn exec_standard_op_on_tensors<B: TensorBackend>(
+    op: &StdTensorOp,
+    inputs: &[&Tensor],
+    backend: &mut B,
+) -> Result<Vec<Tensor>> {
     backend.with_exec_session(|exec| {
         let result = match op {
             StdTensorOp::Add => {

--- a/tenferro/src/extension.rs
+++ b/tenferro/src/extension.rs
@@ -35,7 +35,6 @@ use crate::checkpoint::CheckpointNode;
 #[cfg(feature = "autodiff")]
 use crate::eager::{record_eager_outputs, EagerTensor};
 #[cfg(feature = "autodiff")]
-use crate::eager_exec::exec_op_on_tensors;
 #[cfg(feature = "autodiff")]
 use crate::error::{Error, Result};
 use crate::metadata::{push_metadata_scope, register_scoped_fragment_metadata};
@@ -229,10 +228,11 @@ pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Vec<TracedTe
 
 /// Apply an extension op to eager tensors.
 ///
-/// The forward pass delegates to [`ExtensionOp::eager_execute`] through the
-/// usual eager execution path, then records the same `StdTensorOp::Extension`
-/// node used by traced graphs. Eager backward therefore uses registered
-/// [`ExtensionAdRuleTrait`] rules through the same AD source of truth.
+/// The forward pass delegates through the owning [`EagerRuntime`]'s extension
+/// executor when a runtime is registered, then records the same
+/// `StdTensorOp::Extension` node used by traced graphs. Eager backward
+/// therefore uses registered [`ExtensionAdRuleTrait`] rules through the same AD
+/// source of truth and, for registered runtimes, the same runtime cache owner.
 #[cfg(feature = "autodiff")]
 pub fn apply_eager(op: Arc<dyn ExtensionOp>, inputs: &[&EagerTensor]) -> Result<Vec<EagerTensor>> {
     let Some(first) = inputs.first() else {
@@ -261,10 +261,7 @@ pub fn apply_eager(op: Arc<dyn ExtensionOp>, inputs: &[&EagerTensor]) -> Result<
 
     let op = StdTensorOp::Extension(op);
     let concrete_inputs: Vec<&Tensor> = inputs.iter().map(|tensor| tensor.data.as_ref()).collect();
-    let outputs = {
-        let mut backend = ctx.backend.lock().unwrap();
-        exec_op_on_tensors(&op, &concrete_inputs, &mut *backend)?
-    };
+    let outputs = ctx.exec_outputs(&op, &concrete_inputs)?;
     if outputs.len() != op.n_outputs() {
         return Err(Error::Internal(format!(
             "expected {} eager outputs for {:?}, got {}",

--- a/tenferro/src/lib.rs
+++ b/tenferro/src/lib.rs
@@ -54,7 +54,9 @@ pub mod traced_tensor;
 pub mod typed_tensor;
 
 #[cfg(feature = "autodiff")]
-pub use eager::{EagerRuntime, EagerTensor};
+pub use eager::{EagerRuntime, EagerRuntimeCacheStats, EagerTensor};
+#[cfg(feature = "autodiff")]
+pub use eager_backend::EagerBackend;
 pub use error::ContextId;
 pub use graph::{
     CpuGraphExecutorCacheStats, GraphCompiler, GraphCompilerCacheStats, GraphExecutor,

--- a/tenferro/tests/extension_op.rs
+++ b/tenferro/tests/extension_op.rs
@@ -26,11 +26,13 @@ use chainrules_core::ADRuleResult;
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
+use num_complex::{Complex32, Complex64};
 use tenferro::extension::{
     apply, apply_eager, register_extension_rule, ExtensionAdRuleTrait, ExtensionExecutionContext,
     ExtensionRuntime,
 };
 use tenferro::{CpuBackend, EagerRuntime, EagerTensor, GraphExecutor, Tensor, TracedTensor};
+use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, SymDim};
@@ -328,6 +330,210 @@ impl ExtensionOp for TestNoAd {
 }
 
 // ----------------------------------------------------------------------
+// TestProbeIdentity: identity op whose linearization carries a second
+// non-differentiated input so eager transpose materializes missing tangents.
+// ----------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+struct TestProbeIdentity {
+    probe_shape: Vec<usize>,
+}
+
+impl ExtensionOp for TestProbeIdentity {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.probe_identity.v1"
+    }
+
+    fn payload_hash(&self, hasher: &mut dyn Hasher) {
+        hash_shape(&self.probe_shape, hasher);
+    }
+
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other.as_any().downcast_ref::<TestProbeIdentity>() == Some(self)
+    }
+
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+        Arc::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn n_inputs(&self) -> usize {
+        2
+    }
+
+    fn n_outputs(&self) -> usize {
+        1
+    }
+
+    fn infer_output_meta(
+        &self,
+        input_dtypes: &[DType],
+        input_shapes: &[&[SymDim]],
+    ) -> Vec<(DType, Vec<SymDim>)> {
+        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    }
+
+    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Ok(vec![inputs[0].clone()])
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct TestProbeLinear {
+    probe_shape: Vec<usize>,
+}
+
+impl ExtensionOp for TestProbeLinear {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.probe_linear.v1"
+    }
+
+    fn payload_hash(&self, hasher: &mut dyn Hasher) {
+        hash_shape(&self.probe_shape, hasher);
+    }
+
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other.as_any().downcast_ref::<TestProbeLinear>() == Some(self)
+    }
+
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+        Arc::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn n_inputs(&self) -> usize {
+        2
+    }
+
+    fn n_outputs(&self) -> usize {
+        1
+    }
+
+    fn infer_output_meta(
+        &self,
+        input_dtypes: &[DType],
+        input_shapes: &[&[SymDim]],
+    ) -> Vec<(DType, Vec<SymDim>)> {
+        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    }
+
+    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Ok(vec![inputs[0].clone()])
+    }
+}
+
+fn ensure_probe_registered() {
+    register_rule_once(Arc::new(TestProbeIdentityRule));
+    register_rule_once(Arc::new(TestProbeLinearRule));
+}
+
+#[derive(Debug)]
+struct TestProbeIdentityRule;
+
+impl ExtensionAdRuleTrait for TestProbeIdentityRule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.probe_identity.v1"
+    }
+
+    fn linearize(
+        &self,
+        op: &dyn ExtensionOp,
+        builder: &mut FragmentBuilder<StdTensorOp>,
+        _primal_in: &[GlobalValKey<StdTensorOp>],
+        _primal_out: &[GlobalValKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValId>],
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        let op = op
+            .as_any()
+            .downcast_ref::<TestProbeIdentity>()
+            .expect("TestProbeIdentityRule received a different op");
+        let Some(dx) = tangent_in[0] else {
+            return Ok(vec![None]);
+        };
+        let Some(dprobe) = tangent_in[1] else {
+            return Ok(vec![Some(dx)]);
+        };
+
+        let out = builder.add_op(
+            StdTensorOp::Extension(Arc::new(TestProbeLinear {
+                probe_shape: op.probe_shape.clone(),
+            })),
+            vec![ValRef::Local(dx), ValRef::Local(dprobe)],
+            OpMode::Linear {
+                active_mask: vec![true, true],
+            },
+        );
+        Ok(vec![Some(out[0])])
+    }
+
+    fn transpose_rule(
+        &self,
+        _op: &dyn ExtensionOp,
+        _emitter: &mut dyn OpEmitter<StdTensorOp>,
+        cotangent_out: &[Option<LocalValId>],
+        _inputs: &[ValRef<StdTensorOp>],
+        _mode: &OpMode,
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        Ok(vec![cotangent_out[0], None])
+    }
+}
+
+#[derive(Debug)]
+struct TestProbeLinearRule;
+
+impl ExtensionAdRuleTrait for TestProbeLinearRule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.probe_linear.v1"
+    }
+
+    fn linearize(
+        &self,
+        _op: &dyn ExtensionOp,
+        _builder: &mut FragmentBuilder<StdTensorOp>,
+        _primal_in: &[GlobalValKey<StdTensorOp>],
+        _primal_out: &[GlobalValKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValId>],
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        Ok(vec![tangent_in[0]])
+    }
+
+    fn transpose_rule(
+        &self,
+        op: &dyn ExtensionOp,
+        emitter: &mut dyn OpEmitter<StdTensorOp>,
+        cotangent_out: &[Option<LocalValId>],
+        inputs: &[ValRef<StdTensorOp>],
+        _mode: &OpMode,
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        let Some(ct) = cotangent_out[0] else {
+            return Ok(vec![None, None]);
+        };
+        let op = op
+            .as_any()
+            .downcast_ref::<TestProbeLinear>()
+            .expect("TestProbeLinearRule received a different op");
+        let _probe_value = emitter.add_op(
+            StdTensorOp::Reshape {
+                to_shape: DimExpr::from_concrete(&op.probe_shape),
+            },
+            vec![inputs[1].clone()],
+            OpMode::Primal,
+        );
+        Ok(vec![Some(ct), None])
+    }
+}
+
+// ----------------------------------------------------------------------
 // TestBadOutputCount: malformed extension for facade validation paths.
 // ----------------------------------------------------------------------
 
@@ -380,6 +586,13 @@ impl ExtensionOp for TestBadOutputCount {
 // ----------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------
+
+fn hash_shape(shape: &[usize], hasher: &mut dyn Hasher) {
+    hasher.write_usize(shape.len());
+    for &dim in shape {
+        hasher.write_usize(dim);
+    }
+}
 
 fn f64_slice(tensor: &Tensor) -> &[f64] {
     match tensor {
@@ -484,6 +697,44 @@ fn scale_by_2_eager_backward_uses_registered_rule() {
         x.grad().unwrap().as_slice::<f64>().unwrap(),
         &[2.0, 2.0, 2.0, 2.0]
     );
+}
+
+fn assert_probe_identity_eager_backward(probe: Tensor) {
+    ensure_probe_registered();
+
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]),
+        ctx.clone(),
+    );
+    let probe_shape = probe.shape().to_vec();
+    let probe = EagerTensor::from_tensor_in(probe, ctx);
+    let y = apply_eager(Arc::new(TestProbeIdentity { probe_shape }), &[&x, &probe])
+        .expect("probe identity eager apply")
+        .into_iter()
+        .next()
+        .expect("single probe identity output");
+    let loss = y.reduce_sum(&[0]).expect("loss");
+
+    let _ = loss.backward().expect("eager backward");
+
+    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[1.0, 1.0]);
+}
+
+#[test]
+fn eager_backward_materializes_missing_tangent_zeros_for_all_probe_dtypes() {
+    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]));
+    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]));
+    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(vec![2], vec![1_i64, 2]));
+    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(vec![2], vec![true, false]));
+    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(
+        vec![2],
+        vec![Complex32::new(1.0, -1.0), Complex32::new(2.0, -2.0)],
+    ));
+    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(
+        vec![2],
+        vec![Complex64::new(1.0, -1.0), Complex64::new(2.0, -2.0)],
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Move eager extension execution onto `EagerRuntime`-owned `ExtensionExecutor<EagerBackend>` state, so registered runtimes such as `tenferro.einsum.v1` use context-owned cache storage instead of hidden direct eager caches.
- Remove the hidden thread-local eager einsum plan cache from `tenferro-einsum`; direct eager helpers now plan per call, while `EagerTensor` einsum registers and uses the runtime-owned extension cache.
- Fix GPU reduction `Auto` strategy so large reduce axes use plane/subgroup reduction instead of silently falling back to one worker, and enable the guard test.
- Add CUDA/CubeCL coverage for `I32` tensors on transfer, structural/indexing paths, and integer sum/product reductions.
- Add CUDA/CubeCL `Bool` transfer and metadata-only reshape support, with explicit unsupported errors for numeric reductions and other unsupported kernels.
- Update docs for extension cache ownership, GPU reduction strategy, and the CUDA dtype coverage matrix.

## Root Cause

The eager extension path was still able to call `ExtensionOp::eager_execute` without an owning runtime cache context. For einsum, this left a long-lived plan cache outside `EagerRuntime`, which conflicts with the repository cache ownership rule. GPU reduction `Auto` also treated large reduce axes like bounded unit work, hiding unbounded serial work in one worker.

After `I32` and `Bool` were added to the public tensor enum, the CubeCL backend still only matched the older dtype set in transfer, linalg, structural, and reduction dispatch. That made CUDA builds fail before ignored GPU tests could run.

## Validation

- `cargo fmt --all --check`
- `cargo check -p tenferro-tensor --features cuda`
- `cargo test -p tenferro-tensor --features cuda --tests`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/local/cuda-12.0/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-tensor --features cuda i32 -- --ignored`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/local/cuda-12.0/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-tensor --features cuda bool -- --ignored`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/local/cuda-12.0/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-tensor --features cuda full_round_trip_all_dtypes -- --ignored`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/local/cuda-12.0/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-tensor --features cuda reduction -- --ignored`
- `cargo test -p tenferro-gpubackend --tests`
- `cargo test -p tenferro-gpubackend --doc`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo test -p tenferro-einsum --release --no-default-features --features cpu-blas --test traced_graph_cache --no-run`
- `cargo test -p tenferro --release --test extension_op eager_backward_materializes_missing_tangent_zeros_for_all_probe_dtypes -- --nocapture`
- `cargo test -p tenferro-tensor --release gemm_analysis_cache_reuses_matching_direct_plan_and_reports_stats`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`