### PR TITLE
[codex] Use tensor4all CubeCL fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,9 @@ lapack = "0.20"
 lapack-src = "0.13"
 lapack-inject = "0.1.2"
 cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12000"] }
-cubecl = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96", features = ["cuda"] }
-cubecl-cuda = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96" }
-cubecl-runtime = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96" }
+cubecl = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692", features = ["cuda"] }
+cubecl-cuda = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
+cubecl-runtime = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
 tenferro-gpubackend = { path = "tenferro-gpubackend" }
 sha2 = "0.10"
 omeco = "0.2.4"

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -70,12 +70,12 @@ concerns rather than reusable static kernels.
 
 ## Dependency Source
 
-The workspace intentionally depends on the `shinaoka/cubecl` fork:
+The workspace intentionally depends on the `tensor4all/cubecl` fork:
 
 ```toml
-cubecl = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96", features = ["cuda"] }
-cubecl-cuda = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96" }
-cubecl-runtime = { git = "https://github.com/shinaoka/cubecl.git", rev = "929c8a96" }
+cubecl = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692", features = ["cuda"] }
+cubecl-cuda = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
+cubecl-runtime = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
 ```
 
 Keep this fork dependency until upstream CubeCL has the required support and the

--- a/tenferro-gpubackend/src/elementwise.rs
+++ b/tenferro-gpubackend/src/elementwise.rs
@@ -16,7 +16,7 @@ macro_rules! binary_kernel {
         }
 
         #[cube(launch_unchecked)]
-        pub fn $complex_name<C: Complex>(
+        pub fn $complex_name<C: ComplexCore>(
             out: &mut Array<C>,
             lhs: &Array<C>,
             rhs: &Array<C>,
@@ -50,7 +50,7 @@ macro_rules! unary_both_kernel {
         }
 
         #[cube(launch_unchecked)]
-        pub fn $complex_name<C: Complex>(out: &mut Array<C>, input: &Array<C>) {
+        pub fn $complex_name<C: ComplexCore>(out: &mut Array<C>, input: &Array<C>) {
             if ABSOLUTE_POS < out.len() {
                 let $value = input[ABSOLUTE_POS];
                 out[ABSOLUTE_POS] = $body;
@@ -187,7 +187,7 @@ pub fn clamp_float<F: Float>(
 }
 
 #[cube(launch_unchecked)]
-pub fn conj_complex<C: Complex>(out: &mut Array<C>, input: &Array<C>) {
+pub fn conj_complex<C: ComplexCore>(out: &mut Array<C>, input: &Array<C>) {
     if ABSOLUTE_POS < out.len() {
         out[ABSOLUTE_POS] = input[ABSOLUTE_POS].conj();
     }

--- a/tenferro-gpubackend/src/indexing.rs
+++ b/tenferro-gpubackend/src/indexing.rs
@@ -64,7 +64,9 @@ pub(crate) fn flat_to_index_batch_index<I: CubePrimitive>(
             indices_rank
         }
     };
-    let batch_buf_len = if batch_rank == 0 { 1 } else { batch_rank };
+    let batch_buf_len = comptime! {
+        if batch_rank == 0 { 1 } else { batch_rank }
+    };
     let mut batch_idx = Array::<usize>::new(batch_buf_len);
     let mut batch_axis = 0usize;
     #[unroll]
@@ -86,7 +88,9 @@ pub(crate) fn flat_to_update_window_index<E: CubePrimitive>(
     #[comptime] update_window_dims: Sequence<usize>,
 ) -> Array<usize> {
     let window_rank = update_window_dims.len();
-    let window_buf_len = if window_rank == 0 { 1 } else { window_rank };
+    let window_buf_len = comptime! {
+        if window_rank == 0 { 1 } else { window_rank }
+    };
     let mut window_idx = Array::<usize>::new(window_buf_len);
     #[unroll]
     for pos in 0..window_rank {
@@ -213,7 +217,9 @@ pub fn gather_kernel<E: CubePrimitive, I: Numeric + CubePrimitive>(
                 start_indices_rank
             }
         };
-        let batch_buf_len = if batch_rank == 0 { 1 } else { batch_rank };
+        let batch_buf_len = comptime! {
+            if batch_rank == 0 { 1 } else { batch_rank }
+        };
         let mut batch_idx = Array::<usize>::new(batch_buf_len);
         let mut window_offsets = Array::<usize>::new(operand_rank);
         #[unroll]
@@ -377,7 +383,7 @@ pub fn scatter_float_kernel<E: Float, I: Numeric + CubePrimitive>(
 }
 
 #[cube(launch_unchecked)]
-pub fn scatter_complex_kernel<E: Complex, F: Float, I: Numeric + CubePrimitive>(
+pub fn scatter_complex_kernel<E: ComplexCore, F: Float, I: Numeric + CubePrimitive>(
     out_parts: &mut Array<Atomic<F>>,
     operand: &Tensor<E>,
     scatter_indices: &Tensor<I>,

--- a/tenferro-gpubackend/src/reduce/kernels.rs
+++ b/tenferro-gpubackend/src/reduce/kernels.rs
@@ -48,10 +48,10 @@ macro_rules! reduce_binary_kernel {
 
 reduce_binary_kernel!(reduce_sum_float, Float, +);
 reduce_binary_kernel!(reduce_sum_int, Int, +);
-reduce_binary_kernel!(reduce_sum_complex, Complex, +);
+reduce_binary_kernel!(reduce_sum_complex, ComplexCore, +);
 reduce_binary_kernel!(reduce_prod_float, Float, *);
 reduce_binary_kernel!(reduce_prod_int, Int, *);
-reduce_binary_kernel!(reduce_prod_complex, Complex, *);
+reduce_binary_kernel!(reduce_prod_complex, ComplexCore, *);
 
 macro_rules! reduce_binary_plane_kernel {
     ($name:ident, $bound:ident, $op:tt, $plane_reduce:ident) => {
@@ -101,10 +101,10 @@ macro_rules! reduce_binary_plane_kernel {
 
 reduce_binary_plane_kernel!(reduce_sum_float_plane, Float, +, plane_sum);
 reduce_binary_plane_kernel!(reduce_sum_int_plane, Int, +, plane_sum);
-reduce_binary_plane_kernel!(reduce_sum_complex_plane, Complex, +, plane_sum);
+reduce_binary_plane_kernel!(reduce_sum_complex_plane, ComplexCore, +, plane_sum);
 reduce_binary_plane_kernel!(reduce_prod_float_plane, Float, *, plane_prod);
 reduce_binary_plane_kernel!(reduce_prod_int_plane, Int, *, plane_prod);
-reduce_binary_plane_kernel!(reduce_prod_complex_plane, Complex, *, plane_prod);
+reduce_binary_plane_kernel!(reduce_prod_complex_plane, ComplexCore, *, plane_prod);
 
 #[cube(launch_unchecked)]
 pub(crate) fn reduce_max_float<F: Float>(

--- a/tenferro-gpubackend/src/reduce/launch.rs
+++ b/tenferro-gpubackend/src/reduce/launch.rs
@@ -337,7 +337,7 @@ pub fn launch_sum_int<R: Runtime, I: Int + CubeElement>(
 /// launch_sum_complex::<R, Complex64>(client, input, output, 0, ReduceStrategy::Auto)
 /// # }
 /// ```
-pub fn launch_sum_complex<R: Runtime, C: Complex + CubeElement>(
+pub fn launch_sum_complex<R: Runtime, C: ComplexCore + CubeElement>(
     client: &ComputeClient<R>,
     input: TensorBinding<R>,
     output: TensorBinding<R>,
@@ -512,7 +512,7 @@ pub fn launch_prod_int<R: Runtime, I: Int + CubeElement>(
 /// launch_prod_complex::<R, Complex32>(client, input, output, 0, ReduceStrategy::Auto)
 /// # }
 /// ```
-pub fn launch_prod_complex<R: Runtime, C: Complex + CubeElement>(
+pub fn launch_prod_complex<R: Runtime, C: ComplexCore + CubeElement>(
     client: &ComputeClient<R>,
     input: TensorBinding<R>,
     output: TensorBinding<R>,

--- a/tenferro-gpubackend/src/structural.rs
+++ b/tenferro-gpubackend/src/structural.rs
@@ -129,7 +129,7 @@ pub fn convert_f64_to_c64_raw(out: &mut Array<f64>, input: &Array<f64>) {
 }
 
 #[cube(launch_unchecked)]
-pub fn convert_complex_to_complex<Out: Complex, In: Complex>(
+pub fn convert_complex_to_complex<Out: ComplexCore, In: ComplexCore>(
     out: &mut Array<Out>,
     input: &Array<In>,
 ) {

--- a/tenferro-tensor/src/cubecl/mod.rs
+++ b/tenferro-tensor/src/cubecl/mod.rs
@@ -79,7 +79,7 @@ use std::cell::OnceCell;
 use cubecl::client::ComputeClient;
 use cubecl::features::AtomicUsage;
 use cubecl::prelude::{
-    ArrayArg, Complex as CubeComplex, CubeElement, CubePrimitive, Float as CubeFloat,
+    ArrayArg, ComplexCore as CubeComplex, CubeElement, CubePrimitive, Float as CubeFloat,
     Numeric as CubeNumeric,
 };
 use cubecl::prelude::{Int as CubeInt, StorageType, TensorBinding, Type};


### PR DESCRIPTION
## Summary

- Switch CubeCL workspace dependencies from `shinaoka/cubecl` to `tensor4all/cubecl` at `f5e5ec178f9aebca9362b829ffef708f720ff692`.
- Update tenferro GPU kernel bounds for CubeCL 0.10 `ComplexCore` naming and compile-time local array lengths.
- Refresh the GPU backend design note so the documented fork source matches the workspace dependency.

## Verification

- `cargo fmt --all --check`
- `cargo check -p tenferro-tensor --features cuda`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `scripts/build_docs_site.sh`
- `python3 scripts/check-docs-site.py`
