### PR TITLE
[codex] Make compare return bool tensors

### DIFF
--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -109,7 +109,7 @@ Legend:
 | `neg` | `F32`, `F64`, `C32`, `C64` | Integer and `Bool` negation are not implemented |
 | `conj` | `F32`, `F64`, `C32`, `C64` | Real floating dtypes are identity; integer and `Bool` inputs are not implemented |
 | `abs`, `sign` | `F32`, `F64` | Complex, integer, and `Bool` inputs are not implemented |
-| `maximum`, `minimum`, `compare`, `select`, `clamp` | `F32`, `F64` | Complex ordering is not defined; `compare` returns a numeric 0/1 tensor |
+| `maximum`, `minimum`, `compare`, `select`, `clamp` | `F32`, `F64` | Complex ordering is not defined; `compare` returns a `Bool` tensor and `select` takes a `Bool` predicate |
 | `exp`, `log`, `sin`, `cos`, `tanh`, `sqrt`, `rsqrt`, `expm1`, `log1p` | `F32`, `F64` | Complex analytic kernels are not implemented |
 | `pow` | `F32`, `F64` | Same dtype inputs only |
 | `reshape` | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Metadata-only shape change |

--- a/docs/spec/extension-op.md
+++ b/docs/spec/extension-op.md
@@ -1018,7 +1018,7 @@ both within the spec's flexibility:
   argmax indices. The core op vocabulary intentionally does not
   include an `ArgMax` variant, so the implementation uses the mathematically
   equivalent **indicator-mask**
-  construction (the same `Compare(Eq) + Mul + ReduceSum + Div` pattern
+  construction (the same `Compare(Eq) + Convert + Mul + ReduceSum + Div` pattern
   used by the core `ReduceMax` / `ReduceMin` AD rule in
   `tenferro-internal-ops/src/ad/contraction.rs`). The two are two expressions
   of the same subgradient; only the indicator form is expressible in

--- a/docs/spec/primitive-catalog.md
+++ b/docs/spec/primitive-catalog.md
@@ -342,8 +342,8 @@ See `../reference/stablehlo-primitives.md` for the StableHLO-facing reference an
 | `Sign` | `y[i] = sign(x[i])` | Often used in stabilization logic |
 | `Maximum` | `y[i] = max(x0[i], x1[i])` | Ordered real comparison |
 | `Minimum` | `y[i] = min(x0[i], x1[i])` | Ordered real comparison |
-| `Compare(dir)` | Produce a predicate/mask tensor from an elementwise comparison | `dir` is things like `eq`, `lt`, `le`, `gt`, `ge` |
-| `Select` | `y[i] = pred[i] ? on_true[i] : on_false[i]` | Canonical conditional elementwise choice |
+| `Compare(dir)` | Produce a `Bool` tensor from an elementwise comparison | `dir` is things like `eq`, `lt`, `le`, `gt`, `ge` |
+| `Select` | `y[i] = pred[i] ? on_true[i] : on_false[i]` | `pred` is `Bool`; value inputs determine the output dtype |
 | `Clamp` | `y[i] = min(max(x[i], lower[i]), upper[i])` | Canonical clipping primitive |
 
 ### Analytic elementwise primitives

--- a/tenferro-internal-gpubackend/src/elementwise.rs
+++ b/tenferro-internal-gpubackend/src/elementwise.rs
@@ -137,8 +137,8 @@ pub fn pow_float<F: Float>(out: &mut Array<F>, lhs: &Array<F>, rhs: &Array<F>) {
 }
 
 #[cube(launch_unchecked)]
-pub fn compare_float<F: Float>(
-    out: &mut Array<F>,
+pub fn compare_float_bool<F: Float>(
+    out: &mut Array<bool>,
     lhs: &Array<F>,
     rhs: &Array<F>,
     #[comptime] mode: usize,
@@ -154,19 +154,19 @@ pub fn compare_float<F: Float>(
             COMPARE_GE => x >= y,
             _ => false,
         };
-        out[ABSOLUTE_POS] = if pred { F::new(1.0) } else { F::new(0.0) };
+        out[ABSOLUTE_POS] = pred;
     }
 }
 
 #[cube(launch_unchecked)]
-pub fn select_float<F: Float>(
+pub fn select_bool_float<F: Float>(
     out: &mut Array<F>,
-    pred: &Array<F>,
+    pred: &Array<bool>,
     on_true: &Array<F>,
     on_false: &Array<F>,
 ) {
     if ABSOLUTE_POS < out.len() {
-        out[ABSOLUTE_POS] = if pred[ABSOLUTE_POS] != F::new(0.0) {
+        out[ABSOLUTE_POS] = if pred[ABSOLUTE_POS] {
             on_true[ABSOLUTE_POS]
         } else {
             on_false[ABSOLUTE_POS]

--- a/tenferro-internal-ops/src/ad/contraction.rs
+++ b/tenferro-internal-ops/src/ad/contraction.rs
@@ -1,7 +1,7 @@
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
-use tenferro_tensor::{CompareDir, DotGeneralConfig};
+use tenferro_tensor::{CompareDir, DType, DotGeneralConfig};
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::support::{conjugate_primal_if_complex, conjugate_primal_if_dtype_complex};
@@ -169,9 +169,11 @@ pub fn linearize_reduce_chooser(
         ValRef::External(primal_in[0].clone()),
         ValRef::Local(answer_broadcast),
     );
+    let input_dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
+    let numeric_indicators = numeric_indicators(builder, indicators, input_dtype);
     let weighted_tangent = builder.add_op(
         StdTensorOp::Mul,
-        vec![ValRef::Local(indicators), ValRef::Local(dx)],
+        vec![ValRef::Local(numeric_indicators), ValRef::Local(dx)],
         OpMode::Linear {
             active_mask: vec![false, true],
         },
@@ -185,7 +187,7 @@ pub fn linearize_reduce_chooser(
             active_mask: vec![true],
         },
     )[0];
-    let counts = reduction_location_counts(builder, indicators, axes);
+    let counts = reduction_location_counts(builder, numeric_indicators, axes);
     let out = builder.add_op(
         StdTensorOp::Div,
         vec![ValRef::Local(tangent_sum), ValRef::Local(counts)],
@@ -427,7 +429,9 @@ pub fn transpose_reduce_chooser(
                 inputs[0].clone(),
                 ValRef::Local(answer_broadcast),
             );
-            let counts = reduction_location_counts(emitter, indicators, axes);
+            let input_dtype = ctx.dtype_of(&inputs[0]);
+            let numeric_indicators = numeric_indicators(emitter, indicators, input_dtype);
+            let counts = reduction_location_counts(emitter, numeric_indicators, axes);
             let counts_broadcast = broadcast_reduction_output(
                 emitter,
                 ValRef::Local(counts),
@@ -437,10 +441,12 @@ pub fn transpose_reduce_chooser(
             );
             let weights = emitter.add_op(
                 StdTensorOp::Div,
-                vec![ValRef::Local(indicators), ValRef::Local(counts_broadcast)],
+                vec![
+                    ValRef::Local(numeric_indicators),
+                    ValRef::Local(counts_broadcast),
+                ],
                 OpMode::Primal,
             )[0];
-            let input_dtype = ctx.dtype_of(&inputs[0]);
             let weights_conj =
                 conjugate_primal_if_dtype_complex(emitter, ValRef::Local(weights), input_dtype);
             let out = emitter.add_op(
@@ -558,6 +564,21 @@ fn reduction_location_counts(
     emitter.add_op(
         StdTensorOp::ReduceSum {
             axes: axes.to_vec(),
+        },
+        vec![ValRef::Local(indicators)],
+        OpMode::Primal,
+    )[0]
+}
+
+fn numeric_indicators(
+    emitter: &mut impl OpEmitter<StdTensorOp>,
+    indicators: LocalValId,
+    dtype: DType,
+) -> LocalValId {
+    emitter.add_op(
+        StdTensorOp::Convert {
+            from: DType::Bool,
+            to: dtype,
         },
         vec![ValRef::Local(indicators)],
         OpMode::Primal,

--- a/tenferro-internal-tensor/src/backend.rs
+++ b/tenferro-internal-tensor/src/backend.rs
@@ -33,8 +33,6 @@ pub enum ElementwiseFusionOp {
     Abs,
     Maximum,
     Minimum,
-    Compare(CompareDir),
-    Select,
     Clamp,
     Exp,
     Log,

--- a/tenferro-internal-tensor/src/cpu/elementwise.rs
+++ b/tenferro-internal-tensor/src/cpu/elementwise.rs
@@ -32,8 +32,10 @@ pub(crate) trait Tier2Elem: Copy + Clone + One + Zero {
     fn sign_elem(self) -> Self;
     fn max_elem(self, other: Self) -> Self;
     fn min_elem(self, other: Self) -> Self;
-    fn compare_elem(self, other: Self, dir: &CompareDir) -> Self;
-    fn is_nonzero(self) -> bool;
+}
+
+pub(crate) trait CompareElem: Copy {
+    fn compare_elem(self, other: Self, dir: &CompareDir) -> bool;
 }
 
 macro_rules! impl_tier2_elem_real {
@@ -66,24 +68,17 @@ macro_rules! impl_tier2_elem_real {
                     other
                 }
             }
+        }
 
-            fn compare_elem(self, other: Self, dir: &CompareDir) -> Self {
-                let pred = match dir {
+        impl CompareElem for $ty {
+            fn compare_elem(self, other: Self, dir: &CompareDir) -> bool {
+                match dir {
                     CompareDir::Eq => self == other,
                     CompareDir::Lt => self < other,
                     CompareDir::Le => self <= other,
                     CompareDir::Gt => self > other,
                     CompareDir::Ge => self >= other,
-                };
-                if pred {
-                    Self::one()
-                } else {
-                    Self::zero()
                 }
-            }
-
-            fn is_nonzero(self) -> bool {
-                self != Self::zero()
             }
         }
     };
@@ -119,24 +114,17 @@ macro_rules! impl_tier2_elem_complex {
                     other
                 }
             }
+        }
 
-            fn compare_elem(self, other: Self, dir: &CompareDir) -> Self {
-                let pred = match dir {
+        impl CompareElem for Complex<$real> {
+            fn compare_elem(self, other: Self, dir: &CompareDir) -> bool {
+                match dir {
                     CompareDir::Eq => self == other,
                     CompareDir::Lt => self.norm_sqr() < other.norm_sqr(),
                     CompareDir::Le => self.norm_sqr() <= other.norm_sqr(),
                     CompareDir::Gt => self.norm_sqr() > other.norm_sqr(),
                     CompareDir::Ge => self.norm_sqr() >= other.norm_sqr(),
-                };
-                if pred {
-                    Self::one()
-                } else {
-                    Self::zero()
                 }
-            }
-
-            fn is_nonzero(self) -> bool {
-                !self.is_zero()
             }
         }
     };
@@ -146,6 +134,26 @@ impl_tier2_elem_real!(f32);
 impl_tier2_elem_real!(f64);
 impl_tier2_elem_complex!(f32);
 impl_tier2_elem_complex!(f64);
+
+macro_rules! impl_compare_elem_ord {
+    ($ty:ty) => {
+        impl CompareElem for $ty {
+            fn compare_elem(self, other: Self, dir: &CompareDir) -> bool {
+                match dir {
+                    CompareDir::Eq => self == other,
+                    CompareDir::Lt => self < other,
+                    CompareDir::Le => self <= other,
+                    CompareDir::Gt => self > other,
+                    CompareDir::Ge => self >= other,
+                }
+            }
+        }
+    };
+}
+
+impl_compare_elem_ord!(i32);
+impl_compare_elem_ord!(i64);
+impl_compare_elem_ord!(bool);
 
 fn complex_scalar_tensor<T>(scalar: T) -> TypedTensor<Complex<T>>
 where
@@ -424,16 +432,25 @@ pub(crate) fn compare_with_pool(
 ) -> crate::Result<Tensor> {
     match (lhs, rhs) {
         (Tensor::F32(a), Tensor::F32(b)) => {
-            Ok(Tensor::F32(typed_compare_with_pool(buffers, a, b, dir)?))
+            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
         }
         (Tensor::F64(a), Tensor::F64(b)) => {
-            Ok(Tensor::F64(typed_compare_with_pool(buffers, a, b, dir)?))
+            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
+        }
+        (Tensor::I32(a), Tensor::I32(b)) => {
+            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
+        }
+        (Tensor::I64(a), Tensor::I64(b)) => {
+            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
+        }
+        (Tensor::Bool(a), Tensor::Bool(b)) => {
+            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
         }
         (Tensor::C32(a), Tensor::C32(b)) => {
-            Ok(Tensor::C32(typed_compare_with_pool(buffers, a, b, dir)?))
+            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
         }
         (Tensor::C64(a), Tensor::C64(b)) => {
-            Ok(Tensor::C64(typed_compare_with_pool(buffers, a, b, dir)?))
+            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
         }
         _ => Err(crate::Error::DTypeMismatch {
             op: "compare",
@@ -453,9 +470,39 @@ pub(crate) fn select_with_pool(
     on_true: &Tensor,
     on_false: &Tensor,
 ) -> crate::Result<Tensor> {
-    dispatch_ternary_result_with_pool!("select", pred, on_true, on_false, |p, t, f| {
-        typed_select_with_pool(buffers, p, t, f)
-    })
+    match (pred, on_true, on_false) {
+        (Tensor::Bool(p), Tensor::F32(t), Tensor::F32(f)) => {
+            Ok(Tensor::F32(typed_select_with_pool(buffers, p, t, f)?))
+        }
+        (Tensor::Bool(p), Tensor::F64(t), Tensor::F64(f)) => {
+            Ok(Tensor::F64(typed_select_with_pool(buffers, p, t, f)?))
+        }
+        (Tensor::Bool(p), Tensor::I32(t), Tensor::I32(f)) => {
+            Ok(Tensor::I32(typed_select_with_pool(buffers, p, t, f)?))
+        }
+        (Tensor::Bool(p), Tensor::I64(t), Tensor::I64(f)) => {
+            Ok(Tensor::I64(typed_select_with_pool(buffers, p, t, f)?))
+        }
+        (Tensor::Bool(p), Tensor::Bool(t), Tensor::Bool(f)) => {
+            Ok(Tensor::Bool(typed_select_with_pool(buffers, p, t, f)?))
+        }
+        (Tensor::Bool(p), Tensor::C32(t), Tensor::C32(f)) => {
+            Ok(Tensor::C32(typed_select_with_pool(buffers, p, t, f)?))
+        }
+        (Tensor::Bool(p), Tensor::C64(t), Tensor::C64(f)) => {
+            Ok(Tensor::C64(typed_select_with_pool(buffers, p, t, f)?))
+        }
+        (Tensor::Bool(_), _, _) => Err(crate::Error::DTypeMismatch {
+            op: "select",
+            lhs: on_true.dtype(),
+            rhs: on_false.dtype(),
+        }),
+        _ => Err(crate::Error::DTypeMismatch {
+            op: "select",
+            lhs: pred.dtype(),
+            rhs: crate::DType::Bool,
+        }),
+    }
 }
 
 pub fn clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor> {
@@ -798,9 +845,9 @@ pub(crate) fn typed_compare<T>(
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     dir: &CompareDir,
-) -> crate::Result<TypedTensor<T>>
+) -> crate::Result<TypedTensor<bool>>
 where
-    T: Tier2Elem + PoolScalar,
+    T: CompareElem,
 {
     with_local_pool(|buffers| typed_compare_with_pool(buffers, lhs, rhs, dir))
 }
@@ -810,9 +857,9 @@ pub(crate) fn typed_compare_with_pool<T>(
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     dir: &CompareDir,
-) -> crate::Result<TypedTensor<T>>
+) -> crate::Result<TypedTensor<bool>>
 where
-    T: Tier2Elem + PoolScalar,
+    T: CompareElem,
 {
     if lhs.shape != rhs.shape {
         return Err(crate::Error::ShapeMismatch {
@@ -835,12 +882,12 @@ where
 
 pub(crate) fn typed_select_with_pool<T>(
     buffers: &mut BufferPool,
-    pred: &TypedTensor<T>,
+    pred: &TypedTensor<bool>,
     on_true: &TypedTensor<T>,
     on_false: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Tier2Elem + PoolScalar,
+    T: Copy + PoolScalar,
 {
     if pred.shape != on_true.shape {
         return Err(crate::Error::ShapeMismatch {
@@ -863,7 +910,7 @@ where
         &typed_view(pred),
         &typed_view(on_true),
         &typed_view(on_false),
-        |p, t, f| if p.is_nonzero() { t } else { f },
+        |p, t, f| if p { t } else { f },
     )
     .map_err(|err| backend_failure("select", err))?;
     Ok(tensor_from_array(out))

--- a/tenferro-internal-tensor/src/cubecl/dispatch.rs
+++ b/tenferro-internal-tensor/src/cubecl/dispatch.rs
@@ -196,6 +196,16 @@ pub(crate) fn alloc_output<T: CubeElement + Clone>(
     )
 }
 
+pub(crate) fn alloc_bool_output(rt: &CubeclRuntime, shape: &[usize]) -> TypedTensor<bool> {
+    let len: usize = shape.iter().product();
+    let handle = rt.client().empty(len);
+    typed_from_cubecl(
+        shape.to_vec(),
+        CubeclBuffer::new(handle, len),
+        rt.device_ordinal(),
+    )
+}
+
 pub(crate) fn typed_tensor_array_arg<T: CubeElement + Clone>(
     tensor: &TypedTensor<T>,
     op: &'static str,
@@ -207,6 +217,19 @@ pub(crate) fn typed_tensor_array_arg<T: CubeElement + Clone>(
     // `validate_cubecl_buffer_len` proves `buffer.len` equals the dense shape
     // product, so raw linear kernels that index `0..out.len()` cannot observe
     // an array longer than the logical tensor allocation.
+    Ok(unsafe { ArrayArg::from_raw_parts(buffer.handle.clone(), buffer.len) })
+}
+
+pub(crate) fn bool_tensor_array_arg(
+    tensor: &TypedTensor<bool>,
+    op: &'static str,
+) -> crate::Result<ArrayArg<CudaRuntime>> {
+    let buffer = cubecl_buffer(tensor, op)?;
+    validate_cubecl_buffer_len(tensor, buffer, op)?;
+
+    // SAFETY: CubeCL bool tensors are stored as one-byte predicate buffers by
+    // `memory::upload_bool` and `alloc_bool_output`. The validated buffer
+    // length is the logical element count consumed by raw Array<bool> kernels.
     Ok(unsafe { ArrayArg::from_raw_parts(buffer.handle.clone(), buffer.len) })
 }
 
@@ -438,6 +461,48 @@ where
     Ok(output)
 }
 
+pub(crate) fn launch_compare_bool<T>(
+    rt: &CubeclRuntime,
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+    out_shape: &[usize],
+    op: &'static str,
+    launch: impl FnOnce(
+        &ComputeClient<CudaRuntime>,
+        CubeCount,
+        CubeDim,
+        ArrayArg<CudaRuntime>,
+        ArrayArg<CudaRuntime>,
+        ArrayArg<CudaRuntime>,
+    ),
+) -> crate::Result<TypedTensor<bool>>
+where
+    T: CubeElement + Clone,
+{
+    validate_raw_binary_shapes(lhs, rhs, out_shape, op)?;
+    let output = alloc_bool_output(rt, out_shape);
+    let len = output.n_elements();
+    if len == 0 {
+        return Ok(output);
+    }
+    let client = rt.client();
+    let output_arg = bool_tensor_array_arg(&output, op)?;
+    let lhs_arg = typed_tensor_array_arg(lhs, op)?;
+    let rhs_arg = typed_tensor_array_arg(rhs, op)?;
+    // SAFETY: Shape validation proves all raw arrays share the dense element
+    // count. Bool output storage uses one byte per element and the kernel
+    // guards with `ABSOLUTE_POS < out.len()`.
+    launch(
+        client,
+        cube_count_for_len(len),
+        cube_dim_1d(),
+        output_arg,
+        lhs_arg,
+        rhs_arg,
+    );
+    Ok(output)
+}
+
 pub(crate) fn launch_binary_tensor<TLhs, TRhs, TOut>(
     rt: &CubeclRuntime,
     lhs: &TypedTensor<TLhs>,
@@ -479,6 +544,52 @@ where
         output_arg,
         lhs_arg,
         rhs_arg,
+    );
+    Ok(output)
+}
+
+pub(crate) fn launch_select_bool<T>(
+    rt: &CubeclRuntime,
+    pred: &TypedTensor<bool>,
+    on_true: &TypedTensor<T>,
+    on_false: &TypedTensor<T>,
+    out_shape: &[usize],
+    op: &'static str,
+    launch: impl FnOnce(
+        &ComputeClient<CudaRuntime>,
+        CubeCount,
+        CubeDim,
+        ArrayArg<CudaRuntime>,
+        ArrayArg<CudaRuntime>,
+        ArrayArg<CudaRuntime>,
+        ArrayArg<CudaRuntime>,
+    ),
+) -> crate::Result<TypedTensor<T>>
+where
+    T: CubeElement + Clone,
+{
+    validate_raw_ternary_shapes(pred, on_true, on_false, out_shape, op)?;
+    let output = alloc_output::<T>(rt, out_shape);
+    let len = output.n_elements();
+    if len == 0 {
+        return Ok(output);
+    }
+    let client = rt.client();
+    let output_arg = typed_tensor_array_arg(&output, op)?;
+    let pred_arg = bool_tensor_array_arg(pred, op)?;
+    let true_arg = typed_tensor_array_arg(on_true, op)?;
+    let false_arg = typed_tensor_array_arg(on_false, op)?;
+    // SAFETY: Shape validation proves all raw arrays share the dense element
+    // count. The predicate buffer is a validated one-byte Bool tensor buffer,
+    // matching the Array<bool> kernel view.
+    launch(
+        client,
+        cube_count_for_len(len),
+        cube_dim_1d(),
+        output_arg,
+        pred_arg,
+        true_arg,
+        false_arg,
     );
     Ok(output)
 }

--- a/tenferro-internal-tensor/src/cubecl/fusion/classify.rs
+++ b/tenferro-internal-tensor/src/cubecl/fusion/classify.rs
@@ -91,8 +91,6 @@ impl FusionElement for f32 {
                 | ElementwiseFusionOp::Abs
                 | ElementwiseFusionOp::Maximum
                 | ElementwiseFusionOp::Minimum
-                | ElementwiseFusionOp::Compare(_)
-                | ElementwiseFusionOp::Select
                 | ElementwiseFusionOp::Clamp
                 | ElementwiseFusionOp::Exp
                 | ElementwiseFusionOp::Log

--- a/tenferro-internal-tensor/src/cubecl/fusion/codegen.rs
+++ b/tenferro-internal-tensor/src/cubecl/fusion/codegen.rs
@@ -1,7 +1,7 @@
 use cubecl::ir::{
-    Arithmetic, BinaryOperator, Branch, Builtin, ClampOperator, Comparison, ConstantValue,
-    ElemType, If, IndexAssignOperator, IndexOperator, Instruction, ManagedVariable, Metadata,
-    Operator, Select, Type, UnaryOperator, Variable,
+    Arithmetic, BinaryOperator, Branch, Builtin, ClampOperator, Comparison, ElemType, If,
+    IndexAssignOperator, IndexOperator, Instruction, ManagedVariable, Metadata, Operator, Type,
+    UnaryOperator, Variable,
 };
 use cubecl::prelude::{
     AddressType, CubeDim, CubeElement, CubePrimitive, KernelBuilder, KernelDefinition,
@@ -130,16 +130,6 @@ where
         ElementwiseFusionOp::Minimum => {
             emit_binary_arithmetic(scope, &inputs[0], &inputs[1], Arithmetic::Min)
         }
-        ElementwiseFusionOp::Compare(dir) => {
-            let pred =
-                emit_bool_binary(scope, inputs[0].clone(), inputs[1].clone(), compare_op(dir));
-            emit_numeric_select::<T>(scope, pred, true)
-        }
-        ElementwiseFusionOp::Select => {
-            let zero = numeric_constant::<T>(scope, 0.0);
-            let pred = emit_bool_binary(scope, inputs[0].clone(), zero, Comparison::NotEqual);
-            emit_select(scope, pred, inputs[1].clone(), inputs[2].clone())
-        }
         ElementwiseFusionOp::Clamp => emit_clamp(scope, &inputs[0], &inputs[1], &inputs[2]),
         ElementwiseFusionOp::Exp => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Exp),
         ElementwiseFusionOp::Log => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Log),
@@ -156,39 +146,6 @@ where
         ElementwiseFusionOp::Expm1 => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Expm1),
         ElementwiseFusionOp::Log1p => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Log1p),
     }
-}
-
-fn compare_op(dir: &crate::CompareDir) -> fn(BinaryOperator) -> Comparison {
-    match dir {
-        crate::CompareDir::Eq => Comparison::Equal,
-        crate::CompareDir::Lt => Comparison::Lower,
-        crate::CompareDir::Le => Comparison::LowerEqual,
-        crate::CompareDir::Gt => Comparison::Greater,
-        crate::CompareDir::Ge => Comparison::GreaterEqual,
-    }
-}
-
-fn emit_numeric_select<T>(
-    scope: &mut cubecl::prelude::Scope,
-    pred: ManagedVariable,
-    if_true: bool,
-) -> ManagedVariable
-where
-    T: CubeElement + CubePrimitive + Clone,
-{
-    let on_true = numeric_constant::<T>(scope, if if_true { 1.0 } else { 0.0 });
-    let on_false = numeric_constant::<T>(scope, if if_true { 0.0 } else { 1.0 });
-    emit_select(scope, pred, on_true, on_false)
-}
-
-fn numeric_constant<T>(scope: &cubecl::prelude::Scope, value: f64) -> ManagedVariable
-where
-    T: CubeElement + CubePrimitive + Clone,
-{
-    ManagedVariable::Plain(Variable::constant(
-        ConstantValue::Float(value),
-        T::as_type(scope),
-    ))
 }
 
 fn emit_unary_arithmetic(
@@ -225,27 +182,6 @@ fn emit_bool_binary(
     let rhs = rhs.consume();
     let out = scope.create_local(Type::scalar(ElemType::Bool));
     scope.register(Instruction::new(op(BinaryOperator { lhs, rhs }), *out));
-    out
-}
-
-fn emit_select(
-    scope: &mut cubecl::prelude::Scope,
-    pred: ManagedVariable,
-    then_value: ManagedVariable,
-    else_value: ManagedVariable,
-) -> ManagedVariable {
-    let pred = pred.consume();
-    let then_value = then_value.consume();
-    let else_value = else_value.consume();
-    let out = scope.create_local(then_value.ty);
-    scope.register(Instruction::new(
-        Operator::Select(Select {
-            cond: pred,
-            then: then_value,
-            or_else: else_value,
-        }),
-        *out,
-    ));
     out
 }
 

--- a/tenferro-internal-tensor/src/cubecl/mod.rs
+++ b/tenferro-internal-tensor/src/cubecl/mod.rs
@@ -105,9 +105,10 @@ mod runtime;
 use dispatch::{
     alloc_output, comptime_sequence, cube_count_for_len, cube_dim_1d, dtype_mismatch,
     ensure_axes_unique, ensure_axis, ensure_rank, ensure_resident_on_runtime, launch_binary,
-    launch_binary_tensor, launch_nullary_into, launch_ternary, launch_unary, launch_unary_tensor,
-    launch_unary_tensor_into, ternary_dtype_mismatch, typed_tensor_array_arg,
-    typed_tensor_array_arg_as, typed_tensor_binding,
+    launch_binary_tensor, launch_compare_bool, launch_nullary_into, launch_select_bool,
+    launch_ternary, launch_unary, launch_unary_tensor, launch_unary_tensor_into,
+    ternary_dtype_mismatch, typed_tensor_array_arg, typed_tensor_array_arg_as,
+    typed_tensor_binding,
 };
 
 pub use memory::{device_ptr, download_tensor, upload_tensor};
@@ -1699,14 +1700,14 @@ impl TensorBackend for CubeclBackend {
 
     fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor> {
         match (lhs, rhs) {
-            (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_binary(
+            (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_compare_bool(
                 self.runtime(),
                 lhs,
                 rhs,
                 &lhs.shape,
                 "compare",
                 |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                    elementwise::compare_float::launch_unchecked::<f32, CudaRuntime>(
+                    elementwise::compare_float_bool::launch_unchecked::<f32, CudaRuntime>(
                         client,
                         count,
                         dim,
@@ -1717,15 +1718,15 @@ impl TensorBackend for CubeclBackend {
                     );
                 },
             )
-            .map(Tensor::F32),
-            (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_binary(
+            .map(Tensor::Bool),
+            (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_compare_bool(
                 self.runtime(),
                 lhs,
                 rhs,
                 &lhs.shape,
                 "compare",
                 |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                    elementwise::compare_float::launch_unchecked::<f64, CudaRuntime>(
+                    elementwise::compare_float_bool::launch_unchecked::<f64, CudaRuntime>(
                         client,
                         count,
                         dim,
@@ -1736,7 +1737,7 @@ impl TensorBackend for CubeclBackend {
                     );
                 },
             )
-            .map(Tensor::F64),
+            .map(Tensor::Bool),
             (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => {
                 Err(crate::Error::BackendFailure {
                     op: "compare",
@@ -1754,34 +1755,38 @@ impl TensorBackend for CubeclBackend {
         on_false: &Tensor,
     ) -> crate::Result<Tensor> {
         match (pred, on_true, on_false) {
-            (Tensor::F32(pred), Tensor::F32(on_true), Tensor::F32(on_false)) => launch_ternary(
-                self.runtime(),
-                pred,
-                on_true,
-                on_false,
-                &pred.shape,
-                "select",
-                |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
-                    elementwise::select_float::launch_unchecked::<f32, CudaRuntime>(
-                        client, count, dim, out, pred_arg, true_arg, false_arg,
-                    );
-                },
-            )
-            .map(Tensor::F32),
-            (Tensor::F64(pred), Tensor::F64(on_true), Tensor::F64(on_false)) => launch_ternary(
-                self.runtime(),
-                pred,
-                on_true,
-                on_false,
-                &pred.shape,
-                "select",
-                |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
-                    elementwise::select_float::launch_unchecked::<f64, CudaRuntime>(
-                        client, count, dim, out, pred_arg, true_arg, false_arg,
-                    );
-                },
-            )
-            .map(Tensor::F64),
+            (Tensor::Bool(pred), Tensor::F32(on_true), Tensor::F32(on_false)) => {
+                launch_select_bool(
+                    self.runtime(),
+                    pred,
+                    on_true,
+                    on_false,
+                    &pred.shape,
+                    "select",
+                    |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
+                        elementwise::select_bool_float::launch_unchecked::<f32, CudaRuntime>(
+                            client, count, dim, out, pred_arg, true_arg, false_arg,
+                        );
+                    },
+                )
+                .map(Tensor::F32)
+            }
+            (Tensor::Bool(pred), Tensor::F64(on_true), Tensor::F64(on_false)) => {
+                launch_select_bool(
+                    self.runtime(),
+                    pred,
+                    on_true,
+                    on_false,
+                    &pred.shape,
+                    "select",
+                    |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
+                        elementwise::select_bool_float::launch_unchecked::<f64, CudaRuntime>(
+                            client, count, dim, out, pred_arg, true_arg, false_arg,
+                        );
+                    },
+                )
+                .map(Tensor::F64)
+            }
             (Tensor::C32(_), Tensor::C32(_), Tensor::C32(_))
             | (Tensor::C64(_), Tensor::C64(_), Tensor::C64(_)) => {
                 Err(crate::Error::BackendFailure {

--- a/tenferro-internal-tensor/src/cubecl/tests/fusion_tests.rs
+++ b/tenferro-internal-tensor/src/cubecl/tests/fusion_tests.rs
@@ -1,6 +1,5 @@
 // Run with: cargo test --features cuda -- --ignored
 use crate::backend::ElementwiseFusionPlan;
-use crate::config::CompareDir;
 use crate::{ElementwiseFusionInst, ElementwiseFusionOp, TensorBackend};
 
 use super::{
@@ -315,39 +314,4 @@ fn test_fused_empty_tensor() {
         .expect("fusion should handle empty tensors");
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].shape(), &[0]);
-}
-
-/// Compare produces 0/1 output.
-fn compare_plan() -> ElementwiseFusionPlan {
-    ElementwiseFusionPlan {
-        dtype: crate::DType::F64,
-        n_inputs: 2,
-        outputs: vec![2],
-        ops: vec![ElementwiseFusionInst {
-            op: ElementwiseFusionOp::Compare(CompareDir::Gt),
-            inputs: vec![0, 1],
-        }],
-    }
-}
-
-#[test]
-#[ignore]
-fn test_fused_compare() {
-    let a = tensor_f64(vec![4], vec![1.0, 5.0, 3.0, 2.0]);
-    let b = tensor_f64(vec![4], vec![2.0, 3.0, 3.0, 4.0]);
-
-    let mut cpu = cpu_backend();
-    let expected = cpu.compare(&a, &b, &CompareDir::Gt).unwrap();
-
-    let mut gpu = gpu_backend();
-    let gpu_a = upload(&gpu, &a);
-    let gpu_b = upload(&gpu, &b);
-
-    let plan = compare_plan();
-    let result = gpu
-        .execute_elementwise_fusion(&[&gpu_a, &gpu_b], &plan)
-        .unwrap()
-        .expect("fusion should succeed for compare");
-    let actual = download(&gpu, &result[0]);
-    assert_tensor_close(&actual, &expected, 1e-12);
 }

--- a/tenferro-internal-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-internal-tensor/src/tests/cpu_tests.rs
@@ -56,6 +56,20 @@ fn get_i64(t: &Tensor, idx: &[usize]) -> i64 {
     }
 }
 
+fn get_i32(t: &Tensor, idx: &[usize]) -> i32 {
+    match t {
+        Tensor::I32(inner) => *inner.get(idx),
+        _ => panic!("expected I32 tensor"),
+    }
+}
+
+fn get_bool(t: &Tensor, idx: &[usize]) -> bool {
+    match t {
+        Tensor::Bool(inner) => *inner.get(idx),
+        _ => panic!("expected Bool tensor"),
+    }
+}
+
 fn assert_f64_close(actual: f64, expected: f64) {
     assert!(
         (actual - expected).abs() < 1.0e-12,
@@ -1708,9 +1722,9 @@ fn test_tier2_elementwise_ops_real() {
         vec![3],
         vec![2.0, 5.0, 3.0],
     ));
-    let pred = Tensor::F64(TypedTensor::from_vec_col_major(
+    let pred = Tensor::Bool(TypedTensor::from_vec_col_major(
         vec![3],
-        vec![0.0, -1.0, 2.0],
+        vec![false, true, true],
     ));
     let on_true = Tensor::F64(TypedTensor::from_vec_col_major(
         vec![3],
@@ -1756,29 +1770,29 @@ fn test_tier2_elementwise_ops_real() {
     assert_eq!(get_f64(&minimum, &[2]), 3.0);
 
     let eq = backend.compare(&lhs, &rhs, &CompareDir::Eq).unwrap();
-    assert_eq!(get_f64(&eq, &[0]), 0.0);
-    assert_eq!(get_f64(&eq, &[1]), 0.0);
-    assert_eq!(get_f64(&eq, &[2]), 0.0);
+    assert!(!get_bool(&eq, &[0]));
+    assert!(!get_bool(&eq, &[1]));
+    assert!(!get_bool(&eq, &[2]));
 
     let lt = backend.compare(&lhs, &rhs, &CompareDir::Lt).unwrap();
-    assert_eq!(get_f64(&lt, &[0]), 0.0);
-    assert_eq!(get_f64(&lt, &[1]), 1.0);
-    assert_eq!(get_f64(&lt, &[2]), 0.0);
+    assert!(!get_bool(&lt, &[0]));
+    assert!(get_bool(&lt, &[1]));
+    assert!(!get_bool(&lt, &[2]));
 
     let le = backend.compare(&lhs, &rhs, &CompareDir::Le).unwrap();
-    assert_eq!(get_f64(&le, &[0]), 0.0);
-    assert_eq!(get_f64(&le, &[1]), 1.0);
-    assert_eq!(get_f64(&le, &[2]), 0.0);
+    assert!(!get_bool(&le, &[0]));
+    assert!(get_bool(&le, &[1]));
+    assert!(!get_bool(&le, &[2]));
 
     let gt = backend.compare(&lhs, &rhs, &CompareDir::Gt).unwrap();
-    assert_eq!(get_f64(&gt, &[0]), 1.0);
-    assert_eq!(get_f64(&gt, &[1]), 0.0);
-    assert_eq!(get_f64(&gt, &[2]), 1.0);
+    assert!(get_bool(&gt, &[0]));
+    assert!(!get_bool(&gt, &[1]));
+    assert!(get_bool(&gt, &[2]));
 
     let ge = backend.compare(&lhs, &rhs, &CompareDir::Ge).unwrap();
-    assert_eq!(get_f64(&ge, &[0]), 1.0);
-    assert_eq!(get_f64(&ge, &[1]), 0.0);
-    assert_eq!(get_f64(&ge, &[2]), 1.0);
+    assert!(get_bool(&ge, &[0]));
+    assert!(!get_bool(&ge, &[1]));
+    assert!(get_bool(&ge, &[2]));
 
     let select = backend.select(&pred, &on_true, &on_false).unwrap();
     assert_eq!(get_f64(&select, &[0]), 1.0);
@@ -1828,7 +1842,7 @@ fn test_tier2_elementwise_ops_complex() {
 fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
     let lhs_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![8.0f32, -2.0]));
     let rhs_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![2.0f32, 5.0]));
-    let pred_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![0.0f32, 1.0]));
+    let pred_bool = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![false, true]));
     let lower_f32 = Tensor::F32(TypedTensor::from_vec_col_major(
         vec![2],
         vec![-1.0f32, -1.0],
@@ -1856,10 +1870,10 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
     assert_eq!(get_f32(&min_out, &[1]), -2.0);
 
     let cmp_out = compare(&lhs_f32, &rhs_f32, &CompareDir::Gt).unwrap();
-    assert_eq!(get_f32(&cmp_out, &[0]), 1.0);
-    assert_eq!(get_f32(&cmp_out, &[1]), 0.0);
+    assert!(get_bool(&cmp_out, &[0]));
+    assert!(!get_bool(&cmp_out, &[1]));
 
-    let select_out = select(&pred_f32, &lhs_f32, &rhs_f32).unwrap();
+    let select_out = select(&pred_bool, &lhs_f32, &rhs_f32).unwrap();
     assert_eq!(get_f32(&select_out, &[0]), 2.0);
     assert_eq!(get_f32(&select_out, &[1]), -2.0);
 
@@ -1878,10 +1892,6 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
     let rhs_c32 = Tensor::C32(TypedTensor::from_vec_col_major(
         vec![2],
         vec![Complex32::new(1.0, 0.0), Complex32::new(0.0, 2.0)],
-    ));
-    let pred_c32 = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(0.0, 0.0), Complex32::new(1.0, 0.0)],
     ));
     let lower_c32 = Tensor::C32(TypedTensor::from_vec_col_major(
         vec![2],
@@ -1906,9 +1916,9 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
     assert_eq!(get_c32(&min_c32, &[1]), Complex32::new(1.0, 0.0));
 
     let cmp_c32 = compare(&lhs_c32, &rhs_c32, &CompareDir::Eq).unwrap();
-    assert_eq!(get_c32(&cmp_c32, &[0]), Complex32::new(0.0, 0.0));
+    assert!(!get_bool(&cmp_c32, &[0]));
 
-    let select_c32 = select(&pred_c32, &lhs_c32, &rhs_c32).unwrap();
+    let select_c32 = select(&pred_bool, &lhs_c32, &rhs_c32).unwrap();
     assert_eq!(get_c32(&select_c32, &[0]), Complex32::new(1.0, 0.0));
     assert_eq!(get_c32(&select_c32, &[1]), Complex32::new(1.0, 0.0));
 
@@ -1952,10 +1962,16 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     let lhs_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.5f64, -3.0]));
     let rhs_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![2.0f64, 4.0]));
     let scalar_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![2.0f64]));
-    let pred_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![0.0f64, 1.0]));
+    let pred_bool = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![false, true]));
     let lower_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![0.0f64, -2.0]));
     let upper_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![2.0f64, 3.0]));
     let short_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0f64]));
+    let lhs_i32 = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1i32, 3]));
+    let rhs_i32 = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![2i32, 3]));
+    let lhs_i64 = Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![5i64, -1]));
+    let rhs_i64 = Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![2i64, -1]));
+    let lhs_bool = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]));
+    let rhs_bool = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![false, false]));
 
     let add_out = add(&lhs_f64, &rhs_f64).unwrap();
     assert_eq!(get_f64(&add_out, &[0]), 3.5);
@@ -1982,12 +1998,43 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     assert_eq!(get_f64(&conj_out, &[1]), -3.0);
 
     let compare_out = compare(&lhs_f64, &rhs_f64, &CompareDir::Lt).unwrap();
-    assert_eq!(get_f64(&compare_out, &[0]), 1.0);
-    assert_eq!(get_f64(&compare_out, &[1]), 1.0);
+    assert!(get_bool(&compare_out, &[0]));
+    assert!(get_bool(&compare_out, &[1]));
 
-    let select_out = select(&pred_f64, &lhs_f64, &rhs_f64).unwrap();
+    let select_out = select(&pred_bool, &lhs_f64, &rhs_f64).unwrap();
     assert_eq!(get_f64(&select_out, &[0]), 2.0);
     assert_eq!(get_f64(&select_out, &[1]), -3.0);
+
+    assert!(get_bool(
+        &compare(&lhs_i32, &rhs_i32, &CompareDir::Lt).unwrap(),
+        &[0]
+    ));
+    assert!(get_bool(
+        &compare(&lhs_i32, &rhs_i32, &CompareDir::Le).unwrap(),
+        &[1]
+    ));
+    assert!(get_bool(
+        &compare(&lhs_i64, &rhs_i64, &CompareDir::Gt).unwrap(),
+        &[0]
+    ));
+    assert!(get_bool(
+        &compare(&lhs_i64, &rhs_i64, &CompareDir::Ge).unwrap(),
+        &[1]
+    ));
+    assert!(get_bool(
+        &compare(&lhs_bool, &rhs_bool, &CompareDir::Eq).unwrap(),
+        &[1]
+    ));
+
+    let select_i32 = select(&pred_bool, &lhs_i32, &rhs_i32).unwrap();
+    assert_eq!(get_i32(&select_i32, &[0]), 2);
+    assert_eq!(get_i32(&select_i32, &[1]), 3);
+    let select_i64 = select(&pred_bool, &lhs_i64, &rhs_i64).unwrap();
+    assert_eq!(get_i64(&select_i64, &[0]), 2);
+    assert_eq!(get_i64(&select_i64, &[1]), -1);
+    let select_bool = select(&pred_bool, &lhs_bool, &rhs_bool).unwrap();
+    assert!(!get_bool(&select_bool, &[0]));
+    assert!(!get_bool(&select_bool, &[1]));
 
     let clamp_out = clamp(&lhs_f64, &lower_f64, &upper_f64).unwrap();
     assert_eq!(get_f64(&clamp_out, &[0]), 1.5);
@@ -2000,10 +2047,6 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     let rhs_c64 = Tensor::C64(TypedTensor::from_vec_col_major(
         vec![2],
         vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 2.0)],
-    ));
-    let pred_c64 = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
     ));
     let lower_c64 = Tensor::C64(TypedTensor::from_vec_col_major(
         vec![2],
@@ -2052,12 +2095,12 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     let compare_le = compare(&lhs_c64, &rhs_c64, &CompareDir::Le).unwrap();
     let compare_gt = compare(&lhs_c64, &rhs_c64, &CompareDir::Gt).unwrap();
     let compare_ge = compare(&lhs_c64, &rhs_c64, &CompareDir::Ge).unwrap();
-    assert_c64_close(get_c64(&compare_lt, &[0]), Complex64::new(0.0, 0.0));
-    assert_c64_close(get_c64(&compare_le, &[0]), Complex64::new(0.0, 0.0));
-    assert_c64_close(get_c64(&compare_gt, &[0]), Complex64::new(1.0, 0.0));
-    assert_c64_close(get_c64(&compare_ge, &[0]), Complex64::new(1.0, 0.0));
+    assert!(!get_bool(&compare_lt, &[0]));
+    assert!(!get_bool(&compare_le, &[0]));
+    assert!(get_bool(&compare_gt, &[0]));
+    assert!(get_bool(&compare_ge, &[0]));
 
-    let select_c64 = select(&pred_c64, &lhs_c64, &rhs_c64).unwrap();
+    let select_c64 = select(&pred_bool, &lhs_c64, &rhs_c64).unwrap();
     assert_c64_close(get_c64(&select_c64, &[0]), Complex64::new(1.0, 0.0));
     assert_c64_close(get_c64(&select_c64, &[1]), Complex64::new(1.0, 0.0));
 
@@ -2089,10 +2132,7 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     ));
     assert!(matches!(
         select(&lhs_f32, &lhs_f32, &rhs_f64),
-        Err(crate::Error::BackendFailure {
-            op: "select",
-            message,
-        }) if message == "dtype mismatch"
+        Err(crate::Error::DTypeMismatch { op: "select", .. })
     ));
     assert!(matches!(
         clamp(&lhs_f32, &lhs_f32, &rhs_f64),
@@ -2127,11 +2167,11 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
         Err(crate::Error::ShapeMismatch { op: "compare", .. })
     ));
     assert!(matches!(
-        select(&pred_f64, &short_f64, &rhs_f64),
+        select(&pred_bool, &short_f64, &rhs_f64),
         Err(crate::Error::ShapeMismatch { op: "select", .. })
     ));
     assert!(matches!(
-        select(&pred_f64, &rhs_f64, &short_f64),
+        select(&pred_bool, &rhs_f64, &short_f64),
         Err(crate::Error::ShapeMismatch { op: "select", .. })
     ));
     assert!(matches!(
@@ -4346,12 +4386,10 @@ fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
         get_c64(&minimum(&a, &b).unwrap(), &[0]),
         Complex64::new(0.0, 2.0),
     );
+    assert!(get_bool(&compare(&a, &b, &CompareDir::Ge).unwrap(), &[0]));
+    let pred = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, true]));
     assert_c64_close(
-        get_c64(&compare(&a, &b, &CompareDir::Ge).unwrap(), &[0]),
-        Complex64::new(1.0, 0.0),
-    );
-    assert_c64_close(
-        get_c64(&select(&a, &a, &b).unwrap(), &[1]),
+        get_c64(&select(&pred, &a, &b).unwrap(), &[1]),
         Complex64::new(1.0, 0.0),
     );
     assert_c64_close(

--- a/tenferro-linalg/src/traced.rs
+++ b/tenferro-linalg/src/traced.rs
@@ -210,6 +210,7 @@ pub fn pinv_with_rtol(a: &TracedTensor, rtol: f64) -> TracedTensor {
     let s_shape = s.concrete_shape();
     let threshold = broadcast_batch_scalar_to_leading_axis(&threshold, &s_shape);
     let mask = abs_s.compare(&threshold, CompareDir::Gt);
+    let mask = mask.convert(s.dtype);
     let ones = ones_like(&s);
     let denom = &s + &(&ones + &(-&mask));
     let s_inv = &mask / &denom;
@@ -399,7 +400,7 @@ fn matrix_norm(a: &TracedTensor, axes: &[usize], ord: Option<f64>) -> TracedTens
 
 fn count_nonzero(abs: &TracedTensor, axes: &[usize]) -> TracedTensor {
     let mask = abs.compare(&zero_scalar(abs.dtype), CompareDir::Gt);
-    mask.reduce_sum(axes)
+    mask.convert(abs.dtype).reduce_sum(axes)
 }
 
 fn matrix_row_sum_norm(abs: &TracedTensor, take_max: bool) -> TracedTensor {

--- a/tenferro/src/eager_exec.rs
+++ b/tenferro/src/eager_exec.rs
@@ -207,9 +207,11 @@ fn exec_standard_op_on_tensors<B: TensorBackend>(
             StdTensorOp::Convert { to, .. } => vec![exec.convert(inputs[0], *to)?],
             StdTensorOp::Constant { dtype, bytes } => vec![constant_tensor(*dtype, bytes)],
             StdTensorOp::Select => {
-                let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                let (a, c) = promote_binary(exec, a.tensor(), inputs[2], op)?;
-                vec![exec.select(a.tensor(), b.tensor(), c.tensor())?]
+                let value_dtype =
+                    crate::shape_infer::promote_dtype(inputs[1].dtype(), inputs[2].dtype());
+                let b = promote_to_dtype(exec, inputs[1], value_dtype)?;
+                let c = promote_to_dtype(exec, inputs[2], value_dtype)?;
+                vec![exec.select(inputs[0], b.tensor(), c.tensor())?]
             }
             StdTensorOp::Clamp => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;

--- a/tenferro/src/eager_ops_elementwise.rs
+++ b/tenferro/src/eager_ops_elementwise.rs
@@ -271,7 +271,7 @@ impl EagerTensor {
     /// use tenferro::{CpuBackend, EagerRuntime, EagerTensor, Tensor};
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    /// let condition = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]), ctx.clone());
+    /// let condition = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![false, true]), ctx.clone());
     /// let on_true = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![10.0_f64, 20.0]), ctx.clone());
     /// let on_false = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
     /// let y = EagerTensor::select(&condition, &on_true, &on_false).unwrap();

--- a/tenferro/src/eager_tensor.rs
+++ b/tenferro/src/eager_tensor.rs
@@ -132,7 +132,7 @@ pub fn sub(lhs: &EagerTensor, rhs: &EagerTensor) -> Result<EagerTensor> {
 
 /// Elementwise comparison with NumPy-style broadcasting.
 ///
-/// Current eager comparison follows the primitive numeric-mask dtype policy.
+/// The result is a bool tensor.
 ///
 /// # Examples
 ///
@@ -142,6 +142,7 @@ pub fn sub(lhs: &EagerTensor, rhs: &EagerTensor) -> Result<EagerTensor> {
 /// # let x = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]), ctx.clone());
 /// # let y = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]), ctx);
 /// let z = eager_tensor::compare(&x, &y, CompareDir::Gt).unwrap();
+/// assert_eq!(z.data().as_slice::<bool>().unwrap(), &[true, false]);
 /// ```
 pub fn compare(lhs: &EagerTensor, rhs: &EagerTensor, dir: CompareDir) -> Result<EagerTensor> {
     let (lhs, rhs) = broadcast_binary(lhs, rhs)?;

--- a/tenferro/src/segment.rs
+++ b/tenferro/src/segment.rs
@@ -433,8 +433,6 @@ fn map_exec_op_to_elementwise_fusion(op: &ExecOp) -> Option<ElementwiseFusionOp>
         ExecOp::Abs => Some(ElementwiseFusionOp::Abs),
         ExecOp::Maximum => Some(ElementwiseFusionOp::Maximum),
         ExecOp::Minimum => Some(ElementwiseFusionOp::Minimum),
-        ExecOp::Compare(dir) => Some(ElementwiseFusionOp::Compare(dir.clone())),
-        ExecOp::Select => Some(ElementwiseFusionOp::Select),
         ExecOp::Clamp => Some(ElementwiseFusionOp::Clamp),
         ExecOp::Exp => Some(ElementwiseFusionOp::Exp),
         ExecOp::Log => Some(ElementwiseFusionOp::Log),

--- a/tenferro/src/shape_infer.rs
+++ b/tenferro/src/shape_infer.rs
@@ -104,18 +104,18 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         StdTensorOp::Constant { dtype, .. } => *dtype,
         StdTensorOp::Convert { to, .. } => *to,
         StdTensorOp::Extension(ext) => extension_first_output_dtype(ext.as_ref(), input_dtypes),
+        StdTensorOp::Compare(_) => DType::Bool,
+        StdTensorOp::Select => promote_dtype(input_dtypes[1], input_dtypes[2]),
+        StdTensorOp::Clamp => promote_dtypes(input_dtypes.iter().copied()),
         // Binary / ternary / N-ary ops — promote input dtypes.
         StdTensorOp::Add
         | StdTensorOp::Mul
         | StdTensorOp::Maximum
         | StdTensorOp::Minimum
-        | StdTensorOp::Select
-        | StdTensorOp::Clamp
         | StdTensorOp::DotGeneral { .. }
         | StdTensorOp::Concatenate { .. }
         | StdTensorOp::PadToMatch { .. }
-        | StdTensorOp::DynamicTruncate { .. }
-        | StdTensorOp::Compare(_) => promote_dtype(input_dtypes[0], input_dtypes[1]),
+        | StdTensorOp::DynamicTruncate { .. } => promote_dtype(input_dtypes[0], input_dtypes[1]),
         StdTensorOp::Div | StdTensorOp::Pow => {
             promote_dtype_div_like(input_dtypes[0], input_dtypes[1])
         }

--- a/tenferro/src/tensor.rs
+++ b/tenferro/src/tensor.rs
@@ -135,7 +135,7 @@ pub fn sub(lhs: &Tensor, rhs: &Tensor, backend: &mut impl TensorBackend) -> Resu
 
 /// Elementwise comparison with NumPy-style broadcasting.
 ///
-/// Current concrete comparison follows the primitive numeric-mask dtype policy.
+/// The result is a bool tensor.
 ///
 /// # Examples
 ///
@@ -145,6 +145,7 @@ pub fn sub(lhs: &Tensor, rhs: &Tensor, backend: &mut impl TensorBackend) -> Resu
 /// # let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]);
 /// # let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
 /// let z = tensor::compare(&x, &y, CompareDir::Gt, &mut backend).unwrap();
+/// assert_eq!(z.as_slice::<bool>().unwrap(), &[true, false]);
 /// ```
 pub fn compare(
     lhs: &Tensor,
@@ -153,8 +154,6 @@ pub fn compare(
     backend: &mut impl TensorBackend,
 ) -> Result<Tensor> {
     let (lhs, rhs) = broadcast_binary(lhs, rhs, backend)?;
-    // TODO: Migrate public compare to bool output when primitive dtype inference
-    // and backend compare kernels are updated together.
     backend.with_exec_session(|exec| exec.compare(&lhs, &rhs, &dir))
 }
 

--- a/tenferro/src/traced.rs
+++ b/tenferro/src/traced.rs
@@ -2030,16 +2030,17 @@ pub(crate) fn apply_binary(
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
 ) -> TracedTensor {
-    let out_dtype = crate::shape_infer::promote_dtype_for_binary_op(&op, lhs.dtype, rhs.dtype);
+    let input_dtype = crate::shape_infer::promote_dtype_for_binary_op(&op, lhs.dtype, rhs.dtype);
+    let out_dtype = crate::shape_infer::infer_output_dtype(&op, &[lhs.dtype, rhs.dtype]);
 
-    // Insert Convert ops when an input dtype differs from the promoted result.
-    let lhs = if lhs.dtype != out_dtype {
-        lhs.convert(out_dtype)
+    // Insert Convert ops when an input dtype differs from the primitive input dtype.
+    let lhs = if lhs.dtype != input_dtype {
+        lhs.convert(input_dtype)
     } else {
         lhs.clone()
     };
-    let rhs = if rhs.dtype != out_dtype {
-        rhs.convert(out_dtype)
+    let rhs = if rhs.dtype != input_dtype {
+        rhs.convert(input_dtype)
     } else {
         rhs.clone()
     };
@@ -2092,21 +2093,43 @@ pub(crate) fn apply_ternary(
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
 ) -> TracedTensor {
-    let out_dtype = crate::shape_infer::promote_dtypes([first.dtype, second.dtype, third.dtype]);
-    let first = if first.dtype != out_dtype {
-        first.convert(out_dtype)
-    } else {
-        first.clone()
-    };
-    let second = if second.dtype != out_dtype {
-        second.convert(out_dtype)
-    } else {
-        second.clone()
-    };
-    let third = if third.dtype != out_dtype {
-        third.convert(out_dtype)
-    } else {
-        third.clone()
+    let out_dtype =
+        crate::shape_infer::infer_output_dtype(&op, &[first.dtype, second.dtype, third.dtype]);
+    let (first, second, third) = match op {
+        StdTensorOp::Select => {
+            let value_dtype = crate::shape_infer::promote_dtype(second.dtype, third.dtype);
+            let second = if second.dtype != value_dtype {
+                second.convert(value_dtype)
+            } else {
+                second.clone()
+            };
+            let third = if third.dtype != value_dtype {
+                third.convert(value_dtype)
+            } else {
+                third.clone()
+            };
+            (first.clone(), second, third)
+        }
+        _ => {
+            let input_dtype =
+                crate::shape_infer::promote_dtypes([first.dtype, second.dtype, third.dtype]);
+            let first = if first.dtype != input_dtype {
+                first.convert(input_dtype)
+            } else {
+                first.clone()
+            };
+            let second = if second.dtype != input_dtype {
+                second.convert(input_dtype)
+            } else {
+                second.clone()
+            };
+            let third = if third.dtype != input_dtype {
+                third.convert(input_dtype)
+            } else {
+                third.clone()
+            };
+            (first, second, third)
+        }
     };
     apply_ternary_with_output_dtype(
         op,

--- a/tenferro/src/traced_tensor.rs
+++ b/tenferro/src/traced_tensor.rs
@@ -134,7 +134,7 @@ pub fn minimum(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
 
 /// Elementwise comparison with NumPy-style broadcasting.
 ///
-/// Current traced comparison follows the primitive numeric-mask dtype policy.
+/// The result is a bool tensor.
 ///
 /// # Examples
 ///
@@ -143,6 +143,7 @@ pub fn minimum(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
 /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]);
 /// # let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
 /// let z = tenferro::traced_tensor::compare(&x, &y, CompareDir::Gt);
+/// assert_eq!(z.dtype, tenferro::DType::Bool);
 /// ```
 pub fn compare(lhs: &TracedTensor, rhs: &TracedTensor, dir: CompareDir) -> TracedTensor {
     crate::traced::apply_broadcast_binary_op(StdTensorOp::Compare(dir), lhs, rhs)

--- a/tenferro/src/typed_tensor.rs
+++ b/tenferro/src/typed_tensor.rs
@@ -124,7 +124,7 @@ pub fn sub<T: TensorScalar>(
 
 /// Elementwise comparison with NumPy-style broadcasting.
 ///
-/// Current typed comparison follows the primitive numeric-mask dtype policy.
+/// The result is a bool tensor.
 ///
 /// # Examples
 ///
@@ -134,13 +134,14 @@ pub fn sub<T: TensorScalar>(
 /// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]);
 /// # let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]);
 /// let z = typed_tensor::compare(&x, &y, CompareDir::Gt, &mut backend).unwrap();
+/// assert_eq!(z.host_data(), &[true, false]);
 /// ```
 pub fn compare<T: TensorScalar>(
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     dir: CompareDir,
     backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
+) -> Result<TypedTensor<bool>> {
     let out = crate::tensor::compare(&erase(lhs), &erase(rhs), dir, backend)?;
     try_into_typed_result("compare", out)
 }
@@ -160,7 +161,7 @@ pub fn compare<T: TensorScalar>(
 /// let z = typed_tensor::where_select(&condition, &x, &y, &mut backend).unwrap();
 /// ```
 pub fn where_select<T: TensorScalar>(
-    condition: &TypedTensor<T>,
+    condition: &TypedTensor<bool>,
     on_true: &TypedTensor<T>,
     on_false: &TypedTensor<T>,
     backend: &mut impl TensorBackend,

--- a/tenferro/tests/ad_structural_primitives.rs
+++ b/tenferro/tests/ad_structural_primitives.rs
@@ -129,7 +129,7 @@ fn eager_maximum_and_minimum_gradients_match_finite_diff() {
 #[test]
 fn eager_select_gradients_match_finite_diff() {
     let ctx = test_ctx();
-    let condition_data = vec![0.0_f64, -1.0, 2.0, 0.0];
+    let condition_data = vec![false, true, true, false];
     let true_data = vec![10.0_f64, 20.0, 30.0, 40.0];
     let false_data = vec![1.0_f64, 2.0, 3.0, 4.0];
     let weights = vec![0.5_f64, -1.0, 2.0, 1.25];
@@ -165,7 +165,7 @@ fn eager_select_gradients_match_finite_diff() {
                 .iter()
                 .zip(values.iter())
                 .zip(false_data.iter())
-                .map(|((&cond, &t), &f)| if cond != 0.0 { t } else { f }),
+                .map(|((&cond, &t), &f)| if cond { t } else { f }),
             &weights,
         )
     };
@@ -175,7 +175,7 @@ fn eager_select_gradients_match_finite_diff() {
                 .iter()
                 .zip(true_data.iter())
                 .zip(values.iter())
-                .map(|((&cond, &t), &f)| if cond != 0.0 { t } else { f }),
+                .map(|((&cond, &t), &f)| if cond { t } else { f }),
             &weights,
         )
     };

--- a/tenferro/tests/eager_tensor.rs
+++ b/tenferro/tests/eager_tensor.rs
@@ -905,7 +905,7 @@ fn eager_pow_maximum_and_minimum_primal() {
 #[test]
 fn eager_select_primal() {
     let condition = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![0.0_f64, -1.0, 2.0]),
+        Tensor::from_vec_col_major(vec![3], vec![false, true, true]),
         test_ctx(),
     );
     let on_true = EagerTensor::from_tensor_in(

--- a/tenferro/tests/numpy_api.rs
+++ b/tenferro/tests/numpy_api.rs
@@ -1,6 +1,6 @@
 use tenferro::{
-    traced_tensor, CompareDir, CpuBackend, GraphCompiler, GraphExecutor, Tensor, TracedTensor,
-    TypedTensor,
+    traced_tensor, CompareDir, CpuBackend, DType, GraphCompiler, GraphExecutor, Tensor,
+    TracedTensor, TypedTensor,
 };
 
 #[cfg(feature = "autodiff")]
@@ -51,6 +51,30 @@ fn traced_tensor_module_exposes_initial_elementwise_free_functions() {
     let _ = traced_tensor::rsqrt(&x);
     let _ = traced_tensor::expm1(&x);
     let _ = traced_tensor::log1p(&x);
+}
+
+#[test]
+fn traced_compare_returns_bool_and_where_select_accepts_bool_condition() {
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]);
+    let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
+    let cond = traced_tensor::compare(&x, &y, CompareDir::Gt);
+    assert_eq!(cond.dtype, DType::Bool);
+
+    let selected = traced_tensor::where_select(&cond, &x, &y);
+
+    let mut compiler = GraphCompiler::new();
+    let cond_program = compiler.compile(&cond).unwrap();
+    let selected_program = compiler.compile(&selected).unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    let cond_out = executor.run(&cond_program).unwrap();
+    let selected_out = executor.run(&selected_program).unwrap();
+
+    assert_eq!(cond_out.dtype(), DType::Bool);
+    assert_eq!(cond_out.as_slice::<bool>().unwrap(), &[true, false]);
+    assert_eq!(
+        selected_out.try_into_vec_col_major::<f64>().unwrap().1,
+        vec![2.0, 8.0]
+    );
 }
 
 #[cfg(feature = "autodiff")]
@@ -114,6 +138,33 @@ fn eager_tensor_module_exposes_initial_elementwise_free_functions() {
     let _ = eager_tensor::log1p(&x).unwrap();
 }
 
+#[cfg(feature = "autodiff")]
+#[test]
+fn eager_compare_returns_bool_and_where_select_accepts_bool_condition() {
+    let ctx = EagerRuntime::new();
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]),
+        ctx.clone(),
+    );
+    let y =
+        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]), ctx);
+
+    let cond = eager_tensor::compare(&x, &y, CompareDir::Gt).unwrap();
+    let selected = eager_tensor::where_select(&cond, &x, &y).unwrap();
+
+    assert_eq!(cond.data().dtype(), DType::Bool);
+    assert_eq!(cond.data().as_slice::<bool>().unwrap(), &[true, false]);
+    assert_eq!(
+        selected
+            .data()
+            .clone()
+            .try_into_vec_col_major::<f64>()
+            .unwrap()
+            .1,
+        vec![2.0, 8.0]
+    );
+}
+
 #[test]
 fn tensor_add_uses_numpy_broadcasting_with_explicit_backend() {
     let mut backend = CpuBackend::new();
@@ -160,6 +211,23 @@ fn tensor_module_exposes_initial_elementwise_free_functions() {
 }
 
 #[test]
+fn tensor_compare_returns_bool_and_where_select_accepts_bool_condition() {
+    let mut backend = CpuBackend::new();
+    let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]);
+    let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
+
+    let cond = tenferro::tensor::compare(&x, &y, CompareDir::Gt, &mut backend).unwrap();
+    let selected = tenferro::tensor::where_select(&cond, &x, &y, &mut backend).unwrap();
+
+    assert_eq!(cond.dtype(), DType::Bool);
+    assert_eq!(cond.as_slice::<bool>().unwrap(), &[true, false]);
+    assert_eq!(
+        selected.try_into_vec_col_major::<f64>().unwrap().1,
+        vec![2.0, 8.0]
+    );
+}
+
+#[test]
 fn typed_tensor_add_uses_numpy_broadcasting_with_explicit_backend() {
     let mut backend = CpuBackend::new();
     let lhs = TypedTensor::<f64>::from_vec_row_major(vec![3, 1], vec![1.0, 2.0, 3.0]);
@@ -202,4 +270,18 @@ fn typed_tensor_module_exposes_initial_elementwise_free_functions() {
     let _ = tenferro::typed_tensor::rsqrt(&x, &mut backend).unwrap();
     let _ = tenferro::typed_tensor::expm1(&x, &mut backend).unwrap();
     let _ = tenferro::typed_tensor::log1p(&x, &mut backend).unwrap();
+}
+
+#[test]
+fn typed_tensor_compare_returns_bool_and_where_select_accepts_bool_condition() {
+    let mut backend = CpuBackend::new();
+    let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]);
+    let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]);
+
+    let cond: TypedTensor<bool> =
+        tenferro::typed_tensor::compare(&x, &y, CompareDir::Gt, &mut backend).unwrap();
+    let selected = tenferro::typed_tensor::where_select(&cond, &x, &y, &mut backend).unwrap();
+
+    assert_eq!(cond.host_data(), &[true, false]);
+    assert_eq!(selected.try_into_vec_col_major().unwrap().1, vec![2.0, 8.0]);
 }


### PR DESCRIPTION
## Summary
- Make `Compare` produce `Bool` tensors across traced, eager, concrete, typed, CPU, and CUDA/CubeCL paths.
- Make `Select`/`where_select` consume `Bool` predicates and promote only the true/false value inputs.
- Remove compare/select from single-dtype elementwise fusion until mixed Bool/value fusion can represent the contract, and update AD/linalg mask consumers with explicit numeric conversion.

## Impact
This is an intentional breaking API cleanup with no numeric-mask compatibility shim. `typed_tensor::compare` now returns `TypedTensor<bool>`, and `typed_tensor::where_select` requires `TypedTensor<bool>` for the condition.

Closes #893.

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo check -p tenferro-internal-tensor --features cuda --tests`
