### PR TITLE
Add tensordot sugar to einsum extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ crates.
 | Crate | What it provides |
 | --- | --- |
 | `tenferro-linalg` | SVD, QR, Cholesky, LU, solve, eig/eigh, triangular solve, and related linalg APIs |
-| `tenferro-einsum` | NumPy/JAX-style einsum with contraction planning |
+| `tenferro-einsum` | NumPy/JAX-style einsum with contraction planning and tensordot contraction sugar |
 | `tenferro-fft` | FFT extension operations |
 
 ## EagerTensor Execution

--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -4,6 +4,8 @@ Einsum is a standard extension crate, not part of the `tenferro` facade.
 The public user-facing paths live under `tenferro_einsum`, for example
 `tenferro_einsum::traced_tensor::einsum` for traced graph construction and
 `tenferro_einsum::eager_tensor::einsum` for immediate eager execution.
+The same namespaces expose `tensordot` as NumPy-style contraction sugar over
+axis pairs; it is not a `tenferro-linalg` API.
 
 `tenferro` must not expose einsum facade paths such as `tenferro::einsum`,
 `tenferro::traced_tensor::einsum`, `tenferro::eager_tensor::einsum`,

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -78,6 +78,7 @@ operations.
 | --- | --- | --- | --- |
 | Everyday tensor ops | `tenferro::tensor` functions; selected `tenferro::typed_tensor` wrappers | `tenferro::eager_tensor` functions | `tenferro::traced_tensor` functions |
 | Einsum | Internal to `tenferro-einsum` runtime execution | `tenferro_einsum::eager_tensor::einsum` | `tenferro_einsum::traced_tensor::einsum` plus `register_runtime` |
+| Tensordot sugar | Use `matmul` or `dot_general` directly | `tenferro_einsum::eager_tensor::tensordot` | `tenferro_einsum::traced_tensor::tensordot` |
 | Linear algebra | `Tensor` methods; selected `TypedTensor<T>` methods | `tenferro_linalg::eager_tensor` helpers | `tenferro_linalg::traced_tensor` helpers |
 | Automatic differentiation | Not applicable | Scalar-loss `backward()` on tracked values | `grad`, `vjp`, `jvp`, HVP via composition |
 | External operations | Extension-defined concrete hooks | Extension-defined eager hooks and optional AD rules | Extension-defined graph hooks and optional AD rules |

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -2,8 +2,10 @@
 
 `einsum` is a standard extension, not part of `tenferro` core. Add the
 `tenferro-einsum` crate and call traced graph operations explicitly as
-`tenferro_einsum::traced_tensor::einsum`. Compiled execution also requires
-explicit runtime registration.
+`tenferro_einsum::traced_tensor::einsum`. The same extension crate also owns
+`tensordot` contraction sugar; it is not part of the linalg namespace.
+Compiled execution also requires explicit runtime registration for einsum
+extension ops.
 
 ```toml
 [dependencies]
@@ -57,6 +59,25 @@ let diag = tenferro_einsum::eager_tensor::einsum(&[&v], "i->ii").unwrap();
 
 assert_eq!(outer.data().shape(), &[2, 3]);
 assert_eq!(diag.data().shape(), &[3, 3]);
+```
+
+## Tensordot Sugar
+
+Use `tensordot` when the operation is naturally described as "contract these
+axis pairs" instead of by writing explicit labels. `TensorDotAxes::Count(n)`
+contracts the last `n` axes of the left tensor with the first `n` axes of the
+right tensor. `TensorDotAxes::Axes` accepts explicit axis pairs, including
+negative axes.
+
+```rust
+use tenferro::TracedTensor;
+use tenferro_einsum::{traced_tensor, TensorDotAxes};
+
+let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
+let rhs = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
+let out = traced_tensor::tensordot(&lhs, &rhs, TensorDotAxes::Count(1)).unwrap();
+
+assert_eq!(out.rank, 2);
 ```
 
 ## Optimization Controls

--- a/tenferro-einsum/src/eager_tensor.rs
+++ b/tenferro-einsum/src/eager_tensor.rs
@@ -9,7 +9,7 @@ use tenferro::EagerTensor;
 use crate::extension::{
     ensure_einsum_extension_rule_registered, register_runtime, EinsumExtensionOp,
 };
-use crate::{parse_einsum_subscripts, EinsumSubscripts};
+use crate::{parse_einsum_subscripts, EinsumSubscripts, TensorDotAxes};
 
 /// Execute an einsum eagerly on [`EagerTensor`] values.
 pub fn einsum(inputs: &[&EagerTensor], subscripts: &str) -> Result<EagerTensor> {
@@ -36,4 +36,46 @@ pub fn einsum_subscripts(
     outputs
         .pop()
         .ok_or_else(|| Error::Internal("einsum extension produced no eager output".to_string()))
+}
+
+/// Execute a NumPy-style tensor contraction on [`EagerTensor`] values.
+///
+/// This helper lives in the einsum extension namespace because it is
+/// contraction sugar over `dot_general`, not a linear algebra facade.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::{CpuBackend, EagerRuntime, EagerTensor, Tensor};
+/// use tenferro_einsum::{eager_tensor, TensorDotAxes};
+///
+/// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+/// let lhs = EagerTensor::from_tensor_in(
+///     Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]),
+///     ctx.clone(),
+/// );
+/// let rhs = EagerTensor::from_tensor_in(
+///     Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]),
+///     ctx,
+/// );
+/// let out = eager_tensor::tensordot(&lhs, &rhs, TensorDotAxes::Count(1)).unwrap();
+///
+/// assert_eq!(out.data().shape(), &[2, 4]);
+/// ```
+pub fn tensordot(
+    lhs: &EagerTensor,
+    rhs: &EagerTensor,
+    axes: TensorDotAxes<'_>,
+) -> Result<EagerTensor> {
+    let config = crate::tensordot::dot_general_config(
+        axes,
+        lhs.data().shape().len(),
+        rhs.data().shape().len(),
+    )?;
+    crate::tensordot::validate_concrete_contract_dims(
+        lhs.data().shape(),
+        rhs.data().shape(),
+        &config,
+    )?;
+    lhs.dot_general(rhs, config)
 }

--- a/tenferro-einsum/src/lib.rs
+++ b/tenferro-einsum/src/lib.rs
@@ -10,6 +10,9 @@
 //!   `"i->ii"` embeds a vector on a diagonal
 //! - **N-ary contraction**: Automatic or manual optimization of pairwise
 //!   contraction order via [`ContractionTree`]
+//! - **Tensordot sugar**: NumPy-style axis-pair contraction helpers in the
+//!   traced and eager tensor namespaces, implemented as contraction sugar
+//!   rather than as linear algebra APIs.
 //! - **Extension runtime**: traced einsum lowers to a registered tenferro
 //!   extension runtime, keeping core op definitions small.
 //! - **Traced tensor namespace**: graph-building helpers are available under
@@ -49,6 +52,7 @@ mod optimize;
 mod planning;
 mod subscripts;
 mod syntax;
+mod tensordot;
 mod traced;
 pub mod traced_tensor;
 #[cfg(test)]
@@ -62,6 +66,7 @@ pub use planning::tree::{ContractionOptimizerOptions, ContractionTree};
 pub use subscripts::{parse_einsum_subscripts, EinsumSubscripts};
 pub use syntax::nested::NestedEinsum;
 pub use syntax::subscripts::Subscripts;
+pub use tensordot::TensorDotAxes;
 pub use traced::{einsum, einsum_subscripts, einsum_subscripts_with, einsum_with};
 
 #[cfg(test)]

--- a/tenferro-einsum/src/tensordot.rs
+++ b/tenferro-einsum/src/tensordot.rs
@@ -1,0 +1,185 @@
+use std::collections::HashSet;
+
+use tenferro::error::{Error, Result};
+use tenferro::{DotGeneralConfig, TracedTensor};
+
+/// Axis specification for [`tensordot`](crate::traced_tensor::tensordot)
+/// contraction sugar.
+///
+/// `Count(n)` contracts the last `n` axes of the left operand with the first
+/// `n` axes of the right operand. `Axes` contracts the explicitly paired axes
+/// in the order they are provided, accepting negative indices relative to each
+/// operand rank.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_einsum::TensorDotAxes;
+///
+/// let count = TensorDotAxes::Count(2);
+/// let explicit = TensorDotAxes::Axes {
+///     lhs: &[-1],
+///     rhs: &[0],
+/// };
+///
+/// assert_eq!(count, TensorDotAxes::Count(2));
+/// assert_ne!(count, explicit);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TensorDotAxes<'a> {
+    /// Contract the last `n` left axes with the first `n` right axes.
+    Count(usize),
+    /// Contract explicit left/right axis pairs.
+    Axes {
+        /// Left operand axes. Negative axes are normalized against the left rank.
+        lhs: &'a [isize],
+        /// Right operand axes. Negative axes are normalized against the right rank.
+        rhs: &'a [isize],
+    },
+}
+
+pub(crate) fn dot_general_config(
+    axes: TensorDotAxes<'_>,
+    lhs_rank: usize,
+    rhs_rank: usize,
+) -> Result<DotGeneralConfig> {
+    let (lhs_contracting_dims, rhs_contracting_dims) = match axes {
+        TensorDotAxes::Count(count) => {
+            if count > lhs_rank || count > rhs_rank {
+                return Err(contraction_error(format!(
+                    "TensorDotAxes::Count({count}) cannot contract {count} axes \
+                     for lhs rank {lhs_rank} and rhs rank {rhs_rank}"
+                )));
+            }
+            ((lhs_rank - count..lhs_rank).collect(), (0..count).collect())
+        }
+        TensorDotAxes::Axes { lhs, rhs } => {
+            if lhs.len() != rhs.len() {
+                return Err(contraction_error(format!(
+                    "tensordot explicit axes must have matching lengths, got lhs {} and rhs {}",
+                    lhs.len(),
+                    rhs.len()
+                )));
+            }
+            (
+                normalize_axes(lhs, lhs_rank, "lhs")?,
+                normalize_axes(rhs, rhs_rank, "rhs")?,
+            )
+        }
+    };
+
+    let config = DotGeneralConfig {
+        lhs_contracting_dims,
+        rhs_contracting_dims,
+        lhs_batch_dims: Vec::new(),
+        rhs_batch_dims: Vec::new(),
+    };
+    config
+        .validate_dims_with_ranks(lhs_rank, rhs_rank)
+        .map_err(contraction_error)?;
+    Ok(config)
+}
+
+#[cfg(feature = "autodiff")]
+pub(crate) fn validate_concrete_contract_dims(
+    lhs_shape: &[usize],
+    rhs_shape: &[usize],
+    config: &DotGeneralConfig,
+) -> Result<()> {
+    config
+        .validate_dims_with_ranks(lhs_shape.len(), rhs_shape.len())
+        .map_err(contraction_error)?;
+    for (&lhs_axis, &rhs_axis) in config
+        .lhs_contracting_dims
+        .iter()
+        .zip(config.rhs_contracting_dims.iter())
+    {
+        let lhs_dim = lhs_shape[lhs_axis];
+        let rhs_dim = rhs_shape[rhs_axis];
+        if lhs_dim != rhs_dim {
+            return Err(contracted_dims_error(lhs_axis, lhs_dim, rhs_axis, rhs_dim));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_traced_contract_dims(
+    lhs: &TracedTensor,
+    rhs: &TracedTensor,
+    config: &DotGeneralConfig,
+) -> Result<()> {
+    config
+        .validate_dims_with_ranks(lhs.rank, rhs.rank)
+        .map_err(contraction_error)?;
+    for (&lhs_axis, &rhs_axis) in config
+        .lhs_contracting_dims
+        .iter()
+        .zip(config.rhs_contracting_dims.iter())
+    {
+        let lhs_dim = lhs.axis_sym_dim(lhs_axis);
+        let rhs_dim = rhs.axis_sym_dim(rhs_axis);
+        if lhs_dim == rhs_dim {
+            continue;
+        }
+        if let (Some(lhs_value), Some(rhs_value)) =
+            (lhs_dim.constant_value(), rhs_dim.constant_value())
+        {
+            if lhs_value != rhs_value {
+                return Err(contracted_dims_error(
+                    lhs_axis, lhs_value, rhs_axis, rhs_value,
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn normalize_axes(axes: &[isize], rank: usize, operand: &str) -> Result<Vec<usize>> {
+    let mut normalized = Vec::with_capacity(axes.len());
+    let mut seen = HashSet::with_capacity(axes.len());
+    for &axis in axes {
+        let normalized_axis = normalize_axis(axis, rank, operand)?;
+        if !seen.insert(normalized_axis) {
+            return Err(contraction_error(format!(
+                "duplicate {operand} axis {normalized_axis} in tensordot axes"
+            )));
+        }
+        normalized.push(normalized_axis);
+    }
+    Ok(normalized)
+}
+
+fn normalize_axis(axis: isize, rank: usize, operand: &str) -> Result<usize> {
+    let rank_isize = isize::try_from(rank).map_err(|_| {
+        contraction_error(format!(
+            "{operand} rank {rank} is too large to normalize tensordot axes"
+        ))
+    })?;
+    let normalized = if axis < 0 { rank_isize + axis } else { axis };
+    if normalized < 0 || normalized >= rank_isize {
+        return Err(contraction_error(format!(
+            "{operand} axis {axis} out of bounds for rank {rank}"
+        )));
+    }
+    usize::try_from(normalized).map_err(|_| {
+        contraction_error(format!(
+            "{operand} axis {axis} could not be normalized for rank {rank}"
+        ))
+    })
+}
+
+fn contracted_dims_error(
+    lhs_axis: usize,
+    lhs_dim: usize,
+    rhs_axis: usize,
+    rhs_dim: usize,
+) -> Error {
+    contraction_error(format!(
+        "contracted dimensions differ for lhs axis {lhs_axis} ({lhs_dim}) \
+         and rhs axis {rhs_axis} ({rhs_dim})"
+    ))
+}
+
+fn contraction_error(message: impl Into<String>) -> Error {
+    Error::ContractionError(message.into())
+}

--- a/tenferro-einsum/src/traced_tensor.rs
+++ b/tenferro-einsum/src/traced_tensor.rs
@@ -3,4 +3,38 @@
 //! This module is the canonical traced tensor namespace for the einsum
 //! extension crate. Root-level re-exports remain available for compatibility.
 
+use tenferro::error::Result;
+use tenferro::TracedTensor;
+
+use crate::TensorDotAxes;
+
 pub use crate::traced::{einsum, einsum_subscripts, einsum_subscripts_with, einsum_with};
+
+/// Build a traced NumPy-style tensor contraction from axis-pair sugar.
+///
+/// This helper lives in the einsum extension namespace because it is
+/// contraction sugar over `dot_general`, not a linear algebra facade. It does
+/// not require einsum runtime registration unless the surrounding graph also
+/// contains einsum extension ops.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::TracedTensor;
+/// use tenferro_einsum::{traced_tensor, TensorDotAxes};
+///
+/// let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
+/// let rhs = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
+/// let out = traced_tensor::tensordot(&lhs, &rhs, TensorDotAxes::Count(1)).unwrap();
+///
+/// assert_eq!(out.rank, 2);
+/// ```
+pub fn tensordot(
+    lhs: &TracedTensor,
+    rhs: &TracedTensor,
+    axes: TensorDotAxes<'_>,
+) -> Result<TracedTensor> {
+    let config = crate::tensordot::dot_general_config(axes, lhs.rank, rhs.rank)?;
+    crate::tensordot::validate_traced_contract_dims(lhs, rhs, &config)?;
+    Ok(lhs.dot_general(rhs, config))
+}

--- a/tenferro-einsum/tests/eager_tensor.rs
+++ b/tenferro-einsum/tests/eager_tensor.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use tenferro::{CpuBackend, EagerRuntime, EagerTensor, Tensor};
-use tenferro_einsum::eager_tensor::{einsum, einsum_subscripts};
-use tenferro_einsum::EinsumSubscripts;
+use tenferro_einsum::eager_tensor::{einsum, einsum_subscripts, tensordot};
+use tenferro_einsum::{EinsumSubscripts, TensorDotAxes};
 
 fn f64_data(tensor: &Tensor) -> &[f64] {
     tensor.as_slice::<f64>().unwrap()
@@ -34,6 +34,100 @@ fn eager_tensor_einsum_matmul_primal_matches_expected_values() {
 
     assert_eq!(c.data().shape(), &[2, 2]);
     assert_eq!(f64_data(c.data()), &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn eager_tensor_tensordot_count_contracts_last_lhs_with_first_rhs_axes() {
+    let ctx = test_ctx();
+    let lhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 3, 4], (1..=24).map(f64::from).collect::<Vec<_>>()),
+        ctx.clone(),
+    );
+    let rhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(
+            vec![3, 4, 2],
+            (1..=24).map(|value| f64::from(value) * 0.5).collect(),
+        ),
+        ctx.clone(),
+    );
+
+    let out = tensordot(&lhs, &rhs, TensorDotAxes::Count(2)).unwrap();
+
+    assert_eq!(out.data().shape(), &[2, 2]);
+    assert_eq!(f64_data(out.data()), &[611.0, 650.0, 1475.0, 1586.0]);
+}
+
+#[test]
+fn eager_tensor_tensordot_explicit_axes_accept_negative_indices() {
+    let ctx = test_ctx();
+    let lhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
+    let rhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ctx.clone(),
+    );
+
+    let out = tensordot(
+        &lhs,
+        &rhs,
+        TensorDotAxes::Axes {
+            lhs: &[-1],
+            rhs: &[0],
+        },
+    )
+    .unwrap();
+
+    assert_eq!(out.data().shape(), &[2, 2]);
+    assert_eq!(f64_data(out.data()), &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn eager_tensor_tensordot_rejects_shape_mismatch() {
+    let ctx = test_ctx();
+    let lhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]),
+        ctx.clone(),
+    );
+    let rhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]),
+        ctx.clone(),
+    );
+
+    let err = match tensordot(&lhs, &rhs, TensorDotAxes::Count(1)) {
+        Ok(_) => panic!("expected tensordot shape mismatch"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("contracted dimensions differ"));
+}
+
+#[test]
+fn eager_tensor_tensordot_rejects_explicit_out_of_bounds_axis() {
+    let ctx = test_ctx();
+    let lhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]),
+        ctx.clone(),
+    );
+    let rhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]),
+        ctx.clone(),
+    );
+
+    let err = match tensordot(
+        &lhs,
+        &rhs,
+        TensorDotAxes::Axes {
+            lhs: &[2],
+            rhs: &[0],
+        },
+    ) {
+        Ok(_) => panic!("expected explicit tensordot axis bounds error"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("lhs axis 2 out of bounds"));
 }
 
 #[test]

--- a/tenferro-einsum/tests/traced_correctness.rs
+++ b/tenferro-einsum/tests/traced_correctness.rs
@@ -7,7 +7,9 @@ use num_complex::Complex64;
 use tenferro::error::Result;
 use tenferro::{CpuBackend, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
 use tenferro_einsum::EinsumOptimize;
-use tenferro_einsum::{ContractionTree, NestedEinsum, Subscripts, EINSUM_EXTENSION_FAMILY_ID};
+use tenferro_einsum::{
+    ContractionTree, NestedEinsum, Subscripts, TensorDotAxes, EINSUM_EXTENSION_FAMILY_ID,
+};
 use tenferro_tensor::TypedTensor;
 
 // ============================================================================
@@ -147,6 +149,91 @@ fn traced_tensor_namespace_exposes_einsum() {
     let y = tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&a, &b], "ij,jk->ik").unwrap();
 
     assert_eq!(y.rank, 2);
+}
+
+#[test]
+fn traced_tensor_namespace_tensordot_count_contracts_last_lhs_with_first_rhs_axes() {
+    let lhs = TracedTensor::from_vec_col_major(
+        vec![2, 3, 4],
+        (1..=24).map(f64::from).collect::<Vec<_>>(),
+    );
+    let rhs = TracedTensor::from_vec_col_major(
+        vec![3, 4, 2],
+        (1..=24).map(|value| f64::from(value) * 0.5).collect(),
+    );
+
+    let out =
+        tenferro_einsum::traced_tensor::tensordot(&lhs, &rhs, TensorDotAxes::Count(2)).unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    let result = out.run_with(&mut executor).unwrap();
+
+    assert_eq!(result.shape(), &[2, 2]);
+    assert_close(get_v2(&result, &[0, 0]), 611.0, "tensordot_count[0,0]");
+    assert_close(get_v2(&result, &[1, 0]), 650.0, "tensordot_count[1,0]");
+    assert_close(get_v2(&result, &[0, 1]), 1475.0, "tensordot_count[0,1]");
+    assert_close(get_v2(&result, &[1, 1]), 1586.0, "tensordot_count[1,1]");
+}
+
+#[test]
+fn traced_tensor_namespace_tensordot_explicit_axes_accept_negative_indices() {
+    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let out = tenferro_einsum::traced_tensor::tensordot(
+        &lhs,
+        &rhs,
+        TensorDotAxes::Axes {
+            lhs: &[-1],
+            rhs: &[0],
+        },
+    )
+    .unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    let result = out.run_with(&mut executor).unwrap();
+
+    assert_eq!(result.shape(), &[2, 2]);
+    assert_eq!(get_f64_data(&result), &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn traced_tensor_namespace_tensordot_rejects_invalid_axes() {
+    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
+    let rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
+
+    let duplicate = match tenferro_einsum::traced_tensor::tensordot(
+        &lhs,
+        &rhs,
+        TensorDotAxes::Axes {
+            lhs: &[0, 0],
+            rhs: &[0, 1],
+        },
+    ) {
+        Ok(_) => panic!("expected duplicate tensordot axis error"),
+        Err(err) => err,
+    };
+    assert!(duplicate.to_string().contains("duplicate lhs axis"));
+
+    let out_of_bounds =
+        match tenferro_einsum::traced_tensor::tensordot(&lhs, &rhs, TensorDotAxes::Count(3)) {
+            Ok(_) => panic!("expected Count(3) tensordot axis error"),
+            Err(err) => err,
+        };
+    assert!(out_of_bounds.to_string().contains("Count(3)"));
+
+    let explicit_out_of_bounds = match tenferro_einsum::traced_tensor::tensordot(
+        &lhs,
+        &rhs,
+        TensorDotAxes::Axes {
+            lhs: &[2],
+            rhs: &[0],
+        },
+    ) {
+        Ok(_) => panic!("expected explicit tensordot axis bounds error"),
+        Err(err) => err,
+    };
+    assert!(explicit_out_of_bounds
+        .to_string()
+        .contains("lhs axis 2 out of bounds"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `TensorDotAxes` and `tenferro_einsum::traced_tensor::tensordot` / `eager_tensor::tensordot`
- normalize negative axes, reject duplicate/out-of-bounds axes, and validate contracted dimension sizes before dispatch
- document tensordot as einsum-extension contraction sugar rather than linalg

Closes #894

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p tenferro-einsum --release`
- `cargo check -p tenferro-einsum --no-default-features --features cpu-faer` (existing `tenferro` dead_code warning only)
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Authored with OpenAI Codex.