### PR TITLE
[codex] Fix batched solve backward transpose

### DIFF
--- a/tenferro-linalg/src/extension.rs
+++ b/tenferro-linalg/src/extension.rs
@@ -231,7 +231,8 @@ fn execute_linalg<B: TensorBackend>(
         LinalgOp::Solve { transpose_a } => {
             let a_transposed;
             let a = if transpose_a {
-                a_transposed = backend.transpose(inputs[0], &[1, 0])?;
+                let perm = matrix_transpose_perm(inputs[0])?;
+                a_transposed = backend.transpose(inputs[0], &perm)?;
                 &a_transposed
             } else {
                 inputs[0]
@@ -252,6 +253,19 @@ fn execute_linalg<B: TensorBackend>(
             unit_diagonal,
         )?]),
     }
+}
+
+fn matrix_transpose_perm(input: &Tensor) -> tenferro_tensor::Result<Vec<usize>> {
+    let rank = input.shape().len();
+    if rank < 2 {
+        return Err(tenferro_tensor::Error::InvalidConfig {
+            op: "solve",
+            message: "matrix operand rank must be at least 2".into(),
+        });
+    }
+    let mut perm: Vec<usize> = (0..rank).collect();
+    perm.swap(0, 1);
+    Ok(perm)
 }
 
 fn lu_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {

--- a/tenferro-linalg/tests/eager_tensor.rs
+++ b/tenferro-linalg/tests/eager_tensor.rs
@@ -2,12 +2,21 @@
 
 use num_complex::Complex64;
 use std::sync::{Arc, OnceLock};
-use tenferro_ad::{CpuBackend, EagerRuntime, EagerTensor, Tensor};
+use tenferro_ad::{AdContext, CpuBackend, EagerRuntime, EagerTensor, Tensor};
 
 fn test_ctx() -> Arc<EagerRuntime> {
     static CTX: OnceLock<Arc<EagerRuntime>> = OnceLock::new();
     CTX.get_or_init(|| EagerRuntime::with_cpu_backend(CpuBackend::new()))
         .clone()
+}
+
+fn ad_test_ctx() -> Arc<EagerRuntime> {
+    let ad = AdContext::builder()
+        .with_core_rules()
+        .with_extension_rules(tenferro_linalg::ad_rules().unwrap())
+        .build()
+        .unwrap();
+    EagerRuntime::with_cpu_backend_and_ad_context(CpuBackend::new(), &ad)
 }
 
 fn f64_data(tensor: &Tensor) -> &[f64] {
@@ -16,6 +25,17 @@ fn f64_data(tensor: &Tensor) -> &[f64] {
 
 fn c64_data(tensor: &Tensor) -> &[Complex64] {
     tensor.as_slice::<Complex64>().unwrap()
+}
+
+fn assert_close_slice(actual: &[f64], expected: &[f64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (&actual, &expected)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (actual - expected).abs();
+        assert!(
+            diff <= tol,
+            "idx {idx}: expected {expected}, got {actual}, diff {diff}"
+        );
+    }
 }
 
 #[test]
@@ -104,6 +124,34 @@ fn solve_returns_expected_solution() {
 
     assert_eq!(x.data().shape(), &[2, 1]);
     assert_eq!(f64_data(x.data()), &[2.0, 2.0]);
+}
+
+#[test]
+fn batched_solve_sum_backward_wrt_matrix_uses_native_batch_layout() {
+    let ctx = ad_test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(
+            vec![2, 2, 2],
+            vec![2.0_f64, 0.0, 0.0, 4.0, 3.0, 0.0, 0.0, 5.0],
+        ),
+        ctx.clone(),
+    );
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 1, 2], vec![4.0_f64, 8.0, 6.0, 10.0]),
+        ctx,
+    );
+
+    let x = tenferro_linalg::eager_tensor::solve(&a, &b).unwrap();
+    let loss = x.reduce_sum(&[0, 1, 2]).unwrap();
+    let _ = loss.backward().unwrap();
+    let grad = a.grad().unwrap();
+
+    assert_eq!(grad.shape(), &[2, 2, 2]);
+    assert_close_slice(
+        f64_data(grad.as_ref()),
+        &[-1.0, -0.5, -1.0, -0.5, -2.0 / 3.0, -0.4, -2.0 / 3.0, -0.4],
+        1.0e-12,
+    );
 }
 
 #[test]

--- a/tenferro-linalg/tests/traced_ad_explicit.rs
+++ b/tenferro-linalg/tests/traced_ad_explicit.rs
@@ -52,6 +52,17 @@ fn assert_finite_tensor(tensor: &Tensor) {
     panic!("expected floating tensor, got {:?}", tensor.dtype());
 }
 
+fn assert_close_slice(actual: &[f64], expected: &[f64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (&actual, &expected)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (actual - expected).abs();
+        assert!(
+            diff <= tol,
+            "idx {idx}: expected {expected}, got {actual}, diff {diff}"
+        );
+    }
+}
+
 fn ad_context() -> AdContext {
     AdContext::builder()
         .with_core_rules()
@@ -219,6 +230,32 @@ fn solve_and_triangular_solve_grad_use_extension_transpose_rules() {
         assert_eq!(result.shape(), &[2, 1]);
         assert_eq!(get_f64_data(result), &[0.5, 0.25]);
     }
+}
+
+#[test]
+fn batched_solve_sum_grad_wrt_matrix_uses_native_batch_layout() {
+    let ad = ad_context();
+
+    let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(
+        vec![2, 2, 2],
+        vec![2.0, 0.0, 0.0, 4.0, 3.0, 0.0, 0.0, 5.0],
+    ));
+    let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(
+        vec![2, 1, 2],
+        vec![4.0, 8.0, 6.0, 10.0],
+    ));
+
+    let x = tenferro_linalg::solve(&a, &b);
+    let loss = x.reduce_sum(&[0, 1, 2]);
+    let grad_a = ad.grad(&loss, &a).unwrap();
+    let out = eval(&grad_a);
+
+    assert_eq!(out.shape(), &[2, 2, 2]);
+    assert_close_slice(
+        get_f64_data(&out),
+        &[-1.0, -0.5, -1.0, -0.5, -2.0 / 3.0, -0.4, -2.0 / 3.0, -0.4],
+        1.0e-12,
+    );
 }
 
 fn finite_diff_scalar(f: impl Fn(&[f64]) -> f64, base: &[f64], index: usize, step: f64) -> f64 {


### PR DESCRIPTION
## Summary
- Fix linalg extension execution for `Solve { transpose_a: true }` on batched matrix operands by building a rank-aware matrix transpose permutation.
- Add eager and traced AD regressions for native batched solve backward through a sum loss, including exact gradient checks.

## Root Cause
`Solve { transpose_a: true }` used the fixed 2-D permutation `[1, 0]`. For batched solve backward, the matrix operand is rank 3, so the extension executor failed with a transpose rank mismatch before native batched solve could run.

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `git diff --check`

Closes #896

Generated with Codex.