### PR TITLE
Split TensorBackend into capability traits

### DIFF
--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -41,7 +41,7 @@ For a time-axis diagram, see [Execution Models](execution-models.md).
 <!-- snippet-source: tenferro-gpu/examples/cuda_quickstart.rs -->
 ```rust
 use tenferro_gpu::{download_tensor, upload_tensor, CubeclBackend as CudaBackend};
-use tenferro_tensor::{Tensor, TensorBackend};
+use tenferro_tensor::{Tensor, TensorElementwise};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !tenferro_gpu::gpu_available() {

--- a/tenferro-ad/src/eager_backend.rs
+++ b/tenferro-ad/src/eager_backend.rs
@@ -2,9 +2,11 @@
 use tenferro_gpu::cubecl::CubeclBackend;
 use tenferro_tensor::cpu::CpuBackend;
 use tenferro_tensor::{
-    BackendSession, CompareDir, DType, DotGeneralConfig, ElementwiseFusionPlan, GatherConfig,
-    PadConfig, Result as TensorResult, ScatterConfig, SliceConfig, Tensor, TensorBackend,
-    TensorRead,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir, DType,
+    DotGeneralConfig, ElementwiseFusionPlan, GatherConfig, PadConfig, Result as TensorResult,
+    ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
+    TensorReduction, TensorStructural,
 };
 
 pub enum EagerBackend {
@@ -44,9 +46,11 @@ macro_rules! delegate_tensor_backend_methods {
     };
 }
 
-impl TensorBackend for EagerBackend {
+impl BackendRuntimeCache for EagerBackend {
     type RuntimeCache = ();
+}
 
+impl TensorElementwise for EagerBackend {
     delegate_tensor_backend_methods! {
         fn add(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
         fn mul(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
@@ -60,6 +64,11 @@ impl TensorBackend for EagerBackend {
         fn compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> TensorResult<Tensor>;
         fn select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> TensorResult<Tensor>;
         fn clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> TensorResult<Tensor>;
+    }
+}
+
+impl TensorAnalytic for EagerBackend {
+    delegate_tensor_backend_methods! {
         fn exp(input: &Tensor) -> TensorResult<Tensor>;
         fn log(input: &Tensor) -> TensorResult<Tensor>;
         fn sin(input: &Tensor) -> TensorResult<Tensor>;
@@ -70,6 +79,11 @@ impl TensorBackend for EagerBackend {
         fn pow(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
         fn expm1(input: &Tensor) -> TensorResult<Tensor>;
         fn log1p(input: &Tensor) -> TensorResult<Tensor>;
+    }
+}
+
+impl TensorStructural for EagerBackend {
+    delegate_tensor_backend_methods! {
         fn transpose(input: &Tensor, perm: &[usize]) -> TensorResult<Tensor>;
         fn reshape(input: &Tensor, shape: &[usize]) -> TensorResult<Tensor>;
         fn broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> TensorResult<Tensor>;
@@ -78,13 +92,28 @@ impl TensorBackend for EagerBackend {
         fn embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult<Tensor>;
         fn tril(input: &Tensor, k: i64) -> TensorResult<Tensor>;
         fn triu(input: &Tensor, k: i64) -> TensorResult<Tensor>;
+    }
+}
+
+impl TensorReduction for EagerBackend {
+    delegate_tensor_backend_methods! {
         fn reduce_sum(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
         fn reduce_prod(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
         fn reduce_max(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
         fn reduce_min(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+    }
+}
+
+impl TensorDot for EagerBackend {
+    delegate_tensor_backend_methods! {
         fn dot_general(lhs: &Tensor, rhs: &Tensor, config: &DotGeneralConfig) -> TensorResult<Tensor>;
         fn dot_general_read(lhs: TensorRead<'_>, rhs: TensorRead<'_>, config: &DotGeneralConfig) -> TensorResult<Tensor>;
         fn dot_general_with_conj(lhs: &Tensor, rhs: &Tensor, config: &DotGeneralConfig, lhs_conj: bool, rhs_conj: bool) -> TensorResult<Tensor>;
+    }
+}
+
+impl TensorIndexing for EagerBackend {
+    delegate_tensor_backend_methods! {
         fn gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> TensorResult<Tensor>;
         fn scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> TensorResult<Tensor>;
         fn slice(input: &Tensor, config: &SliceConfig) -> TensorResult<Tensor>;
@@ -94,18 +123,33 @@ impl TensorBackend for EagerBackend {
         fn concatenate(inputs: &[&Tensor], axis: usize) -> TensorResult<Tensor>;
         fn reverse(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
     }
+}
 
-    fn with_backend_session<R: Send>(
-        &mut self,
-        f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
-    ) -> R {
+impl BackendSessionHost for EagerBackend {
+    fn with_backend_session<R>(&mut self, f: impl FnOnce(&mut dyn BackendSession) -> R) -> R {
         dispatch!(self, with_backend_session(f))
     }
+}
 
+impl TensorDeviceTransfer for EagerBackend {
     delegate_tensor_backend_methods! {
         fn download_to_host(tensor: &Tensor) -> TensorResult<Tensor>;
         fn upload_host_tensor(tensor: &Tensor) -> TensorResult<Tensor>;
+    }
+}
+
+impl TensorBuffer for EagerBackend {
+    delegate_tensor_backend_methods! {
         fn reclaim_buffer(tensor: Tensor) -> ();
+    }
+}
+
+impl TensorFusion for EagerBackend {
+    delegate_tensor_backend_methods! {
         fn execute_elementwise_fusion(inputs: &[&Tensor], plan: &ElementwiseFusionPlan) -> TensorResult<Option<Vec<Tensor>>>;
     }
 }
+
+impl BackendCachedDot for EagerBackend {}
+
+impl TensorBackend for EagerBackend {}

--- a/tenferro-ad/tests/ad.rs
+++ b/tenferro-ad/tests/ad.rs
@@ -29,7 +29,7 @@ use tenferro_runtime::{GraphExecutor, TracedTensor};
 use tenferro_tensor::cpu::CpuBackend;
 use tenferro_tensor::{
     DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor,
-    TensorBackend, TypedTensor,
+    TensorReduction, TypedTensor,
 };
 use tidu::{differentiate, transpose, LinearFragment};
 

--- a/tenferro-ad/tests/exec_dispatch.rs
+++ b/tenferro-ad/tests/exec_dispatch.rs
@@ -4,8 +4,10 @@ use tenferro_ops::ShapeExtent;
 use tenferro_runtime::error::Error;
 use tenferro_runtime::exec::{eval_exec_ir, ExecInstruction, ExecOp, ExecProgram};
 use tenferro_tensor::{
-    CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
-    Tensor, TensorBackend, TypedTensor,
+    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, CompareDir, DType, DotGeneralConfig,
+    GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend,
+    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorReduction, TensorStructural, TypedTensor,
 };
 
 fn dim_shape(shape: &[usize]) -> Vec<DimExpr> {
@@ -103,9 +105,11 @@ impl FakeTensorBackend {
     }
 }
 
-impl TensorBackend for FakeTensorBackend {
+impl BackendRuntimeCache for FakeTensorBackend {
     type RuntimeCache = ();
+}
 
+impl TensorElementwise for FakeTensorBackend {
     fn add(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("add", 1.0)
     }
@@ -157,6 +161,9 @@ impl TensorBackend for FakeTensorBackend {
     ) -> tenferro_tensor::Result<Tensor> {
         self.result("clamp", 12.0)
     }
+}
+
+impl TensorAnalytic for FakeTensorBackend {
     fn exp(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("exp", 13.0)
     }
@@ -187,6 +194,9 @@ impl TensorBackend for FakeTensorBackend {
     fn log1p(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.result("log1p", 22.0)
     }
+}
+
+impl TensorStructural for FakeTensorBackend {
     fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("transpose", 23.0)
     }
@@ -226,6 +236,9 @@ impl TensorBackend for FakeTensorBackend {
     fn triu(&mut self, _input: &Tensor, _k: i64) -> tenferro_tensor::Result<Tensor> {
         self.result("triu", 27.75)
     }
+}
+
+impl TensorReduction for FakeTensorBackend {
     fn reduce_sum(&mut self, _input: &Tensor, _axes: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("reduce_sum", 28.0)
     }
@@ -238,6 +251,9 @@ impl TensorBackend for FakeTensorBackend {
     fn reduce_min(&mut self, _input: &Tensor, _axes: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("reduce_min", 31.0)
     }
+}
+
+impl TensorDot for FakeTensorBackend {
     fn dot_general(
         &mut self,
         _lhs: &Tensor,
@@ -246,6 +262,9 @@ impl TensorBackend for FakeTensorBackend {
     ) -> tenferro_tensor::Result<Tensor> {
         self.result("dot_general", 32.0)
     }
+}
+
+impl TensorIndexing for FakeTensorBackend {
     fn gather(
         &mut self,
         _operand: &Tensor,
@@ -296,10 +315,23 @@ impl TensorBackend for FakeTensorBackend {
     fn reverse(&mut self, _input: &Tensor, _axes: &[usize]) -> tenferro_tensor::Result<Tensor> {
         self.result("reverse", 39.0)
     }
+}
+
+impl TensorBuffer for FakeTensorBackend {
     fn reclaim_buffer(&mut self, _tensor: Tensor) {
         self.reclaimed += 1;
     }
 }
+
+impl TensorFusion for FakeTensorBackend {}
+
+impl TensorDeviceTransfer for FakeTensorBackend {}
+
+impl BackendCachedDot for FakeTensorBackend {}
+
+impl BackendSessionHost for FakeTensorBackend {}
+
+impl TensorBackend for FakeTensorBackend {}
 
 #[test]
 fn eval_exec_ir_dispatches_tensor_ops_to_backend_methods() {

--- a/tenferro-einsum/src/eager/tests.rs
+++ b/tenferro-einsum/src/eager/tests.rs
@@ -1,4 +1,4 @@
-use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend, TensorRead, TensorView};
+use tenferro_tensor::{cpu::CpuBackend, BackendSessionHost, Tensor, TensorRead, TensorView};
 
 use super::{
     binary_contract, eager_einsum_exec_read, try_eager_einsum_binary_read_fast, LabeledTensor,

--- a/tenferro-einsum/src/typed_eager_tests.rs
+++ b/tenferro-einsum/src/typed_eager_tests.rs
@@ -1,6 +1,8 @@
 use tenferro_tensor::{
-    cpu::CpuBackend, CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
-    SliceConfig, Tensor, TensorBackend, TensorRead, TensorView, TypedTensor,
+    cpu::CpuBackend, BackendCachedDot, BackendRuntimeCache, BackendSessionHost, CompareDir, DType,
+    DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor, TensorAnalytic,
+    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorRead, TensorReduction, TensorStructural, TensorView, TypedTensor,
 };
 
 use crate::eager::{
@@ -24,9 +26,11 @@ macro_rules! panic_backend_methods {
     };
 }
 
-impl TensorBackend for WrongDTypeBackend {
+impl BackendRuntimeCache for WrongDTypeBackend {
     type RuntimeCache = ();
+}
 
+impl TensorElementwise for WrongDTypeBackend {
     panic_backend_methods! {
         add(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
         mul(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
@@ -39,6 +43,15 @@ impl TensorBackend for WrongDTypeBackend {
         compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> tenferro_tensor::Result<Tensor>;
         select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> tenferro_tensor::Result<Tensor>;
         clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> tenferro_tensor::Result<Tensor>;
+    }
+
+    fn conj(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+        CpuBackend::new().conj(input)
+    }
+}
+
+impl TensorAnalytic for WrongDTypeBackend {
+    panic_backend_methods! {
         exp(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
         log(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
         sin(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
@@ -49,6 +62,11 @@ impl TensorBackend for WrongDTypeBackend {
         pow(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
         expm1(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
         log1p(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+    }
+}
+
+impl TensorStructural for WrongDTypeBackend {
+    panic_backend_methods! {
         transpose(input: &Tensor, perm: &[usize]) -> tenferro_tensor::Result<Tensor>;
         reshape(input: &Tensor, shape: &[usize]) -> tenferro_tensor::Result<Tensor>;
         broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> tenferro_tensor::Result<Tensor>;
@@ -57,10 +75,20 @@ impl TensorBackend for WrongDTypeBackend {
         embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> tenferro_tensor::Result<Tensor>;
         tril(input: &Tensor, k: i64) -> tenferro_tensor::Result<Tensor>;
         triu(input: &Tensor, k: i64) -> tenferro_tensor::Result<Tensor>;
+    }
+}
+
+impl TensorReduction for WrongDTypeBackend {
+    panic_backend_methods! {
         reduce_sum(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
         reduce_prod(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
         reduce_max(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
         reduce_min(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+    }
+}
+
+impl TensorIndexing for WrongDTypeBackend {
+    panic_backend_methods! {
         gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> tenferro_tensor::Result<Tensor>;
         scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> tenferro_tensor::Result<Tensor>;
         slice(input: &Tensor, config: &SliceConfig) -> tenferro_tensor::Result<Tensor>;
@@ -70,7 +98,9 @@ impl TensorBackend for WrongDTypeBackend {
         concatenate(inputs: &[&Tensor], axis: usize) -> tenferro_tensor::Result<Tensor>;
         reverse(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
     }
+}
 
+impl TensorDot for WrongDTypeBackend {
     fn dot_general(
         &mut self,
         _lhs: &Tensor,
@@ -82,11 +112,19 @@ impl TensorBackend for WrongDTypeBackend {
             vec![1.0, 2.0, 3.0, 4.0],
         )))
     }
-
-    fn conj(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
-        CpuBackend::new().conj(input)
-    }
 }
+
+impl BackendCachedDot for WrongDTypeBackend {}
+
+impl BackendSessionHost for WrongDTypeBackend {}
+
+impl TensorDeviceTransfer for WrongDTypeBackend {}
+
+impl TensorBuffer for WrongDTypeBackend {}
+
+impl TensorFusion for WrongDTypeBackend {}
+
+impl TensorBackend for WrongDTypeBackend {}
 
 #[test]
 fn typed_einsum_f64() {
@@ -218,12 +256,18 @@ fn tensor_backend_default_cached_methods_delegate_to_backend_ops() {
     let mut backend = WrongDTypeBackend;
     let mut cache = ();
 
-    let direct =
-        TensorBackend::dot_general_cached(&mut backend, &mut cache, Some(7), &lhs, &rhs, &config)
-            .unwrap();
+    let direct = BackendCachedDot::dot_general_cached(
+        &mut backend,
+        &mut cache,
+        Some(7),
+        &lhs,
+        &rhs,
+        &config,
+    )
+    .unwrap();
     assert_eq!(direct.shape(), &[2, 2]);
 
-    let read = TensorBackend::dot_general_read(
+    let read = TensorDot::dot_general_read(
         &mut backend,
         TensorRead::from_tensor(&lhs),
         TensorRead::from_tensor(&rhs),
@@ -234,7 +278,7 @@ fn tensor_backend_default_cached_methods_delegate_to_backend_ops() {
 
     let rhs_shape = [1usize, 1];
     let rhs_data = [3.0_f64];
-    let read_view = TensorBackend::dot_general_read(
+    let read_view = TensorDot::dot_general_read(
         &mut backend,
         TensorRead::from_tensor(&lhs),
         TensorRead::from_view(TensorView::f64(&rhs_shape, &rhs_data).unwrap()),
@@ -244,11 +288,10 @@ fn tensor_backend_default_cached_methods_delegate_to_backend_ops() {
     assert_eq!(read_view.shape(), &[2, 2]);
 
     let folded =
-        TensorBackend::dot_general_with_conj(&mut backend, &lhs, &rhs, &config, true, true)
-            .unwrap();
+        TensorDot::dot_general_with_conj(&mut backend, &lhs, &rhs, &config, true, true).unwrap();
     assert_eq!(folded.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
 
-    let value = TensorBackend::with_backend_session_cached(&mut backend, &mut cache, |exec| {
+    let value = BackendSessionHost::with_backend_session_cached(&mut backend, &mut cache, |exec| {
         let cached = exec
             .dot_general_cached(Some(3), &lhs, &rhs, &config)
             .unwrap();

--- a/tenferro-gpu/examples/cuda_quickstart.rs
+++ b/tenferro-gpu/examples/cuda_quickstart.rs
@@ -1,5 +1,5 @@
 use tenferro_gpu::{download_tensor, upload_tensor, CubeclBackend as CudaBackend};
-use tenferro_tensor::{Tensor, TensorBackend};
+use tenferro_tensor::{Tensor, TensorElementwise};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !tenferro_gpu::gpu_available() {

--- a/tenferro-gpu/src/cubecl/mod.rs
+++ b/tenferro-gpu/src/cubecl/mod.rs
@@ -39,7 +39,7 @@
 //!
 //! ```rust
 //! use tenferro_gpu::cubecl::{CubeclBackend, upload_tensor, download_tensor};
-//! use tenferro_tensor::{Tensor, TensorBackend, TypedTensor};
+//! use tenferro_tensor::{Tensor, TensorElementwise, TypedTensor};
 //!
 //! fn main() -> tenferro_tensor::Result<()> {
 //! // 1. Create the GPU backend (device ordinal 0)
@@ -87,7 +87,11 @@ use cubecl_cuda::CudaRuntime;
 use num_complex::{Complex32, Complex64};
 use tenferro_core_ops::PrimitiveOpKind;
 
-use crate::backend::TensorBackend;
+use crate::backend::{
+    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, TensorAnalytic, TensorBackend,
+    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorReduction, TensorStructural,
+};
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
@@ -1276,9 +1280,11 @@ impl CubeclBackend {
     }
 }
 
-impl TensorBackend for CubeclBackend {
+impl BackendRuntimeCache for CubeclBackend {
     type RuntimeCache = ();
+}
 
+impl TensorElementwise for CubeclBackend {
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         dispatch::dispatch_binary_float_complex!(
             self,
@@ -1537,7 +1543,9 @@ impl TensorBackend for CubeclBackend {
             _ => Err(ternary_dtype_mismatch(op, input, lower, upper)),
         }
     }
+}
 
+impl TensorAnalytic for CubeclBackend {
     fn exp(&mut self, input: &Tensor) -> crate::Result<Tensor> {
         dispatch::dispatch_unary_float_only!(self, input, PrimitiveOpKind::Exp, exp_float)
     }
@@ -1577,7 +1585,9 @@ impl TensorBackend for CubeclBackend {
     fn log1p(&mut self, input: &Tensor) -> crate::Result<Tensor> {
         dispatch::dispatch_unary_float_only!(self, input, PrimitiveOpKind::Log1p, log1p_float)
     }
+}
 
+impl TensorStructural for CubeclBackend {
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
         match input {
             Tensor::F32(t) => self.transpose_typed(t, perm).map(Tensor::F32),
@@ -1788,7 +1798,9 @@ impl TensorBackend for CubeclBackend {
             Tensor::C64(t) => self.triu_typed(t, k).map(Tensor::C64),
         }
     }
+}
 
+impl TensorReduction for CubeclBackend {
     fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         let op = op_name(
             PrimitiveOpKind::ReduceSum,
@@ -1854,7 +1866,9 @@ impl TensorBackend for CubeclBackend {
             }
         }
     }
+}
 
+impl TensorDot for CubeclBackend {
     fn dot_general(
         &mut self,
         lhs: &Tensor,
@@ -1874,7 +1888,9 @@ impl TensorBackend for CubeclBackend {
     ) -> crate::Result<Tensor> {
         gemm::dot_general_with_conj(self, lhs, rhs, config, lhs_conj, rhs_conj)
     }
+}
 
+impl TensorIndexing for CubeclBackend {
     fn gather(
         &mut self,
         operand: &Tensor,
@@ -2221,7 +2237,9 @@ impl TensorBackend for CubeclBackend {
             Tensor::C64(t) => self.reverse_typed(t, axes).map(Tensor::C64),
         }
     }
+}
 
+impl TensorDeviceTransfer for CubeclBackend {
     fn download_to_host(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         download_tensor(self.runtime(), tensor)
     }
@@ -2229,7 +2247,9 @@ impl TensorBackend for CubeclBackend {
     fn upload_host_tensor(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         upload_tensor(self.runtime(), tensor)
     }
+}
 
+impl TensorFusion for CubeclBackend {
     fn execute_elementwise_fusion(
         &mut self,
         inputs: &[&Tensor],
@@ -2238,6 +2258,14 @@ impl TensorBackend for CubeclBackend {
         fusion::execute_elementwise_fusion(self, inputs, plan)
     }
 }
+
+impl BackendCachedDot for CubeclBackend {}
+
+impl BackendSessionHost for CubeclBackend {}
+
+impl TensorBuffer for CubeclBackend {}
+
+impl TensorBackend for CubeclBackend {}
 
 fn validate_permutation(op: &'static str, perm: &[usize], rank: usize) -> crate::Result<()> {
     ensure_rank(op, rank, perm.len())?;

--- a/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
@@ -1,7 +1,8 @@
 // Run with: cargo test --features cuda -- --ignored
 use crate::config::CompareDir;
 use crate::cubecl::gpu_available;
-use crate::{DType, DeviceKind, GpuBackendKind, Tensor, TensorBackend};
+use crate::{DType, DeviceKind, GpuBackendKind, Tensor};
+use tenferro_tensor::{TensorAnalytic, TensorElementwise, TensorStructural};
 
 use super::{
     assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c64, tensor_f64, upload,

--- a/tenferro-gpu/src/cubecl/tests/fusion_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/fusion_tests.rs
@@ -1,6 +1,7 @@
 // Run with: cargo test --features cuda -- --ignored
 use crate::backend::ElementwiseFusionPlan;
-use crate::{ElementwiseFusionInst, ElementwiseFusionOp, TensorBackend};
+use crate::{ElementwiseFusionInst, ElementwiseFusionOp};
+use tenferro_tensor::{TensorAnalytic, TensorElementwise, TensorFusion};
 
 use super::{
     assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c32, tensor_c64, tensor_f64,

--- a/tenferro-gpu/src/cubecl/tests/gemm_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/gemm_tests.rs
@@ -3,7 +3,7 @@ use num_complex::{Complex32, Complex64};
 
 use crate::DotGeneralConfig;
 use crate::Tensor;
-use crate::TensorBackend;
+use tenferro_tensor::TensorDot;
 
 use super::{
     assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c32, tensor_c64, tensor_f32,

--- a/tenferro-gpu/src/cubecl/tests/indexing_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/indexing_tests.rs
@@ -1,7 +1,7 @@
 // Run with: cargo test --features cuda -- --ignored
 use crate::config::{PadConfig, ScatterConfig, SliceConfig};
-use crate::TensorBackend;
 use num_complex::Complex64;
+use tenferro_tensor::TensorIndexing;
 
 use super::{
     assert_tensor_close, cpu_backend, diagonal_scatter_config, download, gpu_backend,

--- a/tenferro-gpu/src/cubecl/tests/reduction_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/reduction_tests.rs
@@ -1,5 +1,5 @@
 // Run with: cargo test --features cuda -- --ignored
-use crate::TensorBackend;
+use tenferro_tensor::TensorReduction;
 
 use super::{
     assert_tensor_close, cpu_backend, download, gpu_backend, tensor_bool, tensor_c64, tensor_f64,

--- a/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
@@ -5,7 +5,7 @@ use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 use crate::cubecl::memory::{device_ptr, download_tensor, upload_tensor};
 use crate::cubecl::{gpu_available, CubeclBackend, CubeclRuntime};
 use crate::Tensor;
-use crate::TensorBackend;
+use tenferro_tensor::TensorElementwise;
 
 #[cube(launch_unchecked)]
 fn kernel_add_f64(output: &mut Array<f64>, a: &Array<f64>, b: &Array<f64>) {

--- a/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -1,6 +1,6 @@
 // Run with: cargo test --features cuda -- --ignored
 use crate::DType;
-use crate::TensorBackend;
+use tenferro_tensor::{TensorIndexing, TensorStructural};
 
 use super::{
     assert_tensor_close, cpu_backend, download, gpu_backend, tensor_bool, tensor_c64, tensor_f64,

--- a/tenferro-gpu/src/lib.rs
+++ b/tenferro-gpu/src/lib.rs
@@ -6,7 +6,7 @@
 //! #[cfg(feature = "cuda")]
 //! {
 //!     use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CubeclBackend};
-//!     use tenferro_tensor::{Tensor, TensorBackend};
+//!     use tenferro_tensor::{Tensor, TensorElementwise};
 //!
 //!     if gpu_available() {
 //!         let mut backend = CubeclBackend::new(0).unwrap();

--- a/tenferro-linalg/src/cpu/backend.rs
+++ b/tenferro-linalg/src/cpu/backend.rs
@@ -3,7 +3,7 @@ use crate::backend::LinalgBackend;
 use super::linalg;
 
 use tenferro_tensor::cpu::CpuBackend;
-use tenferro_tensor::{DType, Error, Tensor, TensorBackend, TypedTensor};
+use tenferro_tensor::{DType, Error, Tensor, TensorStructural, TypedTensor};
 
 impl LinalgBackend for CpuBackend {
     fn cholesky(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {

--- a/tenferro-linalg/src/gpu/linalg.rs
+++ b/tenferro-linalg/src/gpu/linalg.rs
@@ -22,7 +22,10 @@ use tenferro_tensor::config::{DotGeneralConfig, SliceConfig};
 // validate_nonsingular_gpu uses backend ops (extract_diagonal, abs, reduce_min)
 // then downloads a single scalar — no bulk host roundtrip.
 use tenferro_gpu::CubeclBuffer;
-use tenferro_tensor::{Buffer, DType, Error, Tensor, TensorBackend, TypedTensor};
+use tenferro_tensor::{
+    Buffer, DType, Error, Tensor, TensorDot, TensorElementwise, TensorReduction, TensorStructural,
+    TypedTensor,
+};
 
 type Result<T> = tenferro_tensor::Result<T>;
 

--- a/tenferro-linalg/tests/full_piv_lu.rs
+++ b/tenferro-linalg/tests/full_piv_lu.rs
@@ -1,5 +1,7 @@
 use tenferro_linalg::LinalgBackend;
-use tenferro_tensor::{cpu::CpuBackend, DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
+use tenferro_tensor::{
+    cpu::CpuBackend, DotGeneralConfig, Tensor, TensorDot, TensorStructural, TypedTensor,
+};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data))

--- a/tenferro-tensor/benches/cpu_install_overhead.rs
+++ b/tenferro-tensor/benches/cpu_install_overhead.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tenferro_tensor::{
     buffer_pool::BufferPool,
     cpu::{CpuBackend, CpuContext},
-    TensorBackend,
+    BackendRuntimeCache,
 };
 
 fn bench_cpu_context_entry_overhead(c: &mut Criterion) {
@@ -43,7 +43,7 @@ fn bench_cpu_context_entry_overhead(c: &mut Criterion) {
     group.bench_function("ctx_install_inline_with_buffer_pool_and_cache", |b| {
         let ctx = CpuContext::with_threads(1);
         let mut buffers = BufferPool::new();
-        let mut cache = <CpuBackend as TensorBackend>::RuntimeCache::default();
+        let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
         b.iter(|| {
             let mut taken = std::mem::take(black_box(&mut buffers));
             let (result, returned) = ctx.install(|| {

--- a/tenferro-tensor/benches/dot_general_overhead.rs
+++ b/tenferro-tensor/benches/dot_general_overhead.rs
@@ -1,6 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use num_complex::Complex64;
-use tenferro_tensor::{cpu::CpuBackend, DotGeneralConfig, Tensor, TensorBackend};
+use tenferro_tensor::{
+    cpu::CpuBackend, BackendCachedDot, BackendRuntimeCache, BackendSessionHost, DotGeneralConfig,
+    Tensor, TensorDot,
+};
 
 const L: usize = 32;
 const PHYS_DIM: usize = 2;
@@ -100,7 +103,7 @@ fn inner_fresh_backend_cache(
 
 fn inner_persistent_backend_cache(
     backend: &mut CpuBackend,
-    cache: &mut <CpuBackend as TensorBackend>::RuntimeCache,
+    cache: &mut <CpuBackend as BackendRuntimeCache>::RuntimeCache,
     bra: &[Tensor],
     ket: &[Tensor],
     configs: &LocalPathConfigs,
@@ -135,7 +138,7 @@ fn inner_persistent_backend_cache(
 
 fn inner_single_exec_session(
     backend: &mut CpuBackend,
-    cache: &mut <CpuBackend as TensorBackend>::RuntimeCache,
+    cache: &mut <CpuBackend as BackendRuntimeCache>::RuntimeCache,
     bra: &[Tensor],
     ket: &[Tensor],
     configs: &LocalPathConfigs,
@@ -192,7 +195,7 @@ fn bench_dot_general_overhead(c: &mut Criterion) {
                 || {
                     (
                         CpuBackend::with_threads(1),
-                        <CpuBackend as TensorBackend>::RuntimeCache::default(),
+                        <CpuBackend as BackendRuntimeCache>::RuntimeCache::default(),
                     )
                 },
                 |(mut backend, mut cache)| {
@@ -214,7 +217,7 @@ fn bench_dot_general_overhead(c: &mut Criterion) {
                 || {
                     (
                         CpuBackend::with_threads(1),
-                        <CpuBackend as TensorBackend>::RuntimeCache::default(),
+                        <CpuBackend as BackendRuntimeCache>::RuntimeCache::default(),
                     )
                 },
                 |(mut backend, mut cache)| {

--- a/tenferro-tensor/benches/pairwise_contraction.rs
+++ b/tenferro-tensor/benches/pairwise_contraction.rs
@@ -2,7 +2,9 @@ use std::env;
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use num_complex::Complex64;
-use tenferro_tensor::{cpu::CpuBackend, DotGeneralConfig, Tensor, TensorBackend};
+use tenferro_tensor::{
+    cpu::CpuBackend, BackendCachedDot, BackendRuntimeCache, DotGeneralConfig, Tensor, TensorDot,
+};
 
 const PHYS_DIM: usize = 2;
 const CHIS: &[usize] = &[1, 2, 4, 8, 16, 32];
@@ -150,7 +152,7 @@ fn run_case_normal(
 
 fn run_case_cached(
     backend: &mut CpuBackend,
-    cache: &mut <CpuBackend as TensorBackend>::RuntimeCache,
+    cache: &mut <CpuBackend as BackendRuntimeCache>::RuntimeCache,
     fixtures: &Fixtures,
     configs: &Configs,
     case: PairwiseCase,
@@ -256,7 +258,7 @@ fn bench_pairwise_contraction(c: &mut Criterion) {
                 BenchmarkId::new("cached_analysis_per_call", &case_params),
                 |b| {
                     let mut backend = CpuBackend::with_threads(threads);
-                    let mut cache = <CpuBackend as TensorBackend>::RuntimeCache::default();
+                    let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
                     b.iter(|| {
                         let output = run_case_cached(
                             black_box(&mut backend),

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -46,26 +46,18 @@ pub enum ElementwiseFusionOp {
     Log1p,
 }
 
-/// Execution session surface for dense tensor backends.
-///
-/// All operations run within a backend-owned execution scope such as a CPU
-/// rayon pool or a GPU stream. Individual ops must not try to re-enter that
-/// scope.
+/// Elementwise tensor operations.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend, TypedTensor};
+/// use tenferro_tensor::{cpu::CpuBackend, TensorElementwise};
 ///
+/// fn accepts_elementwise<B: TensorElementwise>(_backend: &mut B) {}
 /// let mut backend = CpuBackend::new();
-/// let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
-/// let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]));
-/// let sum = backend
-///     .with_backend_session(|exec| exec.add(&a, &b))
-///     .unwrap();
-/// assert_eq!(sum.shape(), &[2]);
+/// accepts_elementwise(&mut backend);
 /// ```
-pub trait BackendSession {
+pub trait TensorElementwise {
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
     fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
     fn neg(&mut self, input: &Tensor) -> crate::Result<Tensor>;
@@ -83,7 +75,20 @@ pub trait BackendSession {
         on_false: &Tensor,
     ) -> crate::Result<Tensor>;
     fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor>;
+}
 
+/// Analytic unary and binary tensor operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, TensorAnalytic};
+///
+/// fn accepts_analytic<B: TensorAnalytic>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_analytic(&mut backend);
+/// ```
+pub trait TensorAnalytic {
     fn exp(&mut self, input: &Tensor) -> crate::Result<Tensor>;
     fn log(&mut self, input: &Tensor) -> crate::Result<Tensor>;
     fn sin(&mut self, input: &Tensor) -> crate::Result<Tensor>;
@@ -94,7 +99,20 @@ pub trait BackendSession {
     fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
     fn expm1(&mut self, input: &Tensor) -> crate::Result<Tensor>;
     fn log1p(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+}
 
+/// Shape, layout, and dtype transformation operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, TensorStructural};
+///
+/// fn accepts_structural<B: TensorStructural>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_structural(&mut backend);
+/// ```
+pub trait TensorStructural {
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor>;
     fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor>;
     fn broadcast_in_dim(
@@ -118,12 +136,38 @@ pub trait BackendSession {
     ) -> crate::Result<Tensor>;
     fn tril(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor>;
     fn triu(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor>;
+}
 
+/// Reduction operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, TensorReduction};
+///
+/// fn accepts_reduction<B: TensorReduction>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_reduction(&mut backend);
+/// ```
+pub trait TensorReduction {
     fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
     fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
     fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
     fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+}
 
+/// Dot-general operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, TensorDot};
+///
+/// fn accepts_dot<B: TensorDot>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_dot(&mut backend);
+/// ```
+pub trait TensorDot: TensorElementwise {
     fn dot_general(
         &mut self,
         lhs: &Tensor,
@@ -149,17 +193,6 @@ pub trait BackendSession {
     }
 
     #[doc(hidden)]
-    fn dot_general_cached(
-        &mut self,
-        _cache_slot: Option<usize>,
-        lhs: &Tensor,
-        rhs: &Tensor,
-        config: &DotGeneralConfig,
-    ) -> crate::Result<Tensor> {
-        self.dot_general(lhs, rhs, config)
-    }
-
-    #[doc(hidden)]
     fn dot_general_with_conj(
         &mut self,
         lhs: &Tensor,
@@ -188,6 +221,32 @@ pub trait BackendSession {
         };
         self.dot_general(lhs_ref, rhs_ref, config)
     }
+}
+
+/// Session-scoped cached dot-general operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, BackendSession, BackendSessionHost};
+///
+/// let mut backend = CpuBackend::new();
+/// backend.with_backend_session(|session| {
+///     fn accepts_session_dot<S: BackendSession + ?Sized>(_session: &mut S) {}
+///     accepts_session_dot(session);
+/// });
+/// ```
+pub trait SessionCachedDot: TensorDot {
+    #[doc(hidden)]
+    fn dot_general_cached(
+        &mut self,
+        _cache_slot: Option<usize>,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        self.dot_general(lhs, rhs, config)
+    }
 
     #[doc(hidden)]
     fn dot_general_with_conj_cached(
@@ -201,7 +260,20 @@ pub trait BackendSession {
     ) -> crate::Result<Tensor> {
         self.dot_general_with_conj(lhs, rhs, config, lhs_conj, rhs_conj)
     }
+}
 
+/// Indexing, slicing, and padding operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, TensorIndexing};
+///
+/// fn accepts_indexing<B: TensorIndexing>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_indexing(&mut backend);
+/// ```
+pub trait TensorIndexing {
     fn gather(
         &mut self,
         operand: &Tensor,
@@ -231,9 +303,20 @@ pub trait BackendSession {
     fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+}
 
-    fn reclaim_buffer(&mut self, tensor: Tensor);
-
+/// Optional elementwise fusion execution.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, TensorFusion};
+///
+/// fn accepts_fusion<B: TensorFusion>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_fusion(&mut backend);
+/// ```
+pub trait TensorFusion {
     #[doc(hidden)]
     fn execute_elementwise_fusion(
         &mut self,
@@ -244,99 +327,205 @@ pub trait BackendSession {
     }
 }
 
-struct BackendSessionAdapter<'a, B: TensorBackend + ?Sized> {
-    backend: &'a mut B,
+/// Backend buffer lifecycle operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, TensorBuffer};
+///
+/// fn accepts_buffer<B: TensorBuffer>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_buffer(&mut backend);
+/// ```
+pub trait TensorBuffer {
+    fn reclaim_buffer(&mut self, _tensor: Tensor) {}
 }
 
-macro_rules! forward_exec_to_backend {
-    ($($name:ident($($arg:ident : $argty:ty),*) -> $ret:ty;)+) => {
-        $(
-            fn $name(&mut self, $($arg: $argty),*) -> $ret {
-                self.backend.$name($($arg),*)
-            }
-        )+
-    };
+/// Device transfer operations on backend boundaries.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, TensorDeviceTransfer};
+///
+/// fn accepts_transfer<B: TensorDeviceTransfer>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_transfer(&mut backend);
+/// ```
+pub trait TensorDeviceTransfer {
+    fn download_to_host(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
+        Ok(tensor.clone())
+    }
+
+    fn upload_host_tensor(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
+        Ok(tensor.clone())
+    }
 }
 
-impl<B: TensorBackend + ?Sized> BackendSession for BackendSessionAdapter<'_, B> {
-    fn dot_general_read(
+/// Runtime cache associated with a backend.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, BackendRuntimeCache};
+///
+/// fn accepts_runtime_cache<B: BackendRuntimeCache>(_backend: &B) {}
+/// let backend = CpuBackend::new();
+/// accepts_runtime_cache(&backend);
+/// ```
+pub trait BackendRuntimeCache {
+    #[doc(hidden)]
+    type RuntimeCache: RuntimeCacheControl;
+}
+
+/// Backend-owned cached dot-general operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, BackendCachedDot};
+///
+/// fn accepts_backend_cached_dot<B: BackendCachedDot>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_backend_cached_dot(&mut backend);
+/// ```
+pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
+    #[doc(hidden)]
+    fn dot_general_cached(
         &mut self,
-        lhs: TensorRead<'_>,
-        rhs: TensorRead<'_>,
+        _cache: &mut Self::RuntimeCache,
+        _cache_slot: Option<usize>,
+        lhs: &Tensor,
+        rhs: &Tensor,
         config: &DotGeneralConfig,
     ) -> crate::Result<Tensor> {
-        self.backend.dot_general_read(lhs, rhs, config)
+        self.dot_general(lhs, rhs, config)
     }
 
-    forward_exec_to_backend! {
-        add(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-        mul(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-        neg(input: &Tensor) -> crate::Result<Tensor>;
-        conj(input: &Tensor) -> crate::Result<Tensor>;
-        div(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-        abs(input: &Tensor) -> crate::Result<Tensor>;
-        sign(input: &Tensor) -> crate::Result<Tensor>;
-        maximum(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-        minimum(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-        compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor>;
-        select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> crate::Result<Tensor>;
-        clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor>;
-        exp(input: &Tensor) -> crate::Result<Tensor>;
-        log(input: &Tensor) -> crate::Result<Tensor>;
-        sin(input: &Tensor) -> crate::Result<Tensor>;
-        cos(input: &Tensor) -> crate::Result<Tensor>;
-        tanh(input: &Tensor) -> crate::Result<Tensor>;
-        sqrt(input: &Tensor) -> crate::Result<Tensor>;
-        rsqrt(input: &Tensor) -> crate::Result<Tensor>;
-        pow(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-        expm1(input: &Tensor) -> crate::Result<Tensor>;
-        log1p(input: &Tensor) -> crate::Result<Tensor>;
-        transpose(input: &Tensor, perm: &[usize]) -> crate::Result<Tensor>;
-        reshape(input: &Tensor, shape: &[usize]) -> crate::Result<Tensor>;
-        broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> crate::Result<Tensor>;
-        convert(input: &Tensor, to: crate::DType) -> crate::Result<Tensor>;
-        extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor>;
-        embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor>;
-        tril(input: &Tensor, k: i64) -> crate::Result<Tensor>;
-        triu(input: &Tensor, k: i64) -> crate::Result<Tensor>;
-        reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
-        reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
-        reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
-        reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
-        dot_general(lhs: &Tensor, rhs: &Tensor, config: &DotGeneralConfig) -> crate::Result<Tensor>;
-        dot_general_with_conj(
-            lhs: &Tensor,
-            rhs: &Tensor,
-            config: &DotGeneralConfig,
-            lhs_conj: bool,
-            rhs_conj: bool
-        ) -> crate::Result<Tensor>;
-        gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> crate::Result<Tensor>;
-        scatter(
-            operand: &Tensor,
-            scatter_indices: &Tensor,
-            updates: &Tensor,
-            config: &ScatterConfig
-        ) -> crate::Result<Tensor>;
-        slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor>;
-        dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> crate::Result<Tensor>;
-        dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> crate::Result<Tensor>;
-        pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
-        concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;
-        reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
-        reclaim_buffer(tensor: Tensor) -> ();
-        execute_elementwise_fusion(
-            inputs: &[&Tensor],
-            plan: &ElementwiseFusionPlan
-        ) -> crate::Result<Option<Vec<Tensor>>>;
+    #[doc(hidden)]
+    fn dot_general_with_conj_cached(
+        &mut self,
+        _cache: &mut Self::RuntimeCache,
+        _cache_slot: Option<usize>,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+        lhs_conj: bool,
+        rhs_conj: bool,
+    ) -> crate::Result<Tensor> {
+        self.dot_general_with_conj(lhs, rhs, config, lhs_conj, rhs_conj)
     }
 }
 
-/// Run a closure using the default execution-session adapter.
+/// Backend execution-session entry points.
 ///
-/// This forwards [`BackendSession`] calls back to the backend's existing
-/// [`TensorBackend`] methods, which is suitable for backends whose individual
-/// ops already manage their own execution context.
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, BackendSessionHost};
+///
+/// fn accepts_session_host<B: BackendSessionHost>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_session_host(&mut backend);
+/// ```
+pub trait BackendSessionHost: BackendRuntimeCache {
+    fn with_backend_session<R>(&mut self, f: impl FnOnce(&mut dyn BackendSession) -> R) -> R
+    where
+        Self: TensorBackend + Sized,
+    {
+        default_backend_session(self, f)
+    }
+
+    #[doc(hidden)]
+    fn with_backend_session_cached<R>(
+        &mut self,
+        _cache: &mut Self::RuntimeCache,
+        f: impl FnOnce(&mut dyn BackendSession) -> R,
+    ) -> R
+    where
+        Self: TensorBackend + Sized,
+    {
+        self.with_backend_session(f)
+    }
+}
+
+/// Operation capabilities shared by backends and backend sessions.
+#[doc(hidden)]
+pub trait TensorBackendOps:
+    TensorElementwise
+    + TensorAnalytic
+    + TensorStructural
+    + TensorReduction
+    + TensorIndexing
+    + TensorDot
+    + TensorFusion
+    + TensorBuffer
+{
+}
+
+impl<T> TensorBackendOps for T where
+    T: TensorElementwise
+        + TensorAnalytic
+        + TensorStructural
+        + TensorReduction
+        + TensorIndexing
+        + TensorDot
+        + TensorFusion
+        + TensorBuffer
+        + ?Sized
+{
+}
+
+/// Execution session surface for dense tensor backends.
+///
+/// All operations run within a backend-owned execution scope such as a CPU
+/// thread policy or a GPU stream. Individual ops must not try to re-enter that
+/// scope.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, BackendSessionHost, Tensor, TypedTensor};
+///
+/// let mut backend = CpuBackend::new();
+/// let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
+/// let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]));
+/// let sum = backend
+///     .with_backend_session(|exec| exec.add(&a, &b))
+///     .unwrap();
+/// assert_eq!(sum.shape(), &[2]);
+/// ```
+pub trait BackendSession: TensorBackendOps + SessionCachedDot {}
+
+impl<T> BackendSession for T where T: TensorBackendOps + SessionCachedDot + ?Sized {}
+
+/// Standard runtime backend over dynamic [`Tensor`] values.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{cpu::CpuBackend, TensorBackend};
+///
+/// fn accepts_backend<B: TensorBackend>(_backend: &mut B) {}
+/// let mut backend = CpuBackend::new();
+/// accepts_backend(&mut backend);
+/// ```
+pub trait TensorBackend:
+    BackendRuntimeCache
+    + TensorBackendOps
+    + BackendCachedDot
+    + TensorDeviceTransfer
+    + BackendSessionHost
+{
+}
+
+impl<T> SessionCachedDot for T where T: TensorBackend + ?Sized {}
+
+/// Run a closure using the backend itself as a default execution session.
+///
+/// This is suitable for backends whose individual ops already manage their own
+/// execution context.
 ///
 /// # Examples
 ///
@@ -346,288 +535,9 @@ impl<B: TensorBackend + ?Sized> BackendSession for BackendSessionAdapter<'_, B> 
 /// let mut backend = CpuBackend::new();
 /// let _ = default_backend_session(&mut backend, |_exec| 1usize);
 /// ```
-pub fn default_backend_session<B: TensorBackend + ?Sized, R: Send>(
+pub fn default_backend_session<B: TensorBackend, R>(
     backend: &mut B,
-    f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
+    f: impl FnOnce(&mut dyn BackendSession) -> R,
 ) -> R {
-    let mut adapter = BackendSessionAdapter { backend };
-    f(&mut adapter)
-}
-
-/// Standard runtime backend over dynamic [`Tensor`] values.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_tensor::{cpu::CpuBackend, TensorBackend};
-///
-/// let mut backend = CpuBackend::new();
-/// ```
-pub trait TensorBackend {
-    #[doc(hidden)]
-    type RuntimeCache: RuntimeCacheControl;
-
-    fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-    fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-    fn neg(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-    fn abs(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn sign(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn maximum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-    fn minimum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-    fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor>;
-    fn select(
-        &mut self,
-        pred: &Tensor,
-        on_true: &Tensor,
-        on_false: &Tensor,
-    ) -> crate::Result<Tensor>;
-    fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor>;
-
-    fn exp(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn log(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn sin(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn cos(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn tanh(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn sqrt(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn rsqrt(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
-    fn expm1(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-    fn log1p(&mut self, input: &Tensor) -> crate::Result<Tensor>;
-
-    fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor>;
-    fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor>;
-    fn broadcast_in_dim(
-        &mut self,
-        input: &Tensor,
-        shape: &[usize],
-        dims: &[usize],
-    ) -> crate::Result<Tensor>;
-    fn convert(&mut self, input: &Tensor, to: crate::DType) -> crate::Result<Tensor>;
-    fn extract_diagonal(
-        &mut self,
-        input: &Tensor,
-        axis_a: usize,
-        axis_b: usize,
-    ) -> crate::Result<Tensor>;
-    fn embed_diagonal(
-        &mut self,
-        input: &Tensor,
-        axis_a: usize,
-        axis_b: usize,
-    ) -> crate::Result<Tensor>;
-    fn tril(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor>;
-    fn triu(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor>;
-
-    fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
-    fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
-    fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
-    fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
-
-    fn dot_general(
-        &mut self,
-        lhs: &Tensor,
-        rhs: &Tensor,
-        config: &DotGeneralConfig,
-    ) -> crate::Result<Tensor>;
-
-    #[doc(hidden)]
-    fn dot_general_read(
-        &mut self,
-        lhs: TensorRead<'_>,
-        rhs: TensorRead<'_>,
-        config: &DotGeneralConfig,
-    ) -> crate::Result<Tensor> {
-        match (lhs.as_tensor(), rhs.as_tensor()) {
-            (Some(lhs), Some(rhs)) => self.dot_general(lhs, rhs, config),
-            _ => {
-                let lhs = self.upload_host_tensor(&lhs.to_tensor())?;
-                let rhs = self.upload_host_tensor(&rhs.to_tensor())?;
-                self.dot_general(&lhs, &rhs, config)
-            }
-        }
-    }
-
-    #[doc(hidden)]
-    fn dot_general_cached(
-        &mut self,
-        _cache: &mut Self::RuntimeCache,
-        _cache_slot: Option<usize>,
-        lhs: &Tensor,
-        rhs: &Tensor,
-        config: &DotGeneralConfig,
-    ) -> crate::Result<Tensor> {
-        self.dot_general(lhs, rhs, config)
-    }
-
-    #[doc(hidden)]
-    fn dot_general_with_conj(
-        &mut self,
-        lhs: &Tensor,
-        rhs: &Tensor,
-        config: &DotGeneralConfig,
-        lhs_conj: bool,
-        rhs_conj: bool,
-    ) -> crate::Result<Tensor> {
-        if !lhs_conj && !rhs_conj {
-            return self.dot_general(lhs, rhs, config);
-        }
-
-        let lhs_tmp;
-        let lhs_ref = if lhs_conj {
-            lhs_tmp = self.conj(lhs)?;
-            &lhs_tmp
-        } else {
-            lhs
-        };
-        let rhs_tmp;
-        let rhs_ref = if rhs_conj {
-            rhs_tmp = self.conj(rhs)?;
-            &rhs_tmp
-        } else {
-            rhs
-        };
-        self.dot_general(lhs_ref, rhs_ref, config)
-    }
-
-    #[doc(hidden)]
-    fn dot_general_with_conj_cached(
-        &mut self,
-        _cache: &mut Self::RuntimeCache,
-        _cache_slot: Option<usize>,
-        lhs: &Tensor,
-        rhs: &Tensor,
-        config: &DotGeneralConfig,
-        lhs_conj: bool,
-        rhs_conj: bool,
-    ) -> crate::Result<Tensor> {
-        self.dot_general_with_conj(lhs, rhs, config, lhs_conj, rhs_conj)
-    }
-
-    fn gather(
-        &mut self,
-        operand: &Tensor,
-        start_indices: &Tensor,
-        config: &GatherConfig,
-    ) -> crate::Result<Tensor>;
-    fn scatter(
-        &mut self,
-        operand: &Tensor,
-        scatter_indices: &Tensor,
-        updates: &Tensor,
-        config: &ScatterConfig,
-    ) -> crate::Result<Tensor>;
-    fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor>;
-    fn dynamic_slice(
-        &mut self,
-        input: &Tensor,
-        starts: &Tensor,
-        slice_sizes: &[usize],
-    ) -> crate::Result<Tensor>;
-    fn dynamic_update_slice(
-        &mut self,
-        operand: &Tensor,
-        update: &Tensor,
-        starts: &Tensor,
-    ) -> crate::Result<Tensor>;
-    fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
-    fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;
-    fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
-
-    /// Execute a batch of operations inside the backend's execution context.
-    ///
-    /// Backends can override this to establish one shared scope for many ops,
-    /// such as a rayon pool install on CPU.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::{cpu::CpuBackend, TensorBackend};
-    ///
-    /// let mut backend = CpuBackend::new();
-    /// let _value = backend.with_backend_session(|_exec| 1usize);
-    /// ```
-    fn with_backend_session<R: Send>(
-        &mut self,
-        f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
-    ) -> R {
-        default_backend_session(self, f)
-    }
-
-    /// Execute a batch of operations with an externally owned runtime cache.
-    ///
-    /// The default implementation ignores the cache. Backends can override
-    /// this to use Engine-owned prepared plans or analysis caches while keeping
-    /// cache lifetime and clearing under the caller's control.
-    #[doc(hidden)]
-    fn with_backend_session_cached<R: Send>(
-        &mut self,
-        _cache: &mut Self::RuntimeCache,
-        f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
-    ) -> R {
-        self.with_backend_session(f)
-    }
-
-    /// Materialize a backend tensor into host memory.
-    ///
-    /// Backends that already operate on host tensors can keep the default
-    /// implementation, which clones the input tensor.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend, TypedTensor};
-    ///
-    /// let mut backend = CpuBackend::new();
-    /// let tensor = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
-    /// let host = backend.download_to_host(&tensor).unwrap();
-    /// assert_eq!(host.shape(), &[2]);
-    /// ```
-    fn download_to_host(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
-        Ok(tensor.clone())
-    }
-
-    /// Upload a host tensor into backend-owned storage when needed.
-    ///
-    /// Backends that already use host tensors can keep the default
-    /// implementation, which clones the input tensor.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend, TypedTensor};
-    ///
-    /// let mut backend = CpuBackend::new();
-    /// let tensor = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
-    /// let uploaded = backend.upload_host_tensor(&tensor).unwrap();
-    /// assert_eq!(uploaded.shape(), &[2]);
-    /// ```
-    fn upload_host_tensor(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
-        Ok(tensor.clone())
-    }
-
-    /// Reclaim a tensor buffer for backend-specific reuse.
-    ///
-    /// Backends that do not pool buffers can ignore the tensor and let it drop.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorBackend, TypedTensor};
-    ///
-    /// let mut backend = CpuBackend::new();
-    /// let tensor = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
-    /// backend.reclaim_buffer(tensor);
-    /// ```
-    fn reclaim_buffer(&mut self, _tensor: Tensor) {}
-
-    #[doc(hidden)]
-    fn execute_elementwise_fusion(
-        &mut self,
-        _inputs: &[&Tensor],
-        _plan: &ElementwiseFusionPlan,
-    ) -> crate::Result<Option<Vec<Tensor>>> {
-        Ok(None)
-    }
+    f(backend)
 }

--- a/tenferro-tensor/src/cpu/backend.rs
+++ b/tenferro-tensor/src/cpu/backend.rs
@@ -4,7 +4,11 @@ use std::env;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-use crate::backend::{BackendSession, TensorBackend};
+use crate::backend::{
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, TensorAnalytic,
+    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorReduction, TensorStructural,
+};
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
@@ -427,9 +431,11 @@ impl CpuBackend {
     }
 }
 
-impl TensorBackend for CpuBackend {
+impl BackendRuntimeCache for CpuBackend {
     type RuntimeCache = gemm::GemmAnalysisCache;
+}
 
+impl TensorElementwise for CpuBackend {
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         self.install_with_pool(|buffers| elementwise::add_with_pool(buffers, lhs, rhs))
     }
@@ -484,7 +490,9 @@ impl TensorBackend for CpuBackend {
     fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor> {
         self.install_with_pool(|buffers| elementwise::clamp_with_pool(buffers, input, lower, upper))
     }
+}
 
+impl TensorAnalytic for CpuBackend {
     fn exp(&mut self, input: &Tensor) -> crate::Result<Tensor> {
         self.install_with_pool(|buffers| analytic::exp_with_pool(buffers, input))
     }
@@ -524,7 +532,9 @@ impl TensorBackend for CpuBackend {
     fn log1p(&mut self, input: &Tensor) -> crate::Result<Tensor> {
         self.install_with_pool(|buffers| analytic::log1p_with_pool(buffers, input))
     }
+}
 
+impl TensorStructural for CpuBackend {
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
         self.install_with_pool(|buffers| structural::transpose_with_pool(buffers, input, perm))
     }
@@ -577,7 +587,9 @@ impl TensorBackend for CpuBackend {
     fn triu(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor> {
         self.install_with_pool(|buffers| structural::triu_with_pool(buffers, input, k))
     }
+}
 
+impl TensorReduction for CpuBackend {
     fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         self.install(|| reduction::reduce_sum(input, axes))
     }
@@ -593,7 +605,9 @@ impl TensorBackend for CpuBackend {
     fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         self.install(|| reduction::reduce_min(input, axes))
     }
+}
 
+impl TensorDot for CpuBackend {
     fn dot_general(
         &mut self,
         lhs: &Tensor,
@@ -601,9 +615,52 @@ impl TensorBackend for CpuBackend {
         config: &DotGeneralConfig,
     ) -> crate::Result<Tensor> {
         let mut cache = gemm::GemmAnalysisCache::default();
-        self.dot_general_cached(&mut cache, None, lhs, rhs, config)
+        BackendCachedDot::dot_general_cached(self, &mut cache, None, lhs, rhs, config)
     }
 
+    fn dot_general_read(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        let mut cache = gemm::GemmAnalysisCache::default();
+        #[cfg(feature = "cpu-faer")]
+        let direct = {
+            let ctx = Arc::clone(&self.ctx);
+            self.install_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
+                gemm::dot_general_read_cached(buffers, cache, None, ctx.as_ref(), lhs, rhs, config)
+            })?
+        };
+        #[cfg(feature = "cpu-blas")]
+        let direct = self.run_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
+            gemm::dot_general_read_cached(buffers, cache, None, lhs, rhs, config)
+        })?;
+        if let Some(result) = direct {
+            return Ok(result);
+        }
+
+        let lhs = lhs.to_tensor();
+        let rhs = rhs.to_tensor();
+        BackendCachedDot::dot_general_cached(self, &mut cache, None, &lhs, &rhs, config)
+    }
+
+    fn dot_general_with_conj(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+        lhs_conj: bool,
+        rhs_conj: bool,
+    ) -> crate::Result<Tensor> {
+        let mut cache = gemm::GemmAnalysisCache::default();
+        BackendCachedDot::dot_general_with_conj_cached(
+            self, &mut cache, None, lhs, rhs, config, lhs_conj, rhs_conj,
+        )
+    }
+}
+
+impl BackendCachedDot for CpuBackend {
     fn dot_general_cached(
         &mut self,
         cache: &mut Self::RuntimeCache,
@@ -666,45 +723,6 @@ impl TensorBackend for CpuBackend {
                 }),
             })
         }
-    }
-
-    fn dot_general_read(
-        &mut self,
-        lhs: TensorRead<'_>,
-        rhs: TensorRead<'_>,
-        config: &DotGeneralConfig,
-    ) -> crate::Result<Tensor> {
-        let mut cache = gemm::GemmAnalysisCache::default();
-        #[cfg(feature = "cpu-faer")]
-        let direct = {
-            let ctx = Arc::clone(&self.ctx);
-            self.install_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
-                gemm::dot_general_read_cached(buffers, cache, None, ctx.as_ref(), lhs, rhs, config)
-            })?
-        };
-        #[cfg(feature = "cpu-blas")]
-        let direct = self.run_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
-            gemm::dot_general_read_cached(buffers, cache, None, lhs, rhs, config)
-        })?;
-        if let Some(result) = direct {
-            return Ok(result);
-        }
-
-        let lhs = lhs.to_tensor();
-        let rhs = rhs.to_tensor();
-        self.dot_general_cached(&mut cache, None, &lhs, &rhs, config)
-    }
-
-    fn dot_general_with_conj(
-        &mut self,
-        lhs: &Tensor,
-        rhs: &Tensor,
-        config: &DotGeneralConfig,
-        lhs_conj: bool,
-        rhs_conj: bool,
-    ) -> crate::Result<Tensor> {
-        let mut cache = gemm::GemmAnalysisCache::default();
-        self.dot_general_with_conj_cached(&mut cache, None, lhs, rhs, config, lhs_conj, rhs_conj)
     }
 
     fn dot_general_with_conj_cached(
@@ -804,7 +822,9 @@ impl TensorBackend for CpuBackend {
             })
         }
     }
+}
 
+impl TensorIndexing for CpuBackend {
     fn gather(
         &mut self,
         operand: &Tensor,
@@ -865,21 +885,20 @@ impl TensorBackend for CpuBackend {
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         self.install_with_pool(|buffers| indexing::reverse_with_pool(buffers, input, axes))
     }
+}
 
-    fn with_backend_session<R: Send>(
-        &mut self,
-        f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
-    ) -> R {
+impl BackendSessionHost for CpuBackend {
+    fn with_backend_session<R>(&mut self, f: impl FnOnce(&mut dyn BackendSession) -> R) -> R {
         let mut cache = profile_cpu_session_section("with_backend_session.cache_default", || {
             gemm::GemmAnalysisCache::default()
         });
         self.with_backend_session_cached(&mut cache, f)
     }
 
-    fn with_backend_session_cached<R: Send>(
+    fn with_backend_session_cached<R>(
         &mut self,
         cache: &mut Self::RuntimeCache,
-        f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
+        f: impl FnOnce(&mut dyn BackendSession) -> R,
     ) -> R {
         if !cpu_session_profile_enabled() {
             let mut buffers = std::mem::take(&mut self.buffers);
@@ -928,7 +947,9 @@ impl TensorBackend for CpuBackend {
         maybe_print_cpu_session_profile();
         result
     }
+}
 
+impl TensorBuffer for CpuBackend {
     fn reclaim_buffer(&mut self, tensor: Tensor) {
         match tensor {
             Tensor::F32(t) => reclaim_typed(&mut self.buffers, t),
@@ -941,6 +962,12 @@ impl TensorBackend for CpuBackend {
         }
     }
 }
+
+impl TensorFusion for CpuBackend {}
+
+impl TensorDeviceTransfer for CpuBackend {}
+
+impl TensorBackend for CpuBackend {}
 
 pub(crate) fn reclaim_typed<T: PoolScalar>(pool: &mut BufferPool, typed: TypedTensor<T>) {
     match typed.buffer {

--- a/tenferro-tensor/src/cpu/exec_session.rs
+++ b/tenferro-tensor/src/cpu/exec_session.rs
@@ -1,4 +1,7 @@
-use crate::backend::BackendSession;
+use crate::backend::{
+    SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorReduction, TensorStructural,
+};
 use crate::buffer_pool::BufferPool;
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
@@ -31,7 +34,7 @@ macro_rules! delegate_with_pool {
     };
 }
 
-impl BackendSession for CpuExecSession<'_> {
+impl TensorElementwise for CpuExecSession<'_> {
     // Elementwise — direct delegation, no install
     delegate_with_pool!(add(lhs: &Tensor, rhs: &Tensor) => elementwise::add_with_pool);
     delegate_with_pool!(mul(lhs: &Tensor, rhs: &Tensor) => elementwise::mul_with_pool);
@@ -45,7 +48,9 @@ impl BackendSession for CpuExecSession<'_> {
     delegate_with_pool!(compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) => elementwise::compare_with_pool);
     delegate_with_pool!(select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) => elementwise::select_with_pool);
     delegate_with_pool!(clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) => elementwise::clamp_with_pool);
+}
 
+impl TensorAnalytic for CpuExecSession<'_> {
     // Analytic
     delegate_with_pool!(exp(input: &Tensor) => analytic::exp_with_pool);
     delegate_with_pool!(log(input: &Tensor) => analytic::log_with_pool);
@@ -57,7 +62,9 @@ impl BackendSession for CpuExecSession<'_> {
     delegate_with_pool!(pow(lhs: &Tensor, rhs: &Tensor) => analytic::pow_with_pool);
     delegate_with_pool!(expm1(input: &Tensor) => analytic::expm1_with_pool);
     delegate_with_pool!(log1p(input: &Tensor) => analytic::log1p_with_pool);
+}
 
+impl TensorStructural for CpuExecSession<'_> {
     // Structural
     delegate_with_pool!(transpose(input: &Tensor, perm: &[usize]) => structural::transpose_with_pool);
     delegate!(reshape(input: &Tensor, shape: &[usize]) => structural::reshape(input, shape));
@@ -67,13 +74,17 @@ impl BackendSession for CpuExecSession<'_> {
     delegate_with_pool!(embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) => structural::embed_diagonal_with_pool);
     delegate_with_pool!(tril(input: &Tensor, k: i64) => structural::tril_with_pool);
     delegate_with_pool!(triu(input: &Tensor, k: i64) => structural::triu_with_pool);
+}
 
+impl TensorReduction for CpuExecSession<'_> {
     // Reduction
     delegate!(reduce_sum(input: &Tensor, axes: &[usize]) => reduction::reduce_sum(input, axes));
     delegate!(reduce_prod(input: &Tensor, axes: &[usize]) => reduction::reduce_prod(input, axes));
     delegate!(reduce_max(input: &Tensor, axes: &[usize]) => reduction::reduce_max(input, axes));
     delegate!(reduce_min(input: &Tensor, axes: &[usize]) => reduction::reduce_min(input, axes));
+}
 
+impl TensorDot for CpuExecSession<'_> {
     // GEMM — dtype dispatch, pool + ctx
     fn dot_general(
         &mut self,
@@ -84,6 +95,54 @@ impl BackendSession for CpuExecSession<'_> {
         self.dot_general_cached(None, lhs, rhs, config)
     }
 
+    fn dot_general_read(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        #[cfg(feature = "cpu-faer")]
+        if let Some(result) = gemm::dot_general_read_cached(
+            self.buffers,
+            self.gemm_analysis_cache,
+            None,
+            self.ctx,
+            lhs,
+            rhs,
+            config,
+        )? {
+            return Ok(result);
+        }
+        #[cfg(feature = "cpu-blas")]
+        if let Some(result) = gemm::dot_general_read_cached(
+            self.buffers,
+            self.gemm_analysis_cache,
+            None,
+            lhs,
+            rhs,
+            config,
+        )? {
+            return Ok(result);
+        }
+
+        let lhs = lhs.to_tensor();
+        let rhs = rhs.to_tensor();
+        self.dot_general_cached(None, &lhs, &rhs, config)
+    }
+
+    fn dot_general_with_conj(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+        lhs_conj: bool,
+        rhs_conj: bool,
+    ) -> crate::Result<Tensor> {
+        self.dot_general_with_conj_cached(None, lhs, rhs, config, lhs_conj, rhs_conj)
+    }
+}
+
+impl SessionCachedDot for CpuExecSession<'_> {
     fn dot_general_cached(
         &mut self,
         cache_slot: Option<usize>,
@@ -182,52 +241,6 @@ impl BackendSession for CpuExecSession<'_> {
                 rhs: rhs.dtype(),
             }),
         }
-    }
-
-    fn dot_general_read(
-        &mut self,
-        lhs: TensorRead<'_>,
-        rhs: TensorRead<'_>,
-        config: &DotGeneralConfig,
-    ) -> crate::Result<Tensor> {
-        #[cfg(feature = "cpu-faer")]
-        if let Some(result) = gemm::dot_general_read_cached(
-            self.buffers,
-            self.gemm_analysis_cache,
-            None,
-            self.ctx,
-            lhs,
-            rhs,
-            config,
-        )? {
-            return Ok(result);
-        }
-        #[cfg(feature = "cpu-blas")]
-        if let Some(result) = gemm::dot_general_read_cached(
-            self.buffers,
-            self.gemm_analysis_cache,
-            None,
-            lhs,
-            rhs,
-            config,
-        )? {
-            return Ok(result);
-        }
-
-        let lhs = lhs.to_tensor();
-        let rhs = rhs.to_tensor();
-        self.dot_general_cached(None, &lhs, &rhs, config)
-    }
-
-    fn dot_general_with_conj(
-        &mut self,
-        lhs: &Tensor,
-        rhs: &Tensor,
-        config: &DotGeneralConfig,
-        lhs_conj: bool,
-        rhs_conj: bool,
-    ) -> crate::Result<Tensor> {
-        self.dot_general_with_conj_cached(None, lhs, rhs, config, lhs_conj, rhs_conj)
     }
 
     fn dot_general_with_conj_cached(
@@ -347,7 +360,9 @@ impl BackendSession for CpuExecSession<'_> {
             }),
         }
     }
+}
 
+impl TensorIndexing for CpuExecSession<'_> {
     // Indexing
     fn gather(
         &mut self,
@@ -368,7 +383,9 @@ impl BackendSession for CpuExecSession<'_> {
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         indexing::reverse_with_pool(self.buffers, input, axes)
     }
+}
 
+impl TensorBuffer for CpuExecSession<'_> {
     fn reclaim_buffer(&mut self, tensor: Tensor) {
         match tensor {
             Tensor::F32(t) => reclaim_typed(self.buffers, t),
@@ -381,3 +398,5 @@ impl BackendSession for CpuExecSession<'_> {
         }
     }
 }
+
+impl TensorFusion for CpuExecSession<'_> {}

--- a/tenferro-tensor/src/lib.rs
+++ b/tenferro-tensor/src/lib.rs
@@ -73,8 +73,11 @@ pub mod validate;
     not(all(feature = "cpu-faer", feature = "cpu-blas"))
 ))]
 pub use backend::{
-    default_backend_session, BackendSession, ElementwiseFusionInst, ElementwiseFusionOp,
-    ElementwiseFusionPlan, TensorBackend,
+    default_backend_session, BackendCachedDot, BackendRuntimeCache, BackendSession,
+    BackendSessionHost, ElementwiseFusionInst, ElementwiseFusionOp, ElementwiseFusionPlan,
+    SessionCachedDot, TensorAnalytic, TensorBackend, TensorBackendOps, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorReduction, TensorStructural,
 };
 #[cfg(all(
     any(feature = "cpu-faer", feature = "cpu-blas"),

--- a/tenferro-tensor/src/tests/cpu_indexing_coverage_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_indexing_coverage_tests.rs
@@ -1,6 +1,6 @@
 use num_complex::{Complex32, Complex64};
 
-use crate::backend::TensorBackend;
+use crate::backend::{BackendSessionHost, TensorIndexing};
 use crate::config::{DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig};
 use crate::cpu::{dynamic_slice, gather, pad, scatter, CpuBackend};
 use crate::types::{Tensor, TypedTensor};

--- a/tenferro-tensor/src/tests/cpu_tests.rs
+++ b/tenferro-tensor/src/tests/cpu_tests.rs
@@ -7,7 +7,11 @@ use std::{ffi::OsString, sync::MutexGuard};
 
 use num_complex::{Complex32, Complex64};
 
-use crate::backend::TensorBackend;
+use crate::backend::{
+    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, SessionCachedDot, TensorAnalytic,
+    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorReduction, TensorStructural,
+};
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };

--- a/tenferro-tensor/src/tests/cpu_tests/backend_misc.rs
+++ b/tenferro-tensor/src/tests/cpu_tests/backend_misc.rs
@@ -4,7 +4,7 @@ use super::*;
 fn test_reclaim_buffer_returns_host_buffer_to_pool() {
     let mut backend = CpuBackend::new();
     assert_eq!(backend.buffer_pool_len(), 0);
-    let t = TensorBackend::add(
+    let t = TensorElementwise::add(
         &mut backend,
         &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0])),
         &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0])),
@@ -188,7 +188,7 @@ fn test_reclaim_buffer_covers_all_dtypes() {
 #[test]
 fn test_install_with_pool_preserves_buffers() {
     let mut backend = CpuBackend::with_threads(1);
-    let t = TensorBackend::add(
+    let t = TensorElementwise::add(
         &mut backend,
         &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0])),
         &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0])),
@@ -214,9 +214,11 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         };
     }
 
-    impl TensorBackend for DefaultOnlyBackend {
+    impl BackendRuntimeCache for DefaultOnlyBackend {
         type RuntimeCache = ();
+    }
 
+    impl TensorElementwise for DefaultOnlyBackend {
         panic_backend_methods! {
         add(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
         mul(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
@@ -229,6 +231,15 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor>;
         select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> crate::Result<Tensor>;
         clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor>;
+        }
+
+        fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+            CpuBackend::new().conj(input)
+        }
+    }
+
+    impl TensorAnalytic for DefaultOnlyBackend {
+        panic_backend_methods! {
         exp(input: &Tensor) -> crate::Result<Tensor>;
         log(input: &Tensor) -> crate::Result<Tensor>;
         sin(input: &Tensor) -> crate::Result<Tensor>;
@@ -239,6 +250,11 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         pow(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
         expm1(input: &Tensor) -> crate::Result<Tensor>;
         log1p(input: &Tensor) -> crate::Result<Tensor>;
+        }
+    }
+
+    impl TensorStructural for DefaultOnlyBackend {
+        panic_backend_methods! {
         transpose(input: &Tensor, perm: &[usize]) -> crate::Result<Tensor>;
         reshape(input: &Tensor, shape: &[usize]) -> crate::Result<Tensor>;
         broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> crate::Result<Tensor>;
@@ -247,10 +263,20 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor>;
         tril(input: &Tensor, k: i64) -> crate::Result<Tensor>;
         triu(input: &Tensor, k: i64) -> crate::Result<Tensor>;
+        }
+    }
+
+    impl TensorReduction for DefaultOnlyBackend {
+        panic_backend_methods! {
         reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
         reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
         reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
         reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+        }
+    }
+
+    impl TensorIndexing for DefaultOnlyBackend {
+        panic_backend_methods! {
         gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> crate::Result<Tensor>;
         scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> crate::Result<Tensor>;
         slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor>;
@@ -258,12 +284,11 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> crate::Result<Tensor>;
         pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
         concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;
-        reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;        }
-
-        fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-            CpuBackend::new().conj(input)
+        reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
         }
+    }
 
+    impl TensorDot for DefaultOnlyBackend {
         fn dot_general(
             &mut self,
             lhs: &Tensor,
@@ -273,10 +298,22 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
             CpuBackend::new().dot_general(lhs, rhs, config)
         }
     }
+
+    impl BackendCachedDot for DefaultOnlyBackend {}
+
+    impl BackendSessionHost for DefaultOnlyBackend {}
+
+    impl TensorDeviceTransfer for DefaultOnlyBackend {}
+
+    impl TensorBuffer for DefaultOnlyBackend {}
+
+    impl TensorFusion for DefaultOnlyBackend {}
+
+    impl TensorBackend for DefaultOnlyBackend {}
 
     struct DefaultOnlyExec;
 
-    impl crate::backend::BackendSession for DefaultOnlyExec {
+    impl TensorElementwise for DefaultOnlyExec {
         panic_backend_methods! {
         add(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
         mul(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
@@ -289,6 +326,15 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor>;
         select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> crate::Result<Tensor>;
         clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor>;
+        }
+
+        fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor> {
+            CpuBackend::new().conj(input)
+        }
+    }
+
+    impl TensorAnalytic for DefaultOnlyExec {
+        panic_backend_methods! {
         exp(input: &Tensor) -> crate::Result<Tensor>;
         log(input: &Tensor) -> crate::Result<Tensor>;
         sin(input: &Tensor) -> crate::Result<Tensor>;
@@ -299,6 +345,11 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         pow(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
         expm1(input: &Tensor) -> crate::Result<Tensor>;
         log1p(input: &Tensor) -> crate::Result<Tensor>;
+        }
+    }
+
+    impl TensorStructural for DefaultOnlyExec {
+        panic_backend_methods! {
         transpose(input: &Tensor, perm: &[usize]) -> crate::Result<Tensor>;
         reshape(input: &Tensor, shape: &[usize]) -> crate::Result<Tensor>;
         broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> crate::Result<Tensor>;
@@ -307,10 +358,20 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor>;
         tril(input: &Tensor, k: i64) -> crate::Result<Tensor>;
         triu(input: &Tensor, k: i64) -> crate::Result<Tensor>;
+        }
+    }
+
+    impl TensorReduction for DefaultOnlyExec {
+        panic_backend_methods! {
         reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
         reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
         reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
         reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
+        }
+    }
+
+    impl TensorIndexing for DefaultOnlyExec {
+        panic_backend_methods! {
         gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> crate::Result<Tensor>;
         scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> crate::Result<Tensor>;
         slice(input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor>;
@@ -318,12 +379,11 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> crate::Result<Tensor>;
         pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
         concatenate(inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;
-        reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;        }
-
-        fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor> {
-            CpuBackend::new().conj(input)
+        reverse(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
         }
+    }
 
+    impl TensorDot for DefaultOnlyExec {
         fn dot_general(
             &mut self,
             lhs: &Tensor,
@@ -332,9 +392,15 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         ) -> crate::Result<Tensor> {
             CpuBackend::new().dot_general(lhs, rhs, config)
         }
+    }
 
+    impl SessionCachedDot for DefaultOnlyExec {}
+
+    impl TensorBuffer for DefaultOnlyExec {
         fn reclaim_buffer(&mut self, _tensor: Tensor) {}
     }
+
+    impl TensorFusion for DefaultOnlyExec {}
 
     let lhs = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64]);
     let rhs = Tensor::from_vec_col_major(vec![1, 1], vec![3.0_f64]);
@@ -350,22 +416,26 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
     let mut backend = DefaultOnlyBackend;
     let mut cache = ();
 
-    let direct =
-        TensorBackend::dot_general_cached(&mut backend, &mut cache, Some(0), &lhs, &rhs, &config)
-            .unwrap();
+    let direct = BackendCachedDot::dot_general_cached(
+        &mut backend,
+        &mut cache,
+        Some(0),
+        &lhs,
+        &rhs,
+        &config,
+    )
+    .unwrap();
     assert_eq!(direct.as_slice::<f64>().unwrap(), &[6.0]);
 
     let lhs_folded =
-        TensorBackend::dot_general_with_conj(&mut backend, &lhs, &rhs, &config, true, false)
-            .unwrap();
+        TensorDot::dot_general_with_conj(&mut backend, &lhs, &rhs, &config, true, false).unwrap();
     assert_eq!(lhs_folded.as_slice::<f64>().unwrap(), &[6.0]);
 
     let both_folded =
-        TensorBackend::dot_general_with_conj(&mut backend, &lhs, &rhs, &config, true, true)
-            .unwrap();
+        TensorDot::dot_general_with_conj(&mut backend, &lhs, &rhs, &config, true, true).unwrap();
     assert_eq!(both_folded.as_slice::<f64>().unwrap(), &[6.0]);
 
-    let read_views = TensorBackend::dot_general_read(
+    let read_views = TensorDot::dot_general_read(
         &mut backend,
         TensorRead::from_view(TensorView::f64(&one_shape, &lhs_data).unwrap()),
         TensorRead::from_view(TensorView::f64(&one_shape, &rhs_data).unwrap()),
@@ -374,7 +444,7 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
     .unwrap();
     assert_eq!(read_views.as_slice::<f64>().unwrap(), &[6.0]);
 
-    let rhs_folded = TensorBackend::dot_general_with_conj_cached(
+    let rhs_folded = BackendCachedDot::dot_general_with_conj_cached(
         &mut backend,
         &mut cache,
         Some(1),
@@ -405,7 +475,7 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         .is_none());
 
     let session_value =
-        TensorBackend::with_backend_session_cached(&mut backend, &mut cache, |exec| {
+        BackendSessionHost::with_backend_session_cached(&mut backend, &mut cache, |exec| {
             let cached = exec
                 .dot_general_cached(Some(2), &lhs, &rhs, &config)
                 .unwrap();
@@ -417,7 +487,7 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
     assert_eq!(session_value, 12.0);
 
     let mut exec = DefaultOnlyExec;
-    let exec_read_tensor = crate::backend::BackendSession::dot_general_read(
+    let exec_read_tensor = TensorDot::dot_general_read(
         &mut exec,
         TensorRead::from_tensor(&lhs),
         TensorRead::from_tensor(&rhs),
@@ -425,7 +495,7 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
     )
     .unwrap();
     assert_eq!(exec_read_tensor.as_slice::<f64>().unwrap(), &[6.0]);
-    let exec_read_views = crate::backend::BackendSession::dot_general_read(
+    let exec_read_views = TensorDot::dot_general_read(
         &mut exec,
         TensorRead::from_view(TensorView::f64(&one_shape, &lhs_data).unwrap()),
         TensorRead::from_view(TensorView::f64(&one_shape, &rhs_data).unwrap()),
@@ -433,25 +503,17 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
     )
     .unwrap();
     assert_eq!(exec_read_views.as_slice::<f64>().unwrap(), &[6.0]);
-    let exec_no_conj = crate::backend::BackendSession::dot_general_with_conj(
-        &mut exec, &lhs, &rhs, &config, false, false,
-    )
-    .unwrap();
+    let exec_no_conj =
+        TensorDot::dot_general_with_conj(&mut exec, &lhs, &rhs, &config, false, false).unwrap();
     assert_eq!(exec_no_conj.as_slice::<f64>().unwrap(), &[6.0]);
-    let exec_lhs_conj = crate::backend::BackendSession::dot_general_with_conj(
-        &mut exec, &lhs, &rhs, &config, true, false,
-    )
-    .unwrap();
+    let exec_lhs_conj =
+        TensorDot::dot_general_with_conj(&mut exec, &lhs, &rhs, &config, true, false).unwrap();
     assert_eq!(exec_lhs_conj.as_slice::<f64>().unwrap(), &[6.0]);
-    let exec_rhs_conj = crate::backend::BackendSession::dot_general_with_conj(
-        &mut exec, &lhs, &rhs, &config, false, true,
-    )
-    .unwrap();
+    let exec_rhs_conj =
+        TensorDot::dot_general_with_conj(&mut exec, &lhs, &rhs, &config, false, true).unwrap();
     assert_eq!(exec_rhs_conj.as_slice::<f64>().unwrap(), &[6.0]);
-    let exec_both_conj = crate::backend::BackendSession::dot_general_with_conj(
-        &mut exec, &lhs, &rhs, &config, true, true,
-    )
-    .unwrap();
+    let exec_both_conj =
+        TensorDot::dot_general_with_conj(&mut exec, &lhs, &rhs, &config, true, true).unwrap();
     assert_eq!(exec_both_conj.as_slice::<f64>().unwrap(), &[6.0]);
 }
 

--- a/tenferro-tensor/src/tests/cpu_tests/dot_structural_analytic.rs
+++ b/tenferro-tensor/src/tests/cpu_tests/dot_structural_analytic.rs
@@ -576,7 +576,7 @@ fn test_cpu_backend_dispatches_tensor_backend_ops() {
     let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
     let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]));
     let mut backend = CpuBackend::new();
-    let out = TensorBackend::add(&mut backend, &a, &b).unwrap();
+    let out = TensorElementwise::add(&mut backend, &a, &b).unwrap();
     assert_eq!(get_f64(&out, &[0]), 4.0);
     assert_eq!(get_f64(&out, &[1]), 6.0);
 }

--- a/tenferro-tensor/src/tests/cpu_tests/indexing.rs
+++ b/tenferro-tensor/src/tests/cpu_tests/indexing.rs
@@ -495,7 +495,7 @@ fn test_backend_mul_neg_conj_dispatch() {
     ));
     let mut backend = CpuBackend::new();
 
-    let prod = TensorBackend::mul(&mut backend, &a, &b).unwrap();
+    let prod = TensorElementwise::mul(&mut backend, &a, &b).unwrap();
     assert_eq!(get_f64(&prod, &[0]), 3.0);
     assert_eq!(get_f64(&prod, &[1]), -8.0);
 
@@ -541,7 +541,7 @@ fn test_backend_structural_ops_dispatch() {
     assert_eq!(triu_result.shape(), &[2, 2]);
     assert_eq!(get_f64(&triu_result, &[1, 0]), 0.0);
 
-    let summed = TensorBackend::reduce_sum(&mut backend, &a, &[0]).unwrap();
+    let summed = TensorReduction::reduce_sum(&mut backend, &a, &[0]).unwrap();
     assert_eq!(summed.shape(), &[2]);
     assert_eq!(get_f64(&summed, &[0]), 3.0);
     assert_eq!(get_f64(&summed, &[1]), 7.0);

--- a/tenferro-tensor/tests/backend_capability_contracts.rs
+++ b/tenferro-tensor/tests/backend_capability_contracts.rs
@@ -1,0 +1,55 @@
+use tenferro_tensor::{
+    cpu::CpuBackend, BackendSession, BackendSessionHost, TensorAnalytic, TensorBackend,
+    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorReduction, TensorStructural,
+};
+
+fn accepts_backend_capabilities<B>()
+where
+    B: TensorElementwise
+        + TensorAnalytic
+        + TensorStructural
+        + TensorReduction
+        + TensorIndexing
+        + TensorDot
+        + TensorFusion
+        + TensorBuffer
+        + TensorDeviceTransfer
+        + BackendSessionHost
+        + TensorBackend,
+{
+}
+
+fn accepts_session_capabilities<S>(_: &mut S)
+where
+    S: TensorElementwise
+        + TensorAnalytic
+        + TensorStructural
+        + TensorReduction
+        + TensorIndexing
+        + TensorDot
+        + TensorFusion
+        + TensorBuffer
+        + BackendSession
+        + ?Sized,
+{
+}
+
+#[test]
+fn cpu_backend_exposes_narrow_capability_bounds() {
+    accepts_backend_capabilities::<CpuBackend>();
+}
+
+#[test]
+fn backend_session_exposes_narrow_capability_bounds() {
+    let mut backend = CpuBackend::new();
+    backend.with_backend_session(|session| {
+        accepts_session_capabilities(session);
+    });
+}
+
+#[test]
+fn backend_surface_no_longer_uses_forwarding_macro() {
+    let backend_source = include_str!("../src/backend.rs");
+    assert!(!backend_source.contains("forward_exec_to_backend"));
+}

--- a/tenferro-tensor/tests/inject_tests.rs
+++ b/tenferro-tensor/tests/inject_tests.rs
@@ -9,7 +9,7 @@ use tenferro_tensor::inject::{
     register_blas_gemm_fn_ptrs, register_lapack_full_piv_lu_fn_ptrs, register_lapack_provider_ptrs,
     BlasGemmFnPtrSet, LapackFullPivLuFnPtrSet, LapackProviderPtrSet, ProviderAbi,
 };
-use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorDot, TypedTensor};
 
 static REGISTER_ONCE: Once = Once::new();
 static TEST_LOCK: Mutex<()> = Mutex::new(());

--- a/tenferro-tensor/tests/runtime_error_tests.rs
+++ b/tenferro-tensor/tests/runtime_error_tests.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use tenferro_tensor::{
     cpu::CpuBackend, Buffer, BufferHandle, DeviceId, DeviceKind, DotGeneralConfig, Error,
-    GpuBackendKind, MemoryKind, PadConfig, Placement, SliceConfig, Tensor, TensorBackend,
-    TypedTensor,
+    GpuBackendKind, MemoryKind, PadConfig, Placement, SliceConfig, Tensor, TensorAnalytic,
+    TensorDot, TensorElementwise, TensorIndexing, TensorStructural, TypedTensor,
 };
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
@@ -112,7 +112,7 @@ fn add_rejects_shape_mismatch() {
     let rhs = f64_tensor(vec![3], vec![3.0, 4.0, 5.0]);
     let mut backend = CpuBackend::new();
 
-    let err = <CpuBackend as TensorBackend>::add(&mut backend, &lhs, &rhs).unwrap_err();
+    let err = <CpuBackend as TensorElementwise>::add(&mut backend, &lhs, &rhs).unwrap_err();
 
     assert!(matches!(
         err,
@@ -131,7 +131,7 @@ fn cpu_backend_rejects_backend_buffers_without_panicking() {
     let mut backend = CpuBackend::new();
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        <CpuBackend as TensorBackend>::add(&mut backend, &lhs, &rhs)
+        <CpuBackend as TensorElementwise>::add(&mut backend, &lhs, &rhs)
     }));
 
     assert!(result.is_ok(), "CPU backend should return Err, not panic");


### PR DESCRIPTION
## Summary

- split TensorBackend and BackendSession into narrow capability traits for elementwise, analytic, structural, reduction, dot, indexing, fusion, buffers, transfer, runtime cache, cached dot, and session hosting
- remove BackendSessionAdapter and forward_exec_to_backend!, making TensorBackend and BackendSession marker surfaces over capability sets
- split CpuBackend, CpuExecSession, CubeclBackend, EagerBackend, and test fakes onto capability impls; remove unnecessary Send bounds from session entrypoints
- update CUDA examples/tests/docs snippets and add backend capability contract tests

Closes #904

## Verification

- cargo fmt --all --check
- git diff --check
- cargo check --workspace --all-targets
- cargo test --workspace --release
- cargo llvm-cov --workspace --release --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py
- CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-gpu --features cuda -- --ignored
- CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.0 LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-linalg --features cuda -- --ignored
- cargo test -p tenferro-tensor --test backend_capability_contracts --release