### PR TITLE
[codex] Align cudarc CUDA feature with CubeCL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,13 +188,13 @@ python3 scripts/check-coverage.py coverage.json
 cargo doc --workspace --no-deps
 python3 scripts/check-docs-site.py
 
-# GPU (CUDA/CubeCL) tests — requires NVIDIA GPU + CUDA 12
+# GPU (CUDA/CubeCL) tests — requires NVIDIA GPU + CUDA 12.8+
 # Set CUBECL_DEBUG_LOG=0 to suppress verbose JIT compilation logs.
 # GPU tests are marked #[ignore] so they don't fail on non-GPU machines.
 # Use --ignored to actually run them.
 CUBECL_DEBUG_LOG=0 \
-CUDA_PATH=/usr/local/cuda-12.0 \
-LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH \
+CUDA_PATH=/usr/local/cuda-12.8 \
+LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH \
   cargo test -p tenferro-gpu --features cuda -- --ignored
 ```
 
@@ -203,7 +203,7 @@ LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor
 | Variable | Value | Purpose |
 |----------|-------|---------|
 | `CUBECL_DEBUG_LOG` | `0` | Suppress JIT compilation log output (default is verbose) |
-| `CUDA_PATH` | `/usr/local/cuda-12.0` | CUDA toolkit root for NVRTC header resolution |
+| `CUDA_PATH` | `/usr/local/cuda-12.8` | CUDA toolkit root for NVRTC header resolution |
 | `LD_LIBRARY_PATH` | Include CUDA + cuTENSOR lib dirs | Runtime library loading |
 
 Set these in CI and local dev shells. Without `CUBECL_DEBUG_LOG=0`, cubecl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,9 @@ blas-src = { version = "0.14", default-features = false }
 lapack = "0.20"
 lapack-src = "0.13"
 lapack-inject = "0.1.2"
-cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12000"] }
+# Match CubeCL's CUDA API floor. CUDA 12.8 is the oldest cudarc binding set
+# that exposes the driver symbols used by the current cubecl-cuda revision.
+cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12080"] }
 cubecl = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692", features = ["cuda"] }
 cubecl-cuda = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
 cubecl-runtime = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -256,8 +256,8 @@ a CUDA machine with:
 
 ```sh
 CUBECL_DEBUG_LOG=0 \
-CUDA_PATH=/usr/local/cuda-12.0 \
-LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH \
+CUDA_PATH=/usr/local/cuda-12.8 \
+LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH \
   cargo test -p tenferro-gpu --features cuda -- --ignored
 ```
 

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -72,8 +72,8 @@ cargo check -p tenferro-gpu --features cuda --example cuda_quickstart
 Run it on a configured CUDA machine:
 
 ```bash
-CUDA_PATH=/usr/local/cuda-12.0 \
-LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:$LD_LIBRARY_PATH \
+CUDA_PATH=/usr/local/cuda-12.8 \
+LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:$LD_LIBRARY_PATH \
   cargo run -p tenferro-gpu --features cuda --example cuda_quickstart
 ```
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -6,8 +6,8 @@ If a CUDA run fails while loading cuTENSOR, cuSOLVER, or cuBLAS, first check
 that the CUDA runtime libraries are on the dynamic-linker path:
 
 ```bash
-CUDA_PATH=/usr/local/cuda-12.0
-LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:$LD_LIBRARY_PATH
+CUDA_PATH=/usr/local/cuda-12.8
+LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:$LD_LIBRARY_PATH
 ```
 
 For non-standard installs, set the exact library paths:

--- a/tenferro-ad/tests/gpu_f32_fusion.rs
+++ b/tenferro-ad/tests/gpu_f32_fusion.rs
@@ -16,7 +16,7 @@ fn upload_traced(backend: &CubeclBackend, tensor: &Tensor) -> TracedTensor {
 }
 
 #[test]
-#[ignore = "requires CUDA 12+ GPU"]
+#[ignore = "requires CUDA 12.8+ GPU"]
 fn test_f32_gpu_fusion_chain_e2e() {
     if !gpu_available() {
         eprintln!("skipping test_f32_gpu_fusion_chain_e2e — no CUDA device found");

--- a/tenferro-gpu/src/cubecl/mod.rs
+++ b/tenferro-gpu/src/cubecl/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides GPU acceleration via [CubeCL](https://github.com/tracel-ai/cubecl)
 //! running on NVIDIA CUDA devices. It is gated behind the `cuda` feature flag and
-//! requires **CUDA 12+** with a compatible NVIDIA GPU.
+//! requires **CUDA 12.8+** with a compatible NVIDIA GPU.
 //!
 //! # Enabling the feature
 //!
@@ -18,14 +18,14 @@
 //! # Prerequisites
 //!
 //! - NVIDIA GPU with CUDA compute capability ≥ 7.0
-//! - CUDA Toolkit 12.x installed (provides NVRTC for JIT kernel compilation)
+//! - CUDA Toolkit 12.8 or newer installed (provides NVRTC for JIT kernel compilation)
 //! - cuTENSOR shared library available on `LD_LIBRARY_PATH`
 //!
 //! ## Environment variables
 //!
 //! | Variable | Purpose |
 //! |----------|---------|
-//! | `CUDA_PATH` | CUDA toolkit root (e.g. `/usr/local/cuda-12.0`) |
+//! | `CUDA_PATH` | CUDA toolkit root (e.g. `/usr/local/cuda-12.8`) |
 //! | `CUBECL_DEBUG_LOG` | Set to `0` to suppress verbose JIT logs |
 //! | `TENFERRO_CUTENSOR_PATH` | Override cuTENSOR library search path |
 //!
@@ -68,7 +68,7 @@
 //!
 //! ```sh
 //! CUBECL_DEBUG_LOG=0 \
-//! CUDA_PATH=/usr/local/cuda-12.0 \
+//! CUDA_PATH=/usr/local/cuda-12.8 \
 //! cargo test -p tenferro-gpu --features cuda -- --ignored
 //! ```
 

--- a/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
@@ -9,7 +9,7 @@ use super::{
 };
 
 #[test]
-#[ignore = "requires CUDA 12+ GPU"]
+#[ignore = "requires CUDA 12.8+ GPU"]
 fn test_log1p_small_x_f32_precision() {
     if !gpu_available() {
         eprintln!("skipping test_log1p_small_x_f32_precision — no CUDA device found");
@@ -38,7 +38,7 @@ fn test_log1p_small_x_f32_precision() {
 }
 
 #[test]
-#[ignore = "requires CUDA 12+ GPU"]
+#[ignore = "requires CUDA 12.8+ GPU"]
 fn test_expm1_small_x_f32_precision() {
     if !gpu_available() {
         eprintln!("skipping test_expm1_small_x_f32_precision — no CUDA device found");
@@ -307,7 +307,7 @@ fn test_cubecl_complex_elementwise_matches_cpu_and_rejects_unsupported_ops() {
 }
 
 #[test]
-#[ignore = "requires CUDA 12+ GPU"]
+#[ignore = "requires CUDA 12.8+ GPU"]
 fn test_cubecl_float_to_complex_convert_preserves_resident_device() {
     if !gpu_available() {
         eprintln!(
@@ -334,7 +334,7 @@ fn test_cubecl_float_to_complex_convert_preserves_resident_device() {
 }
 
 #[test]
-#[ignore = "requires CUDA 12+ GPU"]
+#[ignore = "requires CUDA 12.8+ GPU"]
 fn test_cubecl_conj_real_clone_rejects_missing_resident_device_metadata() {
     if !gpu_available() {
         eprintln!(

--- a/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
@@ -17,7 +17,7 @@ fn kernel_add_f64(output: &mut Array<f64>, a: &Array<f64>, b: &Array<f64>) {
 macro_rules! gpu_test {
     ($name:ident, $body:expr) => {
         #[test]
-        #[ignore = "requires CUDA 12+ GPU"]
+        #[ignore = "requires CUDA 12.8+ GPU"]
         fn $name() {
             if !gpu_available() {
                 eprintln!("skipping {} — no CUDA device found", stringify!($name));

--- a/tenferro-linalg/tests/gpu_linalg.rs
+++ b/tenferro-linalg/tests/gpu_linalg.rs
@@ -473,7 +473,7 @@ fn test_cubecl_eigh_c64_reconstructs_input() {
 }
 
 #[test]
-#[ignore = "requires CUDA 12+ GPU"]
+#[ignore = "requires CUDA 12.8+ GPU"]
 fn test_gpu_eig_returns_unsupported_error() {
     if !gpu_available() {
         eprintln!("skipping test_gpu_eig_returns_unsupported_error — no CUDA device found");


### PR DESCRIPTION
## Summary
- change the workspace `cudarc` CUDA binding feature from `cuda-12000` to `cuda-12080`, matching the current `cubecl-cuda` driver-symbol requirements
- update CUDA user docs, agent instructions, and ignored GPU test metadata to state the CUDA 12.8+ floor

## Why
`cubecl-cuda` references CUDA 12.8+ driver symbols such as wide tensor-map APIs. With `cudarc` forced to `cuda-12000`, those bindings are configured out and `cargo check -p tenferro-linalg --features cuda` fails before reaching tenferro code.

Keeping an explicit `cuda-12080` floor avoids falling through to `cudarc`'s latest-version fallback while still exposing the symbols required by the current CubeCL revision.

## Verification
- `cargo fmt --all --check`
- `cargo check -p tenferro-linalg --features cuda`
- `cargo check -p tenferro-internal-device --features cuda`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `/opt/homebrew/bin/python3.12 scripts/check-docs-site.py`

Note: local `/usr/bin/python3` is Python 3.9.6 and lacks `tomllib`, so the docs-site check was run with Python 3.12.

Generated with Codex.