### PR TITLE
[codex] Add contribution guidelines and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,6 +5,12 @@ title: "[Feature]: "
 labels: ["enhancement"]
 ---
 
+New features start here. Please do not open a new-feature implementation PR
+before maintainers accept the issue and agree that implementation should start.
+
+If you already have prototype code, link to a fork branch, gist, or repository
+from this issue.
+
 ## What are you trying to do?
 
 <!-- Describe the user goal or workflow. -->
@@ -13,10 +19,18 @@ labels: ["enhancement"]
 
 <!-- Explain the current limitation, friction, or missing documentation. -->
 
+## Proposed behavior or API
+
+<!-- Optional, but useful. Show the public API, command, or workflow you want. -->
+
 ## Relevant area
 
 <!-- TypedTensor / Tensor / EagerTensor / TracedTensor / CUDA / AD / Docs / Performance / Unsure -->
 
+## Dependency, backend, or AD impact
+
+<!-- Optional. Note expected CPU/GPU/backend/provider/dependency/AD implications if known. -->
+
 ## Notes, examples, or related APIs
 
-<!-- Optional: code sketch, math notation, links, or similar APIs from PyTorch/JAX/Julia/etc. -->
+<!-- Optional: prototype link, code sketch, math notation, links, or similar APIs from PyTorch/JAX/Julia/etc. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+> [!IMPORTANT]
+> New features must start as a feature request issue.
+> Please do not open a new-feature implementation PR before maintainers accept
+> the issue and agree that implementation should start.
+>
+> If you already have prototype code, link to a fork branch, gist, or
+> repository from the feature request issue instead of opening a PR.
+>
+> New-feature PRs opened before an accepted issue may be closed and redirected
+> to an issue.
+
+## Type
+
+- [ ] Bug fix
+- [ ] Documentation
+- [ ] Refactor / cleanup
+- [ ] Implementation of accepted issue
+
+## Related issue
+
+Fixes/Refs #
+
+## Summary
+
+<!-- What changed and why? -->
+
+## Checklist
+
+- [ ] I read `CONTRIBUTING.md`.
+- [ ] I added or updated tests/docs as needed.
+- [ ] If this implements a new feature, the linked issue has been accepted by
+      maintainers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing
+
+Thanks for helping improve tenferro-rs. This file describes the external
+contribution path. Repository-specific implementation rules live in
+`REPOSITORY_RULES.md`.
+
+## Bug fixes
+
+Bug-fix pull requests are welcome.
+
+A bug-fix PR should fix behavior that is already intended by current docs,
+specs, or tests. It should not introduce a new public API, operation family,
+backend, dependency, feature flag, or architectural layer.
+
+Please include a minimal reproducer or regression test when practical.
+
+## New features
+
+New features must start as a feature request issue. Please do not open a
+new-feature implementation PR before maintainers accept the issue and agree
+that implementation should start.
+
+If you already have prototype code, link to a fork branch, gist, or repository
+from the feature request issue. The issue remains the source of truth for the
+accepted API, dependency impact, backend behavior, AD behavior, tests, and
+roadmap decision.
+
+New-feature implementation PRs opened before an accepted issue may be closed
+with a request to continue in an issue.
+
+## Prototype code and provenance
+
+By submitting code directly to this repository, you represent that you have the
+right to submit it under this repository's license, `MIT OR Apache-2.0`.
+
+If you link prototype code from a feature request issue, clearly state its
+license if it is not `MIT OR Apache-2.0` or if the project should not use it as
+an implementation reference.
+
+If maintainers implement a feature using your prototype code as a basis,
+including by rewriting it manually or with AI assistance, the resulting
+implementation may still be derived from the prototype. In that case, the
+project will preserve appropriate copyright notices, license obligations,
+attribution, and links to the original prototype or issue discussion.
+
+If your prototype is only meant to illustrate behavior and must not be used as
+an implementation reference, say so explicitly in the issue.
+
+## Contributors
+
+Contributors may be listed in `CONTRIBUTORS.md`. Contributor recognition does
+not imply maintainer status, merge authority, copyright transfer, or ownership
+of project direction.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,5 +14,7 @@ Contributors include people who provide code, design proposals, accepted
 feature requests, bug reports, documentation feedback, benchmarks, review
 comments, or other substantial project input.
 
+- Jin-Guo Liu: early Tensor4all meta-design and project direction.
+
 Contributor entries may describe the contribution type. A contributor listing
 does not imply maintainer status or GitHub repository permissions.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,16 @@
+# Contributors
+
+## Maintainers
+
+Maintainers have merge authority and responsibility for project policy.
+
+- Hiroshi Shinaoka
+
+## Contributors
+
+Contributors include people who provide code, design proposals, accepted
+feature requests, bug reports, documentation feedback, benchmarks, review
+comments, or other substantial project input.
+
+Contributor entries may describe the contribution type. A contributor listing
+does not imply maintainer status or merge authority.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,7 +14,7 @@ Contributors include people who provide code, design proposals, accepted
 feature requests, bug reports, documentation feedback, benchmarks, review
 comments, or other substantial project input.
 
-- Jin-Guo Liu: early Tensor4all meta-design and project direction.
+- Jin-Guo Liu: early tensor4all meta-design and project direction.
 - Satoshi Terasaki: benchmark development and related project support.
 
 Contributor entries may describe the contribution type. A contributor listing

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,7 +2,9 @@
 
 ## Maintainers
 
-Maintainers have merge authority and responsibility for project policy.
+Maintainers are the listed project stewards for tenferro-rs policy and release
+direction. GitHub write/admin access may be broader than this list and does not
+by itself confer maintainer status.
 
 - Hiroshi Shinaoka
 
@@ -13,4 +15,4 @@ feature requests, bug reports, documentation feedback, benchmarks, review
 comments, or other substantial project input.
 
 Contributor entries may describe the contribution type. A contributor listing
-does not imply maintainer status or merge authority.
+does not imply maintainer status or GitHub repository permissions.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ feature requests, bug reports, documentation feedback, benchmarks, review
 comments, or other substantial project input.
 
 - Jin-Guo Liu: early Tensor4all meta-design and project direction.
+- Satoshi Terasaki: benchmark development and related project support.
 
 Contributor entries may describe the contribution type. A contributor listing
 does not imply maintainer status or GitHub repository permissions.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hiroshi Shinaoka and tenferro-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ the project with AI agents for implementation, documentation, review, issue
 triage, and verification. Human maintainers own design decisions, review
 outcomes, and merge decisions.
 
-Bug reports should include a minimal reproducer, expected behavior, actual
-behavior, and the backend/device involved. Feature requests can stay informal:
-describe what you are trying to do, what is hard today, and any examples or
-related APIs that help explain the desired workflow.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the external contribution policy.
+Bug-fix pull requests are welcome. New features must start as feature request
+issues before implementation PRs are opened.

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -1,12 +1,18 @@
 # Repository Rules
 
-These are tenferro-specific rules. Apply them on top of the shared Tensor4all
+These are tenferro-specific rules. Apply them on top of the shared tensor4all
 rules from `tensor4all-agent-rules`.
 
 ## Public Surface Drift
 
 - `README`, rustdoc, and examples must not claim capabilities beyond the current public surface.
 - When the public API changes, check for stale names, stale capability claims, and deleted paths in `README`, rustdoc, and examples before considering the work complete.
+
+## Naming Style
+
+- Prefer `tensor4all` over `Tensor4all` in project prose, documentation,
+  issue text, comments, and contributor notes unless quoting an external name
+  or preserving an existing proper noun.
 
 ## Public Surface Discipline
 

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -25,6 +25,24 @@ rules from `tensor4all-agent-rules`.
   public contract. If the answer is unclear, keep it `pub(crate)` and expose a
   smaller high-level API instead.
 
+## External Contribution Intake
+
+- Bug-fix PRs may be reviewed as merge candidates when they fix behavior that
+  is already intended by current docs, specs, or tests.
+- New features must start as feature request issues. Do not treat a
+  new-feature implementation PR as the source of truth unless maintainers
+  already accepted the linked issue and agreed that implementation should
+  start.
+- New-feature PRs opened before an accepted issue may be closed and redirected
+  to an issue. Prototype code should be linked from the issue as reference
+  material.
+- Accepted feature issues, specs, and repository rules are the source of truth
+  for implementation. External prototype code may inform implementation only
+  when its license and provenance are compatible with this repository.
+- When maintainer or AI-assisted implementation is based on external prototype
+  code, preserve appropriate copyright notices, license obligations,
+  attribution, and links to the original prototype or issue discussion.
+
 ## Standard Extension Boundary
 
 - Standard operation families (`tenferro-einsum`, `tenferro-linalg`,


### PR DESCRIPTION
## Summary

Implements the contribution-guideline pieces discussed in #925:

- adds `CONTRIBUTING.md` with the bug-fix PR path, issue-first new-feature policy, and prototype-code provenance/copyright language
- adds `CONTRIBUTORS.md` with the minimal `Maintainers` / `Contributors` split, clarifying that GitHub write/admin access is separate from maintainer status
- adds initial contributor entries for Jin-Guo Liu and Satoshi Terasaki
- adds root `LICENSE-MIT` and `LICENSE-APACHE` files matching the workspace `MIT OR Apache-2.0` declaration
- adds a single PR template whose first section redirects new-feature proposals to issues
- expands the feature request template with prototype-code, API, dependency/backend, and AD impact prompts
- links the contribution policy from `README.md`
- records the external contribution intake rule in `REPOSITORY_RULES.md` for maintainers and AI agents
- records the naming rule to prefer `tensor4all` over `Tensor4all` in project prose

## Validation

- `git diff --check`
- `cargo fmt --all --check`

Full tests were not run because this PR only changes docs, templates, and license files.
