### PR TITLE
[codex] Run CUDA CI after non-GPU PR checks

### DIFF
--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -7,10 +7,10 @@ name: CI_gpu
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 permissions:
+  actions: read
+  checks: read
   contents: read
 
 concurrency:
@@ -89,10 +89,91 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  pre-gpu-gate:
+    name: Wait for non-GPU CI
+    needs: [cuda-archive]
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Wait for prerequisite checks
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const required = [
+              "rustfmt",
+              "cargo test (blas inject)",
+              "tensor core dependency boundary",
+              "coverage",
+              "docs-site",
+              "CI gate (PR workspace tests)",
+            ];
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const ref = context.sha;
+            const deadline = Date.now() + 85 * 60 * 1000;
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            while (Date.now() < deadline) {
+              const runs = await github.paginate(github.rest.checks.listForRef, {
+                owner,
+                repo,
+                ref,
+                per_page: 100,
+              });
+
+              const latest = new Map();
+              for (const run of runs) {
+                if (!required.includes(run.name)) {
+                  continue;
+                }
+                const previous = latest.get(run.name);
+                const runTime = new Date(run.started_at || run.created_at || 0);
+                const previousTime = previous
+                  ? new Date(previous.started_at || previous.created_at || 0)
+                  : new Date(0);
+                if (!previous || runTime > previousTime) {
+                  latest.set(run.name, run);
+                }
+              }
+
+              const missing = required.filter((name) => !latest.has(name));
+              const pending = required.filter((name) => {
+                const run = latest.get(name);
+                return run && run.status !== "completed";
+              });
+              const failed = required.filter((name) => {
+                const run = latest.get(name);
+                return run && run.status === "completed" && run.conclusion !== "success";
+              });
+
+              if (failed.length > 0) {
+                for (const name of failed) {
+                  const run = latest.get(name);
+                  core.error(`${name} concluded ${run.conclusion}: ${run.html_url}`);
+                }
+                core.setFailed("A prerequisite non-GPU CI check failed.");
+                return;
+              }
+              if (missing.length === 0 && pending.length === 0) {
+                core.info(`All prerequisite checks passed: ${required.join(", ")}`);
+                return;
+              }
+
+              core.info(
+                `Waiting for prerequisite checks. Missing: ${missing.join(", ") || "none"}. ` +
+                  `Pending: ${pending.join(", ") || "none"}.`
+              );
+              await sleep(30_000);
+            }
+
+            core.setFailed(`Timed out waiting for prerequisite checks: ${required.join(", ")}`);
+
   cuda-run:
     name: CUDA tests (${{ matrix.gpu_vendor }})
-    needs: [cuda-archive]
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: [cuda-archive, pre-gpu-gate]
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-gpu
     timeout-minutes: 45
     strategy:
@@ -325,15 +406,16 @@ jobs:
 
   cuda-gate:
     name: CI GPU gate
-    needs: [cuda-archive, cuda-run]
+    needs: [cuda-archive, pre-gpu-gate, cuda-run]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - name: Require CUDA GPU tests
         env:
           ARCHIVE_RESULT: ${{ needs.cuda-archive.result }}
+          PRE_GPU_RESULT: ${{ needs.pre-gpu-gate.result }}
           CUDA_RESULT: ${{ needs.cuda-run.result }}
-          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          IS_FORK_PR: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           set -euo pipefail
           if [ "${ARCHIVE_RESULT}" != "success" ]; then
@@ -343,6 +425,10 @@ jobs:
           if [ "${IS_FORK_PR}" = "true" ]; then
             echo "Fork PR: GPU tests skipped on the org larger GPU runner; archive build passed."
             exit 0
+          fi
+          if [ "${PRE_GPU_RESULT}" != "success" ]; then
+            echo "Expected pre-gpu-gate to succeed; got pre-gpu-gate=${PRE_GPU_RESULT}"
+            exit 1
           fi
           if [ "${CUDA_RESULT}" = "success" ]; then
             exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,7 @@ python3 scripts/check-docs-site.py
 # Set CUBECL_DEBUG_LOG=0 to suppress verbose JIT compilation logs.
 # GPU tests are marked #[ignore] so they don't fail on non-GPU machines.
 # Use --ignored to actually run them.
+# If `/usr/local/cuda-12.8` is absent, find an installed CUDA root with `ls -d /usr/local/cuda*`.
 CUBECL_DEBUG_LOG=0 \
 CUDA_PATH=/usr/local/cuda-12.8 \
 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH \


### PR DESCRIPTION
## Summary
- Limit the CUDA GPU workflow to pull requests so it does not run again on main pushes.
- Add a non-GPU CI gate before cuda-run so the expensive GPU runner starts only after CPU, coverage, docs, and PR workspace checks pass.
- Document how to find an installed CUDA root when /usr/local/cuda-12.8 is absent.

## Validation
- git diff --check
- Static workflow structure check for PR-only trigger and gate dependencies
- node --check for the embedded github-script body

Generated with Codex.