### PR TITLE
[codex] Require CUDA gate before auto-merge

### DIFF
--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -216,6 +216,8 @@ jobs:
               python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['cuda']['version'].rsplit('.', 1)[0])" "${root}/version.json" 2>/dev/null || true
             elif [ -f "${root}/version.txt" ]; then
               sed -n 's/.*CUDA Version \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' "${root}/version.txt" | head -1
+            else
+              basename "${root}" | sed -n 's/^cuda-\([0-9][0-9]*\.[0-9][0-9]*\)$/\1/p'
             fi
           }
 
@@ -241,6 +243,10 @@ jobs:
           accept_cuda_toolkit() {
             local candidate="$1"
             if [ ! -d "${candidate}" ]; then
+              return 1
+            fi
+            if [ ! -d "${candidate}/lib64" ] && [ ! -d "${candidate}/targets/x86_64-linux/lib" ]; then
+              echo "Skipping CUDA toolkit at ${candidate} (library directory not found)."
               return 1
             fi
             local version

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -111,7 +111,7 @@ jobs:
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const ref = context.sha;
+            const ref = context.payload.pull_request.head.sha;
             const deadline = Date.now() + 85 * 60 * 1000;
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/ai/repo-settings.local.json
+++ b/ai/repo-settings.local.json
@@ -9,7 +9,8 @@
       "cargo test (blas inject)",
       "coverage",
       "docs-site",
-      "CI gate (PR workspace tests)"
+      "CI gate (PR workspace tests)",
+      "CI GPU gate"
     ]
   },
   "pages": {

--- a/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/tenferro-gpu/src/cubecl/dispatch.rs
@@ -113,6 +113,13 @@ pub fn cubecl_view_mut_buffer<'a, T: 'static>(
 }
 
 pub(crate) fn cubecl_shape_and_strides(shape: &[usize]) -> (Vec<usize>, Vec<usize>) {
+    // CubeCL CUDA kernels still receive a dynamic metadata pointer for tensor
+    // args. Rank-0 tensors need one dense metadata element so that launch
+    // argument layout stays consistent, while tenferro keeps the public shape
+    // as `[]` and passes the logical rank separately where needed.
+    if shape.is_empty() {
+        return (vec![1], vec![1]);
+    }
     let strides = crate::types::col_major_strides(shape)
         .into_iter()
         .map(|stride| stride as usize)

--- a/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
@@ -12,7 +12,7 @@ use crate::{
 
 #[test]
 fn cubecl_metadata_uses_dense_column_major_strides() {
-    assert_eq!(cubecl_shape_and_strides(&[]), (vec![], vec![]));
+    assert_eq!(cubecl_shape_and_strides(&[]), (vec![1], vec![1]));
     assert_eq!(
         cubecl_shape_and_strides(&[2, 3, 4]),
         (vec![2, 3, 4], vec![1, 2, 6])


### PR DESCRIPTION
## Summary
- Add `CI GPU gate` to the repository-local required status-check settings so auto-merge waits for CUDA CI.
- Make the CUDA pre-gate query the PR head SHA explicitly, matching the SHA that other PR checks report on.
- Accept CUDA runtime package roots such as `/usr/local/cuda-12.8` when the minimal runtime packages omit `version.json` / `version.txt`.
- Fix CubeCL CUDA rank-0 tensor launch metadata so scalar `to_contiguous` no longer segfaults in the GPU test run.

## Root cause
PR #937 merged before `CI_gpu` completed because branch protection required only the non-GPU checks. The wait job also used `context.sha`, which is ambiguous on `pull_request` workflows. After that was fixed, the GPU runner failed before running tests because the installed minimal CUDA 12.8 runtime tree had no version metadata even though `/usr/local/cuda-12.8` existed.

Once the runner reached the CUDA tests, `cuda_to_contiguous_rank_zero_scalar_stays_on_cuda` segfaulted. The generated CubeCL CUDA kernel still had a `dynamic_meta` launch parameter for tensor args, but rank-0 tensor metadata produced no dynamic metadata buffer. The launch argument layout was therefore mismatched. tenferro now maps rank-0 CubeCL tensor metadata to one dense metadata element while keeping the public tensor shape as `[]`.

## Validation
- `git diff --check`
- Static workflow structure checks
- `node --check` for the embedded `github-script` body
- `bash scripts/check-repo-settings.sh --quiet` after applying the live repo settings
- `cargo fmt --all --check`
- `cargo test -p tenferro-gpu --features cuda cuda_to_contiguous_rank_zero_scalar_stays_on_cuda -- --ignored --test-threads=1`
- `cargo test -p tenferro-gpu --features cuda -- --ignored --test-threads=1`
- `cargo nextest run --release -p tenferro-internal-device -p tenferro-gpu -p tenferro-ad -p tenferro-linalg --features cuda --run-ignored all --no-fail-fast -j 1` (632 passed)

Bug-fix scope gate applied. Generated with Codex.