### PR TITLE
[codex] Document TypedTensor operation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,21 @@ tenferro-gpu = { path = "tenferro-gpu", features = ["cuda"] }
 tenferro-linalg = { path = "tenferro-linalg", features = ["autodiff", "cuda"] }
 ```
 
-Start with `Tensor` and `CpuBackend` for ndarray-like CPU work. Move to
-`EagerTensor` when you want immediate execution with optional `backward()`, and
-move to `TracedTensor` when you need graph reuse, transform AD, or repeated
-compile/run execution. CUDA is available as an explicit backend/device choice
-for supported operations.
+Start with `TypedTensor<T, R>` for no-AD work when the scalar type is known at
+compile time. Use `Tensor` and `CpuBackend` when dtype should remain dynamic or
+when you want dtype-erased backend dispatch. Move to `EagerTensor` when you
+want immediate execution with optional `backward()`, and move to `TracedTensor`
+when you need graph reuse, transform AD, or repeated compile/run execution.
+CUDA is available as an explicit backend/device choice for supported
+operations.
 
 ## Direct Tensor Execution
 
 This is the closest entry point for users coming from ndarray: create concrete
 tensors, pass a backend context to operations, and get concrete tensors back.
+This example uses `Tensor` to show dtype-erased backend dispatch. If the scalar
+type is fixed in your Rust code, prefer `TypedTensor<T, R>` and the typed
+operation entry points described in the tensor operations guide.
 
 ```rust
 use tenferro_runtime::{tensor, CpuBackend, Tensor};

--- a/docs/guides/tensor-operations.md
+++ b/docs/guides/tensor-operations.md
@@ -8,12 +8,20 @@ traced graph execution.
 
 ## Layer Coverage
 
-| Layer | Operation style |
-| --- | --- |
-| `TypedTensor<T, R>` | Fixed-dtype runtime storage with optional compile-time rank; may be host-backed or backend-backed |
-| `Tensor` | Dtype-erased, dynamic-rank concrete tensor operations through `tenferro_runtime::tensor` and an explicit backend |
-| `EagerTensor` | Immediate forward operations through `tenferro_ad::eager_tensor`; tracked variables also record state for `backward()` |
-| `TracedTensor` | Lazy graph-building operations through `tenferro_runtime::traced_tensor` |
+Choose the tensor layer first, then choose the operation entry point.
+
+| Layer | Start here when | Operation entry point | AD |
+| --- | --- | --- | --- |
+| `TypedTensor<T, R>` | No AD, scalar type known at compile time | direct typed accessors; selected `tenferro_runtime::typed_tensor` wrappers for dynamic-rank `TypedTensor<T>` | No |
+| `Tensor` | No AD, dtype selected at runtime or passed through backend dispatch | `tenferro_runtime::tensor` functions with an explicit backend | No |
+| `EagerTensor` | Immediate execution in an `EagerRuntime`, optionally with scalar-loss `backward()` | `tenferro_ad::eager_tensor` functions and methods | Yes, for tracked values |
+| `TracedTensor` | Graph transforms, compilation, `grad`, `vjp`, `jvp`, or graph reuse | `tenferro_runtime::traced_tensor` functions and methods | Yes, through graph transforms |
+
+For most no-AD code, start with `TypedTensor<T, R>` when the scalar type is
+known in Rust, and use `Tensor` when the dtype must remain dynamic. `Tensor`
+is the concrete dtype-erased value type underneath eager and traced execution,
+but AD workflows should normally enter through `EagerTensor` or
+`TracedTensor`, not by using `Tensor` directly.
 
 CUDA is a backend/device choice for supported operations on `Tensor`,
 `EagerTensor`, and `TracedTensor`; it is not a separate tensor layer.
@@ -21,9 +29,152 @@ Owned runtime tensors are compact column-major. Arbitrary strides live on
 views, and compact-only operations may canonicalize those views within the same
 placement without silently transferring CPU/GPU data.
 
-## Concrete Tensor Example
+## Common Concepts And Differences
 
-Use `Tensor` with a backend when you want direct no-AD computation.
+All tensor layers use the same basic tensor vocabulary: shape, rank, dtype or
+scalar type, column-major dense storage for owned runtime tensors, explicit
+backend execution, explicit CPU/GPU transfers, and NumPy-style broadcasting
+where the operation supports it. The difference is which facts are represented
+in Rust's type system and when computation happens.
+
+| Capability | `TypedTensor<T, R>` | `Tensor` | `EagerTensor` | `TracedTensor` |
+| --- | --- | --- | --- | --- |
+| Scalar type in Rust type | Yes, `T` | No, runtime dtype enum | No, wraps `Tensor` | No, graph metadata |
+| Rank in Rust type | Optional, `R = DynRank` or `Rank<N>` | Dynamic | Dynamic | Dynamic or symbolic metadata |
+| Host typed slice access | Direct `&[T]` on host-backed tensors | Fallible `as_slice::<T>()` | Through concrete data | Only after graph execution |
+| Host iteration | Direct `iter()` and `iter_mut()` on host-backed tensors | Fallible `iter::<T>()` and `iter_mut::<T>()` | Through concrete data | Not a concrete-data API |
+| Backend math | Selected typed wrappers | Broad concrete backend surface | Eager runtime surface | Graph-building surface |
+| AD | No | No | Optional reverse-mode for tracked values | Transform AD and graph reuse |
+
+Use this distinction when reading operation examples:
+
+- direct typed accessors are `TypedTensor`-specific conveniences;
+- backend elementwise, structural, reduction, and dot operations are concrete
+  execution concepts shared by the no-AD, eager, and traced surfaces;
+- AD-only operations such as `backward`, `grad`, `vjp`, and `jvp` live on the
+  eager or traced layers.
+
+## TypedTensor For Fixed Scalar Types
+
+`TypedTensor<T, R = DynRank>` is the fixed-scalar-type runtime tensor. Use it
+when ordinary Rust code knows the element type and you do not need AD.
+`R` defaults to dynamic rank; use `Rank<N>` when the rank itself should be
+validated and carried in the Rust type.
+
+```rust
+use tenferro_tensor::{Rank, TypedTensor};
+
+let mut x = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 2],
+    vec![1.0, 2.0, 3.0, 4.0],
+);
+assert_eq!(x.shape(), &[2, 2]);
+assert_eq!(x.get(&[1, 0]), &2.0);
+
+*x.get_mut(&[0, 1]) = 5.0;
+assert_eq!(x.try_get(&[1, 1]), Some(&4.0));
+
+let sum: f64 = x.iter().copied().sum();
+assert_eq!(sum, 12.0);
+
+let static_rank = TypedTensor::<f64, Rank<2>>::from_vec_col_major(
+    [2, 2],
+    vec![1.0, 2.0, 3.0, 4.0],
+);
+assert_eq!(static_rank.rank(), 2);
+```
+
+The flat slice and iterator APIs expose the physical column-major host buffer.
+They are useful for host-side inspection, small manual edits, and
+interoperability with code that expects slices. They are not backend kernels
+and they do not configure CPU parallelism.
+
+## TypedTensor Backend Operations
+
+For common typed no-AD math, `tenferro_runtime::typed_tensor` provides selected
+wrappers that accept dynamic-rank `TypedTensor<T>` values and return typed
+results.
+
+```rust
+use tenferro_runtime::{typed_tensor, CompareDir, CpuBackend, TypedTensor};
+
+let mut backend = CpuBackend::new();
+let x = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]);
+let y = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![4.0, 5.0, 6.0]);
+
+let sum = typed_tensor::add(&x, &y, &mut backend).unwrap();
+let product = typed_tensor::mul(&x, &y, &mut backend).unwrap();
+let mask = typed_tensor::compare(&sum, &product, CompareDir::Lt, &mut backend).unwrap();
+let selected = typed_tensor::where_select(&mask, &sum, &product, &mut backend).unwrap();
+
+assert_eq!(sum.as_slice(), &[5.0, 7.0, 9.0]);
+assert_eq!(product.as_slice(), &[4.0, 10.0, 18.0]);
+assert_eq!(mask.as_slice(), &[false, true, true]);
+assert_eq!(selected.as_slice(), &[4.0, 7.0, 9.0]);
+```
+
+The current typed wrapper set covers:
+
+- elementwise arithmetic and analytic operations: `add`, `sub`, `mul`, `div`,
+  `pow`, `maximum`, `minimum`, `neg`, `abs`, `sign`, `conj`, `exp`, `log`,
+  `sin`, `cos`, `tanh`, `sqrt`, `rsqrt`, `expm1`, and `log1p`;
+- boolean-producing and selection operations: `compare`, `where_select`, and
+  `clamp`;
+- rank-2 matrix multiplication through `matmul`.
+
+These wrappers are a convenience layer over concrete tensor backend execution.
+For backend-resident CUDA tensors or operation families not covered by the
+typed wrappers, use the dtype-erased `Tensor` path or the eager/traced layer
+that matches the workflow.
+
+## Map, Iteration, And Parallelism
+
+`TypedTensor` exposes slice-style host iteration:
+
+```rust
+use tenferro_tensor::TypedTensor;
+
+let mut x = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]);
+for value in x.iter_mut() {
+    *value *= 2.0;
+}
+assert_eq!(x.as_slice(), &[2.0, 4.0, 6.0]);
+```
+
+There is no public closure-style `TypedTensor::map` or `mapv` method in the
+current public API. For host-only transformations, use `iter`, `iter_mut`,
+`as_slice`, `host_data_mut`, or `as_physical_slice_mut`. For tensor math that
+should use backend kernels, use typed wrappers or the dtype-erased `Tensor`,
+`EagerTensor`, or `TracedTensor` operation surface.
+
+Host iterators are ordinary Rust slice iterators. Backend CPU parallelism is
+controlled by the backend execution context, not by `iter()` itself. See
+[Parallelism and Caching](parallelism-and-caching.md) for CPU thread-count
+controls.
+
+## Scalar Types
+
+`TypedTensor<T, R>` is generic enough to hold host data for many Rust element
+types when you only need construction, shape/layout metadata, and host access.
+The tenferro operation and dtype system is intentionally narrower. Backend
+operations and dtype-erased `Tensor` conversion require `T: TensorScalar`,
+which is the supported scalar set:
+
+- `f32` and `f64`;
+- `i32` and `i64`;
+- `bool`;
+- `num_complex::Complex32` and `num_complex::Complex64`.
+
+`bool` is a first-class dtype for masks, comparisons, and selection. It does
+not mean every numeric or analytic operation is valid for boolean tensors.
+Arbitrary non-numeric Rust structs can be useful as host-side typed storage,
+but they are not part of backend math, CUDA execution, AD, or the dtype-erased
+`Tensor` operation surface.
+
+## DType-Erased Tensor Example
+
+Use `Tensor` with a backend when you want direct no-AD computation but the dtype
+should remain dynamic.
 
 ```rust
 use tenferro_runtime::{tensor, CpuBackend, Tensor};


### PR DESCRIPTION
## Summary

- feature `TypedTensor<T, R>` as the no-AD fixed-scalar-type starting point in the tensor operations guide
- add a tensor-layer comparison table covering common concepts, TypedTensor-specific accessors, AD layers, map/iterator behavior, parallelism, and supported scalar types
- align README guidance so `TypedTensor` is recommended before dtype-erased `Tensor` when the scalar type is known

Closes #939.

## Verification

- `cargo fmt --all --check`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

Generated with Codex.
