### PR TITLE
Add TypedTensor tutorials and backend-aware wrappers

### DIFF
--- a/.github/workflows/CI_rs_selfhost.yml
+++ b/.github/workflows/CI_rs_selfhost.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - name: Run unit and integration tests
+        # `tenferro-tutorial-code` is a workspace test package. Keep runnable
+        # tutorials in this command so CI reuses the unit-test target dir
+        # instead of recompiling tenferro in a separate tutorial job.
         run: cargo nextest run --workspace --release --no-fail-fast
       - name: Run doc tests
         run: cargo test --doc --workspace --release
@@ -65,6 +68,9 @@ jobs:
           ldconfig -p | grep -E 'libopenblas\.so' >/dev/null
           ldconfig -p | grep -E 'liblapack\.so' >/dev/null
       - name: Run unit and integration tests
+        # `tenferro-tutorial-code` is a workspace test package. Keep runnable
+        # tutorials in this command so CI reuses the unit-test target dir
+        # instead of recompiling tenferro in a separate tutorial job.
         run: cargo nextest run --workspace --release ${{ matrix.feature_args }} --no-fail-fast
       - name: Run doc tests
         run: cargo test --doc --workspace --release ${{ matrix.feature_args }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "tenferro-einsum",
     "tenferro-linalg",
     "tenferro-fft",
+    "docs/tutorial-code",
 ]
 default-members = [
     "tenferro-tensor",

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -4,6 +4,7 @@ project:
   render:
     - index.md
     - getting-started/**/*.md
+    - tutorials/**/*.md
     - guides/**/*.md
     - api/**/*.md
     - internals/**/*.md
@@ -28,6 +29,12 @@ website:
           - getting-started/index.md
           - getting-started/core-concepts.md
           - getting-started/pytorch-jax-mapping.md
+      - section: "Tutorials"
+        contents:
+          - tutorials/index.md
+          - tutorials/typed-tensor-non-ad.md
+          - tutorials/eager-autodiff-pytorch-style.md
+          - tutorials/traced-autodiff-jax-style.md
       - section: "Guides"
         contents:
           - guides/choosing-an-api.md

--- a/docs/guides/tensor-operations.md
+++ b/docs/guides/tensor-operations.md
@@ -105,11 +105,13 @@ let y = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![4.0, 5.0, 6.0]);
 
 let sum = typed_tensor::add(&x, &y, &mut backend).unwrap();
 let product = typed_tensor::mul(&x, &y, &mut backend).unwrap();
+let total = typed_tensor::reduce_sum(&product, &[0], &mut backend).unwrap();
 let mask = typed_tensor::compare(&sum, &product, CompareDir::Lt, &mut backend).unwrap();
 let selected = typed_tensor::where_select(&mask, &sum, &product, &mut backend).unwrap();
 
 assert_eq!(sum.as_slice(), &[5.0, 7.0, 9.0]);
 assert_eq!(product.as_slice(), &[4.0, 10.0, 18.0]);
+assert_eq!(total.as_slice(), &[32.0]);
 assert_eq!(mask.as_slice(), &[false, true, true]);
 assert_eq!(selected.as_slice(), &[4.0, 7.0, 9.0]);
 ```
@@ -121,12 +123,17 @@ The current typed wrapper set covers:
   `sin`, `cos`, `tanh`, `sqrt`, `rsqrt`, `expm1`, and `log1p`;
 - boolean-producing and selection operations: `compare`, `where_select`, and
   `clamp`;
+- reduction and structural operations that preserve scalar type: `reduce_sum`,
+  `reshape`, `transpose`, and `broadcast_in_dim`;
 - rank-2 matrix multiplication through `matmul`.
 
 These wrappers are a convenience layer over concrete tensor backend execution.
 For backend-resident CUDA tensors or operation families not covered by the
 typed wrappers, use the dtype-erased `Tensor` path or the eager/traced layer
-that matches the workflow.
+that matches the workflow. Prefer backend-aware typed wrappers for tensor
+reductions and shape operations; reserve `iter()` and `as_slice()` for
+host-side inspection, small assertions, or interoperability with ordinary Rust
+slice code.
 
 ## Map, Iteration, And Parallelism
 
@@ -144,9 +151,10 @@ assert_eq!(x.as_slice(), &[2.0, 4.0, 6.0]);
 
 There is no public closure-style `TypedTensor::map` or `mapv` method in the
 current public API. For host-only transformations, use `iter`, `iter_mut`,
-`as_slice`, `host_data_mut`, or `as_physical_slice_mut`. For tensor math that
-should use backend kernels, use typed wrappers or the dtype-erased `Tensor`,
-`EagerTensor`, or `TracedTensor` operation surface.
+`as_slice`, `host_data_mut`, or `as_physical_slice_mut`. For tensor math,
+reductions, or shape operations that should use backend execution, use typed
+wrappers or the dtype-erased `Tensor`, `EagerTensor`, or `TracedTensor`
+operation surface.
 
 Host iterators are ordinary Rust slice iterators. Backend CPU parallelism is
 controlled by the backend execution context, not by `iter()` itself. See

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ when the workflow needs them.
 ## Start Here
 
 - [Core Concepts](getting-started/core-concepts.md)
+- [Tutorials](tutorials/index.md)
 - [Choosing a Tensor Layer](guides/choosing-an-api.md)
 - [Execution Models](guides/execution-models.md)
 - [Memory Order](guides/memory-order.md)
@@ -67,6 +68,7 @@ symbolic inputs, and reuse.
 
 | Workflow | Start with |
 | --- | --- |
+| Step-by-step runnable examples | [`Tutorials`](tutorials/index.md) |
 | No-AD computation with a fixed scalar type | [`TypedTensor<T>` and direct tensor workflows](guides/choosing-an-api.md) |
 | No-AD dynamic dtype computation | [`Tensor` with a backend](guides/eager-operations.md) |
 | PyTorch-like eager execution and optional scalar-loss `backward()` | [`EagerTensor` and `EagerRuntime`](guides/eager-operations.md) |

--- a/docs/tutorial-code/Cargo.toml
+++ b/docs/tutorial-code/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "tenferro-tutorial-code"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[features]
+default = ["cpu-faer"]
+cpu-faer = ["tenferro-ad/cpu-faer", "tenferro-cpu/cpu-faer"]
+cpu-blas = ["tenferro-ad/cpu-blas", "tenferro-cpu/cpu-blas"]
+
+[dependencies]
+tenferro-ad = { path = "../../tenferro-ad", default-features = false }
+tenferro-cpu = { path = "../../tenferro-cpu", default-features = false }
+tenferro-runtime = { path = "../../tenferro-runtime", default-features = false }
+
+[[bin]]
+name = "typed_tensor_non_ad"
+path = "src/bin/typed_tensor_non_ad.rs"
+
+[[bin]]
+name = "eager_autodiff_pytorch_style"
+path = "src/bin/eager_autodiff_pytorch_style.rs"
+
+[[bin]]
+name = "traced_autodiff_jax_style"
+path = "src/bin/traced_autodiff_jax_style.rs"

--- a/docs/tutorial-code/README.md
+++ b/docs/tutorial-code/README.md
@@ -1,0 +1,13 @@
+# tenferro Tutorial Code
+
+Runnable source code for the tenferro tutorial pages.
+
+The online tutorials quote these binaries as their source of truth. Run them
+with:
+
+```bash
+cargo test -p tenferro-tutorial-code --release
+```
+
+In CI, this package is executed by the existing workspace test command. Do not
+add a separate tutorial workflow that recompiles tenferro after unit tests.

--- a/docs/tutorial-code/scripts/check.sh
+++ b/docs/tutorial-code/scripts/check.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+cargo test -p tenferro-tutorial-code --release

--- a/docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs
+++ b/docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs
@@ -1,0 +1,36 @@
+use tenferro_ad::{EagerRuntime, Tensor};
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, error={error}"
+        );
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let runtime = EagerRuntime::new();
+    let x = runtime.variable_from(Tensor::from_vec_row_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
+
+    let prediction = &x * &x;
+    let loss = prediction.reduce_sum(&[0])?;
+
+    assert_eq!(loss.data().shape(), &[]);
+    assert_close(loss.data().as_slice::<f64>().unwrap(), &[14.0]);
+
+    loss.backward()?;
+
+    let grad = x
+        .grad()
+        .expect("tracked variable should receive a gradient");
+    assert_eq!(grad.shape(), &[3]);
+    assert_close(grad.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
+
+    x.clear_grad();
+    assert!(x.grad().is_none());
+
+    Ok(())
+}

--- a/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
+++ b/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
@@ -1,0 +1,43 @@
+use tenferro_ad::TracedTensorAdExt;
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, error={error}"
+        );
+    }
+}
+
+fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runtime::Error> {
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(tensor)?;
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor.run(&program)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let x = TracedTensor::from_vec_row_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let y = (&x * &x).reduce_sum(&[0]);
+
+    let y_value = run(&y)?;
+    assert_eq!(y_value.shape(), &[]);
+    assert_close(y_value.as_slice::<f64>().unwrap(), &[14.0]);
+
+    let grad = y.grad(&x)?;
+    let grad_value = run(&grad)?;
+    assert_eq!(grad_value.shape(), &[3]);
+    assert_close(grad_value.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
+
+    let tangent = TracedTensor::from_vec_row_major(vec![3], vec![0.1_f64, 1.0, -2.0]);
+    let directional = y.jvp(&x, &tangent);
+    let directional_value = run(&directional)?;
+    assert_eq!(directional_value.shape(), &[]);
+    assert_close(directional_value.as_slice::<f64>().unwrap(), &[-7.8]);
+
+    Ok(())
+}

--- a/docs/tutorial-code/src/bin/typed_tensor_non_ad.rs
+++ b/docs/tutorial-code/src/bin/typed_tensor_non_ad.rs
@@ -1,0 +1,43 @@
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{typed_tensor, TypedTensor};
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, error={error}"
+        );
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut backend = CpuBackend::new();
+
+    let x = TypedTensor::<f64>::from_vec_row_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    assert_eq!(x.shape(), &[2, 3]);
+    assert_eq!(x.rank(), 2);
+    assert_eq!(x.host_data(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+
+    let column_offsets = TypedTensor::<f64>::from_vec_col_major(vec![1, 3], vec![10.0, 20.0, 30.0]);
+    let shifted = typed_tensor::add(&x, &column_offsets, &mut backend)?;
+    assert_close(shifted.host_data(), &[11.0, 14.0, 22.0, 25.0, 33.0, 36.0]);
+
+    let squared = typed_tensor::mul(&shifted, &shifted, &mut backend)?;
+    let squared_total = typed_tensor::reduce_sum(&squared, &[0, 1], &mut backend)?;
+    assert_eq!(squared_total.shape(), &[]);
+    assert_close(squared_total.host_data(), &[3811.0]);
+
+    let transposed = typed_tensor::transpose(&x, &[1, 0], &mut backend)?;
+    assert_eq!(transposed.shape(), &[3, 2]);
+    assert_close(transposed.host_data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let weights =
+        TypedTensor::<f64>::from_vec_row_major(vec![3, 2], vec![0.5, 1.0, -1.0, 2.0, 1.5, -0.5]);
+    let projected = typed_tensor::matmul(&x, &weights, &mut backend)?;
+    assert_eq!(projected.shape(), &[2, 2]);
+    assert_close(projected.host_data(), &[3.0, 6.0, 3.5, 11.0]);
+
+    Ok(())
+}

--- a/docs/tutorial-code/tests/tutorial_binaries.rs
+++ b/docs/tutorial-code/tests/tutorial_binaries.rs
@@ -1,0 +1,30 @@
+use std::process::Command;
+
+fn run_tutorial(name: &str, path: &str) {
+    let output = Command::new(path)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run tutorial binary {name}: {err}"));
+    assert!(
+        output.status.success(),
+        "tutorial binary {name} failed\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn tutorial_binaries_run_successfully() {
+    run_tutorial(
+        "typed_tensor_non_ad",
+        env!("CARGO_BIN_EXE_typed_tensor_non_ad"),
+    );
+    run_tutorial(
+        "eager_autodiff_pytorch_style",
+        env!("CARGO_BIN_EXE_eager_autodiff_pytorch_style"),
+    );
+    run_tutorial(
+        "traced_autodiff_jax_style",
+        env!("CARGO_BIN_EXE_traced_autodiff_jax_style"),
+    );
+}

--- a/docs/tutorials/eager-autodiff-pytorch-style.md
+++ b/docs/tutorials/eager-autodiff-pytorch-style.md
@@ -1,0 +1,51 @@
+# Eager Autodiff, PyTorch Style
+
+Use `EagerTensor` when you want operations to execute immediately and want a
+PyTorch-like scalar-loss `backward()` workflow. Tracked tensors created from an
+`EagerRuntime` accumulate gradients until you clear them.
+
+The example below computes `loss = sum(x * x)`, runs `backward()`, and checks
+that the gradient is `2 * x`.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs -->
+```rust
+use tenferro_ad::{EagerRuntime, Tensor};
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, error={error}"
+        );
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let runtime = EagerRuntime::new();
+    let x = runtime.variable_from(Tensor::from_vec_row_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
+
+    let prediction = &x * &x;
+    let loss = prediction.reduce_sum(&[0])?;
+
+    assert_eq!(loss.data().shape(), &[]);
+    assert_close(loss.data().as_slice::<f64>().unwrap(), &[14.0]);
+
+    loss.backward()?;
+
+    let grad = x
+        .grad()
+        .expect("tracked variable should receive a gradient");
+    assert_eq!(grad.shape(), &[3]);
+    assert_close(grad.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
+
+    x.clear_grad();
+    assert!(x.grad().is_none());
+
+    Ok(())
+}
+```
+<!-- end-snippet-source -->
+
+For the broader eager API, see the [eager operations guide](../guides/eager-operations.md).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,28 @@
+# Tutorials
+
+These tutorials are ordered, runnable introductions to the main tenferro
+workflows. They complement the guides: tutorials show one complete path, while
+guides describe the broader API surface and tradeoffs.
+
+All non-trivial code in this section is sourced from `docs/tutorial-code` and
+is run by the workspace test workflow.
+
+## Suggested Order
+
+| Tutorial | Use it when |
+| --- | --- |
+| [TypedTensor for no-AD numeric computation](typed-tensor-non-ad.md) | You know the scalar type in Rust and want ndarray-like CPU tensor computation without AD. |
+| [Eager autodiff, PyTorch style](eager-autodiff-pytorch-style.md) | You want immediate execution, scalar losses, `backward()`, and accumulated gradients. |
+| [Traced autodiff, JAX style](traced-autodiff-jax-style.md) | You want to build a graph, compile/run it, and apply transform-style AD such as `grad` or `jvp`. |
+
+## Running The Tutorial Code
+
+From the repository root:
+
+```bash
+cargo test -p tenferro-tutorial-code --release
+```
+
+The CI workflow runs this package through the existing workspace test command,
+so tutorial execution does not add a second tenferro compilation step after
+unit tests.

--- a/docs/tutorials/traced-autodiff-jax-style.md
+++ b/docs/tutorials/traced-autodiff-jax-style.md
@@ -1,0 +1,60 @@
+# Traced Autodiff, JAX Style
+
+Use `TracedTensor` when you want graph construction separated from execution.
+This is the natural entry point for JAX-like transform AD: build a graph,
+compile and run it, then derive transformed graphs such as gradients or
+Jacobian-vector products.
+
+The example below evaluates `sum(x * x)`, builds its gradient with respect to
+`x`, and evaluates a directional derivative with `jvp`.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs -->
+```rust
+use tenferro_ad::TracedTensorAdExt;
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, error={error}"
+        );
+    }
+}
+
+fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runtime::Error> {
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(tensor)?;
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor.run(&program)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let x = TracedTensor::from_vec_row_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let y = (&x * &x).reduce_sum(&[0]);
+
+    let y_value = run(&y)?;
+    assert_eq!(y_value.shape(), &[]);
+    assert_close(y_value.as_slice::<f64>().unwrap(), &[14.0]);
+
+    let grad = y.grad(&x)?;
+    let grad_value = run(&grad)?;
+    assert_eq!(grad_value.shape(), &[3]);
+    assert_close(grad_value.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
+
+    let tangent = TracedTensor::from_vec_row_major(vec![3], vec![0.1_f64, 1.0, -2.0]);
+    let directional = y.jvp(&x, &tangent);
+    let directional_value = run(&directional)?;
+    assert_eq!(directional_value.shape(), &[]);
+    assert_close(directional_value.as_slice::<f64>().unwrap(), &[-7.8]);
+
+    Ok(())
+}
+```
+<!-- end-snippet-source -->
+
+For execution model details, see the [execution models guide](../guides/execution-models.md)
+and the [autodiff guide](../guides/autodiff.md).

--- a/docs/tutorials/typed-tensor-non-ad.md
+++ b/docs/tutorials/typed-tensor-non-ad.md
@@ -1,0 +1,67 @@
+# TypedTensor For No-AD Numeric Computation
+
+Use `TypedTensor<T>` when the scalar type is fixed in Rust and the workflow does
+not need automatic differentiation. This is the closest tenferro path for
+ndarray or NumPy-style numeric code: construct tensors, run typed backend
+operations, and inspect deterministic values.
+
+The example below shows four details that matter in real code:
+
+- `from_vec_row_major` accepts row-major data and stores it in tenferro's native
+  column-major layout.
+- `typed_tensor::*` operations keep the scalar type fixed and return
+  `TypedTensor<T>`.
+- Reductions such as `typed_tensor::reduce_sum` are backend-aware tensor
+  operations, unlike small host-only checks over `iter()`.
+- Structural helpers such as `typed_tensor::transpose` preserve the typed
+  workflow without switching to dtype-erased `Tensor`.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/typed_tensor_non_ad.rs -->
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{typed_tensor, TypedTensor};
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, error={error}"
+        );
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut backend = CpuBackend::new();
+
+    let x = TypedTensor::<f64>::from_vec_row_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    assert_eq!(x.shape(), &[2, 3]);
+    assert_eq!(x.rank(), 2);
+    assert_eq!(x.host_data(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+
+    let column_offsets = TypedTensor::<f64>::from_vec_col_major(vec![1, 3], vec![10.0, 20.0, 30.0]);
+    let shifted = typed_tensor::add(&x, &column_offsets, &mut backend)?;
+    assert_close(shifted.host_data(), &[11.0, 14.0, 22.0, 25.0, 33.0, 36.0]);
+
+    let squared = typed_tensor::mul(&shifted, &shifted, &mut backend)?;
+    let squared_total = typed_tensor::reduce_sum(&squared, &[0, 1], &mut backend)?;
+    assert_eq!(squared_total.shape(), &[]);
+    assert_close(squared_total.host_data(), &[3811.0]);
+
+    let transposed = typed_tensor::transpose(&x, &[1, 0], &mut backend)?;
+    assert_eq!(transposed.shape(), &[3, 2]);
+    assert_close(transposed.host_data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let weights =
+        TypedTensor::<f64>::from_vec_row_major(vec![3, 2], vec![0.5, 1.0, -1.0, 2.0, 1.5, -0.5]);
+    let projected = typed_tensor::matmul(&x, &weights, &mut backend)?;
+    assert_eq!(projected.shape(), &[2, 2]);
+    assert_close(projected.host_data(), &[3.0, 6.0, 3.5, 11.0]);
+
+    Ok(())
+}
+```
+<!-- end-snippet-source -->
+
+For more operation coverage, see the [tensor operations guide](../guides/tensor-operations.md).

--- a/tenferro-cpu/src/backend.rs
+++ b/tenferro-cpu/src/backend.rs
@@ -838,6 +838,15 @@ impl TensorStructural for CpuBackend {
         self.install_with_pool(|buffers| structural::transpose_with_pool(buffers, input, perm))
     }
 
+    fn transpose_read(&mut self, input: TensorRead<'_>, perm: &[usize]) -> crate::Result<Tensor> {
+        if let Some(input) = input.as_tensor() {
+            return self.transpose(input, perm);
+        }
+
+        let input = materialize_tensor_read("transpose", input)?;
+        self.transpose(&input, perm)
+    }
+
     fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
         self.install(|| structural::reshape(input, shape))
     }

--- a/tenferro-cpu/src/exec_session.rs
+++ b/tenferro-cpu/src/exec_session.rs
@@ -98,6 +98,15 @@ impl TensorAnalytic for CpuExecSession<'_> {
 impl TensorStructural for CpuExecSession<'_> {
     // Structural
     delegate_with_pool!(transpose(input: &Tensor, perm: &[usize]) => structural::transpose_with_pool);
+    fn transpose_read(&mut self, input: TensorRead<'_>, perm: &[usize]) -> crate::Result<Tensor> {
+        if let Some(input) = input.as_tensor() {
+            return structural::transpose_with_pool(self.buffers, input, perm);
+        }
+
+        let input = materialize_tensor_read("transpose", input)?;
+        structural::transpose_with_pool(self.buffers, &input, perm)
+    }
+
     delegate!(reshape(input: &Tensor, shape: &[usize]) => structural::reshape(input, shape));
     fn reshape_read(&mut self, input: TensorRead<'_>, shape: &[usize]) -> crate::Result<Tensor> {
         if let Some(input) = input.as_tensor() {

--- a/tenferro-runtime/src/typed_tensor.rs
+++ b/tenferro-runtime/src/typed_tensor.rs
@@ -270,6 +270,102 @@ pub fn matmul<T: TensorScalar>(
     try_into_typed_result("matmul", out)
 }
 
+/// Sum elements across one or more axes.
+///
+/// # Examples
+///
+/// ```rust
+/// # use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{typed_tensor, TypedTensor};
+/// # let mut backend = CpuBackend::new();
+/// let x = TypedTensor::<f64>::from_vec_row_major(
+///     vec![2, 3],
+///     vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+/// );
+/// let row_sums = typed_tensor::reduce_sum(&x, &[1], &mut backend).unwrap();
+/// assert_eq!(row_sums.host_data(), &[6.0, 15.0]);
+/// ```
+pub fn reduce_sum<T: TensorScalar>(
+    input: &TypedTensor<T>,
+    axes: &[usize],
+    backend: &mut impl TensorBackend,
+) -> Result<TypedTensor<T>> {
+    let out =
+        backend.with_backend_session(|exec| exec.reduce_sum_read(T::tensor_read(input), axes))?;
+    try_into_typed_result("reduce_sum", out)
+}
+
+/// Reshape a typed tensor through the backend structural operation.
+///
+/// # Examples
+///
+/// ```rust
+/// # use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{typed_tensor, TypedTensor};
+/// # let mut backend = CpuBackend::new();
+/// let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]);
+/// let y = typed_tensor::reshape(&x, &[3, 2], &mut backend).unwrap();
+/// assert_eq!(y.shape(), &[3, 2]);
+/// ```
+pub fn reshape<T: TensorScalar>(
+    input: &TypedTensor<T>,
+    shape: &[usize],
+    backend: &mut impl TensorBackend,
+) -> Result<TypedTensor<T>> {
+    let out =
+        backend.with_backend_session(|exec| exec.reshape_read(T::tensor_read(input), shape))?;
+    try_into_typed_result("reshape", out)
+}
+
+/// Permute typed tensor axes through the backend structural operation.
+///
+/// # Examples
+///
+/// ```rust
+/// # use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{typed_tensor, TypedTensor};
+/// # let mut backend = CpuBackend::new();
+/// let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]);
+/// let y = typed_tensor::transpose(&x, &[1, 0], &mut backend).unwrap();
+/// assert_eq!(y.shape(), &[3, 2]);
+/// ```
+pub fn transpose<T: TensorScalar>(
+    input: &TypedTensor<T>,
+    perm: &[usize],
+    backend: &mut impl TensorBackend,
+) -> Result<TypedTensor<T>> {
+    let out =
+        backend.with_backend_session(|exec| exec.transpose_read(T::tensor_read(input), perm))?;
+    try_into_typed_result("transpose", out)
+}
+
+/// Broadcast a typed tensor into a larger shape.
+///
+/// `dims` maps each input axis to its output axis, following the concrete
+/// backend `broadcast_in_dim` contract.
+///
+/// # Examples
+///
+/// ```rust
+/// # use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{typed_tensor, TypedTensor};
+/// # let mut backend = CpuBackend::new();
+/// let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]);
+/// let matrix = typed_tensor::broadcast_in_dim(&row, &[2, 3], &[1], &mut backend).unwrap();
+/// assert_eq!(matrix.shape(), &[2, 3]);
+/// ```
+pub fn broadcast_in_dim<T: TensorScalar>(
+    input: &TypedTensor<T>,
+    shape: &[usize],
+    dims: &[usize],
+    backend: &mut impl TensorBackend,
+) -> Result<TypedTensor<T>> {
+    let out = backend.with_backend_session(|exec| {
+        exec.broadcast_in_dim_read(T::tensor_read(input), shape, dims)
+    })?;
+    try_into_typed_result("broadcast_in_dim", out)
+}
+
 enum ReadInput<'a> {
     Borrowed(TensorRead<'a>),
     Owned(Tensor),

--- a/tenferro-runtime/tests/typed_tensor_ops.rs
+++ b/tenferro-runtime/tests/typed_tensor_ops.rs
@@ -1,0 +1,40 @@
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{typed_tensor, TypedTensor};
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, error={error}"
+        );
+    }
+}
+
+#[test]
+fn typed_tensor_reduction_and_structural_wrappers_preserve_values() {
+    let mut backend = CpuBackend::new();
+    let x = TypedTensor::<f64>::from_vec_row_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let row_sums = typed_tensor::reduce_sum(&x, &[1], &mut backend).unwrap();
+    assert_eq!(row_sums.shape(), &[2]);
+    assert_close(row_sums.host_data(), &[6.0, 15.0]);
+
+    let total = typed_tensor::reduce_sum(&x, &[0, 1], &mut backend).unwrap();
+    assert_eq!(total.shape(), &[]);
+    assert_close(total.host_data(), &[21.0]);
+
+    let reshaped = typed_tensor::reshape(&x, &[3, 2], &mut backend).unwrap();
+    assert_eq!(reshaped.shape(), &[3, 2]);
+    assert_close(reshaped.host_data(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+
+    let transposed = typed_tensor::transpose(&x, &[1, 0], &mut backend).unwrap();
+    assert_eq!(transposed.shape(), &[3, 2]);
+    assert_close(transposed.host_data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+    let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![10.0, 20.0, 30.0]);
+    let broadcast = typed_tensor::broadcast_in_dim(&row, &[2, 3], &[1], &mut backend).unwrap();
+    assert_eq!(broadcast.shape(), &[2, 3]);
+    assert_close(broadcast.host_data(), &[10.0, 10.0, 20.0, 20.0, 30.0, 30.0]);
+}

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -230,6 +230,10 @@ pub trait TensorAnalytic {
 /// ```
 pub trait TensorStructural {
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor>;
+    fn transpose_read(&mut self, input: TensorRead<'_>, perm: &[usize]) -> crate::Result<Tensor> {
+        self.transpose(read_tensor("transpose", input)?, perm)
+    }
+
     fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor>;
     fn reshape_read(&mut self, input: TensorRead<'_>, shape: &[usize]) -> crate::Result<Tensor> {
         self.reshape(read_tensor("reshape", input)?, shape)


### PR DESCRIPTION
## Summary

Closes #941.

- Add `typed_tensor::reduce_sum`, `reshape`, `transpose`, and `broadcast_in_dim` wrappers that preserve `TypedTensor<T>` output.
- Add a missing `transpose_read` backend entrypoint and CPU overrides so typed structural wrappers can consume `TensorRead` inputs consistently.
- Add runnable tutorial binaries for no-AD `TypedTensor`, eager autodiff, and traced autodiff, and include them in the workspace test path instead of a separate tutorial compile step.
- Feature the new TypedTensor reduction path in the tensor operations guide and add the tutorial section to the docs site.

## Verification

- `cargo fmt --all --check`
- `cargo test -p tenferro-runtime --test typed_tensor_ops --release`
- `cargo test -p tenferro-tutorial-code --release`
- `cargo tree --workspace --no-default-features --features cpu-blas -e features -i tenferro-cpu`
- `RUSTFLAGS='-l dylib=openblas -l dylib=lapack' cargo test -p tenferro-tutorial-code --release --no-default-features --features cpu-blas`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo test --doc --workspace --release`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo test --workspace --release`
