### PR TITLE
[codex] Gate rust clippy warnings

### DIFF
--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -102,6 +102,7 @@ jobs:
           script: |
             const required = [
               "rustfmt",
+              "clippy",
               "cargo test (blas inject)",
               "tensor core dependency boundary",
               "coverage",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all --check
 
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Run workspace clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Run tropical extension clippy
+        run: cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
+
   # test-workspace:
   #   name: cargo test (workspace)
   #   runs-on: ubuntu-latest

--- a/docs/superpowers/plans/2026-05-30-quality-ci-gate.md
+++ b/docs/superpowers/plans/2026-05-30-quality-ci-gate.md
@@ -1,0 +1,403 @@
+# Quality CI Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make clippy a required CI quality gate and remove the low-risk lint/dead-code debt that currently prevents the gate from passing.
+
+**Architecture:** Add one isolated GitHub Actions job for clippy, then fix only local mechanical Rust lints and unused crate-private wrappers. Keep numerical behavior, public APIs, backend dispatch, and broad operation-wrapper abstractions unchanged.
+
+**Tech Stack:** Rust, Cargo, Clippy, GitHub Actions, `rg`, existing tenferro workspace crates.
+
+---
+
+## File Structure
+
+- Modify `.github/workflows/ci.yml`: add the `clippy` job for the root workspace and `ext/tropical`.
+- Modify `.github/workflows/CI_gpu.yml`: add `clippy` to the non-GPU prerequisite list.
+- Modify `tenferro-core-ops/src/catalog.rs`: replace the primitive count macro expression that triggers `unused_unit`.
+- Modify `tenferro-tensor-core/src/layout.rs`: replace manual zero-extent scans with `contains`.
+- Modify `tenferro-tensor-core/src/lib.rs`: replace manual zero-extent scans with `contains`.
+- Modify `tenferro-cpu/src/elementwise.rs`: delete unused local-pool convenience wrappers for Tier2 elementwise helpers.
+- Modify `tenferro-cpu/src/gemm/mod.rs`: delete unused uncached GEMM convenience wrappers.
+- Modify `tenferro-cpu/src/gemm/tests.rs`: call the retained cached BLAS helper directly.
+
+## Task 1: Verify the Red Clippy Baseline
+
+**Files:**
+- No edits.
+
+- [ ] **Step 1: Run workspace clippy and confirm it fails for the known lints**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: FAIL with `unused_unit` in `tenferro-core-ops/src/catalog.rs` and
+`manual_contains` in `tenferro-tensor-core/src/layout.rs` and
+`tenferro-tensor-core/src/lib.rs`.
+
+## Task 2: Fix Mechanical Clippy Lints
+
+**Files:**
+- Modify `tenferro-core-ops/src/catalog.rs`
+- Modify `tenferro-tensor-core/src/layout.rs`
+- Modify `tenferro-tensor-core/src/lib.rs`
+
+- [ ] **Step 1: Replace the primitive count expression**
+
+In `tenferro-core-ops/src/catalog.rs`, replace:
+
+```rust
+pub const COUNT: usize = <[()]>::len(&[$({ let _ = stringify!($variant); () }),*]);
+```
+
+with:
+
+```rust
+pub const COUNT: usize = [$(PrimitiveOpKind::$variant),*].len();
+```
+
+- [ ] **Step 2: Replace manual zero checks in `layout.rs`**
+
+In `tenferro-tensor-core/src/layout.rs`, replace:
+
+```rust
+if shape.iter().any(|&extent| extent == 0) {
+```
+
+with:
+
+```rust
+if shape.contains(&0) {
+```
+
+and replace:
+
+```rust
+if self.shape().iter().any(|&extent| extent == 0) {
+```
+
+with:
+
+```rust
+if self.shape().contains(&0) {
+```
+
+- [ ] **Step 3: Replace manual zero checks in `lib.rs`**
+
+In `tenferro-tensor-core/src/lib.rs`, replace each:
+
+```rust
+if shape.iter().any(|&extent| extent == 0) {
+```
+
+with:
+
+```rust
+if shape.contains(&0) {
+```
+
+and replace:
+
+```rust
+self.shape.iter().any(|&extent| extent == 0)
+```
+
+with:
+
+```rust
+self.shape.contains(&0)
+```
+
+- [ ] **Step 4: Run focused clippy for the touched crates**
+
+Run:
+
+```bash
+cargo clippy -p tenferro-core-ops -p tenferro-tensor-core --all-targets -- -D warnings
+```
+
+Expected: PASS.
+
+## Task 3: Remove Low-Risk Dead Code Wrappers
+
+**Files:**
+- Modify `tenferro-cpu/src/elementwise.rs`
+- Modify `tenferro-cpu/src/gemm/mod.rs`
+- Modify `tenferro-cpu/src/gemm/tests.rs`
+
+- [ ] **Step 1: Confirm elementwise wrappers have no call sites**
+
+Run:
+
+```bash
+rg -n '\btyped_abs\b|\btyped_sign\b|\btyped_maximum\b|\btyped_minimum\b|\btyped_compare\b' tenferro-cpu/src
+```
+
+Expected: only the wrapper definitions in `tenferro-cpu/src/elementwise.rs`.
+
+- [ ] **Step 2: Delete the unused elementwise wrappers**
+
+Delete these wrapper functions from `tenferro-cpu/src/elementwise.rs`, keeping
+the corresponding `_with_pool` functions:
+
+```rust
+pub(crate) fn typed_abs<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
+where
+    T: Tier2Elem + PoolScalar,
+{
+    with_local_pool(|buffers| typed_abs_with_pool(buffers, input))
+}
+```
+
+```rust
+pub(crate) fn typed_sign<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
+where
+    T: Tier2Elem + PoolScalar,
+{
+    with_local_pool(|buffers| typed_sign_with_pool(buffers, input))
+}
+```
+
+```rust
+pub(crate) fn typed_maximum<T>(
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: Tier2Elem + PoolScalar,
+{
+    with_local_pool(|buffers| typed_maximum_with_pool(buffers, lhs, rhs))
+}
+```
+
+```rust
+pub(crate) fn typed_minimum<T>(
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: Tier2Elem + PoolScalar,
+{
+    with_local_pool(|buffers| typed_minimum_with_pool(buffers, lhs, rhs))
+}
+```
+
+```rust
+pub(crate) fn typed_compare<T>(
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+    dir: &CompareDir,
+) -> crate::Result<TypedTensor<bool>>
+where
+    T: CompareElem,
+{
+    with_local_pool(|buffers| typed_compare_with_pool(buffers, lhs, rhs, dir))
+}
+```
+
+- [ ] **Step 3: Confirm uncached GEMM wrappers are unused or test-only**
+
+Run:
+
+```bash
+rg -n '\bdot_general_faer\b|\bdot_general_faer_with_conj\b|\bdot_general_blas\b|\bdot_general_blas_with_conj\b' tenferro-cpu/src
+```
+
+Expected: faer wrappers and BLAS-with-conj wrapper appear only as definitions;
+`dot_general_blas` also appears in `tenferro-cpu/src/gemm/tests.rs`.
+
+- [ ] **Step 4: Delete unused uncached GEMM wrappers**
+
+Delete these wrapper functions from `tenferro-cpu/src/gemm/mod.rs`, keeping the
+retained cached variants with the same backend implementation:
+
+- `dot_general_faer`
+- `dot_general_faer_with_conj`
+- `dot_general_blas`
+- `dot_general_blas_with_conj`
+
+- [ ] **Step 5: Update the BLAS GEMM test to call the cached helper**
+
+In `tenferro-cpu/src/gemm/tests.rs`, replace the BLAS import:
+
+```rust
+use super::dot_general_blas;
+```
+
+with:
+
+```rust
+use super::dot_general_blas_cached;
+```
+
+Then replace the test call:
+
+```rust
+let out = dot_general_blas(&mut buffers, &mut cache, &lhs, &rhs, &config)
+    .expect("dot_general should succeed");
+```
+
+with:
+
+```rust
+let out = dot_general_blas_cached(&mut buffers, &mut cache, None, &lhs, &rhs, &config)
+    .expect("dot_general should succeed");
+```
+
+- [ ] **Step 6: Run focused CPU clippy**
+
+Run:
+
+```bash
+cargo clippy -p tenferro-cpu --all-targets -- -D warnings
+```
+
+Expected: PASS. If a feature-conditional helper still needs `#[allow(dead_code)]`,
+leave it in place and add no broad cleanup.
+
+## Task 4: Add the CI Clippy Gate
+
+**Files:**
+- Modify `.github/workflows/ci.yml`
+- Modify `.github/workflows/CI_gpu.yml`
+
+- [ ] **Step 1: Add a clippy job to the main CI workflow**
+
+Add this job after `fmt` in `.github/workflows/ci.yml`:
+
+```yaml
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Run workspace clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Run tropical extension clippy
+        run: cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
+```
+
+- [ ] **Step 2: Make the GPU workflow wait for clippy**
+
+In `.github/workflows/CI_gpu.yml`, update:
+
+```javascript
+const required = [
+  "rustfmt",
+  "cargo test (blas inject)",
+  "tensor core dependency boundary",
+  "coverage",
+  "docs-site",
+  "CI gate (PR workspace tests)",
+];
+```
+
+to:
+
+```javascript
+const required = [
+  "rustfmt",
+  "clippy",
+  "cargo test (blas inject)",
+  "tensor core dependency boundary",
+  "coverage",
+  "docs-site",
+  "CI gate (PR workspace tests)",
+];
+```
+
+## Task 5: Full Local Verification
+
+**Files:**
+- No edits unless verification exposes a real regression.
+
+- [ ] **Step 1: Check formatting**
+
+Run:
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run root workspace clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run tropical extension clippy**
+
+Run:
+
+```bash
+cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run root workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run tropical extension tests**
+
+Run:
+
+```bash
+cargo test --manifest-path ext/tropical/Cargo.toml
+```
+
+Expected: PASS.
+
+## Task 6: Commit the Implementation
+
+**Files:**
+- All modified source and workflow files from Tasks 2-4.
+
+- [ ] **Step 1: Review the diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff --check
+git status --short --branch
+```
+
+Expected: no whitespace errors, and only the planned files are modified.
+
+- [ ] **Step 2: Commit**
+
+Run:
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/CI_gpu.yml \
+  tenferro-core-ops/src/catalog.rs \
+  tenferro-tensor-core/src/layout.rs \
+  tenferro-tensor-core/src/lib.rs \
+  tenferro-cpu/src/elementwise.rs \
+  tenferro-cpu/src/gemm/mod.rs \
+  tenferro-cpu/src/gemm/tests.rs
+git commit -m "ci: gate rust clippy warnings"
+```
+
+Expected: one implementation commit after the spec and plan commits.

--- a/docs/superpowers/specs/2026-05-30-quality-ci-gate-design.md
+++ b/docs/superpowers/specs/2026-05-30-quality-ci-gate-design.md
@@ -1,0 +1,147 @@
+# Quality refactor and CI gate
+
+**Date:** 2026-05-30
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+The workspace currently passes formatting, `cargo check`, and tests, but
+`cargo clippy --workspace --all-targets -- -D warnings` fails. That means CI can
+merge changes that keep tests green while accumulating lint regressions and
+avoidable dead code.
+
+The quality review also found broader maintainability pressure:
+
+- Some simple code paths trigger clippy warnings that are safe to fix without
+  changing behavior.
+- `ext/tropical` is a standalone crate outside the root workspace and needs an
+  explicit gate if it should stay healthy.
+- Several production modules use `#[allow(dead_code)]` around crate-private
+  helpers. Some are feature-combination artifacts, but some are removable thin
+  wrappers.
+- Large public operation surfaces duplicate forwarding code across tensor API
+  layers. That is real DRY debt, but it is too broad to fix safely in the same
+  change as introducing a CI gate.
+
+## Scope
+
+In scope:
+
+- Add a CI clippy gate for the root Rust workspace.
+- Include `ext/tropical` in the clippy gate because it is not a workspace
+  member.
+- Fix the currently failing clippy lints.
+- Remove low-risk unused crate-private wrappers where `rg` confirms there are
+  no call sites.
+- Leave any feature-conditional helper in place unless it is clearly unused
+  across the crate.
+
+Out of scope:
+
+- Splitting large modules such as GPU CubeCL dispatch, tensor type surfaces, or
+  runtime compiler planning.
+- Reworking public tensor/eager/traced operation wrappers into a generated or
+  macro-based abstraction.
+- Changing coverage thresholds.
+- Changing numerical behavior, backend dispatch, tensor layout, or public API.
+
+## Design
+
+### CI gate
+
+Add a `clippy` job to `.github/workflows/ci.yml`:
+
+```yaml
+clippy:
+  name: clippy
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+    - uses: Swatinem/rust-cache@v2
+    - name: Run workspace clippy
+      run: cargo clippy --workspace --all-targets -- -D warnings
+    - name: Run tropical extension clippy
+      run: cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
+```
+
+Update `.github/workflows/CI_gpu.yml` so the GPU workflow waits for `clippy`
+alongside the existing non-GPU checks. This preserves the current pattern where
+the expensive GPU lane starts only after cheaper required checks pass.
+
+### Clippy fixes
+
+Fix only mechanical warnings with no behavior change:
+
+- Replace manual zero-extent scans such as
+  `shape.iter().any(|&extent| extent == 0)` with `shape.contains(&0)`.
+- Replace the primitive catalog count expression that expands to an unnecessary
+  unit expression with an array-length expression.
+
+These changes are intentionally local and do not alter shape semantics.
+
+### Dead code cleanup
+
+Use repository search before deletion:
+
+```bash
+rg 'typed_abs\(' tenferro-cpu
+rg 'dot_general_faer\(' tenferro-cpu
+```
+
+Remove only crate-private wrappers that have no call sites and simply delegate
+to still-retained `_with_pool` or cached variants. Keep helpers that are used in
+non-default feature combinations, and prefer a short reason comment only when a
+dead-code allow is still necessary after clippy passes.
+
+### DRY boundary
+
+Do not introduce a macro for the public operation wrapper families in this
+change. The duplicated tensor/eager/traced wrappers are public-surface code, and
+collapsing them safely requires API-level review. This change should make CI
+enforce the baseline first; larger wrapper consolidation can follow once the
+gate prevents regression.
+
+## Testing strategy
+
+Before implementation, verify the red condition:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+After implementation, run:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
+cargo test --workspace
+cargo test --manifest-path ext/tropical/Cargo.toml
+```
+
+No new Rust unit tests are required because this change is intended to preserve
+behavior and remove unused wrappers. If any refactor changes a callable helper
+or public behavior, add a targeted test in the owning crate before production
+code changes.
+
+## Risks
+
+- Feature-gated CPU helpers may appear dead in the default local build while
+  being needed under a different feature set. Deletion must be limited to
+  helpers confirmed unused by repository search and by the clippy gate.
+- Adding clippy as `-D warnings` may expose future lint changes when stable Rust
+  updates. That is intentional for CI, but fixes should remain mechanical and
+  localized.
+- The root CI workflow currently has a commented-out full workspace test job.
+  This change does not alter that policy; it only adds the missing lint gate.
+
+## Success criteria
+
+- Root workspace clippy passes with `-D warnings`.
+- Tropical extension clippy passes with `-D warnings`.
+- Existing workspace tests still pass.
+- CI lists `clippy` as a non-GPU prerequisite before CUDA tests run.
+- The diff does not introduce new public APIs or numerical behavior changes.

--- a/tenferro-ad/src/eager.rs
+++ b/tenferro-ad/src/eager.rs
@@ -864,7 +864,7 @@ impl EagerTensor {
         let cotangents = try_backward_dag(&sorted, &self.key, seed, &mut callbacks, &mut ad_ctx)
             .map_err(|err| Error::Internal(err.to_string()))?;
         drop(callbacks);
-        self.ctx.store_grads(&cotangents, &mut *backend)?;
+        self.ctx.store_grads(&cotangents, &mut backend)?;
         Ok(cotangents)
     }
 }
@@ -900,7 +900,7 @@ pub(crate) fn record_eager_outputs(
     outputs: &[Arc<Tensor>],
     inputs: &[&EagerTensor],
 ) -> RecordedEagerOutputs {
-    let input_values: Vec<_> = inputs.iter().map(|tensor| eager_value(*tensor)).collect();
+    let input_values: Vec<_> = inputs.iter().map(|tensor| eager_value(tensor)).collect();
     let mut key_source = EagerTensorKeySource;
     let traces = tidu::record_eager_op(&mut key_source, op.clone(), &input_values, outputs);
 

--- a/tenferro-ad/src/eager/backward.rs
+++ b/tenferro-ad/src/eager/backward.rs
@@ -180,7 +180,7 @@ impl<B: TensorBackend + 'static> BackwardCallbacks<StdTensorOp>
                     panic!("eager forward exec failed for {:?}: {}", op_node.op, err)
                 });
 
-            for (output_id, output) in op_node.outputs.iter().zip(outputs.into_iter()) {
+            for (output_id, output) in op_node.outputs.iter().zip(outputs) {
                 let key = fragment.vals()[*output_id].key.clone();
                 all_values.insert(key, Arc::new(output));
             }

--- a/tenferro-ad/src/eager_exec.rs
+++ b/tenferro-ad/src/eager_exec.rs
@@ -13,7 +13,7 @@ use crate::shape_infer::promote_dtype_for_binary_op;
 
 enum PromotedTensor<'a> {
     Borrowed(&'a Tensor),
-    Owned(Tensor),
+    Owned(Box<Tensor>),
 }
 
 impl<'a> PromotedTensor<'a> {
@@ -33,9 +33,9 @@ fn promote_to_dtype<'a>(
     if tensor.dtype() == promoted {
         Ok(PromotedTensor::Borrowed(tensor))
     } else {
-        Ok(PromotedTensor::Owned(
+        Ok(PromotedTensor::Owned(Box::new(
             exec.convert(tensor, promoted).map_err(Error::from)?,
-        ))
+        )))
     }
 }
 

--- a/tenferro-ad/tests/ad.rs
+++ b/tenferro-ad/tests/ad.rs
@@ -35,7 +35,7 @@ use tidu::{differentiate, transpose, LinearFragment};
 
 const TOL: f64 = 1e-6;
 
-fn finite_diff_scalar(f: impl Fn(&[f64]) -> f64, x: &[f64], idx: usize, h: f64) -> f64 {
+fn finite_diff_scalar(f: &impl Fn(&[f64]) -> f64, x: &[f64], idx: usize, h: f64) -> f64 {
     let mut xp = x.to_vec();
     let mut xm = x.to_vec();
     xp[idx] += h;
@@ -44,7 +44,7 @@ fn finite_diff_scalar(f: impl Fn(&[f64]) -> f64, x: &[f64], idx: usize, h: f64) 
 }
 
 fn finite_diff_scalar_lhs(
-    f: impl Fn(&[f64], &[f64]) -> f64,
+    f: &impl Fn(&[f64], &[f64]) -> f64,
     lhs: &[f64],
     rhs: &[f64],
     idx: usize,
@@ -58,7 +58,7 @@ fn finite_diff_scalar_lhs(
 }
 
 fn finite_diff_scalar_rhs(
-    f: impl Fn(&[f64], &[f64]) -> f64,
+    f: &impl Fn(&[f64], &[f64]) -> f64,
     lhs: &[f64],
     rhs: &[f64],
     idx: usize,
@@ -540,12 +540,12 @@ fn assert_jvp_matches_finite_diff(
 
 fn assert_grad_matches_finite_diff(actual: &[f64], base: &[f64], f: impl Fn(&[f64]) -> f64) {
     assert_eq!(actual.len(), base.len());
-    for index in 0..base.len() {
+    for (index, &actual_value) in actual.iter().enumerate().take(base.len()) {
         let expected = finite_diff_scalar(&f, base, index, 1e-6);
         assert!(
-            (actual[index] - expected).abs() <= TOL,
+            (actual_value - expected).abs() <= TOL,
             "index {index}: expected {expected}, got {}",
-            actual[index]
+            actual_value
         );
     }
 }
@@ -557,12 +557,12 @@ fn assert_grad_matches_finite_diff_lhs(
     f: &impl Fn(&[f64], &[f64]) -> f64,
 ) {
     assert_eq!(actual.len(), lhs.len());
-    for index in 0..lhs.len() {
+    for (index, &actual_value) in actual.iter().enumerate().take(lhs.len()) {
         let expected = finite_diff_scalar_lhs(&f, lhs, rhs, index, 1e-6);
         assert!(
-            (actual[index] - expected).abs() <= TOL,
+            (actual_value - expected).abs() <= TOL,
             "lhs index {index}: expected {expected}, got {}",
-            actual[index]
+            actual_value
         );
     }
 }
@@ -574,12 +574,12 @@ fn assert_grad_matches_finite_diff_rhs(
     f: &impl Fn(&[f64], &[f64]) -> f64,
 ) {
     assert_eq!(actual.len(), rhs.len());
-    for index in 0..rhs.len() {
+    for (index, &actual_value) in actual.iter().enumerate().take(rhs.len()) {
         let expected = finite_diff_scalar_rhs(&f, lhs, rhs, index, 1e-6);
         assert!(
-            (actual[index] - expected).abs() <= TOL,
+            (actual_value - expected).abs() <= TOL,
             "rhs index {index}: expected {expected}, got {}",
-            actual[index]
+            actual_value
         );
     }
 }
@@ -683,12 +683,12 @@ fn grad_matmul_sum() {
         eval_scalar(matmul(&a, &b).sum(&[0, 1]))
     };
 
-    for index in 0..a_data.len() {
+    for (index, &grad_value) in grad_data.iter().enumerate().take(a_data.len()) {
         let expected = finite_diff_scalar(&f, &a_data, index, 1e-6);
         assert!(
-            (grad_data[index] - expected).abs() <= TOL,
+            (grad_value - expected).abs() <= TOL,
             "index {index}: expected {expected}, got {}",
-            grad_data[index]
+            grad_value
         );
     }
 }
@@ -716,12 +716,12 @@ fn grad_matmul_sum_wrt_rhs() {
         eval_scalar(loss)
     };
 
-    for index in 0..b_data.len() {
+    for (index, &grad_value) in grad_data.iter().enumerate().take(b_data.len()) {
         let expected = finite_diff_scalar(&f, &b_data, index, 1e-6);
         assert!(
-            (grad_data[index] - expected).abs() <= TOL,
+            (grad_value - expected).abs() <= TOL,
             "index {index}: expected {expected}, got {}",
-            grad_data[index]
+            grad_value
         );
     }
 }
@@ -745,12 +745,12 @@ fn grad_matmul_sum_shared_input() {
         eval_scalar(loss)
     };
 
-    for index in 0..a_data.len() {
+    for (index, &grad_value) in grad_data.iter().enumerate().take(a_data.len()) {
         let expected = finite_diff_scalar(&f, &a_data, index, 1e-6);
         assert!(
-            (grad_data[index] - expected).abs() <= TOL,
+            (grad_value - expected).abs() <= TOL,
             "index {index}: expected {expected}, got {}",
-            grad_data[index]
+            grad_value
         );
     }
 }
@@ -780,12 +780,12 @@ fn grad_batched_matmul_sum() {
         eval_scalar(loss)
     };
 
-    for index in 0..a_data.len() {
+    for (index, &grad_value) in grad_data.iter().enumerate().take(a_data.len()) {
         let expected = finite_diff_scalar(&f, &a_data, index, 1e-6);
         assert!(
-            (grad_data[index] - expected).abs() <= TOL,
+            (grad_value - expected).abs() <= TOL,
             "index {index}: expected {expected}, got {}",
-            grad_data[index]
+            grad_value
         );
     }
 }

--- a/tenferro-ad/tests/ad/reductions_and_indexing.rs
+++ b/tenferro-ad/tests/ad/reductions_and_indexing.rs
@@ -761,7 +761,7 @@ fn grad_dynamic_slice_clamped_start_matches_finite_diff() {
             .sum()
     };
     let expected: Vec<f64> = (0..input_data.len())
-        .map(|idx| finite_diff_scalar(loss, &input_data, idx, 1.0e-6))
+        .map(|idx| finite_diff_scalar(&loss, &input_data, idx, 1.0e-6))
         .collect();
     assert_close_slice(get_f64_data(&grad), &expected);
 }
@@ -850,10 +850,10 @@ fn grad_dynamic_update_slice_matches_finite_diff() {
             .sum()
     };
     let expected_operand: Vec<f64> = (0..operand_data.len())
-        .map(|idx| finite_diff_scalar_lhs(loss_with, &operand_data, &update_data, idx, 1.0e-6))
+        .map(|idx| finite_diff_scalar_lhs(&loss_with, &operand_data, &update_data, idx, 1.0e-6))
         .collect();
     let expected_update: Vec<f64> = (0..update_data.len())
-        .map(|idx| finite_diff_scalar_rhs(loss_with, &operand_data, &update_data, idx, 1.0e-6))
+        .map(|idx| finite_diff_scalar_rhs(&loss_with, &operand_data, &update_data, idx, 1.0e-6))
         .collect();
 
     assert_close_slice(get_f64_data(&grad_operand), &expected_operand);

--- a/tenferro-ad/tests/compiler_passes.rs
+++ b/tenferro-ad/tests/compiler_passes.rs
@@ -484,7 +484,7 @@ fn test_full_pipeline_matmul() {
         lhs_batch_dims: vec![],
         rhs_batch_dims: vec![],
     };
-    let mut program = CompiledProgram {
+    let program = CompiledProgram {
         instructions: vec![make_std_instr(
             StdTensorOp::DotGeneral {
                 config: config.clone(),
@@ -498,7 +498,7 @@ fn test_full_pipeline_matmul() {
     };
 
     let exec = compile_std_to_exec(
-        &mut program,
+        &program,
         &[DType::F64, DType::F64],
         &[dim_shape(&[2, 3]), dim_shape(&[3, 4])],
     );
@@ -534,7 +534,7 @@ fn test_full_pipeline_transpose_matmul() {
         vec![2, 1],
         vec![3],
     );
-    let mut program = CompiledProgram {
+    let program = CompiledProgram {
         instructions: vec![transpose, dot],
         input_slots: vec![0, 1],
         output_slots: vec![3],
@@ -542,7 +542,7 @@ fn test_full_pipeline_transpose_matmul() {
     };
 
     let exec = compile_std_to_exec(
-        &mut program,
+        &program,
         &[DType::F64, DType::F64],
         &[dim_shape(&[3, 2]), dim_shape(&[3, 4])],
     );
@@ -586,7 +586,7 @@ fn test_full_pipeline_dot_absorbs_conj_without_layout_materialization() {
         rhs_batch_dims: vec![],
     };
     let dot = make_std_instr(StdTensorOp::DotGeneral { config }, vec![0, 2], vec![3]);
-    let mut program = CompiledProgram {
+    let program = CompiledProgram {
         instructions: vec![conj, dot],
         input_slots: vec![0, 1],
         output_slots: vec![3],
@@ -594,7 +594,7 @@ fn test_full_pipeline_dot_absorbs_conj_without_layout_materialization() {
     };
 
     let exec = compile_std_to_exec(
-        &mut program,
+        &program,
         &[DType::C64, DType::C64],
         &[dim_shape(&[2, 3]), dim_shape(&[3, 4, 5])],
     );

--- a/tenferro-ad/tests/eager_exec.rs
+++ b/tenferro-ad/tests/eager_exec.rs
@@ -155,13 +155,13 @@ fn constant_f64_parses_bytes() {
     let result = exec_op_on_tensors(
         &StdTensorOp::Constant {
             dtype: DType::F64,
-            bytes: 3.14_f64.to_le_bytes().to_vec(),
+            bytes: 3.125_f64.to_le_bytes().to_vec(),
         },
         &[],
         &mut b,
     )
     .unwrap();
-    assert!((data(&result[0])[0] - 3.14).abs() < 1e-12);
+    assert!((data(&result[0])[0] - 3.125).abs() < 1e-12);
 }
 
 #[test]

--- a/tenferro-core-ops/src/catalog.rs
+++ b/tenferro-core-ops/src/catalog.rs
@@ -157,7 +157,7 @@ macro_rules! define_kind {
             ///
             /// assert!(PrimitiveOpKind::COUNT > 0);
             /// ```
-            pub const COUNT: usize = <[()]>::len(&[$({ let _ = stringify!($variant); () }),*]);
+            pub const COUNT: usize = [$(PrimitiveOpKind::$variant),*].len();
 
             /// Return this kind's dense catalog index.
             ///

--- a/tenferro-cpu/src/elementwise.rs
+++ b/tenferro-cpu/src/elementwise.rs
@@ -1049,14 +1049,6 @@ where
     Ok(tensor_from_array(out))
 }
 
-#[allow(dead_code)]
-pub(crate) fn typed_abs<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
-where
-    T: Tier2Elem + PoolScalar,
-{
-    with_local_pool(|buffers| typed_abs_with_pool(buffers, input))
-}
-
 pub(crate) fn typed_abs_with_pool<T>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
@@ -1073,14 +1065,6 @@ where
     Ok(tensor_from_array(out))
 }
 
-#[allow(dead_code)]
-pub(crate) fn typed_sign<T>(input: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
-where
-    T: Tier2Elem + PoolScalar,
-{
-    with_local_pool(|buffers| typed_sign_with_pool(buffers, input))
-}
-
 pub(crate) fn typed_sign_with_pool<T>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
@@ -1095,17 +1079,6 @@ where
     })
     .map_err(|err| crate::Error::backend_failure("sign", err))?;
     Ok(tensor_from_array(out))
-}
-
-#[allow(dead_code)]
-pub(crate) fn typed_maximum<T>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-) -> crate::Result<TypedTensor<T>>
-where
-    T: Tier2Elem + PoolScalar,
-{
-    with_local_pool(|buffers| typed_maximum_with_pool(buffers, lhs, rhs))
 }
 
 pub(crate) fn typed_maximum_with_pool<T>(
@@ -1135,17 +1108,6 @@ where
     Ok(tensor_from_array(out))
 }
 
-#[allow(dead_code)]
-pub(crate) fn typed_minimum<T>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-) -> crate::Result<TypedTensor<T>>
-where
-    T: Tier2Elem + PoolScalar,
-{
-    with_local_pool(|buffers| typed_minimum_with_pool(buffers, lhs, rhs))
-}
-
 pub(crate) fn typed_minimum_with_pool<T>(
     buffers: &mut BufferPool,
     lhs: &TypedTensor<T>,
@@ -1171,18 +1133,6 @@ where
     )
     .map_err(|err| crate::Error::backend_failure("minimum", err))?;
     Ok(tensor_from_array(out))
-}
-
-#[allow(dead_code)]
-pub(crate) fn typed_compare<T>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    dir: &CompareDir,
-) -> crate::Result<TypedTensor<bool>>
-where
-    T: CompareElem,
-{
-    with_local_pool(|buffers| typed_compare_with_pool(buffers, lhs, rhs, dir))
 }
 
 pub(crate) fn typed_compare_with_pool<T>(

--- a/tenferro-cpu/src/gemm/mod.rs
+++ b/tenferro-cpu/src/gemm/mod.rs
@@ -236,6 +236,8 @@ impl GemmAnalysisCache {
             .map(|plan| plan.dims.clone())
     }
 
+    // Cache entries mirror the full analyzed GEMM key to avoid rebuilding a temporary key object.
+    #[allow(clippy::too_many_arguments)]
     fn store(
         &mut self,
         slot: usize,
@@ -697,22 +699,6 @@ where
 }
 
 #[cfg(feature = "cpu-faer")]
-#[allow(dead_code)]
-pub(crate) fn dot_general_faer<T>(
-    buffers: &mut BufferPool,
-    cache: &mut GemmAnalysisCache,
-    ctx: &crate::CpuContext,
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    config: &DotGeneralConfig,
-) -> crate::Result<TypedTensor<T>>
-where
-    T: FaerGemm + PoolScalar + Copy + Clone + Zero + One + PartialEq + 'static,
-{
-    dot_general_faer_cached(buffers, cache, None, ctx, lhs, rhs, config)
-}
-
-#[cfg(feature = "cpu-faer")]
 pub(crate) fn dot_general_faer_cached<T>(
     buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,
@@ -731,26 +717,8 @@ where
 }
 
 #[cfg(feature = "cpu-faer")]
-#[allow(dead_code)]
-pub(crate) fn dot_general_faer_with_conj<T>(
-    buffers: &mut BufferPool,
-    cache: &mut GemmAnalysisCache,
-    ctx: &crate::CpuContext,
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    config: &DotGeneralConfig,
-    lhs_conj: bool,
-    rhs_conj: bool,
-) -> crate::Result<TypedTensor<T>>
-where
-    T: FaerGemm + PoolScalar + Copy + Clone + Zero + One + PartialEq + 'static,
-{
-    dot_general_faer_with_conj_cached(
-        buffers, cache, None, ctx, lhs, rhs, config, lhs_conj, rhs_conj,
-    )
-}
-
-#[cfg(feature = "cpu-faer")]
+// Matches the public dot-general parameters plus cache metadata and conjugation flags.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn dot_general_faer_with_conj_cached<T>(
     buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,
@@ -918,6 +886,8 @@ pub(crate) fn dot_general_faer_read_cached(
 }
 
 #[cfg(feature = "cpu-faer")]
+// Internal GEMM fast path needs cache metadata, backend context, operands, and conjugation flags together.
+#[allow(clippy::too_many_arguments)]
 fn typed_faer_gemm<L, R, T>(
     buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,
@@ -1022,21 +992,6 @@ where
 }
 
 #[cfg(feature = "cpu-blas")]
-#[allow(dead_code)]
-pub(crate) fn dot_general_blas<T>(
-    buffers: &mut BufferPool,
-    cache: &mut GemmAnalysisCache,
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    config: &DotGeneralConfig,
-) -> crate::Result<TypedTensor<T>>
-where
-    T: BlasGemm + PoolScalar + Copy + Clone + Zero + One + 'static,
-{
-    dot_general_blas_cached(buffers, cache, None, lhs, rhs, config)
-}
-
-#[cfg(feature = "cpu-blas")]
 pub(crate) fn dot_general_blas_cached<T>(
     buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,
@@ -1086,23 +1041,6 @@ where
             "CPU GEMM requires host-backed canonical inputs",
         )
     })
-}
-
-#[cfg(feature = "cpu-blas")]
-#[allow(dead_code)]
-pub(crate) fn dot_general_blas_with_conj<T>(
-    buffers: &mut BufferPool,
-    cache: &mut GemmAnalysisCache,
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    config: &DotGeneralConfig,
-    lhs_conj: bool,
-    rhs_conj: bool,
-) -> crate::Result<TypedTensor<T>>
-where
-    T: BlasGemm + PoolScalar + Copy + Clone + Zero + One + ConjElem + 'static,
-{
-    dot_general_blas_with_conj_cached(buffers, cache, None, lhs, rhs, config, lhs_conj, rhs_conj)
 }
 
 #[cfg(feature = "cpu-blas")]

--- a/tenferro-cpu/src/gemm/tests.rs
+++ b/tenferro-cpu/src/gemm/tests.rs
@@ -6,7 +6,7 @@ use super::{
 #[cfg(feature = "cpu-blas")]
 use super::blas_gemm::BlasGemm;
 #[cfg(feature = "cpu-blas")]
-use super::dot_general_blas;
+use super::dot_general_blas_cached;
 #[cfg(feature = "cpu-faer")]
 use super::faer_gemm::FaerGemm;
 #[cfg(feature = "cpu-blas")]
@@ -167,7 +167,7 @@ fn blas_dot_general_contract_trailing_rhs_dim() {
     };
     let mut buffers = BufferPool::new();
     let mut cache = GemmAnalysisCache::default();
-    let out = dot_general_blas(&mut buffers, &mut cache, &lhs, &rhs, &config)
+    let out = dot_general_blas_cached(&mut buffers, &mut cache, None, &lhs, &rhs, &config)
         .expect("dot_general should succeed");
 
     assert_eq!(out.shape(), &[2, 2]);

--- a/tenferro-cpu/src/indexing.rs
+++ b/tenferro-cpu/src/indexing.rs
@@ -374,7 +374,7 @@ fn typed_slice<T: Copy + Clone + PoolScalar>(
                 });
             }
             let span = limit - start;
-            Ok((span + stride - 1) / stride)
+            Ok(span.div_ceil(stride))
         })
         .collect::<crate::Result<Vec<_>>>()?;
 
@@ -1325,17 +1325,17 @@ fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
     }
 
     let mut out_shape = Vec::with_capacity(input_shape.len());
-    for axis in 0..input_shape.len() {
+    for (axis, &input_extent) in input_shape.iter().enumerate() {
         if config.interior_padding[axis] < 0 {
             return Err(crate::Error::InvalidConfig {
                 op: "pad",
                 message: format!("interior padding must be non-negative on axis {axis}"),
             });
         }
-        let base = if input_shape[axis] == 0 {
+        let base = if input_extent == 0 {
             0
         } else {
-            (input_shape[axis] as i64 - 1) * (config.interior_padding[axis] + 1) + 1
+            (input_extent as i64 - 1) * (config.interior_padding[axis] + 1) + 1
         };
         let dim = config.edge_padding_low[axis] + config.edge_padding_high[axis] + base;
         out_shape.push(

--- a/tenferro-cpu/src/structural.rs
+++ b/tenferro-cpu/src/structural.rs
@@ -613,19 +613,24 @@ where
         crate::Buffer::Backend(_) => return Err(cpu_backend_buffer_error("embed_diagonal")),
     };
 
-    for flat in 0..tensor.n_elements() {
+    for (flat, value) in input_data
+        .iter()
+        .copied()
+        .enumerate()
+        .take(tensor.n_elements())
+    {
         flat_to_multi(flat, tensor.shape(), &mut in_idx);
         let diag_val = in_idx[axis_a];
         let mut src_axis = 0usize;
-        for out_axis in 0..out_rank {
+        for (out_axis, out_slot) in out_idx.iter_mut().enumerate().take(out_rank) {
             if out_axis == axis_b {
-                out_idx[out_axis] = diag_val;
+                *out_slot = diag_val;
             } else {
-                out_idx[out_axis] = in_idx[src_axis];
+                *out_slot = in_idx[src_axis];
                 src_axis += 1;
             }
         }
-        *out.get_mut(&out_idx) = input_data[flat];
+        *out.get_mut(&out_idx) = value;
     }
     Ok(out)
 }

--- a/tenferro-cpu/src/tests.rs
+++ b/tenferro-cpu/src/tests.rs
@@ -209,8 +209,8 @@ fn matrix_f64_from_tensor(t: &Tensor, rows: usize, cols: usize) -> Vec<f64> {
 
 fn batch_vector_f64_from_tensor(t: &Tensor, len: usize, batch_idx: usize) -> Vec<f64> {
     let mut out = vec![0.0; len];
-    for i in 0..len {
-        out[i] = get_f64(t, &[i, batch_idx]);
+    for (i, value) in out.iter_mut().enumerate().take(len) {
+        *value = get_f64(t, &[i, batch_idx]);
     }
     out
 }
@@ -242,16 +242,16 @@ fn batch_matrix_c64_from_tensor(
 
 fn vector_c64_from_tensor(t: &Tensor, len: usize) -> Vec<Complex64> {
     let mut out = vec![Complex64::new(0.0, 0.0); len];
-    for i in 0..len {
-        out[i] = get_c64(t, &[i]);
+    for (i, value) in out.iter_mut().enumerate().take(len) {
+        *value = get_c64(t, &[i]);
     }
     out
 }
 
 fn batch_vector_c64_from_tensor(t: &Tensor, len: usize, batch_idx: usize) -> Vec<Complex64> {
     let mut out = vec![Complex64::new(0.0, 0.0); len];
-    for i in 0..len {
-        out[i] = get_c64(t, &[i, batch_idx]);
+    for (i, value) in out.iter_mut().enumerate().take(len) {
+        *value = get_c64(t, &[i, batch_idx]);
     }
     out
 }

--- a/tenferro-einsum/src/eager.rs
+++ b/tenferro-einsum/src/eager.rs
@@ -97,7 +97,7 @@ struct BinaryDotFastPlan {
 }
 
 fn small_contains(labels: &[u32], label: u32) -> bool {
-    labels.iter().any(|candidate| *candidate == label)
+    labels.contains(&label)
 }
 
 fn labels_are_unique(labels: &[u32]) -> bool {
@@ -709,7 +709,7 @@ fn eager_einsum_exec(
     record_eager_einsum_profile("exec.enter", Duration::ZERO);
     let values = inputs
         .iter()
-        .map(|tensor| TensorValue::Borrowed(*tensor))
+        .map(|tensor| TensorValue::Borrowed(tensor))
         .collect();
     eager_einsum_exec_values(exec, values, tree)
 }
@@ -724,7 +724,7 @@ fn eager_einsum_exec_read(
     let values = inputs
         .iter()
         .map(|input| match input {
-            TensorRead::Tensor(tensor) => TensorValue::Borrowed(*tensor),
+            TensorRead::Tensor(tensor) => TensorValue::Borrowed(tensor),
             TensorRead::View(view) => TensorValue::View(view.clone()),
         })
         .collect();

--- a/tenferro-einsum/src/eager/profile.rs
+++ b/tenferro-einsum/src/eager/profile.rs
@@ -15,11 +15,11 @@ thread_local! {
     static EAGER_EINSUM_PROFILE_STATE: RefCell<HashMap<&'static str, EagerEinsumProfileEntry>> =
         RefCell::new(HashMap::new());
     #[cfg(test)]
-    static EAGER_EINSUM_PROFILE_ENABLED_OVERRIDE: RefCell<Option<bool>> = RefCell::new(None);
+    static EAGER_EINSUM_PROFILE_ENABLED_OVERRIDE: RefCell<Option<bool>> = const { RefCell::new(None) };
     #[cfg(test)]
-    static EAGER_EINSUM_TRACE_ENABLED_OVERRIDE: RefCell<Option<bool>> = RefCell::new(None);
+    static EAGER_EINSUM_TRACE_ENABLED_OVERRIDE: RefCell<Option<bool>> = const { RefCell::new(None) };
     #[cfg(test)]
-    static EAGER_EINSUM_PRINT_EVERY_OVERRIDE: RefCell<Option<Option<usize>>> = RefCell::new(None);
+    static EAGER_EINSUM_PRINT_EVERY_OVERRIDE: RefCell<Option<Option<usize>>> = const { RefCell::new(None) };
 }
 
 pub(super) fn eager_einsum_profile_enabled() -> bool {

--- a/tenferro-einsum/src/planning/tree.rs
+++ b/tenferro-einsum/src/planning/tree.rs
@@ -417,10 +417,7 @@ fn gemm_plan_retained_bytes(plan: &GemmPlan) -> usize {
 fn step_plan_retained_bytes(plan: &StepPlan) -> usize {
     plan.diag_a.as_ref().map_or(0, diag_plan_retained_bytes)
         + plan.diag_b.as_ref().map_or(0, diag_plan_retained_bytes)
-        + plan
-            .strict_binary
-            .as_ref()
-            .map_or(0, |plan| size_of_val(plan))
+        + plan.strict_binary.as_ref().map_or(0, size_of_val)
         + gemm_plan_retained_bytes(&plan.gemm)
 }
 

--- a/tenferro-einsum/src/planning/tree/tests.rs
+++ b/tenferro-einsum/src/planning/tree/tests.rs
@@ -276,14 +276,12 @@ fn self_greedy_with_four_operands_chooses_cheapest_pairs() {
     let pairs = optimize_self_greedy_pairs(&subs, &size_dict).unwrap();
     assert_eq!(pairs.len(), 3);
     let mut live: Vec<usize> = (0..4).collect();
-    let mut next = 4;
-    for &(l, r) in &pairs {
+    for (next, &(l, r)) in (4..).zip(pairs.iter()) {
         assert!(l < next);
         assert!(r < next);
         assert_ne!(l, r);
         live.retain(|&x| x != l && x != r);
         live.push(next);
-        next += 1;
     }
     assert_eq!(live.len(), 1);
 }

--- a/tenferro-einsum/src/traced.rs
+++ b/tenferro-einsum/src/traced.rs
@@ -190,7 +190,7 @@ fn infer_symbolic_output_shape(
                 shape.len()
             )));
         }
-        for (&label, dim) in labels.iter().zip(shape.into_iter()) {
+        for (&label, dim) in labels.iter().zip(shape) {
             label_dims.entry(label).or_insert(dim);
         }
     }

--- a/tenferro-einsum/tests/traced_correctness.rs
+++ b/tenferro-einsum/tests/traced_correctness.rs
@@ -109,7 +109,7 @@ fn row_major_to_column_major(data: &[f64], shape: &[usize]) -> Vec<f64> {
     if rank <= 1 {
         return data.to_vec();
     }
-    for rm_flat in 0..n {
+    for (rm_flat, value) in data.iter().copied().enumerate().take(n) {
         let mut idx = vec![0usize; rank];
         let mut rem = rm_flat;
         for d in (0..rank).rev() {
@@ -122,7 +122,7 @@ fn row_major_to_column_major(data: &[f64], shape: &[usize]) -> Vec<f64> {
             cm_flat += idx[d] * stride;
             stride *= shape[d];
         }
-        col_data[cm_flat] = data[rm_flat];
+        col_data[cm_flat] = value;
     }
     col_data
 }

--- a/tenferro-einsum/tests/traced_correctness/ported_and_paths.rs
+++ b/tenferro-einsum/tests/traced_correctness/ported_and_paths.rs
@@ -610,10 +610,10 @@ fn einsum_binary_diag_ii_jk_to_ijk() {
 
     assert_eq!(result.shape(), &[3, 2, 2]);
     let diag_a = [1.0, 2.0, 3.0];
-    for i in 0..3 {
+    for (i, &diag) in diag_a.iter().enumerate() {
         for j in 0..2 {
             for k in 0..2 {
-                let expected = diag_a[i] * get_v2(&b, &[j, k]);
+                let expected = diag * get_v2(&b, &[j, k]);
                 assert_close(
                     get_v2(&result, &[i, j, k]),
                     expected,
@@ -683,11 +683,11 @@ fn einsum_binary_diag_ii_jj_to_ij() {
     assert_eq!(result.shape(), &[3, 2]);
     let diag_a = [1.0, 2.0, 3.0];
     let diag_b = [10.0, 20.0];
-    for i in 0..3 {
-        for j in 0..2 {
+    for (i, &diag_left) in diag_a.iter().enumerate() {
+        for (j, &diag_right) in diag_b.iter().enumerate() {
             assert_close(
                 get_v2(&result, &[i, j]),
-                diag_a[i] * diag_b[j],
+                diag_left * diag_right,
                 &format!("ii_jj_ij[{i},{j}]"),
             );
         }

--- a/tenferro-internal-ops/src/ad/structural.rs
+++ b/tenferro-internal-ops/src/ad/structural.rs
@@ -531,7 +531,7 @@ pub fn transpose_slice(
         let selected_len = if limit == start {
             0
         } else {
-            (limit - start + stride - 1) / stride
+            (limit - start).div_ceil(stride)
         };
         let covered = if selected_len == 0 {
             0

--- a/tenferro-internal-ops/src/dim_expr.rs
+++ b/tenferro-internal-ops/src/dim_expr.rs
@@ -172,6 +172,8 @@ impl DimExpr {
     /// let expr = DimExpr::add(DimExpr::Const(2), DimExpr::Const(3));
     /// assert_eq!(expr.eval(&[]), 5);
     /// ```
+    // Public constructor names mirror the DimExpr variants; operator traits are a separate API choice.
+    #[allow(clippy::should_implement_trait)]
     pub fn add(a: Self, b: Self) -> Self {
         Self::Add(Box::new(a), Box::new(b))
     }
@@ -186,6 +188,8 @@ impl DimExpr {
     /// let expr = DimExpr::sub(DimExpr::Const(7), DimExpr::Const(2));
     /// assert_eq!(expr.eval(&[]), 5);
     /// ```
+    // Public constructor names mirror the DimExpr variants; operator traits are a separate API choice.
+    #[allow(clippy::should_implement_trait)]
     pub fn sub(a: Self, b: Self) -> Self {
         Self::Sub(Box::new(a), Box::new(b))
     }
@@ -200,6 +204,8 @@ impl DimExpr {
     /// let expr = DimExpr::mul(DimExpr::Const(3), DimExpr::Const(4));
     /// assert_eq!(expr.eval(&[]), 12);
     /// ```
+    // Public constructor names mirror the DimExpr variants; operator traits are a separate API choice.
+    #[allow(clippy::should_implement_trait)]
     pub fn mul(a: Self, b: Self) -> Self {
         Self::Mul(Box::new(a), Box::new(b))
     }

--- a/tenferro-internal-ops/src/sym_dim.rs
+++ b/tenferro-internal-ops/src/sym_dim.rs
@@ -159,11 +159,7 @@ fn raw_constant_value(raw: &RawSymDim) -> Option<usize> {
         RawSymDim::Mul(lhs, rhs) => raw_constant_value(lhs)?.checked_mul(raw_constant_value(rhs)?),
         RawSymDim::FloorDiv(lhs, rhs) => {
             let rhs = raw_constant_value(rhs)?;
-            if rhs == 0 {
-                None
-            } else {
-                Some(raw_constant_value(lhs)? / rhs)
-            }
+            raw_constant_value(lhs)?.checked_div(rhs)
         }
         RawSymDim::Min(lhs, rhs) => Some(raw_constant_value(lhs)?.min(raw_constant_value(rhs)?)),
         RawSymDim::Max(lhs, rhs) => Some(raw_constant_value(lhs)?.max(raw_constant_value(rhs)?)),

--- a/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -41,6 +41,8 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         b: &TypedTensor<Self>,
         transpose_a: bool,
     ) -> tenferro_tensor::Result<TypedTensor<Self>>;
+    // Mirrors triangular-solve math flags directly at the scalar backend boundary.
+    #[allow(clippy::too_many_arguments)]
     fn triangular_solve_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -2260,6 +2262,8 @@ pub(crate) fn solve<T: FaerLinalg>(
     })
 }
 
+// Keeps triangular-solve operands and flags explicit at the CPU backend boundary.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn triangular_solve<T: FaerLinalg>(
     ctx: &CpuContext,
     buffers: &mut BufferPool,

--- a/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -81,8 +81,8 @@ fn test_batched_svd() {
 
 #[test]
 fn test_batched_qr() {
-    let a0 = vec![1.0, 2.0, 3.0, 4.0, 0.5, -1.0];
-    let a1 = vec![2.0, -1.0, 0.5, 3.0, -0.25, 1.5];
+    let a0 = [1.0, 2.0, 3.0, 4.0, 0.5, -1.0];
+    let a1 = [2.0, -1.0, 0.5, 3.0, -0.25, 1.5];
     let input = Tensor::F64(TypedTensor::from_vec_col_major(
         vec![3, 2, 2],
         a0.iter().chain(a1.iter()).copied().collect(),

--- a/tenferro-linalg/src/cpu/tests/mod.rs
+++ b/tenferro-linalg/src/cpu/tests/mod.rs
@@ -206,8 +206,8 @@ fn matrix_f64_from_tensor(t: &Tensor, rows: usize, cols: usize) -> Vec<f64> {
 
 fn batch_vector_f64_from_tensor(t: &Tensor, len: usize, batch_idx: usize) -> Vec<f64> {
     let mut out = vec![0.0; len];
-    for i in 0..len {
-        out[i] = get_f64(t, &[i, batch_idx]);
+    for (i, value) in out.iter_mut().enumerate().take(len) {
+        *value = get_f64(t, &[i, batch_idx]);
     }
     out
 }
@@ -239,16 +239,16 @@ fn batch_matrix_c64_from_tensor(
 
 fn vector_c64_from_tensor(t: &Tensor, len: usize) -> Vec<Complex64> {
     let mut out = vec![Complex64::new(0.0, 0.0); len];
-    for i in 0..len {
-        out[i] = get_c64(t, &[i]);
+    for (i, value) in out.iter_mut().enumerate().take(len) {
+        *value = get_c64(t, &[i]);
     }
     out
 }
 
 fn batch_vector_c64_from_tensor(t: &Tensor, len: usize, batch_idx: usize) -> Vec<Complex64> {
     let mut out = vec![Complex64::new(0.0, 0.0); len];
-    for i in 0..len {
-        out[i] = get_c64(t, &[i, batch_idx]);
+    for (i, value) in out.iter_mut().enumerate().take(len) {
+        *value = get_c64(t, &[i, batch_idx]);
     }
     out
 }

--- a/tenferro-linalg/src/traced.rs
+++ b/tenferro-linalg/src/traced.rs
@@ -466,7 +466,7 @@ pub fn norm(
                 None => frobenius_norm(&abs, &axes),
                 Some(p) if p == f64::INFINITY => abs.reduce_max(&axes),
                 Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(&axes),
-                Some(p) if p == 0.0 => count_nonzero(&abs, &axes),
+                Some(0.0) => count_nonzero(&abs, &axes),
                 Some(p) => p_norm(&abs, &axes, p),
             }
         }
@@ -652,7 +652,7 @@ fn vector_norm(a: &TracedTensor, axis: usize, ord: Option<f64>) -> TracedTensor 
     let abs = a.abs();
     match ord {
         None => frobenius_norm(&abs, &[axis]),
-        Some(p) if p == 0.0 => count_nonzero(&abs, &[axis]),
+        Some(0.0) => count_nonzero(&abs, &[axis]),
         Some(p) if p == f64::INFINITY => abs.reduce_max(&[axis]),
         Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(&[axis]),
         Some(p) => p_norm(&abs, &[axis], p),
@@ -666,17 +666,17 @@ fn matrix_norm(a: &TracedTensor, axes: &[usize], ord: Option<f64>) -> Result<Tra
         None => frobenius_norm(&abs, &[0, 1]),
         Some(p) if p == f64::INFINITY => matrix_row_sum_norm(&abs, true),
         Some(p) if p == f64::NEG_INFINITY => matrix_row_sum_norm(&abs, false),
-        Some(p) if p == 1.0 => matrix_col_sum_norm(&abs, true),
-        Some(p) if p == -1.0 => matrix_col_sum_norm(&abs, false),
-        Some(p) if p == 2.0 => {
+        Some(1.0) => matrix_col_sum_norm(&abs, true),
+        Some(-1.0) => matrix_col_sum_norm(&abs, false),
+        Some(2.0) => {
             let singular_values = svd(&matrix)?.1.abs();
             singular_values.reduce_max(&[0])
         }
-        Some(p) if p == -2.0 => {
+        Some(-2.0) => {
             let singular_values = svd(&matrix)?.1.abs();
             singular_values.reduce_min(&[0])
         }
-        Some(p) if p == 0.0 => count_nonzero(&abs, &[0, 1]),
+        Some(0.0) => count_nonzero(&abs, &[0, 1]),
         Some(p) => p_norm(&abs, &[0, 1], p),
     })
 }
@@ -716,8 +716,8 @@ fn move_axes_to_front(tensor: &TracedTensor, axes: &[usize]) -> TracedTensor {
 
     let mut perm = Vec::with_capacity(tensor.rank);
     perm.extend_from_slice(axes);
-    for axis in 0..tensor.rank {
-        if !selected[axis] {
+    for (axis, is_selected) in selected.iter().enumerate().take(tensor.rank) {
+        if !*is_selected {
             perm.push(axis);
         }
     }

--- a/tenferro-runtime/src/compiler/mod.rs
+++ b/tenferro-runtime/src/compiler/mod.rs
@@ -68,11 +68,9 @@ pub fn compile_std_to_exec(
                 })
                 .collect();
 
-            let (output_dtype, output_shapes, output_extents): (
-                DType,
-                Vec<Vec<DimExpr>>,
-                Vec<Vec<ShapeExtent<DimExpr>>>,
-            ) = if let StdTensorOp::Extension(ext) = &instr.op {
+            let (output_dtype, output_shapes, output_extents) = if let StdTensorOp::Extension(ext) =
+                &instr.op
+            {
                 let metas =
                     infer_extension_output_meta(ext.as_ref(), &input_dtypes, &input_shapes_refs);
                 assert_eq!(
@@ -1414,8 +1412,8 @@ fn emit_merge_reshape_rhs(
 fn merge_span(shape: &[DimExpr], start: usize, end: usize) -> DimExpr {
     assert!(end > start, "merge_span: empty range");
     let mut result = shape[start].clone();
-    for axis in (start + 1)..end {
-        result = DimExpr::mul(result, shape[axis].clone());
+    for dim in shape.iter().take(end).skip(start + 1) {
+        result = DimExpr::mul(result, dim.clone());
     }
     result
 }
@@ -1604,9 +1602,7 @@ fn find_dot_operand_conj_fold(
     let mut layout_chain = Vec::new();
     let mut seen = std::collections::HashSet::new();
     while seen.insert(slot) {
-        let Some(producer_idx) = producer_by_slot.get(slot).copied().flatten() else {
-            return None;
-        };
+        let producer_idx = producer_by_slot.get(slot).copied().flatten()?;
         let producer = &program.instructions[producer_idx];
 
         if matches!(producer.op, ExecOp::Conj) && producer.input_slots.len() == 1 {

--- a/tenferro-runtime/src/exec.rs
+++ b/tenferro-runtime/src/exec.rs
@@ -380,7 +380,7 @@ fn execute_extension_instruction<B: TensorBackend + 'static>(
             },
         ));
     }
-    for (slot, tensor) in inst.output_slots.iter().copied().zip(outputs.into_iter()) {
+    for (slot, tensor) in inst.output_slots.iter().copied().zip(outputs) {
         slots[slot] = Some(tensor);
     }
     Ok(())

--- a/tenferro-runtime/src/segment.rs
+++ b/tenferro-runtime/src/segment.rs
@@ -225,9 +225,7 @@ pub(crate) fn eval_exec_segmented_with_cache_and_workspace<B: TensorBackend + 's
                                         output_slots.len()
                                     )));
                                 }
-                                for (slot, tensor) in
-                                    output_slots.iter().copied().zip(outputs.into_iter())
-                                {
+                                for (slot, tensor) in output_slots.iter().copied().zip(outputs) {
                                     slots[slot] = Some(tensor);
                                 }
                                 reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
@@ -392,8 +390,7 @@ fn build_elementwise_fusion_plan(
     }
 
     let mut ops = Vec::with_capacity(instructions.len());
-    let mut next_value = input_slots.len();
-    for inst in instructions {
+    for (next_value, inst) in (input_slots.len()..).zip(instructions.iter()) {
         if inst.dtype != dtype || inst.output_slots.len() != 1 {
             return None;
         }
@@ -405,7 +402,6 @@ fn build_elementwise_fusion_plan(
             .collect::<Option<Vec<_>>>()?;
         ops.push(ElementwiseFusionInst { op, inputs });
         slot_to_value.insert(inst.output_slots[0], next_value);
-        next_value += 1;
     }
 
     let outputs = output_slots

--- a/tenferro-runtime/src/shape_infer.rs
+++ b/tenferro-runtime/src/shape_infer.rs
@@ -58,7 +58,7 @@ pub fn promote_dtype(lhs: DType, rhs: DType) -> DType {
 pub fn promote_dtypes(dtypes: impl IntoIterator<Item = DType>) -> DType {
     dtypes
         .into_iter()
-        .reduce(|a, b| promote_dtype(a, b))
+        .reduce(promote_dtype)
         .unwrap_or(DType::F64)
 }
 
@@ -664,7 +664,7 @@ fn slice_shape(input_shape: &[DimExpr], config: &SliceConfig) -> Vec<DimExpr> {
     (0..rank)
         .map(|axis| {
             let span = config.limits[axis] - config.starts[axis];
-            DimExpr::Const((span + config.strides[axis] - 1) / config.strides[axis])
+            DimExpr::Const(span.div_ceil(config.strides[axis]))
         })
         .collect()
 }

--- a/tenferro-tensor-core/src/layout.rs
+++ b/tenferro-tensor-core/src/layout.rs
@@ -17,7 +17,7 @@ pub(crate) fn reachable_offset_range(
     strides: &[isize],
     offset: isize,
 ) -> Result<Option<(isize, isize)>> {
-    if shape.iter().any(|&extent| extent == 0) {
+    if shape.contains(&0) {
         return Ok(None);
     }
 
@@ -307,7 +307,7 @@ impl<R: TensorRank> TensorLayout<R> {
     /// # Ok::<(), tenferro_tensor_core::Error>(())
     /// ```
     pub fn validate_mutable_no_overlap(&self) -> Result<()> {
-        if self.shape().iter().any(|&extent| extent == 0) {
+        if self.shape().contains(&0) {
             return Ok(());
         }
 

--- a/tenferro-tensor-core/src/lib.rs
+++ b/tenferro-tensor-core/src/lib.rs
@@ -461,7 +461,7 @@ fn for_each_col_major_index(
         f(&[])?;
         return Ok(());
     }
-    if shape.iter().any(|&extent| extent == 0) {
+    if shape.contains(&0) {
         return Ok(());
     }
     let mut index = vec![0usize; shape.len()];
@@ -490,7 +490,7 @@ fn for_each_row_major_index(
         f(&[])?;
         return Ok(());
     }
-    if shape.iter().any(|&extent| extent == 0) {
+    if shape.contains(&0) {
         return Ok(());
     }
     let mut index = vec![0usize; shape.len()];
@@ -875,7 +875,7 @@ impl<'a, T> HostTensorView<'a, T> {
     /// # Ok::<(), tenferro_tensor_core::Error>(())
     /// ```
     pub fn is_empty(&self) -> bool {
-        self.shape.iter().any(|&extent| extent == 0)
+        self.shape.contains(&0)
     }
 
     /// Return whether this view has compact column-major logical strides.

--- a/tenferro-tensor-core/tests/core.rs
+++ b/tenferro-tensor-core/tests/core.rs
@@ -539,7 +539,7 @@ fn scalar_row_major_helpers_cover_scalar_and_empty_shapes() {
 
 #[test]
 fn dynamic_tensor_accessors_cover_all_dtype_variants() {
-    let tensors = vec![
+    let tensors = [
         Tensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap(),
         Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap(),
         Tensor::from_vec_col_major(vec![1], vec![3_i32]).unwrap(),

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -472,6 +472,8 @@ pub trait SessionCachedDot: TensorDot {
         self.dot_general(lhs, rhs, config)
     }
 
+    // Mirrors the dot-general signature plus runtime-cache metadata.
+    #[allow(clippy::too_many_arguments)]
     #[doc(hidden)]
     fn dot_general_with_conj_cached(
         &mut self,
@@ -651,6 +653,8 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
         self.dot_general(lhs, rhs, config)
     }
 
+    // Mirrors the dot-general signature plus runtime-cache metadata.
+    #[allow(clippy::too_many_arguments)]
     #[doc(hidden)]
     fn dot_general_with_conj_cached(
         &mut self,

--- a/tenferro-tensor/src/tests/op_vocabulary_contract_tests.rs
+++ b/tenferro-tensor/src/tests/op_vocabulary_contract_tests.rs
@@ -105,7 +105,8 @@ fn is_current_text_file(relative_path: &Path) -> bool {
 fn files_containing(files: &[(PathBuf, String)], needle: &str) -> Vec<PathBuf> {
     files
         .iter()
-        .filter_map(|(path, contents)| contents.contains(needle).then(|| path.clone()))
+        .filter(|(_, contents)| contents.contains(needle))
+        .map(|(path, _)| path.clone())
         .collect()
 }
 

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -842,7 +842,7 @@ fn tensor_view_covers_dtype_shape_and_materialization() {
 #[test]
 fn typed_tensor_view_materializes_sliced_host_layouts() {
     let row_major = [1_i32, 2, 3, 4, 5, 6];
-    let view = TypedTensorView::from_slice(&[2, 3], &[3, 1], 0, &row_major).unwrap();
+    let view = TypedTensorView::from_slice([2, 3], [3, 1], 0, &row_major).unwrap();
 
     assert_eq!(view.shape(), &[2, 3]);
     assert_eq!(view.strides(), &[3, 1]);
@@ -912,7 +912,7 @@ fn tensor_view_covers_strided_i32_and_bool() {
 #[test]
 fn strided_tensor_view_mut_updates_sliced_host_layouts() {
     let mut row_major = [1_i32, 2, 3, 4, 5, 6];
-    let mut view = TypedTensorViewMut::from_slice(&[2, 3], &[3, 1], 0, &mut row_major).unwrap();
+    let mut view = TypedTensorViewMut::from_slice([2, 3], [3, 1], 0, &mut row_major).unwrap();
 
     assert_eq!(view.shape(), &[2, 3]);
     assert_eq!(view.strides(), &[3, 1]);
@@ -925,7 +925,7 @@ fn strided_tensor_view_mut_updates_sliced_host_layouts() {
         let mut transposed = view.transpose_view([1, 0]).unwrap();
         *transposed.get_mut(&[2, 1]).unwrap() = 600;
     }
-    let mut view = TypedTensorViewMut::from_slice(&[2, 3], &[3, 1], 0, &mut row_major).unwrap();
+    let mut view = TypedTensorViewMut::from_slice([2, 3], [3, 1], 0, &mut row_major).unwrap();
     assert_eq!(view.get(&[1, 2]), Some(&600));
 
     {
@@ -942,30 +942,30 @@ fn strided_tensor_view_mut_updates_sliced_host_layouts() {
 #[test]
 fn strided_tensor_view_mut_rejects_aliasing_layouts() {
     let data = [1_i32, 2, 3, 4];
-    assert!(TypedTensorView::from_slice(&[2, 2], &[1, 1], 0, &data).is_ok());
+    assert!(TypedTensorView::from_slice([2, 2], [1, 1], 0, &data).is_ok());
 
     let mut data = [1_i32, 2, 3, 4];
-    let err = TypedTensorViewMut::from_slice(&[2, 2], &[1, 1], 0, &mut data).unwrap_err();
+    let err = TypedTensorViewMut::from_slice([2, 2], [1, 1], 0, &mut data).unwrap_err();
     assert!(matches!(err, Error::InvalidConfig { .. }));
 
     let mut data = [1_i32, 2];
-    assert!(TypedTensorViewMut::from_slice(&[2], &[0], 0, &mut data).is_err());
+    assert!(TypedTensorViewMut::from_slice([2], [0], 0, &mut data).is_err());
 
     let mut data = [1_i32, 2, 3];
-    let mut reversed = TypedTensorViewMut::from_slice(&[3], &[-1], 2, &mut data).unwrap();
+    let mut reversed = TypedTensorViewMut::from_slice([3], [-1], 2, &mut data).unwrap();
     *reversed.get_mut(&[2]).unwrap() = 10;
     assert_eq!(reversed.as_physical_slice(), &[10, 2, 3]);
 
     let mut data = [1_i32, 2];
     let singleton_zero_stride =
-        TypedTensorViewMut::from_slice(&[1, 2], &[0, 1], 0, &mut data).unwrap();
+        TypedTensorViewMut::from_slice([1, 2], [0, 1], 0, &mut data).unwrap();
     assert_eq!(singleton_zero_stride.shape(), &[1, 2]);
 }
 
 #[test]
 fn strided_tensor_view_mut_multi_slice_returns_option() {
     let mut data = [1_i32, 2, 3, 4, 5, 6];
-    let mut view = TypedTensorViewMut::from_slice(&[6], &[1], 0, &mut data).unwrap();
+    let mut view = TypedTensorViewMut::from_slice([6], [1], 0, &mut data).unwrap();
 
     {
         let (mut left, mut right) = view
@@ -1044,7 +1044,7 @@ fn typed_tensor_view_mut_multi_slice_returns_option_for_strided_layouts() {
 fn strided_tensor_view_validation_covers_error_edges() {
     let data = [1_i32, 2, 3];
 
-    let empty = TypedTensorView::from_slice(&[0, 3], &[1, 0], 3, &data).unwrap();
+    let empty = TypedTensorView::from_slice([0, 3], [1, 0], 3, &data).unwrap();
     assert_eq!(empty.n_elements(), 0);
     assert_eq!(
         materialize_typed_view_col_major(&empty, "test")
@@ -1054,38 +1054,38 @@ fn strided_tensor_view_validation_covers_error_edges() {
     );
     assert_eq!(empty.get(&[0, 0]), None);
     assert!(matches!(
-        TypedTensorView::<i32>::from_slice(&[0], &[1], 4, &data),
+        TypedTensorView::<i32>::from_slice([0], [1], 4, &data),
         Err(Error::InvalidConfig { .. })
     ));
 
     assert!(matches!(
-        TypedTensorView::<i32>::from_slice(&[2], &[1, 1], 0, &data),
+        TypedTensorView::<i32>::from_slice([2], [1, 1], 0, &data),
         Err(Error::RankMismatch { .. })
     ));
     assert!(matches!(
-        TypedTensorView::<i32>::from_slice(&[2], &[-1], 0, &data[..1]),
+        TypedTensorView::<i32>::from_slice([2], [-1], 0, &data[..1]),
         Err(Error::InvalidConfig { .. })
     ));
     assert!(matches!(
-        TypedTensorView::<i32>::from_slice(&[2], &[2], 0, &data[..1]),
+        TypedTensorView::<i32>::from_slice([2], [2], 0, &data[..1]),
         Err(Error::InvalidConfig { .. })
     ));
 
-    let view = TypedTensorView::from_slice(&[3], &[1], 0, &data).unwrap();
+    let view = TypedTensorView::from_slice([3], [1], 0, &data).unwrap();
     assert_eq!(view.try_get(&[1]), Some(&2));
     assert_eq!(view.try_linear_offset(&[0, 0]), None);
     assert_eq!(view.try_linear_offset(&[3]), None);
 
     assert!(matches!(
-        TypedTensorView::<i32>::from_slice(&[usize::MAX, 2], &[1, 1], 0, &[]),
+        TypedTensorView::<i32>::from_slice([usize::MAX, 2], [1, 1], 0, &[]),
         Err(Error::InvalidConfig { .. })
     ));
     assert!(matches!(
-        TypedTensorView::<i32>::from_slice(&[3], &[isize::MAX], 0, &[]),
+        TypedTensorView::<i32>::from_slice([3], [isize::MAX], 0, &[]),
         Err(Error::InvalidConfig { .. })
     ));
     assert!(matches!(
-        TypedTensorView::<i32>::from_slice(&[2, 2], &[isize::MAX, 1], 0, &[]),
+        TypedTensorView::<i32>::from_slice([2, 2], [isize::MAX, 1], 0, &[]),
         Err(Error::InvalidConfig { .. })
     ));
 }
@@ -1093,7 +1093,7 @@ fn strided_tensor_view_validation_covers_error_edges() {
 #[test]
 fn typed_tensor_view_slice_transpose_and_reshape_cover_boundaries() {
     let data = [1_i32, 2, 3, 4, 5, 6];
-    let view = TypedTensorView::from_slice(&[2, 3], &[3, 1], 0, &data).unwrap();
+    let view = TypedTensorView::from_slice([2, 3], [3, 1], 0, &data).unwrap();
 
     assert!(matches!(
         view.transpose_view([0]),
@@ -1157,14 +1157,14 @@ fn typed_tensor_view_slice_transpose_and_reshape_cover_boundaries() {
     assert_eq!(scalar.strides(), &[] as &[isize]);
     assert_eq!(scalar.get(&[]), Some(&1));
 
-    let singleton_axis = TypedTensorView::from_slice(&[1, 3], &[99, 1], 0, &data).unwrap();
+    let singleton_axis = TypedTensorView::from_slice([1, 3], [99, 1], 0, &data).unwrap();
     assert_eq!(singleton_axis.try_reshape(&[3]).unwrap().strides(), &[1]);
 }
 
 #[test]
 fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cases() {
     let mut data = [0_i32, 1, 2, 3, 4, 5];
-    let mut view = TypedTensorViewMut::from_slice(&[6], &[1], 0, &mut data).unwrap();
+    let mut view = TypedTensorViewMut::from_slice([6], [1], 0, &mut data).unwrap();
     {
         let (mut high, mut low) = view
             .try_multi_slice_mut(
@@ -1178,7 +1178,7 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
     assert_eq!(view.as_physical_slice(), &[0, 1, 20, 3, 40, 5]);
 
     let mut data = [0_i32, 1, 2, 3];
-    let mut view = TypedTensorViewMut::from_slice(&[4], &[1], 0, &mut data).unwrap();
+    let mut view = TypedTensorViewMut::from_slice([4], [1], 0, &mut data).unwrap();
     {
         let (empty, mut right) = view
             .try_multi_slice_mut(
@@ -1192,7 +1192,7 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
     assert_eq!(view.as_physical_slice(), &[0, 1, 20, 3]);
 
     let mut data = [0_i32, 1, 2, 3];
-    let mut view = TypedTensorViewMut::from_slice(&[4], &[1], 0, &mut data).unwrap();
+    let mut view = TypedTensorViewMut::from_slice([4], [1], 0, &mut data).unwrap();
     {
         let (mut left, empty) = view
             .try_multi_slice_mut(
@@ -1206,7 +1206,7 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
     assert_eq!(view.as_physical_slice(), &[0, 10, 2, 3]);
 
     let mut data = [0_i32, 1, 2, 3];
-    let mut view = TypedTensorViewMut::from_slice(&[4], &[1], 0, &mut data).unwrap();
+    let mut view = TypedTensorViewMut::from_slice([4], [1], 0, &mut data).unwrap();
     let (empty_left, empty_right) = view
         .try_multi_slice_mut(
             &[StridedSliceSpec::new(0, Some(0), 1)],
@@ -1217,7 +1217,7 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
     assert_eq!(empty_right.n_elements(), 0);
 
     let mut data = [0_i32, 1, 2, 3, 4, 5];
-    let mut view = TypedTensorViewMut::from_slice(&[6], &[1], 0, &mut data).unwrap();
+    let mut view = TypedTensorViewMut::from_slice([6], [1], 0, &mut data).unwrap();
     {
         let (mut reversed_high, mut low) = view
             .try_multi_slice_mut(
@@ -1232,7 +1232,7 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
     assert_eq!(view.as_physical_slice(), &[0, 1, 20, 30, 4, 5]);
 
     let mut data = [0_i32, 1, 2, 3, 4, 5];
-    let mut view = TypedTensorViewMut::from_slice(&[6], &[1], 0, &mut data).unwrap();
+    let mut view = TypedTensorViewMut::from_slice([6], [1], 0, &mut data).unwrap();
     assert!(view
         .try_multi_slice_mut(
             &[StridedSliceSpec::new(0, Some(6), 2)],

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -1399,7 +1399,7 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
         let placement = self.placement.clone();
         match &mut self.buffer {
             TensorBufferRefMut::Host(data) => Ok(TypedTensorViewMut {
-                buffer: TensorBufferRefMut::Host(&mut *data),
+                buffer: TensorBufferRefMut::Host(data),
                 layout,
                 placement,
             }),
@@ -1612,7 +1612,7 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
         let placement = self.placement.clone();
         match &mut self.buffer {
             TensorBufferRefMut::Host(data) => Ok(TypedTensorViewMut {
-                buffer: TensorBufferRefMut::Host(&mut *data),
+                buffer: TensorBufferRefMut::Host(data),
                 layout,
                 placement,
             }),
@@ -2073,6 +2073,8 @@ pub enum TensorView<'a> {
 /// assert_eq!(read.dtype(), DType::F64);
 /// assert_eq!(read.shape(), &[2]);
 /// ```
+// Keep borrowed views inline to avoid allocation on read-only tensor dispatch paths.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum TensorRead<'a> {
     Tensor(&'a Tensor),
@@ -2601,7 +2603,7 @@ fn for_each_layout_offset_col_major(
         });
     }
 
-    if shape.iter().any(|&dim| dim == 0) {
+    if shape.contains(&0) {
         return Ok(());
     }
 
@@ -2677,7 +2679,7 @@ fn reachable_layout_span(
     strides: &[isize],
     offset: isize,
 ) -> crate::Result<Option<(usize, usize)>> {
-    if shape.iter().any(|&extent| extent == 0) {
+    if shape.contains(&0) {
         return Ok(None);
     }
 
@@ -3023,7 +3025,7 @@ fn for_each_index(shape: &[usize], mut f: impl FnMut(&[usize])) {
         f(&[]);
         return;
     }
-    if shape.iter().any(|&dim| dim == 0) {
+    if shape.contains(&0) {
         return;
     }
 
@@ -3050,7 +3052,7 @@ fn for_each_row_major_index(shape: &[usize], mut f: impl FnMut(&[usize])) {
         f(&[]);
         return;
     }
-    if shape.iter().any(|&dim| dim == 0) {
+    if shape.contains(&0) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- Add a CI `clippy` job that gates the root workspace and the standalone `ext/tropical` crate with `-D warnings`.
- Make the CUDA workflow wait for the new `clippy` prerequisite before starting GPU tests.
- Remove unused CPU helper wrappers and clean existing clippy warnings across workspace code and tests.

## Why
`cargo clippy --workspace --all-targets -- -D warnings` was failing locally, so CI could merge warning regressions even when formatting and tests passed. This PR establishes the lint baseline and adds the CI gate to keep it from regressing.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test --manifest-path ext/tropical/Cargo.toml`
