### PR TITLE
Resolve repository quality cleanup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,13 @@ Fixes/Refs #
 
 <!-- What changed and why? -->
 
+## Work log
+
+<!-- Link docs/worklogs/<date>-<topic>.md when this PR is a nontrivial refactor,
+cleanup stream, AI-assisted implementation, or explicit design tradeoff. Include
+the context read, reference code, decisions, rejected/deferred options, and
+residual risks there instead of relying only on this PR body. -->
+
 ## Checklist
 
 - [ ] I read `CONTRIBUTING.md`.
@@ -35,3 +42,5 @@ Fixes/Refs #
       maintainers.
 - [ ] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from
       `ai/contribution-workflows/bugfix-pr.md`.
+- [ ] If this PR needs a work log, I added one under `docs/worklogs/` and
+      linked it above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,20 @@ tenferro-rs depends on strided-rs but does not absorb it. strided-rs has no BLAS
 
 See [`docs/design/`](docs/design/) for architecture and design documents.
 
+### Work Logs And Review Intent
+
+For nontrivial refactors, cleanup streams, AI-assisted implementation, or
+changes that make explicit design tradeoffs, check [`docs/worklogs/`](docs/worklogs/)
+before reviewing the code. Work logs record the session summary, context read,
+reference code, chosen design, rejected alternatives, and residual risks. A
+review that challenges scope, abstraction, or design intent should engage with
+the linked work log instead of treating the diff as context-free.
+
+When a PR establishes or changes durable design intent, update the appropriate
+document under [`docs/design/`](docs/design/) in the same PR. Work logs explain
+why a session made a decision; design docs record decisions future work should
+continue to follow.
+
 **Note**: Files under `docs/plans/` are historical records of past design discussions and decisions. They may contradict the current API or design — do not update them to match the current state.
 
 ## Performance, Layout, And Backend Rules
@@ -174,6 +188,7 @@ Additionally, verify the following before pushing:
 - **Side review**: Re-read `REPOSITORY_RULES.md` and review the local diff against repository rules before creating a PR. Fix any findings, or explicitly document residual risks.
 - **Sample code verification**: All code examples in `README.md` and `docs/getting-started/` must compile and run correctly. Extract and test any changed examples.
 - **Design document updates**: When code changes affect architecture or specifications, update the corresponding documents in `docs/architecture/`, `docs/spec/`, or `docs/design/`. Stale documentation is worse than no documentation.
+- **Work log updates**: For nontrivial refactors, cleanup streams, AI-assisted implementation, or explicit tradeoff decisions, add or update a work log under `docs/worklogs/` and link it from the PR body.
 
 ### PR Creation Rules
 

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -37,6 +37,44 @@ rules from `tensor4all-agent-rules`.
   `transpose_view`, `slice_view`, or `reshape_view`. Do not use `_view` for
   operations that allocate, canonicalize, execute kernels, or transfer data.
 
+## Wrapper DRY And Codegen
+
+- Do not assume tensor, eager, traced, and extension wrapper surfaces are fully
+  isomorphic. Public wrapper layers often differ in dtype constraints, feature
+  gates, error ownership, shape metadata, AD behavior, or rustdoc examples.
+- Do not categorically avoid `macro_rules!`, build-time code generation, or
+  small descriptors for wrapper families. They are acceptable when the wrapper
+  family is genuinely same-shaped and the invocation remains easier to review
+  than the duplicated hand-written code.
+- Avoid opportunistic macro/codegen refactors that hide public semantics,
+  erase clear rustdoc, obscure feature gates, move errors to the wrong crate,
+  or force unlike wrappers into a generic parameter bag.
+- When macro/codegen is used for public wrappers, keep generated public names,
+  docs, feature gating, and error behavior obvious at the call site, and add
+  focused tests or doctests that would fail if one generated wrapper stops
+  forwarding correctly.
+
+## Work Logs And Design Records
+
+- Nontrivial refactors, cleanup streams, AI-assisted implementation, and PRs
+  that make explicit design tradeoffs must leave a curated work log under
+  `docs/worklogs/`. The work log should record the session summary, code and
+  documents read, reference implementations considered, decisions made,
+  alternatives rejected or deferred, verification performed, and remaining
+  risks.
+- Work logs are not raw transcripts and are not implementation plans. They are
+  reviewer-facing decision records for the completed work. Keep them concise
+  enough to review, but specific enough that a later reviewer can understand
+  why an abstraction, split, macro, descriptor, public API choice, or deferral
+  was selected.
+- PR bodies for work that requires a work log must link the relevant
+  `docs/worklogs/` file. Reviewers should read linked work logs before
+  challenging scope, abstraction choices, or design intent.
+- When a PR establishes or changes durable design intent, update the
+  appropriate document under `docs/design/` in the same PR. Use work logs for
+  session-level rationale and design docs for decisions future implementation
+  and review should continue to follow.
+
 ## External Contribution Intake
 
 - Bug-fix PRs may be reviewed as merge candidates when they fix behavior that

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -29,6 +29,7 @@ architecture see [Architecture](../architecture/). For normative specs see
 | [capi.md](./capi.md) | C-API: opaque handles, DLPack, einsum + SVD + AD |
 | [capi-error-handling.md](./capi-error-handling.md) | C-API error handling policy |
 | [testing.md](./testing.md) | Testing and performance verification strategy |
+| [review-decision-records.md](./review-decision-records.md) | Relationship between historical plans, reviewer-facing work logs, and durable design records |
 
 ## Reference
 

--- a/docs/design/review-decision-records.md
+++ b/docs/design/review-decision-records.md
@@ -1,0 +1,34 @@
+# Review decision records
+
+tenferro keeps three different kinds of long-lived engineering notes:
+
+- `docs/plans/`: historical implementation plans and prior discussions. These
+  files can become stale and should not be updated to match current code.
+- `docs/worklogs/`: curated records of completed nontrivial work. These explain
+  what the implementer read, what reference code informed the change, which
+  design was chosen, which alternatives were rejected or deferred, and what
+  risks remain.
+- `docs/design/`: durable design intent that future implementation and review
+  should continue to follow.
+
+## PR workflow
+
+Nontrivial refactors, cleanup streams, AI-assisted implementation, and PRs that
+make explicit tradeoffs should add or update a work log. The PR body should
+link that work log so reviewers can evaluate the diff against the actual design
+context instead of inferring intent from the changed files alone.
+
+If the PR establishes a design rule that should outlive the session, the same
+PR should also update `docs/design/`. A work log may explain why a decision was
+made in one session, but design docs are the source reviewers should use when
+the decision applies to future code.
+
+## Review workflow
+
+Before challenging a nontrivial abstraction, module split, macro/codegen choice,
+public API boundary, or deferral, reviewers should read the linked work log and
+any linked design docs. A review can still disagree with the decision, but it
+should address the recorded rationale directly.
+
+This keeps review feedback aligned with repository intent and avoids repeatedly
+re-litigating decisions that were already made explicit.

--- a/docs/reference/repository-quality-cleanup.md
+++ b/docs/reference/repository-quality-cleanup.md
@@ -56,6 +56,12 @@ duplication, but they are near public API boundaries. DRY refactors here must
 preserve public names, feature gates, rustdoc clarity, error ownership, and
 behavior. Prefer one narrow wrapper family per PR.
 
+Do not assume these wrapper surfaces are fully isomorphic. Macro/codegen is
+allowed only when the chosen wrapper family is genuinely same-shaped and the
+invocation keeps public names, docs, feature gating, and error behavior obvious.
+For mixed wrapper families, prefer explicit public wrappers plus small private
+helpers or descriptors.
+
 ### Performance TODOs
 
 Einsum v2 performance items such as transpose folding, dot decomposition,
@@ -79,3 +85,8 @@ correctness tests and should not be mixed into lint or file-organization PRs.
 Each PR should cover one debt class or one module family. Numeric behavior,
 backend dispatch, tensor layout semantics, and AD semantics must stay unchanged
 unless a separate accepted issue explicitly scopes that change.
+
+Cleanup PRs should link a work log under `docs/worklogs/` when they make
+nontrivial abstraction, module-split, macro/codegen, or deferral decisions. If
+the cleanup establishes durable design intent, update `docs/design/` in the
+same PR.

--- a/docs/worklogs/2026-05-30-issue-955-repository-quality-cleanup.md
+++ b/docs/worklogs/2026-05-30-issue-955-repository-quality-cleanup.md
@@ -1,0 +1,125 @@
+# Repository quality cleanup work log
+
+Issue: <https://github.com/tensor4all/tenferro-rs/issues/955>
+
+Child issues:
+
+- <https://github.com/tensor4all/tenferro-rs/issues/951>
+- <https://github.com/tensor4all/tenferro-rs/issues/952>
+- <https://github.com/tensor4all/tenferro-rs/issues/953>
+- <https://github.com/tensor4all/tenferro-rs/issues/954>
+
+Date: 2026-05-30
+
+## Session summary
+
+This cleanup closed the remaining repository-quality stream by combining four
+small, related changes:
+
+- local lint/dead-code cleanup and reason comments
+- focused argument objects for internal compiler helpers
+- a real module split for the runtime dot-decomposition pass
+- a narrow DRY refactor for same-shape traced unary wrappers
+- a portability fix for the lightweight PR gate
+
+The PR also added durable rules for reviewer-facing work logs. The goal is to
+make future reviews read the implementer's recorded design context before
+challenging abstraction, split, macro/codegen, or deferral choices.
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| `AGENTS.md` | Locate the agent/reviewer entry point and existing design-doc guidance. | Added review guidance there instead of burying it only in PR template text. |
+| `REPOSITORY_RULES.md` | Find the durable tenferro-specific rules location. | Added wrapper DRY/codegen rules and work-log/design-record rules there. |
+| `.github/pull_request_template.md` | Check where PR authors see required metadata. | Added a work-log link section and checklist item. |
+| `docs/reference/repository-quality-cleanup.md` | Reuse the #955 quality cleanup policy from #950. | Added wrapper codegen criteria and cleanup work-log expectations. |
+| `tenferro-runtime/src/compiler/mod.rs` | Inspect large-module boundaries and `too_many_arguments` sites. | Chose `DotDecomposer` as the split boundary and converted local helper state into named objects. |
+| `tenferro-ad/tests/compiler_passes.rs` and `tenferro-ad/tests/compiler_passes/dot_decomposer_tests.rs` | Confirm existing coverage around compiler passes and dot decomposition. | Used existing dot-decomposer tests as behavior coverage for the split and argument refactor. |
+| `tenferro-runtime/src/traced.rs` | Inspect duplicated public traced unary wrappers. | Chose a private same-shape unary helper while preserving explicit public methods and rustdoc. |
+| `tenferro-runtime/src/tensor.rs`, `tenferro-runtime/src/typed_tensor.rs`, and `tenferro-runtime/src/traced_tensor.rs` | Check existing macro-based wrapper style in neighboring free-function surfaces. | Treated macros as valid prior art, but not the right first change for `TracedTensor` methods. |
+| `tenferro-ad/tests/numpy_api.rs` | Locate public wrapper exposure tests. | Added a forwarding behavior test for traced unary methods. |
+| `scripts/check-pr-fast.sh` | Run the local PR gate after committing the cleanup. | Replaced Bash 4-only `mapfile` usage with Bash 3.2-compatible read loops so the gate runs on macOS default Bash. |
+
+## Decisions made
+
+- **Work logs are separate from plans.** `docs/plans/` remains historical and
+  may be stale. New PR/session rationale belongs in `docs/worklogs/`, while
+  durable design intent belongs in `docs/design/`.
+- **Reviews should use work logs as context.** `AGENTS.md` now tells reviewers
+  to read linked work logs and design docs before challenging scope,
+  abstraction, or design intent.
+- **Dot decomposition is a real module boundary.** The dot-decomposition pass
+  owns canonical dot layout analysis and instruction emission, and already had
+  dedicated tests. Moving it to `compiler/dot_decomposer.rs` improves navigation
+  without splitting by line count alone.
+- **Compiler argument objects should be local and semantic.** `ConjSinkingState`,
+  `DotDecomposeInput`, `OperandMeta`, `InstructionEmitter`, and
+  `MergeReshapeSpec` replace long internal helper signatures without changing
+  public APIs or backend behavior.
+- **Wrapper DRY should keep public methods explicit.** `TracedTensor` unary
+  methods now share `apply_same_shape_unary`, but public names and docs remain
+  hand-written.
+- **Local PR gates should run on the supported developer shell.**
+  `check-pr-fast.sh` still uses Bash arrays, but no longer depends on Bash
+  4-only `mapfile`, which is absent from macOS default Bash.
+
+## Rejected or deferred alternatives
+
+- **No broad workspace-wide `too_many_arguments` removal.** FFI, BLAS/LAPACK,
+  backend trait, AD rule, and extension boundaries still keep explicit argument
+  lists where that is the clearest contract.
+- **No arbitrary large-file split.** GPU, linalg, tensor types, and registry
+  files remain untouched because this PR did not expose a similarly low-risk
+  responsibility boundary there.
+- **No macro/codegen for `TracedTensor` methods in this PR.** Neighboring
+  free-function modules use macros successfully, but `TracedTensor` methods
+  carry public rustdoc and mixed operation-specific semantics. A private helper
+  reduced real duplication without hiding public API behavior.
+- **No wrapper-family rewrite across eager/traced/tensor/extension layers.**
+  Those surfaces are not fully isomorphic. Future macro/codegen remains allowed
+  only for a genuinely same-shaped family with tests and visible docs/features.
+- **No deletion of feature-gated backend helpers.** Some `dead_code` allowances
+  are dormant only under the currently compiled feature set. They were retained
+  with reason comments instead of deleting feature-path diagnostics or provider
+  entry points.
+
+## Reference code
+
+- Existing macro wrappers in `tenferro-runtime/src/tensor.rs`,
+  `tenferro-runtime/src/typed_tensor.rs`, and
+  `tenferro-runtime/src/traced_tensor.rs` show that macros are acceptable when
+  the generated free-function family is same-shaped and remains visible at the
+  invocation site.
+- Existing compiler-pass tests in `tenferro-ad/tests/compiler_passes.rs` and
+  `tenferro-ad/tests/compiler_passes/dot_decomposer_tests.rs` were the primary
+  behavior reference for the dot-decomposition split.
+- Existing `#[allow]` reason comments around ABI/backend boundaries were used
+  as the style reference for retained production allowances.
+
+## Verification performed
+
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-ad --test numpy_api traced_unary_methods_forward_to_distinct_primal_ops`
+- `cargo test -p tenferro-ad --test compiler_passes dot_decomposer`
+- `cargo clippy -p tenferro-runtime --all-targets -- -D warnings`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --no-fail-fast`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `python3 scripts/check-crate-boundaries.py`
+- `python3 scripts/check-no-facade-crate.py`
+- `python3 scripts/check-ad-boundaries.py`
+- `python3 scripts/check-linalg-ad-boundaries.py`
+- `cargo test --manifest-path ext/tropical/Cargo.toml --no-fail-fast`
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-ad --test numpy_api traced_unary_methods_forward_to_distinct_primal_ops' --test 'cargo test -p tenferro-ad --test compiler_passes dot_decomposer'`
+
+## Remaining risk
+
+- The compiler split is behavior-preserving and covered by existing pass tests,
+  but it moved a large block of code. Review should check module visibility and
+  that only `dot_decomposer` moved out of `compiler/mod.rs`.
+- Retained lint allowances still exist at backend, FFI, AD, and test boundaries.
+  They are intentional after this cleanup, but future work can continue reducing
+  them one boundary at a time.

--- a/docs/worklogs/README.md
+++ b/docs/worklogs/README.md
@@ -1,0 +1,23 @@
+# Work logs
+
+Work logs are reviewer-facing records for completed nontrivial work. Use them
+when a PR includes a refactor, cleanup stream, AI-assisted implementation, or
+explicit design tradeoff.
+
+Unlike `docs/plans/`, work logs describe what actually happened during the
+session and why the final design was chosen. They should be curated summaries,
+not raw transcripts.
+
+Include the following sections when they are relevant:
+
+- Session summary
+- Context read
+- Reference code or prior art consulted
+- Decisions made
+- Rejected or deferred alternatives
+- Verification performed
+- Remaining risks or follow-up work
+
+If a decision should guide future implementation beyond the current PR, record
+that durable design intent in `docs/design/` as well and link it from the work
+log.

--- a/scripts/check-pr-fast.sh
+++ b/scripts/check-pr-fast.sh
@@ -107,7 +107,10 @@ log "branch: ${branch}"
 log "base:   ${BASE_REF} (${base_short})"
 log "head:   ${head_short}"
 
-mapfile -t changed_files < <(
+changed_files=()
+while IFS= read -r path; do
+  changed_files+=("$path")
+done < <(
   {
     git diff --name-only "${BASE_REF}...HEAD"
     git diff --cached --name-only
@@ -116,7 +119,10 @@ mapfile -t changed_files < <(
   } | awk 'NF' | sort -u
 )
 
-mapfile -t untracked_files < <(git ls-files --others --exclude-standard | awk 'NF' | sort -u)
+untracked_files=()
+while IFS= read -r path; do
+  untracked_files+=("$path")
+done < <(git ls-files --others --exclude-standard | awk 'NF' | sort -u)
 
 if [[ "${#changed_files[@]}" -eq 0 ]]; then
   log "changed files: none"

--- a/tenferro-ad/tests/numpy_api.rs
+++ b/tenferro-ad/tests/numpy_api.rs
@@ -1,3 +1,4 @@
+use num_complex::Complex64;
 use tenferro_ad::{EagerRuntime, EagerTensor};
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{
@@ -52,6 +53,48 @@ fn traced_tensor_module_exposes_initial_elementwise_free_functions() {
     let _ = traced_tensor::rsqrt(&x);
     let _ = traced_tensor::expm1(&x);
     let _ = traced_tensor::log1p(&x);
+}
+
+#[test]
+fn traced_unary_methods_forward_to_distinct_primal_ops() {
+    fn run(output: &TracedTensor) -> Tensor {
+        let mut compiler = GraphCompiler::new();
+        let program = compiler.compile(output).unwrap();
+        let mut executor = GraphExecutor::new(CpuBackend::new());
+        executor.run(&program).unwrap()
+    }
+
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]);
+    assert_eq!(run(&x.neg()).as_slice::<f64>().unwrap(), &[-1.0, -4.0]);
+    assert_eq!(run(&x.abs()).as_slice::<f64>().unwrap(), &[1.0, 4.0]);
+    assert_eq!(run(&x.sign()).as_slice::<f64>().unwrap(), &[1.0, 1.0]);
+    assert_eq!(run(&x.sqrt()).as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    assert_eq!(run(&x.rsqrt()).as_slice::<f64>().unwrap(), &[1.0, 0.5]);
+
+    let analytic = TracedTensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]);
+    let exp = run(&analytic.exp());
+    let log = run(&x.log());
+    let sin = run(&analytic.sin());
+    let cos = run(&analytic.cos());
+    let tanh = run(&analytic.tanh());
+    let expm1 = run(&analytic.expm1());
+    let log1p = run(&analytic.log1p());
+    assert_eq!(exp.as_slice::<f64>().unwrap(), &[1.0, std::f64::consts::E]);
+    assert_eq!(log.as_slice::<f64>().unwrap(), &[0.0, 4.0_f64.ln()]);
+    assert_eq!(sin.as_slice::<f64>().unwrap(), &[0.0, 1.0_f64.sin()]);
+    assert_eq!(cos.as_slice::<f64>().unwrap(), &[1.0, 1.0_f64.cos()]);
+    assert_eq!(tanh.as_slice::<f64>().unwrap(), &[0.0, 1.0_f64.tanh()]);
+    assert_eq!(expm1.as_slice::<f64>().unwrap(), &[0.0, 1.0_f64.exp_m1()]);
+    assert_eq!(log1p.as_slice::<f64>().unwrap(), &[0.0, 1.0_f64.ln_1p()]);
+
+    let z = TracedTensor::from_vec_col_major(
+        vec![2],
+        vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)],
+    );
+    assert_eq!(
+        run(&z.conj()).as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(1.0, -2.0), Complex64::new(3.0, 4.0)]
+    );
 }
 
 #[test]

--- a/tenferro-cpu/src/backend.rs
+++ b/tenferro-cpu/src/backend.rs
@@ -156,6 +156,8 @@ impl CpuBackendKind {
         }
     }
 
+    // Used by feature-specific diagnostics; some feature combinations leave
+    // the formatter path inactive.
     #[allow(dead_code)]
     pub(crate) fn name(self) -> &'static str {
         match self {
@@ -197,6 +199,8 @@ fn ensure_cpu_backend_kind_available(kind: CpuBackendKind, op: &'static str) -> 
     }
 }
 
+// Used by feature-disabled backend paths; a given feature build may compile no
+// direct call site for one provider.
 #[allow(dead_code)]
 pub(super) fn unavailable_cpu_backend_kind(kind: CpuBackendKind, op: &'static str) -> crate::Error {
     crate::Error::InvalidConfig {
@@ -565,6 +569,8 @@ impl CpuBackend {
         result
     }
 
+    // Selected when the BLAS provider is active; default Faer-only builds keep
+    // it dormant.
     #[allow(dead_code)]
     fn run_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R) -> R {
         let mut buffers = std::mem::take(&mut self.buffers);
@@ -596,6 +602,8 @@ impl CpuBackend {
         Arc::clone(&self.ctx)
     }
 
+    // Selected when the Faer provider handles cached GEMM execution; some
+    // feature combinations compile only the uncached or BLAS path.
     #[allow(dead_code)]
     fn install_with_pool_and_gemm_cache<R>(
         &mut self,
@@ -608,6 +616,8 @@ impl CpuBackend {
         result
     }
 
+    // Selected when the BLAS provider handles cached GEMM execution; default
+    // Faer-only builds keep it dormant.
     #[allow(dead_code)]
     fn run_with_pool_and_gemm_cache<R>(
         &mut self,

--- a/tenferro-cpu/src/gemm/blas_gemm.rs
+++ b/tenferro-cpu/src/gemm/blas_gemm.rs
@@ -4,6 +4,8 @@ use num_complex::{Complex32, Complex64};
 use crate::Error;
 
 pub(crate) trait BlasGemm: Sized {
+    // Kept as a provider-local contiguous BLAS entry point for direct BLAS
+    // validation even when the optimized path uses explicit strides.
     #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
     fn contiguous_gemm(

--- a/tenferro-einsum/src/cache.rs
+++ b/tenferro-einsum/src/cache.rs
@@ -1,6 +1,6 @@
 use std::mem::size_of;
 
-use crate::{EinsumSubscripts, Subscripts};
+use crate::EinsumSubscripts;
 
 /// Stable family identifier for the standard tenferro einsum extension.
 pub const EINSUM_EXTENSION_FAMILY_ID: &str = "tenferro.einsum.v1";
@@ -30,13 +30,4 @@ fn vec_retained_bytes<T>(values: &Vec<T>) -> usize {
 
 fn vec_of_vec_retained_bytes<T>(values: &[Vec<T>]) -> usize {
     values.iter().map(vec_retained_bytes).sum()
-}
-
-fn subscripts_retained_bytes(subscripts: &Subscripts) -> usize {
-    vec_of_vec_retained_bytes(&subscripts.inputs) + vec_retained_bytes(&subscripts.output)
-}
-
-#[allow(dead_code)]
-fn subscripts_cache_key_retained_bytes(key: &(Subscripts, Vec<Vec<usize>>)) -> usize {
-    subscripts_retained_bytes(&key.0) + vec_of_vec_retained_bytes(&key.1)
 }

--- a/tenferro-linalg/src/cpu/backend.rs
+++ b/tenferro-linalg/src/cpu/backend.rs
@@ -717,6 +717,8 @@ fn zeros_like_tensor(input: &Tensor) -> Tensor {
     }
 }
 
+// Used only by feature-disabled provider branches, so default feature builds
+// may not compile a direct call site.
 #[allow(dead_code)]
 fn unsupported_provider(op: &'static str, kind: CpuBackendKind) -> Error {
     Error::InvalidConfig {

--- a/tenferro-runtime/src/compiler/dot_decomposer.rs
+++ b/tenferro-runtime/src/compiler/dot_decomposer.rs
@@ -1,0 +1,669 @@
+use tenferro_ops::dim_expr::DimExpr;
+use tenferro_ops::ShapeExtent;
+use tenferro_tensor::{DType, DotGeneralConfig};
+
+use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
+
+use super::exact_extents_from_shape;
+
+// ============================================================================
+// Pass 3: DotDecomposer
+// ============================================================================
+//
+// Canonicalize `ExecOp::DotGeneral` into a shape consumable by canonical
+// batched GEMM kernels. Runs after `transpose_folding` so that pre-existing
+// foldable transposes are already absorbed. Per-instruction `output_shapes`
+// (populated by `shape_infer`) gives the shapes needed to emit `Reshape`
+// instructions that merge free/contracting groups and restore the original
+// output shape.
+//
+// Canonical form (tenferro column-major with batch trailing):
+//
+//   LHS: [M?, K, B0, B1, ...]
+//     - lhs_contracting_dims = [|free_L|']
+//     - lhs_batch_dims       = [|free_L|' + 1, ..., |free_L|' + nb]
+//     where |free_L|' = 1 if the original LHS had any free dim, else 0.
+//
+//   RHS: [K, N?, B0, B1, ...]
+//     - rhs_contracting_dims = [0]
+//     - rhs_batch_dims       = [|free_R|' + 1, ..., |free_R|' + nb]
+//     where |free_R|' = 1 if the original RHS had any free dim, else 0.
+//
+// The XLA-style algorithm per non-canonical DotGeneral:
+//
+//   1. Transpose LHS to target order (free ++ contracting ++ batch).
+//   2. Reshape LHS to merge multiple free/contracting dims.
+//   3. Transpose RHS to target order (contracting ++ free ++ batch).
+//   4. Reshape RHS to merge multiple free/contracting dims.
+//   5. Emit canonical `DotGeneral`.
+//   6. Reshape output back to the original shape (required when either side
+//      had multiple free dims). Without this, downstream consumers would
+//      observe a rank-collapsed tensor.
+//
+// Only steps that are non-trivial for the specific operand are emitted.
+
+/// Canonicalize all non-canonical `DotGeneral` instructions in `program`.
+///
+/// `input_shapes` are the program-input shapes (matching `program.input_slots`).
+/// They are needed because `ExecProgram` does not otherwise carry input-slot
+/// shape metadata.
+pub fn dot_decomposer(program: &mut ExecProgram, input_shapes: &[Vec<DimExpr>]) {
+    assert_eq!(
+        program.input_slots.len(),
+        input_shapes.len(),
+        "dot_decomposer: input shape count must match input slot count"
+    );
+
+    let mut slot_shapes: Vec<Option<Vec<DimExpr>>> = vec![None; program.n_slots];
+    let mut slot_extents: Vec<Option<Vec<ShapeExtent<DimExpr>>>> = vec![None; program.n_slots];
+    for (index, &slot) in program.input_slots.iter().enumerate() {
+        slot_shapes[slot] = Some(input_shapes[index].clone());
+        slot_extents[slot] = Some(exact_extents_from_shape(&input_shapes[index]));
+    }
+    for instr in &program.instructions {
+        for ((slot, shape), extents) in instr
+            .output_slots
+            .iter()
+            .zip(instr.output_shapes.iter())
+            .zip(instr.output_extents.iter())
+        {
+            slot_shapes[*slot] = Some(shape.clone());
+            slot_extents[*slot] = Some(extents.clone());
+        }
+    }
+
+    let mut new_instructions: Vec<ExecInstruction> = Vec::with_capacity(program.instructions.len());
+    let mut n_slots = program.n_slots;
+
+    for instr in &program.instructions {
+        let dot_config_and_conj = match &instr.op {
+            ExecOp::DotGeneral(config) => Some((config, false, false)),
+            ExecOp::DotGeneralWithConj {
+                config,
+                lhs_conj,
+                rhs_conj,
+            } => Some((config, *lhs_conj, *rhs_conj)),
+            _ => None,
+        };
+
+        if let Some((config, lhs_conj, rhs_conj)) = dot_config_and_conj {
+            if instr.input_slots.len() == 2 && !config.lhs_contracting_dims.is_empty() {
+                let lhs_slot = instr.input_slots[0];
+                let rhs_slot = instr.input_slots[1];
+                let lhs_shape = require_slot_shape(&slot_shapes, lhs_slot);
+                let rhs_shape = require_slot_shape(&slot_shapes, rhs_slot);
+                let lhs_extents = require_slot_extents(&slot_extents, lhs_slot);
+                let rhs_extents = require_slot_extents(&slot_extents, rhs_slot);
+                if !is_dot_canonical(config, lhs_shape.len(), rhs_shape.len()) {
+                    let mut emitter = InstructionEmitter {
+                        n_slots: &mut n_slots,
+                        instructions: &mut new_instructions,
+                    };
+                    decompose_dot(
+                        DotDecomposeInput {
+                            instr,
+                            config,
+                            lhs: OperandMeta {
+                                slot: lhs_slot,
+                                shape: lhs_shape,
+                                extents: lhs_extents,
+                            },
+                            rhs: OperandMeta {
+                                slot: rhs_slot,
+                                shape: rhs_shape,
+                                extents: rhs_extents,
+                            },
+                            lhs_conj,
+                            rhs_conj,
+                        },
+                        &mut emitter,
+                    );
+                    continue;
+                }
+            }
+        }
+        new_instructions.push(instr.clone());
+    }
+
+    program.instructions = new_instructions;
+    program.n_slots = n_slots;
+}
+
+#[derive(Clone, Copy)]
+struct OperandMeta<'a> {
+    slot: usize,
+    shape: &'a [DimExpr],
+    extents: &'a [ShapeExtent<DimExpr>],
+}
+
+struct EmittedOperand {
+    slot: usize,
+    shape: Vec<DimExpr>,
+    extents: Vec<ShapeExtent<DimExpr>>,
+}
+
+struct DotDecomposeInput<'a> {
+    instr: &'a ExecInstruction,
+    config: &'a DotGeneralConfig,
+    lhs: OperandMeta<'a>,
+    rhs: OperandMeta<'a>,
+    lhs_conj: bool,
+    rhs_conj: bool,
+}
+
+struct InstructionEmitter<'a> {
+    n_slots: &'a mut usize,
+    instructions: &'a mut Vec<ExecInstruction>,
+}
+
+#[derive(Clone, Copy)]
+struct MergeReshapeSpec {
+    free_count: usize,
+    contracting_count: usize,
+    batch_count: usize,
+    side: MergeSide,
+}
+
+#[derive(Clone, Copy)]
+enum MergeSide {
+    Lhs,
+    Rhs,
+}
+
+impl InstructionEmitter<'_> {
+    fn next_slot(&mut self) -> usize {
+        let slot = *self.n_slots;
+        *self.n_slots += 1;
+        slot
+    }
+
+    fn push(&mut self, instr: ExecInstruction) {
+        self.instructions.push(instr);
+    }
+}
+
+fn require_slot_shape(slot_shapes: &[Option<Vec<DimExpr>>], slot: usize) -> &[DimExpr] {
+    slot_shapes[slot]
+        .as_ref()
+        .unwrap_or_else(|| panic!("dot_decomposer: missing shape for slot {slot}"))
+        .as_slice()
+}
+
+fn require_slot_extents(
+    slot_extents: &[Option<Vec<ShapeExtent<DimExpr>>>],
+    slot: usize,
+) -> &[ShapeExtent<DimExpr>] {
+    slot_extents[slot]
+        .as_ref()
+        .unwrap_or_else(|| panic!("dot_decomposer: missing extents for slot {slot}"))
+        .as_slice()
+}
+
+/// Canonical form predicate for a `DotGeneral` with the given operand ranks.
+fn is_dot_canonical(config: &DotGeneralConfig, lhs_rank: usize, rhs_rank: usize) -> bool {
+    if config.lhs_contracting_dims.len() != 1 || config.rhs_contracting_dims.len() != 1 {
+        return false;
+    }
+    if config.lhs_batch_dims.len() != config.rhs_batch_dims.len() {
+        return false;
+    }
+    let nb = config.lhs_batch_dims.len();
+
+    // LHS: [M?, K, B...]. free_L is 0 or 1 elems.
+    let lhs_has_free = match lhs_rank.checked_sub(nb + 1) {
+        Some(0) => false,
+        Some(1) => true,
+        _ => return false,
+    };
+    let lhs_expected_contracting = if lhs_has_free { 1 } else { 0 };
+    let lhs_expected_batch: Vec<usize> =
+        ((lhs_expected_contracting + 1)..(lhs_expected_contracting + 1 + nb)).collect();
+    if config.lhs_contracting_dims != vec![lhs_expected_contracting]
+        || config.lhs_batch_dims != lhs_expected_batch
+    {
+        return false;
+    }
+
+    // RHS: [K, N?, B...]. free_R is 0 or 1 elems, contracting is always at 0.
+    let rhs_has_free = match rhs_rank.checked_sub(nb + 1) {
+        Some(0) => false,
+        Some(1) => true,
+        _ => return false,
+    };
+    let rhs_free_count = usize::from(rhs_has_free);
+    let rhs_expected_batch: Vec<usize> =
+        ((rhs_free_count + 1)..(rhs_free_count + 1 + nb)).collect();
+    if config.rhs_contracting_dims != vec![0] || config.rhs_batch_dims != rhs_expected_batch {
+        return false;
+    }
+
+    true
+}
+
+fn free_axes_of(rank: usize, contracting: &[usize], batch: &[usize]) -> Vec<usize> {
+    (0..rank)
+        .filter(|axis| !contracting.contains(axis) && !batch.contains(axis))
+        .collect()
+}
+
+fn product_of_input_dims(input_idx: usize, start: usize, end: usize) -> DimExpr {
+    assert!(end > start, "product_of_input_dims: empty range");
+    let mut result = DimExpr::InputDim {
+        input_idx,
+        axis: start,
+    };
+    for axis in (start + 1)..end {
+        result = DimExpr::mul(result, DimExpr::InputDim { input_idx, axis });
+    }
+    result
+}
+
+/// Emit decomposed instructions for a single non-canonical DotGeneral.
+fn decompose_dot(input: DotDecomposeInput<'_>, emitter: &mut InstructionEmitter<'_>) {
+    let instr = input.instr;
+    let config = input.config;
+    let lhs = input.lhs;
+    let rhs = input.rhs;
+
+    let lhs_rank = lhs.shape.len();
+    let rhs_rank = rhs.shape.len();
+    let nb = config.lhs_batch_dims.len();
+    assert_eq!(
+        nb,
+        config.rhs_batch_dims.len(),
+        "dot_decomposer: mismatched batch dim count"
+    );
+
+    let lhs_free = free_axes_of(
+        lhs_rank,
+        &config.lhs_contracting_dims,
+        &config.lhs_batch_dims,
+    );
+    let rhs_free = free_axes_of(
+        rhs_rank,
+        &config.rhs_contracting_dims,
+        &config.rhs_batch_dims,
+    );
+    let fi_l = lhs_free.len();
+    let ci_l = config.lhs_contracting_dims.len();
+    let fi_r = rhs_free.len();
+    let ci_r = config.rhs_contracting_dims.len();
+
+    let lhs_target_perm: Vec<usize> = lhs_free
+        .iter()
+        .chain(config.lhs_contracting_dims.iter())
+        .chain(config.lhs_batch_dims.iter())
+        .copied()
+        .collect();
+    let lhs_after_transpose = emit_transpose_if_needed(lhs, &lhs_target_perm, instr.dtype, emitter);
+
+    let lhs_canon = if fi_l > 1 || ci_l > 1 {
+        emit_merge_reshape(
+            &lhs_after_transpose,
+            MergeReshapeSpec {
+                free_count: fi_l,
+                contracting_count: ci_l,
+                batch_count: nb,
+                side: MergeSide::Lhs,
+            },
+            instr.dtype,
+            emitter,
+        )
+    } else {
+        lhs_after_transpose
+    };
+
+    let rhs_target_perm: Vec<usize> = config
+        .rhs_contracting_dims
+        .iter()
+        .chain(rhs_free.iter())
+        .chain(config.rhs_batch_dims.iter())
+        .copied()
+        .collect();
+    let rhs_after_transpose = emit_transpose_if_needed(rhs, &rhs_target_perm, instr.dtype, emitter);
+
+    let rhs_canon = if fi_r > 1 || ci_r > 1 {
+        emit_merge_reshape(
+            &rhs_after_transpose,
+            MergeReshapeSpec {
+                free_count: fi_r,
+                contracting_count: ci_r,
+                batch_count: nb,
+                side: MergeSide::Rhs,
+            },
+            instr.dtype,
+            emitter,
+        )
+    } else {
+        rhs_after_transpose
+    };
+
+    let lhs_free_count_canon = usize::from(fi_l > 0);
+    let rhs_free_count_canon = usize::from(fi_r > 0);
+    let canonical_config = DotGeneralConfig {
+        lhs_contracting_dims: vec![lhs_free_count_canon],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: ((lhs_free_count_canon + 1)..(lhs_free_count_canon + 1 + nb)).collect(),
+        rhs_batch_dims: ((rhs_free_count_canon + 1)..(rhs_free_count_canon + 1 + nb)).collect(),
+    };
+
+    let needs_output_reshape = fi_l > 1 || fi_r > 1;
+
+    let canonical_output_slot = if needs_output_reshape {
+        emitter.next_slot()
+    } else {
+        instr.output_slots[0]
+    };
+
+    // Compute canonical output shape directly: [M?, N?, batch...] referencing
+    // the canonical operand shapes we just built.
+    let mut canonical_output_shape: Vec<DimExpr> = Vec::new();
+    let mut canonical_output_extents: Vec<ShapeExtent<DimExpr>> = Vec::new();
+    if fi_l > 0 {
+        canonical_output_shape.push(lhs_canon.shape[0].clone());
+        canonical_output_extents.push(lhs_canon.extents[0].clone());
+    }
+    if fi_r > 0 {
+        canonical_output_shape.push(rhs_canon.shape[rhs_free_count_canon].clone());
+        canonical_output_extents.push(rhs_canon.extents[rhs_free_count_canon].clone());
+    }
+    for axis_offset in 0..nb {
+        canonical_output_shape
+            .push(lhs_canon.shape[lhs_free_count_canon + 1 + axis_offset].clone());
+        canonical_output_extents
+            .push(lhs_canon.extents[lhs_free_count_canon + 1 + axis_offset].clone());
+    }
+
+    emitter.push(ExecInstruction {
+        op: if input.lhs_conj || input.rhs_conj {
+            ExecOp::DotGeneralWithConj {
+                config: canonical_config,
+                lhs_conj: input.lhs_conj,
+                rhs_conj: input.rhs_conj,
+            }
+        } else {
+            ExecOp::DotGeneral(canonical_config)
+        },
+        input_slots: vec![lhs_canon.slot, rhs_canon.slot],
+        output_slots: vec![canonical_output_slot],
+        dtype: instr.dtype,
+        output_shapes: vec![canonical_output_shape.clone()],
+        output_extents: vec![canonical_output_extents],
+        last_use: Vec::new(),
+    });
+
+    if needs_output_reshape {
+        // Target output shape: original DotGeneral output =
+        //   [lhs_free_sizes..., rhs_free_sizes..., batch_sizes...]
+        // Expressed via `InputDim{1, axis}` (original LHS) and
+        // `InputDim{2, axis}` (original RHS) so the Reshape can evaluate
+        // dynamic sizes at runtime.
+        let mut to_shape: Vec<DimExpr> = Vec::new();
+        for &axis in &lhs_free {
+            to_shape.push(DimExpr::InputDim { input_idx: 1, axis });
+        }
+        for &axis in &rhs_free {
+            to_shape.push(DimExpr::InputDim { input_idx: 2, axis });
+        }
+        for &axis in &config.lhs_batch_dims {
+            to_shape.push(DimExpr::InputDim { input_idx: 1, axis });
+        }
+
+        // Metadata `output_shapes` uses the original DotGeneral output shape
+        // directly, which we cloned from `instr` above.
+        let metadata_shape = instr.output_shapes[0].clone();
+
+        emitter.push(ExecInstruction {
+            op: ExecOp::Reshape {
+                shape: to_shape.clone(),
+            },
+            input_slots: vec![canonical_output_slot, lhs.slot, rhs.slot],
+            output_slots: vec![instr.output_slots[0]],
+            dtype: instr.dtype,
+            output_shapes: vec![metadata_shape],
+            output_extents: instr.output_extents.clone(),
+            last_use: Vec::new(),
+        });
+    }
+}
+
+fn emit_transpose_if_needed(
+    operand: OperandMeta<'_>,
+    target_perm: &[usize],
+    dtype: DType,
+    emitter: &mut InstructionEmitter<'_>,
+) -> EmittedOperand {
+    let is_identity = target_perm.iter().enumerate().all(|(i, &p)| i == p);
+    if is_identity {
+        return EmittedOperand {
+            slot: operand.slot,
+            shape: operand.shape.to_vec(),
+            extents: operand.extents.to_vec(),
+        };
+    }
+    let transposed_shape: Vec<DimExpr> = target_perm
+        .iter()
+        .map(|&axis| operand.shape[axis].clone())
+        .collect();
+    let transposed_extents: Vec<ShapeExtent<DimExpr>> = target_perm
+        .iter()
+        .map(|&axis| operand.extents[axis].clone())
+        .collect();
+    let out_slot = emitter.next_slot();
+    emitter.push(ExecInstruction {
+        op: ExecOp::Transpose {
+            perm: target_perm.to_vec(),
+        },
+        input_slots: vec![operand.slot],
+        output_slots: vec![out_slot],
+        dtype,
+        output_shapes: vec![transposed_shape.clone()],
+        output_extents: vec![transposed_extents.clone()],
+        last_use: Vec::new(),
+    });
+    EmittedOperand {
+        slot: out_slot,
+        shape: transposed_shape,
+        extents: transposed_extents,
+    }
+}
+
+fn emit_merge_reshape(
+    operand: &EmittedOperand,
+    spec: MergeReshapeSpec,
+    dtype: DType,
+    emitter: &mut InstructionEmitter<'_>,
+) -> EmittedOperand {
+    let to_shape = match spec.side {
+        MergeSide::Lhs => lhs_merge_shape(spec),
+        MergeSide::Rhs => rhs_merge_shape(spec),
+    };
+    let (output_shape_meta, output_extents_meta) = match spec.side {
+        MergeSide::Lhs => lhs_merge_meta(operand, spec),
+        MergeSide::Rhs => rhs_merge_meta(operand, spec),
+    };
+
+    let out_slot = emitter.next_slot();
+    emitter.push(ExecInstruction {
+        op: ExecOp::Reshape { shape: to_shape },
+        input_slots: vec![operand.slot],
+        output_slots: vec![out_slot],
+        dtype,
+        output_shapes: vec![output_shape_meta.clone()],
+        output_extents: vec![output_extents_meta.clone()],
+        last_use: Vec::new(),
+    });
+    EmittedOperand {
+        slot: out_slot,
+        shape: output_shape_meta,
+        extents: output_extents_meta,
+    }
+}
+
+fn lhs_merge_shape(spec: MergeReshapeSpec) -> Vec<DimExpr> {
+    // Runtime `shape` (op parameter) uses `InputDim{0, axis}` referring to
+    // this Reshape's own input slot.
+    let mut to_shape: Vec<DimExpr> = Vec::new();
+    if spec.free_count > 0 {
+        if spec.free_count == 1 {
+            to_shape.push(DimExpr::InputDim {
+                input_idx: 0,
+                axis: 0,
+            });
+        } else {
+            to_shape.push(product_of_input_dims(0, 0, spec.free_count));
+        }
+    }
+    if spec.contracting_count == 1 {
+        to_shape.push(DimExpr::InputDim {
+            input_idx: 0,
+            axis: spec.free_count,
+        });
+    } else {
+        to_shape.push(product_of_input_dims(
+            0,
+            spec.free_count,
+            spec.free_count + spec.contracting_count,
+        ));
+    }
+    for k in 0..spec.batch_count {
+        to_shape.push(DimExpr::InputDim {
+            input_idx: 0,
+            axis: spec.free_count + spec.contracting_count + k,
+        });
+    }
+    to_shape
+}
+
+fn rhs_merge_shape(spec: MergeReshapeSpec) -> Vec<DimExpr> {
+    let mut to_shape: Vec<DimExpr> = Vec::new();
+    if spec.contracting_count == 1 {
+        to_shape.push(DimExpr::InputDim {
+            input_idx: 0,
+            axis: 0,
+        });
+    } else {
+        to_shape.push(product_of_input_dims(0, 0, spec.contracting_count));
+    }
+    if spec.free_count > 0 {
+        if spec.free_count == 1 {
+            to_shape.push(DimExpr::InputDim {
+                input_idx: 0,
+                axis: spec.contracting_count,
+            });
+        } else {
+            to_shape.push(product_of_input_dims(
+                0,
+                spec.contracting_count,
+                spec.contracting_count + spec.free_count,
+            ));
+        }
+    }
+    for k in 0..spec.batch_count {
+        to_shape.push(DimExpr::InputDim {
+            input_idx: 0,
+            axis: spec.contracting_count + spec.free_count + k,
+        });
+    }
+    to_shape
+}
+
+fn lhs_merge_meta(
+    operand: &EmittedOperand,
+    spec: MergeReshapeSpec,
+) -> (Vec<DimExpr>, Vec<ShapeExtent<DimExpr>>) {
+    let mut shape_meta: Vec<DimExpr> = Vec::new();
+    let mut extents_meta: Vec<ShapeExtent<DimExpr>> = Vec::new();
+    if spec.free_count > 0 {
+        shape_meta.push(merge_span(&operand.shape, 0, spec.free_count));
+        extents_meta.push(merge_extent_span(
+            &operand.shape,
+            &operand.extents,
+            0,
+            spec.free_count,
+        ));
+    }
+    shape_meta.push(merge_span(
+        &operand.shape,
+        spec.free_count,
+        spec.free_count + spec.contracting_count,
+    ));
+    extents_meta.push(merge_extent_span(
+        &operand.shape,
+        &operand.extents,
+        spec.free_count,
+        spec.free_count + spec.contracting_count,
+    ));
+    for k in 0..spec.batch_count {
+        shape_meta.push(operand.shape[spec.free_count + spec.contracting_count + k].clone());
+        extents_meta.push(operand.extents[spec.free_count + spec.contracting_count + k].clone());
+    }
+    (shape_meta, extents_meta)
+}
+
+fn rhs_merge_meta(
+    operand: &EmittedOperand,
+    spec: MergeReshapeSpec,
+) -> (Vec<DimExpr>, Vec<ShapeExtent<DimExpr>>) {
+    let mut shape_meta: Vec<DimExpr> = Vec::new();
+    let mut extents_meta: Vec<ShapeExtent<DimExpr>> = Vec::new();
+    shape_meta.push(merge_span(&operand.shape, 0, spec.contracting_count));
+    extents_meta.push(merge_extent_span(
+        &operand.shape,
+        &operand.extents,
+        0,
+        spec.contracting_count,
+    ));
+    if spec.free_count > 0 {
+        shape_meta.push(merge_span(
+            &operand.shape,
+            spec.contracting_count,
+            spec.contracting_count + spec.free_count,
+        ));
+        extents_meta.push(merge_extent_span(
+            &operand.shape,
+            &operand.extents,
+            spec.contracting_count,
+            spec.contracting_count + spec.free_count,
+        ));
+    }
+    for k in 0..spec.batch_count {
+        shape_meta.push(operand.shape[spec.contracting_count + spec.free_count + k].clone());
+        extents_meta.push(operand.extents[spec.contracting_count + spec.free_count + k].clone());
+    }
+    (shape_meta, extents_meta)
+}
+
+fn merge_span(shape: &[DimExpr], start: usize, end: usize) -> DimExpr {
+    assert!(end > start, "merge_span: empty range");
+    let mut result = shape[start].clone();
+    for dim in shape.iter().take(end).skip(start + 1) {
+        result = DimExpr::mul(result, dim.clone());
+    }
+    result
+}
+
+fn merge_extent_span(
+    shape: &[DimExpr],
+    extents: &[ShapeExtent<DimExpr>],
+    start: usize,
+    end: usize,
+) -> ShapeExtent<DimExpr> {
+    assert!(end > start, "merge_extent_span: empty range");
+    let merged_dim = merge_span(shape, start, end);
+    let mut has_upper_bound = false;
+
+    for extent in &extents[start..end] {
+        match extent {
+            ShapeExtent::Exact(_) => {}
+            ShapeExtent::UpperBound(_) => has_upper_bound = true,
+            ShapeExtent::Unknown => return ShapeExtent::unknown(),
+        }
+    }
+
+    if has_upper_bound {
+        ShapeExtent::upper_bound(merged_dim)
+    } else {
+        ShapeExtent::exact(merged_dim)
+    }
+}

--- a/tenferro-runtime/src/compiler/mod.rs
+++ b/tenferro-runtime/src/compiler/mod.rs
@@ -162,7 +162,7 @@ pub fn compile_std_to_exec(
     program
 }
 
-fn exact_extents_from_shape(shape: &[DimExpr]) -> Vec<ShapeExtent<DimExpr>> {
+pub(super) fn exact_extents_from_shape(shape: &[DimExpr]) -> Vec<ShapeExtent<DimExpr>> {
     shape.iter().cloned().map(ShapeExtent::exact).collect()
 }
 
@@ -397,15 +397,15 @@ fn conj_sinking_one_pass(
                     let mut input_slots = producer.input_slots;
                     for input_idx in commuting_inputs {
                         let input_slot = input_slots[input_idx];
-                        input_slots[input_idx] = ensure_conj_slot(
-                            input_slot,
-                            &mut slot_meta,
-                            &mut producer_by_slot,
-                            &mut conj_cache,
-                            &mut new_instructions,
-                            &mut program.n_slots,
-                            &mut redirect,
-                        );
+                        input_slots[input_idx] = ConjSinkingState {
+                            slot_meta: &mut slot_meta,
+                            producer_by_slot: &mut producer_by_slot,
+                            conj_cache: &mut conj_cache,
+                            new_instructions: &mut new_instructions,
+                            n_slots: &mut program.n_slots,
+                            redirect: &mut redirect,
+                        }
+                        .ensure_conj_slot(input_slot);
                     }
                     instr.op = producer.op;
                     instr.input_slots = input_slots;
@@ -455,47 +455,49 @@ fn collect_slot_meta(
     slot_meta
 }
 
-#[allow(clippy::too_many_arguments)]
-fn ensure_conj_slot(
-    slot: usize,
-    slot_meta: &mut Vec<Option<SlotMeta>>,
-    producer_by_slot: &mut ProducerMap,
-    conj_cache: &mut std::collections::HashMap<usize, usize>,
-    new_instructions: &mut Vec<ExecInstruction>,
-    n_slots: &mut usize,
-    redirect: &mut Vec<usize>,
-) -> usize {
-    let slot = resolve_slot_redirect(slot, redirect);
-    if let Some(producer) = producer_for_slot(producer_by_slot, slot) {
-        if matches!(producer.op, ExecOp::Conj) && producer.input_slots.len() == 1 {
-            return resolve_slot_redirect(producer.input_slots[0], redirect);
+struct ConjSinkingState<'a> {
+    slot_meta: &'a mut Vec<Option<SlotMeta>>,
+    producer_by_slot: &'a mut ProducerMap,
+    conj_cache: &'a mut std::collections::HashMap<usize, usize>,
+    new_instructions: &'a mut Vec<ExecInstruction>,
+    n_slots: &'a mut usize,
+    redirect: &'a mut Vec<usize>,
+}
+
+impl ConjSinkingState<'_> {
+    fn ensure_conj_slot(&mut self, slot: usize) -> usize {
+        let slot = resolve_slot_redirect(slot, self.redirect);
+        if let Some(producer) = producer_for_slot(self.producer_by_slot, slot) {
+            if matches!(producer.op, ExecOp::Conj) && producer.input_slots.len() == 1 {
+                return resolve_slot_redirect(producer.input_slots[0], self.redirect);
+            }
         }
-    }
-    if let Some(&conj_slot) = conj_cache.get(&slot) {
-        return conj_slot;
-    }
+        if let Some(&conj_slot) = self.conj_cache.get(&slot) {
+            return conj_slot;
+        }
 
-    let meta = slot_meta[slot]
-        .clone()
-        .unwrap_or_else(|| panic!("conj_sinking: missing metadata for slot {slot}"));
-    let output_slot = *n_slots;
-    *n_slots += 1;
-    redirect.push(output_slot);
-    slot_meta.push(Some(meta.clone()));
+        let meta = self.slot_meta[slot]
+            .clone()
+            .unwrap_or_else(|| panic!("conj_sinking: missing metadata for slot {slot}"));
+        let output_slot = *self.n_slots;
+        *self.n_slots += 1;
+        self.redirect.push(output_slot);
+        self.slot_meta.push(Some(meta.clone()));
 
-    let instr = ExecInstruction {
-        op: ExecOp::Conj,
-        input_slots: vec![slot],
-        output_slots: vec![output_slot],
-        dtype: meta.dtype,
-        output_shapes: vec![meta.shape],
-        output_extents: vec![meta.extents],
-        last_use: Vec::new(),
-    };
-    record_producer(producer_by_slot, &instr);
-    new_instructions.push(instr);
-    conj_cache.insert(slot, output_slot);
-    output_slot
+        let instr = ExecInstruction {
+            op: ExecOp::Conj,
+            input_slots: vec![slot],
+            output_slots: vec![output_slot],
+            dtype: meta.dtype,
+            output_shapes: vec![meta.shape],
+            output_extents: vec![meta.extents],
+            last_use: Vec::new(),
+        };
+        record_producer(self.producer_by_slot, &instr);
+        self.new_instructions.push(instr);
+        self.conj_cache.insert(slot, output_slot);
+        output_slot
+    }
 }
 
 fn record_producer(producer_by_slot: &mut ProducerMap, instr: &ExecInstruction) {
@@ -838,610 +840,9 @@ fn fold_transpose_into_dot(
     new_config
 }
 
-// ============================================================================
-// Pass 3: DotDecomposer
-// ============================================================================
-//
-// Canonicalize `ExecOp::DotGeneral` into a shape consumable by canonical
-// batched GEMM kernels. Runs after `transpose_folding` so that pre-existing
-// foldable transposes are already absorbed. Per-instruction `output_shapes`
-// (populated by `shape_infer`) gives the shapes needed to emit `Reshape`
-// instructions that merge free/contracting groups and restore the original
-// output shape.
-//
-// Canonical form (tenferro column-major with batch trailing):
-//
-//   LHS: [M?, K, B0, B1, ...]
-//     - lhs_contracting_dims = [|free_L|']
-//     - lhs_batch_dims       = [|free_L|' + 1, ..., |free_L|' + nb]
-//     where |free_L|' = 1 if the original LHS had any free dim, else 0.
-//
-//   RHS: [K, N?, B0, B1, ...]
-//     - rhs_contracting_dims = [0]
-//     - rhs_batch_dims       = [|free_R|' + 1, ..., |free_R|' + nb]
-//     where |free_R|' = 1 if the original RHS had any free dim, else 0.
-//
-// The XLA-style algorithm per non-canonical DotGeneral:
-//
-//   1. Transpose LHS to target order (free ++ contracting ++ batch).
-//   2. Reshape LHS to merge multiple free/contracting dims.
-//   3. Transpose RHS to target order (contracting ++ free ++ batch).
-//   4. Reshape RHS to merge multiple free/contracting dims.
-//   5. Emit canonical `DotGeneral`.
-//   6. Reshape output back to the original shape (required when either side
-//      had multiple free dims). Without this, downstream consumers would
-//      observe a rank-collapsed tensor.
-//
-// Only steps that are non-trivial for the specific operand are emitted.
+mod dot_decomposer;
 
-/// Canonicalize all non-canonical `DotGeneral` instructions in `program`.
-///
-/// `input_shapes` are the program-input shapes (matching `program.input_slots`).
-/// They are needed because `ExecProgram` does not otherwise carry input-slot
-/// shape metadata.
-pub fn dot_decomposer(program: &mut ExecProgram, input_shapes: &[Vec<DimExpr>]) {
-    assert_eq!(
-        program.input_slots.len(),
-        input_shapes.len(),
-        "dot_decomposer: input shape count must match input slot count"
-    );
-
-    let mut slot_shapes: Vec<Option<Vec<DimExpr>>> = vec![None; program.n_slots];
-    let mut slot_extents: Vec<Option<Vec<ShapeExtent<DimExpr>>>> = vec![None; program.n_slots];
-    for (index, &slot) in program.input_slots.iter().enumerate() {
-        slot_shapes[slot] = Some(input_shapes[index].clone());
-        slot_extents[slot] = Some(exact_extents_from_shape(&input_shapes[index]));
-    }
-    for instr in &program.instructions {
-        for ((slot, shape), extents) in instr
-            .output_slots
-            .iter()
-            .zip(instr.output_shapes.iter())
-            .zip(instr.output_extents.iter())
-        {
-            slot_shapes[*slot] = Some(shape.clone());
-            slot_extents[*slot] = Some(extents.clone());
-        }
-    }
-
-    let mut new_instructions: Vec<ExecInstruction> = Vec::with_capacity(program.instructions.len());
-    let mut n_slots = program.n_slots;
-
-    for instr in &program.instructions {
-        let dot_config_and_conj = match &instr.op {
-            ExecOp::DotGeneral(config) => Some((config, false, false)),
-            ExecOp::DotGeneralWithConj {
-                config,
-                lhs_conj,
-                rhs_conj,
-            } => Some((config, *lhs_conj, *rhs_conj)),
-            _ => None,
-        };
-
-        if let Some((config, lhs_conj, rhs_conj)) = dot_config_and_conj {
-            if instr.input_slots.len() == 2 && !config.lhs_contracting_dims.is_empty() {
-                let lhs_slot = instr.input_slots[0];
-                let rhs_slot = instr.input_slots[1];
-                let lhs_shape = require_slot_shape(&slot_shapes, lhs_slot);
-                let rhs_shape = require_slot_shape(&slot_shapes, rhs_slot);
-                let lhs_extents = require_slot_extents(&slot_extents, lhs_slot);
-                let rhs_extents = require_slot_extents(&slot_extents, rhs_slot);
-                if !is_dot_canonical(config, lhs_shape.len(), rhs_shape.len()) {
-                    decompose_dot(
-                        instr,
-                        config,
-                        lhs_slot,
-                        rhs_slot,
-                        lhs_shape,
-                        rhs_shape,
-                        lhs_extents,
-                        rhs_extents,
-                        lhs_conj,
-                        rhs_conj,
-                        &mut n_slots,
-                        &mut new_instructions,
-                    );
-                    continue;
-                }
-            }
-        }
-        new_instructions.push(instr.clone());
-    }
-
-    program.instructions = new_instructions;
-    program.n_slots = n_slots;
-}
-
-fn require_slot_shape(slot_shapes: &[Option<Vec<DimExpr>>], slot: usize) -> &[DimExpr] {
-    slot_shapes[slot]
-        .as_ref()
-        .unwrap_or_else(|| panic!("dot_decomposer: missing shape for slot {slot}"))
-        .as_slice()
-}
-
-fn require_slot_extents(
-    slot_extents: &[Option<Vec<ShapeExtent<DimExpr>>>],
-    slot: usize,
-) -> &[ShapeExtent<DimExpr>] {
-    slot_extents[slot]
-        .as_ref()
-        .unwrap_or_else(|| panic!("dot_decomposer: missing extents for slot {slot}"))
-        .as_slice()
-}
-
-/// Canonical form predicate for a `DotGeneral` with the given operand ranks.
-fn is_dot_canonical(config: &DotGeneralConfig, lhs_rank: usize, rhs_rank: usize) -> bool {
-    if config.lhs_contracting_dims.len() != 1 || config.rhs_contracting_dims.len() != 1 {
-        return false;
-    }
-    if config.lhs_batch_dims.len() != config.rhs_batch_dims.len() {
-        return false;
-    }
-    let nb = config.lhs_batch_dims.len();
-
-    // LHS: [M?, K, B...]. free_L is 0 or 1 elems.
-    let lhs_has_free = match lhs_rank.checked_sub(nb + 1) {
-        Some(0) => false,
-        Some(1) => true,
-        _ => return false,
-    };
-    let lhs_expected_contracting = if lhs_has_free { 1 } else { 0 };
-    let lhs_expected_batch: Vec<usize> =
-        ((lhs_expected_contracting + 1)..(lhs_expected_contracting + 1 + nb)).collect();
-    if config.lhs_contracting_dims != vec![lhs_expected_contracting]
-        || config.lhs_batch_dims != lhs_expected_batch
-    {
-        return false;
-    }
-
-    // RHS: [K, N?, B...]. free_R is 0 or 1 elems, contracting is always at 0.
-    let rhs_has_free = match rhs_rank.checked_sub(nb + 1) {
-        Some(0) => false,
-        Some(1) => true,
-        _ => return false,
-    };
-    let rhs_free_count = usize::from(rhs_has_free);
-    let rhs_expected_batch: Vec<usize> =
-        ((rhs_free_count + 1)..(rhs_free_count + 1 + nb)).collect();
-    if config.rhs_contracting_dims != vec![0] || config.rhs_batch_dims != rhs_expected_batch {
-        return false;
-    }
-
-    true
-}
-
-fn free_axes_of(rank: usize, contracting: &[usize], batch: &[usize]) -> Vec<usize> {
-    (0..rank)
-        .filter(|axis| !contracting.contains(axis) && !batch.contains(axis))
-        .collect()
-}
-
-fn product_of_input_dims(input_idx: usize, start: usize, end: usize) -> DimExpr {
-    assert!(end > start, "product_of_input_dims: empty range");
-    let mut result = DimExpr::InputDim {
-        input_idx,
-        axis: start,
-    };
-    for axis in (start + 1)..end {
-        result = DimExpr::mul(result, DimExpr::InputDim { input_idx, axis });
-    }
-    result
-}
-
-/// Emit decomposed instructions for a single non-canonical DotGeneral.
-#[allow(clippy::too_many_arguments)]
-fn decompose_dot(
-    instr: &ExecInstruction,
-    config: &DotGeneralConfig,
-    lhs_slot: usize,
-    rhs_slot: usize,
-    lhs_shape: &[DimExpr],
-    rhs_shape: &[DimExpr],
-    lhs_extents: &[ShapeExtent<DimExpr>],
-    rhs_extents: &[ShapeExtent<DimExpr>],
-    lhs_conj: bool,
-    rhs_conj: bool,
-    n_slots: &mut usize,
-    new_instructions: &mut Vec<ExecInstruction>,
-) {
-    let lhs_rank = lhs_shape.len();
-    let rhs_rank = rhs_shape.len();
-    let nb = config.lhs_batch_dims.len();
-    assert_eq!(
-        nb,
-        config.rhs_batch_dims.len(),
-        "dot_decomposer: mismatched batch dim count"
-    );
-
-    let lhs_free = free_axes_of(
-        lhs_rank,
-        &config.lhs_contracting_dims,
-        &config.lhs_batch_dims,
-    );
-    let rhs_free = free_axes_of(
-        rhs_rank,
-        &config.rhs_contracting_dims,
-        &config.rhs_batch_dims,
-    );
-    let fi_l = lhs_free.len();
-    let ci_l = config.lhs_contracting_dims.len();
-    let fi_r = rhs_free.len();
-    let ci_r = config.rhs_contracting_dims.len();
-
-    let lhs_target_perm: Vec<usize> = lhs_free
-        .iter()
-        .chain(config.lhs_contracting_dims.iter())
-        .chain(config.lhs_batch_dims.iter())
-        .copied()
-        .collect();
-    let (lhs_after_transpose_slot, lhs_after_transpose_shape, lhs_after_transpose_extents) =
-        emit_transpose_if_needed(
-            lhs_slot,
-            lhs_shape,
-            lhs_extents,
-            &lhs_target_perm,
-            instr.dtype,
-            n_slots,
-            new_instructions,
-        );
-
-    let (lhs_canon_slot, lhs_canon_shape, lhs_canon_extents) = if fi_l > 1 || ci_l > 1 {
-        emit_merge_reshape(
-            lhs_after_transpose_slot,
-            &lhs_after_transpose_shape,
-            &lhs_after_transpose_extents,
-            fi_l,
-            ci_l,
-            nb,
-            instr.dtype,
-            n_slots,
-            new_instructions,
-        )
-    } else {
-        (
-            lhs_after_transpose_slot,
-            lhs_after_transpose_shape,
-            lhs_after_transpose_extents,
-        )
-    };
-
-    let rhs_target_perm: Vec<usize> = config
-        .rhs_contracting_dims
-        .iter()
-        .chain(rhs_free.iter())
-        .chain(config.rhs_batch_dims.iter())
-        .copied()
-        .collect();
-    let (rhs_after_transpose_slot, rhs_after_transpose_shape, rhs_after_transpose_extents) =
-        emit_transpose_if_needed(
-            rhs_slot,
-            rhs_shape,
-            rhs_extents,
-            &rhs_target_perm,
-            instr.dtype,
-            n_slots,
-            new_instructions,
-        );
-
-    let (rhs_canon_slot, rhs_canon_shape, rhs_canon_extents) = if fi_r > 1 || ci_r > 1 {
-        // For RHS the transpose target puts contracting first, then free.
-        emit_merge_reshape_rhs(
-            rhs_after_transpose_slot,
-            &rhs_after_transpose_shape,
-            &rhs_after_transpose_extents,
-            fi_r,
-            ci_r,
-            nb,
-            instr.dtype,
-            n_slots,
-            new_instructions,
-        )
-    } else {
-        (
-            rhs_after_transpose_slot,
-            rhs_after_transpose_shape,
-            rhs_after_transpose_extents,
-        )
-    };
-
-    let lhs_free_count_canon = usize::from(fi_l > 0);
-    let rhs_free_count_canon = usize::from(fi_r > 0);
-    let canonical_config = DotGeneralConfig {
-        lhs_contracting_dims: vec![lhs_free_count_canon],
-        rhs_contracting_dims: vec![0],
-        lhs_batch_dims: ((lhs_free_count_canon + 1)..(lhs_free_count_canon + 1 + nb)).collect(),
-        rhs_batch_dims: ((rhs_free_count_canon + 1)..(rhs_free_count_canon + 1 + nb)).collect(),
-    };
-
-    let needs_output_reshape = fi_l > 1 || fi_r > 1;
-
-    let canonical_output_slot = if needs_output_reshape {
-        let s = *n_slots;
-        *n_slots += 1;
-        s
-    } else {
-        instr.output_slots[0]
-    };
-
-    // Compute canonical output shape directly: [M?, N?, batch...] referencing
-    // the canonical operand shapes we just built.
-    let mut canonical_output_shape: Vec<DimExpr> = Vec::new();
-    let mut canonical_output_extents: Vec<ShapeExtent<DimExpr>> = Vec::new();
-    if fi_l > 0 {
-        canonical_output_shape.push(lhs_canon_shape[0].clone());
-        canonical_output_extents.push(lhs_canon_extents[0].clone());
-    }
-    if fi_r > 0 {
-        canonical_output_shape.push(rhs_canon_shape[rhs_free_count_canon].clone());
-        canonical_output_extents.push(rhs_canon_extents[rhs_free_count_canon].clone());
-    }
-    for axis_offset in 0..nb {
-        canonical_output_shape
-            .push(lhs_canon_shape[lhs_free_count_canon + 1 + axis_offset].clone());
-        canonical_output_extents
-            .push(lhs_canon_extents[lhs_free_count_canon + 1 + axis_offset].clone());
-    }
-
-    new_instructions.push(ExecInstruction {
-        op: if lhs_conj || rhs_conj {
-            ExecOp::DotGeneralWithConj {
-                config: canonical_config,
-                lhs_conj,
-                rhs_conj,
-            }
-        } else {
-            ExecOp::DotGeneral(canonical_config)
-        },
-        input_slots: vec![lhs_canon_slot, rhs_canon_slot],
-        output_slots: vec![canonical_output_slot],
-        dtype: instr.dtype,
-        output_shapes: vec![canonical_output_shape.clone()],
-        output_extents: vec![canonical_output_extents],
-        last_use: Vec::new(),
-    });
-
-    if needs_output_reshape {
-        // Target output shape: original DotGeneral output =
-        //   [lhs_free_sizes..., rhs_free_sizes..., batch_sizes...]
-        // Expressed via `InputDim{1, axis}` (original LHS) and
-        // `InputDim{2, axis}` (original RHS) so the Reshape can evaluate
-        // dynamic sizes at runtime.
-        let mut to_shape: Vec<DimExpr> = Vec::new();
-        for &axis in &lhs_free {
-            to_shape.push(DimExpr::InputDim { input_idx: 1, axis });
-        }
-        for &axis in &rhs_free {
-            to_shape.push(DimExpr::InputDim { input_idx: 2, axis });
-        }
-        for &axis in &config.lhs_batch_dims {
-            to_shape.push(DimExpr::InputDim { input_idx: 1, axis });
-        }
-
-        // Metadata `output_shapes` uses the original DotGeneral output shape
-        // directly, which we cloned from `instr` above.
-        let metadata_shape = instr.output_shapes[0].clone();
-
-        new_instructions.push(ExecInstruction {
-            op: ExecOp::Reshape {
-                shape: to_shape.clone(),
-            },
-            input_slots: vec![canonical_output_slot, lhs_slot, rhs_slot],
-            output_slots: vec![instr.output_slots[0]],
-            dtype: instr.dtype,
-            output_shapes: vec![metadata_shape],
-            output_extents: instr.output_extents.clone(),
-            last_use: Vec::new(),
-        });
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn emit_transpose_if_needed(
-    input_slot: usize,
-    input_shape: &[DimExpr],
-    input_extents: &[ShapeExtent<DimExpr>],
-    target_perm: &[usize],
-    dtype: DType,
-    n_slots: &mut usize,
-    new_instructions: &mut Vec<ExecInstruction>,
-) -> (usize, Vec<DimExpr>, Vec<ShapeExtent<DimExpr>>) {
-    let is_identity = target_perm.iter().enumerate().all(|(i, &p)| i == p);
-    if is_identity {
-        return (input_slot, input_shape.to_vec(), input_extents.to_vec());
-    }
-    let transposed_shape: Vec<DimExpr> = target_perm
-        .iter()
-        .map(|&axis| input_shape[axis].clone())
-        .collect();
-    let transposed_extents: Vec<ShapeExtent<DimExpr>> = target_perm
-        .iter()
-        .map(|&axis| input_extents[axis].clone())
-        .collect();
-    let out_slot = *n_slots;
-    *n_slots += 1;
-    new_instructions.push(ExecInstruction {
-        op: ExecOp::Transpose {
-            perm: target_perm.to_vec(),
-        },
-        input_slots: vec![input_slot],
-        output_slots: vec![out_slot],
-        dtype,
-        output_shapes: vec![transposed_shape.clone()],
-        output_extents: vec![transposed_extents.clone()],
-        last_use: Vec::new(),
-    });
-    (out_slot, transposed_shape, transposed_extents)
-}
-
-/// LHS merge: [free..., contracting..., batch...] -> [M?, K, batch...].
-#[allow(clippy::too_many_arguments)]
-fn emit_merge_reshape(
-    input_slot: usize,
-    input_shape: &[DimExpr],
-    input_extents: &[ShapeExtent<DimExpr>],
-    fi: usize,
-    ci: usize,
-    nb: usize,
-    dtype: DType,
-    n_slots: &mut usize,
-    new_instructions: &mut Vec<ExecInstruction>,
-) -> (usize, Vec<DimExpr>, Vec<ShapeExtent<DimExpr>>) {
-    // Runtime `shape` (op parameter) uses `InputDim{0, axis}` referring to
-    // this Reshape's own input slot.
-    let mut to_shape: Vec<DimExpr> = Vec::new();
-    if fi > 0 {
-        if fi == 1 {
-            to_shape.push(DimExpr::InputDim {
-                input_idx: 0,
-                axis: 0,
-            });
-        } else {
-            to_shape.push(product_of_input_dims(0, 0, fi));
-        }
-    }
-    if ci == 1 {
-        to_shape.push(DimExpr::InputDim {
-            input_idx: 0,
-            axis: fi,
-        });
-    } else {
-        to_shape.push(product_of_input_dims(0, fi, fi + ci));
-    }
-    for k in 0..nb {
-        to_shape.push(DimExpr::InputDim {
-            input_idx: 0,
-            axis: fi + ci + k,
-        });
-    }
-
-    // Metadata `output_shapes` uses original-input DimExprs so downstream
-    // passes can reason about the resulting dims.
-    let mut output_shape_meta: Vec<DimExpr> = Vec::new();
-    let mut output_extents_meta: Vec<ShapeExtent<DimExpr>> = Vec::new();
-    if fi > 0 {
-        output_shape_meta.push(merge_span(input_shape, 0, fi));
-        output_extents_meta.push(merge_extent_span(input_shape, input_extents, 0, fi));
-    }
-    output_shape_meta.push(merge_span(input_shape, fi, fi + ci));
-    output_extents_meta.push(merge_extent_span(input_shape, input_extents, fi, fi + ci));
-    for k in 0..nb {
-        output_shape_meta.push(input_shape[fi + ci + k].clone());
-        output_extents_meta.push(input_extents[fi + ci + k].clone());
-    }
-
-    let out_slot = *n_slots;
-    *n_slots += 1;
-    new_instructions.push(ExecInstruction {
-        op: ExecOp::Reshape { shape: to_shape },
-        input_slots: vec![input_slot],
-        output_slots: vec![out_slot],
-        dtype,
-        output_shapes: vec![output_shape_meta.clone()],
-        output_extents: vec![output_extents_meta.clone()],
-        last_use: Vec::new(),
-    });
-    (out_slot, output_shape_meta, output_extents_meta)
-}
-
-/// RHS merge: [contracting..., free..., batch...] -> [K, N?, batch...].
-#[allow(clippy::too_many_arguments)]
-fn emit_merge_reshape_rhs(
-    input_slot: usize,
-    input_shape: &[DimExpr],
-    input_extents: &[ShapeExtent<DimExpr>],
-    fi: usize,
-    ci: usize,
-    nb: usize,
-    dtype: DType,
-    n_slots: &mut usize,
-    new_instructions: &mut Vec<ExecInstruction>,
-) -> (usize, Vec<DimExpr>, Vec<ShapeExtent<DimExpr>>) {
-    let mut to_shape: Vec<DimExpr> = Vec::new();
-    if ci == 1 {
-        to_shape.push(DimExpr::InputDim {
-            input_idx: 0,
-            axis: 0,
-        });
-    } else {
-        to_shape.push(product_of_input_dims(0, 0, ci));
-    }
-    if fi > 0 {
-        if fi == 1 {
-            to_shape.push(DimExpr::InputDim {
-                input_idx: 0,
-                axis: ci,
-            });
-        } else {
-            to_shape.push(product_of_input_dims(0, ci, ci + fi));
-        }
-    }
-    for k in 0..nb {
-        to_shape.push(DimExpr::InputDim {
-            input_idx: 0,
-            axis: ci + fi + k,
-        });
-    }
-
-    let mut output_shape_meta: Vec<DimExpr> = Vec::new();
-    let mut output_extents_meta: Vec<ShapeExtent<DimExpr>> = Vec::new();
-    output_shape_meta.push(merge_span(input_shape, 0, ci));
-    output_extents_meta.push(merge_extent_span(input_shape, input_extents, 0, ci));
-    if fi > 0 {
-        output_shape_meta.push(merge_span(input_shape, ci, ci + fi));
-        output_extents_meta.push(merge_extent_span(input_shape, input_extents, ci, ci + fi));
-    }
-    for k in 0..nb {
-        output_shape_meta.push(input_shape[ci + fi + k].clone());
-        output_extents_meta.push(input_extents[ci + fi + k].clone());
-    }
-
-    let out_slot = *n_slots;
-    *n_slots += 1;
-    new_instructions.push(ExecInstruction {
-        op: ExecOp::Reshape { shape: to_shape },
-        input_slots: vec![input_slot],
-        output_slots: vec![out_slot],
-        dtype,
-        output_shapes: vec![output_shape_meta.clone()],
-        output_extents: vec![output_extents_meta.clone()],
-        last_use: Vec::new(),
-    });
-    (out_slot, output_shape_meta, output_extents_meta)
-}
-
-fn merge_span(shape: &[DimExpr], start: usize, end: usize) -> DimExpr {
-    assert!(end > start, "merge_span: empty range");
-    let mut result = shape[start].clone();
-    for dim in shape.iter().take(end).skip(start + 1) {
-        result = DimExpr::mul(result, dim.clone());
-    }
-    result
-}
-
-fn merge_extent_span(
-    shape: &[DimExpr],
-    extents: &[ShapeExtent<DimExpr>],
-    start: usize,
-    end: usize,
-) -> ShapeExtent<DimExpr> {
-    assert!(end > start, "merge_extent_span: empty range");
-    let merged_dim = merge_span(shape, start, end);
-    let mut has_upper_bound = false;
-
-    for extent in &extents[start..end] {
-        match extent {
-            ShapeExtent::Exact(_) => {}
-            ShapeExtent::UpperBound(_) => has_upper_bound = true,
-            ShapeExtent::Unknown => return ShapeExtent::unknown(),
-        }
-    }
-
-    if has_upper_bound {
-        ShapeExtent::upper_bound(merged_dim)
-    } else {
-        ShapeExtent::exact(merged_dim)
-    }
-}
+pub use dot_decomposer::dot_decomposer;
 
 // ============================================================================
 // Pass 4: DotConjFolding

--- a/tenferro-runtime/src/graph/cache.rs
+++ b/tenferro-runtime/src/graph/cache.rs
@@ -10,6 +10,8 @@ use tenferro_tensor::CacheStats;
 use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
 
 /// Default capacity for compiled graph programs retained by a [`GraphCompiler`](super::GraphCompiler).
+// Public constant kept as the documented default; the crate-local alias below
+// is what current implementation paths consume.
 #[allow(dead_code)]
 pub const DEFAULT_GRAPH_COMPILE_CACHE_CAPACITY: usize = 256;
 

--- a/tenferro-runtime/src/graph/program.rs
+++ b/tenferro-runtime/src/graph/program.rs
@@ -102,6 +102,8 @@ pub struct GraphProgramInput {
     pub(crate) key: TensorInputKey,
     pub(crate) dtype: DType,
     pub(crate) shape: Vec<usize>,
+    // Preserved for symbolic-shape diagnostics and future graph-input metadata
+    // without exposing `DimExpr` through the stable input-spec accessor.
     #[allow(dead_code)]
     pub(crate) dim_expr_shape: Vec<DimExpr>,
     pub(crate) default_tensor: Option<Arc<Tensor>>,

--- a/tenferro-runtime/src/traced.rs
+++ b/tenferro-runtime/src/traced.rs
@@ -575,6 +575,10 @@ impl TracedTensor {
         )
     }
 
+    fn apply_same_shape_unary(&self, op: StdTensorOp) -> TracedTensor {
+        apply_unary(op, self, self.rank, self.shape_hint.clone())
+    }
+
     /// Elementwise negation.
     ///
     /// Prefer using the unary `-` operator when it reads naturally.
@@ -588,7 +592,7 @@ impl TracedTensor {
     /// let y2 = -&x;
     /// ```
     pub fn neg(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Neg, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Neg)
     }
 
     /// Elementwise complex conjugate.
@@ -605,7 +609,7 @@ impl TracedTensor {
     /// let y = x.conj();
     /// ```
     pub fn conj(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Conj, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Conj)
     }
 
     /// Elementwise absolute value.
@@ -618,7 +622,7 @@ impl TracedTensor {
     /// let y = x.abs();
     /// ```
     pub fn abs(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Abs, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Abs)
     }
 
     /// Elementwise sign.
@@ -631,7 +635,7 @@ impl TracedTensor {
     /// let y = x.sign();
     /// ```
     pub fn sign(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Sign, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Sign)
     }
 
     /// Scale by a real scalar: `y = factor * x`.
@@ -697,7 +701,7 @@ impl TracedTensor {
     /// let y = x.exp();
     /// ```
     pub fn exp(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Exp, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Exp)
     }
 
     /// Elementwise natural logarithm.
@@ -710,7 +714,7 @@ impl TracedTensor {
     /// let y = x.log();
     /// ```
     pub fn log(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Log, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Log)
     }
 
     /// Elementwise sine.
@@ -723,7 +727,7 @@ impl TracedTensor {
     /// let y = x.sin();
     /// ```
     pub fn sin(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Sin, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Sin)
     }
 
     /// Elementwise cosine.
@@ -736,7 +740,7 @@ impl TracedTensor {
     /// let y = x.cos();
     /// ```
     pub fn cos(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Cos, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Cos)
     }
 
     /// Elementwise hyperbolic tangent.
@@ -749,7 +753,7 @@ impl TracedTensor {
     /// let y = x.tanh();
     /// ```
     pub fn tanh(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Tanh, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Tanh)
     }
 
     /// Elementwise square root.
@@ -762,7 +766,7 @@ impl TracedTensor {
     /// let y = x.sqrt();
     /// ```
     pub fn sqrt(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Sqrt, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Sqrt)
     }
 
     /// Elementwise reciprocal square root.
@@ -775,7 +779,7 @@ impl TracedTensor {
     /// let y = x.rsqrt();
     /// ```
     pub fn rsqrt(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Rsqrt, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Rsqrt)
     }
 
     /// Elementwise power with NumPy-style broadcasting.
@@ -809,7 +813,7 @@ impl TracedTensor {
     /// let y = x.expm1();
     /// ```
     pub fn expm1(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Expm1, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Expm1)
     }
 
     /// Elementwise `log(1 + x)`.
@@ -822,7 +826,7 @@ impl TracedTensor {
     /// let y = x.log1p();
     /// ```
     pub fn log1p(&self) -> TracedTensor {
-        apply_unary(StdTensorOp::Log1p, self, self.rank, self.shape_hint.clone())
+        self.apply_same_shape_unary(StdTensorOp::Log1p)
     }
 
     /// Convert the tensor to a different dtype.

--- a/tenferro-tensor/src/types.rs
+++ b/tenferro-tensor/src/types.rs
@@ -3741,6 +3741,8 @@ impl Tensor {
     }
 }
 
+// Kept for crate-local layout tests while tensor indexing helpers remain split
+// across tensor and CPU crates.
 #[allow(dead_code)]
 pub(crate) fn flat_to_multi(mut flat: usize, shape: &[usize], out: &mut [usize]) {
     for i in 0..shape.len() {


### PR DESCRIPTION
## Key points

- Work logs are now a durable reviewer input: nontrivial cleanup/refactor PRs should link `docs/worklogs/`, and durable design intent should land in `docs/design/`.
- Macro/codegen is not banned for wrappers. The rule is narrower: use it when a wrapper family is genuinely same-shaped and still keeps public names, docs, feature gates, and error behavior reviewable.
- This PR avoids a broad wrapper generator because `TracedTensor` methods carry public rustdoc and mixed semantics. It applies a private helper only to the same-shape unary method family and adds forwarding coverage.
- Compiler cleanup stays behavior-preserving: `DotDecomposer` moves to its own module and long internal helper signatures become semantic state/input objects.
- Local lint/dead-code cleanup is intentionally narrow: stale einsum cache dead code is removed; feature-gated/provider-local allowances are retained with reasons.

## Summary

- Add reviewer-facing work log rules in `AGENTS.md`, `REPOSITORY_RULES.md`, the PR template, `docs/worklogs/README.md`, and `docs/design/review-decision-records.md`.
- Split runtime dot decomposition into `tenferro-runtime/src/compiler/dot_decomposer.rs` and remove compiler-local `too_many_arguments` allowances by introducing focused argument/state structs.
- Refactor the traced same-shape unary wrappers through a private helper while keeping explicit public methods and docs.
- Remove stale einsum cache retained-size dead code and document retained production `dead_code` allowances.
- Make `scripts/check-pr-fast.sh` run on macOS default Bash by removing Bash 4-only `mapfile` usage.

## Work log

- `docs/worklogs/2026-05-30-issue-955-repository-quality-cleanup.md`

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p tenferro-ad --test numpy_api traced_unary_methods_forward_to_distinct_primal_ops`
- `cargo test -p tenferro-ad --test compiler_passes dot_decomposer`
- `cargo clippy -p tenferro-runtime --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/check-crate-boundaries.py`
- `python3 scripts/check-no-facade-crate.py`
- `python3 scripts/check-ad-boundaries.py`
- `python3 scripts/check-linalg-ad-boundaries.py`
- `cargo test --manifest-path ext/tropical/Cargo.toml --no-fail-fast`
- `bash scripts/check-repo-settings.sh --quiet`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-ad --test numpy_api traced_unary_methods_forward_to_distinct_primal_ops' --test 'cargo test -p tenferro-ad --test compiler_passes dot_decomposer'`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I read `REPOSITORY_RULES.md` and checked the diff against it.
- [x] I reviewed docs/API consistency for files touched by this PR.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.

Fixes #951
Fixes #952
Fixes #953
Fixes #954
Fixes #955
Refs #950
