### PR TITLE
[codex] Carry einsum plan specs through payload identity

### DIFF
--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -56,10 +56,14 @@ assert_eq!(result.shape(), &[2, 2]);
 | `Auto(ContractionOptimizerOptions)` | TreeSA/omeco path optimization with configured score |
 | `False` | left-to-right contraction |
 | `Nested(NestedEinsum)` | explicit parenthesized contraction tree |
-| `Path(Vec<(usize, usize)>)` | JAX-compatible shrinking-list path |
-| `Tree(ContractionTree)` | precomputed tree |
+| `Path(Vec<(usize, usize)>)` | JAX-compatible shrinking-list path; shape-independent and valid for symbolic traced inputs |
+| `Tree(ContractionTree)` | concrete/precomputed tree; accepted only when concrete shapes are available |
 
 `EinsumOptimize::default()` is time-optimized automatic planning.
+The traced API stores the resolved planning policy as a shape-independent plan
+specification in the extension payload. `Path` pairs remain positional over the
+current shrinking operand list; `Tree` values are converted to fixed
+contraction pairs when accepted for concrete inputs.
 
 ## Eager Tensor API
 
@@ -122,9 +126,12 @@ The traced extension API chooses the lowering mode from input shape availability
 | Any symbolic shape | emit one einsum extension op | optimize from actual input shapes at runtime |
 
 `tenferro_einsum` caches concrete-shape contraction trees in the extension
-cache. Runtime contraction trees are keyed by `(subscripts, input shapes)` so
-repeated symbolic-shape runs with the same concrete shapes amortize planning
-cost.
+cache. Runtime contraction trees are keyed by subscripts, input shapes, and the
+resolved planning policy or explicit path so repeated symbolic-shape runs with
+the same concrete shapes and policy amortize planning cost without conflating
+different optimizer settings. The same plan specification participates in
+traced extension payload identity, so otherwise identical ops that use
+different planner options or paths remain distinct extension ops.
 
 ## Planning
 
@@ -178,6 +185,11 @@ Current GPU status:
 Graph-level AD rules for einsum live in `tenferro-einsum` and are registered as
 extension AD rules. Primitive operations emitted by lowering still use the core
 AD rules from `tenferro-internal-ops/src/ad/`.
+
+VJP construction preserves the primal planning policy. For explicit
+`EinsumOptimize::Path` payloads, the AD rule remaps the positional path to the
+VJP operand list so the gradient contraction inherits the caller's selected
+order where that order is still meaningful.
 
 ## Tests
 

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -90,6 +90,15 @@ The public optimizer surface is limited to the types needed to express that
 choice: `EinsumOptimize`, `ContractionTree`, `ContractionOptimizerOptions`,
 `Subscripts`, `NestedEinsum`, and `EinsumSubscripts`.
 
+`EinsumOptimize::Path` accepts a JAX-style positional path over the current
+operand list. After each contraction the referenced operands are removed and
+the result is appended, so `[(1, 2), (0, 1)]` for `ij,jk,kl->il` contracts the
+last two operands first and then contracts that result with the first operand.
+This path is shape-independent and can be used with symbolic traced inputs.
+`EinsumOptimize::Tree` is for concrete or precomputed `ContractionTree` values;
+it requires concrete shapes and is converted to fixed contraction pairs when a
+concrete traced op is built.
+
 ```rust
 use tenferro_runtime::{GraphCompiler, TracedTensor};
 use tenferro_einsum::EinsumOptimize;
@@ -113,7 +122,18 @@ assert_eq!(c.shape, vec![2, 2]);
 Einsum uses the shared extension cache infrastructure from `tenferro-runtime`.
 Compile-time extension caches live on `GraphCompiler`; runtime
 contraction-plan caches live on `GraphExecutor` and `EagerRuntime`.
+Einsum plan cache identity includes the planning policy or explicit path, not
+only the subscripts and shapes. Traced extension payload identity also includes
+those planner options and paths, so two calls with different policies are not
+treated as identical extension ops.
 
 Use `tenferro_einsum::EINSUM_EXTENSION_FAMILY_ID` with
 `ExtensionCacheSelector` when you need to inspect or clear only einsum cache
 entries.
+
+## Autodiff
+
+With the `autodiff` feature, einsum VJP rules preserve the primal planning
+policy. Explicit positional paths are remapped to the VJP operand order so the
+gradient contraction inherits the caller's intended plan instead of falling
+back to an unrelated default.

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -114,7 +114,7 @@ let c = tenferro_einsum::traced_tensor::einsum_with(
     EinsumOptimize::False,
 ).unwrap();
 
-assert_eq!(c.shape, vec![2, 2]);
+assert_eq!(c.try_concrete_shape(), Some(vec![2, 2]));
 ```
 
 ## Cache Management

--- a/docs/worklogs/2026-05-30-einsum-plan-spec-payload.md
+++ b/docs/worklogs/2026-05-30-einsum-plan-spec-payload.md
@@ -75,6 +75,12 @@ operands.
 - `cargo test -p tenferro-einsum --test traced_correctness einsum_symbolic_explicit_path_matches_static_execution`
 - `cargo test -p tenferro-einsum --doc`
 - `cargo clippy -p tenferro-einsum --features autodiff --all-targets -- -D warnings`
+- `cargo test -p tenferro-tensor --release tensor_buffer_refs_cover_backend_metadata`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
 - `cargo fmt --all --check`
 - `git diff --check`
 
@@ -83,5 +89,3 @@ operands.
 - The VJP plan remapping preserves the primal tree structure where possible,
   but automatic optimizer plans for VJP still resolve independently from VJP
   shapes. That is intentional for `Auto`.
-- Full workspace verification and coverage checks still need to run before the
-  PR is pushed or merged.

--- a/docs/worklogs/2026-05-30-einsum-plan-spec-payload.md
+++ b/docs/worklogs/2026-05-30-einsum-plan-spec-payload.md
@@ -1,0 +1,87 @@
+# Einsum plan-spec payload work log
+
+Date: 2026-05-30
+
+## Session summary
+
+This work made einsum contraction planning part of extension payload identity
+instead of treating only subscripts and shapes as semantically relevant. The
+change lets traced and runtime execution distinguish different automatic
+optimizer options, explicit JAX-style paths, parenthesized trees, and
+precomputed concrete trees.
+
+The implementation also carries the planning policy through traced AD. VJP
+construction inherits automatic and left-to-right policies directly. Explicit
+paths and fixed-pair plans are remapped to the VJP operand list so gradient
+contractions do not accidentally reuse a primal positional path over different
+operands.
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| `AGENTS.md` and `REPOSITORY_RULES.md` | Load tenferro workflow, docs, cache, and worklog requirements. | Kept the change in an isolated worktree from `origin/main`, added this worklog, and updated durable docs. |
+| `tenferro-einsum/src/optimize.rs` | Inspect public strategy API and path conversion helpers. | Added crate-private `EinsumPlanSpec` and reused JAX path-to-fixed-pair conversion for validation and VJP remapping. |
+| `tenferro-einsum/src/traced.rs` | Inspect symbolic/concrete traced lowering and static plan caching. | Stored plan specs in extension payloads and included plan-spec hashes in static-tree cache identity. |
+| `tenferro-einsum/src/extension.rs` | Inspect payload identity, runtime execution, and extension AD rules. | Added plan-spec payload hash/equality, runtime cache-key separation, runtime plan resolution, and VJP plan inheritance. |
+| `tenferro-einsum/src/eager_tensor.rs` | Check eager extension construction and eager AD behavior. | Added concrete output shape hints so eager backward can use the same VJP planning path. |
+| `docs/design/einsum.md` and `docs/guides/einsum.md` | Check current user and design statements. | Documented symbolic `Path`, concrete-only `Tree`, cache identity, and VJP remapping. |
+
+## Decisions made
+
+- **Keep the extension family at `tenferro.einsum.v1`.** The repository has not
+  shipped a serialized payload format for this family. The change is still an
+  in-family payload refinement, and keeping `v1` preserves the current
+  extension family name.
+- **Represent planning policy with a crate-private plan spec.** Public
+  `EinsumOptimize` remains the user API. Internally, `EinsumPlanSpec` preserves
+  the shape-independent policy that should participate in payload identity and
+  cache keys.
+- **Reject shape-dependent `Tree` for symbolic traced inputs.** A
+  `ContractionTree` contains concrete planning state. Symbolic traced calls can
+  use `Path` or parenthesized notation instead.
+- **Exclude resolved static trees from payload identity.** The static tree is
+  an execution hint derived from the plan spec and concrete shapes. The plan
+  spec is the semantic payload field.
+- **Include plan specs in static and runtime cache keys.** Subscripts and
+  concrete shapes alone are not enough when two calls request different
+  optimizer options or explicit paths.
+- **Derive VJP-specific fixed-pair plans for explicit paths.** A primal
+  JAX-style path is positional over the primal operand list. VJP operands are
+  `[cotangent, non-active primal operands...]`, so direct cloning would refer
+  to the wrong tensors for non-first active inputs.
+
+## Rejected or deferred alternatives
+
+- **No public plan-spec API.** The current public surface can express the needed
+  policies through `EinsumOptimize`; exposing an additional plan-spec type would
+  add API weight without a current caller need.
+- **No exact `ctx.shape_of(Local(ct))` dependency in transpose rules.** The
+  current `tidu::try_transpose` path creates cotangent seed locals before their
+  metadata is registered. The einsum AD rule instead uses the extension output
+  shape hint that traced and eager construction now attach.
+- **No broad cache redesign.** The change only extends einsum-specific cache
+  identity with a plan-spec hash and keeps existing extension cache ownership.
+- **No GPU-specific changes.** The planning identity change is backend-neutral;
+  CUDA/CubeCL support continues through existing execution paths.
+
+## Verification performed
+
+- `cargo build -p tenferro-einsum --features autodiff`
+- `cargo test -p tenferro-einsum --features autodiff`
+- `cargo test -p tenferro-einsum --features autodiff extension::tests::vjp_einsum_op --lib`
+- `cargo test -p tenferro-einsum --features autodiff --test traced_ad_migration symbolic_grad_einsum_with_explicit_path`
+- `cargo test -p tenferro-einsum --features autodiff --test eager_tensor eager_tensor_einsum_backward_populates_input_grads`
+- `cargo test -p tenferro-einsum --test traced_correctness einsum_symbolic_explicit_path_matches_static_execution`
+- `cargo test -p tenferro-einsum --doc`
+- `cargo clippy -p tenferro-einsum --features autodiff --all-targets -- -D warnings`
+- `cargo fmt --all --check`
+- `git diff --check`
+
+## Remaining risk
+
+- The VJP plan remapping preserves the primal tree structure where possible,
+  but automatic optimizer plans for VJP still resolve independently from VJP
+  shapes. That is intentional for `Auto`.
+- Full workspace verification and coverage checks still need to run before the
+  PR is pushed or merged.

--- a/tenferro-einsum/src/eager_tensor.rs
+++ b/tenferro-einsum/src/eager_tensor.rs
@@ -9,6 +9,7 @@ use tenferro_ad::EagerTensor;
 use crate::extension::{
     ensure_einsum_extension_rule_registered, register_runtime, EinsumExtensionOp,
 };
+use crate::optimize::{default_auto_options, EinsumPlanSpec};
 use crate::{parse_einsum_subscripts, EinsumSubscripts, TensorDotAxes};
 
 /// Execute an einsum eagerly on [`EagerTensor`] values.
@@ -31,11 +32,71 @@ pub fn einsum_subscripts(
             .map_err(|err| Error::Internal(err.to_string()))?;
     }
 
-    let op = Arc::new(EinsumExtensionOp::new(subscripts.clone()));
+    let output_shape_hint = infer_eager_output_shape(subscripts, inputs)?;
+    let op = Arc::new(EinsumExtensionOp::with_output_shape_hint(
+        subscripts.clone(),
+        output_shape_hint,
+        EinsumPlanSpec::Auto(default_auto_options()),
+    ));
     let mut outputs = apply_eager(op, inputs)?;
     outputs
         .pop()
         .ok_or_else(|| Error::Internal("einsum extension produced no eager output".to_string()))
+}
+
+fn infer_eager_output_shape(
+    subscripts: &EinsumSubscripts,
+    inputs: &[&EagerTensor],
+) -> Result<Vec<tenferro_runtime::SymDim>> {
+    if inputs.is_empty() {
+        return Err(Error::ContractionError(
+            "einsum requires at least one input tensor".into(),
+        ));
+    }
+    if subscripts.inputs.len() != inputs.len() {
+        return Err(Error::ContractionError(format!(
+            "einsum subscripts expect {} inputs, got {}",
+            subscripts.inputs.len(),
+            inputs.len()
+        )));
+    }
+
+    let mut label_dims = std::collections::HashMap::new();
+    for (labels, tensor) in subscripts.inputs.iter().zip(inputs.iter()) {
+        let shape = tensor.data().shape();
+        if labels.len() != shape.len() {
+            return Err(Error::ContractionError(format!(
+                "einsum input rank mismatch: labels={}, shape={}",
+                labels.len(),
+                shape.len()
+            )));
+        }
+        for (&label, &dim) in labels.iter().zip(shape.iter()) {
+            if let Some(existing) = label_dims.insert(label, dim) {
+                if existing != dim {
+                    return Err(Error::ContractionError(format!(
+                        "einsum label {label} has inconsistent dimensions {existing} and {dim}"
+                    )));
+                }
+            }
+        }
+    }
+
+    subscripts
+        .output
+        .iter()
+        .map(|label| {
+            label_dims
+                .get(label)
+                .copied()
+                .map(tenferro_runtime::SymDim::from)
+                .ok_or_else(|| {
+                    Error::ContractionError(format!(
+                        "einsum output label {label} is missing from input labels"
+                    ))
+                })
+        })
+        .collect()
 }
 
 /// Execute a NumPy-style tensor contraction on [`EagerTensor`] values.

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -388,7 +388,7 @@ impl ExtensionAdRule for EinsumAdRule {
                 vjp_inputs,
                 OpMode::Linear {
                     active_mask: std::iter::once(true)
-                        .chain(std::iter::repeat(false).take(n_inputs.saturating_sub(1)))
+                        .chain(std::iter::repeat_n(false, n_inputs.saturating_sub(1)))
                         .collect(),
                 },
             );
@@ -639,10 +639,7 @@ fn hash_value<T: Hash>(value: &T) -> u64 {
 }
 
 #[cfg(feature = "autodiff")]
-fn downcast_ad_op<'a>(
-    op: &'a dyn ExtensionOp,
-    kind: ADRuleKind,
-) -> ADRuleResult<&'a EinsumExtensionOp> {
+fn downcast_ad_op(op: &dyn ExtensionOp, kind: ADRuleKind) -> ADRuleResult<&EinsumExtensionOp> {
     op.as_any()
         .downcast_ref::<EinsumExtensionOp>()
         .ok_or_else(|| ADRuleError::unsupported("tenferro.einsum.v1 payload type mismatch", kind))

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -38,7 +38,7 @@ use crate::cache::{
 };
 #[cfg(any(feature = "autodiff", test))]
 use crate::optimize::default_auto_options;
-use crate::optimize::{hash_einsum_plan_spec, plan_specs_equal, EinsumPlanSpec};
+use crate::optimize::{hash_einsum_plan_spec, plan_specs_equal, resolve_plan_spec, EinsumPlanSpec};
 use crate::{
     ContractionTree, EinsumSubscripts, Error as EinsumError, Result as EinsumResult, Subscripts,
 };
@@ -523,8 +523,8 @@ fn execute_einsum_extension<B: TensorBackend + 'static>(
     let tree = if let Some(tree) = op.static_tree() {
         Arc::clone(tree)
     } else {
-        cached_runtime_tree(ctx, op.subscripts(), &shapes, || {
-            ContractionTree::optimize(&subs, &shape_refs)
+        cached_runtime_tree(ctx, op.subscripts(), op.plan_spec(), &shapes, || {
+            resolve_plan_spec(op.plan_spec(), &subs, &shape_refs)
         })?
     };
 
@@ -604,10 +604,13 @@ fn execute_einsum_extension<B: TensorBackend + 'static>(
 fn cached_runtime_tree<B: TensorBackend>(
     ctx: &mut ExtensionExecutionContext<'_, B>,
     subscripts: &EinsumSubscripts,
+    plan_spec: &EinsumPlanSpec,
     shapes: &[Vec<usize>],
     build: impl FnOnce() -> EinsumResult<ContractionTree>,
 ) -> tenferro_tensor::Result<Arc<ContractionTree>> {
-    let key_data = (subscripts.clone(), shapes.to_vec());
+    let mut plan_hasher = std::collections::hash_map::DefaultHasher::new();
+    hash_einsum_plan_spec(plan_spec, &mut plan_hasher);
+    let key_data = (subscripts.clone(), shapes.to_vec(), plan_hasher.finish());
     let key = ExtensionCacheKey::new(
         EINSUM_EXTENSION_FAMILY_ID,
         EINSUM_RUNTIME_PLANS_CACHE,
@@ -623,6 +626,7 @@ fn cached_runtime_tree<B: TensorBackend>(
             .iter()
             .map(|shape| shape.capacity() * std::mem::size_of::<usize>())
             .sum::<usize>()
+        + std::mem::size_of::<u64>()
         + tree.retained_bytes_for_cache_stats();
     ctx.caches_mut().put(key, Arc::clone(&tree), retained_bytes);
     Ok(tree)

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -38,6 +38,8 @@ use crate::cache::{
 };
 #[cfg(any(feature = "autodiff", test))]
 use crate::optimize::default_auto_options;
+#[cfg(feature = "autodiff")]
+use crate::optimize::jax_path_to_v1_pairs;
 use crate::optimize::{hash_einsum_plan_spec, plan_specs_equal, resolve_plan_spec, EinsumPlanSpec};
 use crate::{
     ContractionTree, EinsumSubscripts, Error as EinsumError, Result as EinsumResult, Subscripts,
@@ -342,8 +344,12 @@ impl ExtensionAdRule for EinsumAdRule {
             .iter()
             .map(|input| ctx.shape_of(input).to_vec())
             .collect();
-        let primal_output_shape =
-            infer_einsum_output_shape(input_labels, output_labels, &primal_input_shapes)?;
+        let cotangent_shape = op.output_shape_hint.clone().ok_or_else(|| {
+            ADRuleError::unsupported(
+                "einsum VJP requires an output shape hint for cotangent planning",
+                ADRuleKind::Transpose,
+            )
+        })?;
 
         let mut result = Vec::with_capacity(n_inputs);
         for active_idx in 0..n_inputs {
@@ -368,7 +374,7 @@ impl ExtensionAdRule for EinsumAdRule {
             let mut vjp_input_shapes = Vec::with_capacity(n_inputs);
             vjp_input_labels.push(output_labels.clone());
             vjp_inputs.push(ValRef::Local(ct));
-            vjp_input_shapes.push(primal_output_shape.clone());
+            vjp_input_shapes.push(cotangent_shape.clone());
 
             for input_idx in 0..n_inputs {
                 if input_idx == active_idx {
@@ -386,6 +392,7 @@ impl ExtensionAdRule for EinsumAdRule {
             let output_shape_hint = primal_input_shapes[active_idx].clone();
             let vjp_op = vjp_einsum_op_with_inherited_plan(
                 op,
+                active_idx,
                 EinsumSubscripts {
                     inputs: vjp_input_labels,
                     output: vjp_output_labels.clone(),
@@ -421,67 +428,316 @@ impl ExtensionAdRule for EinsumAdRule {
 }
 
 #[cfg(feature = "autodiff")]
-fn infer_einsum_output_shape(
-    input_labels: &[Vec<u32>],
-    output_labels: &[u32],
-    input_shapes: &[Vec<SymDim>],
-) -> ADRuleResult<Vec<SymDim>> {
-    let mut label_dims: HashMap<u32, SymDim> = HashMap::new();
-    for (labels, shape) in input_labels.iter().zip(input_shapes.iter()) {
-        if labels.len() != shape.len() {
-            return Err(ADRuleError::unsupported(
-                format!(
-                    "einsum VJP input rank mismatch: labels={}, shape={}",
-                    labels.len(),
-                    shape.len()
-                ),
-                ADRuleKind::Transpose,
-            ));
-        }
-        for (&label, dim) in labels.iter().zip(shape.iter()) {
-            label_dims.entry(label).or_insert_with(|| dim.clone());
-        }
-    }
-
-    output_labels
-        .iter()
-        .map(|label| {
-            label_dims.get(label).cloned().ok_or_else(|| {
-                ADRuleError::unsupported(
-                    format!("einsum VJP output label {label} is missing from inputs"),
-                    ADRuleKind::Transpose,
-                )
-            })
-        })
-        .collect()
-}
-
-#[cfg(feature = "autodiff")]
 fn vjp_einsum_op_with_inherited_plan(
     primal_op: &EinsumExtensionOp,
+    active_idx: usize,
     subscripts: EinsumSubscripts,
     output_shape_hint: Vec<SymDim>,
     input_shapes: &[Vec<SymDim>],
 ) -> ADRuleResult<EinsumExtensionOp> {
+    let plan_spec =
+        vjp_plan_spec_for_active(primal_op.plan_spec(), primal_op.n_inputs(), active_idx)?;
     let mut op = EinsumExtensionOp::with_output_shape_hint(
         subscripts.clone(),
         output_shape_hint,
-        primal_op.plan_spec().clone(),
+        plan_spec.clone(),
     );
     if let Some(concrete_shapes) = concrete_sym_shapes(input_shapes) {
         let shape_refs: Vec<&[usize]> = concrete_shapes.iter().map(Vec::as_slice).collect();
         let raw_subscripts = Subscripts::from(&subscripts);
-        let tree = resolve_plan_spec(primal_op.plan_spec(), &raw_subscripts, &shape_refs).map_err(
-            |err| {
+        let tree =
+            resolve_plan_spec(&plan_spec, &raw_subscripts, &shape_refs).map_err(|err| {
                 ADRuleError::unsupported(
-                    format!("failed to resolve inherited einsum VJP plan: {err}"),
+                    format!(
+                        "failed to resolve inherited einsum VJP plan for active input {active_idx}: {err}"
+                    ),
                     ADRuleKind::Transpose,
                 )
-            },
-        )?;
+            })?;
         op = op.with_static_tree_hint(Arc::new(tree));
     }
     Ok(op)
+}
+
+#[cfg(feature = "autodiff")]
+fn vjp_plan_spec_for_active(
+    primal_plan: &EinsumPlanSpec,
+    n_inputs: usize,
+    active_idx: usize,
+) -> ADRuleResult<EinsumPlanSpec> {
+    if active_idx >= n_inputs {
+        return Err(ADRuleError::unsupported(
+            format!("einsum VJP active input {active_idx} is outside {n_inputs} inputs"),
+            ADRuleKind::Transpose,
+        ));
+    }
+
+    match primal_plan {
+        EinsumPlanSpec::Auto(options) => Ok(EinsumPlanSpec::Auto(options.clone())),
+        EinsumPlanSpec::LeftToRight => Ok(EinsumPlanSpec::LeftToRight),
+        EinsumPlanSpec::Path(path) => {
+            let pairs = jax_path_to_v1_pairs(path, n_inputs).map_err(|err| {
+                ADRuleError::unsupported(
+                    format!(
+                        "failed to inherit einsum Path plan for VJP active input {active_idx}: {err}"
+                    ),
+                    ADRuleKind::Transpose,
+                )
+            })?;
+            derive_vjp_fixed_pairs(&pairs, n_inputs, active_idx).map(EinsumPlanSpec::FixedPairs)
+        }
+        EinsumPlanSpec::FixedPairs(pairs) => {
+            derive_vjp_fixed_pairs(pairs, n_inputs, active_idx).map(EinsumPlanSpec::FixedPairs)
+        }
+    }
+}
+
+#[cfg(feature = "autodiff")]
+fn derive_vjp_fixed_pairs(
+    primal_pairs: &[(usize, usize)],
+    n_inputs: usize,
+    active_idx: usize,
+) -> ADRuleResult<Vec<(usize, usize)>> {
+    if n_inputs == 0 {
+        return Err(ADRuleError::unsupported(
+            "einsum VJP cannot derive a plan for zero primal inputs",
+            ADRuleKind::Transpose,
+        ));
+    }
+    if active_idx >= n_inputs {
+        return Err(ADRuleError::unsupported(
+            format!("einsum VJP active input {active_idx} is outside {n_inputs} inputs"),
+            ADRuleKind::Transpose,
+        ));
+    }
+    let required_steps = n_inputs.saturating_sub(1);
+    if primal_pairs.len() != required_steps {
+        return Err(ADRuleError::unsupported(
+            format!(
+                "einsum VJP cannot inherit explicit plan for active input {active_idx}: \
+                 expected {required_steps} primal steps for {n_inputs} inputs, got {}",
+                primal_pairs.len()
+            ),
+            ADRuleKind::Transpose,
+        ));
+    }
+    if n_inputs == 1 {
+        return Ok(Vec::new());
+    }
+
+    let children = fixed_pair_children(primal_pairs, n_inputs, active_idx)?;
+    let mut primal_to_vjp = vec![None; n_inputs];
+    let mut next_vjp_input = 1;
+    for (input_idx, slot) in primal_to_vjp.iter_mut().enumerate() {
+        if input_idx != active_idx {
+            *slot = Some(next_vjp_input);
+            next_vjp_input += 1;
+        }
+    }
+
+    let root = n_inputs + primal_pairs.len() - 1;
+    let mut pairs = Vec::with_capacity(required_steps);
+    let final_id = emit_vjp_adjoint(
+        root,
+        0,
+        &children,
+        n_inputs,
+        active_idx,
+        &primal_to_vjp,
+        &mut pairs,
+    )?;
+    let expected_final = n_inputs + pairs.len() - 1;
+    if final_id != expected_final || pairs.len() != required_steps {
+        return Err(ADRuleError::unsupported(
+            format!(
+                "einsum VJP plan derivation for active input {active_idx} produced an invalid \
+                 tree: final id {final_id}, expected {expected_final}, steps {}",
+                pairs.len()
+            ),
+            ADRuleKind::Transpose,
+        ));
+    }
+    Ok(pairs)
+}
+
+#[cfg(feature = "autodiff")]
+fn fixed_pair_children(
+    pairs: &[(usize, usize)],
+    n_inputs: usize,
+    active_idx: usize,
+) -> ADRuleResult<Vec<Option<(usize, usize)>>> {
+    let mut live = vec![false; n_inputs + pairs.len()];
+    for slot in live.iter_mut().take(n_inputs) {
+        *slot = true;
+    }
+    let mut children = vec![None; n_inputs + pairs.len()];
+
+    for (step_idx, &(left, right)) in pairs.iter().enumerate() {
+        let next_idx = n_inputs + step_idx;
+        if left == right {
+            return Err(invalid_vjp_plan_error(
+                active_idx,
+                format!("pair ({left}, {right}) references the same operand"),
+            ));
+        }
+        if left >= next_idx || right >= next_idx {
+            return Err(invalid_vjp_plan_error(
+                active_idx,
+                format!("pair ({left}, {right}) references a non-existent operand"),
+            ));
+        }
+        if !live[left] || !live[right] {
+            return Err(invalid_vjp_plan_error(
+                active_idx,
+                format!("pair ({left}, {right}) references an operand that is no longer live"),
+            ));
+        }
+
+        live[left] = false;
+        live[right] = false;
+        live[next_idx] = true;
+        children[next_idx] = Some((left, right));
+    }
+
+    let live_count = live.iter().filter(|&&is_live| is_live).count();
+    if live_count != 1 {
+        return Err(invalid_vjp_plan_error(
+            active_idx,
+            format!("explicit plan leaves {live_count} live operands"),
+        ));
+    }
+
+    Ok(children)
+}
+
+#[cfg(feature = "autodiff")]
+fn emit_vjp_adjoint(
+    node: usize,
+    cotangent_id: usize,
+    children: &[Option<(usize, usize)>],
+    n_inputs: usize,
+    active_idx: usize,
+    primal_to_vjp: &[Option<usize>],
+    pairs: &mut Vec<(usize, usize)>,
+) -> ADRuleResult<usize> {
+    if node < n_inputs {
+        return if node == active_idx {
+            Ok(cotangent_id)
+        } else {
+            Err(invalid_vjp_plan_error(
+                active_idx,
+                format!("adjoint walk reached inactive leaf {node}"),
+            ))
+        };
+    }
+
+    let (left, right) = children.get(node).and_then(|child| *child).ok_or_else(|| {
+        invalid_vjp_plan_error(active_idx, format!("missing children for node {node}"))
+    })?;
+    let left_has_active = subtree_contains_active(left, children, n_inputs, active_idx)?;
+    let right_has_active = subtree_contains_active(right, children, n_inputs, active_idx)?;
+    match (left_has_active, right_has_active) {
+        (true, false) => {
+            let sibling_id =
+                emit_vjp_subtree(right, children, n_inputs, active_idx, primal_to_vjp, pairs)?;
+            let next = push_vjp_pair(cotangent_id, sibling_id, n_inputs, pairs);
+            emit_vjp_adjoint(
+                left,
+                next,
+                children,
+                n_inputs,
+                active_idx,
+                primal_to_vjp,
+                pairs,
+            )
+        }
+        (false, true) => {
+            let sibling_id =
+                emit_vjp_subtree(left, children, n_inputs, active_idx, primal_to_vjp, pairs)?;
+            let next = push_vjp_pair(cotangent_id, sibling_id, n_inputs, pairs);
+            emit_vjp_adjoint(
+                right,
+                next,
+                children,
+                n_inputs,
+                active_idx,
+                primal_to_vjp,
+                pairs,
+            )
+        }
+        (true, true) => Err(invalid_vjp_plan_error(
+            active_idx,
+            format!("both children of node {node} contain the active input"),
+        )),
+        (false, false) => Err(invalid_vjp_plan_error(
+            active_idx,
+            format!("neither child of node {node} contains the active input"),
+        )),
+    }
+}
+
+#[cfg(feature = "autodiff")]
+fn emit_vjp_subtree(
+    node: usize,
+    children: &[Option<(usize, usize)>],
+    n_inputs: usize,
+    active_idx: usize,
+    primal_to_vjp: &[Option<usize>],
+    pairs: &mut Vec<(usize, usize)>,
+) -> ADRuleResult<usize> {
+    if node < n_inputs {
+        return primal_to_vjp[node].ok_or_else(|| {
+            invalid_vjp_plan_error(
+                active_idx,
+                format!("sibling subtree unexpectedly reached active leaf {node}"),
+            )
+        });
+    }
+
+    let (left, right) = children.get(node).and_then(|child| *child).ok_or_else(|| {
+        invalid_vjp_plan_error(active_idx, format!("missing children for node {node}"))
+    })?;
+    let left_id = emit_vjp_subtree(left, children, n_inputs, active_idx, primal_to_vjp, pairs)?;
+    let right_id = emit_vjp_subtree(right, children, n_inputs, active_idx, primal_to_vjp, pairs)?;
+    Ok(push_vjp_pair(left_id, right_id, n_inputs, pairs))
+}
+
+#[cfg(feature = "autodiff")]
+fn push_vjp_pair(
+    left: usize,
+    right: usize,
+    n_vjp_inputs: usize,
+    pairs: &mut Vec<(usize, usize)>,
+) -> usize {
+    pairs.push((left, right));
+    n_vjp_inputs + pairs.len() - 1
+}
+
+#[cfg(feature = "autodiff")]
+fn subtree_contains_active(
+    node: usize,
+    children: &[Option<(usize, usize)>],
+    n_inputs: usize,
+    active_idx: usize,
+) -> ADRuleResult<bool> {
+    if node < n_inputs {
+        return Ok(node == active_idx);
+    }
+    let (left, right) = children.get(node).and_then(|child| *child).ok_or_else(|| {
+        invalid_vjp_plan_error(active_idx, format!("missing children for node {node}"))
+    })?;
+    Ok(
+        subtree_contains_active(left, children, n_inputs, active_idx)?
+            || subtree_contains_active(right, children, n_inputs, active_idx)?,
+    )
+}
+
+#[cfg(feature = "autodiff")]
+fn invalid_vjp_plan_error(active_idx: usize, reason: String) -> ADRuleError {
+    ADRuleError::unsupported(
+        format!("einsum VJP cannot inherit explicit plan for active input {active_idx}: {reason}"),
+        ADRuleKind::Transpose,
+    )
 }
 
 #[cfg(feature = "autodiff")]

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -36,6 +36,9 @@ use crate::builder::build_einsum_fragment;
 use crate::cache::{
     einsum_subscripts_retained_bytes, EINSUM_EXTENSION_FAMILY_ID, EINSUM_RUNTIME_PLANS_CACHE,
 };
+#[cfg(any(feature = "autodiff", test))]
+use crate::optimize::default_auto_options;
+use crate::optimize::{hash_einsum_plan_spec, plan_specs_equal, EinsumPlanSpec};
 use crate::{
     ContractionTree, EinsumSubscripts, Error as EinsumError, Result as EinsumResult, Subscripts,
 };
@@ -48,9 +51,10 @@ use crate::{
 #[derive(Clone)]
 pub(crate) struct EinsumExtensionOp {
     subscripts: EinsumSubscripts,
+    plan_spec: EinsumPlanSpec,
     /// Optional execution hint. This is intentionally excluded from
-    /// `ExtensionOp` identity: contraction order affects performance, not the
-    /// mathematical value of a fixed einsum.
+    /// `ExtensionOp` identity: the shape-independent `plan_spec` carries
+    /// user planning policy, while this tree is a resolved cacheable hint.
     static_tree: Option<Arc<ContractionTree>>,
     output_shape_hint: Option<Vec<SymDim>>,
 }
@@ -59,6 +63,7 @@ impl std::fmt::Debug for EinsumExtensionOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EinsumExtensionOp")
             .field("subscripts", &self.subscripts)
+            .field("plan_spec", &self.plan_spec)
             .field("has_static_tree", &self.static_tree.is_some())
             .field("output_shape_hint", &self.output_shape_hint)
             .finish()
@@ -70,8 +75,14 @@ impl EinsumExtensionOp {
     #[must_use]
     #[cfg(any(feature = "autodiff", test))]
     pub(crate) fn new(subscripts: EinsumSubscripts) -> Self {
+        Self::with_plan_spec(subscripts, EinsumPlanSpec::Auto(default_auto_options()))
+    }
+
+    #[must_use]
+    pub(crate) fn with_plan_spec(subscripts: EinsumSubscripts, plan_spec: EinsumPlanSpec) -> Self {
         Self {
             subscripts,
+            plan_spec,
             static_tree: None,
             output_shape_hint: None,
         }
@@ -84,11 +95,7 @@ impl EinsumExtensionOp {
         subscripts: EinsumSubscripts,
         tree: Arc<ContractionTree>,
     ) -> Self {
-        Self {
-            subscripts,
-            static_tree: Some(tree),
-            output_shape_hint: None,
-        }
+        Self::new(subscripts).with_static_tree_hint(tree)
     }
 
     /// Create an einsum extension payload with an explicit output shape hint.
@@ -96,12 +103,11 @@ impl EinsumExtensionOp {
     pub(crate) fn with_output_shape_hint(
         subscripts: EinsumSubscripts,
         output_shape_hint: Vec<SymDim>,
+        plan_spec: EinsumPlanSpec,
     ) -> Self {
-        Self {
-            subscripts,
-            static_tree: None,
-            output_shape_hint: Some(output_shape_hint),
-        }
+        let mut op = Self::with_plan_spec(subscripts, plan_spec);
+        op.output_shape_hint = Some(output_shape_hint);
+        op
     }
 
     /// Attach a precomputed contraction tree as an execution hint.
@@ -115,6 +121,12 @@ impl EinsumExtensionOp {
     #[must_use]
     pub(crate) fn subscripts(&self) -> &EinsumSubscripts {
         &self.subscripts
+    }
+
+    /// Return the shape-independent planning policy.
+    #[must_use]
+    pub(crate) fn plan_spec(&self) -> &EinsumPlanSpec {
+        &self.plan_spec
     }
 
     /// Return the precomputed contraction tree, if present.
@@ -141,6 +153,7 @@ impl ExtensionOp for EinsumExtensionOp {
         for label in &self.subscripts.output {
             hasher.write_u32(*label);
         }
+        hash_einsum_plan_spec(self.plan_spec(), hasher);
         if let Some(shape) = &self.output_shape_hint {
             hasher.write_usize(shape.len());
             for dim in shape {
@@ -159,7 +172,9 @@ impl ExtensionOp for EinsumExtensionOp {
 
     fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
         other.as_any().downcast_ref::<Self>().is_some_and(|that| {
-            self.subscripts == that.subscripts && self.output_shape_hint == that.output_shape_hint
+            self.subscripts == that.subscripts
+                && plan_specs_equal(self.plan_spec(), that.plan_spec())
+                && self.output_shape_hint == that.output_shape_hint
         })
     }
 
@@ -366,6 +381,7 @@ impl ExtensionAdRule for EinsumAdRule {
                     output: vjp_output_labels.clone(),
                 },
                 output_shape_hint.clone(),
+                op.plan_spec().clone(),
             );
             let out = emitter.add_op(
                 StdTensorOp::Extension(Arc::new(vjp_op)),

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -338,6 +338,12 @@ impl ExtensionAdRule for EinsumAdRule {
             OpMode::Linear { active_mask } => active_mask,
             OpMode::Primal => return Ok(vec![None; n_inputs]),
         };
+        let primal_input_shapes: Vec<Vec<SymDim>> = inputs
+            .iter()
+            .map(|input| ctx.shape_of(input).to_vec())
+            .collect();
+        let primal_output_shape =
+            infer_einsum_output_shape(input_labels, output_labels, &primal_input_shapes)?;
 
         let mut result = Vec::with_capacity(n_inputs);
         for active_idx in 0..n_inputs {
@@ -359,14 +365,17 @@ impl ExtensionAdRule for EinsumAdRule {
                 .collect();
             let mut vjp_input_labels = Vec::with_capacity(n_inputs);
             let mut vjp_inputs = Vec::with_capacity(n_inputs);
+            let mut vjp_input_shapes = Vec::with_capacity(n_inputs);
             vjp_input_labels.push(output_labels.clone());
             vjp_inputs.push(ValRef::Local(ct));
+            vjp_input_shapes.push(primal_output_shape.clone());
 
             for input_idx in 0..n_inputs {
                 if input_idx == active_idx {
                     continue;
                 }
                 vjp_input_labels.push(input_labels[input_idx].clone());
+                vjp_input_shapes.push(primal_input_shapes[input_idx].clone());
                 vjp_inputs.push(conjugate_primal_if_complex(
                     emitter,
                     inputs[input_idx].clone(),
@@ -374,15 +383,16 @@ impl ExtensionAdRule for EinsumAdRule {
                 ));
             }
 
-            let output_shape_hint = ctx.shape_of(&inputs[active_idx]).to_vec();
-            let vjp_op = EinsumExtensionOp::with_output_shape_hint(
+            let output_shape_hint = primal_input_shapes[active_idx].clone();
+            let vjp_op = vjp_einsum_op_with_inherited_plan(
+                op,
                 EinsumSubscripts {
                     inputs: vjp_input_labels,
                     output: vjp_output_labels.clone(),
                 },
                 output_shape_hint.clone(),
-                op.plan_spec().clone(),
-            );
+                &vjp_input_shapes,
+            )?;
             let out = emitter.add_op(
                 StdTensorOp::Extension(Arc::new(vjp_op)),
                 vjp_inputs,
@@ -408,6 +418,78 @@ impl ExtensionAdRule for EinsumAdRule {
 
         Ok(result)
     }
+}
+
+#[cfg(feature = "autodiff")]
+fn infer_einsum_output_shape(
+    input_labels: &[Vec<u32>],
+    output_labels: &[u32],
+    input_shapes: &[Vec<SymDim>],
+) -> ADRuleResult<Vec<SymDim>> {
+    let mut label_dims: HashMap<u32, SymDim> = HashMap::new();
+    for (labels, shape) in input_labels.iter().zip(input_shapes.iter()) {
+        if labels.len() != shape.len() {
+            return Err(ADRuleError::unsupported(
+                format!(
+                    "einsum VJP input rank mismatch: labels={}, shape={}",
+                    labels.len(),
+                    shape.len()
+                ),
+                ADRuleKind::Transpose,
+            ));
+        }
+        for (&label, dim) in labels.iter().zip(shape.iter()) {
+            label_dims.entry(label).or_insert_with(|| dim.clone());
+        }
+    }
+
+    output_labels
+        .iter()
+        .map(|label| {
+            label_dims.get(label).cloned().ok_or_else(|| {
+                ADRuleError::unsupported(
+                    format!("einsum VJP output label {label} is missing from inputs"),
+                    ADRuleKind::Transpose,
+                )
+            })
+        })
+        .collect()
+}
+
+#[cfg(feature = "autodiff")]
+fn vjp_einsum_op_with_inherited_plan(
+    primal_op: &EinsumExtensionOp,
+    subscripts: EinsumSubscripts,
+    output_shape_hint: Vec<SymDim>,
+    input_shapes: &[Vec<SymDim>],
+) -> ADRuleResult<EinsumExtensionOp> {
+    let mut op = EinsumExtensionOp::with_output_shape_hint(
+        subscripts.clone(),
+        output_shape_hint,
+        primal_op.plan_spec().clone(),
+    );
+    if let Some(concrete_shapes) = concrete_sym_shapes(input_shapes) {
+        let shape_refs: Vec<&[usize]> = concrete_shapes.iter().map(Vec::as_slice).collect();
+        let raw_subscripts = Subscripts::from(&subscripts);
+        let tree = resolve_plan_spec(primal_op.plan_spec(), &raw_subscripts, &shape_refs).map_err(
+            |err| {
+                ADRuleError::unsupported(
+                    format!("failed to resolve inherited einsum VJP plan: {err}"),
+                    ADRuleKind::Transpose,
+                )
+            },
+        )?;
+        op = op.with_static_tree_hint(Arc::new(tree));
+    }
+    Ok(op)
+}
+
+#[cfg(feature = "autodiff")]
+fn concrete_sym_shapes(shapes: &[Vec<SymDim>]) -> Option<Vec<Vec<usize>>> {
+    shapes
+        .iter()
+        .map(|shape| shape.iter().map(SymDim::constant_value).collect())
+        .collect()
 }
 
 #[cfg(feature = "autodiff")]

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -36,7 +36,7 @@ use crate::builder::build_einsum_fragment;
 use crate::cache::{
     einsum_subscripts_retained_bytes, EINSUM_EXTENSION_FAMILY_ID, EINSUM_RUNTIME_PLANS_CACHE,
 };
-#[cfg(any(feature = "autodiff", test))]
+#[cfg(test)]
 use crate::optimize::default_auto_options;
 #[cfg(feature = "autodiff")]
 use crate::optimize::jax_path_to_v1_pairs;
@@ -75,7 +75,7 @@ impl std::fmt::Debug for EinsumExtensionOp {
 impl EinsumExtensionOp {
     /// Create an einsum extension payload without a precomputed plan.
     #[must_use]
-    #[cfg(any(feature = "autodiff", test))]
+    #[cfg(test)]
     pub(crate) fn new(subscripts: EinsumSubscripts) -> Self {
         Self::with_plan_spec(subscripts, EinsumPlanSpec::Auto(default_auto_options()))
     }

--- a/tenferro-einsum/src/extension/tests.rs
+++ b/tenferro-einsum/src/extension/tests.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
 
 use super::*;
-use crate::optimize::EinsumPlanSpec;
+use crate::optimize::{plan_specs_equal, EinsumPlanSpec};
 use tenferro_ops::ext_op::ExtensionOp;
 
 #[test]
@@ -76,6 +76,35 @@ fn payload_identity_includes_output_shape_hint() {
 
     assert!(!without_hint.payload_eq(&with_hint));
     assert_ne!(payload_hash(&without_hint), payload_hash(&with_hint));
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn vjp_einsum_op_inherits_plan_spec_and_precomputes_concrete_tree() {
+    let primal_op = EinsumExtensionOp::with_plan_spec(
+        EinsumSubscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]),
+        EinsumPlanSpec::Path(vec![(1, 2), (0, 1)]),
+    );
+    let vjp_subscripts = EinsumSubscripts {
+        inputs: vec![vec![0, 3], vec![1, 2], vec![2, 3]],
+        output: vec![0, 1],
+    };
+    let vjp_shapes = vec![
+        vec![SymDim::from(2usize), SymDim::from(5usize)],
+        vec![SymDim::from(3usize), SymDim::from(4usize)],
+        vec![SymDim::from(4usize), SymDim::from(5usize)],
+    ];
+
+    let op = vjp_einsum_op_with_inherited_plan(
+        &primal_op,
+        vjp_subscripts,
+        vec![SymDim::from(2usize), SymDim::from(3usize)],
+        &vjp_shapes,
+    )
+    .unwrap();
+
+    assert!(plan_specs_equal(op.plan_spec(), primal_op.plan_spec()));
+    assert!(op.static_tree().is_some());
 }
 
 fn payload_hash(op: &EinsumExtensionOp) -> u64 {

--- a/tenferro-einsum/src/extension/tests.rs
+++ b/tenferro-einsum/src/extension/tests.rs
@@ -2,6 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
 
 use super::*;
+use crate::optimize::EinsumPlanSpec;
 use tenferro_ops::ext_op::ExtensionOp;
 
 #[test]
@@ -28,11 +29,22 @@ fn payload_identity_ignores_static_tree_execution_hint() {
         Arc::new(ContractionTree::from_pairs(&raw_subscripts, &shapes, &[(0, 1), (3, 2)]).unwrap());
     let right_first =
         Arc::new(ContractionTree::from_pairs(&raw_subscripts, &shapes, &[(1, 2), (0, 3)]).unwrap());
+    let plan_spec = EinsumPlanSpec::LeftToRight;
 
-    let without_hint = EinsumExtensionOp::new(subscripts.clone());
-    let hinted_left = EinsumExtensionOp::with_static_tree(subscripts.clone(), left_first);
-    let hinted_right = EinsumExtensionOp::with_static_tree(subscripts, right_first);
+    let default_without_hint = EinsumExtensionOp::new(subscripts.clone());
+    let default_hinted =
+        EinsumExtensionOp::with_static_tree(subscripts.clone(), Arc::clone(&left_first));
+    let without_hint = EinsumExtensionOp::with_plan_spec(subscripts.clone(), plan_spec.clone());
+    let hinted_left = EinsumExtensionOp::with_plan_spec(subscripts.clone(), plan_spec.clone())
+        .with_static_tree_hint(left_first);
+    let hinted_right =
+        EinsumExtensionOp::with_plan_spec(subscripts, plan_spec).with_static_tree_hint(right_first);
 
+    assert!(default_without_hint.payload_eq(&default_hinted));
+    assert_eq!(
+        payload_hash(&default_without_hint),
+        payload_hash(&default_hinted)
+    );
     assert!(without_hint.payload_eq(&hinted_left));
     assert!(hinted_left.payload_eq(&hinted_right));
     assert_eq!(payload_hash(&without_hint), payload_hash(&hinted_left));
@@ -40,12 +52,26 @@ fn payload_identity_ignores_static_tree_execution_hint() {
 }
 
 #[test]
+fn payload_identity_includes_plan_spec() {
+    let subscripts = EinsumSubscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]);
+    let left_to_right =
+        EinsumExtensionOp::with_plan_spec(subscripts.clone(), EinsumPlanSpec::LeftToRight);
+    let explicit_path =
+        EinsumExtensionOp::with_plan_spec(subscripts, EinsumPlanSpec::Path(vec![(1, 2), (0, 1)]));
+
+    assert!(!left_to_right.payload_eq(&explicit_path));
+    assert_ne!(payload_hash(&left_to_right), payload_hash(&explicit_path));
+}
+
+#[test]
 fn payload_identity_includes_output_shape_hint() {
     let subscripts = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
-    let without_hint = EinsumExtensionOp::new(subscripts.clone());
+    let plan_spec = EinsumPlanSpec::LeftToRight;
+    let without_hint = EinsumExtensionOp::with_plan_spec(subscripts.clone(), plan_spec.clone());
     let with_hint = EinsumExtensionOp::with_output_shape_hint(
         subscripts,
         vec![SymDim::from(2usize), SymDim::from(4usize)],
+        plan_spec,
     );
 
     assert!(!without_hint.payload_eq(&with_hint));

--- a/tenferro-einsum/src/extension/tests.rs
+++ b/tenferro-einsum/src/extension/tests.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
 
 use super::*;
-use crate::optimize::{plan_specs_equal, EinsumPlanSpec};
+use crate::optimize::EinsumPlanSpec;
 use tenferro_ops::ext_op::ExtensionOp;
 
 #[test]
@@ -97,14 +97,55 @@ fn vjp_einsum_op_inherits_plan_spec_and_precomputes_concrete_tree() {
 
     let op = vjp_einsum_op_with_inherited_plan(
         &primal_op,
+        0,
         vjp_subscripts,
         vec![SymDim::from(2usize), SymDim::from(3usize)],
         &vjp_shapes,
     )
     .unwrap();
 
-    assert!(plan_specs_equal(op.plan_spec(), primal_op.plan_spec()));
-    assert!(op.static_tree().is_some());
+    assert!(matches!(
+        op.plan_spec(),
+        EinsumPlanSpec::FixedPairs(pairs) if pairs == &vec![(1, 2), (0, 3)]
+    ));
+    let tree = op.static_tree().expect("expected concrete VJP tree");
+    assert_eq!(tree.step_pair(0), Some((1, 2)));
+    assert_eq!(tree.step_pair(1), Some((0, 3)));
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn vjp_einsum_op_derives_plan_for_nonfirst_active_input() {
+    let primal_op = EinsumExtensionOp::with_plan_spec(
+        EinsumSubscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]),
+        EinsumPlanSpec::Path(vec![(1, 2), (0, 1)]),
+    );
+    let vjp_subscripts = EinsumSubscripts {
+        inputs: vec![vec![0, 3], vec![0, 1], vec![2, 3]],
+        output: vec![1, 2],
+    };
+    let vjp_shapes = vec![
+        vec![SymDim::from(2usize), SymDim::from(5usize)],
+        vec![SymDim::from(2usize), SymDim::from(3usize)],
+        vec![SymDim::from(4usize), SymDim::from(5usize)],
+    ];
+
+    let op = vjp_einsum_op_with_inherited_plan(
+        &primal_op,
+        1,
+        vjp_subscripts,
+        vec![SymDim::from(3usize), SymDim::from(4usize)],
+        &vjp_shapes,
+    )
+    .unwrap();
+
+    assert!(matches!(
+        op.plan_spec(),
+        EinsumPlanSpec::FixedPairs(pairs) if pairs == &vec![(0, 1), (3, 2)]
+    ));
+    let tree = op.static_tree().expect("expected concrete VJP tree");
+    assert_eq!(tree.step_pair(0), Some((0, 1)));
+    assert_eq!(tree.step_pair(1), Some((3, 2)));
 }
 
 fn payload_hash(op: &EinsumExtensionOp) -> u64 {

--- a/tenferro-einsum/src/optimize.rs
+++ b/tenferro-einsum/src/optimize.rs
@@ -30,10 +30,7 @@ pub enum EinsumOptimize {
 impl Default for EinsumOptimize {
     /// Default: FLOPS-first automatic optimization.
     fn default() -> Self {
-        Self::Auto(ContractionOptimizerOptions {
-            score: ScoreFunction::time_optimized(),
-            ..Default::default()
-        })
+        Self::Auto(default_auto_options())
     }
 }
 
@@ -48,17 +45,10 @@ pub(crate) enum EinsumPlanSpec {
 /// Return the default automatic optimizer options.
 #[must_use]
 pub(crate) fn default_auto_options() -> ContractionOptimizerOptions {
-    match EinsumOptimize::default() {
-        EinsumOptimize::Auto(options) => options,
-        _ => unreachable!("EinsumOptimize::default must be automatic optimization"),
+    ContractionOptimizerOptions {
+        score: ScoreFunction::time_optimized(),
+        ..Default::default()
     }
-}
-
-/// Compare optimizer options with the default policy using bitwise float
-/// equality.
-#[must_use]
-pub(crate) fn is_default_auto_options(options: &ContractionOptimizerOptions) -> bool {
-    optimizer_options_equal_by_bits(options, &default_auto_options())
 }
 
 pub(crate) fn plan_spec_from_optimize(
@@ -246,20 +236,6 @@ fn optimizer_options_equal_by_bits(
         && lhs.niters == rhs.niters
         && f64_slices_equal_by_bits(&lhs.betas, &rhs.betas)
         && score_functions_equal_by_bits(&lhs.score, &rhs.score)
-}
-
-/// Resolve an [`EinsumOptimize`] strategy to a concrete contraction tree.
-///
-/// # Errors
-///
-/// Returns an error if subscripts and shapes are inconsistent or if an
-/// explicit path references invalid operands.
-pub(crate) fn resolve_einsum_strategy(
-    optimize: EinsumOptimize,
-    subscripts: &Subscripts,
-    shapes: &[&[usize]],
-) -> Result<ContractionTree> {
-    resolve_einsum_strategy_with_spec(optimize, subscripts, shapes).map(|(_, tree)| tree)
 }
 
 /// Convert JAX-style position-based path to fixed-ID pairs.

--- a/tenferro-einsum/src/optimize.rs
+++ b/tenferro-einsum/src/optimize.rs
@@ -19,6 +19,27 @@ use crate::{
 /// optimizer options, explicit paths, or fixed plan identities are not treated
 /// as the same extension op, and their compile/runtime plan cache entries are
 /// kept separate.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_einsum::EinsumOptimize;
+/// use tenferro_runtime::{GraphCompiler, TracedTensor};
+///
+/// let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
+/// let rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
+///
+/// let mut compiler = GraphCompiler::new();
+/// let out = tenferro_einsum::traced_tensor::einsum_with(
+///     &mut compiler,
+///     &[&lhs, &rhs],
+///     "ij,jk->ik",
+///     EinsumOptimize::False,
+/// )
+/// .unwrap();
+///
+/// assert_eq!(out.try_concrete_shape(), Some(vec![2, 2]));
+/// ```
 pub enum EinsumOptimize {
     /// Automatic optimization via omeco TreeSA.
     Auto(ContractionOptimizerOptions),

--- a/tenferro-einsum/src/optimize.rs
+++ b/tenferro-einsum/src/optimize.rs
@@ -8,9 +8,16 @@ use crate::{
 
 /// Controls how the contraction path is determined for N-ary einsum.
 ///
-/// This is the runtime-independent strategy enum from the current traced
-/// implementation. Frontends can resolve it to a [`ContractionTree`] once
-/// concrete input shapes are available.
+/// The traced API resolves this enum into a shape-independent plan
+/// specification and stores that specification in the einsum extension
+/// payload. Concrete input shapes are used later to build a [`ContractionTree`]
+/// from that payload when the graph is compiled or executed.
+///
+/// Planner options and explicit paths are part of the extension payload
+/// identity. Two otherwise identical traced einsum ops with different
+/// optimizer options, explicit paths, or fixed plan identities are not treated
+/// as the same extension op, and their compile/runtime plan cache entries are
+/// kept separate.
 pub enum EinsumOptimize {
     /// Automatic optimization via omeco TreeSA.
     Auto(ContractionOptimizerOptions),
@@ -22,8 +29,15 @@ pub enum EinsumOptimize {
     ///
     /// Each pair references positions in a shrinking operand list. After each
     /// contraction, the two operands are removed and the result is appended.
+    /// Because this representation is independent of concrete dimension
+    /// values, it can be used with symbolic traced inputs.
     Path(Vec<(usize, usize)>),
     /// Pre-computed contraction tree.
+    ///
+    /// A tree contains concrete shape-dependent planning results. It is
+    /// accepted when shapes are concrete, then converted into fixed contraction
+    /// pairs for the extension payload. Use [`EinsumOptimize::Path`] instead
+    /// when building a traced graph from symbolic inputs.
     Tree(ContractionTree),
 }
 

--- a/tenferro-einsum/src/optimize.rs
+++ b/tenferro-einsum/src/optimize.rs
@@ -134,13 +134,6 @@ pub(crate) fn resolve_plan_spec(
     }
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "used by extension payload identity in the next integration step"
-    )
-)]
 pub(crate) fn hash_einsum_plan_spec(spec: &EinsumPlanSpec, state: &mut dyn Hasher) {
     match spec {
         EinsumPlanSpec::Auto(options) => {
@@ -159,13 +152,6 @@ pub(crate) fn hash_einsum_plan_spec(spec: &EinsumPlanSpec, state: &mut dyn Hashe
     }
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "used by extension payload identity in the next integration step"
-    )
-)]
 pub(crate) fn plan_specs_equal(lhs: &EinsumPlanSpec, rhs: &EinsumPlanSpec) -> bool {
     match (lhs, rhs) {
         (EinsumPlanSpec::Auto(lhs), EinsumPlanSpec::Auto(rhs)) => {

--- a/tenferro-einsum/src/optimize.rs
+++ b/tenferro-einsum/src/optimize.rs
@@ -1,3 +1,5 @@
+use std::hash::Hasher;
+
 use omeco::ScoreFunction;
 
 use crate::{
@@ -35,6 +37,14 @@ impl Default for EinsumOptimize {
     }
 }
 
+#[derive(Clone, Debug)]
+pub(crate) enum EinsumPlanSpec {
+    Auto(ContractionOptimizerOptions),
+    LeftToRight,
+    Path(Vec<(usize, usize)>),
+    FixedPairs(Vec<(usize, usize)>),
+}
+
 /// Return the default automatic optimizer options.
 #[must_use]
 pub(crate) fn default_auto_options() -> ContractionOptimizerOptions {
@@ -48,11 +58,145 @@ pub(crate) fn default_auto_options() -> ContractionOptimizerOptions {
 /// equality.
 #[must_use]
 pub(crate) fn is_default_auto_options(options: &ContractionOptimizerOptions) -> bool {
-    let default = default_auto_options();
-    options.ntrials == default.ntrials
-        && options.niters == default.niters
-        && f64_slices_equal_by_bits(&options.betas, &default.betas)
-        && score_functions_equal_by_bits(&options.score, &default.score)
+    optimizer_options_equal_by_bits(options, &default_auto_options())
+}
+
+pub(crate) fn plan_spec_from_optimize(
+    optimize: EinsumOptimize,
+    subscripts: &Subscripts,
+) -> Result<EinsumPlanSpec> {
+    match optimize {
+        EinsumOptimize::Auto(options) => {
+            options.validate()?;
+            Ok(EinsumPlanSpec::Auto(options))
+        }
+        EinsumOptimize::False => Ok(EinsumPlanSpec::LeftToRight),
+        EinsumOptimize::Nested(nested) => {
+            let pairs = nested_to_v1_pairs(&nested, subscripts.inputs.len())?;
+            Ok(EinsumPlanSpec::FixedPairs(pairs))
+        }
+        EinsumOptimize::Path(path) => {
+            let _ = jax_path_to_v1_pairs(&path, subscripts.inputs.len())?;
+            Ok(EinsumPlanSpec::Path(path))
+        }
+        EinsumOptimize::Tree(_) => Err(Error::InvalidArgument(
+            "precomputed contraction tree requires concrete input shapes; use Path or parenthesized notation for symbolic traced einsum"
+                .into(),
+        )),
+    }
+}
+
+pub(crate) fn resolve_einsum_strategy_with_spec(
+    optimize: EinsumOptimize,
+    subscripts: &Subscripts,
+    shapes: &[&[usize]],
+) -> Result<(EinsumPlanSpec, ContractionTree)> {
+    match optimize {
+        EinsumOptimize::Tree(tree) => {
+            let pairs = tree_pairs(&tree);
+            let spec = EinsumPlanSpec::FixedPairs(pairs);
+            Ok((spec, tree))
+        }
+        optimize => {
+            let spec = plan_spec_from_optimize(optimize, subscripts)?;
+            let tree = resolve_plan_spec(&spec, subscripts, shapes)?;
+            Ok((spec, tree))
+        }
+    }
+}
+
+pub(crate) fn resolve_plan_spec(
+    spec: &EinsumPlanSpec,
+    subscripts: &Subscripts,
+    shapes: &[&[usize]],
+) -> Result<ContractionTree> {
+    match spec {
+        EinsumPlanSpec::Auto(options) => {
+            ContractionTree::optimize_with_options(subscripts, shapes, options)
+        }
+        EinsumPlanSpec::LeftToRight => {
+            let n = subscripts.inputs.len();
+            if n <= 1 {
+                ContractionTree::from_pairs(subscripts, shapes, &[])
+            } else {
+                let path: Vec<(usize, usize)> = (0..n - 1).map(|_| (0, 1)).collect();
+                let pairs = jax_path_to_v1_pairs(&path, n)?;
+                ContractionTree::from_pairs(subscripts, shapes, &pairs)
+            }
+        }
+        EinsumPlanSpec::Path(path) => {
+            let pairs = jax_path_to_v1_pairs(path, subscripts.inputs.len())?;
+            ContractionTree::from_pairs(subscripts, shapes, &pairs)
+        }
+        EinsumPlanSpec::FixedPairs(pairs) => ContractionTree::from_pairs(subscripts, shapes, pairs),
+    }
+}
+
+pub(crate) fn hash_einsum_plan_spec(spec: &EinsumPlanSpec, state: &mut dyn Hasher) {
+    match spec {
+        EinsumPlanSpec::Auto(options) => {
+            state.write_u8(0);
+            hash_optimizer_options(options, state);
+        }
+        EinsumPlanSpec::LeftToRight => state.write_u8(1),
+        EinsumPlanSpec::Path(path) => {
+            state.write_u8(2);
+            hash_pairs(path, state);
+        }
+        EinsumPlanSpec::FixedPairs(pairs) => {
+            state.write_u8(3);
+            hash_pairs(pairs, state);
+        }
+    }
+}
+
+pub(crate) fn plan_specs_equal(lhs: &EinsumPlanSpec, rhs: &EinsumPlanSpec) -> bool {
+    match (lhs, rhs) {
+        (EinsumPlanSpec::Auto(lhs), EinsumPlanSpec::Auto(rhs)) => {
+            optimizer_options_equal_by_bits(lhs, rhs)
+        }
+        (EinsumPlanSpec::LeftToRight, EinsumPlanSpec::LeftToRight) => true,
+        (EinsumPlanSpec::Path(lhs), EinsumPlanSpec::Path(rhs)) => lhs == rhs,
+        (EinsumPlanSpec::FixedPairs(lhs), EinsumPlanSpec::FixedPairs(rhs)) => lhs == rhs,
+        _ => false,
+    }
+}
+
+fn tree_pairs(tree: &ContractionTree) -> Vec<(usize, usize)> {
+    (0..tree.step_count())
+        .filter_map(|step| tree.step_pair(step))
+        .collect()
+}
+
+fn hash_pairs(pairs: &[(usize, usize)], state: &mut dyn Hasher) {
+    state.write_usize(pairs.len());
+    for &(left, right) in pairs {
+        state.write_usize(left);
+        state.write_usize(right);
+    }
+}
+
+fn hash_optimizer_options(options: &ContractionOptimizerOptions, state: &mut dyn Hasher) {
+    state.write_usize(options.ntrials);
+    state.write_usize(options.niters);
+    state.write_usize(options.betas.len());
+    for value in &options.betas {
+        state.write_u64(value.to_bits());
+    }
+    state.write_u64(options.score.tc_weight.to_bits());
+    state.write_u64(options.score.sc_weight.to_bits());
+    state.write_u64(options.score.rw_weight.to_bits());
+    state.write_u64(options.score.sc_target.to_bits());
+}
+
+fn optimizer_options_equal_by_bits(
+    lhs: &ContractionOptimizerOptions,
+    rhs: &ContractionOptimizerOptions,
+) -> bool {
+    lhs.ntrials == rhs.ntrials
+        && lhs.niters == rhs.niters
+        && f64_slices_equal_by_bits(&lhs.betas, &rhs.betas)
+        && score_functions_equal_by_bits(&lhs.score, &rhs.score)
 }
 
 /// Resolve an [`EinsumOptimize`] strategy to a concrete contraction tree.
@@ -66,32 +210,7 @@ pub(crate) fn resolve_einsum_strategy(
     subscripts: &Subscripts,
     shapes: &[&[usize]],
 ) -> Result<ContractionTree> {
-    match optimize {
-        EinsumOptimize::Auto(opts) => {
-            ContractionTree::optimize_with_options(subscripts, shapes, &opts)
-        }
-        EinsumOptimize::False => {
-            let n = subscripts.inputs.len();
-            if n <= 1 {
-                ContractionTree::from_pairs(subscripts, shapes, &[])
-            } else {
-                let jax_path: Vec<(usize, usize)> = (0..n - 1).map(|_| (0, 1)).collect();
-                let v1_pairs = jax_path_to_v1_pairs(&jax_path, n)?;
-                ContractionTree::from_pairs(subscripts, shapes, &v1_pairs)
-            }
-        }
-        EinsumOptimize::Nested(nested) => {
-            let n = subscripts.inputs.len();
-            let v1_pairs = nested_to_v1_pairs(&nested, n)?;
-            ContractionTree::from_pairs(subscripts, shapes, &v1_pairs)
-        }
-        EinsumOptimize::Path(jax_path) => {
-            let n = subscripts.inputs.len();
-            let v1_pairs = jax_path_to_v1_pairs(&jax_path, n)?;
-            ContractionTree::from_pairs(subscripts, shapes, &v1_pairs)
-        }
-        EinsumOptimize::Tree(tree) => Ok(tree),
-    }
+    resolve_einsum_strategy_with_spec(optimize, subscripts, shapes).map(|(_, tree)| tree)
 }
 
 /// Convert JAX-style position-based path to fixed-ID pairs.

--- a/tenferro-einsum/src/optimize.rs
+++ b/tenferro-einsum/src/optimize.rs
@@ -134,6 +134,13 @@ pub(crate) fn resolve_plan_spec(
     }
 }
 
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "used by extension payload identity in the next integration step"
+    )
+)]
 pub(crate) fn hash_einsum_plan_spec(spec: &EinsumPlanSpec, state: &mut dyn Hasher) {
     match spec {
         EinsumPlanSpec::Auto(options) => {
@@ -152,6 +159,13 @@ pub(crate) fn hash_einsum_plan_spec(spec: &EinsumPlanSpec, state: &mut dyn Hashe
     }
 }
 
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "used by extension payload identity in the next integration step"
+    )
+)]
 pub(crate) fn plan_specs_equal(lhs: &EinsumPlanSpec, rhs: &EinsumPlanSpec) -> bool {
     match (lhs, rhs) {
         (EinsumPlanSpec::Auto(lhs), EinsumPlanSpec::Auto(rhs)) => {

--- a/tenferro-einsum/src/optimize.rs
+++ b/tenferro-einsum/src/optimize.rs
@@ -73,6 +73,7 @@ pub(crate) fn plan_spec_from_optimize(
         EinsumOptimize::False => Ok(EinsumPlanSpec::LeftToRight),
         EinsumOptimize::Nested(nested) => {
             let pairs = nested_to_v1_pairs(&nested, subscripts.inputs.len())?;
+            validate_fixed_pairs(&pairs, subscripts.inputs.len())?;
             Ok(EinsumPlanSpec::FixedPairs(pairs))
         }
         EinsumOptimize::Path(path) => {
@@ -95,6 +96,7 @@ pub(crate) fn resolve_einsum_strategy_with_spec(
         EinsumOptimize::Tree(tree) => {
             let pairs = tree_pairs(&tree);
             let spec = EinsumPlanSpec::FixedPairs(pairs);
+            let tree = resolve_plan_spec(&spec, subscripts, shapes)?;
             Ok((spec, tree))
         }
         optimize => {
@@ -166,6 +168,53 @@ fn tree_pairs(tree: &ContractionTree) -> Vec<(usize, usize)> {
     (0..tree.step_count())
         .filter_map(|step| tree.step_pair(step))
         .collect()
+}
+
+fn validate_fixed_pairs(pairs: &[(usize, usize)], n_inputs: usize) -> Result<()> {
+    let required_steps = n_inputs.saturating_sub(1);
+    if pairs.len() != required_steps {
+        return Err(Error::InvalidArgument(format!(
+            "explicit contraction path for {n_inputs} operands must have {required_steps} steps, got {}",
+            pairs.len()
+        )));
+    }
+
+    let mut live = vec![false; n_inputs + pairs.len()];
+    for slot in live.iter_mut().take(n_inputs) {
+        *slot = true;
+    }
+
+    for (step_idx, &(left, right)) in pairs.iter().enumerate() {
+        let next_idx = n_inputs + step_idx;
+        if left == right {
+            return Err(Error::InvalidArgument(format!(
+                "pair ({left}, {right}) must reference two distinct live operands"
+            )));
+        }
+        if left >= next_idx || right >= next_idx {
+            return Err(Error::InvalidArgument(format!(
+                "pair ({left}, {right}) references non-existent operand"
+            )));
+        }
+        if !live[left] || !live[right] {
+            return Err(Error::InvalidArgument(format!(
+                "pair ({left}, {right}) references an operand or intermediate that is no longer live"
+            )));
+        }
+
+        live[left] = false;
+        live[right] = false;
+        live[next_idx] = true;
+    }
+
+    let live_count = live.iter().filter(|&&is_live| is_live).count();
+    if live_count != 1 {
+        return Err(Error::InvalidArgument(format!(
+            "explicit contraction path must leave exactly one live result, got {live_count}"
+        )));
+    }
+
+    Ok(())
 }
 
 fn hash_pairs(pairs: &[(usize, usize)], state: &mut dyn Hasher) {

--- a/tenferro-einsum/src/optimize.rs
+++ b/tenferro-einsum/src/optimize.rs
@@ -10,8 +10,9 @@ use crate::{
 ///
 /// The traced API resolves this enum into a shape-independent plan
 /// specification and stores that specification in the einsum extension
-/// payload. Concrete input shapes are used later to build a [`ContractionTree`]
-/// from that payload when the graph is compiled or executed.
+/// payload. Concrete traced inputs can resolve a [`ContractionTree`] while the
+/// op is built; symbolic traced inputs carry the plan specification until the
+/// extension runtime sees concrete execution shapes.
 ///
 /// Planner options and explicit paths are part of the extension payload
 /// identity. Two otherwise identical traced einsum ops with different
@@ -42,7 +43,7 @@ pub enum EinsumOptimize {
 }
 
 impl Default for EinsumOptimize {
-    /// Default: FLOPS-first automatic optimization.
+    /// Default: time-optimized automatic planning.
     fn default() -> Self {
         Self::Auto(default_auto_options())
     }

--- a/tenferro-einsum/src/optimize/tests.rs
+++ b/tenferro-einsum/src/optimize/tests.rs
@@ -83,6 +83,98 @@ fn concrete_tree_strategy_converts_to_fixed_pairs() {
     assert_eq!(resolved_tree.step_pair(1), Some((0, 3)));
 }
 
+#[test]
+fn concrete_tree_strategy_revalidates_current_shapes() {
+    let subs = Subscripts::parse("ij,jk->ik").unwrap();
+    let original_shapes = [&[2, 3][..], &[3, 4][..]];
+    let tree = ContractionTree::from_pairs(&subs, &original_shapes, &[(0, 1)]).unwrap();
+    let current_shapes = [&[2, 3][..], &[5, 4][..]];
+
+    let err =
+        match resolve_einsum_strategy_with_spec(EinsumOptimize::Tree(tree), &subs, &current_shapes)
+        {
+            Ok(_) => panic!("expected incompatible shapes to be rejected"),
+            Err(err) => err,
+        };
+
+    assert!(
+        matches!(err, Error::ShapeMismatch { .. }),
+        "expected ShapeMismatch, got {err}"
+    );
+}
+
+#[test]
+fn concrete_tree_strategy_rejects_different_current_arity() {
+    let original_subs = Subscripts::parse("ij,jk,kl->il").unwrap();
+    let original_shapes = [&[2, 3][..], &[3, 4][..], &[4, 5][..]];
+    let tree =
+        ContractionTree::from_pairs(&original_subs, &original_shapes, &[(1, 2), (0, 3)]).unwrap();
+    let current_subs = Subscripts::parse("ij,jk->ik").unwrap();
+    let current_shapes = [&[2, 3][..], &[3, 4][..]];
+
+    let err = match resolve_einsum_strategy_with_spec(
+        EinsumOptimize::Tree(tree),
+        &current_subs,
+        &current_shapes,
+    ) {
+        Ok(_) => panic!("expected different current arity to be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("must have"), "got {err}");
+}
+
+#[test]
+fn plan_spec_from_nested_rejects_duplicate_leaves() {
+    let subs = Subscripts::parse("ij,jk->ik").unwrap();
+    let nested = NestedEinsum::Node {
+        subscripts: subs.clone(),
+        children: vec![NestedEinsum::Leaf(0), NestedEinsum::Leaf(0)],
+    };
+
+    let err = plan_spec_from_optimize(EinsumOptimize::Nested(nested), &subs).unwrap_err();
+
+    assert!(format!("{err}").contains("distinct"), "got {err}");
+}
+
+#[test]
+fn plan_spec_from_nested_rejects_missing_leaves() {
+    let subs = Subscripts::parse("ij,jk,kl->il").unwrap();
+    let nested = NestedEinsum::Node {
+        subscripts: Subscripts::parse("ij,jk->ik").unwrap(),
+        children: vec![NestedEinsum::Leaf(0), NestedEinsum::Leaf(1)],
+    };
+
+    let err = plan_spec_from_optimize(EinsumOptimize::Nested(nested), &subs).unwrap_err();
+
+    assert!(format!("{err}").contains("must have"), "got {err}");
+}
+
+#[test]
+fn plan_spec_from_auto_rejects_nan_options() {
+    let subs = Subscripts::parse("ij,jk->ik").unwrap();
+    let options = ContractionOptimizerOptions {
+        betas: vec![f64::NAN],
+        ..ContractionOptimizerOptions::default()
+    };
+
+    let err = plan_spec_from_optimize(EinsumOptimize::Auto(options), &subs).unwrap_err();
+
+    assert!(
+        format!("{err}").contains("must not contain NaN"),
+        "got {err}"
+    );
+}
+
+#[test]
+fn identical_plan_specs_have_equal_hashes() {
+    let lhs = EinsumPlanSpec::FixedPairs(vec![(1, 2), (0, 3)]);
+    let rhs = EinsumPlanSpec::FixedPairs(vec![(1, 2), (0, 3)]);
+
+    assert!(plan_specs_equal(&lhs, &rhs));
+    assert_eq!(hash_plan_spec(&lhs), hash_plan_spec(&rhs));
+}
+
 fn hash_plan_spec(spec: &EinsumPlanSpec) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     hash_einsum_plan_spec(spec, &mut hasher);

--- a/tenferro-einsum/src/optimize/tests.rs
+++ b/tenferro-einsum/src/optimize/tests.rs
@@ -12,7 +12,8 @@ fn jax_path_to_v1_pairs_matches_shrinking_list_semantics() {
 fn false_strategy_builds_left_to_right_tree() {
     let subs = Subscripts::parse("ij,jk,kl->il").unwrap();
     let shapes = [&[2, 3][..], &[3, 4][..], &[4, 5][..]];
-    let tree = resolve_einsum_strategy(EinsumOptimize::False, &subs, &shapes).unwrap();
+    let spec = plan_spec_from_optimize(EinsumOptimize::False, &subs).unwrap();
+    let tree = resolve_plan_spec(&spec, &subs, &shapes).unwrap();
 
     assert_eq!(tree.step_pair(0), Some((0, 1)));
     assert_eq!(tree.step_pair(1), Some((2, 3)));

--- a/tenferro-einsum/src/optimize/tests.rs
+++ b/tenferro-einsum/src/optimize/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::hash::Hasher;
 
 #[test]
 fn jax_path_to_v1_pairs_matches_shrinking_list_semantics() {
@@ -15,4 +16,75 @@ fn false_strategy_builds_left_to_right_tree() {
 
     assert_eq!(tree.step_pair(0), Some((0, 1)));
     assert_eq!(tree.step_pair(1), Some((2, 3)));
+}
+
+#[test]
+fn plan_spec_from_false_preserves_left_to_right_policy() {
+    let subs = Subscripts::parse("ij,jk,kl->il").unwrap();
+    let spec = plan_spec_from_optimize(EinsumOptimize::False, &subs).unwrap();
+    assert!(matches!(spec, EinsumPlanSpec::LeftToRight));
+
+    let shapes = [&[2, 3][..], &[3, 4][..], &[4, 5][..]];
+    let tree = resolve_plan_spec(&spec, &subs, &shapes).unwrap();
+    assert_eq!(tree.step_pair(0), Some((0, 1)));
+    assert_eq!(tree.step_pair(1), Some((2, 3)));
+}
+
+#[test]
+fn plan_spec_from_path_validates_shape_independent_indices() {
+    let subs = Subscripts::parse("ij,jk,kl->il").unwrap();
+    let err =
+        plan_spec_from_optimize(EinsumOptimize::Path(vec![(0, 99), (0, 1)]), &subs).unwrap_err();
+
+    assert!(
+        format!("{err}").contains("path step 0 references operand positions"),
+        "got {err}"
+    );
+}
+
+#[test]
+fn plan_spec_rejects_symbolic_tree_strategy() {
+    let subs = Subscripts::parse("ij,jk->ik").unwrap();
+    let shapes = [&[2, 3][..], &[3, 4][..]];
+    let tree = ContractionTree::optimize(&subs, &shapes).unwrap();
+    let err = plan_spec_from_optimize(EinsumOptimize::Tree(tree), &subs).unwrap_err();
+
+    assert!(
+        format!("{err}").contains("precomputed contraction tree requires concrete input shapes"),
+        "got {err}"
+    );
+}
+
+#[test]
+fn plan_spec_hash_distinguishes_auto_options() {
+    let lhs = EinsumPlanSpec::Auto(ContractionOptimizerOptions::default());
+    let rhs = EinsumPlanSpec::Auto(ContractionOptimizerOptions {
+        ntrials: 2,
+        ..ContractionOptimizerOptions::default()
+    });
+
+    assert!(!plan_specs_equal(&lhs, &rhs));
+    assert_ne!(hash_plan_spec(&lhs), hash_plan_spec(&rhs));
+}
+
+#[test]
+fn concrete_tree_strategy_converts_to_fixed_pairs() {
+    let subs = Subscripts::parse("ij,jk,kl->il").unwrap();
+    let shapes = [&[2, 3][..], &[3, 4][..], &[4, 5][..]];
+    let tree = ContractionTree::from_pairs(&subs, &shapes, &[(1, 2), (0, 3)]).unwrap();
+
+    let (spec, resolved_tree) =
+        resolve_einsum_strategy_with_spec(EinsumOptimize::Tree(tree), &subs, &shapes).unwrap();
+
+    assert!(
+        matches!(spec, EinsumPlanSpec::FixedPairs(ref pairs) if pairs == &vec![(1, 2), (0, 3)])
+    );
+    assert_eq!(resolved_tree.step_pair(0), Some((1, 2)));
+    assert_eq!(resolved_tree.step_pair(1), Some((0, 3)));
+}
+
+fn hash_plan_spec(spec: &EinsumPlanSpec) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    hash_einsum_plan_spec(spec, &mut hasher);
+    hasher.finish()
 }

--- a/tenferro-einsum/src/planning/tree.rs
+++ b/tenferro-einsum/src/planning/tree.rs
@@ -55,10 +55,24 @@ impl ContractionOptimizerOptions {
         )
     }
 
-    fn validate(&self) -> Result<()> {
+    pub(crate) fn validate(&self) -> Result<()> {
         if self.ntrials == 0 {
             return Err(Error::InvalidArgument(
                 "contraction optimizer ntrials must be at least 1".into(),
+            ));
+        }
+        if self.betas.iter().any(|value| value.is_nan()) {
+            return Err(Error::InvalidArgument(
+                "contraction optimizer betas must not contain NaN".into(),
+            ));
+        }
+        if self.score.tc_weight.is_nan()
+            || self.score.sc_weight.is_nan()
+            || self.score.rw_weight.is_nan()
+            || self.score.sc_target.is_nan()
+        {
+            return Err(Error::InvalidArgument(
+                "contraction optimizer score fields must not contain NaN".into(),
             ));
         }
         Ok(())

--- a/tenferro-einsum/src/planning/tree.rs
+++ b/tenferro-einsum/src/planning/tree.rs
@@ -136,12 +136,12 @@ impl ContractionTree {
         shapes: &[&[usize]],
         options: &ContractionOptimizerOptions,
     ) -> Result<Self> {
+        options.validate()?;
         let n_inputs = subscripts.inputs.len();
         if n_inputs <= 1 {
             return Self::from_pairs(subscripts, shapes, &[]);
         }
 
-        options.validate()?;
         let size_dict = build_size_dict(subscripts, shapes, None)?;
         let pairs =
             if let Some(omeco_pairs) = optimize_omeco_pairs(subscripts, &size_dict, options)? {

--- a/tenferro-einsum/src/planning/tree/tests.rs
+++ b/tenferro-einsum/src/planning/tree/tests.rs
@@ -126,16 +126,66 @@ fn optimizer_options_reject_nan_betas() {
 fn optimizer_options_reject_nan_score_fields() {
     let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
     let shapes = [&[2, 3][..], &[3, 4][..]];
+    let cases = [
+        (
+            "tc_weight",
+            ScoreFunction::new(f64::NAN, 1.0, 0.0, f64::INFINITY),
+        ),
+        (
+            "sc_weight",
+            ScoreFunction::new(1.0, f64::NAN, 0.0, f64::INFINITY),
+        ),
+        (
+            "rw_weight",
+            ScoreFunction::new(1.0, 1.0, f64::NAN, f64::INFINITY),
+        ),
+        ("sc_target", ScoreFunction::new(1.0, 1.0, 0.0, f64::NAN)),
+    ];
+
+    for (field, score) in cases {
+        let options = ContractionOptimizerOptions {
+            score,
+            ..ContractionOptimizerOptions::default()
+        };
+
+        let err = match ContractionTree::optimize_with_options(&subs, &shapes, &options) {
+            Ok(_) => panic!("expected NaN score field {field} to be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, Error::InvalidArgument(message) if message.contains("NaN")),
+            "expected InvalidArgument mentioning NaN for {field}"
+        );
+    }
+}
+
+#[test]
+fn single_operand_optimize_with_options_rejects_invalid_options() {
+    let subs = Subscripts::new(&[&[0, 1]], &[0, 1]);
+    let shapes = [&[2, 3][..]];
     let options = ContractionOptimizerOptions {
-        score: ScoreFunction::new(1.0, f64::NAN, 0.0, f64::INFINITY),
+        ntrials: 0,
         ..ContractionOptimizerOptions::default()
     };
 
     let err = match ContractionTree::optimize_with_options(&subs, &shapes, &options) {
-        Ok(_) => panic!("expected NaN score fields to be rejected"),
+        Ok(_) => panic!("expected invalid single-operand options to be rejected"),
         Err(err) => err,
     };
-    assert!(matches!(err, Error::InvalidArgument(message) if message.contains("NaN")));
+    assert!(matches!(err, Error::InvalidArgument(message) if message.contains("ntrials")));
+}
+
+#[test]
+fn optimizer_options_permit_infinite_betas() {
+    let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+    let shapes = [&[2, 3][..], &[3, 4][..]];
+    let options = ContractionOptimizerOptions {
+        betas: vec![f64::INFINITY],
+        ..ContractionOptimizerOptions::default()
+    };
+
+    let tree = ContractionTree::optimize_with_options(&subs, &shapes, &options).unwrap();
+    assert_eq!(tree.step_count(), 1);
 }
 
 #[test]

--- a/tenferro-einsum/src/planning/tree/tests.rs
+++ b/tenferro-einsum/src/planning/tree/tests.rs
@@ -107,6 +107,38 @@ fn optimize_with_options_rejects_zero_trials() {
 }
 
 #[test]
+fn optimizer_options_reject_nan_betas() {
+    let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+    let shapes = [&[2, 3][..], &[3, 4][..]];
+    let options = ContractionOptimizerOptions {
+        betas: vec![f64::NAN],
+        ..ContractionOptimizerOptions::default()
+    };
+
+    let err = match ContractionTree::optimize_with_options(&subs, &shapes, &options) {
+        Ok(_) => panic!("expected NaN betas to be rejected"),
+        Err(err) => err,
+    };
+    assert!(matches!(err, Error::InvalidArgument(message) if message.contains("NaN")));
+}
+
+#[test]
+fn optimizer_options_reject_nan_score_fields() {
+    let subs = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+    let shapes = [&[2, 3][..], &[3, 4][..]];
+    let options = ContractionOptimizerOptions {
+        score: ScoreFunction::new(1.0, f64::NAN, 0.0, f64::INFINITY),
+        ..ContractionOptimizerOptions::default()
+    };
+
+    let err = match ContractionTree::optimize_with_options(&subs, &shapes, &options) {
+        Ok(_) => panic!("expected NaN score fields to be rejected"),
+        Err(err) => err,
+    };
+    assert!(matches!(err, Error::InvalidArgument(message) if message.contains("NaN")));
+}
+
+#[test]
 fn single_operand_tree_reports_no_steps() {
     let subs = Subscripts::new(&[&[0, 1]], &[0, 1]);
     let tree = ContractionTree::optimize(&subs, &[&[2, 3][..]]).unwrap();

--- a/tenferro-einsum/src/traced.rs
+++ b/tenferro-einsum/src/traced.rs
@@ -22,7 +22,7 @@ use crate::{
     Error as EinsumError, Result as EinsumResult, Subscripts,
 };
 
-/// N-ary einsum with default FLOPS-first optimization.
+/// N-ary einsum with default time-optimized automatic planning.
 ///
 /// The default optimizer is resolved into a shape-independent plan
 /// specification stored in the extension payload. That payload identity

--- a/tenferro-einsum/src/traced.rs
+++ b/tenferro-einsum/src/traced.rs
@@ -23,6 +23,11 @@ use crate::{
 };
 
 /// N-ary einsum with default FLOPS-first optimization.
+///
+/// The default optimizer is resolved into a shape-independent plan
+/// specification stored in the extension payload. That payload identity
+/// participates in traced extension-op equality and in compile/runtime einsum
+/// plan caches.
 pub fn einsum(
     compiler: &mut GraphCompiler,
     inputs: &[&TracedTensor],
@@ -32,6 +37,11 @@ pub fn einsum(
 }
 
 /// N-ary einsum using integer labels and the default contraction strategy.
+///
+/// The default optimizer is resolved into a shape-independent plan
+/// specification stored in the extension payload. That payload identity
+/// participates in traced extension-op equality and in compile/runtime einsum
+/// plan caches.
 pub fn einsum_subscripts(
     compiler: &mut GraphCompiler,
     inputs: &[&TracedTensor],
@@ -41,6 +51,17 @@ pub fn einsum_subscripts(
 }
 
 /// N-ary einsum with explicit contraction strategy.
+///
+/// `optimize` is converted to a shape-independent plan specification carried
+/// by the extension payload. `EinsumOptimize::Path` uses JAX-style positions
+/// over the current shrinking operand list, so it works with symbolic traced
+/// inputs. `EinsumOptimize::Tree` requires concrete shapes; when accepted, the
+/// tree is converted to fixed contraction pairs for the payload.
+///
+/// Planner options, explicit paths, and fixed plan identities affect traced
+/// extension payload identity and the einsum compile/runtime plan caches.
+/// Different options or paths are therefore not treated as identical extension
+/// ops.
 pub fn einsum_with(
     compiler: &mut GraphCompiler,
     inputs: &[&TracedTensor],
@@ -52,6 +73,17 @@ pub fn einsum_with(
 }
 
 /// N-ary einsum with integer labels and explicit contraction strategy.
+///
+/// `optimize` is converted to a shape-independent plan specification carried
+/// by the extension payload. `EinsumOptimize::Path` uses JAX-style positions
+/// over the current shrinking operand list, so it works with symbolic traced
+/// inputs. `EinsumOptimize::Tree` requires concrete shapes; when accepted, the
+/// tree is converted to fixed contraction pairs for the payload.
+///
+/// Planner options, explicit paths, and fixed plan identities affect traced
+/// extension payload identity and the einsum compile/runtime plan caches.
+/// Different options or paths are therefore not treated as identical extension
+/// ops.
 pub fn einsum_subscripts_with(
     compiler: &mut GraphCompiler,
     inputs: &[&TracedTensor],

--- a/tenferro-einsum/src/traced.rs
+++ b/tenferro-einsum/src/traced.rs
@@ -13,7 +13,9 @@ use crate::cache::{
 #[cfg(feature = "autodiff")]
 use crate::extension::ensure_einsum_extension_rule_registered;
 use crate::extension::EinsumExtensionOp;
-use crate::optimize::{is_default_auto_options, resolve_einsum_strategy};
+use crate::optimize::{
+    default_auto_options, is_default_auto_options, resolve_einsum_strategy, EinsumPlanSpec,
+};
 use crate::{
     parse_einsum_subscripts, ContractionTree, EinsumOptimize, EinsumSubscripts,
     Error as EinsumError, Result as EinsumResult, Subscripts,
@@ -72,7 +74,11 @@ pub fn einsum_subscripts_with(
     }
 
     let output_shape_hint = infer_symbolic_output_shape(subscripts, inputs)?;
-    let mut op = EinsumExtensionOp::with_output_shape_hint(subscripts.clone(), output_shape_hint);
+    let mut op = EinsumExtensionOp::with_output_shape_hint(
+        subscripts.clone(),
+        output_shape_hint,
+        EinsumPlanSpec::Auto(default_auto_options()),
+    );
 
     if let Some(shapes) = concrete_shapes(inputs) {
         let shape_refs: Vec<&[usize]> = shapes.iter().map(Vec::as_slice).collect();

--- a/tenferro-einsum/src/traced.rs
+++ b/tenferro-einsum/src/traced.rs
@@ -14,7 +14,8 @@ use crate::cache::{
 use crate::extension::ensure_einsum_extension_rule_registered;
 use crate::extension::EinsumExtensionOp;
 use crate::optimize::{
-    default_auto_options, is_default_auto_options, resolve_einsum_strategy, EinsumPlanSpec,
+    hash_einsum_plan_spec, plan_spec_from_optimize, resolve_einsum_strategy_with_spec,
+    resolve_plan_spec, EinsumPlanSpec,
 };
 use crate::{
     parse_einsum_subscripts, ContractionTree, EinsumOptimize, EinsumSubscripts,
@@ -74,29 +75,52 @@ pub fn einsum_subscripts_with(
     }
 
     let output_shape_hint = infer_symbolic_output_shape(subscripts, inputs)?;
-    let mut op = EinsumExtensionOp::with_output_shape_hint(
-        subscripts.clone(),
-        output_shape_hint,
-        EinsumPlanSpec::Auto(default_auto_options()),
-    );
+    let subs = Subscripts::from(subscripts);
 
-    if let Some(shapes) = concrete_shapes(inputs) {
+    let (plan_spec, static_tree) = if let Some(shapes) = concrete_shapes(inputs) {
         let shape_refs: Vec<&[usize]> = shapes.iter().map(Vec::as_slice).collect();
-        let subs = Subscripts::from(subscripts);
-        let tree = match optimize {
-            EinsumOptimize::Auto(opts) if is_default_auto_options(&opts) => {
-                let key = (subscripts.clone(), shapes.clone());
-                cached_static_tree(compiler.extension_caches_mut(), &key, || {
-                    resolve_einsum_strategy(EinsumOptimize::Auto(opts), &subs, &shape_refs)
-                })?
+        let (plan_spec, tree) = match optimize {
+            EinsumOptimize::Tree(tree) => {
+                let (plan_spec, tree) = resolve_einsum_strategy_with_spec(
+                    EinsumOptimize::Tree(tree),
+                    &subs,
+                    &shape_refs,
+                )
+                .map_err(to_tenferro_error)?;
+                let tree = cached_static_tree(
+                    compiler.extension_caches_mut(),
+                    subscripts,
+                    &plan_spec,
+                    &shapes,
+                    || Ok(tree),
+                )?;
+                (plan_spec, tree)
             }
-            optimize => Arc::new(
-                resolve_einsum_strategy(optimize, &subs, &shape_refs).map_err(to_tenferro_error)?,
-            ),
+            optimize => {
+                let plan_spec =
+                    plan_spec_from_optimize(optimize, &subs).map_err(to_tenferro_error)?;
+                let tree = cached_static_tree(
+                    compiler.extension_caches_mut(),
+                    subscripts,
+                    &plan_spec,
+                    &shapes,
+                    || resolve_plan_spec(&plan_spec, &subs, &shape_refs),
+                )?;
+                (plan_spec, tree)
+            }
         };
-        op = op.with_static_tree_hint(tree);
+        (plan_spec, Some(tree))
     } else {
-        validate_symbolic_optimize(&optimize)?;
+        (
+            plan_spec_from_optimize(optimize, &subs).map_err(to_tenferro_error)?,
+            None,
+        )
+    };
+
+    let mut op =
+        EinsumExtensionOp::with_output_shape_hint(subscripts.clone(), output_shape_hint, plan_spec);
+    if let Some(tree) = static_tree {
+        op = op.with_static_tree_hint(tree);
     }
 
     let outputs = extension::apply(Arc::new(op), inputs);
@@ -129,37 +153,33 @@ fn cached_subscripts(
 
 fn cached_static_tree(
     caches: &mut ExtensionCacheStore,
-    key_data: &(EinsumSubscripts, Vec<Vec<usize>>),
+    subscripts: &EinsumSubscripts,
+    plan_spec: &EinsumPlanSpec,
+    shapes: &[Vec<usize>],
     build: impl FnOnce() -> EinsumResult<ContractionTree>,
 ) -> Result<Arc<ContractionTree>> {
+    let mut plan_hasher = DefaultHasher::new();
+    hash_einsum_plan_spec(plan_spec, &mut plan_hasher);
+    let key_data = (subscripts.clone(), shapes.to_vec(), plan_hasher.finish());
     let key = ExtensionCacheKey::new(
         EINSUM_EXTENSION_FAMILY_ID,
         EINSUM_STATIC_PLANS_CACHE,
-        hash_value(key_data),
+        hash_value(&key_data),
     );
     if let Some(cached) = caches.get::<Arc<ContractionTree>>(&key) {
         return Ok(Arc::clone(cached));
     }
 
     let tree = Arc::new(build().map_err(to_tenferro_error)?);
-    let retained_bytes = einsum_subscripts_retained_bytes(&key_data.0)
-        + key_data
-            .1
+    let retained_bytes = einsum_subscripts_retained_bytes(subscripts)
+        + shapes
             .iter()
             .map(|shape| shape.capacity() * std::mem::size_of::<usize>())
             .sum::<usize>()
+        + std::mem::size_of::<u64>()
         + tree.retained_bytes_for_cache_stats();
     caches.put(key, Arc::clone(&tree), retained_bytes);
     Ok(tree)
-}
-
-fn validate_symbolic_optimize(optimize: &EinsumOptimize) -> Result<()> {
-    match optimize {
-        EinsumOptimize::Auto(opts) if is_default_auto_options(opts) => Ok(()),
-        _ => Err(Error::ContractionError(
-            "symbolic einsum supports only default automatic optimization".into(),
-        )),
-    }
 }
 
 fn concrete_shapes(inputs: &[&TracedTensor]) -> Option<Vec<Vec<usize>>> {

--- a/tenferro-einsum/tests/traced_ad_migration.rs
+++ b/tenferro-einsum/tests/traced_ad_migration.rs
@@ -3,7 +3,7 @@
 use tenferro_ad::TracedTensorAdExt;
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::einsum;
-use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::from_vec_col_major(shape, data)
@@ -17,6 +17,35 @@ fn run_traced(tensor: &TracedTensor) -> Tensor {
         .register_extension(tenferro_einsum::register_runtime)
         .unwrap();
     executor.run(&program).unwrap()
+}
+
+fn run_symbolic_chain_grad(
+    grad: &TracedTensor,
+    a: &TracedTensor,
+    b: &TracedTensor,
+    c: &TracedTensor,
+    a_value: &Tensor,
+    b_value: &Tensor,
+    c_value: &Tensor,
+) -> Tensor {
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(
+            grad,
+            &[
+                (a, DType::F64, &[2, 3]),
+                (b, DType::F64, &[3, 4]),
+                (c, DType::F64, &[4, 2]),
+            ],
+        )
+        .unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor
+        .register_extension(tenferro_einsum::register_runtime)
+        .unwrap();
+    executor
+        .run_with_inputs(&program, &[(a, a_value), (b, b_value), (c, c_value)])
+        .unwrap()
 }
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
@@ -54,9 +83,9 @@ fn grad_einsum_matmul_real_uses_extension_ad_rule() {
 
 #[test]
 fn symbolic_grad_einsum_with_explicit_path_uses_extension_ad_rule() {
-    let a = TracedTensor::input_symbolic_shape(tenferro_runtime::DType::F64, 2);
-    let b = TracedTensor::input_symbolic_shape(tenferro_runtime::DType::F64, 2);
-    let c = TracedTensor::input_symbolic_shape(tenferro_runtime::DType::F64, 2);
+    let a = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let b = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let c = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let mut compiler = GraphCompiler::new();
 
     let y = tenferro_einsum::einsum_with(
@@ -66,22 +95,11 @@ fn symbolic_grad_einsum_with_explicit_path_uses_extension_ad_rule() {
         tenferro_einsum::EinsumOptimize::Path(vec![(1, 2), (0, 1)]),
     )
     .unwrap();
-    let grad_a = y.reduce_sum(&[0, 1]).grad(&a).unwrap();
-    let program = compiler
-        .compile_with_input_specs(
-            &grad_a,
-            &[
-                (&a, tenferro_runtime::DType::F64, &[2, 3]),
-                (&b, tenferro_runtime::DType::F64, &[3, 4]),
-                (&c, tenferro_runtime::DType::F64, &[4, 2]),
-            ],
-        )
-        .unwrap();
+    let loss = y.reduce_sum(&[0, 1]);
+    let grad_a = loss.grad(&a).unwrap();
+    let grad_b = loss.grad(&b).unwrap();
+    let grad_c = loss.grad(&c).unwrap();
 
-    let mut executor = GraphExecutor::new(CpuBackend::new());
-    executor
-        .register_extension(tenferro_einsum::register_runtime)
-        .unwrap();
     let a_value = f64_tensor(vec![2, 3], vec![1.0, -2.0, 0.5, 3.0, 1.25, -0.75]);
     let b_value = f64_tensor(
         vec![3, 4],
@@ -90,10 +108,25 @@ fn symbolic_grad_einsum_with_explicit_path_uses_extension_ad_rule() {
         ],
     );
     let c_value = f64_tensor(vec![4, 2], vec![1.0, 2.0, -0.5, 0.75, 1.5, -1.0, 2.5, 0.25]);
-    let out = executor
-        .run_with_inputs(&program, &[(&a, &a_value), (&b, &b_value), (&c, &c_value)])
-        .unwrap();
+    let out_a = run_symbolic_chain_grad(&grad_a, &a, &b, &c, &a_value, &b_value, &c_value);
+    let out_b = run_symbolic_chain_grad(&grad_b, &a, &b, &c, &a_value, &b_value, &c_value);
+    let out_c = run_symbolic_chain_grad(&grad_c, &a, &b, &c, &a_value, &b_value, &c_value);
 
-    assert_eq!(out.shape(), &[2, 3]);
-    assert_eq!(out.as_slice::<f64>().unwrap().len(), 6);
+    assert_eq!(out_a.shape(), &[2, 3]);
+    assert_close(
+        out_a.as_slice::<f64>().unwrap(),
+        &[12.25, 12.25, -3.625, -3.625, -0.25, -0.25],
+    );
+    assert_eq!(out_b.shape(), &[3, 4]);
+    assert_close(
+        out_b.as_slice::<f64>().unwrap(),
+        &[
+            -2.5, 8.75, 1.25, -1.0, 3.5, 0.5, -2.0, 7.0, 1.0, -1.0, 3.5, 0.5,
+        ],
+    );
+    assert_eq!(out_c.shape(), &[4, 2]);
+    assert_close(
+        out_c.as_slice::<f64>().unwrap(),
+        &[-1.875, -1.625, -7.75, -3.25, -1.875, -1.625, -7.75, -3.25],
+    );
 }

--- a/tenferro-einsum/tests/traced_ad_migration.rs
+++ b/tenferro-einsum/tests/traced_ad_migration.rs
@@ -51,3 +51,49 @@ fn grad_einsum_matmul_real_uses_extension_ad_rule() {
         &[6.0, 6.0, 1.0, 1.0, -2.0, -2.0],
     );
 }
+
+#[test]
+fn symbolic_grad_einsum_with_explicit_path_uses_extension_ad_rule() {
+    let a = TracedTensor::input_symbolic_shape(tenferro_runtime::DType::F64, 2);
+    let b = TracedTensor::input_symbolic_shape(tenferro_runtime::DType::F64, 2);
+    let c = TracedTensor::input_symbolic_shape(tenferro_runtime::DType::F64, 2);
+    let mut compiler = GraphCompiler::new();
+
+    let y = tenferro_einsum::einsum_with(
+        &mut compiler,
+        &[&a, &b, &c],
+        "ij,jk,kl->il",
+        tenferro_einsum::EinsumOptimize::Path(vec![(1, 2), (0, 1)]),
+    )
+    .unwrap();
+    let grad_a = y.reduce_sum(&[0, 1]).grad(&a).unwrap();
+    let program = compiler
+        .compile_with_input_specs(
+            &grad_a,
+            &[
+                (&a, tenferro_runtime::DType::F64, &[2, 3]),
+                (&b, tenferro_runtime::DType::F64, &[3, 4]),
+                (&c, tenferro_runtime::DType::F64, &[4, 2]),
+            ],
+        )
+        .unwrap();
+
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor
+        .register_extension(tenferro_einsum::register_runtime)
+        .unwrap();
+    let a_value = f64_tensor(vec![2, 3], vec![1.0, -2.0, 0.5, 3.0, 1.25, -0.75]);
+    let b_value = f64_tensor(
+        vec![3, 4],
+        vec![
+            2.0, 0.25, -1.5, 4.0, 0.75, -0.5, 1.0, -2.0, 0.5, 1.25, -1.0, 3.0,
+        ],
+    );
+    let c_value = f64_tensor(vec![4, 2], vec![1.0, 2.0, -0.5, 0.75, 1.5, -1.0, 2.5, 0.25]);
+    let out = executor
+        .run_with_inputs(&program, &[(&a, &a_value), (&b, &b_value), (&c, &c_value)])
+        .unwrap();
+
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(out.as_slice::<f64>().unwrap().len(), 6);
+}

--- a/tenferro-einsum/tests/traced_correctness.rs
+++ b/tenferro-einsum/tests/traced_correctness.rs
@@ -10,7 +10,7 @@ use tenferro_einsum::{
     ContractionTree, NestedEinsum, Subscripts, TensorDotAxes, EINSUM_EXTENSION_FAMILY_ID,
 };
 use tenferro_runtime::error::Result;
-use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
 use tenferro_tensor::TypedTensor;
 
 #[path = "traced_correctness/ported_and_paths.rs"]
@@ -468,6 +468,72 @@ fn einsum_symbolic_three_tensor_chain_matches_static_path() {
     )
     .unwrap();
     let actual = actual.run_with(&mut engine).unwrap();
+
+    assert_eq!(actual.shape(), expected.shape());
+    assert_eq!(get_f64_data(&actual), get_f64_data(&expected));
+}
+
+#[test]
+fn einsum_symbolic_explicit_path_matches_static_execution() {
+    let a_value = f64_tensor(vec![2, 3], vec![1.0, -0.5, 2.0, 0.75, -1.25, 1.5]);
+    let b_value = f64_tensor(
+        vec![3, 4],
+        vec![
+            0.5, 1.5, -1.0, 0.25, 2.0, -0.75, 1.25, -1.5, 0.0, 0.5, -2.0, 3.0,
+        ],
+    );
+    let c_value = f64_tensor(
+        vec![4, 2],
+        vec![2.0, -1.5, 0.75, 1.25, -0.5, 1.0, 3.0, -2.0],
+    );
+
+    let mut static_engine = GraphExecutor::new(CpuBackend::new());
+    let a_static = TracedTensor::from_tensor_concrete_shape(a_value.clone());
+    let b_static = TracedTensor::from_tensor_concrete_shape(b_value.clone());
+    let c_static = TracedTensor::from_tensor_concrete_shape(c_value.clone());
+    let expected = einsum_with(
+        &mut static_engine,
+        &[&a_static, &b_static, &c_static],
+        "ij,jk,kl->il",
+        EinsumOptimize::Path(vec![(1, 2), (0, 1)]),
+    )
+    .unwrap();
+    let expected = expected.run_with(&mut static_engine).unwrap().clone();
+
+    let a_symbolic = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let b_symbolic = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let c_symbolic = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let mut compiler = GraphCompiler::new();
+    let actual = einsum_with(
+        &mut compiler,
+        &[&a_symbolic, &b_symbolic, &c_symbolic],
+        "ij,jk,kl->il",
+        EinsumOptimize::Path(vec![(1, 2), (0, 1)]),
+    )
+    .unwrap();
+    let program = compiler
+        .compile_with_input_specs(
+            &actual,
+            &[
+                (&a_symbolic, DType::F64, &[2, 3]),
+                (&b_symbolic, DType::F64, &[3, 4]),
+                (&c_symbolic, DType::F64, &[4, 2]),
+            ],
+        )
+        .unwrap();
+
+    let mut symbolic_engine = GraphExecutor::new(CpuBackend::new());
+    symbolic_engine
+        .register_extension(tenferro_einsum::register_runtime)
+        .unwrap();
+    let run_inputs = [
+        (&a_symbolic, &a_value),
+        (&b_symbolic, &b_value),
+        (&c_symbolic, &c_value),
+    ];
+    let actual = symbolic_engine
+        .run_with_inputs(&program, &run_inputs)
+        .unwrap();
 
     assert_eq!(actual.shape(), expected.shape());
     assert_eq!(get_f64_data(&actual), get_f64_data(&expected));

--- a/tenferro-einsum/tests/traced_graph_cache.rs
+++ b/tenferro-einsum/tests/traced_graph_cache.rs
@@ -6,7 +6,7 @@ use tenferro_ad::EagerRuntime;
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::{
     eager_tensor::einsum as eager_einsum, einsum, einsum_with, parse_einsum_subscripts,
-    ContractionOptimizerOptions, EinsumOptimize,
+    ContractionOptimizerOptions, ContractionTree, EinsumOptimize,
 };
 use tenferro_runtime::extension::ExtensionCacheLimits;
 use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, GraphProgram, Tensor, TracedTensor};
@@ -297,25 +297,52 @@ fn custom_static_auto_options_do_not_reuse_default_extension_cache_entry() {
 }
 
 #[test]
-fn symbolic_einsum_rejects_non_default_optimizer_strategy() {
+fn concrete_traced_einsum_static_cache_distinguishes_plan_spec() {
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
+    let b = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
+    let c = TracedTensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]);
+    let mut compiler = GraphCompiler::new();
+
+    let _ = einsum_with(
+        &mut compiler,
+        &[&a, &b, &c],
+        "ij,jk,kl->il",
+        EinsumOptimize::False,
+    )
+    .unwrap();
+    let after_false = extension_cache_entries(&compiler);
+
+    let _ = einsum_with(
+        &mut compiler,
+        &[&a, &b, &c],
+        "ij,jk,kl->il",
+        EinsumOptimize::Path(vec![(1, 2), (0, 1)]),
+    )
+    .unwrap();
+    let after_path = extension_cache_entries(&compiler);
+
+    assert!(
+        after_path > after_false,
+        "static plan cache should keep separate entries for different plan specs"
+    );
+}
+
+#[test]
+fn symbolic_einsum_accepts_non_default_optimizer_strategy() {
     let a = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let b = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let mut compiler = GraphCompiler::new();
 
     let result = einsum_with(&mut compiler, &[&a, &b], "ij,jk->ik", EinsumOptimize::False);
-    let err = match result {
-        Ok(_) => panic!("expected symbolic einsum to reject non-default optimizer strategy"),
-        Err(err) => err,
-    };
 
     assert!(
-        format!("{err}").contains("symbolic einsum supports only default automatic optimization"),
-        "got {err}"
+        result.is_ok(),
+        "symbolic einsum should carry per-op plan spec"
     );
 }
 
 #[test]
-fn symbolic_einsum_rejects_custom_auto_options() {
+fn symbolic_einsum_accepts_custom_auto_options() {
     let a = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let b = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let mut compiler = GraphCompiler::new();
@@ -325,19 +352,63 @@ fn symbolic_einsum_rejects_custom_auto_options() {
         &[&a, &b],
         "ij,jk->ik",
         EinsumOptimize::Auto(ContractionOptimizerOptions {
-            ntrials: 0,
+            ntrials: 2,
             ..Default::default()
         }),
     );
+
+    assert!(
+        result.is_ok(),
+        "symbolic einsum should retain custom Auto options"
+    );
+}
+
+#[test]
+fn symbolic_einsum_rejects_precomputed_tree() {
+    let concrete_subs = tenferro_einsum::Subscripts::parse("ij,jk->ik").unwrap();
+    let tree = ContractionTree::optimize(&concrete_subs, &[&[2, 3][..], &[3, 4][..]]).unwrap();
+    let a = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let b = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let mut compiler = GraphCompiler::new();
+
+    let result = einsum_with(
+        &mut compiler,
+        &[&a, &b],
+        "ij,jk->ik",
+        EinsumOptimize::Tree(tree),
+    );
     let err = match result {
-        Ok(_) => panic!("expected symbolic einsum to reject custom Auto options"),
+        Ok(_) => panic!("symbolic Tree should be rejected"),
         Err(err) => err,
     };
 
     assert!(
-        format!("{err}").contains("symbolic einsum supports only default automatic optimization"),
+        format!("{err}").contains("precomputed contraction tree requires concrete input shapes"),
         "got {err}"
     );
+}
+
+#[test]
+fn symbolic_einsum_rejects_nan_auto_options() {
+    let a = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let b = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let mut compiler = GraphCompiler::new();
+
+    let result = einsum_with(
+        &mut compiler,
+        &[&a, &b],
+        "ij,jk->ik",
+        EinsumOptimize::Auto(ContractionOptimizerOptions {
+            betas: vec![f64::NAN],
+            ..Default::default()
+        }),
+    );
+    let err = match result {
+        Ok(_) => panic!("NaN options should be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("NaN"), "got {err}");
 }
 
 #[test]

--- a/tenferro-einsum/tests/traced_graph_cache.rs
+++ b/tenferro-einsum/tests/traced_graph_cache.rs
@@ -224,6 +224,148 @@ fn runtime_planned_einsum_reuses_extension_runtime_plan_cache() {
 }
 
 #[test]
+fn runtime_planned_einsum_cache_distinguishes_plan_spec() {
+    let a = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let b = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let c = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let mut compiler = GraphCompiler::new();
+
+    let left_to_right = einsum_with(
+        &mut compiler,
+        &[&a, &b, &c],
+        "ij,jk,kl->il",
+        EinsumOptimize::False,
+    )
+    .unwrap();
+    let explicit_path = einsum_with(
+        &mut compiler,
+        &[&a, &b, &c],
+        "ij,jk,kl->il",
+        EinsumOptimize::Path(vec![(1, 2), (0, 1)]),
+    )
+    .unwrap();
+    let left_program = compiler
+        .compile_with_input_specs(
+            &left_to_right,
+            &[
+                (&a, DType::F64, &[2, 3]),
+                (&b, DType::F64, &[3, 4]),
+                (&c, DType::F64, &[4, 5]),
+            ],
+        )
+        .unwrap();
+    let path_program = compiler
+        .compile_with_input_specs(
+            &explicit_path,
+            &[
+                (&a, DType::F64, &[2, 3]),
+                (&b, DType::F64, &[3, 4]),
+                (&c, DType::F64, &[4, 5]),
+            ],
+        )
+        .unwrap();
+
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    register_runtime(&mut executor);
+    let a_value = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
+    let b_value = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
+    let c_value = Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]);
+
+    let _ = executor
+        .run_with_inputs(
+            &left_program,
+            &[(&a, &a_value), (&b, &b_value), (&c, &c_value)],
+        )
+        .unwrap();
+    let after_left = executor.cache_stats().extensions.entries;
+    let _ = executor
+        .run_with_inputs(
+            &path_program,
+            &[(&a, &a_value), (&b, &b_value), (&c, &c_value)],
+        )
+        .unwrap();
+    let after_path = executor.cache_stats().extensions.entries;
+
+    assert!(
+        after_path > after_left,
+        "runtime plan cache should keep separate entries for different plan specs"
+    );
+}
+
+#[test]
+fn runtime_planned_einsum_honors_explicit_path_execution_order() {
+    let a = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let b = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let c = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let mut compiler = GraphCompiler::new();
+
+    let left_to_right = einsum_with(
+        &mut compiler,
+        &[&a, &b, &c],
+        "ij,jk,kl->il",
+        EinsumOptimize::False,
+    )
+    .unwrap();
+    let explicit_path = einsum_with(
+        &mut compiler,
+        &[&a, &b, &c],
+        "ij,jk,kl->il",
+        EinsumOptimize::Path(vec![(1, 2), (0, 1)]),
+    )
+    .unwrap();
+    let left_program = compiler
+        .compile_with_input_specs(
+            &left_to_right,
+            &[
+                (&a, DType::F64, &[1, 1]),
+                (&b, DType::F64, &[1, 1]),
+                (&c, DType::F64, &[1, 1]),
+            ],
+        )
+        .unwrap();
+    let path_program = compiler
+        .compile_with_input_specs(
+            &explicit_path,
+            &[
+                (&a, DType::F64, &[1, 1]),
+                (&b, DType::F64, &[1, 1]),
+                (&c, DType::F64, &[1, 1]),
+            ],
+        )
+        .unwrap();
+
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    register_runtime(&mut executor);
+    let a_value = Tensor::from_vec_col_major(vec![1, 1], vec![1.0e308_f64]);
+    let b_value = Tensor::from_vec_col_major(vec![1, 1], vec![1.0e308_f64]);
+    let c_value = Tensor::from_vec_col_major(vec![1, 1], vec![1.0e-308_f64]);
+
+    let left_result = executor
+        .run_with_inputs(
+            &left_program,
+            &[(&a, &a_value), (&b, &b_value), (&c, &c_value)],
+        )
+        .unwrap();
+    let path_result = executor
+        .run_with_inputs(
+            &path_program,
+            &[(&a, &a_value), (&b, &b_value), (&c, &c_value)],
+        )
+        .unwrap();
+
+    let left_value = left_result.as_slice::<f64>().unwrap()[0];
+    let path_value = path_result.as_slice::<f64>().unwrap()[0];
+    assert!(
+        left_value.is_infinite(),
+        "left-to-right path should overflow, got {left_value}"
+    );
+    assert!(
+        path_value.is_finite(),
+        "explicit B*C-first path should avoid overflow, got {path_value}"
+    );
+}
+
+#[test]
 fn extension_runtime_cache_limits_bound_runtime_planned_einsum_entries() {
     let mut executor = GraphExecutor::new(CpuBackend::new());
     register_runtime(&mut executor);

--- a/tenferro-tensor/src/tests/types_tests.rs
+++ b/tenferro-tensor/src/tests/types_tests.rs
@@ -6,8 +6,8 @@ use num_complex::{Complex32, Complex64};
 use crate::types::{
     col_major_strides, flat_to_multi, materialize_typed_view_col_major, Buffer, BufferHandle,
     ConjElem, DType, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Rank,
-    StridedSliceSpec, Tensor, TensorLayout, TensorRank, TensorRead, TensorScalar, TensorView,
-    TypedTensor, TypedTensorView, TypedTensorViewMut,
+    StridedSliceSpec, Tensor, TensorBufferRef, TensorBufferRefMut, TensorLayout, TensorRank,
+    TensorRead, TensorScalar, TensorView, TypedTensor, TypedTensorView, TypedTensorViewMut,
 };
 use crate::Error;
 
@@ -527,6 +527,24 @@ fn backend_buffer_handle_metadata_and_host_export_errors_are_explicit() {
     assert!(row_err
         .to_string()
         .contains("backend buffers cannot be exported"));
+}
+
+#[test]
+fn tensor_buffer_refs_cover_backend_metadata() {
+    let read_handle: Arc<dyn crate::types::BackendBuffer<f64>> =
+        Arc::new(BufferHandle::<f64>::new_with_len(7, 0));
+    let read_ref = TensorBufferRef::Backend(Arc::clone(&read_handle));
+    let cloned_read_ref = read_ref.clone();
+
+    assert_eq!(cloned_read_ref.len(), 0);
+    assert!(cloned_read_ref.is_empty());
+
+    let write_handle: Arc<dyn crate::types::BackendBuffer<i32>> =
+        Arc::new(BufferHandle::<i32>::new_with_len(8, 2));
+    let write_ref = TensorBufferRefMut::Backend(write_handle);
+
+    assert_eq!(write_ref.len(), 2);
+    assert!(!write_ref.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add a crate-private einsum plan spec so optimizer options, explicit paths, nested plans, and concrete trees become payload identity instead of transient execution hints.
- Carry the plan spec through traced/eager einsum construction, extension payload equality/hash, static-tree cache keys, and runtime plan cache keys.
- Preserve traced AD behavior by inheriting automatic/left-to-right policies and deriving VJP-specific fixed-pair plans for explicit primal paths.
- Document symbolic `Path`, concrete-only `Tree`, `tenferro.einsum.v1` retention, cache identity, and VJP remapping in guides/design/worklog.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` (`115/115 files passed`)
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `git diff --check`

## Notes

- Worklog: `docs/worklogs/2026-05-30-einsum-plan-spec-payload.md`
- Maintainer-requested implementation; no external prototype code used.
- The extension family stays `tenferro.einsum.v1` because there is no released serialized payload contract for this family yet.