### PR TITLE
[codex] Use tidu AD rule contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,7 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-chainrules-core = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2d7662140d92f0dd73b2402aefc2272feafc9270", package = "chainrules" }
-chainrules = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2d7662140d92f0dd73b2402aefc2272feafc9270" }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "1694275361d2f16abfb3f25ad7941407c88b7c09" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "fe7fb27cf34338d3214fa9f1cc56ce4d0691626e" }
 strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722", features = ["parallel"] }

--- a/docs/worklogs/2026-05-31-issue-26-tidu-rules-migration.md
+++ b/docs/worklogs/2026-05-31-issue-26-tidu-rules-migration.md
@@ -1,0 +1,78 @@
+# tidu AD rule contract migration work log
+
+Issue: <https://github.com/tensor4all/tidu-rs/issues/26>
+
+Date: 2026-05-31
+
+## Session summary
+
+This change migrates tenferro's active AD rule contract imports from the
+former `chainrules` crates to the rule contract now exported by `tidu`.
+
+The companion `tidu-rs` PR first absorbed `ADKey`, `ADRuleError`,
+`ADRuleResult`, `DiffPassId`, and `PrimitiveOp` into `tidu` and exposed them
+from the crate root. This tenferro PR then:
+
+- removes workspace `chainrules` and `chainrules-core` dependencies
+- wires optional `autodiff` features in operation crates through `tidu`
+- updates source and test imports from `chainrules_core` to `tidu`
+- pins `tidu` to the merged `tidu-rs` commit that contains the rule contract
+
+No AD rule semantics were changed in tenferro.
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| `AGENTS.md` | Confirm repository workflow and PR requirements. | Kept workspace dependencies centralized and added this work log before PR creation. |
+| `REPOSITORY_RULES.md` | Review AD source-of-truth, standard extension, and work-log rules. | Preserved graph-level `linearize` and `transpose_rule` terminology and avoided reintroducing ChainRules-style APIs. |
+| `Cargo.toml` and crate manifests | Locate active dependency declarations and feature boundaries. | Replaced only active `chainrules` dependencies with `tidu` wiring. |
+| `tenferro-internal-ops/src/ad/` | Check the owning AD rule contract. | Kept implementations and rule registry behavior unchanged while changing the imported trait/error types. |
+| `ext/tropical/` | Check the out-of-workspace extension manifest and AD import path. | Added its own optional `tidu` git dependency because it has a separate manifest and lockfile. |
+| `tidu-rs` PR #27 | Confirm the merged commit that exports the absorbed rule contract. | Pinned tenferro manifests to `fe7fb27cf34338d3214fa9f1cc56ce4d0691626e`. |
+
+## Decisions made
+
+- **`tidu` is now the shared AD rule contract dependency.** Active tenferro
+  crates import `ADKey`, `ADRuleError`, `ADRuleResult`, `DiffPassId`, and
+  `PrimitiveOp` from `tidu`.
+- **Feature ownership stays with operation crates.** `tenferro-einsum`,
+  `tenferro-linalg`, `tenferro-fft`, and `ext/tropical` keep their
+  `autodiff` features and depend on `tidu` only when that feature is enabled.
+- **No semantic AD rewrite in this PR.** The tenferro rule implementations,
+  registry behavior, and tests continue to exercise the same graph-level
+  rule paths.
+
+## Rejected or deferred alternatives
+
+- **No compatibility aliases for `chainrules_core`.** The correct owning
+  abstraction is the `tidu` rule contract, so downstream crates should import
+  it directly instead of carrying aliases.
+- **No historical docs cleanup.** `docs/plans/` and old coverage artifacts
+  contain stale `chainrules` mentions by design; repository rules say those
+  historical records may contradict the current API.
+- **No broader AD API rename.** This migration follows the existing
+  `linearize` / `transpose_rule` model and does not design a new pullback API.
+
+## Verification performed
+
+- `cargo fmt --all --check`
+- `cargo test --release -p tenferro-internal-ops --features autodiff`
+- `cargo test --release -p tenferro-ad`
+- `cargo check -p tenferro-einsum --features autodiff`
+- `cargo check -p tenferro-linalg --features autodiff`
+- `cargo check -p tenferro-cpu --features cpu-faer -p tenferro-fft --features autodiff`
+- `(cd ext/tropical && cargo check --features autodiff)`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `python3 scripts/check-ad-boundaries.py`
+- `python3 scripts/check-linalg-ad-boundaries.py`
+- `scripts/check-tensor-core-deps.sh`
+- `rg -n "chainrules|1694275361d2f16abfb3f25ad7941407c88b7c09" Cargo.toml Cargo.lock ext/tropical/Cargo.toml ext/tropical/Cargo.lock tenferro-*/Cargo.toml ext/tropical/src tenferro-*/src tenferro-*/tests`
+- `git diff --check`
+
+## Remaining risk
+
+- Full workspace coverage, docs, and docs-site checks were not run locally for
+  this narrow dependency migration. The PR should rely on CI for the complete
+  repository gate.

--- a/ext/tropical/Cargo.toml
+++ b/ext/tropical/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/lib.rs"
 [features]
 default = []
 autodiff = [
-    "dep:chainrules-core",
     "dep:computegraph",
+    "dep:tidu",
     "tenferro-internal-ops/autodiff",
 ]
 tropical-gemm = ["dep:tropical-gemm"]
@@ -30,8 +30,8 @@ tenferro-einsum = { path = "../../tenferro-einsum" }
 tenferro-internal-ops = { path = "../../tenferro-internal-ops", default-features = false }
 tenferro-runtime = { path = "../../tenferro-runtime" }
 tenferro-tensor = { path = "../../tenferro-tensor" }
-chainrules-core = { git = "https://github.com/tensor4all/chainrules-rs.git", rev = "2d7662140d92f0dd73b2402aefc2272feafc9270", package = "chainrules", optional = true }
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "c20e8912560ef11166418bcea089126ef50443cc", optional = true }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "fe7fb27cf34338d3214fa9f1cc56ce4d0691626e", optional = true }
 num-traits = "0.2"
 tropical-gemm = { version = "0.2", default-features = false, optional = true }
 

--- a/ext/tropical/src/extension.rs
+++ b/ext/tropical/src/extension.rs
@@ -4,7 +4,7 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
-use chainrules_core::{ADRuleError, ADRuleKind, ADRuleResult};
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 #[cfg(feature = "autodiff")]
 use computegraph::fragment::FragmentBuilder;
 #[cfg(feature = "autodiff")]

--- a/tenferro-ad/Cargo.toml
+++ b/tenferro-ad/Cargo.toml
@@ -27,7 +27,6 @@ tenferro-internal-ops = { path = "../tenferro-internal-ops", default-features = 
 tenferro-tensor = { path = "../tenferro-tensor", default-features = false }
 tenferro-cpu = { path = "../tenferro-cpu", default-features = false }
 tenferro-gpu = { path = "../tenferro-gpu", default-features = false, optional = true }
-chainrules-core.workspace = true
 computegraph.workspace = true
 lru.workspace = true
 num-complex.workspace = true

--- a/tenferro-ad/src/eager/backward.rs
+++ b/tenferro-ad/src/eager/backward.rs
@@ -228,7 +228,7 @@ impl<B: TensorBackend + 'static> BackwardCallbacks<StdTensorOp>
         cotangent_out: &[Option<Arc<Tensor>>],
         external_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
         ctx: &mut ShapeGuardContext,
-    ) -> chainrules_core::ADRuleResult<Vec<Option<Arc<Tensor>>>> {
+    ) -> tidu::ADRuleResult<Vec<Option<Arc<Tensor>>>> {
         let mut emitter = if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
             EagerEmitter::with_extension_executor(self.backend, extension_executor)
         } else {

--- a/tenferro-ad/src/eager/tests.rs
+++ b/tenferro-ad/src/eager/tests.rs
@@ -2,12 +2,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use chainrules_core::ADKey;
 use computegraph::types::GlobalValKey;
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::SymDim;
 use tenferro_tensor::Tensor;
+use tidu::ADKey;
 
 use super::backward::{
     eager_forward_input_metadata, eager_forward_value, missing_tangent_base_key,

--- a/tenferro-ad/tests/ad.rs
+++ b/tenferro-ad/tests/ad.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use support::{run_many_traced_with, RunTraced};
 
-use chainrules_core::ADKey;
 use computegraph::compile::compile;
 use computegraph::fragment::{Fragment, FragmentBuilder};
 use computegraph::materialize::materialize_merge;
@@ -31,7 +30,7 @@ use tenferro_tensor::{
     DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor,
     TensorReduction, TypedTensor,
 };
-use tidu::{differentiate, transpose, LinearFragment};
+use tidu::{differentiate, transpose, ADKey, LinearFragment};
 
 const TOL: f64 = 1e-6;
 

--- a/tenferro-ad/tests/extension_op.rs
+++ b/tenferro-ad/tests/extension_op.rs
@@ -24,7 +24,6 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::{Arc, Mutex, OnceLock};
 use support::RunTraced;
 
-use chainrules_core::ADRuleResult;
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
@@ -40,6 +39,7 @@ use tenferro_ops::{ShapeGuardContext, SymDim};
 use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionRuntime};
 use tenferro_runtime::{GraphExecutor, Tensor, TracedTensor};
 use tenferro_tensor::{DType, TensorBackend, TypedTensor};
+use tidu::ADRuleResult;
 
 // ----------------------------------------------------------------------
 // Test-only AD rule registration guard. Integration tests may share a process,

--- a/tenferro-einsum/Cargo.toml
+++ b/tenferro-einsum/Cargo.toml
@@ -10,7 +10,7 @@ description = "Subscripts, contraction planning, traced/eager einsum APIs, exten
 [features]
 default = ["cpu-faer"]
 autodiff = [
-    "chainrules-core",
+    "dep:tidu",
     "dep:tenferro-ad",
     "tenferro-internal-ops/autodiff",
 ]
@@ -33,7 +33,7 @@ tenferro-internal-ops = { path = "../tenferro-internal-ops", default-features = 
 tenferro-tensor = { path = "../tenferro-tensor", default-features = false }
 tenferro-cpu = { path = "../tenferro-cpu", default-features = false }
 computegraph.workspace = true
-chainrules-core = { workspace = true, optional = true }
+tidu = { workspace = true, optional = true }
 lru.workspace = true
 omeco.workspace = true
 thiserror.workspace = true

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -5,8 +5,6 @@ use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-#[cfg(feature = "autodiff")]
-use chainrules_core::{ADRuleError, ADRuleKind, ADRuleResult};
 use computegraph::compile::compile;
 use computegraph::fragment::FragmentBuilder;
 use computegraph::materialize::materialize_merge;
@@ -31,6 +29,8 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::sym_dim::SymDim;
 use tenferro_runtime::extension::{ExtensionCacheKey, ExtensionExecutionContext};
 use tenferro_tensor::{DType, Tensor, TensorBackend};
+#[cfg(feature = "autodiff")]
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::builder::build_einsum_fragment;
 use crate::cache::{

--- a/tenferro-fft/Cargo.toml
+++ b/tenferro-fft/Cargo.toml
@@ -12,7 +12,7 @@ default = ["cpu-faer"]
 cpu-faer = ["tenferro-cpu/cpu-faer"]
 cpu-blas = ["tenferro-cpu/cpu-blas"]
 autodiff = [
-    "chainrules-core",
+    "dep:tidu",
     "dep:tenferro-ad",
     "tenferro-internal-ops/autodiff",
 ]
@@ -25,7 +25,7 @@ tenferro-ad = { path = "../tenferro-ad", default-features = false, optional = tr
 tenferro-tensor = { path = "../tenferro-tensor", default-features = false }
 tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros" }
 tenferro-internal-ops = { path = "../tenferro-internal-ops", default-features = false }
-chainrules-core = { workspace = true, optional = true }
+tidu = { workspace = true, optional = true }
 computegraph.workspace = true
 num-complex.workspace = true
 num-traits.workspace = true

--- a/tenferro-fft/src/lib.rs
+++ b/tenferro-fft/src/lib.rs
@@ -37,8 +37,6 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
-use chainrules_core::{ADRuleError, ADRuleKind, ADRuleResult};
-#[cfg(feature = "autodiff")]
 use computegraph::fragment::FragmentBuilder;
 #[cfg(feature = "autodiff")]
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
@@ -60,6 +58,8 @@ use tenferro_ops::SymDim;
 use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionOpTrait};
 use tenferro_runtime::{Error, Result, TracedTensor};
 use tenferro_tensor::{DType, Tensor, TensorBackend, TypedTensor};
+#[cfg(feature = "autodiff")]
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 /// Extension family id used by the tenferro FFT extension.
 ///

--- a/tenferro-internal-ops/Cargo.toml
+++ b/tenferro-internal-ops/Cargo.toml
@@ -12,7 +12,7 @@ name = "tenferro_ops"
 
 [features]
 default = ["autodiff"]
-autodiff = ["chainrules-core"]
+autodiff = ["dep:tidu"]
 gpu = []
 cuda = ["gpu"]
 rocm = ["gpu"]
@@ -22,6 +22,6 @@ tenferro-core-ops = { path = "../tenferro-core-ops" }
 tenferro-tensor = { path = "../tenferro-tensor", default-features = false }
 tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros" }
 computegraph.workspace = true
-chainrules-core = { workspace = true, optional = true }
+tidu = { workspace = true, optional = true }
 num-complex.workspace = true
 thiserror.workspace = true

--- a/tenferro-internal-ops/src/ad/mod.rs
+++ b/tenferro-internal-ops/src/ad/mod.rs
@@ -38,7 +38,7 @@ use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 
 #[cfg(feature = "autodiff")]
-use chainrules_core::{ADRuleKind, ADRuleResult};
+use tidu::{ADRuleKind, ADRuleResult};
 
 #[cfg(feature = "autodiff")]
 use crate::ext_op::{linearize_extension_rule, transpose_extension_rule};

--- a/tenferro-internal-ops/src/ad/registry.rs
+++ b/tenferro-internal-ops/src/ad/registry.rs
@@ -1,8 +1,8 @@
-use chainrules_core::{ADRuleError, ADRuleKind, ADRuleResult};
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use tenferro_core_ops::PrimitiveOpKind;
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use super::context::ShapeGuardContext;
 use super::{

--- a/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
+++ b/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
@@ -1,9 +1,9 @@
 //! Unit tests for elementwise AD helper rules.
 
-use chainrules_core::PrimitiveOp;
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, OpMode, ValRef};
 use tenferro_tensor::{CompareDir, DType};
+use tidu::PrimitiveOp;
 
 use crate::ad::context::ShapeGuardContext;
 use crate::input_key::TensorInputKey;

--- a/tenferro-internal-ops/src/ad/tests/indexing_tests.rs
+++ b/tenferro-internal-ops/src/ad/tests/indexing_tests.rs
@@ -1,9 +1,9 @@
 //! Unit tests for the `Gather` / `Scatter` AD rules in `ad::indexing`.
 
-use chainrules_core::PrimitiveOp;
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use tenferro_tensor::{DType, GatherConfig, ScatterConfig};
+use tidu::PrimitiveOp;
 
 use crate::ad::context::ShapeGuardContext;
 use crate::dim_expr::DimExpr;

--- a/tenferro-internal-ops/src/ext_op.rs
+++ b/tenferro-internal-ops/src/ext_op.rs
@@ -25,14 +25,14 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
-use chainrules_core::{ADRuleError, ADRuleKind, ADRuleResult};
-#[cfg(feature = "autodiff")]
 use computegraph::fragment::FragmentBuilder;
 #[cfg(feature = "autodiff")]
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 #[cfg(feature = "autodiff")]
 use computegraph::OpEmitter;
 use tenferro_tensor::{DType, Tensor};
+#[cfg(feature = "autodiff")]
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 #[cfg(feature = "autodiff")]
 use crate::ad::context::ShapeGuardContext;
@@ -276,7 +276,7 @@ impl ExtensionRuleSet {
     ///
     /// ```
     /// use std::sync::Arc;
-    /// use chainrules_core::ADRuleResult;
+    /// use tidu::ADRuleResult;
     /// use computegraph::fragment::FragmentBuilder;
     /// use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
     /// use computegraph::OpEmitter;
@@ -334,7 +334,7 @@ impl ExtensionRuleSet {
     ///
     /// ```
     /// use std::sync::Arc;
-    /// use chainrules_core::ADRuleResult;
+    /// use tidu::ADRuleResult;
     /// use computegraph::fragment::FragmentBuilder;
     /// use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
     /// use computegraph::OpEmitter;

--- a/tenferro-internal-ops/src/input_key.rs
+++ b/tenferro-internal-ops/src/input_key.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "autodiff")]
-use chainrules_core::{ADKey, DiffPassId};
+use tidu::{ADKey, DiffPassId};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum TensorInputKey {

--- a/tenferro-internal-ops/src/std_tensor_op.rs
+++ b/tenferro-internal-ops/src/std_tensor_op.rs
@@ -2,8 +2,6 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
-use chainrules_core::{ADRuleResult, PrimitiveOp};
-#[cfg(feature = "autodiff")]
 use computegraph::fragment::FragmentBuilder;
 #[cfg(feature = "autodiff")]
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
@@ -11,6 +9,8 @@ use computegraph::GraphOp;
 #[cfg(feature = "autodiff")]
 use computegraph::OpEmitter;
 use num_complex::{Complex32, Complex64};
+#[cfg(feature = "autodiff")]
+use tidu::{ADRuleResult, PrimitiveOp};
 
 use crate::dim_expr::DimExpr;
 use crate::ext_op::{ext_op_eq, hash_extension, ExtensionOp};

--- a/tenferro-internal-ops/src/tests/ext_op_tests.rs
+++ b/tenferro-internal-ops/src/tests/ext_op_tests.rs
@@ -4,10 +4,10 @@ use std::any::Any;
 use std::hash::Hasher;
 use std::sync::Arc;
 
-use chainrules_core::{ADRuleKind, ADRuleResult};
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
+use tidu::{ADRuleKind, ADRuleResult};
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ext_op::{

--- a/tenferro-internal-ops/src/tests/input_key_tests.rs
+++ b/tenferro-internal-ops/src/tests/input_key_tests.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 #[cfg(feature = "autodiff")]
-use chainrules_core::{ADKey, DiffPassId};
+use tidu::{ADKey, DiffPassId};
 
 use crate::input_key::TensorInputKey;
 

--- a/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
@@ -3,7 +3,6 @@ use crate::dim_expr::DimExpr;
 use crate::ext_op::{register_extension_rule, ExtensionAdRule, ExtensionOp};
 use crate::std_tensor_op::StdTensorOp;
 use crate::{SymDim, TensorMeta};
-use chainrules_core::{ADRuleKind, ADRuleResult, PrimitiveOp};
 use computegraph::fragment::{Fragment, FragmentBuilder};
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::{GraphOp, OpEmitter};
@@ -14,6 +13,7 @@ use std::sync::Arc;
 use tenferro_tensor::{
     CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
 };
+use tidu::{ADRuleKind, ADRuleResult, PrimitiveOp};
 
 use crate::input_key::TensorInputKey;
 

--- a/tenferro-linalg/Cargo.toml
+++ b/tenferro-linalg/Cargo.toml
@@ -10,8 +10,8 @@ description = "Linear algebra traced APIs, eager helpers, extension runtime, and
 [features]
 default = ["cpu-faer"]
 autodiff = [
-    "dep:chainrules-core",
     "dep:computegraph",
+    "dep:tidu",
     "dep:tenferro-ad",
     "tenferro-internal-ops/autodiff",
 ]
@@ -51,8 +51,8 @@ tenferro-internal-ops = { path = "../tenferro-internal-ops", default-features = 
 tenferro-tensor = { path = "../tenferro-tensor", default-features = false }
 tenferro-cpu = { path = "../tenferro-cpu", default-features = false }
 cblas-inject = { workspace = true, optional = true }
-chainrules-core = { workspace = true, optional = true }
 computegraph = { workspace = true, optional = true }
+tidu = { workspace = true, optional = true }
 cubecl = { workspace = true, optional = true }
 cubecl-cuda = { workspace = true, optional = true }
 cubecl-runtime = { workspace = true, optional = true }

--- a/tenferro-linalg/src/ad.rs
+++ b/tenferro-linalg/src/ad.rs
@@ -22,7 +22,6 @@
 
 use std::sync::Arc;
 
-use chainrules_core::{ADRuleError, ADRuleKind, ADRuleResult};
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
@@ -32,6 +31,7 @@ use tenferro_ad::extension::{
 };
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::ad_support::{LinalgExtensionOp, LinalgOp};
 use crate::LINALG_EXTENSION_FAMILY_ID;


### PR DESCRIPTION
## Summary

- remove active `chainrules` / `chainrules-core` dependencies from tenferro manifests
- route AD rule contract imports through `tidu`
- pin `tidu` to the merged tidu-rs commit that absorbed the rule contract
- add a reviewer work log: `docs/worklogs/2026-05-31-issue-26-tidu-rules-migration.md`

Depends on tensor4all/tidu-rs#27, merged as `fe7fb27cf34338d3214fa9f1cc56ce4d0691626e`.

## Validation

- `cargo fmt --all --check`
- `cargo test --release -p tenferro-internal-ops --features autodiff`
- `cargo test --release -p tenferro-ad`
- `cargo check -p tenferro-einsum --features autodiff`
- `cargo check -p tenferro-linalg --features autodiff`
- `cargo check -p tenferro-cpu --features cpu-faer -p tenferro-fft --features autodiff`
- `(cd ext/tropical && cargo check --features autodiff)`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `python3 scripts/check-ad-boundaries.py`
- `python3 scripts/check-linalg-ad-boundaries.py`
- `scripts/check-tensor-core-deps.sh`
- active source/manifest sweep for `chainrules` and old tidu rev
- `git diff --check`

Not run locally: full workspace coverage, `cargo doc --workspace --no-deps`, docs-site. Leaving those to CI.
