### PR TITLE
Refactor tenferro eager internals for tidu eager API boundary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "fe7fb27cf34338d3214fa9f1cc56ce4d0691626e" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "6551e2de955c83a1c8c84b3bca0b037954559617" }
 strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722", features = ["parallel"] }

--- a/docs/worklogs/2026-05-31-tidu-eager-api-boundary.md
+++ b/docs/worklogs/2026-05-31-tidu-eager-api-boundary.md
@@ -1,0 +1,78 @@
+# tidu eager API boundary migration work log
+
+Companion PR: <https://github.com/tensor4all/tidu-rs/pull/28>
+
+Date: 2026-05-31
+
+## Session summary
+
+This change migrates tenferro's eager reverse-mode implementation to the
+refined `tidu` eager API boundary.
+
+The companion `tidu-rs` PR moved generic eager recording and backward support
+under `tidu::eager`, moved the transpose emitter helper under `tidu::emit`,
+and made trace node/edge internals private. This tenferro PR then:
+
+- pins `tidu` to the merged commit containing the new eager boundary
+- stores opaque `tidu::eager::Trace` handles instead of `GradNode` internals
+- records eager operations through `tidu::eager::Recorder`
+- runs backward through `tidu::eager::try_backward`
+- executes transpose through `tidu::emit::try_transpose_fragment`
+
+No public tenferro eager tensor API is changed.
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| `AGENTS.md` | Confirm repository workflow, verification, and work-log requirements. | Added this work log and kept dependency changes in manifests. |
+| `REPOSITORY_RULES.md` | Review public surface and abstraction boundary rules. | Kept `tidu` internals out of tenferro's public API and avoided adding compatibility shims. |
+| `tenferro-ad/src/eager.rs` | Locate eager tensor trace storage, operation recording, and backward entry point. | Replaced root-level `tidu` eager internals with `tidu::eager` handles and APIs. |
+| `tenferro-ad/src/eager/backward.rs` | Locate concrete execution hooks for eager backward. | Implemented `BackwardExecutor` and routed transpose execution through `tidu::emit`. |
+| `tenferro-ad/src/eager_ops.rs` and `tenferro-ad/src/extension.rs` | Locate consumers of recorded eager output metadata. | Passed opaque traces through result construction without exposing node layout. |
+| `tidu-rs` PR #28 | Confirm the merged commit and final exported API names. | Pinned manifests to `6551e2de955c83a1c8c84b3bca0b037954559617`. |
+
+## Decisions made
+
+- **tenferro treats eager traces as opaque.** `EagerTensor` keeps
+  `Option<tidu::eager::Trace<StdTensorOp>>`, and tenferro no longer imports or
+  depends on trace node/edge types.
+- **Recording is owned by `tidu::eager::Recorder`.** tenferro still supplies
+  stable tensor input keys, but the graph layout and saved-forward bookkeeping
+  stay behind the tidu boundary.
+- **Backward execution is a downstream hook trait.**
+  `TenferroBackwardCallbacks` implements `tidu::eager::BackwardExecutor`,
+  preserving tenferro's concrete backend execution and extension executor
+  integration while moving traversal ownership into tidu.
+- **No tenferro public API expansion.** The migration adapts existing internals
+  instead of exposing tidu eager types from user-facing constructors or methods.
+
+## Rejected or deferred alternatives
+
+- **No compatibility layer for removed tidu root exports.** The root-level
+  eager symbols were intentionally retired in tidu; tenferro now imports the
+  narrower modules directly.
+- **No local copy of eager trace logic.** Keeping traversal and saved-forward
+  layout in tenferro would recreate the boundary leak this refactor removes.
+- **No broader eager tensor redesign.** This PR keeps current eager semantics,
+  gradient accumulation, extension handling, and metadata registration behavior.
+
+## Verification performed
+
+- `cargo fmt --all --check`
+- `cargo check -p tenferro-ad`
+- `cargo test -p tenferro-ad eager --lib`
+- `cargo test -p tenferro-ad --lib`
+- `cargo clippy -p tenferro-ad --all-targets -- -D warnings`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo nextest run --workspace --release --no-fail-fast`
+- `cargo test --doc --workspace --release`
+- `cargo doc --workspace --no-deps`
+- `git diff --check`
+
+## Remaining risk
+
+- CI remains authoritative for merge gating, but the local verification covered
+  the same workspace release tests, doctests, docs build, and clippy checks used
+  by the current non-GPU gates.

--- a/ext/tropical/Cargo.toml
+++ b/ext/tropical/Cargo.toml
@@ -31,7 +31,7 @@ tenferro-internal-ops = { path = "../../tenferro-internal-ops", default-features
 tenferro-runtime = { path = "../../tenferro-runtime" }
 tenferro-tensor = { path = "../../tenferro-tensor" }
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "c20e8912560ef11166418bcea089126ef50443cc", optional = true }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "fe7fb27cf34338d3214fa9f1cc56ce4d0691626e", optional = true }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "6551e2de955c83a1c8c84b3bca0b037954559617", optional = true }
 num-traits = "0.2"
 tropical-gemm = { version = "0.2", default-features = false, optional = true }
 

--- a/tenferro-ad/src/eager.rs
+++ b/tenferro-ad/src/eager.rs
@@ -16,7 +16,7 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ExtensionRuleSet;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_tensor::{CacheStats, Tensor, TensorBackend, TensorElementwise, TypedTensor};
-use tidu::{topo_sort_grad_dag, try_backward_dag, EagerOutput, EagerValue, GradNode};
+use tidu::eager::{self, Input as EagerInput, KeySource, Output as EagerOutput, Recorder, Trace};
 
 use self::backward::TenferroBackwardCallbacks;
 use crate::eager_backend::EagerBackend;
@@ -515,7 +515,7 @@ impl EagerRuntime {
 pub struct EagerTensor {
     pub(crate) data: Arc<Tensor>,
     pub(crate) key: GlobalValKey<StdTensorOp>,
-    pub(crate) grad_node: Option<Arc<GradNode<StdTensorOp>>>,
+    pub(crate) trace: Option<Trace<StdTensorOp>>,
     pub(crate) requires_grad: bool,
     grad_slot: GradSlot,
     pub(crate) metadata_scopes: Vec<Arc<MetadataScope>>,
@@ -593,7 +593,7 @@ impl EagerTensor {
         Self {
             data: Arc::new(tensor),
             key,
-            grad_node: None,
+            trace: None,
             requires_grad,
             grad_slot,
             metadata_scopes: metadata_scopes_for_scope(metadata_scope),
@@ -606,7 +606,7 @@ impl EagerTensor {
         key: GlobalValKey<StdTensorOp>,
         tensor: Tensor,
         requires_grad: bool,
-        grad_node: Option<Arc<GradNode<StdTensorOp>>>,
+        trace: Option<Trace<StdTensorOp>>,
         metadata_scopes: Vec<Arc<MetadataScope>>,
     ) -> Self {
         Self::new_result_arc(
@@ -614,7 +614,7 @@ impl EagerTensor {
             key,
             Arc::new(tensor),
             requires_grad,
-            grad_node,
+            trace,
             metadata_scopes,
         )
     }
@@ -624,7 +624,7 @@ impl EagerTensor {
         key: GlobalValKey<StdTensorOp>,
         tensor: Arc<Tensor>,
         requires_grad: bool,
-        grad_node: Option<Arc<GradNode<StdTensorOp>>>,
+        trace: Option<Trace<StdTensorOp>>,
         metadata_scopes: Vec<Arc<MetadataScope>>,
     ) -> Self {
         let grad_slot = Arc::new(Mutex::new(None));
@@ -635,7 +635,7 @@ impl EagerTensor {
         Self {
             data: tensor,
             key,
-            grad_node,
+            trace,
             requires_grad,
             grad_slot,
             metadata_scopes,
@@ -848,7 +848,6 @@ impl EagerTensor {
             });
         }
 
-        let sorted = topo_sort_grad_dag(&self.grad_node);
         let mut backend = self.ctx.backend.lock().unwrap();
         let mut extension_executor = self.ctx.extension_executor.lock().unwrap();
         let seed = Arc::new(one_like_tensor(self.data.as_ref(), &mut *backend));
@@ -861,8 +860,14 @@ impl EagerTensor {
         if let Some(extension_rules) = &self.ctx.extension_rules {
             ad_ctx = ad_ctx.with_extension_rules(extension_rules.clone());
         }
-        let cotangents = try_backward_dag(&sorted, &self.key, seed, &mut callbacks, &mut ad_ctx)
-            .map_err(|err| Error::Internal(err.to_string()))?;
+        let cotangents = eager::try_backward(
+            &self.key,
+            self.trace.as_ref(),
+            seed,
+            &mut callbacks,
+            &mut ad_ctx,
+        )
+        .map_err(|err| Error::Internal(err.to_string()))?;
         drop(callbacks);
         self.ctx.store_grads(&cotangents, &mut backend)?;
         Ok(cotangents)
@@ -875,16 +880,16 @@ pub(crate) fn eager_val_key() -> GlobalValKey<StdTensorOp> {
 
 pub(crate) struct EagerTensorKeySource;
 
-impl tidu::EagerKeySource<StdTensorOp> for EagerTensorKeySource {
+impl KeySource<StdTensorOp> for EagerTensorKeySource {
     fn fresh_input_key(&mut self) -> TensorInputKey {
         next_input_key()
     }
 }
 
-pub(crate) fn eager_value(tensor: &EagerTensor) -> EagerValue<StdTensorOp> {
-    EagerValue {
+pub(crate) fn eager_value(tensor: &EagerTensor) -> EagerInput<StdTensorOp> {
+    EagerInput {
         key: tensor.key.clone(),
-        node: tensor.grad_node.clone(),
+        trace: tensor.trace.clone(),
         requires_grad: tensor.requires_grad,
         data: Arc::clone(&tensor.data),
     }
@@ -901,8 +906,8 @@ pub(crate) fn record_eager_outputs(
     inputs: &[&EagerTensor],
 ) -> RecordedEagerOutputs {
     let input_values: Vec<_> = inputs.iter().map(|tensor| eager_value(tensor)).collect();
-    let mut key_source = EagerTensorKeySource;
-    let traces = tidu::record_eager_op(&mut key_source, op.clone(), &input_values, outputs);
+    let mut recorder = Recorder::new(EagerTensorKeySource);
+    let traces = recorder.record(op.clone(), &input_values, outputs);
 
     let mut registrations = Vec::new();
     for trace in &traces {
@@ -911,8 +916,8 @@ pub(crate) fn record_eager_outputs(
         }
     }
 
-    if let Some(node) = traces.iter().find_map(|trace| trace.node.as_ref()) {
-        for (key, value) in node.saved_data() {
+    if let Some(trace) = traces.iter().find_map(|output| output.trace.as_ref()) {
+        for (key, value) in trace.saved_values() {
             registrations.push((key.clone(), tensor_meta_from_tensor(value.as_ref())));
         }
     }

--- a/tenferro-ad/src/eager/backward.rs
+++ b/tenferro-ad/src/eager/backward.rs
@@ -7,7 +7,8 @@ use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, TensorMeta};
 use tenferro_tensor::{Tensor, TensorBackend};
-use tidu::{BackwardCallbacks, LinearFragment};
+use tidu::eager::BackwardExecutor;
+use tidu::LinearFragment;
 
 use crate::eager_emitter::EagerEmitter;
 use crate::eager_exec::{exec_op_on_tensors, exec_op_on_tensors_with_extension_executor};
@@ -118,7 +119,7 @@ fn linear_op_depends_on_tangents(mode: &OpMode) -> bool {
     matches!(mode, OpMode::Linear { active_mask } if active_mask.iter().any(|is_active| *is_active))
 }
 
-impl<B: TensorBackend + 'static> BackwardCallbacks<StdTensorOp>
+impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
     for TenferroBackwardCallbacks<'_, B>
 {
     fn execute_forward(
@@ -193,36 +194,7 @@ impl<B: TensorBackend + 'static> BackwardCallbacks<StdTensorOp>
         all_values
     }
 
-    fn eager_transpose(
-        &mut self,
-        linear: &LinearFragment<StdTensorOp>,
-        cotangent_out: &[Option<Arc<Tensor>>],
-        external_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
-        ctx: &mut ShapeGuardContext,
-    ) -> Vec<Option<Arc<Tensor>>> {
-        let mut emitter = if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
-            EagerEmitter::with_extension_executor(self.backend, extension_executor)
-        } else {
-            EagerEmitter::new(self.backend)
-        };
-        emitter.external_data = external_data.clone();
-        let cotangent_seed_ids = cotangent_out
-            .iter()
-            .map(|maybe_seed| {
-                maybe_seed
-                    .as_ref()
-                    .map(|seed| emitter.push_tensor(Arc::clone(seed)))
-            })
-            .collect::<Vec<_>>();
-
-        ctx.refresh_global_metadata();
-        tidu::eager_transpose_fragment(linear, &mut emitter, &cotangent_seed_ids, ctx)
-            .into_iter()
-            .map(|maybe_id| maybe_id.map(|id| emitter.tensor(id)))
-            .collect()
-    }
-
-    fn try_eager_transpose(
+    fn execute_transpose(
         &mut self,
         linear: &LinearFragment<StdTensorOp>,
         cotangent_out: &[Option<Arc<Tensor>>],
@@ -245,7 +217,7 @@ impl<B: TensorBackend + 'static> BackwardCallbacks<StdTensorOp>
             .collect::<Vec<_>>();
 
         ctx.refresh_global_metadata();
-        tidu::try_eager_transpose_fragment(linear, &mut emitter, &cotangent_seed_ids, ctx).map(
+        tidu::emit::try_transpose_fragment(linear, &mut emitter, &cotangent_seed_ids, ctx).map(
             |cotangent_ids| {
                 cotangent_ids
                     .into_iter()

--- a/tenferro-ad/src/eager_ops.rs
+++ b/tenferro-ad/src/eager_ops.rs
@@ -728,7 +728,7 @@ impl EagerTensor {
                 trace.key,
                 output,
                 trace.requires_grad,
-                trace.node,
+                trace.trace,
                 metadata_scopes,
             )
         });

--- a/tenferro-ad/src/extension.rs
+++ b/tenferro-ad/src/extension.rs
@@ -112,7 +112,7 @@ pub fn apply_eager(op: Arc<dyn ExtensionOp>, inputs: &[&EagerTensor]) -> Result<
                 trace.key,
                 output.as_ref().clone(),
                 trace.requires_grad,
-                trace.node,
+                trace.trace,
                 metadata_scopes.clone(),
             )
         })


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] Documentation
- [x] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs tensor4all/tidu-rs#28

## Summary

- Pins `tidu` to the merged commit from tensor4all/tidu-rs#28 containing the refined eager API boundary.
- Migrates tenferro eager internals from root-level tidu eager exports to `tidu::eager::{Trace, Recorder, try_backward, BackwardExecutor}`.
- Routes eager transpose execution through `tidu::emit::try_transpose_fragment` and keeps tenferro's public eager tensor API unchanged.

## Work log

`docs/worklogs/2026-05-31-tidu-eager-api-boundary.md`

## Verification

- `cargo fmt --all --check`
- `cargo check -p tenferro-ad`
- `cargo test -p tenferro-ad eager --lib`
- `cargo test -p tenferro-ad --lib`
- `cargo clippy -p tenferro-ad --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo nextest run --workspace --release --no-fail-fast`
- `cargo test --doc --workspace --release`
- `cargo doc --workspace --no-deps`
- `git diff --check`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [ ] If this implements a new feature, the linked issue has been accepted by maintainers.
- [ ] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
