### PR TITLE
refactor: consume tidu JAX-aligned API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "6551e2de955c83a1c8c84b3bca0b037954559617" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "f0d91566edb2ea08fac9d61ef26f9cd1754f02df" }
 strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722", features = ["parallel"] }

--- a/ext/tropical/Cargo.toml
+++ b/ext/tropical/Cargo.toml
@@ -31,7 +31,7 @@ tenferro-internal-ops = { path = "../../tenferro-internal-ops", default-features
 tenferro-runtime = { path = "../../tenferro-runtime" }
 tenferro-tensor = { path = "../../tenferro-tensor" }
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "c20e8912560ef11166418bcea089126ef50443cc", optional = true }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "6551e2de955c83a1c8c84b3bca0b037954559617", optional = true }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "f0d91566edb2ea08fac9d61ef26f9cd1754f02df", optional = true }
 num-traits = "0.2"
 tropical-gemm = { version = "0.2", default-features = false, optional = true }
 

--- a/ext/tropical/src/extension.rs
+++ b/ext/tropical/src/extension.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 #[cfg(feature = "autodiff")]
-use computegraph::fragment::FragmentBuilder;
 #[cfg(feature = "autodiff")]
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 #[cfg(feature = "autodiff")]
@@ -411,14 +410,14 @@ impl ExtensionAdRule for TropicalEinsumAdRule {
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut FragmentBuilder<StdTensorOp>,
+        builder: &mut dyn OpEmitter<StdTensorOp>,
         primal_in: &[GlobalValKey<StdTensorOp>],
         _primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
-        let op = downcast_primal_op(op, ADRuleKind::Linearize)?;
-        validate_ad_supported(&op.subscripts, ADRuleKind::Linearize)?;
+        let op = downcast_primal_op(op, ADRuleKind::Jvp)?;
+        validate_ad_supported(&op.subscripts, ADRuleKind::Jvp)?;
         let active_inputs: Vec<usize> = tangent_in
             .iter()
             .enumerate()
@@ -481,7 +480,7 @@ impl ExtensionAdRule for TropicalEinsumJvpAdRule {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        _builder: &mut FragmentBuilder<StdTensorOp>,
+        _builder: &mut dyn OpEmitter<StdTensorOp>,
         _primal_in: &[GlobalValKey<StdTensorOp>],
         _primal_out: &[GlobalValKey<StdTensorOp>],
         _tangent_in: &[Option<LocalValId>],
@@ -489,7 +488,7 @@ impl ExtensionAdRule for TropicalEinsumJvpAdRule {
     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
         Err(ADRuleError::unsupported(
             TROPICAL_EINSUM_JVP_FAMILY_ID,
-            ADRuleKind::Linearize,
+            ADRuleKind::Jvp,
         ))
     }
 

--- a/tenferro-ad/src/eager.rs
+++ b/tenferro-ad/src/eager.rs
@@ -16,7 +16,7 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ExtensionRuleSet;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_tensor::{CacheStats, Tensor, TensorBackend, TensorElementwise, TypedTensor};
-use tidu::eager::{self, Input as EagerInput, KeySource, Output as EagerOutput, Recorder, Trace};
+use tidu::eager::{self, EagerInput, EagerOutput, KeySource, Recorder, Trace};
 
 use self::backward::TenferroBackwardCallbacks;
 use crate::eager_backend::EagerBackend;

--- a/tenferro-ad/src/eager/backward.rs
+++ b/tenferro-ad/src/eager/backward.rs
@@ -8,7 +8,7 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, TensorMeta};
 use tenferro_tensor::{Tensor, TensorBackend};
 use tidu::eager::BackwardExecutor;
-use tidu::LinearFragment;
+use tidu::{LinearizedGraph, PrimitiveGraph};
 
 use crate::eager_emitter::EagerEmitter;
 use crate::eager_exec::{exec_op_on_tensors, exec_op_on_tensors_with_extension_executor};
@@ -124,9 +124,10 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
 {
     fn execute_forward(
         &mut self,
-        fragment: &Fragment<StdTensorOp>,
+        graph: PrimitiveGraph<'_, StdTensorOp>,
         initial_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
     ) -> HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>> {
+        let fragment = graph.as_graph();
         let mut all_values = initial_data.clone();
         let live_values = live_fragment_values(fragment);
         let input_metadata = fragment
@@ -194,9 +195,9 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
         all_values
     }
 
-    fn execute_transpose(
+    fn run_transposed_linear(
         &mut self,
-        linear: &LinearFragment<StdTensorOp>,
+        linear: &LinearizedGraph<StdTensorOp>,
         cotangent_out: &[Option<Arc<Tensor>>],
         external_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
         ctx: &mut ShapeGuardContext,
@@ -217,7 +218,7 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
             .collect::<Vec<_>>();
 
         ctx.refresh_global_metadata();
-        tidu::emit::try_transpose_fragment(linear, &mut emitter, &cotangent_seed_ids, ctx).map(
+        tidu::try_linear_transpose_with_builder(linear, &mut emitter, &cotangent_seed_ids, ctx).map(
             |cotangent_ids| {
                 cotangent_ids
                     .into_iter()

--- a/tenferro-ad/src/eager_emitter.rs
+++ b/tenferro-ad/src/eager_emitter.rs
@@ -6,6 +6,7 @@ use computegraph::{GlobalValKey, LocalValId, OpEmitter, OpMode, ValRef};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{Tensor, TensorBackend, TypedTensor};
+use tidu::{PrimitiveBuilder, PrimitiveValue};
 
 use crate::eager_exec::{exec_op_on_tensors, exec_op_on_tensors_with_extension_executor};
 
@@ -101,6 +102,18 @@ impl<B: TensorBackend + 'static> OpEmitter<StdTensorOp> for EagerEmitter<'_, B> 
             self.results.push(Arc::new(output));
         }
         (base..self.results.len()).collect()
+    }
+}
+
+impl<B: TensorBackend + 'static> PrimitiveBuilder<StdTensorOp> for EagerEmitter<'_, B> {
+    fn add_primitive(
+        &mut self,
+        op: StdTensorOp,
+        inputs: Vec<PrimitiveValue<StdTensorOp>>,
+        mode: OpMode,
+    ) -> Vec<LocalValId> {
+        let inputs = inputs.into_iter().map(ValRef::from).collect();
+        self.add_op(op, inputs, mode)
     }
 }
 

--- a/tenferro-ad/src/traced.rs
+++ b/tenferro-ad/src/traced.rs
@@ -15,7 +15,7 @@ use tenferro_runtime::ad_support::{
 };
 use tenferro_runtime::{Error, GraphCompiler, GraphExecutor, Result, TracedTensor};
 use tenferro_tensor::TensorBackend;
-use tidu::{try_differentiate, try_transpose};
+use tidu::{try_linear_transpose, try_linearize};
 
 static NEXT_DIFF_PASS_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -279,7 +279,7 @@ fn jvp_optional_result_with_rules(
     roots.extend(checkpoint_fragments.iter().cloned());
     let view = resolve(roots);
     let mut ad_ctx = shape_guard_context(extension_rules);
-    let linear = try_differentiate(
+    let linear = try_linearize(
         &view,
         std::slice::from_ref(&output_key),
         std::slice::from_ref(&wrt_input_key),
@@ -288,12 +288,12 @@ fn jvp_optional_result_with_rules(
         &aliases,
     )
     .map_err(|err| Error::Internal(err.to_string()))?;
-    let Some(tangent_output) = linear.tangent_outputs[0] else {
+    let Some(tangent_output) = linear.tangent_outputs()[0] else {
         return Ok(None);
     };
-    let tangent_input_key = linear_input_key(&linear.fragment, linear.tangent_inputs[0].1);
+    let tangent_input_key = linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1);
     let metadata_scope = register_scoped_fragment_metadata(
-        &linear.fragment,
+        linear.as_graph(),
         vec![(
             GlobalValKey::Input(tangent_input_key.clone()),
             tensor_meta_from_tensor(
@@ -325,7 +325,7 @@ fn jvp_optional_result_with_rules(
     Ok(Some(traced_tensor_from_parts(TracedTensorParts {
         rank: output.rank,
         dtype: output.dtype,
-        fragment: Arc::new(linear.fragment),
+        fragment: Arc::new(linear.into_graph()),
         val: tangent_output,
         data: None,
         shape_hint: traced_shape_hint(output),
@@ -364,7 +364,7 @@ fn vjp_optional_result_with_rules(
     roots.extend(checkpoint_fragments.iter().cloned());
     let view = resolve(roots);
     let mut ad_ctx = shape_guard_context(extension_rules);
-    let linear = try_differentiate(
+    let linear = try_linearize(
         &view,
         std::slice::from_ref(&output_key),
         std::slice::from_ref(&wrt_input_key),
@@ -373,24 +373,24 @@ fn vjp_optional_result_with_rules(
         &aliases,
     )
     .map_err(|err| Error::Internal(err.to_string()))?;
-    if linear.tangent_outputs[0].is_none() {
+    if linear.tangent_outputs()[0].is_none() {
         return Ok(None);
     }
-    let linear_seed_key = linear_input_key(&linear.fragment, linear.tangent_inputs[0].1);
+    let linear_seed_key = linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1);
     let linear_metadata_scope = register_scoped_fragment_metadata(
-        &linear.fragment,
+        linear.as_graph(),
         vec![(
             GlobalValKey::Input(linear_seed_key),
             registered_meta(&wrt.fragment.vals()[wrt.val].key),
         )],
     );
     ad_ctx.refresh_global_metadata();
-    let transposed =
-        try_transpose(&linear, &mut ad_ctx).map_err(|err| Error::Internal(err.to_string()))?;
+    let transposed = try_linear_transpose(&linear, &mut ad_ctx)
+        .map_err(|err| Error::Internal(err.to_string()))?;
     let cotangent_input_key =
-        linear_input_key(&transposed.fragment, transposed.tangent_inputs[0].1);
+        linear_input_key(transposed.as_graph(), transposed.tangent_inputs()[0].1);
     let transposed_metadata_scope = register_scoped_fragment_metadata(
-        &transposed.fragment,
+        transposed.as_graph(),
         vec![(
             GlobalValKey::Input(cotangent_input_key.clone()),
             tensor_meta_from_tensor(
@@ -402,8 +402,8 @@ fn vjp_optional_result_with_rules(
             ),
         )],
     );
-    let linear_fragment = Arc::new(linear.fragment);
-    let Some(cotangent_output) = transposed.tangent_outputs[0] else {
+    let linear_fragment = Arc::new(linear.into_graph());
+    let Some(cotangent_output) = transposed.tangent_outputs()[0] else {
         return Ok(None);
     };
 
@@ -426,7 +426,7 @@ fn vjp_optional_result_with_rules(
     Ok(Some(traced_tensor_from_parts(TracedTensorParts {
         rank: wrt.rank,
         dtype: wrt.dtype,
-        fragment: Arc::new(transposed.fragment),
+        fragment: Arc::new(transposed.into_graph()),
         val: cotangent_output,
         data: None,
         shape_hint: traced_shape_hint(wrt),

--- a/tenferro-ad/tests/ad.rs
+++ b/tenferro-ad/tests/ad.rs
@@ -30,7 +30,7 @@ use tenferro_tensor::{
     DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor,
     TensorReduction, TypedTensor,
 };
-use tidu::{differentiate, transpose, ADKey, LinearFragment};
+use tidu::{linear_transpose, linearize, ADKey};
 
 const TOL: f64 = 1e-6;
 
@@ -275,7 +275,7 @@ fn grad_from_fragment_with_inputs_and_cotangent(
     );
     let view = resolve(vec![fragment.clone()]);
     let mut ad_ctx = ShapeGuardContext::with_global_metadata();
-    let linear = differentiate(
+    let linear = linearize(
         &view,
         std::slice::from_ref(&loss_key),
         std::slice::from_ref(&input_key),
@@ -284,7 +284,7 @@ fn grad_from_fragment_with_inputs_and_cotangent(
         &HashMap::new(),
     );
     let _linear_metadata_scope = register_fragment_metadata_for_test(
-        &linear.fragment,
+        linear.as_graph(),
         vec![(
             GlobalValKey::Input(input_key.tangent_of(0)),
             tensor_meta_from_tensor(inputs_map.get(&input_key).expect("missing input tensor")),
@@ -292,21 +292,21 @@ fn grad_from_fragment_with_inputs_and_cotangent(
     );
     ad_ctx.refresh_global_metadata();
     let linear_tangent_input_ids: Vec<LocalValId> = linear
-        .tangent_inputs
+        .tangent_inputs()
         .iter()
         .map(|(_, local_id)| *local_id)
         .collect();
-    let transposed = transpose(&linear, &mut ad_ctx);
-    let linear_fragment = Arc::new(linear.fragment);
-    let grad_key = transposed.tangent_outputs[0]
-        .map(|id| transposed.fragment.vals()[id].key.clone())
+    let transposed = linear_transpose(&linear, &mut ad_ctx);
+    let linear_fragment = Arc::new(linear.into_graph());
+    let grad_key = transposed.tangent_outputs()[0]
+        .map(|id| transposed.as_graph().vals()[id].key.clone())
         .expect("expected active gradient output");
-    let cotangent_input_key = match &transposed.fragment.vals()[transposed.tangent_inputs[0].1].key
-    {
-        GlobalValKey::Input(key) => key.clone(),
-        _ => panic!("expected cotangent input"),
-    };
-    let transposed_fragment = Arc::new(transposed.fragment);
+    let cotangent_input_key =
+        match &transposed.as_graph().vals()[transposed.tangent_inputs()[0].1].key {
+            GlobalValKey::Input(key) => key.clone(),
+            _ => panic!("expected cotangent input"),
+        };
+    let transposed_fragment = Arc::new(transposed.into_graph());
 
     inputs_map.insert(cotangent_input_key, cotangent);
 
@@ -388,7 +388,7 @@ fn jvp_from_fragment_with_inputs(
     );
     let view = resolve(vec![fragment.clone()]);
     let mut ad_ctx = ShapeGuardContext::with_global_metadata();
-    let linear = differentiate(
+    let linear = linearize(
         &view,
         std::slice::from_ref(&output_key),
         std::slice::from_ref(&input_key),
@@ -397,20 +397,20 @@ fn jvp_from_fragment_with_inputs(
         &HashMap::new(),
     );
     let _linear_metadata_scope = register_fragment_metadata_for_test(
-        &linear.fragment,
+        linear.as_graph(),
         vec![(
             GlobalValKey::Input(input_key.tangent_of(0)),
             tensor_meta_from_tensor(&tangent),
         )],
     );
-    let tangent_key = linear.tangent_outputs[0]
-        .map(|id| linear.fragment.vals()[id].key.clone())
+    let tangent_key = linear.tangent_outputs()[0]
+        .map(|id| linear.as_graph().vals()[id].key.clone())
         .expect("expected active tangent output");
-    let tangent_input_key = match &linear.fragment.vals()[linear.tangent_inputs[0].1].key {
+    let tangent_input_key = match &linear.as_graph().vals()[linear.tangent_inputs()[0].1].key {
         GlobalValKey::Input(key) => key.clone(),
         _ => panic!("expected tangent input"),
     };
-    let linear_fragment = Arc::new(linear.fragment);
+    let linear_fragment = Arc::new(linear.into_graph());
 
     inputs_map.insert(tangent_input_key, tangent);
 
@@ -462,43 +462,58 @@ fn transpose_primal_unary_op_with_inputs(
     input: Tensor,
     cotangent: Tensor,
 ) -> Tensor {
-    let tangent_input_key = input_key.tangent_of(90_000);
     let mut builder = FragmentBuilder::<StdTensorOp>::new();
-    let tangent_input = builder.add_input(tangent_input_key.clone());
-    let output = builder.add_op(op, vec![ValRef::Local(tangent_input)], OpMode::Primal)[0];
+    let input_id = builder.add_input(input_key.clone());
+    let output = builder.add_op(op, vec![ValRef::Local(input_id)], OpMode::Primal)[0];
     builder.set_outputs(vec![output]);
 
-    let linear = LinearFragment {
-        fragment: builder.build(),
-        tangent_inputs: vec![(input_key, tangent_input)],
-        tangent_outputs: vec![Some(output)],
-    };
+    let fragment = Arc::new(builder.build());
+    let output_key = fragment.vals()[output].key.clone();
+    let _primal_metadata_scope = register_fragment_metadata_for_test(
+        &fragment,
+        vec![(
+            GlobalValKey::Input(input_key.clone()),
+            tensor_meta_from_tensor(&input),
+        )],
+    );
+    let view = resolve(vec![fragment.clone()]);
+    let mut ad_ctx = ShapeGuardContext::with_global_metadata();
+    let linear = linearize(
+        &view,
+        std::slice::from_ref(&output_key),
+        std::slice::from_ref(&input_key),
+        90_000,
+        &mut ad_ctx,
+        &HashMap::new(),
+    );
+    let tangent_input_key = input_key.tangent_of(90_000);
     let _linear_metadata_scope = register_fragment_metadata_for_test(
-        &linear.fragment,
+        linear.as_graph(),
         vec![(
             GlobalValKey::Input(tangent_input_key.clone()),
             tensor_meta_from_tensor(&input),
         )],
     );
-    let mut ad_ctx = ShapeGuardContext::with_global_metadata();
-    let transposed = transpose(&linear, &mut ad_ctx);
-    let linear_fragment = Arc::new(linear.fragment);
-    let cotangent_input_key = match &transposed.fragment.vals()[transposed.tangent_inputs[0].1].key
-    {
-        GlobalValKey::Input(key) => key.clone(),
-        _ => panic!("expected cotangent seed input"),
-    };
-    let output_key = transposed.tangent_outputs[0]
-        .map(|id| transposed.fragment.vals()[id].key.clone())
+    ad_ctx.refresh_global_metadata();
+    let transposed = linear_transpose(&linear, &mut ad_ctx);
+    let linear_fragment = Arc::new(linear.into_graph());
+    let cotangent_input_key =
+        match &transposed.as_graph().vals()[transposed.tangent_inputs()[0].1].key {
+            GlobalValKey::Input(key) => key.clone(),
+            _ => panic!("expected cotangent seed input"),
+        };
+    let output_key = transposed.tangent_outputs()[0]
+        .map(|id| transposed.as_graph().vals()[id].key.clone())
         .expect("expected active transpose output");
-    let transposed_fragment = Arc::new(transposed.fragment);
+    let transposed_fragment = Arc::new(transposed.into_graph());
 
     let mut inputs_map = HashMap::new();
+    inputs_map.insert(input_key, input.clone());
     inputs_map.insert(tangent_input_key, input);
     inputs_map.insert(cotangent_input_key, cotangent);
 
     eval_fragment_outputs(
-        vec![linear_fragment, transposed_fragment],
+        vec![fragment, linear_fragment, transposed_fragment],
         &[output_key],
         &inputs_map,
     )

--- a/tenferro-ad/tests/extension_op.rs
+++ b/tenferro-ad/tests/extension_op.rs
@@ -24,7 +24,6 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::{Arc, Mutex, OnceLock};
 use support::RunTraced;
 
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use num_complex::{Complex32, Complex64};
@@ -146,7 +145,7 @@ impl ExtensionAdRuleTrait for TestScaleBy2Rule {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        builder: &mut FragmentBuilder<StdTensorOp>,
+        builder: &mut dyn OpEmitter<StdTensorOp>,
         _primal_in: &[GlobalValKey<StdTensorOp>],
         _primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
@@ -263,7 +262,7 @@ impl ExtensionAdRuleTrait for TestSwapRule {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        _builder: &mut FragmentBuilder<StdTensorOp>,
+        _builder: &mut dyn OpEmitter<StdTensorOp>,
         _primal_in: &[GlobalValKey<StdTensorOp>],
         _primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
@@ -447,7 +446,7 @@ impl ExtensionAdRuleTrait for TestProbeIdentityRule {
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut FragmentBuilder<StdTensorOp>,
+        builder: &mut dyn OpEmitter<StdTensorOp>,
         _primal_in: &[GlobalValKey<StdTensorOp>],
         _primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
@@ -500,7 +499,7 @@ impl ExtensionAdRuleTrait for TestProbeLinearRule {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        _builder: &mut FragmentBuilder<StdTensorOp>,
+        _builder: &mut dyn OpEmitter<StdTensorOp>,
         _primal_in: &[GlobalValKey<StdTensorOp>],
         _primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],

--- a/tenferro-ad/tests/extension_op/api_and_registry.rs
+++ b/tenferro-ad/tests/extension_op/api_and_registry.rs
@@ -227,7 +227,7 @@ fn malformed_family_id_is_rejected() {
         fn linearize(
             &self,
             _op: &dyn ExtensionOp,
-            _builder: &mut FragmentBuilder<StdTensorOp>,
+            _builder: &mut dyn OpEmitter<StdTensorOp>,
             _primal_in: &[GlobalValKey<StdTensorOp>],
             _primal_out: &[GlobalValKey<StdTensorOp>],
             _tangent_in: &[Option<LocalValId>],

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -283,13 +283,13 @@ impl ExtensionAdRule for EinsumAdRule {
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut FragmentBuilder<StdTensorOp>,
+        builder: &mut dyn OpEmitter<StdTensorOp>,
         primal_in: &[GlobalValKey<StdTensorOp>],
         _primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
-        let op = downcast_ad_op(op, ADRuleKind::Linearize)?;
+        let op = downcast_ad_op(op, ADRuleKind::Jvp)?;
         let mut terms = Vec::new();
 
         for (active_idx, tangent) in tangent_in.iter().enumerate() {
@@ -989,7 +989,7 @@ fn downcast_ad_op(op: &dyn ExtensionOp, kind: ADRuleKind) -> ADRuleResult<&Einsu
 
 #[cfg(feature = "autodiff")]
 fn sum_terms(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     terms: Vec<LocalValId>,
 ) -> Option<LocalValId> {
     match terms.as_slice() {

--- a/tenferro-fft/src/lib.rs
+++ b/tenferro-fft/src/lib.rs
@@ -37,7 +37,6 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
-use computegraph::fragment::FragmentBuilder;
 #[cfg(feature = "autodiff")]
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 #[cfg(feature = "autodiff")]
@@ -324,17 +323,17 @@ impl ExtensionAdRuleTrait for FftAdRule {
     fn linearize(
         &self,
         op: &dyn ExtensionOpTrait,
-        builder: &mut FragmentBuilder<StdTensorOp>,
+        builder: &mut dyn OpEmitter<StdTensorOp>,
         _primal_in: &[GlobalValKey<StdTensorOp>],
         _primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
-        let fft_op = fft_payload(op, ADRuleKind::Linearize)?;
+        let fft_op = fft_payload(op, ADRuleKind::Jvp)?;
         if !matches!(fft_op.kind, FftKind::C2C { .. }) {
             return Err(ADRuleError::unsupported(
                 FFT_EXTENSION_FAMILY_ID,
-                ADRuleKind::Linearize,
+                ADRuleKind::Jvp,
             ));
         }
 

--- a/tenferro-internal-ops/src/ad/analytic.rs
+++ b/tenferro-internal-ops/src/ad/analytic.rs
@@ -1,4 +1,3 @@
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 
@@ -109,7 +108,7 @@ fn unary_is_active(mode: &OpMode) -> bool {
 }
 
 pub fn linearize_exp(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -129,7 +128,7 @@ pub fn linearize_exp(
 }
 
 pub fn linearize_log(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -149,7 +148,7 @@ pub fn linearize_log(
 }
 
 pub fn linearize_sin(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -171,7 +170,7 @@ pub fn linearize_sin(
 }
 
 pub fn linearize_cos(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -194,7 +193,7 @@ pub fn linearize_cos(
 }
 
 pub fn linearize_tanh(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -216,7 +215,7 @@ pub fn linearize_tanh(
 }
 
 pub fn linearize_sqrt(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -235,7 +234,7 @@ pub fn linearize_sqrt(
 }
 
 pub fn linearize_rsqrt(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -257,7 +256,7 @@ pub fn linearize_rsqrt(
 }
 
 pub fn linearize_pow(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -310,7 +309,7 @@ pub fn linearize_pow(
 }
 
 pub fn linearize_expm1(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -330,7 +329,7 @@ pub fn linearize_expm1(
 }
 
 pub fn linearize_log1p(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {

--- a/tenferro-internal-ops/src/ad/contraction.rs
+++ b/tenferro-internal-ops/src/ad/contraction.rs
@@ -1,4 +1,3 @@
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use tenferro_tensor::{CompareDir, DType, DotGeneralConfig};
@@ -10,7 +9,7 @@ use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
 
 pub fn linearize_dot_general(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     config: &DotGeneralConfig,
@@ -71,7 +70,7 @@ pub fn linearize_dot_general(
 }
 
 pub fn linearize_reduce_sum(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
     op: &StdTensorOp,
     _axes: &[usize],
@@ -92,7 +91,7 @@ pub fn linearize_reduce_sum(
 }
 
 pub fn linearize_reduce_prod(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -142,7 +141,7 @@ pub fn linearize_reduce_prod(
 }
 
 pub fn linearize_reduce_chooser(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],

--- a/tenferro-internal-ops/src/ad/diagonal.rs
+++ b/tenferro-internal-ops/src/ad/diagonal.rs
@@ -1,11 +1,10 @@
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 
 use crate::std_tensor_op::StdTensorOp;
 
 pub fn linearize_extract_diag(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
     axis_a: usize,
     axis_b: usize,
@@ -27,7 +26,7 @@ pub fn linearize_extract_diag(
 }
 
 pub fn linearize_embed_diag(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
     axis_a: usize,
     axis_b: usize,

--- a/tenferro-internal-ops/src/ad/dynamic.rs
+++ b/tenferro-internal-ops/src/ad/dynamic.rs
@@ -1,4 +1,3 @@
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use tenferro_tensor::SliceConfig;
@@ -7,7 +6,7 @@ use crate::ad::context::ShapeGuardContext;
 use crate::std_tensor_op::StdTensorOp;
 
 pub fn linearize_dynamic_truncate(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -71,7 +70,7 @@ pub fn transpose_dynamic_truncate(
 }
 
 pub fn linearize_pad_to_match(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     axis: usize,

--- a/tenferro-internal-ops/src/ad/elementwise.rs
+++ b/tenferro-internal-ops/src/ad/elementwise.rs
@@ -1,4 +1,3 @@
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use tenferro_tensor::CompareDir;
@@ -160,7 +159,7 @@ fn active_mask(mode: &OpMode, len: usize) -> Vec<bool> {
 }
 
 pub fn linearize_div(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -206,7 +205,7 @@ pub fn linearize_div(
 }
 
 pub fn linearize_abs(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -228,7 +227,7 @@ pub fn linearize_abs(
 }
 
 pub fn linearize_sign(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
     match tangent_in[0] {
@@ -238,7 +237,7 @@ pub fn linearize_sign(
 }
 
 pub fn linearize_maximum(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -261,7 +260,7 @@ pub fn linearize_maximum(
 }
 
 pub fn linearize_minimum(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -284,7 +283,7 @@ pub fn linearize_minimum(
 }
 
 pub fn linearize_select(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -297,7 +296,7 @@ pub fn linearize_select(
 }
 
 pub fn linearize_clamp(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {

--- a/tenferro-internal-ops/src/ad/indexing.rs
+++ b/tenferro-internal-ops/src/ad/indexing.rs
@@ -24,7 +24,6 @@
 //! Closing the core op vocabulary under AD is a Stage 7 prerequisite (the
 //! tropical fused backward emits `Gather` / `Scatter` on this vocabulary).
 
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use tenferro_tensor::{GatherConfig, ScatterConfig};
@@ -41,7 +40,7 @@ use crate::sym_dim::SymDim;
 /// is ignored. The output tangent is the same gather applied to the
 /// operand's tangent, reusing the primal indices.
 pub fn linearize_gather(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     config: &GatherConfig,
@@ -70,7 +69,7 @@ pub fn linearize_gather(
 /// shape-source inputs are non-differentiable and are reused from the primal.
 #[allow(clippy::too_many_arguments)]
 pub fn linearize_gather_dynamic_slice_sizes(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     offset_dims: &[usize],
@@ -110,7 +109,7 @@ pub fn linearize_gather_dynamic_slice_sizes(
 /// The source tensor tangent flows through the same dynamic slice. Runtime
 /// start indices are integer-valued and non-differentiable.
 pub fn linearize_dynamic_slice(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     slice_sizes: &[usize],
@@ -140,7 +139,7 @@ pub fn linearize_dynamic_slice(
 /// The operand and update inputs are differentiable. Runtime start indices are
 /// integer-valued and non-differentiable.
 pub fn linearize_dynamic_update_slice(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     ctx: &mut ShapeGuardContext,
@@ -420,7 +419,7 @@ pub fn transpose_dynamic_update_slice(
 ///   `Scatter(operand_dot, indices, updates_dot, config)`; by linearity
 ///   this captures both contributions in a single scatter.
 pub fn linearize_scatter(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     config: &ScatterConfig,

--- a/tenferro-internal-ops/src/ad/mod.rs
+++ b/tenferro-internal-ops/src/ad/mod.rs
@@ -31,19 +31,45 @@ pub mod support;
 mod zeros;
 
 #[cfg(feature = "autodiff")]
-use computegraph::fragment::FragmentBuilder;
-#[cfg(feature = "autodiff")]
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 #[cfg(feature = "autodiff")]
 use computegraph::OpEmitter;
 
 #[cfg(feature = "autodiff")]
-use tidu::{ADRuleKind, ADRuleResult};
+use tidu::{ADRuleKind, ADRuleResult, PrimitiveBuilder, PrimitiveValue};
 
 #[cfg(feature = "autodiff")]
 use crate::ext_op::{linearize_extension_rule, transpose_extension_rule};
 #[cfg(feature = "autodiff")]
 use crate::std_tensor_op::StdTensorOp;
+
+#[cfg(feature = "autodiff")]
+pub(crate) struct PrimitiveBuilderEmitter<'a, B: ?Sized> {
+    inner: &'a mut B,
+}
+
+#[cfg(feature = "autodiff")]
+impl<'a, B: ?Sized> PrimitiveBuilderEmitter<'a, B> {
+    pub(crate) fn new(inner: &'a mut B) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(feature = "autodiff")]
+impl<B> OpEmitter<StdTensorOp> for PrimitiveBuilderEmitter<'_, B>
+where
+    B: PrimitiveBuilder<StdTensorOp> + ?Sized,
+{
+    fn add_op(
+        &mut self,
+        op: StdTensorOp,
+        inputs: Vec<ValRef<StdTensorOp>>,
+        mode: OpMode,
+    ) -> Vec<LocalValId> {
+        let inputs = inputs.into_iter().map(PrimitiveValue::from).collect();
+        self.inner.add_primitive(op, inputs, mode)
+    }
+}
 
 /// Forward-mode AD (JVP) for `StdTensorOp`: given the primal op and its
 /// tangent inputs, emit the linearized fragment into `builder` and return
@@ -55,7 +81,7 @@ use crate::std_tensor_op::StdTensorOp;
 #[cfg(feature = "autodiff")]
 pub fn linearize(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -71,7 +97,7 @@ pub fn linearize(
 #[cfg(feature = "autodiff")]
 pub fn try_linearize(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -92,7 +118,7 @@ pub fn try_linearize(
         .primitive_kind()
         .expect("non-extension StdTensorOp must have a primitive kind");
     let rule = registry::primitive_ad_rule(kind)
-        .ok_or_else(|| registry::missing_rule(kind, ADRuleKind::Linearize))?;
+        .ok_or_else(|| registry::missing_rule(kind, ADRuleKind::Jvp))?;
     rule.linearize(op, builder, primal_in, primal_out, tangent_in, ctx)
 }
 

--- a/tenferro-internal-ops/src/ad/registry.rs
+++ b/tenferro-internal-ops/src/ad/registry.rs
@@ -1,4 +1,3 @@
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use tenferro_core_ops::PrimitiveOpKind;
@@ -12,7 +11,7 @@ use crate::std_tensor_op::StdTensorOp;
 
 pub(crate) type LinearizeFn = fn(
     &StdTensorOp,
-    &mut FragmentBuilder<StdTensorOp>,
+    &mut dyn OpEmitter<StdTensorOp>,
     &[GlobalValKey<StdTensorOp>],
     &[GlobalValKey<StdTensorOp>],
     &[Option<LocalValId>],
@@ -34,7 +33,7 @@ pub(crate) trait PrimitiveAdRule: Send + Sync {
     fn linearize(
         &self,
         op: &StdTensorOp,
-        builder: &mut FragmentBuilder<StdTensorOp>,
+        builder: &mut dyn OpEmitter<StdTensorOp>,
         primal_in: &[GlobalValKey<StdTensorOp>],
         primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
@@ -66,7 +65,7 @@ impl PrimitiveAdRule for FunctionPrimitiveAdRule {
     fn linearize(
         &self,
         op: &StdTensorOp,
-        builder: &mut FragmentBuilder<StdTensorOp>,
+        builder: &mut dyn OpEmitter<StdTensorOp>,
         primal_in: &[GlobalValKey<StdTensorOp>],
         primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
@@ -343,7 +342,7 @@ static PRIMITIVE_AD_RULES: [&'static dyn PrimitiveAdRule; PrimitiveOpKind::COUNT
 
 fn linearize_add(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -365,7 +364,7 @@ fn transpose_add(
 
 fn linearize_mul(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -393,7 +392,7 @@ fn transpose_mul(
 
 fn linearize_neg(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -415,7 +414,7 @@ fn transpose_neg(
 
 fn linearize_conj(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -444,7 +443,7 @@ fn transpose_conj(
 
 fn linearize_div(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -457,7 +456,7 @@ fn linearize_div(
 
 fn linearize_abs(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -468,7 +467,7 @@ fn linearize_abs(
 
 fn linearize_sign(
     _op: &StdTensorOp,
-    _builder: &mut FragmentBuilder<StdTensorOp>,
+    _builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -479,7 +478,7 @@ fn linearize_sign(
 
 fn linearize_maximum(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -492,7 +491,7 @@ fn linearize_maximum(
 
 fn linearize_minimum(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -505,7 +504,7 @@ fn linearize_minimum(
 
 fn linearize_compare(
     _op: &StdTensorOp,
-    _builder: &mut FragmentBuilder<StdTensorOp>,
+    _builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     _tangent_in: &[Option<LocalValId>],
@@ -516,7 +515,7 @@ fn linearize_compare(
 
 fn linearize_select(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -529,7 +528,7 @@ fn linearize_select(
 
 fn linearize_clamp(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -584,7 +583,7 @@ macro_rules! analytic_linearize {
     ($name:ident, $callee:path, primal_in) => {
         fn $name(
             _op: &StdTensorOp,
-            builder: &mut FragmentBuilder<StdTensorOp>,
+            builder: &mut dyn OpEmitter<StdTensorOp>,
             primal_in: &[GlobalValKey<StdTensorOp>],
             _primal_out: &[GlobalValKey<StdTensorOp>],
             tangent_in: &[Option<LocalValId>],
@@ -596,7 +595,7 @@ macro_rules! analytic_linearize {
     ($name:ident, $callee:path, primal_out) => {
         fn $name(
             _op: &StdTensorOp,
-            builder: &mut FragmentBuilder<StdTensorOp>,
+            builder: &mut dyn OpEmitter<StdTensorOp>,
             _primal_in: &[GlobalValKey<StdTensorOp>],
             primal_out: &[GlobalValKey<StdTensorOp>],
             tangent_in: &[Option<LocalValId>],
@@ -615,7 +614,7 @@ analytic_linearize!(linearize_tanh, analytic::linearize_tanh, primal_out);
 analytic_linearize!(linearize_sqrt, analytic::linearize_sqrt, primal_out);
 fn linearize_rsqrt(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -627,7 +626,7 @@ fn linearize_rsqrt(
 }
 fn linearize_pow(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -668,7 +667,7 @@ analytic_transpose!(transpose_log1p, analytic::transpose_log1p);
 
 fn linearize_dot_general(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -705,7 +704,7 @@ fn transpose_dot_general(
 
 fn linearize_reduce_sum(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -738,7 +737,7 @@ fn transpose_reduce_sum(
 
 fn linearize_reduce_prod(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -771,7 +770,7 @@ fn transpose_reduce_prod(
 
 fn linearize_reduce_max(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -787,7 +786,7 @@ fn linearize_reduce_max(
 
 fn linearize_reduce_min(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -837,7 +836,7 @@ fn transpose_reduce_min(
 
 fn linearize_transpose(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -869,7 +868,7 @@ fn transpose_transpose(
 
 fn linearize_reshape(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -899,7 +898,7 @@ fn transpose_reshape(
 
 fn linearize_broadcast_in_dim(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -934,7 +933,7 @@ fn transpose_broadcast_in_dim(
 
 fn linearize_convert(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -972,7 +971,7 @@ macro_rules! diagonal_rule {
     ($lin:ident, $trans:ident, $variant:ident, $lin_call:path, $trans_call:path) => {
         fn $lin(
             op: &StdTensorOp,
-            builder: &mut FragmentBuilder<StdTensorOp>,
+            builder: &mut dyn OpEmitter<StdTensorOp>,
             _primal_in: &[GlobalValKey<StdTensorOp>],
             _primal_out: &[GlobalValKey<StdTensorOp>],
             tangent_in: &[Option<LocalValId>],
@@ -1019,7 +1018,7 @@ macro_rules! triangular_rule {
     ($lin:ident, $trans:ident, $variant:ident, $lin_call:path, $trans_call:path) => {
         fn $lin(
             op: &StdTensorOp,
-            builder: &mut FragmentBuilder<StdTensorOp>,
+            builder: &mut dyn OpEmitter<StdTensorOp>,
             _primal_in: &[GlobalValKey<StdTensorOp>],
             _primal_out: &[GlobalValKey<StdTensorOp>],
             tangent_in: &[Option<LocalValId>],
@@ -1064,7 +1063,7 @@ triangular_rule!(
 
 fn linearize_gather(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1101,7 +1100,7 @@ fn transpose_gather(
 
 fn linearize_gather_dynamic_slice_sizes(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1162,7 +1161,7 @@ fn transpose_gather_dynamic_slice_sizes(
 
 fn linearize_scatter(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1199,7 +1198,7 @@ fn transpose_scatter(
 
 fn linearize_slice(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1234,7 +1233,7 @@ fn transpose_slice(
 
 fn linearize_dynamic_slice(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1270,7 +1269,7 @@ fn transpose_dynamic_slice(
 
 fn linearize_dynamic_update_slice(
     _op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1300,7 +1299,7 @@ fn transpose_dynamic_update_slice(
 
 fn linearize_pad(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1335,7 +1334,7 @@ fn transpose_pad(
 
 fn linearize_concatenate(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1373,7 +1372,7 @@ fn transpose_concatenate(
 
 fn linearize_reverse(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1406,7 +1405,7 @@ fn transpose_reverse(
 
 fn linearize_shape_of(
     _op: &StdTensorOp,
-    _builder: &mut FragmentBuilder<StdTensorOp>,
+    _builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     _tangent_in: &[Option<LocalValId>],
@@ -1428,7 +1427,7 @@ fn transpose_shape_of(
 
 fn linearize_dynamic_truncate(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1463,7 +1462,7 @@ fn transpose_dynamic_truncate(
 
 fn linearize_pad_to_match(
     op: &StdTensorOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -1500,7 +1499,7 @@ fn transpose_pad_to_match(
 
 fn linearize_constant(
     _op: &StdTensorOp,
-    _builder: &mut FragmentBuilder<StdTensorOp>,
+    _builder: &mut dyn OpEmitter<StdTensorOp>,
     _primal_in: &[GlobalValKey<StdTensorOp>],
     _primal_out: &[GlobalValKey<StdTensorOp>],
     _tangent_in: &[Option<LocalValId>],

--- a/tenferro-internal-ops/src/ad/semiring.rs
+++ b/tenferro-internal-ops/src/ad/semiring.rs
@@ -1,4 +1,3 @@
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 
@@ -7,7 +6,7 @@ use crate::ad::support::{conjugate_linear_if_dtype_complex, conjugate_primal_if_
 use crate::std_tensor_op::StdTensorOp;
 
 pub fn linearize_add(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
     match (tangent_in[0], tangent_in[1]) {
@@ -28,7 +27,7 @@ pub fn linearize_add(
 }
 
 pub fn linearize_mul(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
@@ -74,7 +73,7 @@ pub fn linearize_mul(
 }
 
 pub fn linearize_neg(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
 ) -> Vec<Option<LocalValId>> {
     match tangent_in[0] {
@@ -93,7 +92,7 @@ pub fn linearize_neg(
 }
 
 pub fn linearize_conj(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     ctx: &mut ShapeGuardContext,

--- a/tenferro-internal-ops/src/ad/structural.rs
+++ b/tenferro-internal-ops/src/ad/structural.rs
@@ -1,4 +1,3 @@
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use tenferro_tensor::{PadConfig, SliceConfig};
@@ -39,7 +38,7 @@ fn shape_exprs_match_primal_input(
 }
 
 pub fn linearize_transpose(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
     perm: &[usize],
 ) -> Vec<Option<LocalValId>> {
@@ -64,7 +63,7 @@ pub fn linearize_transpose(
 }
 
 pub fn linearize_reshape(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     op: &StdTensorOp,
@@ -102,7 +101,7 @@ pub fn linearize_reshape(
 }
 
 pub fn linearize_broadcast_in_dim(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     shape: &[DimExpr],
@@ -139,7 +138,7 @@ pub fn linearize_broadcast_in_dim(
 }
 
 pub fn linearize_convert(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
     from: tenferro_tensor::DType,
     to: tenferro_tensor::DType,
@@ -160,7 +159,7 @@ pub fn linearize_convert(
 }
 
 pub fn linearize_tril(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
     k: i64,
 ) -> Vec<Option<LocalValId>> {
@@ -180,7 +179,7 @@ pub fn linearize_tril(
 }
 
 pub fn linearize_triu(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
     k: i64,
 ) -> Vec<Option<LocalValId>> {
@@ -200,7 +199,7 @@ pub fn linearize_triu(
 }
 
 pub fn linearize_slice(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
     config: &SliceConfig,
 ) -> Vec<Option<LocalValId>> {
@@ -220,7 +219,7 @@ pub fn linearize_slice(
 }
 
 pub fn linearize_pad(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
     config: &PadConfig,
 ) -> Vec<Option<LocalValId>> {
@@ -240,7 +239,7 @@ pub fn linearize_pad(
 }
 
 pub fn linearize_concatenate(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     axis: usize,
@@ -281,7 +280,7 @@ pub fn linearize_concatenate(
 }
 
 pub fn linearize_reverse(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     tangent_in: &[Option<LocalValId>],
     axes: &[usize],
 ) -> Vec<Option<LocalValId>> {

--- a/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
+++ b/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
@@ -3,7 +3,6 @@
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, OpMode, ValRef};
 use tenferro_tensor::{CompareDir, DType};
-use tidu::PrimitiveOp;
 
 use crate::ad::context::ShapeGuardContext;
 use crate::input_key::TensorInputKey;
@@ -93,7 +92,7 @@ fn linearize_elementwise_inactive_inputs_return_none_without_ops() {
         StdTensorOp::Clamp,
     ] {
         let mut builder = FragmentBuilder::<StdTensorOp>::new();
-        let result = op.linearize(
+        let result = op.jvp_rule(
             &mut builder,
             &keys,
             &[input_key(4)],
@@ -116,7 +115,7 @@ fn linearize_div_with_two_active_inputs_sums_both_terms() {
     let mut ctx = ShapeGuardContext::default();
     let op = StdTensorOp::Div;
 
-    let result = op.linearize(
+    let result = op.jvp_rule(
         &mut builder,
         &[input_key(12), input_key(13)],
         &[input_key(14)],
@@ -138,7 +137,7 @@ fn linearize_extrema_and_select_emit_zero_fill_for_one_sided_tangents() {
 
     let mut max_builder = FragmentBuilder::<StdTensorOp>::new();
     let dx = max_builder.add_input(tensor_input(20));
-    let result = StdTensorOp::Maximum.linearize(
+    let result = StdTensorOp::Maximum.jvp_rule(
         &mut max_builder,
         &[input_key(21), input_key(22)],
         &[],
@@ -152,7 +151,7 @@ fn linearize_extrema_and_select_emit_zero_fill_for_one_sided_tangents() {
 
     let mut min_builder = FragmentBuilder::<StdTensorOp>::new();
     let dy = min_builder.add_input(tensor_input(23));
-    let result = StdTensorOp::Minimum.linearize(
+    let result = StdTensorOp::Minimum.jvp_rule(
         &mut min_builder,
         &[input_key(24), input_key(25)],
         &[],
@@ -173,7 +172,7 @@ fn linearize_clamp_builds_nested_selects_for_active_bounds() {
     let dupper = builder.add_input(tensor_input(32));
     let mut ctx = ShapeGuardContext::default();
 
-    let result = StdTensorOp::Clamp.linearize(
+    let result = StdTensorOp::Clamp.jvp_rule(
         &mut builder,
         &[input_key(33), input_key(34), input_key(35)],
         &[],

--- a/tenferro-internal-ops/src/ad/tests/indexing_tests.rs
+++ b/tenferro-internal-ops/src/ad/tests/indexing_tests.rs
@@ -3,7 +3,6 @@
 use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use tenferro_tensor::{DType, GatherConfig, ScatterConfig};
-use tidu::PrimitiveOp;
 
 use crate::ad::context::ShapeGuardContext;
 use crate::dim_expr::DimExpr;
@@ -66,7 +65,7 @@ fn linearize_gather_reuses_primal_indices_and_emits_gather() {
     let primal_in = vec![operand_key.clone(), indices_key.clone()];
     let tangent_in = [Some(operand_tangent), None];
 
-    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
@@ -98,7 +97,7 @@ fn linearize_gather_inactive_tangent_returns_none() {
     let primal_in = vec![operand_key, indices_key];
     let tangent_in: [Option<LocalValId>; 2] = [None, None];
 
-    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
     assert_eq!(result, vec![None]);
     assert!(builder.build().ops().is_empty());
 }
@@ -129,7 +128,7 @@ fn linearize_dynamic_gather_reuses_primal_indices_and_shape_sources() {
     let primal_in = vec![operand_key, indices_key.clone(), shape_source_key.clone()];
     let tangent_in = [Some(operand_tangent), None, None];
 
-    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
@@ -165,7 +164,7 @@ fn linearize_dynamic_slice_reuses_primal_starts() {
     let primal_in = vec![operand_key, starts_key.clone()];
     let tangent_in = [Some(operand_tangent), None];
 
-    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
@@ -198,7 +197,7 @@ fn linearize_dynamic_slice_inactive_tangent_returns_none() {
     let primal_in = vec![operand_key, starts_key];
     let tangent_in: [Option<LocalValId>; 2] = [None, None];
 
-    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
     assert_eq!(result, vec![None]);
     assert!(builder.build().ops().is_empty());
 }
@@ -217,7 +216,7 @@ fn linearize_dynamic_update_slice_reuses_primal_starts() {
     let primal_in = vec![operand_key, update_key, starts_key.clone()];
     let tangent_in = [Some(operand_tangent), Some(update_tangent), None];
 
-    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");

--- a/tenferro-internal-ops/src/ad/tests/indexing_tests/scatter.rs
+++ b/tenferro-internal-ops/src/ad/tests/indexing_tests/scatter.rs
@@ -11,7 +11,7 @@ fn linearize_scatter_inactive_tangents_returns_none() {
     let op = StdTensorOp::Scatter(rank1_scatter_config());
     let primal_in = vec![operand_key, indices_key, updates_key];
     let tangent_in: [Option<LocalValId>; 3] = [None, None, None];
-    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
     assert_eq!(result, vec![None]);
     assert!(builder.build().ops().is_empty());
 }
@@ -40,7 +40,7 @@ fn linearize_scatter_operand_only_is_identity_passthrough() {
     let primal_in = vec![operand_key, indices_key, updates_key];
     let tangent_in = [Some(operand_tangent), None, None];
 
-    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
     assert_eq!(
         result,
         vec![Some(operand_tangent)],
@@ -81,7 +81,7 @@ fn linearize_scatter_updates_only_uses_zero_operand() {
     ];
     let tangent_in = [None, None, Some(updates_tangent)];
 
-    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
     assert_eq!(result.len(), 1);
     let _ = result[0].expect("output tangent must be active");
 
@@ -152,7 +152,7 @@ fn linearize_scatter_both_tangents_emit_single_scatter() {
     let primal_in = vec![operand_key, indices_key.clone(), updates_key];
     let tangent_in = [Some(operand_tangent), None, Some(updates_tangent)];
 
-    let result = op.linearize(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
     assert_eq!(result.len(), 1);
     let _ = result[0].expect("output tangent must be active");
 

--- a/tenferro-internal-ops/src/ext_op.rs
+++ b/tenferro-internal-ops/src/ext_op.rs
@@ -25,7 +25,6 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
-use computegraph::fragment::FragmentBuilder;
 #[cfg(feature = "autodiff")]
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 #[cfg(feature = "autodiff")]
@@ -197,7 +196,7 @@ pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut FragmentBuilder<StdTensorOp>,
+        builder: &mut dyn OpEmitter<StdTensorOp>,
         primal_in: &[GlobalValKey<StdTensorOp>],
         primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
@@ -292,7 +291,7 @@ impl ExtensionRuleSet {
     ///     fn linearize(
     ///         &self,
     ///         _op: &dyn ExtensionOp,
-    ///         _builder: &mut FragmentBuilder<StdTensorOp>,
+    ///         _builder: &mut dyn OpEmitter<StdTensorOp>,
     ///         _primal_in: &[GlobalValKey<StdTensorOp>],
     ///         _primal_out: &[GlobalValKey<StdTensorOp>],
     ///         tangent_in: &[Option<LocalValId>],
@@ -350,7 +349,7 @@ impl ExtensionRuleSet {
     ///     fn linearize(
     ///         &self,
     ///         _op: &dyn ExtensionOp,
-    ///         _builder: &mut FragmentBuilder<StdTensorOp>,
+    ///         _builder: &mut dyn OpEmitter<StdTensorOp>,
     ///         _primal_in: &[GlobalValKey<StdTensorOp>],
     ///         _primal_out: &[GlobalValKey<StdTensorOp>],
     ///         tangent_in: &[Option<LocalValId>],
@@ -531,7 +530,7 @@ pub fn lookup_extension_rule(family_id: &str) -> Option<Arc<dyn ExtensionAdRule>
 #[cfg(feature = "autodiff")]
 pub fn linearize_extension_rule(
     op: &dyn ExtensionOp,
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -539,10 +538,7 @@ pub fn linearize_extension_rule(
 ) -> ADRuleResult<Vec<Option<LocalValId>>> {
     match ctx.lookup_extension_rule(op.family_id()) {
         Some(rule) => rule.linearize(op, builder, primal_in, primal_out, tangent_in, ctx),
-        None => Err(ADRuleError::unsupported(
-            op.family_id(),
-            ADRuleKind::Linearize,
-        )),
+        None => Err(ADRuleError::unsupported(op.family_id(), ADRuleKind::Jvp)),
     }
 }
 

--- a/tenferro-internal-ops/src/std_tensor_op.rs
+++ b/tenferro-internal-ops/src/std_tensor_op.rs
@@ -2,15 +2,11 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
-use computegraph::fragment::FragmentBuilder;
-#[cfg(feature = "autodiff")]
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
+use computegraph::types::{GlobalValKey, LocalValId, OpMode};
 use computegraph::GraphOp;
-#[cfg(feature = "autodiff")]
-use computegraph::OpEmitter;
 use num_complex::{Complex32, Complex64};
 #[cfg(feature = "autodiff")]
-use tidu::{ADRuleResult, PrimitiveOp};
+use tidu::{ADRuleResult, Primitive, PrimitiveBuilder, PrimitiveValue};
 
 use crate::dim_expr::DimExpr;
 use crate::ext_op::{ext_op_eq, hash_extension, ExtensionOp};
@@ -474,53 +470,106 @@ impl GraphOp for StdTensorOp {
 }
 
 #[cfg(feature = "autodiff")]
-impl PrimitiveOp for StdTensorOp {
+impl Primitive for StdTensorOp {
     type ADContext = crate::ad::context::ShapeGuardContext;
 
     fn add() -> Self {
         StdTensorOp::Add
     }
 
-    fn linearize(
+    fn jvp_rule(
         &self,
-        builder: &mut FragmentBuilder<Self>,
+        builder: &mut impl PrimitiveBuilder<Self>,
         primal_in: &[GlobalValKey<Self>],
         primal_out: &[GlobalValKey<Self>],
         tangent_in: &[Option<LocalValId>],
         ctx: &mut Self::ADContext,
     ) -> Vec<Option<LocalValId>> {
-        crate::ad::linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
+        let mut emitter = crate::ad::PrimitiveBuilderEmitter::new(builder);
+        crate::ad::linearize(self, &mut emitter, primal_in, primal_out, tangent_in, ctx)
     }
 
-    fn try_linearize(
+    fn try_jvp_rule(
         &self,
-        builder: &mut FragmentBuilder<Self>,
+        builder: &mut impl PrimitiveBuilder<Self>,
         primal_in: &[GlobalValKey<Self>],
         primal_out: &[GlobalValKey<Self>],
         tangent_in: &[Option<LocalValId>],
         ctx: &mut Self::ADContext,
     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
-        crate::ad::try_linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
+        let mut emitter = crate::ad::PrimitiveBuilderEmitter::new(builder);
+        crate::ad::try_linearize(self, &mut emitter, primal_in, primal_out, tangent_in, ctx)
     }
 
     fn transpose_rule(
         &self,
-        emitter: &mut impl OpEmitter<Self>,
+        builder: &mut impl PrimitiveBuilder<Self>,
         cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<Self>],
+        inputs: &[PrimitiveValue<Self>],
         mode: &OpMode,
         ctx: &mut Self::ADContext,
+    ) -> Vec<Option<LocalValId>> {
+        let inputs = inputs.iter().cloned().map(Into::into).collect::<Vec<_>>();
+        let mut emitter = crate::ad::PrimitiveBuilderEmitter::new(builder);
+        crate::ad::transpose_rule(self, &mut emitter, cotangent_out, &inputs, mode, ctx)
+    }
+
+    fn try_linear_transpose_rule(
+        &self,
+        builder: &mut impl PrimitiveBuilder<Self>,
+        cotangent_out: &[Option<LocalValId>],
+        inputs: &[PrimitiveValue<Self>],
+        mode: &OpMode,
+        ctx: &mut Self::ADContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        let inputs = inputs.iter().cloned().map(Into::into).collect::<Vec<_>>();
+        let mut emitter = crate::ad::PrimitiveBuilderEmitter::new(builder);
+        crate::ad::try_transpose_rule(self, &mut emitter, cotangent_out, &inputs, mode, ctx)
+    }
+}
+
+#[cfg(all(test, feature = "autodiff"))]
+impl StdTensorOp {
+    pub(crate) fn jvp_rule(
+        &self,
+        builder: &mut computegraph::fragment::FragmentBuilder<Self>,
+        primal_in: &[GlobalValKey<Self>],
+        primal_out: &[GlobalValKey<Self>],
+        tangent_in: &[Option<LocalValId>],
+        ctx: &mut crate::ad::context::ShapeGuardContext,
+    ) -> Vec<Option<LocalValId>> {
+        crate::ad::linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
+    }
+
+    pub(crate) fn try_jvp_rule(
+        &self,
+        builder: &mut computegraph::fragment::FragmentBuilder<Self>,
+        primal_in: &[GlobalValKey<Self>],
+        primal_out: &[GlobalValKey<Self>],
+        tangent_in: &[Option<LocalValId>],
+        ctx: &mut crate::ad::context::ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        crate::ad::try_linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
+    }
+
+    pub(crate) fn transpose_rule(
+        &self,
+        emitter: &mut impl computegraph::OpEmitter<Self>,
+        cotangent_out: &[Option<LocalValId>],
+        inputs: &[computegraph::ValRef<Self>],
+        mode: &OpMode,
+        ctx: &mut crate::ad::context::ShapeGuardContext,
     ) -> Vec<Option<LocalValId>> {
         crate::ad::transpose_rule(self, emitter, cotangent_out, inputs, mode, ctx)
     }
 
-    fn try_transpose_rule(
+    pub(crate) fn try_linear_transpose_rule(
         &self,
-        emitter: &mut impl OpEmitter<Self>,
+        emitter: &mut impl computegraph::OpEmitter<Self>,
         cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<Self>],
+        inputs: &[computegraph::ValRef<Self>],
         mode: &OpMode,
-        ctx: &mut Self::ADContext,
+        ctx: &mut crate::ad::context::ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
         crate::ad::try_transpose_rule(self, emitter, cotangent_out, inputs, mode, ctx)
     }

--- a/tenferro-internal-ops/src/tests/ext_op_tests.rs
+++ b/tenferro-internal-ops/src/tests/ext_op_tests.rs
@@ -130,7 +130,7 @@ impl ExtensionAdRule for CoverageRule {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        _builder: &mut FragmentBuilder<StdTensorOp>,
+        _builder: &mut dyn OpEmitter<StdTensorOp>,
         _primal_in: &[GlobalValKey<StdTensorOp>],
         _primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
@@ -208,7 +208,7 @@ fn explicit_empty_rule_set_does_not_fallback_to_global_registry() {
     let mut ctx = ShapeGuardContext::default().with_extension_rules(ExtensionRuleSet::new());
     let err = linearize_extension_rule(&op, &mut builder, &[], &[], &[Some(dx)], &mut ctx)
         .expect_err("explicit empty rule set must not consult global registry");
-    assert_eq!(err.rule(), ADRuleKind::Linearize);
+    assert_eq!(err.rule(), ADRuleKind::Jvp);
     assert!(err.to_string().contains(family));
 }
 
@@ -275,7 +275,7 @@ fn missing_registered_rule_helpers_return_ad_rule_errors() {
     let mut ctx = ShapeGuardContext::default();
     let linearize_err =
         linearize_extension_rule(&op, &mut builder, &[], &[], &[], &mut ctx).unwrap_err();
-    assert_eq!(linearize_err.rule(), ADRuleKind::Linearize);
+    assert_eq!(linearize_err.rule(), ADRuleKind::Jvp);
     assert!(linearize_err.to_string().contains(op.family_id()));
 
     let mut emitter = FragmentBuilder::<StdTensorOp>::new();

--- a/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use tenferro_tensor::{
     CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
 };
-use tidu::{ADRuleKind, ADRuleResult, PrimitiveOp};
+use tidu::{ADRuleKind, ADRuleResult, Primitive};
 
 use crate::input_key::TensorInputKey;
 
@@ -133,7 +133,7 @@ fn run_linearize_case(
             active.then(|| builder.add_input(tensor_input_key(300 + offset as u64)))
         })
         .collect();
-    let result = op.linearize(
+    let result = op.jvp_rule(
         &mut builder,
         &primal_in,
         &primal_out,
@@ -437,7 +437,7 @@ fn test_std_tensor_op_linearize_add_delegates_to_ad_module() {
     let dy = builder.add_input(TensorInputKey::User { id: 2 });
 
     let result =
-        StdTensorOp::add().linearize(&mut builder, &[], &[], &[Some(dx), Some(dy)], &mut ad_ctx);
+        StdTensorOp::add().jvp_rule(&mut builder, &[], &[], &[Some(dx), Some(dy)], &mut ad_ctx);
 
     assert_eq!(result.len(), 1);
     assert!(result[0].is_some());
@@ -529,7 +529,7 @@ fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation(
     );
     let tangent = builder.add_input(tensor_input_key(540));
     let real_linearized =
-        StdTensorOp::Conj.linearize(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+        StdTensorOp::Conj.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
     let real_linear_fragment = builder.build();
     assert_eq!(real_linearized, vec![Some(tangent)]);
     assert!(real_linear_fragment.ops().is_empty());
@@ -564,7 +564,7 @@ fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation(
     );
     let tangent = builder.add_input(tensor_input_key(560));
     let complex_linearized =
-        StdTensorOp::Conj.linearize(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+        StdTensorOp::Conj.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
     let complex_linear_fragment = builder.build();
     assert!(complex_linearized[0].is_some());
     assert_eq!(complex_linear_fragment.ops().len(), 1);
@@ -660,6 +660,65 @@ fn test_std_tensor_op_hash_covers_remaining_variants() {
 }
 
 #[test]
+fn test_std_tensor_op_reduce_prod_transpose_emits_product_rule() {
+    let (result, _, fragment) = run_transpose_case_with_input_shape(
+        StdTensorOp::ReduceProd { axes: vec![0] },
+        1,
+        &[true],
+        true,
+        Some(sym_shape(&[2, 3])),
+    );
+
+    assert!(result[0].is_some());
+    assert!(fragment.ops().iter().any(|instr| matches!(
+        &instr.op,
+        StdTensorOp::BroadcastInDim { dims, .. } if dims.as_slice() == [1]
+    )));
+    assert!(fragment.ops().iter().any(|instr| matches!(
+        &instr.op,
+        StdTensorOp::ReduceProd { axes } if axes.as_slice() == [0]
+    )));
+    assert!(fragment
+        .ops()
+        .iter()
+        .any(|instr| instr.op == StdTensorOp::Div));
+    assert_eq!(fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+}
+
+#[test]
+fn test_std_tensor_op_reduce_chooser_transpose_emits_tie_split_rule() {
+    let (result, _, fragment) = run_transpose_case_with_input_shape(
+        StdTensorOp::ReduceMax { axes: vec![0, 1] },
+        1,
+        &[true],
+        true,
+        Some(sym_shape(&[2, 3])),
+    );
+
+    assert!(result[0].is_some());
+    assert!(fragment.ops().iter().any(|instr| matches!(
+        &instr.op,
+        StdTensorOp::Reshape { to_shape } if to_shape.is_empty()
+    )));
+    assert!(fragment
+        .ops()
+        .iter()
+        .any(|instr| instr.op == StdTensorOp::Compare(CompareDir::Eq)));
+    assert!(fragment.ops().iter().any(|instr| matches!(
+        &instr.op,
+        StdTensorOp::ReduceSum { axes } if axes.as_slice() == [0, 1]
+    )));
+    assert!(fragment.ops().iter().any(|instr| {
+        instr.op
+            == StdTensorOp::Convert {
+                from: DType::Bool,
+                to: DType::F64,
+            }
+    }));
+    assert_eq!(fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+}
+
+#[test]
 fn test_std_tensor_op_pad_to_match_transpose_uses_static_slice_for_concrete_shape() {
     let (result, _, fragment) = run_transpose_case_with_input_shapes(
         StdTensorOp::PadToMatch { axis: 0 },
@@ -699,7 +758,7 @@ fn test_std_tensor_op_dynamic_truncate_linearize_uses_static_slice_for_narrowed_
         TensorMeta::exact(DType::F64, vec![SymDim::from(2usize)]),
     );
 
-    let result = StdTensorOp::DynamicTruncate { axis: 0 }.linearize(
+    let result = StdTensorOp::DynamicTruncate { axis: 0 }.jvp_rule(
         &mut builder,
         &primal_in,
         &primal_out,

--- a/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
+++ b/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
@@ -33,7 +33,7 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         to_shape: shape![2, 2],
     };
     let identity_reshape_result =
-        identity_reshape.linearize(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+        identity_reshape.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
     let identity_reshape_fragment = builder.build();
     assert_eq!(identity_reshape_result, vec![Some(tangent)]);
     assert!(identity_reshape_fragment.ops().is_empty());
@@ -78,7 +78,7 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         dims: vec![0, 1],
     };
     let identity_broadcast_result =
-        identity_broadcast.linearize(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+        identity_broadcast.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
     let identity_broadcast_fragment = builder.build();
     assert_eq!(identity_broadcast_result, vec![Some(tangent)]);
     assert!(identity_broadcast_fragment.ops().is_empty());
@@ -489,7 +489,7 @@ impl ExtensionAdRule for RuleOnlyIdentityAd {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        _builder: &mut FragmentBuilder<StdTensorOp>,
+        _builder: &mut dyn OpEmitter<StdTensorOp>,
         _primal_in: &[GlobalValKey<StdTensorOp>],
         _primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
@@ -520,7 +520,7 @@ fn extension_try_linearize_uses_registered_rule() {
     let mut ad_ctx = ShapeGuardContext::default();
     let dx = builder.add_input(tensor_input_key(900));
     let result = op
-        .try_linearize(&mut builder, &[], &[], &[Some(dx)], &mut ad_ctx)
+        .try_jvp_rule(&mut builder, &[], &[], &[Some(dx)], &mut ad_ctx)
         .expect("registered extension rule should linearize");
 
     assert_eq!(result, vec![Some(dx)]);
@@ -535,7 +535,7 @@ fn extension_try_transpose_uses_registered_rule() {
     let mut ad_ctx = ShapeGuardContext::default();
     let ct = builder.add_input(tensor_input_key(901));
     let result = op
-        .try_transpose_rule(
+        .try_linear_transpose_rule(
             &mut builder,
             &[Some(ct)],
             &external_inputs(910, 1),
@@ -555,9 +555,9 @@ fn extension_try_linearize_reports_missing_rule() {
     let mut ad_ctx = ShapeGuardContext::default();
     let dx = builder.add_input(tensor_input_key(920));
     let err = op
-        .try_linearize(&mut builder, &[], &[], &[Some(dx)], &mut ad_ctx)
+        .try_jvp_rule(&mut builder, &[], &[], &[Some(dx)], &mut ad_ctx)
         .expect_err("missing extension rule should be an AD error");
 
-    assert_eq!(err.rule(), ADRuleKind::Linearize);
+    assert_eq!(err.rule(), ADRuleKind::Jvp);
     assert!(err.to_string().contains(family));
 }

--- a/tenferro-linalg/src/ad.rs
+++ b/tenferro-linalg/src/ad.rs
@@ -85,13 +85,13 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
     fn linearize(
         &self,
         op: &dyn ExtensionOpTrait,
-        builder: &mut FragmentBuilder<StdTensorOp>,
+        builder: &mut dyn OpEmitter<StdTensorOp>,
         primal_in: &[GlobalValKey<StdTensorOp>],
         primal_out: &[GlobalValKey<StdTensorOp>],
         tangent_in: &[Option<LocalValId>],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
-        let op = downcast_ad_op(op, ADRuleKind::Linearize)?;
+        let op = downcast_ad_op(op, ADRuleKind::Jvp)?;
         let tangents = match op.op() {
             LinalgOp::Lu => rules::linearize_lu(builder, primal_in, primal_out, tangent_in, ctx),
             LinalgOp::FullPivLu => {

--- a/tenferro-linalg/src/ad/rules/mod.rs
+++ b/tenferro-linalg/src/ad/rules/mod.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 
 use crate::ad_support::{LinalgExtensionOp, LinalgOp};
@@ -50,7 +49,7 @@ fn linalg_std_op(op: LinalgOp) -> StdTensorOp {
 }
 
 pub(crate) fn linearize_lu(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -166,7 +165,7 @@ pub(crate) fn linearize_lu(
 }
 
 pub(crate) fn linearize_full_piv_lu(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -234,7 +233,7 @@ pub(crate) fn linearize_full_piv_lu(
 }
 
 pub(crate) fn linearize_eig(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -281,7 +280,7 @@ pub(crate) fn linearize_eig(
 }
 
 pub(crate) fn linearize_svd(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -454,7 +453,7 @@ pub(crate) fn linearize_svd(
 }
 
 pub(crate) fn linearize_eigh(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -522,7 +521,7 @@ pub(crate) fn linearize_eigh(
 }
 
 pub(crate) fn linearize_cholesky(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -588,7 +587,7 @@ pub(crate) fn linearize_cholesky(
 }
 
 pub(crate) fn linearize_qr(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],

--- a/tenferro-linalg/src/ad/rules/solve.rs
+++ b/tenferro-linalg/src/ad/rules/solve.rs
@@ -1,4 +1,3 @@
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use tenferro_ops::ad::context::ShapeGuardContext;
@@ -10,7 +9,7 @@ use super::support::*;
 use super::{conjugate_primal_if_dtype_complex, linalg_std_op};
 
 pub(crate) fn linearize_triangular_solve(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -93,7 +92,7 @@ fn linear_solve_op_name(kind: LinearSolveOp) -> &'static str {
 }
 
 fn linearize_linear_solve(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -148,7 +147,7 @@ fn linearize_linear_solve(
 }
 
 pub(crate) fn linearize_solve(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -167,7 +166,7 @@ pub(crate) fn linearize_solve(
 }
 
 pub(crate) fn linearize_full_piv_lu_solve(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_in: &[GlobalValKey<StdTensorOp>],
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
@@ -186,7 +185,7 @@ pub(crate) fn linearize_full_piv_lu_solve(
 }
 
 fn triangular_solve_rhs_tangent(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     primal_out: &[GlobalValKey<StdTensorOp>],
     tangent_in: &[Option<LocalValId>],
     left_side: bool,

--- a/tenferro-linalg/src/ad/rules/support.rs
+++ b/tenferro-linalg/src/ad/rules/support.rs
@@ -1,4 +1,3 @@
-use computegraph::fragment::FragmentBuilder;
 use computegraph::types::{LocalValId, OpMode, ValRef};
 use computegraph::OpEmitter;
 use tenferro_ops::dim_expr::DimExpr;
@@ -45,7 +44,7 @@ pub(super) fn solve_matrix_cotangent(
 }
 
 pub(super) fn solve_in_graph(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     a: ValRef<StdTensorOp>,
     b: ValRef<StdTensorOp>,
     rank: usize,
@@ -90,7 +89,7 @@ pub(super) fn fixed_unary(
 }
 
 pub(super) fn fixed_binary(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     op: StdTensorOp,
     lhs: ValRef<StdTensorOp>,
     rhs: ValRef<StdTensorOp>,
@@ -113,7 +112,7 @@ pub(super) fn linear_unary(
 }
 
 pub(super) fn linear_binary(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     op: StdTensorOp,
     lhs: LocalValId,
     rhs: LocalValId,
@@ -128,7 +127,7 @@ pub(super) fn linear_binary(
 }
 
 pub(super) fn fixed_add(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     lhs: ValRef<StdTensorOp>,
     rhs: ValRef<StdTensorOp>,
 ) -> LocalValId {
@@ -136,7 +135,7 @@ pub(super) fn fixed_add(
 }
 
 pub(super) fn fixed_mul(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     lhs: ValRef<StdTensorOp>,
     rhs: ValRef<StdTensorOp>,
 ) -> LocalValId {
@@ -144,7 +143,7 @@ pub(super) fn fixed_mul(
 }
 
 pub(super) fn fixed_div(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     lhs: ValRef<StdTensorOp>,
     rhs: ValRef<StdTensorOp>,
 ) -> LocalValId {
@@ -152,7 +151,7 @@ pub(super) fn fixed_div(
 }
 
 pub(super) fn fixed_scale(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: ValRef<StdTensorOp>,
     factor: f64,
 ) -> LocalValId {
@@ -165,7 +164,7 @@ pub(super) fn fixed_scale(
 }
 
 pub(super) fn broadcast_in_dim_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: ValRef<StdTensorOp>,
     shape: Vec<DimExpr>,
     dims: Vec<usize>,
@@ -174,7 +173,7 @@ pub(super) fn broadcast_in_dim_fixed(
 }
 
 pub(super) fn reduce_sum_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: ValRef<StdTensorOp>,
     axes: Vec<usize>,
 ) -> LocalValId {
@@ -182,7 +181,7 @@ pub(super) fn reduce_sum_fixed(
 }
 
 pub(super) fn pad_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: ValRef<StdTensorOp>,
     rank: usize,
     edge_padding_low: Vec<i64>,
@@ -200,7 +199,7 @@ pub(super) fn pad_fixed(
 }
 
 pub(super) fn fixed_sub(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     lhs: ValRef<StdTensorOp>,
     rhs: ValRef<StdTensorOp>,
 ) -> LocalValId {
@@ -209,7 +208,7 @@ pub(super) fn fixed_sub(
 }
 
 pub(super) fn linear_add(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     lhs: LocalValId,
     rhs: LocalValId,
 ) -> LocalValId {
@@ -224,7 +223,7 @@ pub(super) fn linear_neg(
 }
 
 pub(super) fn linear_scale(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: LocalValId,
     factor: f64,
 ) -> LocalValId {
@@ -239,7 +238,7 @@ pub(super) fn linear_scale(
 }
 
 pub(super) fn linear_sub(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     lhs: LocalValId,
     rhs: LocalValId,
 ) -> LocalValId {
@@ -248,7 +247,7 @@ pub(super) fn linear_sub(
 }
 
 pub(super) fn linear_div_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     lhs: LocalValId,
     rhs: ValRef<StdTensorOp>,
 ) -> LocalValId {
@@ -262,7 +261,7 @@ pub(super) fn linear_div_fixed(
 }
 
 pub(super) fn hadamard_fixed_linear(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     fixed: ValRef<StdTensorOp>,
     active: LocalValId,
 ) -> LocalValId {
@@ -276,7 +275,7 @@ pub(super) fn hadamard_fixed_linear(
 }
 
 pub(super) fn one_like_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     anchor: ValRef<StdTensorOp>,
 ) -> LocalValId {
     let zero = fixed_sub(builder, anchor.clone(), anchor);
@@ -284,7 +283,7 @@ pub(super) fn one_like_fixed(
 }
 
 pub(super) fn extract_diag_linear(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: LocalValId,
 ) -> LocalValId {
     builder.add_op(
@@ -300,7 +299,7 @@ pub(super) fn extract_diag_linear(
 }
 
 pub(super) fn embed_diag_linear(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: LocalValId,
 ) -> LocalValId {
     builder.add_op(
@@ -316,7 +315,7 @@ pub(super) fn embed_diag_linear(
 }
 
 pub(super) fn embed_diag_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: ValRef<StdTensorOp>,
 ) -> LocalValId {
     fixed_unary(
@@ -354,7 +353,7 @@ pub(super) fn adjoint_matrix_fixed(
 }
 
 pub(super) fn adjoint_matrix_linear(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: LocalValId,
     rank: usize,
     dtype: DType,
@@ -406,7 +405,7 @@ pub(super) fn project_triangular_operand_linear(
 }
 
 pub(super) fn self_adjoint_from_lower_linear(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: LocalValId,
     rank: usize,
     dtype: DType,
@@ -434,7 +433,7 @@ pub(super) fn self_adjoint_from_lower_linear(
 }
 
 pub(super) fn matmul_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     lhs: ValRef<StdTensorOp>,
     rhs: ValRef<StdTensorOp>,
     rank: usize,
@@ -514,7 +513,7 @@ pub(super) fn vector_to_matrix_broadcast_dims(batch_ndim: usize) -> Vec<usize> {
 }
 
 pub(super) fn leading_column_selector_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     leading_cols: usize,
     total_cols: usize,
     batch_shape: &[DimExpr],
@@ -533,7 +532,7 @@ pub(super) fn leading_column_selector_fixed(
 }
 
 pub(super) fn trailing_column_selector_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     leading_cols: usize,
     trailing_cols: usize,
     batch_shape: &[DimExpr],
@@ -552,7 +551,7 @@ pub(super) fn trailing_column_selector_fixed(
 }
 
 pub(super) fn identity_matrix_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     size: usize,
     batch_shape: &[DimExpr],
     anchor: ValRef<StdTensorOp>,
@@ -569,7 +568,7 @@ pub(super) fn identity_matrix_fixed(
 }
 
 pub(super) fn scalar_one_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     anchor: ValRef<StdTensorOp>,
     anchor_shape: &[DimExpr],
 ) -> LocalValId {
@@ -600,7 +599,7 @@ pub(super) fn pad_matrix_low(rank: usize, row_amount: i64, col_amount: i64) -> V
 }
 
 pub(super) fn augment_unit_lower_to_square_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     l: ValRef<StdTensorOp>,
     rows: usize,
     cols: usize,
@@ -629,7 +628,7 @@ pub(super) fn augment_unit_lower_to_square_fixed(
 }
 
 pub(super) fn augment_upper_to_square_fixed(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     u: ValRef<StdTensorOp>,
     rows: usize,
     cols: usize,
@@ -665,7 +664,7 @@ pub(super) fn augment_upper_to_square_fixed(
 }
 
 pub(super) fn take_leading_cols_linear(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: LocalValId,
     cols: usize,
     total_cols: usize,
@@ -687,7 +686,7 @@ pub(super) fn take_leading_cols_linear(
 }
 
 pub(super) fn take_leading_rows_linear(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut dyn OpEmitter<StdTensorOp>,
     input: LocalValId,
     rows: usize,
     total_rows: usize,


### PR DESCRIPTION
## Summary
- Update the tidu-rs dependency to f0d91566edb2ea08fac9d61ef26f9cd1754f02df.
- Migrate tenferro-rs and ext/tropical from the old tidu eager/AD API to the JAX-aligned Primitive, JVP, linearize, and linear transpose API.
- Add PrimitiveBuilder adapters so existing OpEmitter-based AD rule bodies and eager backward execution can consume the new tidu builder boundary.
- Add direct reduction linear-transpose rule coverage for ReduceProd and ReduceMax tie-splitting paths.

## Verification
- cargo check -p tenferro-ad
- cargo check --workspace --all-targets
- cargo check --manifest-path ext/tropical/Cargo.toml --features autodiff --all-targets
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
- cargo nextest run --workspace --release --no-fail-fast
- cargo test --doc --workspace --release
- cargo test -p tenferro-cpu --test inject_tests --release --no-default-features --features "cpu-blas,provider-inject"
- scripts/check-tensor-core-deps.sh
- bash scripts/build_docs_site.sh
- cargo llvm-cov --workspace --release --json --output-path coverage.json && python3 scripts/check-coverage.py coverage.json