### PR TITLE
[codex] add explicit GPU synchronization API

### DIFF
--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -87,6 +87,12 @@ part of unrelated GPU or documentation work.
 CUDA client for one device. GPU kernels are JIT-compiled by CubeCL, so local
 CUDA toolkit configuration matters.
 
+`CubeclRuntime::synchronize()` is the explicit host-side barrier for direct GPU
+backend code. It synchronizes the current CubeCL CUDA stream and does not
+download tensor data. Higher-level eager CUDA execution exposes the same barrier
+through `EagerRuntime::synchronize()`, with CPU eager runtimes treating the call
+as a no-op.
+
 cuTENSOR, cuSOLVER, and cuBLAS are loaded lazily through the FFI layer. The
 backend first uses default soname/path candidates and allows explicit override
 with these variables:

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -30,13 +30,18 @@ memory, but tenferro does not use that copy as a hidden CPU/GPU transfer.
 ## Eager GPU Synchronization
 
 Eager CUDA execution submits work immediately and returns a CUDA-resident
-`Tensor` handle. It does not expose a user-visible ready flag, and normal
-kernel launches do not imply host synchronization after every op. Subsequent
-CUDA ops can consume the returned handle on the same backend stream.
+`Tensor` handle. Normal kernel launches do not imply host synchronization after
+every op. Subsequent CUDA ops can consume the returned handle on the same
+backend stream.
 
 The host waits when a value is downloaded or otherwise inspected on the host.
 Some library-backed operations also synchronize internally when they must read
 device-side status.
+
+Use `EagerRuntime::synchronize()` when code needs an explicit host-side barrier
+for the eager runtime. CPU runtimes return immediately; CUDA runtimes wait for
+the current backend stream. Direct GPU backend code can call
+`CubeclRuntime::synchronize()` through `backend.runtime()`.
 
 For a time-axis diagram, see [Execution Models](execution-models.md).
 

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -35,8 +35,9 @@ provided by the separate `tenferro-einsum` standard extension.
 
 For CUDA, eager means the operation is submitted immediately. It does not mean
 the host waits after every GPU kernel. Host synchronization happens at
-download/read boundaries or inside operations that must inspect device-side
-status. See [Execution Models](execution-models.md) and
+download/read boundaries, through `EagerRuntime::synchronize()`, or inside
+operations that must inspect device-side status. See
+[Execution Models](execution-models.md) and
 [Devices and GPU](devices-and-gpu.md).
 
 ## Creating tensors

--- a/docs/guides/execution-models.md
+++ b/docs/guides/execution-models.md
@@ -30,7 +30,8 @@ Subsequent CUDA ops can consume that handle on the same backend stream.
 
 The host waits when values are downloaded or otherwise need host inspection.
 Some library-backed operations also synchronize internally when they must read
-device-side status.
+device-side status. Call `EagerRuntime::synchronize()` when a workflow needs an
+explicit host-side barrier without downloading tensor values.
 
 ## Traced Mode
 

--- a/docs/worklogs/2026-06-01-gpu-synchronize-api.md
+++ b/docs/worklogs/2026-06-01-gpu-synchronize-api.md
@@ -1,0 +1,71 @@
+# GPU synchronize API work log
+
+Date: 2026-06-01
+
+## Session summary
+
+This change adds an explicit host-side synchronization API for eager and direct
+CUDA backend execution:
+
+- `EagerRuntime::synchronize()` for eager code,
+- `CubeclRuntime::synchronize()` for direct CubeCL CUDA backend integrations.
+
+Eager CPU runtimes return immediately. Eager CUDA runtimes synchronize the
+current backend stream without downloading tensor data.
+
+The CubeCL module-level doctest was also guarded with `gpu_available()` so
+CUDA-feature doctests remain portable on machines without `libcuda`.
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| `AGENTS.md` | Confirm repository workflow, GPU-code requirements, and work-log expectations. | Read the GPU design document before changing CUDA runtime code and added this work log. |
+| `REPOSITORY_RULES.md` | Review public API and documentation expectations. | Kept the API small and documented the synchronization boundary. |
+| `docs/design/gpu-backend-design.md` | Confirm CubeCL runtime ownership and transfer policy. | Implemented a stream synchronization barrier rather than implicit tensor downloads. |
+| `tenferro-gpu/src/cubecl/runtime.rs` | Locate CUDA context and raw stream access. | Added synchronization beside existing runtime stream APIs. |
+| `tenferro-ad/src/eager.rs` and `tenferro-ad/src/eager_backend.rs` | Locate eager runtime backend ownership. | Routed eager synchronization through the existing backend mutex. |
+| `tenferro-linalg/src/gpu/linalg.rs` | Check existing CUDA stream synchronization usage. | Reused the same `cudaStreamSynchronize` approach on the CubeCL raw stream. |
+| `tenferro-gpu/src/cubecl/mod.rs` | Investigate a CUDA-feature doctest failure on a no-GPU host. | Guarded the module quickstart with `gpu_available()`, matching other GPU docs examples. |
+
+## Decisions made
+
+- **Use `synchronize`, not `wait`.** The name matches CUDA and PyTorch
+  terminology and describes a backend-wide stream barrier better than a tensor
+  readiness flag.
+- **Keep synchronization explicit.** Normal eager CUDA ops still submit work and
+  return CUDA-resident handles without host blocking after every kernel.
+- **Synchronize the current CubeCL CUDA stream.** The method waits for work on
+  the active backend stream and does not copy tensor payloads to host memory.
+- **Make CPU eager synchronization a no-op.** This keeps the API portable across
+  eager backends.
+
+## Rejected or deferred alternatives
+
+- **No implicit eager wait after every GPU op.** That would remove useful CUDA
+  overlap and make eager GPU behavior unnecessarily different from PyTorch-style
+  asynchronous CUDA execution.
+- **No tensor-level ready flag.** The current backend surface has one stream
+  boundary; per-tensor readiness would be a broader async ownership design.
+- **No stream/event API in this change.** A richer stream/event surface can build
+  on this primitive later if the backend exposes multiple public streams.
+
+## Verification performed
+
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-ad eager_runtime_synchronize_is_available_and_cpu_noop`
+- `cargo test -p tenferro-ad --test eager_runtime_api`
+- `cargo test -p tenferro-ad --features cuda --test eager_runtime_api`
+- `cargo test -p tenferro-gpu --test cubecl_launch_contract`
+- `cargo test -p tenferro-gpu --features cuda --test cubecl_launch_contract`
+- `cargo check -p tenferro-ad --features cuda`
+- `cargo check -p tenferro-gpu --features cuda --example cuda_quickstart`
+- `cargo test --doc -p tenferro-ad`
+- `cargo test --doc -p tenferro-gpu --features cuda`
+- `git diff --check`
+
+## Remaining risk
+
+- Local verification compile-checks the CUDA synchronization API and doctests,
+  but does not run ignored GPU hardware tests. A CUDA machine should run the
+  ignored GPU suite before depending on hardware-level behavior changes.

--- a/tenferro-ad/src/eager.rs
+++ b/tenferro-ad/src/eager.rs
@@ -342,6 +342,27 @@ impl EagerRuntime {
             .set_cache_limits(limits);
     }
 
+    /// Block the current thread until backend work submitted by this eager runtime completes.
+    ///
+    /// CPU runtimes return immediately. CUDA runtimes synchronize the current backend stream.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_ad::EagerRuntime;
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// ctx.synchronize().unwrap();
+    /// ```
+    pub fn synchronize(&self) -> Result<()> {
+        self.backend
+            .lock()
+            .unwrap()
+            .synchronize()
+            .map_err(Error::from)
+    }
+
     pub(crate) fn exec_outputs(&self, op: &StdTensorOp, inputs: &[&Tensor]) -> Result<Vec<Tensor>> {
         let mut backend =
             profile_eager_op_section("exec_outputs.lock_backend", || self.backend.lock().unwrap());

--- a/tenferro-ad/src/eager_backend.rs
+++ b/tenferro-ad/src/eager_backend.rs
@@ -24,6 +24,14 @@ impl EagerBackend {
     pub(crate) fn cuda(backend: CubeclBackend) -> Self {
         Self::Cuda(backend)
     }
+
+    pub(crate) fn synchronize(&mut self) -> TensorResult<()> {
+        match self {
+            Self::Cpu(_) => Ok(()),
+            #[cfg(feature = "cuda")]
+            Self::Cuda(backend) => backend.runtime().synchronize(),
+        }
+    }
 }
 
 macro_rules! dispatch {

--- a/tenferro-ad/tests/eager_runtime_api.rs
+++ b/tenferro-ad/tests/eager_runtime_api.rs
@@ -17,3 +17,10 @@ fn eager_runtime_replaces_eager_context_public_name() {
     runtime.clear_grads();
     assert!(x.grad().is_none());
 }
+
+#[test]
+fn eager_runtime_synchronize_is_available_and_cpu_noop() {
+    let runtime = EagerRuntime::with_cpu_backend(CpuBackend::new());
+
+    runtime.synchronize().unwrap();
+}

--- a/tenferro-gpu/src/cubecl/mod.rs
+++ b/tenferro-gpu/src/cubecl/mod.rs
@@ -36,10 +36,14 @@
 //! convention).
 //!
 //! ```rust
-//! use tenferro_gpu::cubecl::{CubeclBackend, upload_tensor, download_tensor};
+//! use tenferro_gpu::cubecl::{download_tensor, gpu_available, upload_tensor, CubeclBackend};
 //! use tenferro_tensor::{Tensor, TensorElementwise, TypedTensor};
 //!
 //! fn main() -> tenferro_tensor::Result<()> {
+//! if !gpu_available() {
+//!     return Ok(());
+//! }
+//!
 //! // 1. Create the GPU backend (device ordinal 0)
 //! let mut backend = CubeclBackend::new(0)?;
 //!

--- a/tenferro-gpu/src/cubecl/runtime.rs
+++ b/tenferro-gpu/src/cubecl/runtime.rs
@@ -5,6 +5,7 @@ use cubecl::stream_id::StreamId;
 use cubecl::Runtime;
 use cubecl_cuda::{CudaDevice, CudaRuntime};
 use cudarc::driver::sys::{CUcontext, CUdevice};
+use cudarc::runtime::{result as cuda_result, sys::cudaStream_t};
 
 /// Returns `true` if a CUDA device is available for CubeCL.
 ///
@@ -27,6 +28,8 @@ pub fn gpu_available() -> bool {
 /// let _ctor: fn(usize) -> tenferro_tensor::Result<CubeclRuntime> = CubeclRuntime::new;
 /// let _stream: fn(&CubeclRuntime) -> tenferro_tensor::Result<u64> =
 ///     CubeclRuntime::raw_cuda_stream;
+/// let _sync: fn(&CubeclRuntime) -> tenferro_tensor::Result<()> =
+///     CubeclRuntime::synchronize;
 /// ```
 pub struct CubeclRuntime {
     client: ComputeClient<CudaRuntime>,
@@ -157,6 +160,25 @@ impl CubeclRuntime {
             .ok_or_else(|| {
                 crate::Error::backend_failure("raw_cuda_stream", "with_server returned None")
             })?
+    }
+
+    /// Block the current thread until work submitted to the current CUDA stream completes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::cubecl::CubeclRuntime;
+    ///
+    /// let _sync: fn(&CubeclRuntime) -> tenferro_tensor::Result<()> =
+    ///     CubeclRuntime::synchronize;
+    /// ```
+    pub fn synchronize(&self) -> crate::Result<()> {
+        const OP: &str = "cubecl_runtime_synchronize";
+        self.set_current_cuda_context(OP)?;
+        let stream = self.raw_cuda_stream()? as usize as cudaStream_t;
+        unsafe { cuda_result::stream::synchronize(stream) }.map_err(|err| {
+            crate::Error::backend_failure(OP, format!("CUDA stream synchronize failed: {err:?}"))
+        })
     }
 }
 

--- a/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -71,3 +71,10 @@ fn cubecl_i64_index_conversion_does_not_roundtrip_through_host() {
         violations.join("\n")
     );
 }
+
+#[cfg(feature = "cuda")]
+#[test]
+fn cubecl_runtime_exposes_explicit_synchronize() {
+    let _sync: fn(&tenferro_gpu::CubeclRuntime) -> tenferro_tensor::Result<()> =
+        tenferro_gpu::CubeclRuntime::synchronize;
+}


### PR DESCRIPTION
## Summary

Adds an explicit host-side synchronization API for eager and direct CubeCL CUDA execution.

- Add `EagerRuntime::synchronize()` as the eager-level barrier.
- Add `CubeclRuntime::synchronize()` as the direct GPU runtime barrier using the current CubeCL CUDA stream.
- Keep CPU eager synchronization as a no-op.
- Document eager GPU synchronization behavior and add a work log.
- Guard the CubeCL module quickstart doctest with `gpu_available()` so CUDA-feature doctests remain portable without `libcuda`.

## Why

Eager CUDA execution submits work immediately but should not force host synchronization after every operation. This gives users an explicit barrier for benchmarks, FFI boundaries, and timing/debug workflows without changing normal asynchronous CUDA behavior or downloading tensor payloads.

## Validation

- `cargo fmt --all --check && git diff --check`
- `cargo test -p tenferro-ad --test eager_runtime_api`
- `cargo test -p tenferro-ad --features cuda --test eager_runtime_api`
- `cargo test -p tenferro-gpu --test cubecl_launch_contract`
- `cargo test -p tenferro-gpu --features cuda --test cubecl_launch_contract`
- `cargo check -p tenferro-ad --features cuda`
- `cargo check -p tenferro-gpu --features cuda --example cuda_quickstart`
- `cargo test --doc -p tenferro-ad`
- `cargo test --doc -p tenferro-gpu --features cuda`

## Notes

Ignored GPU hardware tests were not run in this local environment.