### PR TITLE
[codex] migrate graph terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,9 +293,9 @@ Internal: tenferro-core-ops  - Internal core primitive operation catalog
           tenferro-internal-extension-macros - Extension-op registration macros
 ```
 
-`chainrules-rs` defines the generic `PrimitiveOp` AD contract, independent of
-any tensor type. `tidu-rs` owns generic graph transforms such as
-`differentiate` and `transpose`.
+`tidu-rs` defines the generic `Primitive` AD contract, independent of any
+tensor type, and owns graph transforms such as `linearize` and
+`linear_transpose`.
 `tenferro-tensor-core` owns the lightweight host tensor data model.
 `tenferro-tensor` owns concrete dense runtime value types and CPU backend
 execution surface. `tenferro-gpu` owns CubeCL/CUDA backend code and transfer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "f0d91566edb2ea08fac9d61ef26f9cd1754f02df" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "9934d8b775fcfbbad8e2daf3f9af54477da63e35" }
 strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722" }
 strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "ea37986f4d9cb99cfc1f62a1d4aea561cb3a9722", features = ["parallel"] }
@@ -61,4 +61,4 @@ cubecl-cuda = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec1
 cubecl-runtime = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
 sha2 = "0.10"
 omeco = "0.2.4"
-computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "c20e8912560ef11166418bcea089126ef50443cc" }
+computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7" }

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -128,10 +128,10 @@ rules from `tensor4all-agent-rules`.
 
 ## Rule Source Of Truth
 
-- `PrimitiveOp::linearize` and `PrimitiveOp::transpose_rule` (in `tenferro-internal-ops/src/ad/`)
+- `Primitive::linearize` and `Primitive::transpose_rule` (in `tenferro-internal-ops/src/ad/`)
   are the semantic source of truth for AD rules.
-- These are graph-level rules that emit ops into a `FragmentBuilder`.
-  `tidu::differentiate` calls `linearize`; `tidu::transpose` calls `transpose_rule`.
+- These are graph-level rules that add ops into a `GraphBuilder`.
+  `tidu::linearize` calls `linearize`; `tidu::linear_transpose` calls `transpose_rule`.
 - The canonical tenferro AD model is graph-level `linearize` plus
   `transpose_rule`. Do not model tensor primitive AD by implementing
   `chainrules_core::ReverseRule<StdTensorOp>` or `ForwardRule<StdTensorOp>`;
@@ -147,7 +147,7 @@ rules from `tensor4all-agent-rules`.
   transposing the emitted linear primitive graph. Before filing or closing an
   AD support issue, check the machine-readable AD support manifest in
   `tenferro-internal-ops/src/ad/support.rs`; `SupportedViaLinearize` means a missing
-  direct transpose arm is intentional.
+  direct `transpose_rule` arm is intentional.
 - Reference JAX's implementations (`jax/_src/lax/lax.py`, `jax/_src/lax/linalg.py`)
   when implementing new AD rules.
 
@@ -466,7 +466,7 @@ Tests follow implementation ownership.
   `tenferro_ad`, `tenferro_gpu`, and standard extension crates. Do not
   reference internal crates (`tenferro-internal-ops`, `computegraph`, etc.) in
   user-facing docs.
-- Do NOT expose internal jargon (Fragment, StableHLO, ExecOp, ValRef, etc.) in user-facing pages.
+- Do NOT expose internal jargon (Graph, StableHLO, ExecOp, ValueRef, etc.) in user-facing pages.
 - Provide PyTorch/JAX equivalents when introducing tenferro concepts.
 
 ### User-Facing Code Snippet Consistency

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -70,7 +70,7 @@ website:
               - architecture/index.md
               - architecture/tenferro-crates.md
               - architecture/computegraph.md
-              - architecture/chainrules.md
+              - architecture/primitive-ad.md
               - architecture/tidu.md
               - architecture/ad-pipeline.md
           - section: "Specification"

--- a/docs/architecture/ad-pipeline.md
+++ b/docs/architecture/ad-pipeline.md
@@ -1,8 +1,8 @@
 # AD Architecture
 
-**Repos:** chainrules-rs, tidu-rs, tenferro-rs
+**Repos:** computegraph-rs, tidu-rs, tenferro-rs
 **Parent:** `../index.md`
-**Related:** `computegraph.md`, `chainrules.md`, `tidu.md`, `../spec/backend-contract.md`, `../spec/primitive-catalog.md`
+**Related:** `computegraph.md`, `primitive-ad.md`, `tidu.md`, `../spec/backend-contract.md`, `../spec/primitive-catalog.md`
 
 ---
 
@@ -10,11 +10,11 @@
 
 Build a differentiable programming stack in Rust where:
 
-- `differentiate` is the only derivative-producing transform. It consumes a
-  resolved logical view of computation and produces a new linear fragment.
-- `transpose` is not differentiation. It reverses active linear flow in a
-  linear fragment and reuses the same derivative information.
-- AD transforms operate on **fragments**, not on a single eagerly merged
+- `linearize` is the only derivative-producing transform. It consumes a
+  resolved logical view of computation and produces a new linear graph.
+- `linear_transpose` is not differentiation. It reverses active linear flow in a
+  linear graph and reuses the same derivative information.
+- AD transforms operate on **graphs**, not on a single eagerly merged
   graph.
 - What higher-order AD needs is **resolve**, not physical merge. External
   references must be traceable; they do not need to be copied into one graph
@@ -27,10 +27,10 @@ Build a differentiable programming stack in Rust where:
 This is the intended operation set:
 
 ```text
-build             user constructs a primal fragment
-resolve           create a logical DAG view over one or more fragments
-differentiate     resolved view -> new linear fragment (JVP)
-transpose         linear fragment -> new linear fragment (reverse linear flow)
+build             user constructs a primal graph
+resolve           create a logical DAG view over one or more graphs
+linearize         resolved view -> new linear graph (JVP)
+linear_transpose  linear graph -> new linear graph (reverse linear flow)
 materialize_merge resolved view -> MaterializedGraph (flatten + CSE)
 compile           MaterializedGraph -> CompiledProgram
 eval              CompiledProgram + input values -> output values
@@ -39,13 +39,13 @@ eval              CompiledProgram + input values -> output values
 The key pipeline distinction is:
 
 ```text
-differentiate -> resolve -> differentiate -> resolve -> ...
+linearize -> resolve -> linearize -> resolve -> ...
 ```
 
 not
 
 ```text
-differentiate -> physical merge -> differentiate -> physical merge -> ...
+linearize -> physical merge -> linearize -> physical merge -> ...
 ```
 
 `materialize_merge` is still required, but only when a backend, serializer, or
@@ -55,29 +55,27 @@ Typical pipelines:
 
 ```text
 JVP:
-  build -> resolve -> differentiate -> materialize_merge -> compile -> eval
+  build -> resolve -> linearize -> materialize_merge -> compile -> eval
 
 VJP:
-  build -> resolve -> differentiate -> transpose -> materialize_merge -> compile -> eval
+  build -> resolve -> linearize -> linear_transpose -> materialize_merge -> compile -> eval
 
 2nd directional derivative:
-  build -> resolve -> differentiate -> resolve -> differentiate -> materialize_merge -> compile -> eval
+  build -> resolve -> linearize -> resolve -> linearize -> materialize_merge -> compile -> eval
 
 n-th derivative:
-  build -> (resolve -> differentiate) x n -> [transpose] -> materialize_merge -> compile -> eval
+  build -> (resolve -> linearize) x n -> [linear_transpose] -> materialize_merge -> compile -> eval
 ```
 
 Four crates, strictly layered:
 
 ```text
-computegraph   GraphOp + Operand traits, Fragment, resolve,
+computegraph   GraphOperation + Operand traits, Graph, resolve,
                materialize_merge, compile (SSA), eval,
                compilation cache
     ↓
-chainrules     PrimitiveOp: GraphOp (adds add + linearize + transpose_rule)
-    ↓
-tidu           differentiate, transpose — generic AD transforms
-               over PrimitiveOp; no graph infrastructure of its own
+tidu           Primitive: GraphOperation (adds add + JVP + transpose_rule),
+               linearize, linear_transpose; no graph infrastructure of its own
     ↓
 tenferro       Concrete tensor primitives + execution lowering
 ```
@@ -85,22 +83,22 @@ tenferro       Concrete tensor primitives + execution lowering
 `computegraph` provides the general-purpose computation graph engine. It is
 usable without AD (e.g. multi-tensor einsum as a graph of binary
 contractions). `tidu` is a thin layer that adds AD-specific graph transforms
-(`differentiate`, `transpose`), fully generic over `Op: PrimitiveOp`.
+(`linearize`, `linear_transpose`), fully generic over `Op: Primitive`.
 Neither `computegraph` nor `tidu` references specific primitives. The
 responsibility for ensuring that `linearize` and `transpose_rule` produce
-valid, closed fragments belongs entirely to the downstream primitive
+valid, closed graphs belongs entirely to the downstream primitive
 implementor (tenferro).
 
 ---
 
 ## II. Core Model
 
-### Fragment vs MaterializedGraph
+### Graph vs MaterializedGraph
 
-A **Fragment** is the unit produced by `build`, `differentiate`, and
-`transpose`.
+A **Graph** is the unit produced by `build`, `linearize`, and
+`linear_transpose`.
 
-A fragment:
+A graph:
 
 - owns only its **local** nodes and ops
 - may reference values defined elsewhere through external references
@@ -116,46 +114,46 @@ by `materialize_merge`:
 So the intended mental model is:
 
 ```text
-Fragment          = transform-time object
+Graph          = transform-time object
 ResolvedView      = logical traversal object
 MaterializedGraph = compile-time object
 ```
 
 ### Local ids are local only
 
-Local ids are fragment-scoped. They must not be used as cross-fragment
+Local ids are graph-scoped. They must not be used as cross-graph
 identity.
 
 ```rust
-type LocalValId = usize;
-type LocalOpId = usize;
+type LocalValueId = usize;
+type LocalOperationId = usize;
 
-enum ValRef<Op: GraphOp> {
-    Local(LocalValId),
-    External(GlobalValKey<Op>),
+enum ValueRef<Op: GraphOperation> {
+    Local(LocalValueId),
+    External(ValueKey<Op>),
 }
 
-enum GlobalValKey<Op: GraphOp> {
+enum ValueKey<Op: GraphOperation> {
     Input(Op::InputKey),
     Derived {
-        op: GlobalOpKey<Op>,
+        operation: Arc<OperationKey<Op>>,
         output_slot: u8,
     },
 }
 
-struct GlobalOpKey<Op> {
-    primitive: Op,
-    inputs: Vec<GlobalValKey<Op>>,
-    mode: OpMode,
+struct OperationKey<Op> {
+    operation: Op,
+    inputs: Vec<ValueKey<Op>>,
+    role: OperationRole,
 }
 
-enum OpMode {
-    Primal,
-    Linear { active_mask: Vec<bool> },
+enum OperationRole {
+    Primary,
+    Linearized { active_mask: Vec<bool> },
 }
 ```
 
-`GlobalValKey` is the identity that matters across fragments. It is
+`ValueKey` is the identity that matters across graphs. It is
 structural:
 
 - inputs are keyed by `InputKey`
@@ -165,50 +163,50 @@ structural:
 This is what makes the following possible:
 
 - external reference resolution
-- cross-fragment CSE
-- higher-order tracing through earlier fragments
-- transpose accumulation bucketed by global identity
+- cross-graph CSE
+- higher-order tracing through earlier graphs
+- linear_transpose accumulation bucketed by global identity
 
 ### Active mask is part of identity
 
 Linear nodes use the same primitive set as primal nodes, but the linear mode is
-not optional metadata. It changes the meaning of transpose and therefore must
+not optional metadata. It changes the meaning of linear_transpose and therefore must
 participate in identity.
 
 Examples:
 
 ```text
-Mul(a, b)   mode=Primal
-Mul(a, dx)  mode=Linear { active_mask=[fixed, active] }
-Add(dx, dy) mode=Linear { active_mask=[active, active] }
+Mul(a, b)   role=Primary
+Mul(a, dx)  role=Linearized { active_mask=[fixed, active] }
+Add(dx, dy) role=Linearized { active_mask=[active, active] }
 ```
 
 The first and second node both evaluate as multiplication, but they are not the
-same graph object. They transpose differently, so they must not alias.
+same graph object. They linear_transpose differently, so they must not alias.
 
-### Fragment data structure
+### Graph data structure
 
 Conceptually:
 
 ```rust
-struct ValNode<Op> {
-    key: GlobalValKey<Op>,
-    producer: Option<(LocalOpId, usize)>, // None for fragment inputs
+struct ValueNode<Op> {
+    key: ValueKey<Op>,
+    producer: Option<(LocalOperationId, usize)>, // None for graph inputs
 }
 
-struct OpNode<Op> {
-    op: Op,
-    inputs: Vec<ValRef<Op>>,
-    outputs: Vec<LocalValId>,
-    mode: OpMode,
+struct OperationNode<Op> {
+    operation: Op,
+    inputs: Vec<ValueRef<Op>>,
+    outputs: Vec<LocalValueId>,
+    role: OperationRole,
 }
 
-struct Fragment<Op: GraphOp> {
-    vals: Vec<ValNode<Op>>,
-    ops: Vec<OpNode<Op>>,
-    inputs: Vec<LocalValId>,
-    outputs: Vec<LocalValId>,
-    parents: Vec<Arc<Fragment<Op>>>,
+struct Graph<Op: GraphOperation> {
+    values: Vec<ValueNode<Op>>,
+    operations: Vec<OperationNode<Op>>,
+    inputs: Vec<LocalValueId>,
+    outputs: Vec<LocalValueId>,
+    parents: Vec<Arc<Graph<Op>>>,
 }
 ```
 
@@ -217,32 +215,32 @@ struct Fragment<Op: GraphOp> {
 ### Resolver and ResolvedView
 
 `resolve` does not copy nodes into one graph. It builds a logical lookup view
-over fragments.
+over graphs.
 
 ```rust
-enum ValDef<Op> {
+enum ValueDef<Op> {
     Input {
         key: InputKey,
     },
     Produced {
-        op: Op,
-        inputs: Vec<ValRef<Op>>,
-        mode: OpMode,
+        operation: Op,
+        inputs: Vec<ValueRef<Op>>,
+        role: OperationRole,
         output_slot: usize,
     },
 }
 
 trait Resolver<Op> {
-    fn resolve_val(&self, key: &GlobalValKey<Op>) -> Option<ValDef<Op>>;
+    fn resolve_value(&self, key: &ValueKey<Op>) -> Option<ValueDef<Op>>;
 }
 
 struct ResolvedView<Op> {
-    roots: Vec<Arc<Fragment<Op>>>,
+    roots: Vec<Arc<Graph<Op>>>,
     resolver: Arc<dyn Resolver<Op>>,
 }
 ```
 
-The intended implementation is a resolver assembled from parent fragments, not a
+The intended implementation is a resolver assembled from parent graphs, not a
 mandatory central registry.
 
 `resolve` therefore means:
@@ -262,29 +260,29 @@ It does **not** mean:
 All transform-time walkers operate on the same logical rule:
 
 ```text
-Local(LocalValId)       -> follow the local producer
-External(GlobalValKey)  -> ask the resolver for the defining op
+Local(LocalValueId)       -> follow the local producer
+External(ValueKey)  -> ask the resolver for the defining op
 ```
 
-This must work recursively through any number of fragment boundaries.
+This must work recursively through any number of graph boundaries.
 
 Topological traversal at transform time is therefore **logical**, not physical:
 
-- visitation is keyed by `GlobalValKey`
+- visitation is keyed by `ValueKey`
 - the ordering is computed on the resolved logical DAG
-- local ids only matter inside the fragment currently being built
+- local ids only matter inside the graph currently being built
 
 ### Materialized graph
 
-Compile does not consume a fragment. It consumes the result of
+Compile does not consume a graph. It consumes the result of
 `materialize_merge`.
 
 ```rust
 struct MaterializedGraph<Op> {
-    vals: Vec<MaterializedVal<Op>>,
-    ops: Vec<MaterializedOp<Op>>,
-    inputs: Vec<GlobalValKey<Op>>,
-    outputs: Vec<GlobalValKey<Op>>,
+    values: Vec<MaterializedVal<Op>>,
+    operations: Vec<MaterializedOp<Op>>,
+    inputs: Vec<ValueKey<Op>>,
+    outputs: Vec<ValueKey<Op>>,
 }
 ```
 
@@ -301,10 +299,10 @@ struct MaterializedGraph<Op> {
 
 ### `build`
 
-`build` creates a primal fragment.
+`build` creates a primal graph.
 
-- all nodes are `OpMode::Primal`
-- fragment inputs use `GlobalValKey::Input`
+- all nodes are `OperationRole::Primary`
+- graph inputs use `ValueKey::Input`
 - no eager merge is implied
 
 ### `resolve`
@@ -312,16 +310,16 @@ struct MaterializedGraph<Op> {
 Conceptually:
 
 ```rust
-fn resolve<Op: GraphOp>(roots: Vec<Arc<Fragment<Op>>>) -> ResolvedView<Op>;
+fn resolve<Op: GraphOperation>(roots: Vec<Arc<Graph<Op>>>) -> ResolvedView<Op>;
 ```
 
-`resolve` is cheap and logical. It prepares a traversal view over fragment
+`resolve` is cheap and logical. It prepares a traversal view over graph
 parents and external references.
 
 This is the correct replacement for the old statement:
 
 ```text
-"merge must precede next differentiate"
+"merge must precede next linearize"
 ```
 
 The precise rule is:
@@ -332,34 +330,34 @@ resolve must precede any transform that needs to trace through external refs
 
 In practice:
 
-- higher-order `differentiate` requires `resolve`
+- higher-order `linearize` requires `resolve`
 - dependency analysis requires `resolve`
-- `transpose` usually needs only the linear fragment itself plus active masks
+- `linear_transpose` usually needs only the linear graph itself plus active masks
 
-### `differentiate`
+### `linearize`
 
-`differentiate` consumes a resolved view and returns a new linear fragment.
+`linearize` consumes a resolved view and returns a new linear graph.
 
 ```rust
-struct LinearFragment<Op> {
-    fragment: Fragment<Op>,
-    tangent_inputs: Vec<(InputKey, LocalValId)>,
-    tangent_outputs: Vec<Option<LocalValId>>,
+struct LinearizedGraph<Op> {
+    graph: Graph<Op>,
+    tangent_inputs: Vec<(InputKey, LocalValueId)>,
+    tangent_outputs: Vec<Option<LocalValueId>>,
 }
 
-fn differentiate<Op: PrimitiveOp>(
+fn linearize<Op: Primitive>(
     view: &ResolvedView<Op>,
-    outputs: &[GlobalValKey<Op>],
+    outputs: &[ValueKey<Op>],
     wrt: &[InputKey],
-) -> LinearFragment<Op>;
+) -> LinearizedGraph<Op>;
 ```
 
 Important consequences:
 
-- callers specify **which primal inputs** they differentiate with respect to
-- tangent inputs are created **inside the returned fragment**
+- callers specify **which primal inputs** they linearize with respect to
+- tangent inputs are created **inside the returned graph**
 - those tangent inputs receive fresh `InputKey`s and are returned to the caller
-- primal values are referenced by `External(GlobalValKey)`, not copied
+- primal values are referenced by `External(ValueKey)`, not copied
 
 Algorithm sketch:
 
@@ -367,8 +365,8 @@ Algorithm sketch:
 1. Traverse the reachable logical DAG in topological order.
 2. Seed tangent inputs for the requested primal InputKeys.
 3. For each reachable primitive, call its linearization rule.
-4. Emit new local linear nodes into the new fragment.
-5. Reference primal values through External(GlobalValKey).
+4. Emit new local linear nodes into the new graph.
+5. Reference primal values through External(ValueKey).
 6. Skip unreachable tangent flow with zero propagation.
 ```
 
@@ -382,56 +380,56 @@ dedicated `Scale` primitive.
 Examples:
 
 ```text
-Mul(a, dx)   mode=Linear { active_mask=[fixed, active] }
-Add(dx, dy)  mode=Linear { active_mask=[active, active] }
-Exp(x)       mode=Primal
+Mul(a, dx)   role=Linearized { active_mask=[fixed, active] }
+Add(dx, dy)  role=Linearized { active_mask=[active, active] }
+Exp(x)       role=Primary
 ```
 
 That last line matters: `Exp` itself is not a linear node. The linearization of
 `Exp(x)` emits linear nodes such as:
 
 ```text
-Mul(External(exp(x)), dx) mode=Linear { active_mask=[fixed, active] }
+Mul(External(exp(x)), dx) role=Linearized { active_mask=[fixed, active] }
 ```
 
 The design rule is:
 
 - linearization may reference primal inputs or outputs as fixed operands
 - linearization must stay linear in tangent inputs
-- active-vs-fixed information is recorded in `OpMode::Linear`
+- active-vs-fixed information is recorded in `OperationRole::Linearized`
 
-### `transpose`
+### `linear_transpose`
 
-`transpose` consumes a linear fragment and produces another linear fragment with
+`linear_transpose` consumes a linear graph and produces another linear graph with
 active inputs and outputs reversed.
 
 ```rust
-fn transpose<Op: PrimitiveOp>(
-    linear: &LinearFragment<Op>,
-) -> LinearFragment<Op>;
+fn linear_transpose<Op: Primitive>(
+    linear: &LinearizedGraph<Op>,
+) -> LinearizedGraph<Op>;
 ```
 
-It does not differentiate again. It reuses the same local linear rules with
+It does not linearize again. It reuses the same local linear rules with
 direction reversed.
 
-`tidu::transpose` is generic. It traverses the linear fragment in reverse
+`tidu::linear_transpose` is generic. It traverses the linear graph in reverse
 topological order and, for each op node, calls `Op::transpose_rule` to obtain
 the local transposed contribution. `tidu` does not know which primitives
-exist; it only requires that every op in the linear fragment implements
-`PrimitiveOp::transpose_rule`.
+exist; it only requires that every op in the linear graph implements
+`Primitive::transpose_rule`.
 
 Transpose accumulation must use global identity. When multiple reverse
 contributions flow back to the same original tangent node, bucket by the
-**global key of that tangent value**, not by a fragment-local id.
+**global key of that tangent value**, not by a graph-local id.
 
 ### `materialize_merge`
 
 `materialize_merge` is the physical graph-building step.
 
 ```rust
-fn materialize_merge<Op: GraphOp>(
+fn materialize_merge<Op: GraphOperation>(
     view: &ResolvedView<Op>,
-    outputs: &[GlobalValKey<Op>],
+    outputs: &[ValueKey<Op>],
 ) -> MaterializedGraph<Op>;
 ```
 
@@ -439,7 +437,7 @@ This step:
 
 - walks the resolved logical DAG from the requested outputs
 - collects reachable definitions
-- deduplicates by `GlobalValKey` / `GlobalOpKey`
+- deduplicates by `ValueKey` / `OperationKey`
 - computes one physical DAG
 - prepares the input to `compile`
 
@@ -449,15 +447,15 @@ The terminology should therefore be:
 
 ```text
 resolve            = make external references traceable
-materialize_merge  = flatten fragments into one concrete graph
+materialize_merge  = flatten graphs into one concrete graph
 ```
 
 ### `compile` and `eval`
 
-`compile` consumes a `MaterializedGraph`, not a fragment.
+`compile` consumes a `MaterializedGraph`, not a graph.
 
 ```rust
-let view = resolve(vec![fragment_a, fragment_b, fragment_c]);
+let view = resolve(vec![graph_a, graph_b, graph_c]);
 let graph = materialize_merge(&view, &requested_outputs);
 let prog = compile(&graph);
 let values = prog.run(&runtime_inputs);
@@ -465,7 +463,7 @@ let values = prog.run(&runtime_inputs);
 
 This separation is deliberate:
 
-- transforms stay fragment-based
+- transforms stay graph-based
 - compile stays backend-oriented
 - flattening and CSE happen once, late
 
@@ -473,7 +471,7 @@ This separation is deliberate:
 
 ## IV. Scalar Example: `f(x) = exp(a * x)`
 
-### Step 1: build the primal fragment `F0`
+### Step 1: build the primal graph `F0`
 
 ```text
 p0 = Input(x)
@@ -491,18 +489,18 @@ key(p2) = Derived { op=Mul(Input(x), Input(a)), output_slot=0 }
 key(p3) = Derived { op=Exp(key(p2)), output_slot=0 }
 ```
 
-### Step 2: differentiate the resolved primal view
+### Step 2: linearize the resolved primal view
 
 ```text
-L1 = differentiate(resolve([F0]), outputs=[key(p3)], wrt=[x])
+L1 = linearize(resolve([F0]), outputs=[key(p3)], wrt=[x])
 ```
 
-One possible linear fragment:
+One possible linear graph:
 
 ```text
 t0 = Input(t_x)                                         // new tangent input key
-t1 = Mul(External(key(p1)), Local(t0))                  mode=Linear { active_mask=[fixed, active] }
-t2 = Mul(External(key(p3)), Local(t1))                  mode=Linear { active_mask=[fixed, active] }
+t1 = Mul(External(key(p1)), Local(t0))                  role=Linearized { active_mask=[fixed, active] }
+t2 = Mul(External(key(p3)), Local(t1))                  role=Linearized { active_mask=[fixed, active] }
 ```
 
 Important facts:
@@ -519,7 +517,7 @@ If we want a second derivative, we resolve the combined logical view:
 R1 = resolve([F0, L1])
 ```
 
-Now `differentiate` can trace the output of `L1` through `key(p3)` and then
+Now `linearize` can trace the output of `L1` through `key(p3)` and then
 further through the primal chain back to `x`.
 
 This is the critical distinction:
@@ -529,18 +527,18 @@ R1 is enough for higher-order AD.
 No physical merge is required yet.
 ```
 
-### Step 4: transpose the linear fragment
+### Step 4: linear_transpose the linear graph
 
 ```text
-T1 = transpose(L1)
+T1 = linear_transpose(L1)
 ```
 
-One possible transposed fragment:
+One possible transposed graph:
 
 ```text
 c0 = Input(ct_y)
-c1 = Mul(External(key(p3)), Local(c0))                  mode=Linear { active_mask=[fixed, active] }
-c2 = Mul(External(key(p1)), Local(c1))                  mode=Linear { active_mask=[fixed, active] }
+c1 = Mul(External(key(p3)), Local(c0))                  role=Linearized { active_mask=[fixed, active] }
+c2 = Mul(External(key(p1)), Local(c1))                  role=Linearized { active_mask=[fixed, active] }
 ```
 
 This computes the cotangent with respect to `x`.
@@ -575,10 +573,10 @@ ct_x = a * exp(a*x) * ct_y
 
 ### Higher order
 
-Second directional derivative uses `resolve`, then `differentiate` again:
+Second directional derivative uses `resolve`, then `linearize` again:
 
 ```text
-L2 = differentiate(resolve([F0, L1]), outputs=[key(t2)], wrt=[x])
+L2 = linearize(resolve([F0, L1]), outputs=[key(t2)], wrt=[x])
 ```
 
 Again, no physical merge is required before this step.
@@ -588,14 +586,14 @@ Again, no physical merge is required before this step.
 ## V. Vector Examples
 
 The vector examples remain mathematically identical to the earlier version.
-What changes is only the graph interpretation: fragments stay separate until
+What changes is only the graph interpretation: graphs stay separate until
 `materialize_merge`.
 
 For readability, `Sum` below is shorthand for `ReduceSum` over all axes.
 
 ### Vector example 1: elementwise `y = exp(a * x)` with `x, a in R^2`
 
-Primal fragment:
+Primal graph:
 
 ```text
 u0 = Input(x:[2])
@@ -604,20 +602,20 @@ u2 = Mul(u0, u1)
 u3 = Exp(u2)
 ```
 
-Linear fragment from `differentiate(resolve([F0]), outputs=[key(u3)], wrt=[x])`:
+Linear graph from `linearize(resolve([F0]), outputs=[key(u3)], wrt=[x])`:
 
 ```text
 u4 = Input(t_x:[2])
-u5 = Mul(External(key(u1)), Local(u4))                 mode=Linear { active_mask=[fixed, active] }
-u6 = Mul(External(key(u3)), Local(u5))                 mode=Linear { active_mask=[fixed, active] }
+u5 = Mul(External(key(u1)), Local(u4))                 role=Linearized { active_mask=[fixed, active] }
+u6 = Mul(External(key(u3)), Local(u5))                 role=Linearized { active_mask=[fixed, active] }
 ```
 
-Transposed fragment:
+Transposed graph:
 
 ```text
 u7 = Input(ct_y:[2])
-u8 = Mul(External(key(u3)), Local(u7))                 mode=Linear { active_mask=[fixed, active] }
-u9 = Mul(External(key(u1)), Local(u8))                 mode=Linear { active_mask=[fixed, active] }
+u8 = Mul(External(key(u3)), Local(u7))                 role=Linearized { active_mask=[fixed, active] }
+u9 = Mul(External(key(u1)), Local(u8))                 role=Linearized { active_mask=[fixed, active] }
 ```
 
 Resulting formulas:
@@ -631,11 +629,11 @@ ct_x = [a0 * exp(a0*x0) * ct_y0,
 ```
 
 This stays purely elementwise. The JVP matches finite differences and the
-transpose satisfies `<ct_y, dy> = <ct_x, t_x>`.
+linear_transpose satisfies `<ct_y, dy> = <ct_x, t_x>`.
 
 ### Vector example 2: reduction `y = Sum(exp(a * x))` with `x, a in R^2`
 
-Primal fragment:
+Primal graph:
 
 ```text
 r0 = Input(x:[2])
@@ -645,22 +643,22 @@ r3 = Exp(r2)
 r4 = Sum(r3)
 ```
 
-Linear fragment:
+Linear graph:
 
 ```text
 r5 = Input(t_x:[2])
-r6 = Mul(External(key(r1)), Local(r5))                 mode=Linear { active_mask=[fixed, active] }
-r7 = Mul(External(key(r3)), Local(r6))                 mode=Linear { active_mask=[fixed, active] }
-r8 = Sum(Local(r7))                                    mode=Linear { active_mask=[active] }
+r6 = Mul(External(key(r1)), Local(r5))                 role=Linearized { active_mask=[fixed, active] }
+r7 = Mul(External(key(r3)), Local(r6))                 role=Linearized { active_mask=[fixed, active] }
+r8 = Sum(Local(r7))                                    role=Linearized { active_mask=[active] }
 ```
 
-Transposed fragment:
+Transposed graph:
 
 ```text
 r9  = Input(ct_y:[])
-r10 = BroadcastInDim(Local(r9), shape=[2], dims=[])    mode=Linear { active_mask=[active] }
-r11 = Mul(External(key(r3)), Local(r10))               mode=Linear { active_mask=[fixed, active] }
-r12 = Mul(External(key(r1)), Local(r11))               mode=Linear { active_mask=[fixed, active] }
+r10 = BroadcastInDim(Local(r9), shape=[2], dims=[])    role=Linearized { active_mask=[active] }
+r11 = Mul(External(key(r3)), Local(r10))               role=Linearized { active_mask=[fixed, active] }
+r12 = Mul(External(key(r1)), Local(r11))               role=Linearized { active_mask=[fixed, active] }
 ```
 
 Resulting formulas:
@@ -672,7 +670,7 @@ ct_x = [a0 * exp(a0*x0) * ct_y,
         a1 * exp(a1*x1) * ct_y]
 ```
 
-This is the smallest vector example that makes reduction transpose explicit
+This is the smallest vector example that makes reduction linear_transpose explicit
 without requiring eager merge.
 
 A reproducible checker for these two examples is in
@@ -687,43 +685,43 @@ A reproducible checker for these two examples is in
 `Operand` is the runtime value type (tensor-like; scalars are rank-0 tensors).
 Canonical signature in [`spec/primitive-catalog.md`](../spec/primitive-catalog.md).
 
-### PrimitiveOp
+### Primitive
 
-`PrimitiveOp` extends `GraphOp` with `add()` (cotangent accumulation),
+`Primitive` extends `GraphOperation` with `add()` (cotangent accumulation),
 `linearize`, and `transpose_rule`. tidu is fully generic over this trait.
 Canonical signature in [`spec/ad-contract.md`](../spec/ad-contract.md).
 
-### Linearization and transpose rules
+### Linearization and linear_transpose rules
 
 A primitive's `linearize` must be linear in tangent inputs. It may:
 
-- reference primal inputs or outputs through `External(GlobalValKey)`
-- emit primal primitives in `OpMode::Linear`
-- emit `Conj` when required by transpose semantics
+- reference primal inputs or outputs through `External(ValueKey)`
+- add primal primitives in `OperationRole::Linearized`
+- add `Conj` when required by linear_transpose semantics
 
 It must not introduce nonlinear dependence on tangent inputs.
 
 Fan-out accumulation (when multiple cotangents flow to the same tangent
-node during transpose) is handled internally by `tidu::transpose`, not
+node during linear_transpose) is handled internally by `tidu::linear_transpose`, not
 by an explicit `Dup` primitive. `tidu` buckets reverse contributions by
-`GlobalValKey` and accumulates them by emitting `Op::add()` nodes.
+`ValueKey` and accumulates them by emitting `Op::add()` nodes.
 
 A primitive's `transpose_rule` receives cotangent outputs and must produce
-cotangent inputs. It must only emit primitives that themselves implement
-`PrimitiveOp`. The downstream implementor is responsible for ensuring that
+cotangent inputs. It must only add primitives that themselves implement
+`Primitive`. The downstream implementor is responsible for ensuring that
 the set of primitives reachable through `linearize` and `transpose_rule`
 is closed.
 
 ### Closure responsibility
 
 `tidu` does not define or constrain the primitive set. It is fully generic
-over `Op: PrimitiveOp`. The only rule is:
+over `Op: Primitive`. The only rule is:
 
-> `linearize` and `transpose_rule` must emit only ops that themselves
-> implement `PrimitiveOp`.
+> `linearize` and `transpose_rule` must add only ops that themselves
+> implement `Primitive`.
 
-This ensures that `tidu` can apply `differentiate` and `transpose` to any
-fragment without knowledge of the specific primitives involved. The concrete
+This ensures that `tidu` can apply `linearize` and `linear_transpose` to any
+graph without knowledge of the specific primitives involved. The concrete
 primitive set and its closure guarantees are entirely the downstream
 implementor's responsibility (e.g. tenferro).
 
@@ -736,7 +734,7 @@ There is no dedicated `Scale` primitive in this design.
 ### Pipeline
 
 ```text
-Fragments (primal / linear / transposed)
+Graphs (primal / linear / transposed)
     |
     | resolve                          ← computegraph
     v
@@ -762,7 +760,7 @@ Runtime values
 `computegraph::compile`. Each slot is written exactly once.
 
 ```rust
-struct CompiledProgram<Op: GraphOp> {
+struct CompiledProgram<Op: GraphOperation> {
     instructions: Vec<Instruction<Op>>,
     input_slots: Vec<usize>,
     output_slots: Vec<usize>,
@@ -770,7 +768,7 @@ struct CompiledProgram<Op: GraphOp> {
 }
 
 struct Instruction<Op> {
-    op: Op,
+    operation: Op,
     inputs: Vec<usize>,
     outputs: Vec<usize>,
 }
@@ -792,13 +790,13 @@ details (execution lowering, GPU dispatch) remain in `../spec/backend-contract.m
 
 The important contract is:
 
-- AD transforms (tidu) are fragment-based and resolver-backed
+- AD transforms (tidu) are graph-based and resolver-backed
 - graph infrastructure (computegraph) is AD-agnostic
 - backends only see the materialized or compiled result
 
 ---
 
-## VIII. Advantages of the Fragment + Resolver Model
+## VIII. Advantages of the Graph + Resolver Model
 
 ### No eager merge between transforms
 
@@ -807,12 +805,12 @@ physical merge avoids repeated flattening and repeated global CSE.
 
 ### Better fit for partial transforms
 
-Cross-country evaluation and partial transpose are more natural when transforms
-operate on fragments rather than on one giant graph.
+Cross-country evaluation and partial linear_transpose are more natural when transforms
+operate on graphs rather than on one giant graph.
 
 ### Global identity is explicit
 
-`GlobalValKey` gives one identity mechanism for:
+`ValueKey` gives one identity mechanism for:
 
 - external refs
 - accumulation buckets
@@ -829,7 +827,7 @@ code can stay light and local.
 The rule for higher order is simple:
 
 ```text
-resolve before the next differentiate
+resolve before the next linearize
 materialize_merge before compile
 ```
 
@@ -837,17 +835,17 @@ materialize_merge before compile
 
 ## IX. Golden Tests
 
-Minimal tests that validate the fragment-based transform procedure:
+Minimal tests that validate the graph-based transform procedure:
 
 | # | Function | What it checks |
 |---|----------|----------------|
-| 1 | `x + x` | transpose accumulation buckets by global identity |
+| 1 | `x + x` | linear_transpose accumulation buckets by global identity |
 | 2 | `x * y` | binary linearization with distinct reverse sinks |
-| 3 | `c * z` (complex) | `Conj` appears only in transpose |
+| 3 | `c * z` (complex) | `Conj` appears only in linear_transpose |
 | 4 | `x^2` | higher-order AD without eager physical merge |
-| 5 | `exp(a*x)` | external refs, resolve-before-differentiate, transpose correctness |
-| 6 | `Sum(exp(a*x))` | reduction transpose via `BroadcastInDim` |
-| 7 | `exp(a*x)` 3rd order | repeated higher-order closure over fragments |
+| 5 | `exp(a*x)` | external refs, resolve-before-linearize, linear_transpose correctness |
+| 6 | `Sum(exp(a*x))` | reduction linear_transpose via `BroadcastInDim` |
+| 7 | `exp(a*x)` 3rd order | repeated higher-order closure over graphs |
 
 Expected second-order result for `x^2` with unit seeds:
 
@@ -871,11 +869,11 @@ Expected second-order result for `exp(a*x)` with unit seeds:
 
 ## X. Implementation Status
 
-Phases 1–3 (scalar fragment AD, tensor primitives, backend compilation) are
+Phases 1–3 (scalar graph AD, tensor primitives, backend compilation) are
 implemented and tested. Current work focuses on:
 
 - Logical-DAG-aware checkpoint scheduling
-- Partial transpose / cross-country mode
+- Partial linear_transpose / cross-country mode
 - Late materialization heuristics
 - Operator fusion in compiled IR
 
@@ -887,7 +885,7 @@ This document unifies and supersedes:
 
 - tidu-rs#12: tape AD design
 - tidu-rs#13: graph-based AD design
-- chainrules-rs#7: trait unification
-- chainrules-rs#8: DifferentiableOp trait
+- tidu-rs#7: trait unification
+- tidu-rs#8: DifferentiableOp trait
 - tenferro-rs#616: Traced Tensor + StableHLO IR
 - tenferro-rs#618: tenferro roadmap (AD portions)

--- a/docs/architecture/computegraph.md
+++ b/docs/architecture/computegraph.md
@@ -24,41 +24,41 @@ The graph infrastructure is equally usable for:
 
 ### Operand (removed)
 
-The `Operand` trait has been removed. The associated type `GraphOp::Operand`
+The `Operand` trait has been removed. The associated type `GraphOperation::Operand`
 is now bounded by `Clone + Send + Sync + 'static` only — no trait of its own.
 Downstream consumers supply whatever runtime value type they need; computegraph
 imposes no algebraic or structural interface on it.
 
-### GraphOp
+### GraphOperation
 
-`GraphOp` is the operation node trait for **metadata only**: input/output
+`GraphOperation` is the operation node trait for **metadata only**: input/output
 counts and associated types. `computegraph` is fully generic over this trait
 and never references specific primitives. Associated types: `Operand` (runtime
 value, no trait bound beyond `Clone + Send + Sync + 'static`), `Context`
 (backend execution state), `InputKey` (downstream-chosen key representation).
 
-Evaluation is **not** part of `GraphOp`. See `EvalGraphOp` below.
+Evaluation is **not** part of `GraphOperation`. See `EvaluableGraphOperation` below.
 
 ```rust
-pub trait GraphOp: Clone + Debug + Hash + Eq + Send + Sync + 'static {
+pub trait GraphOperation: Clone + Debug + Hash + Eq + Send + Sync + 'static {
     type Operand: Clone + Send + Sync + 'static;
     type Context;
     type InputKey: Clone + Debug + Hash + Eq + Send + Sync + 'static;
 
-    fn n_inputs(&self) -> usize;
-    fn n_outputs(&self) -> usize;
+    fn input_count(&self) -> usize;
+    fn output_count(&self) -> usize;
 }
 ```
 
-### EvalGraphOp
+### EvaluableGraphOperation
 
-`EvalGraphOp` is an **opt-in** extension trait that adds evaluation capability
-to a `GraphOp`. Not every graph operation needs to be directly evaluable —
+`EvaluableGraphOperation` is an **opt-in** extension trait that adds evaluation capability
+to a `GraphOperation`. Not every graph operation needs to be directly evaluable —
 some operations exist only as logical nodes for analysis or transformation.
 When evaluation is required, implement this trait.
 
 ```rust
-pub trait EvalGraphOp: GraphOp {
+pub trait EvaluableGraphOperation: GraphOperation {
     fn eval(&self, ctx: &mut Self::Context, inputs: &[&Self::Operand]) -> Vec<Self::Operand>;
 }
 ```
@@ -67,38 +67,38 @@ pub trait EvalGraphOp: GraphOp {
 
 ## III. Data Structures
 
-### Fragment
+### Graph
 
-A **Fragment** is the unit of graph construction. It owns only local nodes and
-may reference values in other fragments through external references.
+A **Graph** is the unit of graph construction. It owns only local nodes and
+may reference values in other graphs through external references.
 
 ```rust
-type LocalValId = usize;
-type LocalOpId = usize;
+type LocalValueId = usize;
+type LocalOperationId = usize;
 
-enum ValRef<Op: GraphOp> {
-    Local(LocalValId),
-    External(GlobalValKey<Op>),
+enum ValueRef<Op: GraphOperation> {
+    Local(LocalValueId),
+    External(ValueKey<Op>),
 }
 
-struct ValNode<Op> {
-    key: GlobalValKey<Op>,
-    producer: Option<(LocalOpId, usize)>,
+struct ValueNode<Op> {
+    key: ValueKey<Op>,
+    producer: Option<(LocalOperationId, usize)>,
 }
 
-struct OpNode<Op> {
-    op: Op,
-    inputs: Vec<ValRef<Op>>,
-    outputs: Vec<LocalValId>,
-    mode: OpMode,
+struct OperationNode<Op> {
+    operation: Op,
+    inputs: Vec<ValueRef<Op>>,
+    outputs: Vec<LocalValueId>,
+    role: OperationRole,
 }
 
-struct Fragment<Op: GraphOp> {
-    vals: Vec<ValNode<Op>>,
-    ops: Vec<OpNode<Op>>,
-    inputs: Vec<LocalValId>,
-    outputs: Vec<LocalValId>,
-    parents: Vec<Arc<Fragment<Op>>>,
+struct Graph<Op: GraphOperation> {
+    values: Vec<ValueNode<Op>>,
+    operations: Vec<OperationNode<Op>>,
+    inputs: Vec<LocalValueId>,
+    outputs: Vec<LocalValueId>,
+    parents: Vec<Arc<Graph<Op>>>,
 }
 ```
 
@@ -106,75 +106,75 @@ struct Fragment<Op: GraphOp> {
 
 ### Global Identity
 
-`GlobalValKey` is the cross-fragment identity mechanism. It is structural:
+`ValueKey` is the cross-graph identity mechanism. It is structural:
 
 ```rust
-enum GlobalValKey<Op: GraphOp> {
+enum ValueKey<Op: GraphOperation> {
     Input(Op::InputKey),
     Derived {
-        op: GlobalOpKey<Op>,
+        operation: Arc<OperationKey<Op>>,
         output_slot: u8,
     },
 }
 
-struct GlobalOpKey<Op> {
-    primitive: Op,
-    inputs: Vec<GlobalValKey<Op>>,
-    mode: OpMode,
+struct OperationKey<Op> {
+    operation: Op,
+    inputs: Vec<ValueKey<Op>>,
+    role: OperationRole,
 }
 
-enum OpMode {
-    Primal,
-    Linear { active_mask: Vec<bool> },
+enum OperationRole {
+    Primary,
+    Linearized { active_mask: Vec<bool> },
 }
 ```
 
-`GlobalValKey` enables:
+`ValueKey` enables:
 
 - external reference resolution
-- cross-fragment CSE
+- cross-graph CSE
 - logical reachability analysis
 
 ### Key Interning
 
-`GlobalValKey` is recursive and grows with graph depth. To keep equality
+`ValueKey` is recursive and grows with graph depth. To keep equality
 comparison O(1) and avoid storing duplicate substructure, all keys are
-interned in a global `KeyInterner`:
+interned in a global `ValueKeyInterner`:
 
 ```rust
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-struct ValKeyId(u32);
+struct ValueKeyId(u32);
 
-struct KeyInterner<Op: GraphOp> {
-    map: HashMap<GlobalValKey<Op>, ValKeyId>,
-    keys: Vec<GlobalValKey<Op>>,  // id → full key (reverse lookup)
+struct ValueKeyInterner<Op: GraphOperation> {
+    map: HashMap<ValueKey<Op>, ValueKeyId>,
+    keys: Vec<ValueKey<Op>>,  // id → full key (reverse lookup)
 }
 ```
 
-Fragment construction registers every new `GlobalValKey` with the interner
-and stores the resulting `ValKeyId`. Cross-fragment equality, CSE, and
-compilation cache lookups all use `ValKeyId` comparison (O(1)).
+Graph construction registers every new `ValueKey` with the interner
+and stores the resulting `ValueKeyId`. Cross-graph equality, CSE, and
+compilation cache lookups all use `ValueKeyId` comparison (O(1)).
 
-The interner is global (shared across all fragments). This is appropriate
-because the primary use case is cross-fragment identity. Thread-safe access
-can be added later (`DashMap` or `RwLock<HashMap>`) if parallel fragment
+The interner is global (shared across all graphs). This is appropriate
+because the primary use case is cross-graph identity. Thread-safe access
+can be added later (`DashMap` or `RwLock<HashMap>`) if parallel graph
 construction becomes necessary.
 
-`parents` in `Fragment` form an acyclic structure: a fragment can only
-reference fragments that existed at its construction time, so cycles are
+`parents` in `Graph` form an acyclic structure: a graph can only
+reference graphs that existed at its construction time, so cycles are
 structurally impossible.
 
 ### ResolvedView
 
-`resolve` builds a logical lookup view over fragments without copying nodes.
+`resolve` builds a logical lookup view over graphs without copying nodes.
 
 ```rust
 trait Resolver<Op> {
-    fn resolve_val(&self, key: &GlobalValKey<Op>) -> Option<ValDef<Op>>;
+    fn resolve_value(&self, key: &ValueKey<Op>) -> Option<ValueDef<Op>>;
 }
 
 struct ResolvedView<Op> {
-    roots: Vec<Arc<Fragment<Op>>>,
+    roots: Vec<Arc<Graph<Op>>>,
     resolver: Arc<dyn Resolver<Op>>,
 }
 ```
@@ -185,10 +185,10 @@ The fully flattened graph produced by `materialize_merge`:
 
 ```rust
 struct MaterializedGraph<Op> {
-    vals: Vec<MaterializedVal<Op>>,
-    ops: Vec<MaterializedOp<Op>>,
-    inputs: Vec<GlobalValKey<Op>>,
-    outputs: Vec<GlobalValKey<Op>>,
+    values: Vec<MaterializedVal<Op>>,
+    operations: Vec<MaterializedOp<Op>>,
+    inputs: Vec<ValueKey<Op>>,
+    outputs: Vec<ValueKey<Op>>,
 }
 ```
 
@@ -199,34 +199,34 @@ struct MaterializedGraph<Op> {
 ### `resolve`
 
 ```rust
-fn resolve<Op: GraphOp>(roots: Vec<Arc<Fragment<Op>>>) -> ResolvedView<Op>;
+fn resolve<Op: GraphOperation>(roots: Vec<Arc<Graph<Op>>>) -> ResolvedView<Op>;
 ```
 
-Cheap and logical. Prepares a traversal view over fragment parents and
+Cheap and logical. Prepares a traversal view over graph parents and
 external references. Does not copy nodes or run CSE.
 
 ### `materialize_merge`
 
 ```rust
-fn materialize_merge<Op: GraphOp>(
+fn materialize_merge<Op: GraphOperation>(
     view: &ResolvedView<Op>,
-    outputs: &[GlobalValKey<Op>],
+    outputs: &[ValueKey<Op>],
 ) -> MaterializedGraph<Op>;
 ```
 
 Walks the resolved logical DAG, collects reachable definitions, deduplicates
-by `GlobalValKey`/`GlobalOpKey`, and computes one concrete topological order.
+by `ValueKey`/`OperationKey`, and computes one concrete topological order.
 
 ### `compile`
 
 ```rust
-fn compile<Op: GraphOp>(graph: &MaterializedGraph<Op>) -> CompiledProgram<Op>;
+fn compile<Op: GraphOperation>(graph: &MaterializedGraph<Op>) -> CompiledProgram<Op>;
 ```
 
 Produces an SSA-form instruction sequence. Each slot is written exactly once.
 
 ```rust
-struct CompiledProgram<Op: GraphOp> {
+struct CompiledProgram<Op: GraphOperation> {
     instructions: Vec<Instruction<Op>>,
     input_slots: Vec<usize>,
     output_slots: Vec<usize>,
@@ -234,7 +234,7 @@ struct CompiledProgram<Op: GraphOp> {
 }
 
 struct Instruction<Op> {
-    op: Op,
+    operation: Op,
     inputs: Vec<usize>,
     outputs: Vec<usize>,
 }
@@ -243,24 +243,24 @@ struct Instruction<Op> {
 ### `eval`
 
 ```rust
-impl<Op: EvalGraphOp> CompiledProgram<Op> {
+impl<Op: EvaluableGraphOperation> CompiledProgram<Op> {
     fn eval(&self, ctx: &mut Op::Context, inputs: &[&Op::Operand]) -> Vec<Op::Operand>;
 }
 ```
 
 Compile once, eval many times. Evaluation is **opt-in**: only operations that
-implement `EvalGraphOp` can be evaluated. `CompiledProgram` itself is generic
-over `GraphOp`; the `eval` method is available only when `Op: EvalGraphOp`.
+implement `EvaluableGraphOperation` can be evaluated. `CompiledProgram` itself is generic
+over `GraphOperation`; the `eval` method is available only when `Op: EvaluableGraphOperation`.
 
 ---
 
 ## V. Compilation Cache
 
 `computegraph` caches compiled programs keyed by graph structure
-(`GlobalValKey`-based identity) to avoid recompilation when the same graph
+(`ValueKey`-based identity) to avoid recompilation when the same graph
 is submitted multiple times with different input values.
 
-Note: `GlobalValKey` contains concrete `InputKey` and (via downstream usage)
+Note: `ValueKey` contains concrete `InputKey` and (via downstream usage)
 `DiffPassId` values. Two graphs that differ only in these identity tokens but
 have identical topology are **not** automatic cache hits at the computegraph
 level. Normalization of `InputKey`/`DiffPassId` to achieve cache hits across
@@ -275,16 +275,16 @@ raw structural identity; the compiler maps that to a normalized cache key.
 All walkers operate on the same rule:
 
 ```text
-Local(LocalValId)       -> follow the local producer
-External(GlobalValKey)  -> ask the resolver for the defining op
+Local(LocalValueId)       -> follow the local producer
+External(ValueKey)  -> ask the resolver for the defining op
 ```
 
-This works recursively through any number of fragment boundaries.
+This works recursively through any number of graph boundaries.
 Topological traversal is logical, not physical:
 
-- visitation is keyed by `GlobalValKey`
+- visitation is keyed by `ValueKey`
 - ordering is computed on the resolved logical DAG
-- local ids only matter inside the fragment currently being built
+- local ids only matter inside the graph currently being built
 
 ---
 
@@ -292,14 +292,14 @@ Topological traversal is logical, not physical:
 
 ```text
 computegraph owns:
-  - GraphOp, EvalGraphOp traits
-  - Fragment, ResolvedView, MaterializedGraph
-  - resolve, materialize_merge, compile, eval (opt-in via EvalGraphOp)
+  - GraphOperation, EvaluableGraphOperation traits
+  - Graph, ResolvedView, MaterializedGraph
+  - resolve, materialize_merge, compile, eval (opt-in via EvaluableGraphOperation)
   - compilation cache
 
 computegraph does NOT own:
-  - AD transforms (differentiate, transpose) → tidu-rs
-  - AD traits (linearize, transpose_rule) → chainrules-rs
+  - AD transforms (linearize, linear_transpose) → tidu-rs
+  - AD traits (jvp_rule, transpose_rule) → tidu-rs
   - concrete primitives → downstream (tenferro-rs)
   - backend-specific lowering (StableHLO) → downstream
 ```

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -7,7 +7,7 @@ op semantics), see [Specification](../spec/).
 | Document | Covers |
 |----------|--------|
 | [tenferro-crates.md](./tenferro-crates.md) | Current crate structure, dependency boundaries, extension boundary, AD boundary |
-| [computegraph.md](./computegraph.md) | GraphOp, Operand, Fragment, resolve/materialize/compile/eval pipeline |
-| [chainrules.md](./chainrules.md) | PrimitiveOp trait, AD rule structure |
-| [tidu.md](./tidu.md) | differentiate, transpose, LinearFragment, higher-order AD |
+| [computegraph.md](./computegraph.md) | GraphOperation, Graph, resolve/materialize/compile/eval pipeline |
+| [primitive-ad.md](./primitive-ad.md) | Primitive AD contract and rule structure |
+| [tidu.md](./tidu.md) | linearize, linear_transpose, LinearizedGraph, higher-order AD |
 | [ad-pipeline.md](./ad-pipeline.md) | End-to-end AD pipeline, scalar/vector examples, golden tests |

--- a/docs/architecture/primitive-ad.md
+++ b/docs/architecture/primitive-ad.md
@@ -1,6 +1,6 @@
-# chainrules-rs Design
+# Primitive AD Contract
 
-**Repo:** chainrules-rs
+**Repo:** tidu-rs
 **Parent:** `../index.md`
 **Depends on:** `computegraph-rs`
 
@@ -8,10 +8,9 @@
 
 ## I. Purpose
 
-`chainrules-rs` defines the AD trait (`PrimitiveOp`) that extends
-`computegraph::GraphOp` with a cotangent-accumulation constructor plus
-linearization and transpose rules. It contains no graph infrastructure and no
-concrete primitives.
+`tidu-rs` defines the AD trait (`Primitive`) that extends
+`computegraph::GraphOperation` with a cotangent-accumulation constructor plus
+JVP and transpose rules. It contains no concrete primitives.
 
 This is the counterpart of the AD behavior that JAX stores in
 `primitive_jvps` and `primitive_transposes`. The information is the same kind
@@ -22,16 +21,16 @@ of information, but the representation is different:
 
 ---
 
-## II. PrimitiveOp Trait
+## II. Primitive Trait
 
-`PrimitiveOp` extends `GraphOp` with `add()` (cotangent accumulation
+`Primitive` extends `GraphOperation` with `add()` (cotangent accumulation
 constructor), `linearize` (JVP rule), and `transpose_rule` (VJP rule).
 
 Canonical trait signature: [`../spec/ad-contract.md`](../spec/ad-contract.md).
 
-`add()` returns the primitive used by `tidu::transpose` when multiple
-cotangent contributions flow to the same `GlobalValKey`. This keeps fan-out
-accumulation inside the generic transpose pass without requiring a separate
+`add()` returns the primitive used by `tidu::linear_transpose` when multiple
+cotangent contributions flow to the same `ValueKey`. This keeps fan-out
+accumulation inside the generic linear_transpose pass without requiring a separate
 built-in `Dup` or `Add` primitive in `tidu`.
 
 ---
@@ -40,9 +39,9 @@ built-in `Dup` or `Add` primitive in `tidu`.
 
 A primitive's `linearize` must be linear in tangent inputs. It may:
 
-- reference primal inputs or outputs through `External(GlobalValKey)`
-- emit primitives in `OpMode::Linear`
-- emit `Conj` when required by transpose semantics
+- reference primal inputs or outputs through `External(ValueKey)`
+- add primitives in `OperationRole::Linearized`
+- add `Conj` when required by linear_transpose semantics
 
 It must not introduce nonlinear dependence on tangent inputs.
 
@@ -50,19 +49,19 @@ The intended mental model is close to JAX `linearize`:
 
 - JAX `linearize` applies a primitive's JVP rule and emits a new composition of
   JAX primitives in a jaxpr
-- `PrimitiveOp::linearize` emits a new composition of downstream concrete
-  primitives into a fragment
+- `Primitive::jvp_rule` emits a new composition of downstream concrete
+  primitives into a graph
 
 ---
 
 ## IV. Transpose Rules
 
 A primitive's `transpose_rule` receives cotangent outputs and produces
-cotangent inputs. It must only emit primitives that themselves implement
-`PrimitiveOp`.
+cotangent inputs. It must only add primitives that themselves implement
+`Primitive`.
 
-When transpose encounters fan-out, `tidu` accumulates multiple reverse
-contributions by emitting `PrimitiveOp::add()` nodes. So every downstream
+When linear_transpose encounters fan-out, `tidu` accumulates multiple reverse
+contributions by emitting `Primitive::add()` nodes. So every downstream
 primitive set used with `tidu` must provide an addition primitive suitable for
 cotangent accumulation.
 
@@ -70,23 +69,23 @@ cotangent accumulation.
 
 ## V. ADKey Trait
 
-`chainrules-rs` defines the `ADKey` trait that constrains `InputKey` for AD
+`tidu-rs` defines the `ADKey` trait that constrains `InputKey` for AD
 use. `tidu-rs` uses this trait to generate tangent input keys during
-`differentiate`.
+`linearize`.
 
 ```rust
 pub type DiffPassId = u64;
 
 pub trait ADKey: Clone + Debug + Hash + Eq + Send + Sync + 'static {
     /// Create a tangent input key derived from this key.
-    /// `pass` is a unique identifier for the `differentiate` call.
+    /// `pass` is a unique identifier for the `linearize` call.
     fn tangent_of(&self, pass: DiffPassId) -> Self;
 }
 ```
 
-`PrimitiveOp` requires `Self::InputKey: ADKey`
+`Primitive` requires `Self::InputKey: ADKey`
 (see [`../spec/ad-contract.md`](../spec/ad-contract.md) for the canonical
-`PrimitiveOp` trait signature).
+`Primitive` trait signature).
 
 The concrete implementation of `ADKey` is the downstream implementor's
 choice. A typical pattern is a recursive enum:
@@ -107,21 +106,21 @@ higher-order AD.
 
 ## VI. Closure Responsibility
 
-`chainrules-rs` defines the contract but does not enforce closure. The
+`tidu-rs` defines the contract but does not enforce closure. The
 downstream implementor (e.g. tenferro-rs) is responsible for ensuring that
 the set of primitives reachable through `linearize` and `transpose_rule`
-is closed — i.e., every emitted op also implements `PrimitiveOp`.
+is closed — i.e., every emitted op also implements `Primitive`.
 
 ---
 
 ## VII. Design Boundaries
 
 ```text
-chainrules-rs owns:
-  - PrimitiveOp trait (`add` + `linearize` + `transpose_rule`)
+tidu-rs owns:
+  - Primitive trait (`add` + `jvp_rule` + `transpose_rule`)
+  - AD transforms (`linearize`, `linear_transpose`)
 
-chainrules-rs does NOT own:
+tidu-rs does NOT own:
   - graph infrastructure → computegraph-rs
-  - AD transforms (differentiate, transpose) → tidu-rs
   - concrete primitives → downstream (tenferro-rs)
 ```

--- a/docs/architecture/tenferro-crates.md
+++ b/docs/architecture/tenferro-crates.md
@@ -2,7 +2,7 @@
 
 **Repo:** tenferro-rs
 **Parent:** `../index.md`
-**Related:** `computegraph.md`, `chainrules.md`, `tidu.md`,
+**Related:** `computegraph.md`, `primitive-ad.md`, `tidu.md`,
 `../spec/backend-contract.md`, `../spec/primitive-catalog.md`,
 `../spec/extension-op.md`
 
@@ -163,9 +163,9 @@ See [`../guides/custom-operations.md`](../guides/custom-operations.md) and
 
 ## VI. AD Boundary
 
-`chainrules-rs` owns the generic `PrimitiveOp` contract. `tidu-rs` owns the
-generic graph transforms such as `differentiate` and `transpose`. Neither crate
-is tied to tenferro's concrete tensor types.
+`tidu-rs` owns the generic `Primitive` contract and graph transforms such as
+`linearize` and `linear_transpose`. It is not tied to tenferro's concrete
+tensor types.
 
 tenferro supplies one concrete graph vocabulary, `StdTensorOp`, plus
 operation-family extension carriers. Core primitive AD rule implementations
@@ -176,8 +176,7 @@ the operation family that owns the semantics, for example `tenferro-einsum` or
 This is the current split:
 
 ```text
-chainrules-rs          PrimitiveOp contract
-tidu-rs                generic AD graph transforms
+tidu-rs                Primitive contract and generic AD graph transforms
 tenferro-internal-ops  StdTensorOp AD rules
 tenferro-ad            public eager/traced AD APIs
 operation crates       optional extension-family AD rules

--- a/docs/architecture/tidu.md
+++ b/docs/architecture/tidu.md
@@ -2,50 +2,50 @@
 
 **Repo:** tidu-rs
 **Parent:** `../index.md`
-**Depends on:** `computegraph-rs`, `chainrules-rs`
+**Depends on:** `computegraph-rs`
 
 ---
 
 ## I. Purpose
 
-`tidu-rs` provides AD-specific graph transforms (`differentiate`, `transpose`)
-that are fully generic over `Op: PrimitiveOp`. It owns no graph infrastructure
+`tidu-rs` provides AD-specific graph transforms (`linearize`, `linear_transpose`)
+that are fully generic over `Op: Primitive`. It owns no graph infrastructure
 (that belongs to `computegraph-rs`) and references no specific primitives.
 
-Among the JAX concepts, `differentiate` is the closest analogue to
+Among the JAX concepts, `linearize` is the closest analogue to
 `jax.linearize`: it traverses a primal computation and builds a new linear
 computation by calling each primitive's local linearization rule. The output is
-not StableHLO and not a backend kernel plan; it is another fragment composed of
+not StableHLO and not a backend kernel plan; it is another graph composed of
 the same downstream primitive vocabulary.
 
 ---
 
 ## II. Transforms
 
-### `differentiate`
+### `linearize`
 
-Consumes a resolved view and returns a new linear fragment (JVP).
+Consumes a resolved view and returns a new linear graph (JVP).
 
 ```rust
-use computegraph::{ResolvedView, GlobalValKey, LocalValId, Fragment};
-use chainrules::PrimitiveOp;
+use computegraph::{ResolvedView, ValueKey, LocalValueId, Graph};
+use tidu::Primitive;
 
-struct LinearFragment<Op> {
-    fragment: Fragment<Op>,
-    tangent_inputs: Vec<(Op::InputKey, LocalValId)>,
-    tangent_outputs: Vec<Option<LocalValId>>,
+struct LinearizedGraph<Op> {
+    graph: Graph<Op>,
+    tangent_inputs: Vec<(Op::InputKey, LocalValueId)>,
+    tangent_outputs: Vec<Option<LocalValueId>>,
 }
 
-fn differentiate<Op: PrimitiveOp>(
+fn linearize<Op: Primitive>(
     view: &ResolvedView<Op>,
-    outputs: &[GlobalValKey<Op>],
+    outputs: &[ValueKey<Op>],
     wrt: &[Op::InputKey],
-) -> LinearFragment<Op>;
+) -> LinearizedGraph<Op>;
 ```
 
-Each call to `differentiate` receives a unique `DiffPassId` (monotonically
+Each call to `linearize` receives a unique `DiffPassId` (monotonically
 increasing counter). Tangent input keys are generated via
-`wrt_key.tangent_of(pass_id)` (see `ADKey` trait in `chainrules.md`).
+`wrt_key.tangent_of(pass_id)` (see `ADKey` in the primitive AD contract).
 
 Algorithm:
 
@@ -53,45 +53,45 @@ Algorithm:
 2. Seed tangent inputs for the requested primal `InputKey`s
    (keys generated via `ADKey::tangent_of`).
 3. For each reachable primitive, call `Op::linearize`.
-4. Emit new local linear nodes into the new fragment.
-5. Reference primal values through `External(GlobalValKey)`.
+4. Emit new local linear nodes into the new graph.
+5. Reference primal values through `External(ValueKey)`.
 6. Skip unreachable tangent flow with zero propagation.
 
-This is the fragment-level analogue of JAX building a jaxpr whose linearized
+This is the graph-level analogue of JAX building a jaxpr whose linearized
 body is itself a composition of primitives.
 
-### `transpose`
+### `linear_transpose`
 
-Consumes a linear fragment and produces another with active inputs and outputs
+Consumes a linear graph and produces another with active inputs and outputs
 reversed.
 
 ```rust
-fn transpose<Op: PrimitiveOp>(
-    linear: &LinearFragment<Op>,
-) -> LinearFragment<Op>;
+fn linear_transpose<Op: Primitive>(
+    linear: &LinearizedGraph<Op>,
+) -> LinearizedGraph<Op>;
 ```
 
-Traverses the linear fragment in reverse topological order and, for each op
+Traverses the linear graph in reverse topological order and, for each op
 node, calls `Op::transpose_rule` to obtain the local transposed contribution.
 
 Transpose accumulation must use global identity: when multiple reverse
 contributions flow back to the same original tangent node, bucket by the
-**global key of that tangent value**, not by a fragment-local id.
+**global key of that tangent value**, not by a graph-local id.
 
-Fan-out accumulation is handled internally by `transpose`, not by an
+Fan-out accumulation is handled internally by `linear_transpose`, not by an
 explicit `Dup` primitive. When multiple cotangents flow to the same
-`GlobalValKey`, `transpose` accumulates them by emitting `Op::add()` nodes.
+`ValueKey`, `linear_transpose` accumulates them by emitting `Op::add()` nodes.
 This follows
-the JAX approach where `add_jaxvals` is built into the transpose pass
+the JAX approach where `add_jaxvals` is built into the linear_transpose pass
 rather than expressed as a separate primitive in the graph. Downstream
 primitive implementors do not need to implement `Dup`.
 
 ### Transpose algorithm
 
 ```rust
-fn transpose<Op: PrimitiveOp>(linear: &LinearFragment<Op>) -> LinearFragment<Op> {
-    let mut builder = FragmentBuilder::new();
-    let mut ct_env: HashMap<GlobalValKey<Op>, LocalValId> = HashMap::new();
+fn linear_transpose<Op: Primitive>(linear: &LinearizedGraph<Op>) -> LinearizedGraph<Op> {
+    let mut builder = GraphBuilder::new();
+    let mut ct_env: HashMap<ValueKey<Op>, LocalValueId> = HashMap::new();
 
     // 1. Seed cotangent outputs
     for (out_key, ct_input_id) in cotangent_seeds {
@@ -99,30 +99,30 @@ fn transpose<Op: PrimitiveOp>(linear: &LinearFragment<Op>) -> LinearFragment<Op>
     }
 
     // 2. Reverse topological traversal
-    for op_node in linear.fragment.ops().iter().rev() {
+    for op_node in linear.as_graph().operations().iter().rev() {
         // Look up cotangent for this op's outputs
-        let ct_outs: Vec<Option<LocalValId>> = op_node.outputs.iter()
+        let ct_outs: Vec<Option<LocalValueId>> = op_node.outputs.iter()
             .map(|out_id| ct_env.get(&global_key(out_id)).copied())
             .collect();
 
-        // Delegate to per-op transpose rule
-        let ct_ins = op_node.op.transpose_rule(
-            &mut builder, &ct_outs, &op_node.inputs, &op_node.mode,
+        // Delegate to per-op linear_transpose rule
+        let ct_ins = op_node.operation.transpose_rule(
+            &mut builder, &ct_outs, &op_node.inputs, &op_node.role,
         );
 
-        // 3. Accumulate cotangents by GlobalValKey
+        // 3. Accumulate cotangents by ValueKey
         for (input, ct_in) in op_node.inputs.iter().zip(ct_ins) {
             if let Some(ct) = ct_in {
                 let key = global_key_of(input);
                 match ct_env.entry(key) {
                     Vacant(e)  => { e.insert(ct); }
                     Occupied(e) => {
-                        // Fan-out: emit Add node for accumulation
+                        // Fan-out: add Add node for accumulation
                         let existing = *e.get();
-                        let sum = builder.add_op(
+                        let sum = builder.add_operation(
                             Op::add(),
-                            vec![ValRef::Local(existing), ValRef::Local(ct)],
-                            OpMode::Linear { active_mask: vec![true, true] },
+                            vec![ValueRef::Local(existing), ValueRef::Local(ct)],
+                            OperationRole::Linearized { active_mask: vec![true, true] },
                         );
                         *e.into_mut() = sum[0];
                     }
@@ -130,20 +130,20 @@ fn transpose<Op: PrimitiveOp>(linear: &LinearFragment<Op>) -> LinearFragment<Op>
             }
         }
     }
-    // Build transposed LinearFragment from builder + ct_env
+    // Build transposed LinearizedGraph from builder + ct_env
 }
 ```
 
-The accumulation `Add` nodes emitted during transpose are **normal graph
-nodes** in the transposed fragment. They carry
-`OpMode::Linear { active_mask: [active, active] }` and participate in
-subsequent AD transforms like any other node. This is why `PrimitiveOp`
+The accumulation `Add` nodes emitted during linear_transpose are **normal graph
+nodes** in the transposed graph. They carry
+`OperationRole::Linearized { active_mask: [active, active] }` and participate in
+subsequent AD transforms like any other node. This is why `Primitive`
 includes `add()`: `tidu` needs one generic way to construct those
 accumulation nodes.
 
-### Worked example: transpose of `f(x) = (x+x)*x`
+### Worked example: linear_transpose of `f(x) = (x+x)*x`
 
-Primal fragment F0:
+Primal graph F0:
 
 ```text
 p0 = Input(x)
@@ -167,30 +167,30 @@ Transpose L1, seed ct_y. `ct_env` state after each step:
 seed:  ct_env = { t4.key → c0 }              c0 = Input(ct_y)
 
 Reverse t4 = Add(t2, t3):
-  Add transpose → ct_t2 = c0, ct_t3 = c0
+  Add linear_transpose → ct_t2 = c0, ct_t3 = c0
   ct_env = { t4.key → c0, t2.key → c0, t3.key → c0 }
 
 Reverse t3 = Mul(t1, p0) [active, fixed]:
-  Mul transpose wrt active → ct_t1 = Mul(p0, c0)
+  Mul linear_transpose wrt active → ct_t1 = Mul(p0, c0)
   c1 = Mul(External(p0), Local(c0))
   ct_env = { ..., t1.key → c1 }
 
 Reverse t2 = Mul(p1, t0) [fixed, active]:
-  Mul transpose wrt active → ct_t0 = Mul(p1, c0)
+  Mul linear_transpose wrt active → ct_t0 = Mul(p1, c0)
   c2 = Mul(External(p1), Local(c0))
   ct_env = { ..., t0.key → c2 }                         ← 1st entry for t0
 
 Reverse t1 = Add(t0, t0) [active, active]:
-  Add transpose → both inputs get ct_t1 = c1
-  Left input t0:  ct_env[t0.key] = c2 (existing) → emit Add
+  Add linear_transpose → both inputs get ct_t1 = c1
+  Left input t0:  ct_env[t0.key] = c2 (existing) → add Add
                    c3 = Add(c2, c1)                      ← accumulation #1
                    ct_env[t0.key] = c3
-  Right input t0: ct_env[t0.key] = c3 (existing) → emit Add
+  Right input t0: ct_env[t0.key] = c3 (existing) → add Add
                    c4 = Add(c3, c1)                      ← accumulation #2
                    ct_env[t0.key] = c4
 ```
 
-Transposed fragment T1:
+Transposed graph T1:
 
 ```text
 c0 = Input(ct_y)
@@ -202,17 +202,17 @@ output: c4 = 2x·ct_y + x·ct_y + x·ct_y = 4x·ct_y  ✓  (f'=4x)
 ```
 
 Note: c1 is referenced by both c3 and c4 — fan-out in the transposed
-fragment itself. This is handled correctly by subsequent transforms
+graph itself. This is handled correctly by subsequent transforms
 (see next section).
 
 ---
 
 ## III. Higher-Order AD and Accumulation Correctness
 
-### FoR: differentiate the transposed fragment
+### FoR: linearize the transposed graph
 
-The transposed fragment T1 computes `ct_x = 4x · ct_y` as a function
-of `(x, ct_y)`. To get the second derivative (FoR), differentiate T1
+The transposed graph T1 computes `ct_x = 4x · ct_y` as a function
+of `(x, ct_y)`. To get the second derivative (FoR), linearize T1
 wrt x via `resolve([F0, T1])`.
 
 Primal tangents:
@@ -243,22 +243,22 @@ Result: `dc4 = 4·dx2·ct_y` → f'' = 4 ✓ (f=2x², f'=4x, f''=4)
 ### Why this is self-consistent
 
 1. **Accumulation produces normal graph nodes.** The `Add` nodes emitted
-   during transpose carry `mode=Linear{[active, active]}`. They have the
+   during linear_transpose carry `role=Linearized{[active, active]}`. They have the
    same `linearize` and `transpose_rule` as any other `Add` node.
 
-2. **Fan-out in transposed fragments is safe.** c1 is used by both c3
+2. **Fan-out in transposed graphs is safe.** c1 is used by both c3
    and c4. In the forward direction (FoR), `dc1` feeds into both
    `dc3` and `dc4`'s linearize — this is just multiple references to
    the same tangent value, which is always correct in forward mode.
 
-3. **Further transpose (RoR) also works.** If we transpose the FoR
-   fragment, `dc1` being used twice would cause two cotangents to flow
+3. **Further linear_transpose (RoR) also works.** If we linear_transpose the FoR
+   graph, `dc1` being used twice would cause two cotangents to flow
    to `dc1`'s key. The same `HashMap` accumulation mechanism handles
    this recursively.
 
-4. **No special-casing at any level.** The `differentiate` and `transpose`
-   algorithms are uniform: `differentiate` calls `Op::linearize` for each
-   node, `transpose` calls `Op::transpose_rule` and accumulates. The
+4. **No special-casing at any level.** The `linearize` and `linear_transpose`
+   algorithms are uniform: `linearize` calls `Op::linearize` for each
+   node, `linear_transpose` calls `Op::transpose_rule` and accumulates. The
    accumulation `Add` is indistinguishable from any other `Add` in the
    graph.
 
@@ -268,25 +268,25 @@ Result: `dc4 = 4·dx2·ct_y` → f'' = 4 ✓ (f=2x², f'=4x, f''=4)
 
 ```text
 JVP:
-  build -> resolve -> differentiate -> materialize_merge -> compile -> eval
+  build -> resolve -> linearize -> materialize_merge -> compile -> eval
 
 VJP (grad):
-  build -> resolve -> differentiate -> transpose -> materialize_merge -> compile -> eval
+  build -> resolve -> linearize -> linear_transpose -> materialize_merge -> compile -> eval
 
 2nd directional derivative (FoF):
-  build -> resolve -> differentiate -> resolve -> differentiate
+  build -> resolve -> linearize -> resolve -> linearize
        -> materialize_merge -> compile -> eval
 
 HVP (FoR = jvp(vjp(f))):
-  build -> resolve -> differentiate -> transpose -> resolve -> differentiate
+  build -> resolve -> linearize -> linear_transpose -> resolve -> linearize
        -> materialize_merge -> compile -> eval
 
 n-th derivative:
-  build -> (resolve -> differentiate) x n -> [transpose] -> materialize_merge -> compile -> eval
+  build -> (resolve -> linearize) x n -> [linear_transpose] -> materialize_merge -> compile -> eval
 ```
 
 `resolve`, `materialize_merge`, `compile`, `eval` are provided by
-`computegraph-rs`. `tidu-rs` only adds `differentiate` and `transpose`.
+`computegraph-rs`. `tidu-rs` only adds `linearize` and `linear_transpose`.
 
 ---
 
@@ -296,19 +296,19 @@ The linear graph uses the same primitive set as the primal graph. There is no
 dedicated `Scale` primitive.
 
 ```text
-Mul(a, dx)   mode=Linear { active_mask=[fixed, active] }
-Add(dx, dy)  mode=Linear { active_mask=[active, active] }
-Exp(x)       mode=Primal
+Mul(a, dx)   role=Linearized { active_mask=[fixed, active] }
+Add(dx, dy)  role=Linearized { active_mask=[active, active] }
+Exp(x)       role=Primary
 ```
 
 The linearization of `Exp(x)` emits:
 
 ```text
-Mul(External(exp(x)), dx) mode=Linear { active_mask=[fixed, active] }
+Mul(External(exp(x)), dx) role=Linearized { active_mask=[fixed, active] }
 ```
 
-Active mask is part of identity (`OpMode::Linear` vs `Primal`). Nodes that
-evaluate the same way but transpose differently must not alias.
+Active mask is part of identity (`OperationRole::Linearized` vs `Primary`). Nodes that
+evaluate the same way but linear_transpose differently must not alias.
 
 ---
 
@@ -316,12 +316,12 @@ evaluate the same way but transpose differently must not alias.
 
 ```text
 tidu-rs owns:
-  - differentiate (JVP transform)
-  - transpose (reverse linear flow)
-  - LinearFragment data structure
+  - Primitive trait
+  - linearize (JVP transform)
+  - linear_transpose (reverse linear flow)
+  - LinearizedGraph data structure
 
 tidu-rs does NOT own:
   - graph infrastructure → computegraph-rs
-  - PrimitiveOp trait → chainrules-rs
   - concrete primitives → downstream (tenferro-rs)
 ```

--- a/docs/guides/custom-operations.md
+++ b/docs/guides/custom-operations.md
@@ -92,7 +92,7 @@ When porting Julia `frule` / `rrule` code:
 - map `NoTangent` / `ZeroTangent` to `None` when the tangent slot is inactive,
 - represent scalar parameters as tensor inputs when users need to vary them,
 - use `reduce_sum_all` for broadcasted scalar inputs,
-- emit only built-in tensor operations or extension ops whose AD rules are
+- add only built-in tensor operations or extension ops whose AD rules are
   registered before a later AD pass reaches them.
 
 The lower-level adapter API remains available for specialized extension

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -61,7 +61,7 @@ the result should remain connected to a scalar loss `backward()` pass.
 For linalg eager helpers or linalg AD rules, enable `tenferro-linalg`'s
 `autodiff` feature.
 
-When traced graph AD must differentiate through linalg extension ops, include the
+When traced graph AD must linearize through linalg extension ops, include the
 owned rule set in an explicit context:
 
 ```rust

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -8,7 +8,7 @@ Design rationale for each subsystem — *what* each layer does and *why*.
 
 - [Crate structure](../architecture/tenferro-crates.md)
 - [Computation graph](../architecture/computegraph.md)
-- [ChainRules AD traits](../architecture/chainrules.md)
+- [Primitive AD traits](../architecture/primitive-ad.md)
 - [tidu AD engine](../architecture/tidu.md)
 - [End-to-end AD pipeline](../architecture/ad-pipeline.md)
 

--- a/docs/spec/ad-contract.md
+++ b/docs/spec/ad-contract.md
@@ -2,64 +2,62 @@
 
 **Date:** 2026-05-28
 **Parent:** [`../index.md`](../index.md)
-**Related:** [`primitive-catalog.md`](primitive-catalog.md), [`../architecture/chainrules.md`](../architecture/chainrules.md), [`../architecture/tidu.md`](../architecture/tidu.md)
+**Related:** [`primitive-catalog.md`](primitive-catalog.md), [`../architecture/primitive-ad.md`](../architecture/primitive-ad.md), [`../architecture/tidu.md`](../architecture/tidu.md)
 
 ---
 
 ## Purpose
 
 This document is the normative specification for the AD trait contract that
-concrete primitives must satisfy. It owns the `PrimitiveOp` trait signature
+concrete primitives must satisfy. It owns the `Primitive` trait signature
 and the rules that `linearize` and `transpose_rule` must follow.
 
-For the AD pipeline architecture (differentiate, transpose, higher-order AD),
+For the AD pipeline architecture (linearize, linear_transpose, higher-order AD),
 see [`../architecture/ad-pipeline.md`](../architecture/ad-pipeline.md).
 
 For the AD trait design rationale, see
-[`../architecture/chainrules.md`](../architecture/chainrules.md).
+[`../architecture/primitive-ad.md`](../architecture/primitive-ad.md).
 
 ---
 
-## PrimitiveOp trait (canonical signature)
+## Primitive trait (canonical signature)
 
-Defined in `chainrules-rs/src/primitive_op.rs`. Extends `GraphOp` with
+Defined in `tidu-rs/src/rules/primitive_op.rs`. Extends `GraphOperation` with
 the constraint `Self::InputKey: ADKey`.
 
 ```rust
-pub trait PrimitiveOp: GraphOp
+pub trait Primitive: GraphOperation
 where
     Self::InputKey: ADKey,
 {
+    type ADContext: Default;
+
     /// Returns the addition operation used for cotangent accumulation.
-    /// tidu's `transpose` emits `Op::add()` nodes when multiple cotangents
+    /// tidu's `linear_transpose` emits `Op::add()` nodes when multiple cotangents
     /// flow to the same value.
     fn add() -> Self where Self: Sized;
 
-    /// Emit the linear (JVP) rule for this primitive.
-    ///
-    /// Must be linear in tangent inputs. May reference primal inputs/outputs
-    /// through `External(GlobalValKey)`. Must emit ops in `OpMode::Linear`.
-    fn linearize(
+    /// Emit the JVP rule for this primitive.
+    fn jvp_rule(
         &self,
-        builder: &mut FragmentBuilder<Self>,
-        primal_in: &[GlobalValKey<Self>],
-        primal_out: &[GlobalValKey<Self>],
-        tangent_in: &[Option<LocalValId>],
-    ) -> Vec<Option<LocalValId>>
+        builder: &mut impl PrimitiveBuilder<Self>,
+        primal_inputs: &[ValueKey<Self>],
+        primal_outputs: &[ValueKey<Self>],
+        tangent_inputs: &[Option<LocalValueId>],
+        ctx: &mut Self::ADContext,
+    ) -> Vec<Option<LocalValueId>>
     where
         Self: Sized;
 
     /// Emit the transpose rule for this linear primitive.
-    ///
-    /// Receives cotangent outputs and produces cotangent inputs.
-    /// Must only emit ops that themselves implement `PrimitiveOp`.
     fn transpose_rule(
         &self,
-        builder: &mut FragmentBuilder<Self>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<Self>],
-        mode: &OpMode,
-    ) -> Vec<Option<LocalValId>>
+        builder: &mut impl PrimitiveBuilder<Self>,
+        cotangent_outputs: &[Option<LocalValueId>],
+        inputs: &[PrimitiveValue<Self>],
+        role: &OperationRole,
+        ctx: &mut Self::ADContext,
+    ) -> Vec<Option<LocalValueId>>
     where
         Self: Sized;
 }
@@ -67,48 +65,50 @@ where
 
 ## ADKey trait (canonical signature)
 
-Defined in `chainrules-rs/src/ad_key.rs`. Required bound on
-`PrimitiveOp::InputKey`.
+Defined in `tidu-rs/src/rules/ad_key.rs`. Required bound on
+`Primitive::InputKey`.
 
 ```rust
 pub trait ADKey: Clone + Debug + Hash + Eq + Send + Sync + 'static {
     /// Create a tangent input key derived from this key.
-    /// `pass` is a unique identifier for the `differentiate` call.
+    /// `pass` is a unique identifier for the `linearize` call.
     fn tangent_of(&self, pass: DiffPassId) -> Self;
 }
 ```
 
 `DiffPassId` is `u64`.
 
-## LinearFragment (canonical definition)
+## LinearizedGraph (canonical definition)
 
-Defined in `tidu-rs/src/linear_fragment.rs`. Returned by
-`tidu::differentiate` (which internally calls `PrimitiveOp::linearize`
-per op node — note that `linearize` itself returns
-`Vec<Option<LocalValId>>`, not `LinearFragment`; the fragment is
-assembled by `differentiate`).
+Defined in `tidu-rs/src/linearized_graph.rs`. Returned by
+`tidu::linearize` (which internally calls `Primitive::jvp_rule`
+per operation node — note that `jvp_rule` itself returns
+`Vec<Option<LocalValueId>>`, not `LinearizedGraph`; the graph is
+assembled by `linearize`).
 
 ```rust
-pub struct LinearFragment<Op: GraphOp> {
-    /// The fragment containing linear ops.
-    pub fragment: Fragment<Op>,
-    /// (primal_input_key, tangent_local_val_id) pairs.
-    pub tangent_inputs: Vec<(Op::InputKey, LocalValId)>,
-    /// Tangent outputs, aligned with requested outputs.
-    /// None means the corresponding output is inactive.
-    pub tangent_outputs: Vec<Option<LocalValId>>,
+pub struct LinearizedGraph<Op: GraphOperation> {
+    graph: Graph<Op>,
+    tangent_inputs: Vec<(Op::InputKey, LocalValueId)>,
+    tangent_outputs: Vec<Option<LocalValueId>>,
+}
+
+impl<Op: GraphOperation> LinearizedGraph<Op> {
+    pub fn as_graph(&self) -> &Graph<Op>;
+    pub fn tangent_inputs(&self) -> &[(Op::InputKey, LocalValueId)];
+    pub fn tangent_outputs(&self) -> &[Option<LocalValueId>];
 }
 ```
 
 ## Rules
 
-1. **Closure**: `linearize` and `transpose_rule` must emit only ops that
-   themselves implement `PrimitiveOp`. This is the sole closure requirement.
+1. **Closure**: `linearize` and `transpose_rule` must add only ops that
+   themselves implement `Primitive`. This is the sole closure requirement.
    tenferro-rs is responsible for satisfying it.
 
 2. **Cotangent accumulation**: when a value fans out to multiple consumers,
-   tidu's `transpose` accumulates cotangents via `Op::add()`. This means
-   `Add` must implement `PrimitiveOp` and its transpose rule must be the
+   tidu's `linear_transpose` accumulates cotangents via `Op::add()`. This means
+   `Add` must implement `Primitive` and its linear_transpose rule must be the
    identity (cotangent passes through to both inputs).
 
 3. **Linear ops**: an op whose `linearize` returns itself (identity tangent
@@ -116,7 +116,7 @@ pub struct LinearFragment<Op: GraphOp> {
    `BroadcastInDim`.
 
 4. **Primal reuse**: `linearize` may reference primal values via
-   `External(GlobalValKey)` in the fragment builder. These are resolved
+   `External(ValueKey)` in the graph builder. These are resolved
    during `materialize_merge` so that shared primal computations are not
    duplicated.
 
@@ -127,7 +127,7 @@ pub struct LinearFragment<Op: GraphOp> {
 
 ## Owned by this document
 
-- `PrimitiveOp` trait signature
+- `Primitive` trait signature
 - Closure rule
 - Cotangent accumulation rule
 - Linear op rule

--- a/docs/spec/extension-op.md
+++ b/docs/spec/extension-op.md
@@ -34,14 +34,14 @@ shape (arguments, return types, blanket bounds) of any signature fixed here.
 This spec extends the three normative contracts that already exist in
 `docs/spec/`:
 
-- [`ad-contract.md`](ad-contract.md) owns the `PrimitiveOp` trait. This
+- [`ad-contract.md`](ad-contract.md) owns the `Primitive` trait. This
   document extends it by specifying how an `ExtensionOp` participates in
-  AD **without** itself implementing `PrimitiveOp`: the dispatcher in
+  AD **without** itself implementing `Primitive`: the dispatcher in
   `tenferro-internal-ops/src/ad/mod.rs` routes `StdTensorOp::Extension(op)` to a
   rule for `op.family_id()` in the active `ExtensionRuleSet`. The rule emits
   tangents and cotangents expressed in the core `StdTensorOp` vocabulary, or
   in extension helper families covered by Section 10's AD-closure rules. The
-  ad-contract closure rule (emit only ops that implement `PrimitiveOp`) is
+  ad-contract closure rule (add only ops that implement `Primitive`) is
   preserved at the carrier level because the graph still contains only
   `StdTensorOp` values.
 - [`primitive-catalog.md`](primitive-catalog.md) owns the core op
@@ -158,17 +158,17 @@ pub trait ExtensionOp: std::fmt::Debug + Send + Sync + 'static {
 
     /// Number of primal inputs. MUST be consistent with
     /// `infer_output_meta` (same input count).
-    fn n_inputs(&self) -> usize;
+    fn input_count(&self) -> usize;
 
     /// Number of outputs. MUST match the length of the returned
     /// `Vec` from `infer_output_meta`.
-    fn n_outputs(&self) -> usize;
+    fn output_count(&self) -> usize;
 
     // ----- Shape and dtype inference (Section 7) -----
 
     /// Infer output dtype and shape for each output slot.
     ///
-    /// Returned vector length MUST equal `self.n_outputs()`. Shapes use
+    /// Returned vector length MUST equal `self.output_count()`. Shapes use
     /// graph-global `SymDim` (symbolic dimensions), consistent with
     /// `TensorMeta::shape` in `tenferro-internal-ops/src/ad/context.rs`. Input
     /// metadata is given as slices of `SymDim` / `DType`; see Section 7
@@ -201,7 +201,7 @@ pub trait ExtensionOp: std::fmt::Debug + Send + Sync + 'static {
 ### Carrier traits: how `StdTensorOp::Extension` gets `Clone + Hash + Eq`
 
 The core op enum requires `Clone + Debug + Hash + Eq + Send + Sync +
-'static` (per `computegraph::GraphOp`). `Arc<dyn ExtensionOp>` satisfies
+'static` (per `computegraph::GraphOperation`). `Arc<dyn ExtensionOp>` satisfies
 these through delegation:
 
 - `Clone` via `Arc::clone` (cheap, reference-counted). No deep clone
@@ -283,7 +283,7 @@ op interner, AD rule caching, and structural graph comparison.
 ### Failure signature
 
 - An implementer that does not supply a stable `family_id` breaks op
-  interning across graph builds. Symptom: every call to `builder.add_op`
+  interning across graph builds. Symptom: every call to `builder.add_operation`
   with the "same" extension creates a fresh node, exploding memory and
   defeating CSE.
 - An implementer whose `payload_hash` disagrees with `payload_eq`
@@ -408,24 +408,24 @@ default choice is to add `Any` via a method-based helper to keep
 
 ### Fixed-arity contract
 
-Every `ExtensionOp` MUST declare fixed `n_inputs` and `n_outputs` values
+Every `ExtensionOp` MUST declare fixed `input_count` and `output_count` values
 whose return is independent of runtime input sizes. This aligns with the
 `StdTensorOp` arity dispatcher in
-`tenferro-internal-ops/src/std_tensor_op.rs` (e.g. `n_inputs` for `DotGeneral` is
+`tenferro-internal-ops/src/std_tensor_op.rs` (e.g. `input_count` for `DotGeneral` is
 always `2`).
 
 The dispatcher integration in `tenferro-internal-ops/src/ad/mod.rs` MUST treat
-`StdTensorOp::Extension(op)` as having `op.n_inputs()` inputs and
-`op.n_outputs()` outputs. Validation:
+`StdTensorOp::Extension(op)` as having `op.input_count()` inputs and
+`op.output_count()` outputs. Validation:
 
 - The number of `primal_in` keys passed to `linearize` MUST equal
-  `op.n_inputs()`.
-- The number of `tangent_in` entries MUST equal `op.n_inputs()`.
-- The number of `primal_out` keys MUST equal `op.n_outputs()`.
+  `op.input_count()`.
+- The number of `tangent_in` entries MUST equal `op.input_count()`.
+- The number of `primal_out` keys MUST equal `op.output_count()`.
 - The returned tangent-output vector from `linearize` MUST have length
-  `op.n_outputs()`.
+  `op.output_count()`.
 - The returned cotangent-input vector from `transpose_rule` MUST have
-  length `op.n_inputs()`.
+  length `op.input_count()`.
 
 ### Variable-arity extensions (discouraged)
 
@@ -434,12 +434,12 @@ analogue) are discouraged because they force the dispatcher to
 re-derive arity per instance. If such an op is unavoidable, the
 implementer MUST:
 
-1. Store the arity in the payload (so `n_inputs` reads it from `self`,
+1. Store the arity in the payload (so `input_count` reads it from `self`,
    not from the arguments).
 2. Document in the extension's own doc comment that the arity is
    dynamic, together with the payload field that determines it.
 3. Preserve the invariant that for a given `Arc<dyn ExtensionOp>`
-   value, `n_inputs()` returns the same value every time.
+   value, `input_count()` returns the same value every time.
 
 Variable-arity extensions remain outside `StdTensorOp`'s own variable-arity
 branch. Core variants with dynamic arity, such as `StdTensorOp::Concatenate`,
@@ -447,9 +447,9 @@ store the arity in their payload and are handled by the core enum directly.
 
 ### Failure signature
 
-- `n_inputs` disagreeing with `linearize`'s `primal_in` length in the
+- `input_count` disagreeing with `linearize`'s `primal_in` length in the
   dispatcher causes `Error::InvalidConfig` (see Section 12).
-- `n_outputs` disagreeing with `eager_execute`'s returned vector
+- `output_count` disagreeing with `eager_execute`'s returned vector
   length causes `Error::InvalidConfig`.
 
 ---
@@ -474,9 +474,9 @@ extension.
 ### Contract
 
 - `input_dtypes.len()` and `input_shapes.len()` MUST both equal
-  `self.n_inputs()`. Callers (`compile_std_to_exec`, eager execution)
+  `self.input_count()`. Callers (`compile_std_to_exec`, eager execution)
   guarantee this.
-- The returned vector MUST have length `self.n_outputs()`.
+- The returned vector MUST have length `self.output_count()`.
 - Each `(dtype, shape)` pair gives the inferred dtype and symbolic shape
   for the corresponding output slot.
 - Shapes are expressed as `Vec<SymDim>` to match
@@ -563,8 +563,8 @@ The compiled path runs through
   `StdTensorOp::Extension` variant to `ExecOp::Extension`, calling
   `infer_output_meta` for metadata population, and assigning
   `last_use` markers. It does not invoke backend kernels.
-- **`eager_exec` / `eager_emitter`** are responsible for: resolving
-  inputs from the emitter's tensor cache and calling the runtime-owned
+- **`eager_exec` / `eager_builder`** are responsible for: resolving
+  inputs from the builder's tensor cache and calling the runtime-owned
   extension executor when one is available.
 - **Extension runtime (`ExtensionRuntime<B>`)** is responsible for: actual
   forward computation, backend use, runtime cache entries, and device placement
@@ -676,8 +676,8 @@ from any thread; writes happen only during initialization.
 
 Extension AD is registered independently from the primal op. Extension crates
 implement `ExtensionAdRule` and add it to an `ExtensionRuleSet`. Rule
-signatures mirror `PrimitiveOp::try_linearize` and
-`PrimitiveOp::try_transpose_rule` and return `ADRuleResult<_>` so missing rules
+signatures mirror `Primitive::try_linearize` and
+`Primitive::try_transpose_rule` and return `ADRuleResult<_>` so missing rules
 can propagate without panic:
 
 ```rust
@@ -687,22 +687,22 @@ pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut FragmentBuilder<StdTensorOp>,
-        primal_in: &[GlobalValKey<StdTensorOp>],
-        primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut GraphBuilder<StdTensorOp>,
+        primal_in: &[ValueKey<StdTensorOp>],
+        primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>>;
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
 
     fn transpose_rule(
         &self,
         op: &dyn ExtensionOp,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<StdTensorOp>],
-        mode: &OpMode,
+        builder: &mut dyn PrimitiveBuilder<StdTensorOp>,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
+        mode: &OperationRole,
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>>;
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
 }
 ```
 
@@ -711,13 +711,13 @@ that need payload parameters should downcast via `op.as_any()`.
 
 ### AD closure
 
-`linearize` and `transpose_rule` may emit core `StdTensorOp` values and
+`linearize` and `transpose_rule` may add core `StdTensorOp` values and
 `StdTensorOp::Extension` values. Emitted extension families MUST have their
 own `ExtensionAdRule` in the active `ExtensionRuleSet` before a subsequent AD
 pass reaches them. Terminal first-order helper families MAY omit a separate AD
 rule when the owning extension documents that higher-order AD through that
 helper is unsupported. This keeps out-of-tree operations in the same compute
-graph while preserving the `PrimitiveOp` closure invariant at the
+graph while preserving the `Primitive` closure invariant at the
 `StdTensorOp` carrier level.
 
 ### `ShapeGuardContext` interaction
@@ -814,7 +814,7 @@ these error types / behaviours in the listed scenarios.
 | Graph references an unregistered `family_id` at compile time | Return `Error::Unsupported` from `compile_std_to_exec`. |
 | AD rules (`linearize` / `transpose_rule`) encounter an `Extension` with no rule in the active `ExtensionRuleSet` | Return `ADRuleError::Unsupported` with `family_id` and rule kind; traced `grad` / eager `backward` propagate it through the public `Error` type re-exported by the owning surface crate. |
 | Duplicate AD rule `family_id` in one `ExtensionRuleSet` or the compatibility global registry | Rule registration MUST reject with `ExtensionRegistryError::DuplicateRule`. |
-| Arity mismatch: `n_inputs()` disagrees with the `primal_in.len()` the dispatcher passed | `Error::InvalidConfig { op: "extension", message: "family_id=<id>: expected N inputs, got M" }`. |
+| Arity mismatch: `input_count()` disagrees with the `primal_in.len()` the dispatcher passed | `Error::InvalidConfig { op: "extension", message: "family_id=<id>: expected N inputs, got M" }`. |
 | Output shape disagrees with `infer_output_meta` result length | `Error::InvalidConfig` with `family_id` and the mismatched counts. |
 | Extension runtime returns a tensor on the wrong device | Propagate to the caller as a backend failure (the core pipeline does not re-locate tensors). |
 | AD rule registration with malformed `family_id` | `ExtensionRegistryError::MalformedFamilyId`. |
@@ -914,7 +914,7 @@ tropical einsum:
   registers the primal family `tenferro-ext-tropical.einsum.v1` and the JVP
   helper family `tenferro-ext-tropical.einsum_jvp.v1`. The transposed JVP emits
   runtime-registered VJP execution helper `tenferro-ext-tropical.einsum_vjp.v1`;
-  it is a terminal transpose helper, not a separately registered AD rule family
+  it is a terminal linear_transpose helper, not a separately registered AD rule family
   for higher-order AD.
 - Tropical AD follows the unique-winner subgradient. The JVP gathers the active
   tangent at each first-winning contracted coordinate; the VJP scatters the
@@ -950,8 +950,8 @@ without revisiting this document.
    split are open.
 
 4. **Metrics / observability hooks.** Whether `eager_execute` should
-   emit tracing spans (via `tracing` crate or similar) is deferred.
-   Extensions MAY emit their own; the core pipeline does not
+   add tracing spans (via `tracing` crate or similar) is deferred.
+   Extensions MAY add their own; the core pipeline does not
    instrument extension calls today.
 
 ---

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -8,7 +8,7 @@ link here rather than re-stating.
 |----------|------|
 | [primitive-catalog.md](./primitive-catalog.md) | Tenferro IR op vocabulary, per-op semantics, and core primitive catalog boundary |
 | [backend-contract.md](./backend-contract.md) | Backend pipeline, Execution IR dispatch, backend trait signatures |
-| [ad-contract.md](./ad-contract.md) | PrimitiveOp trait signature, linearize/transpose_rule requirements |
+| [ad-contract.md](./ad-contract.md) | Primitive trait signature, linearize/transpose_rule requirements |
 | [optimizer-passes.md](./optimizer-passes.md) | Optimization pass algorithms and ordering |
 | [tensor-semantics.md](./tensor-semantics.md) | Tensor type semantics, stride model, contiguity rules |
 | [extension-op.md](./extension-op.md) | ExtensionOp trait contract (identity, AD, dispatch, registry) |

--- a/docs/spec/primitive-catalog.md
+++ b/docs/spec/primitive-catalog.md
@@ -27,7 +27,7 @@ different senses. For readability, this document separates them explicitly:
 | Layer | Example | Meaning |
 |-------|---------|---------|
 | Surface API | `einsum`, `sum`, `mean`, `grad`, `svd()` | what users call |
-| Tenferro IR | `DotGeneral`, `ReduceSum`, `BroadcastInDim` | what may appear as `StdTensorOp` nodes in a `Fragment`; fragment construction, AD, einsum decomposition |
+| Tenferro IR | `DotGeneral`, `ReduceSum`, `BroadcastInDim` | what may appear as `StdTensorOp` nodes in a `Graph`; graph construction, AD, einsum decomposition |
 | Core primitive catalog | `PrimitiveOpKind`, descriptors | internal metadata in `tenferro-core-ops` used by graph, runtime, and backend dispatch |
 | Execution IR | `ExecOp` variants | output of the optimizing compiler; input to runtime/backend dispatch |
 | Backend kernel | BLAS GEMM, cuSOLVER SVD, IREE module, faer routine | how an instruction is executed |
@@ -38,7 +38,7 @@ different senses. For readability, this document separates them explicitly:
 ┌─────────────────────────────────────────┐
 │ Tenferro IR                             │
 │ (StdTensorOp)                           │
-│ Fragment construction, AD, einsum        │
+│ Graph construction, AD, einsum          │
 └──────────────┬──────────────────────────┘
                │ compile_std_to_exec()
 ┌──────────────▼──────────────────────────┐
@@ -59,7 +59,7 @@ This document uses **three orthogonal classifications**:
 
 Important distinctions:
 
-- `differentiate`, `transpose`, `resolve`, and `compile` are **transforms**, not
+- `linearize`, `linear_transpose`, `resolve`, and `compile` are **transforms**, not
   primitives.
 - `einsum` is **surface syntax**, not a final persistent Tenferro IR primitive.
   It is lowered into Tenferro IR primitives such as `DotGeneral`, `Mul`,
@@ -77,7 +77,7 @@ Important distinctions:
 
 Responsibility boundary:
 
-- `chainrules-rs` owns the `PrimitiveOp` contract
+- `tidu-rs` owns the `Primitive` contract
 - `tidu-rs` owns generic AD transforms that call `linearize` and
   `transpose_rule`
 - tenferro owns the **concrete per-op derivative rules**
@@ -101,10 +101,10 @@ downstream tenferro design/implementation concern.
 Elementwise primitives such as `Add` and `Mul` do **not** silently broadcast.
 If shapes differ, the graph must contain an explicit `BroadcastInDim`.
 
-### `Transpose` vs AD transpose
+### `Transpose` vs AD linear_transpose
 
 `Transpose(perm)` is the tensor operation "permute axes".
-It is unrelated to the AD transform `transpose(linear_fragment)`.
+It is unrelated to the AD transform `linear_transpose(linear_graph)`.
 
 ### Multi-output primitives
 
@@ -114,7 +114,7 @@ Some primitives produce multiple outputs:
 - `QR(A) -> (Q, R)`
 
 The output ordering must be part of the primitive definition because
-`GlobalValKey` includes `output_slot`.
+`ValueKey` includes `output_slot`.
 
 ### Column-major (Fortran) convention
 
@@ -155,19 +155,19 @@ Key relationships:
 
 ## IV. Core Traits (canonical signatures)
 
-### GraphOp
+### GraphOperation
 
-`GraphOp` is the operation node trait. computegraph-rs is fully generic over
+`GraphOperation` is the operation node trait. computegraph-rs is fully generic over
 it and never references specific primitives.
 
 ```rust
-trait GraphOp: Clone + Debug + Hash + Eq + Send + Sync + 'static {
+trait GraphOperation: Clone + Debug + Hash + Eq + Send + Sync + 'static {
     type Operand: Operand;
     type Context;
     type InputKey: Clone + Debug + Hash + Eq + Send + Sync + 'static;
 
-    fn n_inputs(&self) -> usize;
-    fn n_outputs(&self) -> usize;
+    fn input_count(&self) -> usize;
+    fn output_count(&self) -> usize;
     fn eval(&self, ctx: &mut Self::Context, inputs: &[&Self::Operand]) -> Vec<Self::Operand>;
 }
 ```
@@ -208,7 +208,7 @@ through the runtime tensor and backend APIs described in
 ## V. Tenferro IR Vocabulary
 
 This section is about the graph-level vocabulary that `computegraph-rs`,
-`chainrules-rs`, `tidu-rs`, and tenferro's `StdTensorOp` layer talk about.
+`tidu-rs`, and tenferro's `StdTensorOp` layer talk about.
 
 These ops define the **Tenferro IR**. Core primitives map to
 `PrimitiveOpKind` descriptors in `tenferro-core-ops`; extension payloads are
@@ -223,9 +223,9 @@ These are the tensor primitives needed to express:
 - general contractions (including repeated-index patterns like trace/diagonal)
 - reverse-mode accumulation without hidden fan-out
 
-Every op in this table is expected to implement `PrimitiveOp` directly
+Every op in this table is expected to implement `Primitive` directly
 (for `StdTensorOp`). The set is **AD-closed**: `linearize` and
-`transpose_rule` of any op in this table emit only ops from this table.
+`transpose_rule` of any op in this table add only ops from this table.
 
 **Implementation note:** the boundary between this core set and the
 "Additional dense numeric primitives" (Section V) is primarily an
@@ -363,7 +363,7 @@ and symbolic-shape AD. The remaining indexing ops are dense tensor primitives:
 | `Slice` | Read a static rectangular subregion | Start/limit/stride known in the op |
 | `DynamicSlice` | Read a slice whose start index is data-dependent | Dynamic counterpart of `Slice` |
 | `DynamicUpdateSlice` | Write an update tensor into an operand at data-dependent start indices | Transpose counterpart of `DynamicSlice`; start indices are adjusted with StableHLO `dynamic_update_slice` semantics. |
-| `Pad` | Extend a tensor with edge/interior padding values | Needed for transpose of slicing-like ops |
+| `Pad` | Extend a tensor with edge/interior padding values | Needed by transpose rules for slicing-like ops |
 | `Concatenate` | Join tensors along one axis | Rank-preserving shape change |
 | `Reverse` | Reverse the order of elements along selected axes | Useful for convolutions and sequence models |
 
@@ -391,7 +391,7 @@ primitive catalog.
 | `Eigh` | `(eigenvalues, eigenvectors)` | Hermitian / symmetric eigendecomposition |
 | `Solve` | `(X)` | Solve `A X = B` for `X` |
 
-Linalg derivative rules emit core graph primitives and, where needed, other
+Linalg derivative rules add core graph primitives and, where needed, other
 registered extension operations.
 
 ### Future control-flow primitives
@@ -435,10 +435,10 @@ than as distinct graph primitives.
 ### Constants and literals
 
 Constants (scalar or tensor literals) are **not** Tenferro IR primitives.
-They enter the graph as `Fragment` input nodes with attached data
+They enter the graph as `Graph` input nodes with attached data
 (`TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(...))`).
 Canonical lowerings that reference literal values (e.g., `1 / n` in `mean`,
-`1` in `reciprocal`) construct these as `Fragment` inputs.
+`1` in `reciprocal`) construct these as `Graph` inputs.
 
 ### Lowering table
 
@@ -471,7 +471,7 @@ This catalog defines the **semantic vocabulary at all IR levels** that the
 graph, AD stack, and execution engine talk about.
 
 - The **Tenferro IR** (Section IV) defines the graph-level vocabulary for
-  fragment construction, AD, and einsum decomposition.
+  graph construction, AD, and einsum decomposition.
 - The **core primitive catalog** (`tenferro-core-ops`) defines primitive
   identity and metadata used by graph, runtime, and backend dispatch.
 - The **Execution IR** is the interface between the optimizing

--- a/docs/worklogs/2026-06-01-graph-terminology-migration.md
+++ b/docs/worklogs/2026-06-01-graph-terminology-migration.md
@@ -1,0 +1,93 @@
+# Graph terminology migration work log
+
+Companion PRs:
+
+- computegraph-rs: <https://github.com/tensor4all/computegraph-rs/pull/4>
+- tidu-rs: <https://github.com/tensor4all/tidu-rs/pull/31>
+
+Date: 2026-06-01
+
+## Session summary
+
+This change updates tenferro to the breaking graph terminology API merged in
+`computegraph-rs` and `tidu-rs`.
+
+The companion upstream PRs renamed the old graph-building vocabulary to the
+current API:
+
+- `Fragment` / `FragmentBuilder` became `Graph` / `GraphBuilder`
+- value and operation identifiers use `Value*` / `Operation*` names
+- operation roles use `OperationRole::{Primary, Linearized}`
+- builder APIs use `add_operation`, `values`, `operations`, and
+  `resolve_value`
+- the old `OpEmitter` abstraction was removed
+
+This tenferro PR pins both upstream commits, migrates active source and current
+documentation, and deliberately avoids compatibility aliases.
+
+It also fixes issue #964 by making the `tenferro-linalg/autodiff` AD helpers
+accept the same `PrimitiveRuleBuilder` trait-object boundary used by the
+extension AD rule entrypoints.
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| `AGENTS.md` | Confirm repository workflow and verification expectations. | Kept the change on a feature branch and added this work log. |
+| `REPOSITORY_RULES.md` | Review terminology, docs, and PR gate requirements. | Excluded historical `docs/plans` material and planned the full local gate before PR. |
+| local `computegraph-rs` checkout | Confirm the final renamed API surface. | Migrated field, type, and method names to the merged computegraph API. |
+| local `tidu-rs` checkout | Confirm `PrimitiveBuilder`, `LinearizedGraph`, and eager backward APIs. | Added a tenferro-side `PrimitiveRuleBuilder` bridge and removed dependence on `OpEmitter`. |
+| `tenferro-ad`, `tenferro-runtime`, `tenferro-internal-ops` | Locate graph metadata, eager backward, traced AD, and rule-builder boundaries. | Renamed graph metadata helpers and eager transpose execution to builder terminology. |
+| extension crates (`tenferro-einsum`, `tenferro-linalg`, `tenferro-fft`, `ext/tropical`) | Check optional `autodiff` imports and rule signatures. | Kept feature-gated AD imports and updated rule parameters to `PrimitiveRuleBuilder`. |
+| issue #964 | Confirm the reported `tenferro-linalg/autodiff` failure mode. | Converted remaining linalg AD helper signatures from sized `impl PrimitiveRuleBuilder` to `dyn PrimitiveRuleBuilder`. |
+
+## Decisions made
+
+- **No compatibility aliases.** The public and internal surface now uses the
+  new graph/value/operation terminology directly.
+- **Use `PrimitiveRuleBuilder` for tenferro AD rules.** It bridges
+  `computegraph::GraphBuilder` and `tidu::PrimitiveBuilder` so rule code can
+  call `add_operation` without depending on the removed `OpEmitter` API.
+- **Rename eager transpose execution to builder terminology.**
+  `EagerEmitter` became `EagerPrimitiveBuilder`, and the module moved from
+  `eager_emitter.rs` to `eager_builder.rs`.
+- **Rename graph metadata helpers.** Scoped metadata functions now refer to
+  graphs rather than fragments.
+- **Rename current Primitive AD architecture doc.** The old
+  `docs/architecture/chainrules.md` page moved to
+  `docs/architecture/primitive-ad.md`; historical/reference documents remain
+  unchanged.
+- **Update current docs only.** Historical design notes under `docs/plans` and
+  generated/historical material remain untouched.
+
+## Rejected or deferred alternatives
+
+- **No alias module for old computegraph names.** The user explicitly allowed a
+  destructive migration and no compatibility requirement exists.
+- **No local copy of computegraph/tidu abstractions.** tenferro depends on the
+  merged upstream commits instead of vendoring or shadowing the APIs.
+- **No broad AD semantic rewrite.** The migration is terminology/API shape:
+  graph-level `linearize` and `transpose_rule` semantics stay the same.
+
+## Verification performed
+
+- `cargo check --workspace --all-targets`
+- `cargo check -p tenferro-linalg --features autodiff`
+- `cargo fmt --all --check`
+- `cargo test --workspace --release`
+- `cargo test -p tenferro-linalg --features autodiff --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-doc-snippets.py`
+- `python3 scripts/check-docs-site.py`
+- `cargo clippy --workspace --all-targets --release -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `CUDARC_CUDA_VERSION=12080 cargo test --no-run --package tenferro-gpu --package tenferro-ad --package tenferro-linalg --features cuda --release`
+- `git diff --check`
+- old terminology scan across active source and current docs
+
+## Remaining risk
+
+- CI still needs to validate the branch in GitHub's environment, but the local
+  release-mode workspace, coverage, docs, formatting, and lint gates passed.

--- a/ext/tropical/Cargo.toml
+++ b/ext/tropical/Cargo.toml
@@ -30,8 +30,8 @@ tenferro-einsum = { path = "../../tenferro-einsum" }
 tenferro-internal-ops = { path = "../../tenferro-internal-ops", default-features = false }
 tenferro-runtime = { path = "../../tenferro-runtime" }
 tenferro-tensor = { path = "../../tenferro-tensor" }
-computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "c20e8912560ef11166418bcea089126ef50443cc", optional = true }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "f0d91566edb2ea08fac9d61ef26f9cd1754f02df", optional = true }
+computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7", optional = true }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "9934d8b775fcfbbad8e2daf3f9af54477da63e35", optional = true }
 num-traits = "0.2"
 tropical-gemm = { version = "0.2", default-features = false, optional = true }
 

--- a/ext/tropical/src/extension.rs
+++ b/ext/tropical/src/extension.rs
@@ -4,13 +4,10 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
-use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
-#[cfg(feature = "autodiff")]
-#[cfg(feature = "autodiff")]
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-#[cfg(feature = "autodiff")]
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_einsum::Subscripts;
+#[cfg(feature = "autodiff")]
+use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::ext_op::ExtensionOp;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ext_op::{register_extension_rule, ExtensionAdRule};
@@ -29,6 +26,8 @@ use tenferro_tensor::TensorBackend;
 use tenferro_tensor::{DType, Tensor};
 #[cfg(feature = "autodiff")]
 use tenferro_tensor::{TensorBackend, TensorScalar};
+#[cfg(feature = "autodiff")]
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::einsum::tropical_einsum_subscripts_with_argmax;
 #[cfg(feature = "autodiff")]
@@ -140,11 +139,11 @@ impl ExtensionOp for TropicalEinsumOp {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         2
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -212,11 +211,11 @@ impl ExtensionOp for TropicalEinsumJvpOp {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         2 + self.active_inputs.len()
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -227,16 +226,16 @@ impl ExtensionOp for TropicalEinsumJvpOp {
     ) -> Vec<(DType, Vec<SymDim>)> {
         assert_eq!(
             input_dtypes.len(),
-            self.n_inputs(),
+            self.input_count(),
             "tropical einsum JVP expects {} inputs, got {}",
-            self.n_inputs(),
+            self.input_count(),
             input_dtypes.len()
         );
         assert_eq!(
             input_shapes.len(),
-            self.n_inputs(),
+            self.input_count(),
             "tropical einsum JVP expects {} input shapes, got {}",
-            self.n_inputs(),
+            self.input_count(),
             input_shapes.len()
         );
         let primal =
@@ -256,10 +255,14 @@ impl ExtensionOp for TropicalEinsumJvpOp {
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        if inputs.len() != self.n_inputs() {
+        if inputs.len() != self.input_count() {
             return Err(invalid_config(
                 "tropical_einsum_jvp",
-                format!("expected {} inputs, got {}", self.n_inputs(), inputs.len()),
+                format!(
+                    "expected {} inputs, got {}",
+                    self.input_count(),
+                    inputs.len()
+                ),
             ));
         }
         let primal = tropical_einsum_subscripts_with_argmax(
@@ -328,11 +331,11 @@ impl ExtensionOp for TropicalEinsumVjpOp {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         3
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -410,12 +413,12 @@ impl ExtensionAdRule for TropicalEinsumAdRule {
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut dyn OpEmitter<StdTensorOp>,
-        primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut dyn PrimitiveRuleBuilder,
+        primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_primal_op(op, ADRuleKind::Jvp)?;
         validate_ad_supported(&op.subscripts, ADRuleKind::Jvp)?;
         let active_inputs: Vec<usize> = tangent_in
@@ -428,25 +431,25 @@ impl ExtensionAdRule for TropicalEinsumAdRule {
         }
 
         let mut inputs = vec![
-            ValRef::External(primal_in[0].clone()),
-            ValRef::External(primal_in[1].clone()),
+            ValueRef::External(primal_in[0].clone()),
+            ValueRef::External(primal_in[1].clone()),
         ];
         for &active in &active_inputs {
-            inputs.push(ValRef::Local(
+            inputs.push(ValueRef::Local(
                 tangent_in[active].expect("active tangent is present"),
             ));
         }
         let active_mask = std::iter::repeat_n(false, 2)
             .chain(std::iter::repeat_n(true, active_inputs.len()))
             .collect();
-        let out = builder.add_op(
+        let out = builder.add_operation(
             StdTensorOp::Extension(Arc::new(TropicalEinsumJvpOp::new(
                 op.kind,
                 op.subscripts.clone(),
                 active_inputs,
             ))),
             inputs,
-            OpMode::Linear { active_mask },
+            OperationRole::Linearized { active_mask },
         );
         Ok(vec![Some(out[0])])
     }
@@ -454,12 +457,12 @@ impl ExtensionAdRule for TropicalEinsumAdRule {
     fn transpose_rule(
         &self,
         _op: &dyn ExtensionOp,
-        _emitter: &mut dyn OpEmitter<StdTensorOp>,
-        _cotangent_out: &[Option<LocalValId>],
-        _inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
+        _mode: &OperationRole,
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Err(ADRuleError::unsupported(
             "tropical einsum transpose is supported via its linearized JVP op",
             ADRuleKind::Transpose,
@@ -480,12 +483,12 @@ impl ExtensionAdRule for TropicalEinsumJvpAdRule {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        _builder: &mut dyn OpEmitter<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        _tangent_in: &[Option<LocalValId>],
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        _tangent_in: &[Option<LocalValueId>],
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Err(ADRuleError::unsupported(
             TROPICAL_EINSUM_JVP_FAMILY_ID,
             ADRuleKind::Jvp,
@@ -495,36 +498,36 @@ impl ExtensionAdRule for TropicalEinsumJvpAdRule {
     fn transpose_rule(
         &self,
         op: &dyn ExtensionOp,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<StdTensorOp>],
-        mode: &OpMode,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
+        mode: &OperationRole,
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_jvp_op(op, ADRuleKind::Transpose)?;
         validate_ad_supported(&op.subscripts, ADRuleKind::Transpose)?;
         let Some(ct) = cotangent_out.first().copied().flatten() else {
-            return Ok(vec![None; op.n_inputs()]);
+            return Ok(vec![None; op.input_count()]);
         };
         let active_mask = match mode {
-            OpMode::Linear { active_mask } => active_mask,
-            OpMode::Primal => return Ok(vec![None; op.n_inputs()]),
+            OperationRole::Linearized { active_mask } => active_mask,
+            OperationRole::Primary => return Ok(vec![None; op.input_count()]),
         };
 
-        let mut result = vec![None; op.n_inputs()];
+        let mut result = vec![None; op.input_count()];
         for (active_pos, &active_input) in op.active_inputs.iter().enumerate() {
             let tangent_input_idx = 2 + active_pos;
             if !active_mask.get(tangent_input_idx).copied().unwrap_or(false) {
                 continue;
             }
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Extension(Arc::new(TropicalEinsumVjpOp::new(
                     op.kind,
                     op.subscripts.clone(),
                     active_input,
                 ))),
-                vec![inputs[0].clone(), inputs[1].clone(), ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![inputs[0].clone(), inputs[1].clone(), ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![false, false, true],
                 },
             );

--- a/tenferro-ad/src/eager.rs
+++ b/tenferro-ad/src/eager.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use crate::extension_cache::ExtensionCacheLimits;
 use crate::extension_runtime::{ExtensionExecutor, ExtensionRuntimeRegistryError};
-use computegraph::GlobalValKey;
+use computegraph::ValueKey;
 use tenferro_cpu::CpuBackend;
 #[cfg(feature = "cuda")]
 use tenferro_gpu::cubecl::CubeclBackend;
@@ -151,7 +151,7 @@ pub struct EagerRuntime {
     pub(crate) backend: Mutex<EagerBackend>,
     pub(crate) extension_executor: Mutex<ExtensionExecutor<EagerBackend>>,
     extension_rules: Option<ExtensionRuleSet>,
-    grad_slots: Mutex<HashMap<GlobalValKey<StdTensorOp>, WeakGradSlot>>,
+    grad_slots: Mutex<HashMap<ValueKey<StdTensorOp>, WeakGradSlot>>,
 }
 
 impl EagerRuntime {
@@ -380,7 +380,7 @@ impl EagerRuntime {
         })
     }
 
-    pub(crate) fn register_grad_slot(&self, key: &GlobalValKey<StdTensorOp>, slot: &GradSlot) {
+    pub(crate) fn register_grad_slot(&self, key: &ValueKey<StdTensorOp>, slot: &GradSlot) {
         self.grad_slots
             .lock()
             .unwrap()
@@ -468,7 +468,7 @@ impl EagerRuntime {
 
     fn store_grads(
         &self,
-        cotangents: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
+        cotangents: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
         backend: &mut EagerBackend,
     ) -> Result<()> {
         let mut updates = Vec::new();
@@ -535,7 +535,7 @@ impl EagerRuntime {
 #[derive(Clone)]
 pub struct EagerTensor {
     pub(crate) data: Arc<Tensor>,
-    pub(crate) key: GlobalValKey<StdTensorOp>,
+    pub(crate) key: ValueKey<StdTensorOp>,
     pub(crate) trace: Option<Trace<StdTensorOp>>,
     pub(crate) requires_grad: bool,
     grad_slot: GradSlot,
@@ -624,7 +624,7 @@ impl EagerTensor {
 
     pub(crate) fn new_result(
         ctx: Arc<EagerRuntime>,
-        key: GlobalValKey<StdTensorOp>,
+        key: ValueKey<StdTensorOp>,
         tensor: Tensor,
         requires_grad: bool,
         trace: Option<Trace<StdTensorOp>>,
@@ -642,7 +642,7 @@ impl EagerTensor {
 
     pub(crate) fn new_result_arc(
         ctx: Arc<EagerRuntime>,
-        key: GlobalValKey<StdTensorOp>,
+        key: ValueKey<StdTensorOp>,
         tensor: Arc<Tensor>,
         requires_grad: bool,
         trace: Option<Trace<StdTensorOp>>,
@@ -862,7 +862,7 @@ impl EagerTensor {
     ///
     /// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 4.0, 4.0]);
     /// ```
-    pub fn backward(&self) -> Result<HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>> {
+    pub fn backward(&self) -> Result<HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>> {
         if !self.data.shape().is_empty() {
             return Err(Error::NonScalarGrad {
                 shape: self.data.shape().to_vec(),
@@ -895,8 +895,8 @@ impl EagerTensor {
     }
 }
 
-pub(crate) fn eager_val_key() -> GlobalValKey<StdTensorOp> {
-    GlobalValKey::Input(next_input_key())
+pub(crate) fn eager_val_key() -> ValueKey<StdTensorOp> {
+    ValueKey::Input(next_input_key())
 }
 
 pub(crate) struct EagerTensorKeySource;

--- a/tenferro-ad/src/eager/backward.rs
+++ b/tenferro-ad/src/eager/backward.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use computegraph::fragment::Fragment;
-use computegraph::{GlobalValKey, LocalValId, OpMode, ValRef};
+use computegraph::graph::Graph;
+use computegraph::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, TensorMeta};
@@ -10,11 +10,11 @@ use tenferro_tensor::{Tensor, TensorBackend};
 use tidu::eager::BackwardExecutor;
 use tidu::{LinearizedGraph, PrimitiveGraph};
 
-use crate::eager_emitter::EagerEmitter;
+use crate::eager_builder::EagerPrimitiveBuilder;
 use crate::eager_exec::{exec_op_on_tensors, exec_op_on_tensors_with_extension_executor};
 use crate::extension_runtime::ExtensionExecutor;
 use crate::metadata::{
-    push_metadata_scope, register_scoped_live_fragment_metadata, tensor_meta_from_tensor,
+    push_metadata_scope, register_scoped_live_graph_metadata, tensor_meta_from_tensor,
     MetadataScope,
 };
 
@@ -41,20 +41,20 @@ impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
 }
 
 pub(super) fn missing_tangent_base_key(
-    key: &GlobalValKey<StdTensorOp>,
-) -> Option<GlobalValKey<StdTensorOp>> {
-    let GlobalValKey::Input(tangent_key) = key else {
+    key: &ValueKey<StdTensorOp>,
+) -> Option<ValueKey<StdTensorOp>> {
+    let ValueKey::Input(tangent_key) = key else {
         return None;
     };
     let TensorInputKey::Tangent { of, .. } = tangent_key else {
         return None;
     };
-    Some(GlobalValKey::Input((**of).clone()))
+    Some(ValueKey::Input((**of).clone()))
 }
 
 pub(super) fn eager_forward_input_metadata(
-    key: &GlobalValKey<StdTensorOp>,
-    initial_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
+    key: &ValueKey<StdTensorOp>,
+    initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
 ) -> TensorMeta {
     if let Some(value) = initial_data.get(key) {
         return tensor_meta_from_tensor(value.as_ref());
@@ -69,9 +69,9 @@ pub(super) fn eager_forward_input_metadata(
 }
 
 pub(super) fn eager_forward_value<B: TensorBackend>(
-    all_values: &mut HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
-    key: &GlobalValKey<StdTensorOp>,
-    initial_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
+    all_values: &mut HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+    key: &ValueKey<StdTensorOp>,
+    initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     backend: &mut B,
 ) -> Arc<Tensor> {
     if let Some(value) = all_values.get(key) {
@@ -88,16 +88,16 @@ pub(super) fn eager_forward_value<B: TensorBackend>(
     value
 }
 
-fn live_fragment_values(fragment: &Fragment<StdTensorOp>) -> HashSet<LocalValId> {
+fn live_graph_values(graph: &Graph<StdTensorOp>) -> HashSet<LocalValueId> {
     let mut producers = HashMap::new();
-    for (op_index, op_node) in fragment.ops().iter().enumerate() {
+    for (op_index, op_node) in graph.operations().iter().enumerate() {
         for &output_id in &op_node.outputs {
             producers.insert(output_id, op_index);
         }
     }
 
     let mut live = HashSet::new();
-    let mut stack = fragment.outputs().to_vec();
+    let mut stack = graph.outputs().to_vec();
     while let Some(local_id) = stack.pop() {
         if !live.insert(local_id) {
             continue;
@@ -105,8 +105,8 @@ fn live_fragment_values(fragment: &Fragment<StdTensorOp>) -> HashSet<LocalValId>
         let Some(&op_index) = producers.get(&local_id) else {
             continue;
         };
-        for input in &fragment.ops()[op_index].inputs {
-            if let ValRef::Local(input_id) = input {
+        for input in &graph.operations()[op_index].inputs {
+            if let ValueRef::Local(input_id) = input {
                 stack.push(*input_id);
             }
         }
@@ -115,8 +115,8 @@ fn live_fragment_values(fragment: &Fragment<StdTensorOp>) -> HashSet<LocalValId>
     live
 }
 
-fn linear_op_depends_on_tangents(mode: &OpMode) -> bool {
-    matches!(mode, OpMode::Linear { active_mask } if active_mask.iter().any(|is_active| *is_active))
+fn linear_op_depends_on_tangents(mode: &OperationRole) -> bool {
+    matches!(mode, OperationRole::Linearized { active_mask } if active_mask.iter().any(|is_active| *is_active))
 }
 
 impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
@@ -125,23 +125,23 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
     fn execute_forward(
         &mut self,
         graph: PrimitiveGraph<'_, StdTensorOp>,
-        initial_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
-    ) -> HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>> {
-        let fragment = graph.as_graph();
+        initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+    ) -> HashMap<ValueKey<StdTensorOp>, Arc<Tensor>> {
+        let graph = graph.as_graph();
         let mut all_values = initial_data.clone();
-        let live_values = live_fragment_values(fragment);
-        let input_metadata = fragment
+        let live_values = live_graph_values(graph);
+        let input_metadata = graph
             .inputs()
             .iter()
             .map(|&input_id| {
-                let key = fragment.vals()[input_id].key.clone();
+                let key = graph.values()[input_id].key.clone();
                 let meta = eager_forward_input_metadata(&key, initial_data);
                 (key, meta)
             })
             .collect::<Vec<_>>();
 
-        for op_node in fragment.ops() {
-            if linear_op_depends_on_tangents(&op_node.mode) {
+        for op_node in graph.operations() {
+            if linear_op_depends_on_tangents(&op_node.role) {
                 continue;
             }
             if !op_node
@@ -156,11 +156,11 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
                 .inputs
                 .iter()
                 .map(|input| match input {
-                    ValRef::Local(local_id) => {
-                        let key = &fragment.vals()[*local_id].key;
+                    ValueRef::Local(local_id) => {
+                        let key = &graph.values()[*local_id].key;
                         eager_forward_value(&mut all_values, key, initial_data, self.backend)
                     }
-                    ValRef::External(key) => {
+                    ValueRef::External(key) => {
                         eager_forward_value(&mut all_values, key, initial_data, self.backend)
                     }
                 })
@@ -170,26 +170,29 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
             let outputs =
                 if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
                     exec_op_on_tensors_with_extension_executor(
-                        &op_node.op,
+                        &op_node.operation,
                         &resolved_inputs,
                         self.backend,
                         Some(extension_executor),
                     )
                 } else {
-                    exec_op_on_tensors(&op_node.op, &resolved_inputs, self.backend)
+                    exec_op_on_tensors(&op_node.operation, &resolved_inputs, self.backend)
                 }
                 .unwrap_or_else(|err| {
-                    panic!("eager forward exec failed for {:?}: {}", op_node.op, err)
+                    panic!(
+                        "eager forward exec failed for {:?}: {}",
+                        op_node.operation, err
+                    )
                 });
 
             for (output_id, output) in op_node.outputs.iter().zip(outputs) {
-                let key = fragment.vals()[*output_id].key.clone();
+                let key = graph.values()[*output_id].key.clone();
                 all_values.insert(key, Arc::new(output));
             }
         }
 
         let metadata_scope =
-            register_scoped_live_fragment_metadata(fragment, &live_values, input_metadata);
+            register_scoped_live_graph_metadata(graph, &live_values, input_metadata);
         push_metadata_scope(&mut self.metadata_scopes, Arc::new(metadata_scope));
 
         all_values
@@ -199,30 +202,30 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
         &mut self,
         linear: &LinearizedGraph<StdTensorOp>,
         cotangent_out: &[Option<Arc<Tensor>>],
-        external_data: &HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
+        external_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
         ctx: &mut ShapeGuardContext,
     ) -> tidu::ADRuleResult<Vec<Option<Arc<Tensor>>>> {
-        let mut emitter = if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
-            EagerEmitter::with_extension_executor(self.backend, extension_executor)
+        let mut builder = if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
+            EagerPrimitiveBuilder::with_extension_executor(self.backend, extension_executor)
         } else {
-            EagerEmitter::new(self.backend)
+            EagerPrimitiveBuilder::new(self.backend)
         };
-        emitter.external_data = external_data.clone();
+        builder.external_data = external_data.clone();
         let cotangent_seed_ids = cotangent_out
             .iter()
             .map(|maybe_seed| {
                 maybe_seed
                     .as_ref()
-                    .map(|seed| emitter.push_tensor(Arc::clone(seed)))
+                    .map(|seed| builder.push_tensor(Arc::clone(seed)))
             })
             .collect::<Vec<_>>();
 
         ctx.refresh_global_metadata();
-        tidu::try_linear_transpose_with_builder(linear, &mut emitter, &cotangent_seed_ids, ctx).map(
+        tidu::try_linear_transpose_with_builder(linear, &mut builder, &cotangent_seed_ids, ctx).map(
             |cotangent_ids| {
                 cotangent_ids
                     .into_iter()
-                    .map(|maybe_id| maybe_id.map(|id| emitter.tensor(id)))
+                    .map(|maybe_id| maybe_id.map(|id| builder.tensor(id)))
                     .collect()
             },
         )

--- a/tenferro-ad/src/eager/tests.rs
+++ b/tenferro-ad/src/eager/tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use computegraph::types::GlobalValKey;
+use computegraph::types::ValueKey;
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::SymDim;
@@ -35,8 +35,8 @@ fn eager_op_profile_helpers_cover_enabled_paths() {
 #[test]
 fn eager_forward_helpers_synthesize_tangent_values_from_primal_data() {
     let user = TensorInputKey::User { id: 7 };
-    let base_key = GlobalValKey::Input(user.clone());
-    let tangent_key = GlobalValKey::Input(user.tangent_of(11));
+    let base_key = ValueKey::Input(user.clone());
+    let tangent_key = ValueKey::Input(user.tangent_of(11));
     let base = Arc::new(Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 5.0]));
     let initial_data = HashMap::from([(base_key.clone(), Arc::clone(&base))]);
 

--- a/tenferro-ad/src/eager_builder.rs
+++ b/tenferro-ad/src/eager_builder.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::extension_runtime::ExtensionExecutor;
-use computegraph::{GlobalValKey, LocalValId, OpEmitter, OpMode, ValRef};
+use computegraph::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{Tensor, TensorBackend, TypedTensor};
@@ -10,14 +10,14 @@ use tidu::{PrimitiveBuilder, PrimitiveValue};
 
 use crate::eager_exec::{exec_op_on_tensors, exec_op_on_tensors_with_extension_executor};
 
-pub struct EagerEmitter<'a, B: TensorBackend + 'static> {
+pub struct EagerPrimitiveBuilder<'a, B: TensorBackend + 'static> {
     pub backend: &'a mut B,
     pub extension_executor: Option<&'a mut ExtensionExecutor<B>>,
-    pub external_data: HashMap<GlobalValKey<StdTensorOp>, Arc<Tensor>>,
+    pub external_data: HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     pub results: Vec<Arc<Tensor>>,
 }
 
-impl<'a, B: TensorBackend + 'static> EagerEmitter<'a, B> {
+impl<'a, B: TensorBackend + 'static> EagerPrimitiveBuilder<'a, B> {
     pub fn new(backend: &'a mut B) -> Self {
         Self {
             backend,
@@ -39,45 +39,41 @@ impl<'a, B: TensorBackend + 'static> EagerEmitter<'a, B> {
         }
     }
 
-    pub fn push_tensor(&mut self, tensor: Arc<Tensor>) -> LocalValId {
+    pub fn push_tensor(&mut self, tensor: Arc<Tensor>) -> LocalValueId {
         let id = self.results.len();
         self.results.push(tensor);
         id
     }
 
-    pub fn tensor(&self, id: LocalValId) -> Arc<Tensor> {
+    pub fn tensor(&self, id: LocalValueId) -> Arc<Tensor> {
         Arc::clone(&self.results[id])
     }
 
-    fn external_tensor(&mut self, key: &GlobalValKey<StdTensorOp>) -> Arc<Tensor> {
+    fn external_tensor(&mut self, key: &ValueKey<StdTensorOp>) -> Arc<Tensor> {
         if let Some(tensor) = self.external_data.get(key) {
             return Arc::clone(tensor);
         }
 
         let base_key = missing_tangent_base_key(key)
-            .unwrap_or_else(|| panic!("EagerEmitter: missing external {:?}", key));
-        let base = self
-            .external_data
-            .get(&base_key)
-            .unwrap_or_else(|| panic!("EagerEmitter: missing tangent base {:?}", base_key));
+            .unwrap_or_else(|| panic!("EagerPrimitiveBuilder: missing external {:?}", key));
+        let base = self.external_data.get(&base_key).unwrap_or_else(|| {
+            panic!("EagerPrimitiveBuilder: missing tangent base {:?}", base_key)
+        });
         let zero = Arc::new(zero_like_tensor(base.as_ref()));
         self.external_data.insert(key.clone(), Arc::clone(&zero));
         zero
     }
-}
 
-impl<B: TensorBackend + 'static> OpEmitter<StdTensorOp> for EagerEmitter<'_, B> {
-    fn add_op(
+    fn execute_operation(
         &mut self,
-        op: StdTensorOp,
-        inputs: Vec<ValRef<StdTensorOp>>,
-        _mode: OpMode,
-    ) -> Vec<LocalValId> {
+        operation: StdTensorOp,
+        inputs: Vec<ValueRef<StdTensorOp>>,
+    ) -> Vec<LocalValueId> {
         let concrete_values: Vec<Arc<Tensor>> = inputs
             .iter()
             .map(|value| match value {
-                ValRef::Local(id) => Arc::clone(&self.results[*id]),
-                ValRef::External(key) => self.external_tensor(key),
+                ValueRef::Local(id) => Arc::clone(&self.results[*id]),
+                ValueRef::External(key) => self.external_tensor(key),
             })
             .collect();
         let concrete: Vec<&Tensor> = concrete_values
@@ -87,15 +83,15 @@ impl<B: TensorBackend + 'static> OpEmitter<StdTensorOp> for EagerEmitter<'_, B> 
 
         let outputs = if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
             exec_op_on_tensors_with_extension_executor(
-                &op,
+                &operation,
                 &concrete,
                 self.backend,
                 Some(extension_executor),
             )
         } else {
-            exec_op_on_tensors(&op, &concrete, self.backend)
+            exec_op_on_tensors(&operation, &concrete, self.backend)
         }
-        .unwrap_or_else(|err| panic!("eager exec failed for {:?}: {}", op, err));
+        .unwrap_or_else(|err| panic!("eager exec failed for {:?}: {}", operation, err));
 
         let base = self.results.len();
         for output in outputs {
@@ -105,26 +101,26 @@ impl<B: TensorBackend + 'static> OpEmitter<StdTensorOp> for EagerEmitter<'_, B> 
     }
 }
 
-impl<B: TensorBackend + 'static> PrimitiveBuilder<StdTensorOp> for EagerEmitter<'_, B> {
+impl<B: TensorBackend + 'static> PrimitiveBuilder<StdTensorOp> for EagerPrimitiveBuilder<'_, B> {
     fn add_primitive(
         &mut self,
-        op: StdTensorOp,
+        operation: StdTensorOp,
         inputs: Vec<PrimitiveValue<StdTensorOp>>,
-        mode: OpMode,
-    ) -> Vec<LocalValId> {
-        let inputs = inputs.into_iter().map(ValRef::from).collect();
-        self.add_op(op, inputs, mode)
+        _role: OperationRole,
+    ) -> Vec<LocalValueId> {
+        let inputs = inputs.into_iter().map(ValueRef::from).collect();
+        self.execute_operation(operation, inputs)
     }
 }
 
-fn missing_tangent_base_key(key: &GlobalValKey<StdTensorOp>) -> Option<GlobalValKey<StdTensorOp>> {
-    let GlobalValKey::Input(tangent_key) = key else {
+fn missing_tangent_base_key(key: &ValueKey<StdTensorOp>) -> Option<ValueKey<StdTensorOp>> {
+    let ValueKey::Input(tangent_key) = key else {
         return None;
     };
     let TensorInputKey::Tangent { of, .. } = tangent_key else {
         return None;
     };
-    Some(GlobalValKey::Input((**of).clone()))
+    Some(ValueKey::Input((**of).clone()))
 }
 
 fn zero_like_tensor(input: &Tensor) -> Tensor {

--- a/tenferro-ad/src/eager_ops.rs
+++ b/tenferro-ad/src/eager_ops.rs
@@ -515,7 +515,7 @@ impl EagerTensor {
             tensors,
             StdTensorOp::Concatenate {
                 axis,
-                n_inputs: tensors.len(),
+                input_count: tensors.len(),
             },
         )
     }

--- a/tenferro-ad/src/extension.rs
+++ b/tenferro-ad/src/extension.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use computegraph::GraphOp;
+use computegraph::GraphOperation;
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_runtime::ad_support::push_metadata_scope;
@@ -47,11 +47,11 @@ pub fn apply_eager(op: Arc<dyn ExtensionOp>, inputs: &[&EagerTensor]) -> Result<
             "extension::apply_eager requires at least one input tensor".to_string(),
         ));
     };
-    if inputs.len() != op.n_inputs() {
+    if inputs.len() != op.input_count() {
         return Err(Error::Internal(format!(
             "extension::apply_eager: op family {:?} expects {} inputs, got {}",
             op.family_id(),
-            op.n_inputs(),
+            op.input_count(),
             inputs.len()
         )));
     }
@@ -69,10 +69,10 @@ pub fn apply_eager(op: Arc<dyn ExtensionOp>, inputs: &[&EagerTensor]) -> Result<
     let op = StdTensorOp::Extension(op);
     let concrete_inputs: Vec<&Tensor> = inputs.iter().map(|tensor| tensor.data.as_ref()).collect();
     let outputs = ctx.exec_outputs(&op, &concrete_inputs)?;
-    if outputs.len() != op.n_outputs() {
+    if outputs.len() != op.output_count() {
         return Err(Error::Internal(format!(
             "expected {} eager outputs for {:?}, got {}",
-            op.n_outputs(),
+            op.output_count(),
             op,
             outputs.len()
         )));

--- a/tenferro-ad/src/lib.rs
+++ b/tenferro-ad/src/lib.rs
@@ -21,7 +21,7 @@
 mod context;
 mod eager;
 mod eager_backend;
-mod eager_emitter;
+mod eager_builder;
 pub mod eager_exec;
 pub(crate) mod eager_ops;
 pub(crate) mod eager_ops_elementwise;
@@ -49,8 +49,8 @@ pub mod error {
 pub mod metadata {
     pub use tenferro_runtime::ad_support::{
         metadata_scopes_for_scope, metadata_scopes_with_new, metadata_scopes_with_scope,
-        push_metadata_scope, register_scoped_fragment_metadata,
-        register_scoped_live_fragment_metadata, register_scoped_metadata_batch,
-        register_scoped_value_metadata, tensor_meta_from_tensor, MetadataScope,
+        push_metadata_scope, register_scoped_graph_metadata, register_scoped_live_graph_metadata,
+        register_scoped_metadata_batch, register_scoped_value_metadata, tensor_meta_from_tensor,
+        MetadataScope,
     };
 }

--- a/tenferro-ad/src/traced.rs
+++ b/tenferro-ad/src/traced.rs
@@ -2,13 +2,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use computegraph::resolve::resolve;
-use computegraph::types::GlobalValKey;
+use computegraph::types::ValueKey;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::ExtensionRuleSet;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_runtime::ad_support::{
     checkpoint_traced_tensor, leaf_input_key, linear_input_key, metadata_scopes_with_new,
-    ones_tensor, push_metadata_scope, register_scoped_fragment_metadata, registered_meta,
+    ones_tensor, push_metadata_scope, register_scoped_graph_metadata, registered_meta,
     tensor_meta_from_tensor, traced_checkpoint_chain, traced_extra_roots, traced_inputs_map,
     traced_metadata_scopes, traced_resolve_roots, traced_shape_hint, traced_tensor_from_parts,
     TracedTensorParts,
@@ -265,18 +265,18 @@ fn jvp_optional_result_with_rules(
     extension_rules: Option<&ExtensionRuleSet>,
 ) -> Result<Option<TracedTensor>> {
     let wrt_input_key = leaf_input_key(wrt);
-    let output_key = output.fragment.vals()[output.val].key.clone();
+    let output_key = output.graph.values()[output.val].key.clone();
     let checkpoint_chain = traced_checkpoint_chain(output);
     let aliases = checkpoint_chain
         .as_ref()
         .map(|chain| chain.collect_aliases())
         .unwrap_or_default();
-    let checkpoint_fragments = checkpoint_chain
+    let checkpoint_graphs = checkpoint_chain
         .as_ref()
-        .map(|chain| chain.collect_fragments())
+        .map(|chain| chain.collect_graphs())
         .unwrap_or_default();
     let mut roots = traced_resolve_roots(output);
-    roots.extend(checkpoint_fragments.iter().cloned());
+    roots.extend(checkpoint_graphs.iter().cloned());
     let view = resolve(roots);
     let mut ad_ctx = shape_guard_context(extension_rules);
     let linear = try_linearize(
@@ -292,10 +292,10 @@ fn jvp_optional_result_with_rules(
         return Ok(None);
     };
     let tangent_input_key = linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1);
-    let metadata_scope = register_scoped_fragment_metadata(
+    let metadata_scope = register_scoped_graph_metadata(
         linear.as_graph(),
         vec![(
-            GlobalValKey::Input(tangent_input_key.clone()),
+            ValueKey::Input(tangent_input_key.clone()),
             tensor_meta_from_tensor(
                 tangent
                     .data
@@ -318,14 +318,14 @@ fn jvp_optional_result_with_rules(
             .unwrap_or_else(|| panic!("jvp tangent must have concrete tensor data")),
     );
 
-    let mut extra_roots = vec![output.fragment.clone()];
-    extra_roots.extend(checkpoint_fragments);
+    let mut extra_roots = vec![output.graph.clone()];
+    extra_roots.extend(checkpoint_graphs);
     extra_roots.extend(traced_extra_roots(output));
 
     Ok(Some(traced_tensor_from_parts(TracedTensorParts {
         rank: output.rank,
         dtype: output.dtype,
-        fragment: Arc::new(linear.into_graph()),
+        graph: Arc::new(linear.into_graph()),
         val: tangent_output,
         data: None,
         shape_hint: traced_shape_hint(output),
@@ -350,18 +350,18 @@ fn vjp_optional_result_with_rules(
     extension_rules: Option<&ExtensionRuleSet>,
 ) -> Result<Option<TracedTensor>> {
     let wrt_input_key = leaf_input_key(wrt);
-    let output_key = output.fragment.vals()[output.val].key.clone();
+    let output_key = output.graph.values()[output.val].key.clone();
     let checkpoint_chain = traced_checkpoint_chain(output);
     let aliases = checkpoint_chain
         .as_ref()
         .map(|chain| chain.collect_aliases())
         .unwrap_or_default();
-    let checkpoint_fragments = checkpoint_chain
+    let checkpoint_graphs = checkpoint_chain
         .as_ref()
-        .map(|chain| chain.collect_fragments())
+        .map(|chain| chain.collect_graphs())
         .unwrap_or_default();
     let mut roots = traced_resolve_roots(output);
-    roots.extend(checkpoint_fragments.iter().cloned());
+    roots.extend(checkpoint_graphs.iter().cloned());
     let view = resolve(roots);
     let mut ad_ctx = shape_guard_context(extension_rules);
     let linear = try_linearize(
@@ -377,11 +377,11 @@ fn vjp_optional_result_with_rules(
         return Ok(None);
     }
     let linear_seed_key = linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1);
-    let linear_metadata_scope = register_scoped_fragment_metadata(
+    let linear_metadata_scope = register_scoped_graph_metadata(
         linear.as_graph(),
         vec![(
-            GlobalValKey::Input(linear_seed_key),
-            registered_meta(&wrt.fragment.vals()[wrt.val].key),
+            ValueKey::Input(linear_seed_key),
+            registered_meta(&wrt.graph.values()[wrt.val].key),
         )],
     );
     ad_ctx.refresh_global_metadata();
@@ -389,10 +389,10 @@ fn vjp_optional_result_with_rules(
         .map_err(|err| Error::Internal(err.to_string()))?;
     let cotangent_input_key =
         linear_input_key(transposed.as_graph(), transposed.tangent_inputs()[0].1);
-    let transposed_metadata_scope = register_scoped_fragment_metadata(
+    let transposed_metadata_scope = register_scoped_graph_metadata(
         transposed.as_graph(),
         vec![(
-            GlobalValKey::Input(cotangent_input_key.clone()),
+            ValueKey::Input(cotangent_input_key.clone()),
             tensor_meta_from_tensor(
                 cotangent
                     .data
@@ -402,7 +402,7 @@ fn vjp_optional_result_with_rules(
             ),
         )],
     );
-    let linear_fragment = Arc::new(linear.into_graph());
+    let linear_graph = Arc::new(linear.into_graph());
     let Some(cotangent_output) = transposed.tangent_outputs()[0] else {
         return Ok(None);
     };
@@ -419,14 +419,14 @@ fn vjp_optional_result_with_rules(
             .unwrap_or_else(|| panic!("vjp cotangent must have concrete tensor data")),
     );
 
-    let mut extra_roots = vec![output.fragment.clone(), linear_fragment];
-    extra_roots.extend(checkpoint_fragments);
+    let mut extra_roots = vec![output.graph.clone(), linear_graph];
+    extra_roots.extend(checkpoint_graphs);
     extra_roots.extend(traced_extra_roots(output));
 
     Ok(Some(traced_tensor_from_parts(TracedTensorParts {
         rank: wrt.rank,
         dtype: wrt.dtype,
-        fragment: Arc::new(transposed.into_graph()),
+        graph: Arc::new(transposed.into_graph()),
         val: cotangent_output,
         data: None,
         shape_hint: traced_shape_hint(wrt),

--- a/tenferro-ad/tests/ad.rs
+++ b/tenferro-ad/tests/ad.rs
@@ -7,11 +7,11 @@ use std::sync::Arc;
 use support::{run_many_traced_with, RunTraced};
 
 use computegraph::compile::compile;
-use computegraph::fragment::{Fragment, FragmentBuilder};
+use computegraph::graph::{Graph, GraphBuilder};
 use computegraph::materialize::materialize_merge;
 use computegraph::resolve::resolve;
-use computegraph::types::{GlobalValKey, OpMode, ValRef};
-use computegraph::LocalValId;
+use computegraph::types::{OperationRole, ValueKey, ValueRef};
+use computegraph::LocalValueId;
 use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::ad::context::{
@@ -132,22 +132,22 @@ fn tensor_meta_from_tensor(tensor: &Tensor) -> TensorMeta {
     )
 }
 
-fn register_fragment_metadata_for_test(
-    fragment: &Fragment<StdTensorOp>,
-    seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
+fn register_graph_metadata_for_test(
+    graph: &Graph<StdTensorOp>,
+    seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
 ) -> GlobalMetadataScope {
     let seeded: Vec<_> = seeded.into_iter().collect();
     let mut known: HashMap<_, _> = seeded.iter().cloned().collect();
 
     let mut registrations = seeded;
-    for op_node in fragment.ops() {
+    for op_node in graph.operations() {
         let input_metas: Vec<_> = op_node
             .inputs
             .iter()
             .map(|input| {
                 let key = match input {
-                    ValRef::Local(local_id) => &fragment.vals()[*local_id].key,
-                    ValRef::External(key) => key,
+                    ValueRef::Local(local_id) => &graph.values()[*local_id].key,
+                    ValueRef::External(key) => key,
                 };
                 match known.get(key).cloned() {
                     Some(meta) => meta,
@@ -169,7 +169,7 @@ fn register_fragment_metadata_for_test(
         let input_shape_refs: Vec<&[DimExpr]> =
             input_shape_exprs.iter().map(Vec::as_slice).collect();
         let input_dtypes: Vec<DType> = input_metas.iter().map(|meta| meta.dtype).collect();
-        let output_dtype = infer_output_dtype(&op_node.op, &input_dtypes);
+        let output_dtype = infer_output_dtype(&op_node.operation, &input_dtypes);
         let resolved_inputs: Vec<&[SymDim]> = input_metas
             .iter()
             .map(|meta| meta.shape.as_slice())
@@ -178,14 +178,14 @@ fn register_fragment_metadata_for_test(
         for (&output_id, extents) in op_node
             .outputs
             .iter()
-            .zip(infer_output_extents(&op_node.op, &input_shape_refs))
+            .zip(infer_output_extents(&op_node.operation, &input_shape_refs))
         {
             let resolved_extents = extents
                 .into_iter()
                 .map(|extent| extent.map(|dim| SymDim::from_dim_expr(&dim, &resolved_inputs)))
                 .collect();
             let meta = TensorMeta::with_extents(output_dtype, resolved_extents);
-            let key = fragment.vals()[output_id].key.clone();
+            let key = graph.values()[output_id].key.clone();
             known.insert(key.clone(), meta.clone());
             registrations.push((key, meta));
         }
@@ -225,9 +225,9 @@ fn tensor_input_key(id: u64) -> TensorInputKey {
     TensorInputKey::User { id }
 }
 
-fn eval_fragment_outputs(
-    roots: Vec<Arc<Fragment<StdTensorOp>>>,
-    outputs: &[GlobalValKey<StdTensorOp>],
+fn eval_graph_outputs(
+    roots: Vec<Arc<Graph<StdTensorOp>>>,
+    outputs: &[ValueKey<StdTensorOp>],
     inputs_map: &HashMap<TensorInputKey, Tensor>,
 ) -> Vec<Tensor> {
     let view = resolve(roots);
@@ -239,7 +239,7 @@ fn eval_fragment_outputs(
         .inputs
         .iter()
         .map(|key| match key {
-            GlobalValKey::Input(k) => {
+            ValueKey::Input(k) => {
                 let tensor = inputs_map.get(k).expect("missing tensor input");
                 input_dtypes.push(tensor.dtype());
                 input_shapes.push(DimExpr::from_concrete(tensor.shape()));
@@ -257,23 +257,23 @@ fn scalar_f64_tensor(value: f64) -> Tensor {
     f64_tensor(vec![], vec![value])
 }
 
-fn grad_from_fragment_with_inputs_and_cotangent(
-    fragment: Arc<Fragment<StdTensorOp>>,
-    loss_key: GlobalValKey<StdTensorOp>,
+fn grad_from_graph_with_inputs_and_cotangent(
+    graph: Arc<Graph<StdTensorOp>>,
+    loss_key: ValueKey<StdTensorOp>,
     input_key: TensorInputKey,
     mut inputs_map: HashMap<TensorInputKey, Tensor>,
     cotangent: Tensor,
 ) -> Tensor {
-    let _primal_metadata_scope = register_fragment_metadata_for_test(
-        fragment.as_ref(),
+    let _primal_metadata_scope = register_graph_metadata_for_test(
+        graph.as_ref(),
         inputs_map.iter().map(|(key, tensor)| {
             (
-                GlobalValKey::Input(key.clone()),
+                ValueKey::Input(key.clone()),
                 tensor_meta_from_tensor(tensor),
             )
         }),
     );
-    let view = resolve(vec![fragment.clone()]);
+    let view = resolve(vec![graph.clone()]);
     let mut ad_ctx = ShapeGuardContext::with_global_metadata();
     let linear = linearize(
         &view,
@@ -283,35 +283,35 @@ fn grad_from_fragment_with_inputs_and_cotangent(
         &mut ad_ctx,
         &HashMap::new(),
     );
-    let _linear_metadata_scope = register_fragment_metadata_for_test(
+    let _linear_metadata_scope = register_graph_metadata_for_test(
         linear.as_graph(),
         vec![(
-            GlobalValKey::Input(input_key.tangent_of(0)),
+            ValueKey::Input(input_key.tangent_of(0)),
             tensor_meta_from_tensor(inputs_map.get(&input_key).expect("missing input tensor")),
         )],
     );
     ad_ctx.refresh_global_metadata();
-    let linear_tangent_input_ids: Vec<LocalValId> = linear
+    let linear_tangent_input_ids: Vec<LocalValueId> = linear
         .tangent_inputs()
         .iter()
         .map(|(_, local_id)| *local_id)
         .collect();
     let transposed = linear_transpose(&linear, &mut ad_ctx);
-    let linear_fragment = Arc::new(linear.into_graph());
+    let linear_graph = Arc::new(linear.into_graph());
     let grad_key = transposed.tangent_outputs()[0]
-        .map(|id| transposed.as_graph().vals()[id].key.clone())
+        .map(|id| transposed.as_graph().values()[id].key.clone())
         .expect("expected active gradient output");
     let cotangent_input_key =
-        match &transposed.as_graph().vals()[transposed.tangent_inputs()[0].1].key {
-            GlobalValKey::Input(key) => key.clone(),
+        match &transposed.as_graph().values()[transposed.tangent_inputs()[0].1].key {
+            ValueKey::Input(key) => key.clone(),
             _ => panic!("expected cotangent input"),
         };
-    let transposed_fragment = Arc::new(transposed.into_graph());
+    let transposed_graph = Arc::new(transposed.into_graph());
 
     inputs_map.insert(cotangent_input_key, cotangent);
 
-    // Linear-mode tangent ops in the transposed fragment may reference values
-    // whose dependency chain passes through the linear fragment's tangent
+    // Linear-mode tangent ops in the transposed graph may reference values
+    // whose dependency chain passes through the linear graph's tangent
     // inputs (e.g. shape-source references). Provide zero placeholders for
     // those inputs so materialize_merge can satisfy the dependency.
     let input_tensor = inputs_map
@@ -320,15 +320,15 @@ fn grad_from_fragment_with_inputs_and_cotangent(
         .expect("missing primal input tensor for zero-tangent fill");
     let zero_tangent = zeros_by_dtype(input_tensor.dtype(), input_tensor.shape().to_vec());
     for local_id in linear_tangent_input_ids {
-        if let GlobalValKey::Input(key) = &linear_fragment.vals()[local_id].key {
+        if let ValueKey::Input(key) = &linear_graph.values()[local_id].key {
             inputs_map
                 .entry(key.clone())
                 .or_insert_with(|| zero_tangent.clone());
         }
     }
 
-    eval_fragment_outputs(
-        vec![fragment, linear_fragment, transposed_fragment.clone()],
+    eval_graph_outputs(
+        vec![graph, linear_graph, transposed_graph.clone()],
         &[grad_key],
         &inputs_map,
     )
@@ -355,14 +355,14 @@ fn zeros_by_dtype(dtype: DType, shape: Vec<usize>) -> Tensor {
     }
 }
 
-fn grad_from_fragment_with_inputs(
-    fragment: Arc<Fragment<StdTensorOp>>,
-    loss_key: GlobalValKey<StdTensorOp>,
+fn grad_from_graph_with_inputs(
+    graph: Arc<Graph<StdTensorOp>>,
+    loss_key: ValueKey<StdTensorOp>,
     input_key: TensorInputKey,
     inputs_map: HashMap<TensorInputKey, Tensor>,
 ) -> Tensor {
-    grad_from_fragment_with_inputs_and_cotangent(
-        fragment,
+    grad_from_graph_with_inputs_and_cotangent(
+        graph,
         loss_key,
         input_key,
         inputs_map,
@@ -370,23 +370,23 @@ fn grad_from_fragment_with_inputs(
     )
 }
 
-fn jvp_from_fragment_with_inputs(
-    fragment: Arc<Fragment<StdTensorOp>>,
-    output_key: GlobalValKey<StdTensorOp>,
+fn jvp_from_graph_with_inputs(
+    graph: Arc<Graph<StdTensorOp>>,
+    output_key: ValueKey<StdTensorOp>,
     input_key: TensorInputKey,
     mut inputs_map: HashMap<TensorInputKey, Tensor>,
     tangent: Tensor,
 ) -> Tensor {
-    let _primal_metadata_scope = register_fragment_metadata_for_test(
-        fragment.as_ref(),
+    let _primal_metadata_scope = register_graph_metadata_for_test(
+        graph.as_ref(),
         inputs_map.iter().map(|(key, tensor)| {
             (
-                GlobalValKey::Input(key.clone()),
+                ValueKey::Input(key.clone()),
                 tensor_meta_from_tensor(tensor),
             )
         }),
     );
-    let view = resolve(vec![fragment.clone()]);
+    let view = resolve(vec![graph.clone()]);
     let mut ad_ctx = ShapeGuardContext::with_global_metadata();
     let linear = linearize(
         &view,
@@ -396,41 +396,41 @@ fn jvp_from_fragment_with_inputs(
         &mut ad_ctx,
         &HashMap::new(),
     );
-    let _linear_metadata_scope = register_fragment_metadata_for_test(
+    let _linear_metadata_scope = register_graph_metadata_for_test(
         linear.as_graph(),
         vec![(
-            GlobalValKey::Input(input_key.tangent_of(0)),
+            ValueKey::Input(input_key.tangent_of(0)),
             tensor_meta_from_tensor(&tangent),
         )],
     );
     let tangent_key = linear.tangent_outputs()[0]
-        .map(|id| linear.as_graph().vals()[id].key.clone())
+        .map(|id| linear.as_graph().values()[id].key.clone())
         .expect("expected active tangent output");
-    let tangent_input_key = match &linear.as_graph().vals()[linear.tangent_inputs()[0].1].key {
-        GlobalValKey::Input(key) => key.clone(),
+    let tangent_input_key = match &linear.as_graph().values()[linear.tangent_inputs()[0].1].key {
+        ValueKey::Input(key) => key.clone(),
         _ => panic!("expected tangent input"),
     };
-    let linear_fragment = Arc::new(linear.into_graph());
+    let linear_graph = Arc::new(linear.into_graph());
 
     inputs_map.insert(tangent_input_key, tangent);
 
-    eval_fragment_outputs(vec![fragment, linear_fragment], &[tangent_key], &inputs_map)
+    eval_graph_outputs(vec![graph, linear_graph], &[tangent_key], &inputs_map)
         .into_iter()
         .next()
         .expect("tangent output")
 }
 
-fn build_unary_fragment(
+fn build_unary_graph(
     op: StdTensorOp,
     input_key: TensorInputKey,
 ) -> (
-    Arc<Fragment<StdTensorOp>>,
+    Arc<Graph<StdTensorOp>>,
     TensorInputKey,
-    GlobalValKey<StdTensorOp>,
+    ValueKey<StdTensorOp>,
 ) {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let input = builder.add_input(input_key.clone());
-    let output = builder.add_op(op, vec![ValRef::Local(input)], OpMode::Primal)[0];
+    let output = builder.add_operation(op, vec![ValueRef::Local(input)], OperationRole::Primary)[0];
     let output_key = builder.global_key(output).clone();
     builder.set_outputs(vec![output]);
     (Arc::new(builder.build()), input_key, output_key)
@@ -462,21 +462,22 @@ fn transpose_primal_unary_op_with_inputs(
     input: Tensor,
     cotangent: Tensor,
 ) -> Tensor {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let input_id = builder.add_input(input_key.clone());
-    let output = builder.add_op(op, vec![ValRef::Local(input_id)], OpMode::Primal)[0];
+    let output =
+        builder.add_operation(op, vec![ValueRef::Local(input_id)], OperationRole::Primary)[0];
     builder.set_outputs(vec![output]);
 
-    let fragment = Arc::new(builder.build());
-    let output_key = fragment.vals()[output].key.clone();
-    let _primal_metadata_scope = register_fragment_metadata_for_test(
-        &fragment,
+    let graph = Arc::new(builder.build());
+    let output_key = graph.values()[output].key.clone();
+    let _primal_metadata_scope = register_graph_metadata_for_test(
+        &graph,
         vec![(
-            GlobalValKey::Input(input_key.clone()),
+            ValueKey::Input(input_key.clone()),
             tensor_meta_from_tensor(&input),
         )],
     );
-    let view = resolve(vec![fragment.clone()]);
+    let view = resolve(vec![graph.clone()]);
     let mut ad_ctx = ShapeGuardContext::with_global_metadata();
     let linear = linearize(
         &view,
@@ -487,33 +488,33 @@ fn transpose_primal_unary_op_with_inputs(
         &HashMap::new(),
     );
     let tangent_input_key = input_key.tangent_of(90_000);
-    let _linear_metadata_scope = register_fragment_metadata_for_test(
+    let _linear_metadata_scope = register_graph_metadata_for_test(
         linear.as_graph(),
         vec![(
-            GlobalValKey::Input(tangent_input_key.clone()),
+            ValueKey::Input(tangent_input_key.clone()),
             tensor_meta_from_tensor(&input),
         )],
     );
     ad_ctx.refresh_global_metadata();
     let transposed = linear_transpose(&linear, &mut ad_ctx);
-    let linear_fragment = Arc::new(linear.into_graph());
+    let linear_graph = Arc::new(linear.into_graph());
     let cotangent_input_key =
-        match &transposed.as_graph().vals()[transposed.tangent_inputs()[0].1].key {
-            GlobalValKey::Input(key) => key.clone(),
+        match &transposed.as_graph().values()[transposed.tangent_inputs()[0].1].key {
+            ValueKey::Input(key) => key.clone(),
             _ => panic!("expected cotangent seed input"),
         };
     let output_key = transposed.tangent_outputs()[0]
-        .map(|id| transposed.as_graph().vals()[id].key.clone())
+        .map(|id| transposed.as_graph().values()[id].key.clone())
         .expect("expected active transpose output");
-    let transposed_fragment = Arc::new(transposed.into_graph());
+    let transposed_graph = Arc::new(transposed.into_graph());
 
     let mut inputs_map = HashMap::new();
     inputs_map.insert(input_key, input.clone());
     inputs_map.insert(tangent_input_key, input);
     inputs_map.insert(cotangent_input_key, cotangent);
 
-    eval_fragment_outputs(
-        vec![fragment, linear_fragment, transposed_fragment],
+    eval_graph_outputs(
+        vec![graph, linear_graph, transposed_graph],
         &[output_key],
         &inputs_map,
     )

--- a/tenferro-ad/tests/ad/reductions_and_indexing.rs
+++ b/tenferro-ad/tests/ad/reductions_and_indexing.rs
@@ -4,8 +4,7 @@ use super::*;
 fn test_reduce_prod_jvp() {
     let op = StdTensorOp::ReduceProd { axes: vec![0] };
     let input_shape = vec![4usize];
-    let (fragment, input_key, output_key) =
-        build_unary_fragment(op.clone(), tensor_input_key(60_000));
+    let (graph, input_key, output_key) = build_unary_graph(op.clone(), tensor_input_key(60_000));
     let x_data = vec![1.5, -2.0, 0.75, 4.0];
     let dx_data = vec![0.25, -0.5, 1.0, 0.75];
     let mut inputs_map = HashMap::new();
@@ -14,8 +13,8 @@ fn test_reduce_prod_jvp() {
         f64_tensor(input_shape.clone(), x_data.clone()),
     );
 
-    let tangent = jvp_from_fragment_with_inputs(
-        fragment,
+    let tangent = jvp_from_graph_with_inputs(
+        graph,
         output_key,
         input_key,
         inputs_map,
@@ -54,8 +53,7 @@ fn test_reduce_prod_vjp() {
 fn test_reduce_max_jvp() {
     let op = StdTensorOp::ReduceMax { axes: vec![0] };
     let input_shape = vec![2usize, 3];
-    let (fragment, input_key, output_key) =
-        build_unary_fragment(op.clone(), tensor_input_key(60_002));
+    let (graph, input_key, output_key) = build_unary_graph(op.clone(), tensor_input_key(60_002));
     let x_data = vec![2.0, 2.0, 4.0, 1.0, -3.0, -3.0];
     let dx_data = vec![1.0, -0.5, 0.75, -1.25, 2.0, -1.0];
     let mut inputs_map = HashMap::new();
@@ -64,8 +62,8 @@ fn test_reduce_max_jvp() {
         f64_tensor(input_shape.clone(), x_data.clone()),
     );
 
-    let tangent = jvp_from_fragment_with_inputs(
-        fragment,
+    let tangent = jvp_from_graph_with_inputs(
+        graph,
         output_key,
         input_key,
         inputs_map,
@@ -100,8 +98,7 @@ fn test_reduce_max_vjp() {
 fn test_reduce_min_jvp() {
     let op = StdTensorOp::ReduceMin { axes: vec![0] };
     let input_shape = vec![4usize];
-    let (fragment, input_key, output_key) =
-        build_unary_fragment(op.clone(), tensor_input_key(60_004));
+    let (graph, input_key, output_key) = build_unary_graph(op.clone(), tensor_input_key(60_004));
     let x_data = vec![1.0, -2.0, 4.0, -2.0];
     let dx_data = vec![0.5, 1.0, -1.0, -0.5];
     let mut inputs_map = HashMap::new();
@@ -110,8 +107,8 @@ fn test_reduce_min_jvp() {
         f64_tensor(input_shape.clone(), x_data.clone()),
     );
 
-    let tangent = jvp_from_fragment_with_inputs(
-        fragment,
+    let tangent = jvp_from_graph_with_inputs(
+        graph,
         output_key,
         input_key,
         inputs_map,
@@ -480,24 +477,24 @@ fn grad_log1p() {
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
 
-fn build_gather_reduce_sum_fragment(
+fn build_gather_reduce_sum_graph(
     operand_key: TensorInputKey,
     indices_key: TensorInputKey,
     config: GatherConfig,
     reduce_axes: Vec<usize>,
-) -> (Arc<Fragment<StdTensorOp>>, GlobalValKey<StdTensorOp>) {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+) -> (Arc<Graph<StdTensorOp>>, ValueKey<StdTensorOp>) {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let operand = builder.add_input(operand_key);
     let indices = builder.add_input(indices_key);
-    let gathered = builder.add_op(
+    let gathered = builder.add_operation(
         StdTensorOp::Gather(config),
-        vec![ValRef::Local(operand), ValRef::Local(indices)],
-        OpMode::Primal,
+        vec![ValueRef::Local(operand), ValueRef::Local(indices)],
+        OperationRole::Primary,
     )[0];
-    let loss = builder.add_op(
+    let loss = builder.add_operation(
         StdTensorOp::ReduceSum { axes: reduce_axes },
-        vec![ValRef::Local(gathered)],
-        OpMode::Primal,
+        vec![ValueRef::Local(gathered)],
+        OperationRole::Primary,
     )[0];
     let loss_key = builder.global_key(loss).clone();
     builder.set_outputs(vec![loss]);
@@ -519,8 +516,8 @@ fn grad_gather_reduce_sum_accumulates_indices_correctly() {
         index_vector_dim: 1,
         slice_sizes: vec![1],
     };
-    let (fragment, loss_key) =
-        build_gather_reduce_sum_fragment(operand_key.clone(), indices_key.clone(), config, vec![0]);
+    let (graph, loss_key) =
+        build_gather_reduce_sum_graph(operand_key.clone(), indices_key.clone(), config, vec![0]);
 
     let operand_data = vec![10.0_f64, 20.0, 30.0, 40.0, 50.0];
     let indices_data = vec![2_i64, 4, 0, 2, 2];
@@ -531,7 +528,7 @@ fn grad_gather_reduce_sum_accumulates_indices_correctly() {
     );
     inputs_map.insert(indices_key, i64_tensor(vec![5, 1], indices_data));
 
-    let grad = grad_from_fragment_with_inputs(fragment, loss_key, operand_key, inputs_map);
+    let grad = grad_from_graph_with_inputs(graph, loss_key, operand_key, inputs_map);
     assert_eq!(grad.shape(), &[5]);
     assert_close_slice(get_f64_data(&grad), &[1.0, 0.0, 3.0, 0.0, 1.0]);
 }
@@ -565,96 +562,96 @@ fn jvp_traced_index_select_gathers_tangent() {
 
 /// Build `y = ReduceSum(Scatter(operand, indices, updates, config))`,
 /// where the Scatter output has the same shape as `operand`.
-fn build_scatter_reduce_sum_fragment(
+fn build_scatter_reduce_sum_graph(
     operand_key: TensorInputKey,
     indices_key: TensorInputKey,
     updates_key: TensorInputKey,
     config: ScatterConfig,
     reduce_axes: Vec<usize>,
-) -> (Arc<Fragment<StdTensorOp>>, GlobalValKey<StdTensorOp>) {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+) -> (Arc<Graph<StdTensorOp>>, ValueKey<StdTensorOp>) {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let operand = builder.add_input(operand_key);
     let indices = builder.add_input(indices_key);
     let updates = builder.add_input(updates_key);
-    let scattered = builder.add_op(
+    let scattered = builder.add_operation(
         StdTensorOp::Scatter(config),
         vec![
-            ValRef::Local(operand),
-            ValRef::Local(indices),
-            ValRef::Local(updates),
+            ValueRef::Local(operand),
+            ValueRef::Local(indices),
+            ValueRef::Local(updates),
         ],
-        OpMode::Primal,
+        OperationRole::Primary,
     )[0];
-    let loss = builder.add_op(
+    let loss = builder.add_operation(
         StdTensorOp::ReduceSum { axes: reduce_axes },
-        vec![ValRef::Local(scattered)],
-        OpMode::Primal,
+        vec![ValueRef::Local(scattered)],
+        OperationRole::Primary,
     )[0];
     let loss_key = builder.global_key(loss).clone();
     builder.set_outputs(vec![loss]);
     (Arc::new(builder.build()), loss_key)
 }
 
-fn build_weighted_unary_sum_fragment(
+fn build_weighted_unary_sum_graph(
     input_key: TensorInputKey,
     weights_key: TensorInputKey,
     op: StdTensorOp,
     reduce_axes: Vec<usize>,
-) -> (Arc<Fragment<StdTensorOp>>, GlobalValKey<StdTensorOp>) {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+) -> (Arc<Graph<StdTensorOp>>, ValueKey<StdTensorOp>) {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let input = builder.add_input(input_key);
     let weights = builder.add_input(weights_key);
-    let output = builder.add_op(op, vec![ValRef::Local(input)], OpMode::Primal)[0];
-    let weighted = builder.add_op(
+    let output = builder.add_operation(op, vec![ValueRef::Local(input)], OperationRole::Primary)[0];
+    let weighted = builder.add_operation(
         StdTensorOp::Mul,
-        vec![ValRef::Local(output), ValRef::Local(weights)],
-        OpMode::Primal,
+        vec![ValueRef::Local(output), ValueRef::Local(weights)],
+        OperationRole::Primary,
     )[0];
-    let loss = builder.add_op(
+    let loss = builder.add_operation(
         StdTensorOp::ReduceSum { axes: reduce_axes },
-        vec![ValRef::Local(weighted)],
-        OpMode::Primal,
+        vec![ValueRef::Local(weighted)],
+        OperationRole::Primary,
     )[0];
     let loss_key = builder.global_key(loss).clone();
     builder.set_outputs(vec![loss]);
     (Arc::new(builder.build()), loss_key)
 }
 
-fn build_dynamic_slice_fragment(
+fn build_dynamic_slice_graph(
     input_key: TensorInputKey,
     starts_key: TensorInputKey,
     slice_sizes: Vec<usize>,
-) -> (Arc<Fragment<StdTensorOp>>, GlobalValKey<StdTensorOp>) {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+) -> (Arc<Graph<StdTensorOp>>, ValueKey<StdTensorOp>) {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let input = builder.add_input(input_key);
     let starts = builder.add_input(starts_key);
-    let output = builder.add_op(
+    let output = builder.add_operation(
         StdTensorOp::DynamicSlice { slice_sizes },
-        vec![ValRef::Local(input), ValRef::Local(starts)],
-        OpMode::Primal,
+        vec![ValueRef::Local(input), ValueRef::Local(starts)],
+        OperationRole::Primary,
     )[0];
     let output_key = builder.global_key(output).clone();
     builder.set_outputs(vec![output]);
     (Arc::new(builder.build()), output_key)
 }
 
-fn build_dynamic_update_slice_fragment(
+fn build_dynamic_update_slice_graph(
     operand_key: TensorInputKey,
     update_key: TensorInputKey,
     starts_key: TensorInputKey,
-) -> (Arc<Fragment<StdTensorOp>>, GlobalValKey<StdTensorOp>) {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+) -> (Arc<Graph<StdTensorOp>>, ValueKey<StdTensorOp>) {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let operand = builder.add_input(operand_key);
     let update = builder.add_input(update_key);
     let starts = builder.add_input(starts_key);
-    let output = builder.add_op(
+    let output = builder.add_operation(
         StdTensorOp::DynamicUpdateSlice,
         vec![
-            ValRef::Local(operand),
-            ValRef::Local(update),
-            ValRef::Local(starts),
+            ValueRef::Local(operand),
+            ValueRef::Local(update),
+            ValueRef::Local(starts),
         ],
-        OpMode::Primal,
+        OperationRole::Primary,
     )[0];
     let output_key = builder.global_key(output).clone();
     builder.set_outputs(vec![output]);
@@ -676,7 +673,7 @@ fn grad_scatter_reduce_sum_wrt_updates_is_ones() {
         scatter_dims_to_operand_dims: vec![0],
         index_vector_dim: 1,
     };
-    let (fragment, loss_key) = build_scatter_reduce_sum_fragment(
+    let (graph, loss_key) = build_scatter_reduce_sum_graph(
         operand_key.clone(),
         indices_key.clone(),
         updates_key.clone(),
@@ -695,7 +692,7 @@ fn grad_scatter_reduce_sum_wrt_updates_is_ones() {
         f64_tensor(vec![3], updates_data.clone()),
     );
 
-    let grad = grad_from_fragment_with_inputs(fragment, loss_key, updates_key, inputs_map);
+    let grad = grad_from_graph_with_inputs(graph, loss_key, updates_key, inputs_map);
     assert_eq!(grad.shape(), &[3]);
     // reduce_sum over the scatter output contributes a 1 to each updated
     // slot; the inverse Gather reads one value for each `indices` entry.
@@ -706,8 +703,8 @@ fn grad_scatter_reduce_sum_wrt_updates_is_ones() {
 fn jvp_dynamic_slice_matches_finite_diff() {
     let input_key = tensor_input_key(61_500);
     let starts_key = tensor_input_key(61_501);
-    let (fragment, output_key) =
-        build_dynamic_slice_fragment(input_key.clone(), starts_key.clone(), vec![3]);
+    let (graph, output_key) =
+        build_dynamic_slice_graph(input_key.clone(), starts_key.clone(), vec![3]);
 
     let input_data = vec![0.5_f64, -1.0, 2.5, 4.0, -3.0];
     let starts_data = vec![1_i64];
@@ -717,8 +714,8 @@ fn jvp_dynamic_slice_matches_finite_diff() {
         (starts_key, i64_tensor(vec![1], starts_data)),
     ]);
 
-    let tangent = jvp_from_fragment_with_inputs(
-        fragment,
+    let tangent = jvp_from_graph_with_inputs(
+        graph,
         output_key,
         input_key,
         inputs_map,
@@ -734,8 +731,8 @@ fn jvp_dynamic_slice_matches_finite_diff() {
 fn grad_dynamic_slice_clamped_start_matches_finite_diff() {
     let input_key = tensor_input_key(61_510);
     let starts_key = tensor_input_key(61_511);
-    let (fragment, output_key) =
-        build_dynamic_slice_fragment(input_key.clone(), starts_key.clone(), vec![3]);
+    let (graph, output_key) =
+        build_dynamic_slice_graph(input_key.clone(), starts_key.clone(), vec![3]);
 
     let input_data = vec![0.5_f64, -1.0, 2.5, 4.0, -3.0];
     let starts_data = vec![4_i64];
@@ -745,8 +742,8 @@ fn grad_dynamic_slice_clamped_start_matches_finite_diff() {
         (starts_key, i64_tensor(vec![1], starts_data)),
     ]);
 
-    let grad = grad_from_fragment_with_inputs_and_cotangent(
-        fragment,
+    let grad = grad_from_graph_with_inputs_and_cotangent(
+        graph,
         output_key,
         input_key,
         inputs_map,
@@ -771,7 +768,7 @@ fn jvp_dynamic_update_slice_update_matches_finite_diff() {
     let operand_key = tensor_input_key(61_520);
     let update_key = tensor_input_key(61_521);
     let starts_key = tensor_input_key(61_522);
-    let (fragment, output_key) = build_dynamic_update_slice_fragment(
+    let (graph, output_key) = build_dynamic_update_slice_graph(
         operand_key.clone(),
         update_key.clone(),
         starts_key.clone(),
@@ -787,8 +784,8 @@ fn jvp_dynamic_update_slice_update_matches_finite_diff() {
         (starts_key, i64_tensor(vec![1], starts_data)),
     ]);
 
-    let tangent = jvp_from_fragment_with_inputs(
-        fragment,
+    let tangent = jvp_from_graph_with_inputs(
+        graph,
         output_key,
         update_key,
         inputs_map,
@@ -807,7 +804,7 @@ fn grad_dynamic_update_slice_matches_finite_diff() {
     let operand_key = tensor_input_key(61_530);
     let update_key = tensor_input_key(61_531);
     let starts_key = tensor_input_key(61_532);
-    let (fragment, output_key) = build_dynamic_update_slice_fragment(
+    let (graph, output_key) = build_dynamic_update_slice_graph(
         operand_key.clone(),
         update_key.clone(),
         starts_key.clone(),
@@ -826,15 +823,15 @@ fn grad_dynamic_update_slice_matches_finite_diff() {
         (starts_key, i64_tensor(vec![1], starts_data)),
     ]);
 
-    let grad_operand = grad_from_fragment_with_inputs_and_cotangent(
-        fragment.clone(),
+    let grad_operand = grad_from_graph_with_inputs_and_cotangent(
+        graph.clone(),
         output_key.clone(),
         operand_key,
         inputs_map.clone(),
         f64_tensor(vec![5], cotangent_data.clone()),
     );
-    let grad_update = grad_from_fragment_with_inputs_and_cotangent(
-        fragment,
+    let grad_update = grad_from_graph_with_inputs_and_cotangent(
+        graph,
         output_key,
         update_key,
         inputs_map,
@@ -869,7 +866,7 @@ fn grad_slice_weighted_sum_matches_finite_diff() {
         limits: vec![5],
         strides: vec![2],
     };
-    let (fragment, loss_key) = build_weighted_unary_sum_fragment(
+    let (graph, loss_key) = build_weighted_unary_sum_graph(
         input_key.clone(),
         weights_key.clone(),
         StdTensorOp::Slice(config),
@@ -883,7 +880,7 @@ fn grad_slice_weighted_sum_matches_finite_diff() {
         (weights_key, f64_tensor(vec![2], weights_data.clone())),
     ]);
 
-    let grad = grad_from_fragment_with_inputs(fragment, loss_key, input_key, inputs_map);
+    let grad = grad_from_graph_with_inputs(graph, loss_key, input_key, inputs_map);
     assert_grad_matches_finite_diff(get_f64_data(&grad), &input_data, |xs| {
         xs[1] * weights_data[0] + xs[3] * weights_data[1]
     });
@@ -898,7 +895,7 @@ fn grad_pad_weighted_sum_matches_finite_diff() {
         edge_padding_high: vec![2],
         interior_padding: vec![1],
     };
-    let (fragment, loss_key) = build_weighted_unary_sum_fragment(
+    let (graph, loss_key) = build_weighted_unary_sum_graph(
         input_key.clone(),
         weights_key.clone(),
         StdTensorOp::Pad(config),
@@ -912,7 +909,7 @@ fn grad_pad_weighted_sum_matches_finite_diff() {
         (weights_key, f64_tensor(vec![8], weights_data.clone())),
     ]);
 
-    let grad = grad_from_fragment_with_inputs(fragment, loss_key, input_key, inputs_map);
+    let grad = grad_from_graph_with_inputs(graph, loss_key, input_key, inputs_map);
     assert_grad_matches_finite_diff(get_f64_data(&grad), &input_data, |xs| {
         xs[0] * weights_data[1] + xs[1] * weights_data[3] + xs[2] * weights_data[5]
     });
@@ -922,7 +919,7 @@ fn grad_pad_weighted_sum_matches_finite_diff() {
 fn grad_reverse_weighted_sum_matches_finite_diff() {
     let input_key = tensor_input_key(64_000);
     let weights_key = tensor_input_key(64_001);
-    let (fragment, loss_key) = build_weighted_unary_sum_fragment(
+    let (graph, loss_key) = build_weighted_unary_sum_graph(
         input_key.clone(),
         weights_key.clone(),
         StdTensorOp::Reverse { axes: vec![0] },
@@ -936,7 +933,7 @@ fn grad_reverse_weighted_sum_matches_finite_diff() {
         (weights_key, f64_tensor(vec![4], weights_data.clone())),
     ]);
 
-    let grad = grad_from_fragment_with_inputs(fragment, loss_key, input_key, inputs_map);
+    let grad = grad_from_graph_with_inputs(graph, loss_key, input_key, inputs_map);
     assert_grad_matches_finite_diff(get_f64_data(&grad), &input_data, |xs| {
         xs[0] * weights_data[3]
             + xs[1] * weights_data[2]
@@ -953,10 +950,10 @@ fn dropped_traced_graph_releases_registered_metadata() {
 
     {
         let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]);
-        leaf_key = GlobalValKey::Input(x.input_key().expect("leaf input key"));
+        leaf_key = ValueKey::Input(x.input_key().expect("leaf input key"));
 
         y = &x + &x;
-        derived_key = y.fragment.vals()[y.val].key.clone();
+        derived_key = y.graph.values()[y.val].key.clone();
 
         assert!(lookup_global_metadata(&leaf_key).is_some());
         assert!(lookup_global_metadata(&derived_key).is_some());

--- a/tenferro-ad/tests/compiler_passes.rs
+++ b/tenferro-ad/tests/compiler_passes.rs
@@ -77,7 +77,7 @@ fn make_std_instr(
     outputs: Vec<usize>,
 ) -> Instruction<StdTensorOp> {
     Instruction {
-        op,
+        operation: op,
         inputs,
         outputs,
     }

--- a/tenferro-ad/tests/compiler_wiring.rs
+++ b/tenferro-ad/tests/compiler_wiring.rs
@@ -26,7 +26,7 @@ fn make_instr(
     outputs: Vec<usize>,
 ) -> Instruction<StdTensorOp> {
     Instruction {
-        op,
+        operation: op,
         inputs,
         outputs,
     }
@@ -52,7 +52,7 @@ fn compile_std_to_exec_wires_remaining_simple_ops() {
         make_instr(
             StdTensorOp::Concatenate {
                 axis: 0,
-                n_inputs: 2,
+                input_count: 2,
             },
             vec![0, 1],
             vec![8],

--- a/tenferro-ad/tests/exec_dispatch.rs
+++ b/tenferro-ad/tests/exec_dispatch.rs
@@ -14,8 +14,8 @@ fn dim_shape(shape: &[usize]) -> Vec<DimExpr> {
     DimExpr::from_concrete(shape)
 }
 
-fn empty_extents(n_outputs: usize) -> Vec<Vec<ShapeExtent<DimExpr>>> {
-    vec![Vec::new(); n_outputs]
+fn empty_extents(output_count: usize) -> Vec<Vec<ShapeExtent<DimExpr>>> {
+    vec![Vec::new(); output_count]
 }
 
 fn scalar_tensor(value: f64) -> Tensor {
@@ -67,20 +67,20 @@ fn pad_config() -> PadConfig {
     }
 }
 
-fn single_instruction_program(op: ExecOp, n_inputs: usize) -> ExecProgram {
+fn single_instruction_program(op: ExecOp, input_count: usize) -> ExecProgram {
     ExecProgram {
         instructions: vec![ExecInstruction {
             op,
-            input_slots: (0..n_inputs).collect(),
-            output_slots: vec![n_inputs],
+            input_slots: (0..input_count).collect(),
+            output_slots: vec![input_count],
             dtype: DType::F64,
             output_shapes: vec![Vec::new()],
             output_extents: empty_extents(1),
-            last_use: vec![false; n_inputs],
+            last_use: vec![false; input_count],
         }],
-        input_slots: (0..n_inputs).collect(),
-        output_slots: vec![n_inputs],
-        n_slots: n_inputs + 1,
+        input_slots: (0..input_count).collect(),
+        output_slots: vec![input_count],
+        n_slots: input_count + 1,
     }
 }
 
@@ -438,10 +438,10 @@ fn eval_exec_ir_dispatches_tensor_ops_to_backend_methods() {
         (ExecOp::ReduceMin { axes: vec![0] }, 1, "reduce_min", 31.0),
     ];
 
-    for (op, n_inputs, expected_call, expected_value) in cases {
+    for (op, input_count, expected_call, expected_value) in cases {
         let mut backend = FakeTensorBackend::default();
-        let program = single_instruction_program(op, n_inputs);
-        let inputs = (0..n_inputs)
+        let program = single_instruction_program(op, input_count);
+        let inputs = (0..input_count)
             .map(|idx| scalar_tensor(idx as f64 + 1.0))
             .collect();
         let outputs = eval_exec_ir(&mut backend, &program, inputs).unwrap();

--- a/tenferro-ad/tests/extension_op.rs
+++ b/tenferro-ad/tests/extension_op.rs
@@ -24,13 +24,13 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::{Arc, Mutex, OnceLock};
 use support::RunTraced;
 
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use num_complex::{Complex32, Complex64};
 use tenferro_ad::extension::{
     apply_eager, register_extension_rule, ExtensionAdRuleTrait, ExtensionRuleSet,
 };
 use tenferro_cpu::CpuBackend;
+use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -91,11 +91,11 @@ impl ExtensionOp for TestScaleBy2 {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -145,18 +145,18 @@ impl ExtensionAdRuleTrait for TestScaleBy2Rule {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        builder: &mut dyn OpEmitter<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         match tangent_in[0] {
             Some(dx) => {
-                let sum = builder.add_op(
+                let sum = builder.add_operation(
                     StdTensorOp::Add,
-                    vec![ValRef::Local(dx), ValRef::Local(dx)],
-                    OpMode::Linear {
+                    vec![ValueRef::Local(dx), ValueRef::Local(dx)],
+                    OperationRole::Linearized {
                         active_mask: vec![true, true],
                     },
                 );
@@ -169,18 +169,18 @@ impl ExtensionAdRuleTrait for TestScaleBy2Rule {
     fn transpose_rule(
         &self,
         _op: &dyn ExtensionOp,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        _inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
+        _mode: &OperationRole,
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         match cotangent_out[0] {
             Some(ct) => {
-                let sum = emitter.add_op(
+                let sum = builder.add_operation(
                     StdTensorOp::Add,
-                    vec![ValRef::Local(ct), ValRef::Local(ct)],
-                    OpMode::Linear {
+                    vec![ValueRef::Local(ct), ValueRef::Local(ct)],
+                    OperationRole::Linearized {
                         active_mask: vec![true, true],
                     },
                 );
@@ -217,11 +217,11 @@ impl ExtensionOp for TestSwap {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         2
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         2
     }
 
@@ -262,24 +262,24 @@ impl ExtensionAdRuleTrait for TestSwapRule {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        _builder: &mut dyn OpEmitter<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![tangent_in[1], tangent_in[0]])
     }
 
     fn transpose_rule(
         &self,
         _op: &dyn ExtensionOp,
-        _emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        _inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
+        _mode: &OperationRole,
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![cotangent_out[1], cotangent_out[0]])
     }
 }
@@ -310,11 +310,11 @@ impl ExtensionOp for TestNoAd {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -362,11 +362,11 @@ impl ExtensionOp for TestProbeIdentity {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         2
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -409,11 +409,11 @@ impl ExtensionOp for TestProbeLinear {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         2
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -446,12 +446,12 @@ impl ExtensionAdRuleTrait for TestProbeIdentityRule {
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut dyn OpEmitter<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = op
             .as_any()
             .downcast_ref::<TestProbeIdentity>()
@@ -463,12 +463,12 @@ impl ExtensionAdRuleTrait for TestProbeIdentityRule {
             return Ok(vec![Some(dx)]);
         };
 
-        let out = builder.add_op(
+        let out = builder.add_operation(
             StdTensorOp::Extension(Arc::new(TestProbeLinear {
                 probe_shape: op.probe_shape.clone(),
             })),
-            vec![ValRef::Local(dx), ValRef::Local(dprobe)],
-            OpMode::Linear {
+            vec![ValueRef::Local(dx), ValueRef::Local(dprobe)],
+            OperationRole::Linearized {
                 active_mask: vec![true, true],
             },
         );
@@ -478,12 +478,12 @@ impl ExtensionAdRuleTrait for TestProbeIdentityRule {
     fn transpose_rule(
         &self,
         _op: &dyn ExtensionOp,
-        _emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        _inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
+        _mode: &OperationRole,
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![cotangent_out[0], None])
     }
 }
@@ -499,24 +499,24 @@ impl ExtensionAdRuleTrait for TestProbeLinearRule {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        _builder: &mut dyn OpEmitter<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![tangent_in[0]])
     }
 
     fn transpose_rule(
         &self,
         op: &dyn ExtensionOp,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
+        _mode: &OperationRole,
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let Some(ct) = cotangent_out[0] else {
             return Ok(vec![None, None]);
         };
@@ -524,12 +524,12 @@ impl ExtensionAdRuleTrait for TestProbeLinearRule {
             .as_any()
             .downcast_ref::<TestProbeLinear>()
             .expect("TestProbeLinearRule received a different op");
-        let _probe_value = emitter.add_op(
+        let _probe_value = builder.add_operation(
             StdTensorOp::Reshape {
                 to_shape: DimExpr::from_concrete(&op.probe_shape),
             },
             vec![inputs[1].clone()],
-            OpMode::Primal,
+            OperationRole::Primary,
         );
         Ok(vec![Some(ct), None])
     }
@@ -564,11 +564,11 @@ impl ExtensionOp for TestBadOutputCount {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         2
     }
 

--- a/tenferro-ad/tests/extension_op/api_and_registry.rs
+++ b/tenferro-ad/tests/extension_op/api_and_registry.rs
@@ -227,23 +227,23 @@ fn malformed_family_id_is_rejected() {
         fn linearize(
             &self,
             _op: &dyn ExtensionOp,
-            _builder: &mut dyn OpEmitter<StdTensorOp>,
-            _primal_in: &[GlobalValKey<StdTensorOp>],
-            _primal_out: &[GlobalValKey<StdTensorOp>],
-            _tangent_in: &[Option<LocalValId>],
+            _builder: &mut dyn PrimitiveRuleBuilder,
+            _primal_in: &[ValueKey<StdTensorOp>],
+            _primal_out: &[ValueKey<StdTensorOp>],
+            _tangent_in: &[Option<LocalValueId>],
             _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             Ok(vec![])
         }
         fn transpose_rule(
             &self,
             _op: &dyn ExtensionOp,
-            _emitter: &mut dyn OpEmitter<StdTensorOp>,
-            _cotangent_out: &[Option<LocalValId>],
-            _inputs: &[ValRef<StdTensorOp>],
-            _mode: &OpMode,
+            _builder: &mut dyn PrimitiveRuleBuilder,
+            _cotangent_out: &[Option<LocalValueId>],
+            _inputs: &[ValueRef<StdTensorOp>],
+            _mode: &OperationRole,
             _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             Ok(vec![])
         }
     }

--- a/tenferro-ad/tests/graph_compile.rs
+++ b/tenferro-ad/tests/graph_compile.rs
@@ -40,11 +40,11 @@ impl ExtensionOpTrait for ConstantDebugExtension {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 

--- a/tenferro-ad/tests/iterative_ad.rs
+++ b/tenferro-ad/tests/iterative_ad.rs
@@ -14,7 +14,7 @@ mod support;
 use std::collections::HashSet;
 use support::{run_many_traced_with, RunTraced};
 
-use computegraph::fragment::Fragment;
+use computegraph::graph::Graph;
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_runtime::traced::TracedTensor;
@@ -35,28 +35,28 @@ fn get_f64_scalar(t: &Tensor) -> f64 {
     }
 }
 
-/// Count total ops across all fragments in the fragment tree, deduplicating
-/// by pointer identity (the same `Arc<Fragment>` may appear multiple times).
-fn total_ops(fragment: &Fragment<StdTensorOp>) -> usize {
+/// Count total ops across all graphs in the graph tree, deduplicating
+/// by pointer identity (the same `Arc<Graph>` may appear multiple times).
+fn total_ops(graph: &Graph<StdTensorOp>) -> usize {
     let mut visited = HashSet::new();
     let mut count = 0;
-    count_ops_recursive(fragment, &mut visited, &mut count);
+    count_ops_recursive(graph, &mut visited, &mut count);
     count
 }
 
-// Deduplication uses raw pointer identity, which works because Fragment
+// Deduplication uses raw pointer identity, which works because Graph
 // parents share the same Arc allocation (not cloned data).
 fn count_ops_recursive(
-    fragment: &Fragment<StdTensorOp>,
-    visited: &mut HashSet<*const Fragment<StdTensorOp>>,
+    graph: &Graph<StdTensorOp>,
+    visited: &mut HashSet<*const Graph<StdTensorOp>>,
     count: &mut usize,
 ) {
-    let ptr: *const Fragment<StdTensorOp> = fragment;
+    let ptr: *const Graph<StdTensorOp> = graph;
     if !visited.insert(ptr) {
         return;
     }
-    *count += fragment.ops().len();
-    for parent in fragment.parents() {
+    *count += graph.operations().len();
+    for parent in graph.parents() {
         count_ops_recursive(parent, visited, count);
     }
 }
@@ -178,7 +178,7 @@ fn eval_all_evaluates_primal_and_gradient() {
     let primal = x_final.clone();
     let grad = x_final.grad(&a).unwrap();
 
-    // run_many_traced_with merges fragments and deduplicates shared subexpressions.
+    // run_many_traced_with merges graphs and deduplicates shared subexpressions.
     // If this panics or returns wrong values, deduplication is broken.
     let results = run_many_traced_with(&mut engine, &[&primal, &grad]).unwrap();
     assert_eq!(results.len(), 2);
@@ -207,14 +207,14 @@ fn eval_all_evaluates_primal_and_gradient() {
 #[test]
 fn graph_size_grows_linearly() {
     // Run with a fixed number of iterations (no convergence check)
-    // and measure fragment op count.
+    // and measure graph op count.
     fn ops_for_k_iters(k: usize) -> usize {
         let a = TracedTensor::from_tensor_concrete_shape(f64_scalar(0.8));
         let mut x = TracedTensor::from_tensor_concrete_shape(f64_scalar(0.5));
         for _ in 0..k {
             x = &a * &x.cos();
         }
-        total_ops(&x.fragment)
+        total_ops(&x.graph)
     }
 
     let ops_10 = ops_for_k_iters(10);

--- a/tenferro-ad/tests/segment_tests.rs
+++ b/tenferro-ad/tests/segment_tests.rs
@@ -15,9 +15,9 @@ fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
 }
 
 fn scalar_extents(
-    n_outputs: usize,
+    output_count: usize,
 ) -> Vec<Vec<tenferro_ops::ShapeExtent<tenferro_ops::dim_expr::DimExpr>>> {
-    vec![Vec::new(); n_outputs]
+    vec![Vec::new(); output_count]
 }
 
 fn matmul_config() -> DotGeneralConfig {

--- a/tenferro-ad/tests/shape_inference.rs
+++ b/tenferro-ad/tests/shape_inference.rs
@@ -246,7 +246,7 @@ fn test_structural_indexing_and_dynamic_shapes() {
 
     let concat = StdTensorOp::Concatenate {
         axis: 1,
-        n_inputs: 2,
+        input_count: 2,
     };
     let rhs = vec![cst(4), cst(7)];
     assert_eq!(

--- a/tenferro-core-ops/src/catalog.rs
+++ b/tenferro-core-ops/src/catalog.rs
@@ -321,7 +321,7 @@ macro_rules! define_std_tensor_op {
             Pad(PadConfig),
             Concatenate {
                 axis: usize,
-                n_inputs: usize,
+                input_count: usize,
             },
             Reverse {
                 axes: Vec<usize>,
@@ -524,7 +524,7 @@ macro_rules! define_std_tensor_op {
                     }),
                     $crate::PrimitiveOpKind::Concatenate => Self::Concatenate {
                         axis: 0,
-                        n_inputs: 1,
+                        input_count: 1,
                     },
                     $crate::PrimitiveOpKind::Reverse => Self::Reverse { axes: vec![0] },
                     $crate::PrimitiveOpKind::ShapeOf => Self::ShapeOf { axis: 0 },

--- a/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -690,7 +690,7 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
 
     let fusion_plan = tenferro_tensor::ElementwiseFusionPlan {
         dtype: DType::F64,
-        n_inputs: 0,
+        input_count: 0,
         outputs: vec![],
         ops: vec![],
     };

--- a/tenferro-einsum/src/builder.rs
+++ b/tenferro-einsum/src/builder.rs
@@ -36,8 +36,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use computegraph::fragment::FragmentBuilder;
-use computegraph::types::{OpMode, ValRef};
+use computegraph::graph::GraphBuilder;
+use computegraph::types::{OperationRole, ValueRef};
 
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -48,7 +48,7 @@ use crate::{Error, Result};
 
 #[derive(Clone, Debug)]
 struct LabeledVal {
-    val: ValRef<StdTensorOp>,
+    val: ValueRef<StdTensorOp>,
     labels: Vec<u32>,
     shape: Vec<usize>,
 }
@@ -92,7 +92,7 @@ fn labeled_operand<'a>(
 }
 
 fn reduce_val(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut GraphBuilder<StdTensorOp>,
     lv: &LabeledVal,
     reduce_labels: &HashSet<u32>,
 ) -> LabeledVal {
@@ -124,13 +124,13 @@ fn reduce_val(
         .filter(|(i, _)| !reduce_set.contains(i))
         .map(|(_, &s)| s)
         .collect();
-    let outputs = builder.add_op(
+    let outputs = builder.add_operation(
         StdTensorOp::ReduceSum { axes: reduce_axes },
         vec![lv.val.clone()],
-        OpMode::Primal,
+        OperationRole::Primary,
     );
     LabeledVal {
-        val: ValRef::Local(outputs[0]),
+        val: ValueRef::Local(outputs[0]),
         labels: new_labels,
         shape: new_shape,
     }
@@ -140,7 +140,7 @@ fn reduce_val(
 /// than the current tensor has. For example, "i->ii" needs to embed axis 0
 /// into a new axis 1 of the same size.
 fn embed_repeated(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut GraphBuilder<StdTensorOp>,
     lv: &LabeledVal,
     output_labels: &[u32],
 ) -> Result<LabeledVal> {
@@ -156,17 +156,17 @@ fn embed_repeated(
             // Insert the new axis right after axis_a.
             let axis_b = axis_a + 1;
             let n = result.shape[axis_a];
-            let outputs = builder.add_op(
+            let outputs = builder.add_operation(
                 StdTensorOp::EmbedDiag { axis_a, axis_b },
                 vec![result.val.clone()],
-                OpMode::Primal,
+                OperationRole::Primary,
             );
             let mut new_labels = result.labels.clone();
             new_labels.insert(axis_b, label);
             let mut new_shape = result.shape.clone();
             new_shape.insert(axis_b, n);
             result = LabeledVal {
-                val: ValRef::Local(outputs[0]),
+                val: ValueRef::Local(outputs[0]),
                 labels: new_labels,
                 shape: new_shape,
             };
@@ -177,25 +177,25 @@ fn embed_repeated(
     Ok(result)
 }
 
-fn diagonalize_repeated(builder: &mut FragmentBuilder<StdTensorOp>, lv: &LabeledVal) -> LabeledVal {
+fn diagonalize_repeated(builder: &mut GraphBuilder<StdTensorOp>, lv: &LabeledVal) -> LabeledVal {
     let mut seen: HashMap<u32, usize> = HashMap::new();
     for (i, &label) in lv.labels.iter().enumerate() {
         if let Some(&first) = seen.get(&label) {
             // Found repeated label at axes `first` and `i`
-            let outputs = builder.add_op(
+            let outputs = builder.add_operation(
                 StdTensorOp::ExtractDiag {
                     axis_a: first,
                     axis_b: i,
                 },
                 vec![lv.val.clone()],
-                OpMode::Primal,
+                OperationRole::Primary,
             );
             let mut new_labels = lv.labels.clone();
             new_labels.remove(i);
             let mut new_shape = lv.shape.clone();
             new_shape.remove(i);
             let result = LabeledVal {
-                val: ValRef::Local(outputs[0]),
+                val: ValueRef::Local(outputs[0]),
                 labels: new_labels,
                 shape: new_shape,
             };
@@ -208,7 +208,7 @@ fn diagonalize_repeated(builder: &mut FragmentBuilder<StdTensorOp>, lv: &Labeled
 }
 
 fn binary_contract(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut GraphBuilder<StdTensorOp>,
     lhs: &LabeledVal,
     rhs: &LabeledVal,
     survive_labels: &[u32],
@@ -311,14 +311,14 @@ fn binary_contract(
             .map(|&l| label_to_size(l))
             .collect::<Result<_>>()?;
 
-        let outputs = builder.add_op(
+        let outputs = builder.add_operation(
             StdTensorOp::DotGeneral { config },
             vec![lhs.val.clone(), rhs.val.clone()],
-            OpMode::Primal,
+            OperationRole::Primary,
         );
 
         LabeledVal {
-            val: ValRef::Local(outputs[0]),
+            val: ValueRef::Local(outputs[0]),
             labels: result_labels,
             shape: result_shape,
         }
@@ -368,21 +368,21 @@ fn binary_contract(
     }
 
     let new_shape: Vec<usize> = perm.iter().map(|&p| result.shape[p]).collect();
-    let outputs = builder.add_op(
+    let outputs = builder.add_operation(
         StdTensorOp::Transpose { perm },
         vec![result.val.clone()],
-        OpMode::Primal,
+        OperationRole::Primary,
     );
 
     Ok(LabeledVal {
-        val: ValRef::Local(outputs[0]),
+        val: ValueRef::Local(outputs[0]),
         labels: target_labels,
         shape: new_shape,
     })
 }
 
 fn outer_product(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut GraphBuilder<StdTensorOp>,
     lhs: &LabeledVal,
     rhs: &LabeledVal,
     batch_labels: &[u32],
@@ -403,13 +403,13 @@ fn outer_product(
 
     if lhs.labels == rhs.labels {
         // Same labels: just Mul
-        let outputs = builder.add_op(
+        let outputs = builder.add_operation(
             StdTensorOp::Mul,
             vec![lhs.val.clone(), rhs.val.clone()],
-            OpMode::Primal,
+            OperationRole::Primary,
         );
         return Ok(LabeledVal {
-            val: ValRef::Local(outputs[0]),
+            val: ValueRef::Local(outputs[0]),
             labels: lhs.labels.clone(),
             shape: lhs.shape.clone(),
         });
@@ -427,51 +427,51 @@ fn outer_product(
         .map(|l| find_label_axis(&combined_labels, *l))
         .collect::<Result<_>>()?;
 
-    let lhs_bc = builder.add_op(
+    let lhs_bc = builder.add_operation(
         StdTensorOp::BroadcastInDim {
             shape: DimExpr::from_concrete(&combined_shape),
             dims: lhs_dims,
         },
         vec![lhs.val.clone()],
-        OpMode::Primal,
+        OperationRole::Primary,
     );
-    let rhs_bc = builder.add_op(
+    let rhs_bc = builder.add_operation(
         StdTensorOp::BroadcastInDim {
             shape: DimExpr::from_concrete(&combined_shape),
             dims: rhs_dims,
         },
         vec![rhs.val.clone()],
-        OpMode::Primal,
+        OperationRole::Primary,
     );
-    let outputs = builder.add_op(
+    let outputs = builder.add_operation(
         StdTensorOp::Mul,
-        vec![ValRef::Local(lhs_bc[0]), ValRef::Local(rhs_bc[0])],
-        OpMode::Primal,
+        vec![ValueRef::Local(lhs_bc[0]), ValueRef::Local(rhs_bc[0])],
+        OperationRole::Primary,
     );
     Ok(LabeledVal {
-        val: ValRef::Local(outputs[0]),
+        val: ValueRef::Local(outputs[0]),
         labels: combined_labels,
         shape: combined_shape,
     })
 }
 
-/// Lower a planned einsum contraction tree into a compute graph fragment.
+/// Lower a planned einsum contraction tree into a compute graph graph.
 ///
 /// # Errors
 ///
 /// Returns an error if the supplied tree, input values, or input shapes are
 /// internally inconsistent.
-pub(crate) fn build_einsum_fragment(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+pub(crate) fn build_einsum_graph(
+    builder: &mut GraphBuilder<StdTensorOp>,
     tree: &ContractionTree,
-    input_vals: &[ValRef<StdTensorOp>],
+    input_vals: &[ValueRef<StdTensorOp>],
     input_shapes: &[Vec<usize>],
-) -> Result<ValRef<StdTensorOp>> {
+) -> Result<ValueRef<StdTensorOp>> {
     let subscripts = &tree.subscripts;
-    let n_inputs = subscripts.inputs.len();
-    if n_inputs != input_vals.len() {
+    let input_count = subscripts.inputs.len();
+    if input_count != input_vals.len() {
         return Err(builder_invalid_argument(format!(
-            "number of subscripts inputs ({n_inputs}) must match number of input values ({})",
+            "number of subscripts inputs ({input_count}) must match number of input values ({})",
             input_vals.len()
         )));
     }
@@ -510,7 +510,7 @@ pub(crate) fn build_einsum_fragment(
         *lv = diagonalize_repeated(builder, lv);
     }
 
-    if n_inputs == 1 || tree.step_count() == 0 {
+    if input_count == 1 || tree.step_count() == 0 {
         // Unary: reduce, embed, and reorder
         let lv = &labeled[0];
         let output_set: HashSet<u32> = output_labels.iter().copied().collect();
@@ -536,16 +536,16 @@ pub(crate) fn build_einsum_fragment(
         if perm.iter().enumerate().all(|(i, &p)| i == p) {
             return Ok(result.val);
         }
-        let outputs = builder.add_op(
+        let outputs = builder.add_operation(
             StdTensorOp::Transpose { perm },
             vec![result.val],
-            OpMode::Primal,
+            OperationRole::Primary,
         );
-        return Ok(ValRef::Local(outputs[0]));
+        return Ok(ValueRef::Local(outputs[0]));
     }
 
     // N >= 2: use contraction tree from v1
-    // Operand indices: 0..n_inputs are originals, n_inputs+step_idx are intermediates
+    // Operand indices: 0..input_count are originals, input_count+step_idx are intermediates
     for step_idx in 0..tree.step_count() {
         let (left, right) = tree.step_pair(step_idx).ok_or_else(|| {
             builder_invalid_argument(format!("missing contraction pair for step {step_idx}"))
@@ -569,8 +569,8 @@ pub(crate) fn build_einsum_fragment(
         labeled.push(result);
     }
 
-    // The final result is the last intermediate: labeled[n_inputs + step_count - 1]
-    let final_idx = n_inputs + tree.step_count() - 1;
+    // The final result is the last intermediate: labeled[input_count + step_count - 1]
+    let final_idx = input_count + tree.step_count() - 1;
     let result = labeled_operand(&labeled, final_idx, "final result")?;
 
     // Final reduction if result has labels not in output
@@ -599,10 +599,10 @@ pub(crate) fn build_einsum_fragment(
     if perm.iter().enumerate().all(|(i, &p)| i == p) {
         return Ok(result.val);
     }
-    let outputs = builder.add_op(
+    let outputs = builder.add_operation(
         StdTensorOp::Transpose { perm },
         vec![result.val.clone()],
-        OpMode::Primal,
+        OperationRole::Primary,
     );
-    Ok(ValRef::Local(outputs[0]))
+    Ok(ValueRef::Local(outputs[0]))
 }

--- a/tenferro-einsum/src/eager.rs
+++ b/tenferro-einsum/src/eager.rs
@@ -617,7 +617,7 @@ fn eager_einsum_exec_values<'a>(
 ) -> Result<Tensor> {
     record_eager_einsum_profile("exec_values.enter", Duration::ZERO);
     let subscripts = &tree.subscripts;
-    let n_inputs = subscripts.inputs.len();
+    let input_count = subscripts.inputs.len();
     let output_labels = &subscripts.output;
 
     let mut labeled: Vec<Option<LabeledTensor<'a>>> =
@@ -642,7 +642,7 @@ fn eager_einsum_exec_values<'a>(
         Ok(())
     })?;
 
-    if n_inputs == 1 || tree.step_count() == 0 {
+    if input_count == 1 || tree.step_count() == 0 {
         let operand = take_labeled(&mut labeled, 0, "input")?;
         let output_set: HashSet<u32> = output_labels.iter().copied().collect();
         let reduce_labels: HashSet<u32> = operand
@@ -680,7 +680,7 @@ fn eager_einsum_exec_values<'a>(
         labeled.push(Some(result));
     }
 
-    let final_index = n_inputs + tree.step_count() - 1;
+    let final_index = input_count + tree.step_count() - 1;
     let result = take_labeled(&mut labeled, final_index, "result")?;
     let extra_labels: HashSet<u32> =
         profile_eager_einsum_section("exec.final_label_analysis", || {
@@ -857,7 +857,7 @@ pub(crate) fn eager_einsum_subscripts(
         let total_us = total_started.elapsed().as_secs_f64() * 1.0e6;
 
         eprintln!(
-            "tenferro_eager_einsum_profile,n_inputs={},shapes={:?},steps={},shape_us={shape_us:.3},plan_us={plan_us:.3},exec_us={exec_us:.3},total_us={total_us:.3}",
+            "tenferro_eager_einsum_profile,input_count={},shapes={:?},steps={},shape_us={shape_us:.3},plan_us={plan_us:.3},exec_us={exec_us:.3},total_us={total_us:.3}",
             inputs.len(),
             shapes,
             tree.step_count(),

--- a/tenferro-einsum/src/extension.rs
+++ b/tenferro-einsum/src/extension.rs
@@ -6,19 +6,19 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use computegraph::compile::compile;
-use computegraph::fragment::FragmentBuilder;
+use computegraph::graph::GraphBuilder;
 use computegraph::materialize::materialize_merge;
 use computegraph::resolve::resolve;
-use computegraph::types::{GlobalValKey, ValRef};
 #[cfg(feature = "autodiff")]
-use computegraph::types::{LocalValId, OpMode};
-#[cfg(feature = "autodiff")]
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole};
+use computegraph::types::{ValueKey, ValueRef};
 use tenferro_extension_macros::define_extension_runtime;
 #[cfg(feature = "autodiff")]
 use tenferro_extension_macros::define_idempotent_rule_registration;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ad::context::ShapeGuardContext;
+#[cfg(feature = "autodiff")]
+use tenferro_ops::ad::PrimitiveRuleBuilder;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::dim_expr::DimExpr;
 #[cfg(feature = "autodiff")]
@@ -32,7 +32,7 @@ use tenferro_tensor::{DType, Tensor, TensorBackend};
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
-use crate::builder::build_einsum_fragment;
+use crate::builder::build_einsum_graph;
 use crate::cache::{
     einsum_subscripts_retained_bytes, EINSUM_EXTENSION_FAMILY_ID, EINSUM_RUNTIME_PLANS_CACHE,
 };
@@ -188,11 +188,11 @@ impl ExtensionOp for EinsumExtensionOp {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         self.subscripts.inputs.len()
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -283,12 +283,12 @@ impl ExtensionAdRule for EinsumAdRule {
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut dyn OpEmitter<StdTensorOp>,
-        primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut dyn PrimitiveRuleBuilder,
+        primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_ad_op(op, ADRuleKind::Jvp)?;
         let mut terms = Vec::new();
 
@@ -300,16 +300,16 @@ impl ExtensionAdRule for EinsumAdRule {
             let mut inputs = Vec::with_capacity(primal_in.len());
             for (input_idx, key) in primal_in.iter().enumerate() {
                 if input_idx == active_idx {
-                    inputs.push(ValRef::Local(*dt));
+                    inputs.push(ValueRef::Local(*dt));
                 } else {
-                    inputs.push(ValRef::External(key.clone()));
+                    inputs.push(ValueRef::External(key.clone()));
                 }
             }
 
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Extension(Arc::new(op.clone())),
                 inputs,
-                OpMode::Linear {
+                OperationRole::Linearized {
                     active_mask: (0..primal_in.len()).map(|idx| idx == active_idx).collect(),
                 },
             );
@@ -322,23 +322,23 @@ impl ExtensionAdRule for EinsumAdRule {
     fn transpose_rule(
         &self,
         op: &dyn ExtensionOp,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<StdTensorOp>],
-        mode: &OpMode,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
+        mode: &OperationRole,
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_ad_op(op, ADRuleKind::Transpose)?;
         let input_labels = &op.subscripts.inputs;
         let output_labels = &op.subscripts.output;
-        let n_inputs = input_labels.len();
+        let input_count = input_labels.len();
 
         let Some(ct) = cotangent_out.first().copied().flatten() else {
-            return Ok(vec![None; n_inputs]);
+            return Ok(vec![None; input_count]);
         };
         let active_mask = match mode {
-            OpMode::Linear { active_mask } => active_mask,
-            OpMode::Primal => return Ok(vec![None; n_inputs]),
+            OperationRole::Linearized { active_mask } => active_mask,
+            OperationRole::Primary => return Ok(vec![None; input_count]),
         };
         let primal_input_shapes: Vec<Vec<SymDim>> = inputs
             .iter()
@@ -351,8 +351,8 @@ impl ExtensionAdRule for EinsumAdRule {
             )
         })?;
 
-        let mut result = Vec::with_capacity(n_inputs);
-        for active_idx in 0..n_inputs {
+        let mut result = Vec::with_capacity(input_count);
+        for active_idx in 0..input_count {
             if !active_mask.get(active_idx).copied().unwrap_or(false) {
                 result.push(None);
                 continue;
@@ -369,21 +369,21 @@ impl ExtensionAdRule for EinsumAdRule {
                 .copied()
                 .filter(|label| available_labels.contains(label))
                 .collect();
-            let mut vjp_input_labels = Vec::with_capacity(n_inputs);
-            let mut vjp_inputs = Vec::with_capacity(n_inputs);
-            let mut vjp_input_shapes = Vec::with_capacity(n_inputs);
+            let mut vjp_input_labels = Vec::with_capacity(input_count);
+            let mut vjp_inputs = Vec::with_capacity(input_count);
+            let mut vjp_input_shapes = Vec::with_capacity(input_count);
             vjp_input_labels.push(output_labels.clone());
-            vjp_inputs.push(ValRef::Local(ct));
+            vjp_inputs.push(ValueRef::Local(ct));
             vjp_input_shapes.push(cotangent_shape.clone());
 
-            for input_idx in 0..n_inputs {
+            for input_idx in 0..input_count {
                 if input_idx == active_idx {
                     continue;
                 }
                 vjp_input_labels.push(input_labels[input_idx].clone());
                 vjp_input_shapes.push(primal_input_shapes[input_idx].clone());
                 vjp_inputs.push(conjugate_primal_if_complex(
-                    emitter,
+                    builder,
                     inputs[input_idx].clone(),
                     ctx,
                 ));
@@ -400,19 +400,19 @@ impl ExtensionAdRule for EinsumAdRule {
                 output_shape_hint.clone(),
                 &vjp_input_shapes,
             )?;
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Extension(Arc::new(vjp_op)),
                 vjp_inputs,
-                OpMode::Linear {
+                OperationRole::Linearized {
                     active_mask: std::iter::once(true)
-                        .chain(std::iter::repeat_n(false, n_inputs.saturating_sub(1)))
+                        .chain(std::iter::repeat_n(false, input_count.saturating_sub(1)))
                         .collect(),
                 },
             );
             let mut cotangent = out[0];
             if vjp_output_labels != input_labels[active_idx] {
                 cotangent = broadcast_einsum_vjp_to_input_shape(
-                    emitter,
+                    builder,
                     cotangent,
                     &vjp_output_labels,
                     &input_labels[active_idx],
@@ -436,7 +436,7 @@ fn vjp_einsum_op_with_inherited_plan(
     input_shapes: &[Vec<SymDim>],
 ) -> ADRuleResult<EinsumExtensionOp> {
     let plan_spec =
-        vjp_plan_spec_for_active(primal_op.plan_spec(), primal_op.n_inputs(), active_idx)?;
+        vjp_plan_spec_for_active(primal_op.plan_spec(), primal_op.input_count(), active_idx)?;
     let mut op = EinsumExtensionOp::with_output_shape_hint(
         subscripts.clone(),
         output_shape_hint,
@@ -462,12 +462,12 @@ fn vjp_einsum_op_with_inherited_plan(
 #[cfg(feature = "autodiff")]
 fn vjp_plan_spec_for_active(
     primal_plan: &EinsumPlanSpec,
-    n_inputs: usize,
+    input_count: usize,
     active_idx: usize,
 ) -> ADRuleResult<EinsumPlanSpec> {
-    if active_idx >= n_inputs {
+    if active_idx >= input_count {
         return Err(ADRuleError::unsupported(
-            format!("einsum VJP active input {active_idx} is outside {n_inputs} inputs"),
+            format!("einsum VJP active input {active_idx} is outside {input_count} inputs"),
             ADRuleKind::Transpose,
         ));
     }
@@ -476,7 +476,7 @@ fn vjp_plan_spec_for_active(
         EinsumPlanSpec::Auto(options) => Ok(EinsumPlanSpec::Auto(options.clone())),
         EinsumPlanSpec::LeftToRight => Ok(EinsumPlanSpec::LeftToRight),
         EinsumPlanSpec::Path(path) => {
-            let pairs = jax_path_to_v1_pairs(path, n_inputs).map_err(|err| {
+            let pairs = jax_path_to_v1_pairs(path, input_count).map_err(|err| {
                 ADRuleError::unsupported(
                     format!(
                         "failed to inherit einsum Path plan for VJP active input {active_idx}: {err}"
@@ -484,10 +484,10 @@ fn vjp_plan_spec_for_active(
                     ADRuleKind::Transpose,
                 )
             })?;
-            derive_vjp_fixed_pairs(&pairs, n_inputs, active_idx).map(EinsumPlanSpec::FixedPairs)
+            derive_vjp_fixed_pairs(&pairs, input_count, active_idx).map(EinsumPlanSpec::FixedPairs)
         }
         EinsumPlanSpec::FixedPairs(pairs) => {
-            derive_vjp_fixed_pairs(pairs, n_inputs, active_idx).map(EinsumPlanSpec::FixedPairs)
+            derive_vjp_fixed_pairs(pairs, input_count, active_idx).map(EinsumPlanSpec::FixedPairs)
         }
     }
 }
@@ -495,38 +495,38 @@ fn vjp_plan_spec_for_active(
 #[cfg(feature = "autodiff")]
 fn derive_vjp_fixed_pairs(
     primal_pairs: &[(usize, usize)],
-    n_inputs: usize,
+    input_count: usize,
     active_idx: usize,
 ) -> ADRuleResult<Vec<(usize, usize)>> {
-    if n_inputs == 0 {
+    if input_count == 0 {
         return Err(ADRuleError::unsupported(
             "einsum VJP cannot derive a plan for zero primal inputs",
             ADRuleKind::Transpose,
         ));
     }
-    if active_idx >= n_inputs {
+    if active_idx >= input_count {
         return Err(ADRuleError::unsupported(
-            format!("einsum VJP active input {active_idx} is outside {n_inputs} inputs"),
+            format!("einsum VJP active input {active_idx} is outside {input_count} inputs"),
             ADRuleKind::Transpose,
         ));
     }
-    let required_steps = n_inputs.saturating_sub(1);
+    let required_steps = input_count.saturating_sub(1);
     if primal_pairs.len() != required_steps {
         return Err(ADRuleError::unsupported(
             format!(
                 "einsum VJP cannot inherit explicit plan for active input {active_idx}: \
-                 expected {required_steps} primal steps for {n_inputs} inputs, got {}",
+                 expected {required_steps} primal steps for {input_count} inputs, got {}",
                 primal_pairs.len()
             ),
             ADRuleKind::Transpose,
         ));
     }
-    if n_inputs == 1 {
+    if input_count == 1 {
         return Ok(Vec::new());
     }
 
-    let children = fixed_pair_children(primal_pairs, n_inputs, active_idx)?;
-    let mut primal_to_vjp = vec![None; n_inputs];
+    let children = fixed_pair_children(primal_pairs, input_count, active_idx)?;
+    let mut primal_to_vjp = vec![None; input_count];
     let mut next_vjp_input = 1;
     for (input_idx, slot) in primal_to_vjp.iter_mut().enumerate() {
         if input_idx != active_idx {
@@ -535,18 +535,18 @@ fn derive_vjp_fixed_pairs(
         }
     }
 
-    let root = n_inputs + primal_pairs.len() - 1;
+    let root = input_count + primal_pairs.len() - 1;
     let mut pairs = Vec::with_capacity(required_steps);
     let final_id = emit_vjp_adjoint(
         root,
         0,
         &children,
-        n_inputs,
+        input_count,
         active_idx,
         &primal_to_vjp,
         &mut pairs,
     )?;
-    let expected_final = n_inputs + pairs.len() - 1;
+    let expected_final = input_count + pairs.len() - 1;
     if final_id != expected_final || pairs.len() != required_steps {
         return Err(ADRuleError::unsupported(
             format!(
@@ -563,17 +563,17 @@ fn derive_vjp_fixed_pairs(
 #[cfg(feature = "autodiff")]
 fn fixed_pair_children(
     pairs: &[(usize, usize)],
-    n_inputs: usize,
+    input_count: usize,
     active_idx: usize,
 ) -> ADRuleResult<Vec<Option<(usize, usize)>>> {
-    let mut live = vec![false; n_inputs + pairs.len()];
-    for slot in live.iter_mut().take(n_inputs) {
+    let mut live = vec![false; input_count + pairs.len()];
+    for slot in live.iter_mut().take(input_count) {
         *slot = true;
     }
-    let mut children = vec![None; n_inputs + pairs.len()];
+    let mut children = vec![None; input_count + pairs.len()];
 
     for (step_idx, &(left, right)) in pairs.iter().enumerate() {
-        let next_idx = n_inputs + step_idx;
+        let next_idx = input_count + step_idx;
         if left == right {
             return Err(invalid_vjp_plan_error(
                 active_idx,
@@ -615,12 +615,12 @@ fn emit_vjp_adjoint(
     node: usize,
     cotangent_id: usize,
     children: &[Option<(usize, usize)>],
-    n_inputs: usize,
+    input_count: usize,
     active_idx: usize,
     primal_to_vjp: &[Option<usize>],
     pairs: &mut Vec<(usize, usize)>,
 ) -> ADRuleResult<usize> {
-    if node < n_inputs {
+    if node < input_count {
         return if node == active_idx {
             Ok(cotangent_id)
         } else {
@@ -634,32 +634,44 @@ fn emit_vjp_adjoint(
     let (left, right) = children.get(node).and_then(|child| *child).ok_or_else(|| {
         invalid_vjp_plan_error(active_idx, format!("missing children for node {node}"))
     })?;
-    let left_has_active = subtree_contains_active(left, children, n_inputs, active_idx)?;
-    let right_has_active = subtree_contains_active(right, children, n_inputs, active_idx)?;
+    let left_has_active = subtree_contains_active(left, children, input_count, active_idx)?;
+    let right_has_active = subtree_contains_active(right, children, input_count, active_idx)?;
     match (left_has_active, right_has_active) {
         (true, false) => {
-            let sibling_id =
-                emit_vjp_subtree(right, children, n_inputs, active_idx, primal_to_vjp, pairs)?;
-            let next = push_vjp_pair(cotangent_id, sibling_id, n_inputs, pairs);
+            let sibling_id = emit_vjp_subtree(
+                right,
+                children,
+                input_count,
+                active_idx,
+                primal_to_vjp,
+                pairs,
+            )?;
+            let next = push_vjp_pair(cotangent_id, sibling_id, input_count, pairs);
             emit_vjp_adjoint(
                 left,
                 next,
                 children,
-                n_inputs,
+                input_count,
                 active_idx,
                 primal_to_vjp,
                 pairs,
             )
         }
         (false, true) => {
-            let sibling_id =
-                emit_vjp_subtree(left, children, n_inputs, active_idx, primal_to_vjp, pairs)?;
-            let next = push_vjp_pair(cotangent_id, sibling_id, n_inputs, pairs);
+            let sibling_id = emit_vjp_subtree(
+                left,
+                children,
+                input_count,
+                active_idx,
+                primal_to_vjp,
+                pairs,
+            )?;
+            let next = push_vjp_pair(cotangent_id, sibling_id, input_count, pairs);
             emit_vjp_adjoint(
                 right,
                 next,
                 children,
-                n_inputs,
+                input_count,
                 active_idx,
                 primal_to_vjp,
                 pairs,
@@ -680,12 +692,12 @@ fn emit_vjp_adjoint(
 fn emit_vjp_subtree(
     node: usize,
     children: &[Option<(usize, usize)>],
-    n_inputs: usize,
+    input_count: usize,
     active_idx: usize,
     primal_to_vjp: &[Option<usize>],
     pairs: &mut Vec<(usize, usize)>,
 ) -> ADRuleResult<usize> {
-    if node < n_inputs {
+    if node < input_count {
         return primal_to_vjp[node].ok_or_else(|| {
             invalid_vjp_plan_error(
                 active_idx,
@@ -697,9 +709,23 @@ fn emit_vjp_subtree(
     let (left, right) = children.get(node).and_then(|child| *child).ok_or_else(|| {
         invalid_vjp_plan_error(active_idx, format!("missing children for node {node}"))
     })?;
-    let left_id = emit_vjp_subtree(left, children, n_inputs, active_idx, primal_to_vjp, pairs)?;
-    let right_id = emit_vjp_subtree(right, children, n_inputs, active_idx, primal_to_vjp, pairs)?;
-    Ok(push_vjp_pair(left_id, right_id, n_inputs, pairs))
+    let left_id = emit_vjp_subtree(
+        left,
+        children,
+        input_count,
+        active_idx,
+        primal_to_vjp,
+        pairs,
+    )?;
+    let right_id = emit_vjp_subtree(
+        right,
+        children,
+        input_count,
+        active_idx,
+        primal_to_vjp,
+        pairs,
+    )?;
+    Ok(push_vjp_pair(left_id, right_id, input_count, pairs))
 }
 
 #[cfg(feature = "autodiff")]
@@ -717,18 +743,18 @@ fn push_vjp_pair(
 fn subtree_contains_active(
     node: usize,
     children: &[Option<(usize, usize)>],
-    n_inputs: usize,
+    input_count: usize,
     active_idx: usize,
 ) -> ADRuleResult<bool> {
-    if node < n_inputs {
+    if node < input_count {
         return Ok(node == active_idx);
     }
     let (left, right) = children.get(node).and_then(|child| *child).ok_or_else(|| {
         invalid_vjp_plan_error(active_idx, format!("missing children for node {node}"))
     })?;
     Ok(
-        subtree_contains_active(left, children, n_inputs, active_idx)?
-            || subtree_contains_active(right, children, n_inputs, active_idx)?,
+        subtree_contains_active(left, children, input_count, active_idx)?
+            || subtree_contains_active(right, children, input_count, active_idx)?,
     )
 }
 
@@ -750,31 +776,31 @@ fn concrete_sym_shapes(shapes: &[Vec<SymDim>]) -> Option<Vec<Vec<usize>>> {
 
 #[cfg(feature = "autodiff")]
 fn broadcast_einsum_vjp_to_input_shape(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent: LocalValueId,
     cotangent_labels: &[u32],
     input_labels: &[u32],
-    shape_source: ValRef<StdTensorOp>,
+    shape_source: ValueRef<StdTensorOp>,
     input_shape: &[SymDim],
-) -> LocalValId {
+) -> LocalValueId {
     let shape: Vec<DimExpr> = input_shape
         .iter()
         .enumerate()
         .map(|(axis, _)| DimExpr::InputDim { input_idx: 1, axis })
         .collect();
     let dims = map_label_occurrences(cotangent_labels, input_labels);
-    let mut inputs = vec![ValRef::Local(cotangent)];
+    let mut inputs = vec![ValueRef::Local(cotangent)];
     if !shape.is_empty() {
         inputs.push(shape_source);
     }
-    let broadcast = emitter.add_op(
+    let broadcast = builder.add_operation(
         StdTensorOp::BroadcastInDim { shape, dims },
         inputs,
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![true, false],
         },
     )[0];
-    project_repeated_labels_to_diagonal(emitter, broadcast, input_labels)
+    project_repeated_labels_to_diagonal(builder, broadcast, input_labels)
 }
 
 #[cfg(feature = "autodiff")]
@@ -796,10 +822,10 @@ fn map_label_occurrences(source_labels: &[u32], target_labels: &[u32]) -> Vec<us
 
 #[cfg(feature = "autodiff")]
 fn project_repeated_labels_to_diagonal(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent: LocalValueId,
     labels: &[u32],
-) -> LocalValId {
+) -> LocalValueId {
     let mut result = cotangent;
     let mut seen = HashSet::new();
     for (axis_a, label) in labels.iter().copied().enumerate() {
@@ -814,17 +840,17 @@ fn project_repeated_labels_to_diagonal(
         else {
             continue;
         };
-        let extracted = emitter.add_op(
+        let extracted = builder.add_operation(
             StdTensorOp::ExtractDiag { axis_a, axis_b },
-            vec![ValRef::Local(result)],
-            OpMode::Linear {
+            vec![ValueRef::Local(result)],
+            OperationRole::Linearized {
                 active_mask: vec![true],
             },
         )[0];
-        result = emitter.add_op(
+        result = builder.add_operation(
             StdTensorOp::EmbedDiag { axis_a, axis_b },
-            vec![ValRef::Local(extracted)],
-            OpMode::Linear {
+            vec![ValueRef::Local(extracted)],
+            OperationRole::Linearized {
                 active_mask: vec![true],
             },
         )[0];
@@ -866,20 +892,20 @@ fn execute_einsum_extension<B: TensorBackend + 'static>(
         })?
     };
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut input_vals = Vec::with_capacity(inputs.len());
     for input_idx in 0..inputs.len() {
         let local = builder.add_input(TensorInputKey::User {
             id: input_idx as u64,
         });
-        input_vals.push(ValRef::Local(local));
+        input_vals.push(ValueRef::Local(local));
     }
 
-    let result_ref = build_einsum_fragment(&mut builder, tree.as_ref(), &input_vals, &shapes)
+    let result_ref = build_einsum_graph(&mut builder, tree.as_ref(), &input_vals, &shapes)
         .map_err(einsum_runtime_error)?;
     let result_local = match result_ref {
-        ValRef::Local(local) => local,
-        ValRef::External(_) => {
+        ValueRef::Local(local) => local,
+        ValueRef::External(_) => {
             return Err(tenferro_tensor::Error::backend_failure(
                 "einsum_extension",
                 "einsum builder returned an external value at runtime",
@@ -887,10 +913,10 @@ fn execute_einsum_extension<B: TensorBackend + 'static>(
         }
     };
     builder.set_outputs(vec![result_local]);
-    let fragment = Arc::new(builder.build());
-    let output_key = fragment.vals()[result_local].key.clone();
+    let graph = Arc::new(builder.build());
+    let output_key = graph.values()[result_local].key.clone();
 
-    let view = resolve(vec![fragment]);
+    let view = resolve(vec![graph]);
     let graph = materialize_merge(&view, &[output_key]);
     let compiled = compile(&graph);
 
@@ -899,7 +925,7 @@ fn execute_einsum_extension<B: TensorBackend + 'static>(
     let mut input_shapes = Vec::with_capacity(graph.inputs.len());
     for key in &graph.inputs {
         match key {
-            GlobalValKey::Input(TensorInputKey::User { id }) => {
+            ValueKey::Input(TensorInputKey::User { id }) => {
                 let input_idx = *id as usize;
                 let tensor = inputs.get(input_idx).ok_or_else(|| {
                     tenferro_tensor::Error::backend_failure(
@@ -989,19 +1015,19 @@ fn downcast_ad_op(op: &dyn ExtensionOp, kind: ADRuleKind) -> ADRuleResult<&Einsu
 
 #[cfg(feature = "autodiff")]
 fn sum_terms(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    terms: Vec<LocalValId>,
-) -> Option<LocalValId> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    terms: Vec<LocalValueId>,
+) -> Option<LocalValueId> {
     match terms.as_slice() {
         [] => None,
         [only] => Some(*only),
         [head, tail @ ..] => {
             let mut result = *head;
             for &term in tail {
-                let sum = builder.add_op(
+                let sum = builder.add_operation(
                     StdTensorOp::Add,
-                    vec![ValRef::Local(result), ValRef::Local(term)],
-                    OpMode::Linear {
+                    vec![ValueRef::Local(result), ValueRef::Local(term)],
+                    OperationRole::Linearized {
                         active_mask: vec![true, true],
                     },
                 );
@@ -1014,15 +1040,15 @@ fn sum_terms(
 
 #[cfg(feature = "autodiff")]
 fn conjugate_primal_if_complex(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
     ctx: &mut ShapeGuardContext,
-) -> ValRef<StdTensorOp> {
+) -> ValueRef<StdTensorOp> {
     match ctx.dtype_of(&input) {
         DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => input,
-        DType::C32 | DType::C64 => {
-            ValRef::Local(emitter.add_op(StdTensorOp::Conj, vec![input], OpMode::Primal)[0])
-        }
+        DType::C32 | DType::C64 => ValueRef::Local(
+            builder.add_operation(StdTensorOp::Conj, vec![input], OperationRole::Primary)[0],
+        ),
     }
 }
 

--- a/tenferro-einsum/src/optimize.rs
+++ b/tenferro-einsum/src/optimize.rs
@@ -196,22 +196,22 @@ fn tree_pairs(tree: &ContractionTree) -> Vec<(usize, usize)> {
         .collect()
 }
 
-fn validate_fixed_pairs(pairs: &[(usize, usize)], n_inputs: usize) -> Result<()> {
-    let required_steps = n_inputs.saturating_sub(1);
+fn validate_fixed_pairs(pairs: &[(usize, usize)], input_count: usize) -> Result<()> {
+    let required_steps = input_count.saturating_sub(1);
     if pairs.len() != required_steps {
         return Err(Error::InvalidArgument(format!(
-            "explicit contraction path for {n_inputs} operands must have {required_steps} steps, got {}",
+            "explicit contraction path for {input_count} operands must have {required_steps} steps, got {}",
             pairs.len()
         )));
     }
 
-    let mut live = vec![false; n_inputs + pairs.len()];
-    for slot in live.iter_mut().take(n_inputs) {
+    let mut live = vec![false; input_count + pairs.len()];
+    for slot in live.iter_mut().take(input_count) {
         *slot = true;
     }
 
     for (step_idx, &(left, right)) in pairs.iter().enumerate() {
-        let next_idx = n_inputs + step_idx;
+        let next_idx = input_count + step_idx;
         if left == right {
             return Err(Error::InvalidArgument(format!(
                 "pair ({left}, {right}) must reference two distinct live operands"
@@ -278,8 +278,8 @@ fn optimizer_options_equal_by_bits(
 ///
 /// JAX format: each pair `(i, j)` refers to positions in a shrinking list.
 /// After contraction, the two operands are removed and the result is appended.
-/// Fixed-ID format keeps original operands at `0..n_inputs` and gives
-/// intermediate at step `k` the ID `n_inputs + k`.
+/// Fixed-ID format keeps original operands at `0..input_count` and gives
+/// intermediate at step `k` the ID `input_count + k`.
 ///
 /// # Errors
 ///
@@ -287,17 +287,17 @@ fn optimizer_options_equal_by_bits(
 /// position outside the current shrinking list.
 pub(crate) fn jax_path_to_v1_pairs(
     jax_path: &[(usize, usize)],
-    n_inputs: usize,
+    input_count: usize,
 ) -> Result<Vec<(usize, usize)>> {
-    let required_steps = n_inputs.saturating_sub(1);
+    let required_steps = input_count.saturating_sub(1);
     if jax_path.len() != required_steps {
         return Err(Error::InvalidArgument(format!(
-            "explicit contraction path for {n_inputs} operands must have {required_steps} steps, got {}",
+            "explicit contraction path for {input_count} operands must have {required_steps} steps, got {}",
             jax_path.len()
         )));
     }
 
-    let mut positions: Vec<usize> = (0..n_inputs).collect();
+    let mut positions: Vec<usize> = (0..input_count).collect();
     let mut v1_pairs = Vec::with_capacity(jax_path.len());
 
     for (step, &(pos_a, pos_b)) in jax_path.iter().enumerate() {
@@ -324,7 +324,7 @@ pub(crate) fn jax_path_to_v1_pairs(
 
         positions.remove(hi);
         positions.remove(lo);
-        positions.push(n_inputs + step);
+        positions.push(input_count + step);
     }
 
     Ok(v1_pairs)
@@ -334,16 +334,16 @@ pub(crate) fn jax_path_to_v1_pairs(
 ///
 /// # Errors
 ///
-/// Returns an error if a leaf references an input outside `0..n_inputs` or if
+/// Returns an error if a leaf references an input outside `0..input_count` or if
 /// a node has no children.
 pub(crate) fn nested_to_v1_pairs(
     nested: &NestedEinsum,
-    n_inputs: usize,
+    input_count: usize,
 ) -> Result<Vec<(usize, usize)>> {
-    let mut pairs = Vec::with_capacity(n_inputs.saturating_sub(1));
-    let mut next_id = n_inputs;
-    let root_id = walk_nested(nested, n_inputs, &mut pairs, &mut next_id)?;
-    if n_inputs == 0 || root_id >= next_id {
+    let mut pairs = Vec::with_capacity(input_count.saturating_sub(1));
+    let mut next_id = input_count;
+    let root_id = walk_nested(nested, input_count, &mut pairs, &mut next_id)?;
+    if input_count == 0 || root_id >= next_id {
         return Err(Error::InvalidArgument(
             "nested einsum did not produce a valid root operand".into(),
         ));
@@ -353,15 +353,15 @@ pub(crate) fn nested_to_v1_pairs(
 
 fn walk_nested(
     nested: &NestedEinsum,
-    n_inputs: usize,
+    input_count: usize,
     pairs: &mut Vec<(usize, usize)>,
     next_id: &mut usize,
 ) -> Result<usize> {
     match nested {
         NestedEinsum::Leaf(idx) => {
-            if *idx >= n_inputs {
+            if *idx >= input_count {
                 return Err(Error::InvalidArgument(format!(
-                    "nested einsum leaf {idx} is outside 0..{n_inputs}"
+                    "nested einsum leaf {idx} is outside 0..{input_count}"
                 )));
             }
             Ok(*idx)
@@ -372,9 +372,9 @@ fn walk_nested(
                     "nested einsum node must have at least one child".into(),
                 ));
             };
-            let mut result_id = walk_nested(first, n_inputs, pairs, next_id)?;
+            let mut result_id = walk_nested(first, input_count, pairs, next_id)?;
             for child in &children[1..] {
-                let child_id = walk_nested(child, n_inputs, pairs, next_id)?;
+                let child_id = walk_nested(child, input_count, pairs, next_id)?;
                 pairs.push((result_id, child_id));
                 result_id = *next_id;
                 *next_id += 1;

--- a/tenferro-einsum/src/planning/plan.rs
+++ b/tenferro-einsum/src/planning/plan.rs
@@ -374,7 +374,7 @@ fn product_or_one_for_empty(sizes: &[usize]) -> usize {
 ///   2. Pre-reduction (if unique-only axes)
 ///   3. GEMM (always, after steps 1-2 make all labels unique)
 pub(crate) fn compile_step_plans(tree: &ContractionTree) -> EinsumResult<Vec<StepPlan>> {
-    let n_inputs = tree.subscripts.inputs.len();
+    let input_count = tree.subscripts.inputs.len();
     let size_dict = &tree.size_dict;
 
     tree.steps
@@ -387,7 +387,7 @@ pub(crate) fn compile_step_plans(tree: &ContractionTree) -> EinsumResult<Vec<Ste
             let subs_c = if is_last {
                 &tree.subscripts.output
             } else {
-                &tree.operand_subs[n_inputs + step_idx]
+                &tree.operand_subs[input_count + step_idx]
             };
             compile_pairwise_step_plan(subs_a, subs_b, subs_c, size_dict)
         })

--- a/tenferro-einsum/src/planning/tree.rs
+++ b/tenferro-einsum/src/planning/tree.rs
@@ -97,7 +97,7 @@ pub struct ContractionTree {
     pub(crate) steps: Vec<ContractionStep>,
     /// Label → dimension size mapping.
     pub(crate) size_dict: HashMap<u32, usize>,
-    /// Subscripts for each operand (0..n_inputs from input, then intermediates).
+    /// Subscripts for each operand (0..input_count from input, then intermediates).
     pub(crate) operand_subs: Vec<Vec<u32>>,
     /// Pre-compiled step plans (cached to avoid recomputation per execute call).
     pub(crate) step_plans: Vec<StepPlan>,
@@ -137,8 +137,8 @@ impl ContractionTree {
         options: &ContractionOptimizerOptions,
     ) -> Result<Self> {
         options.validate()?;
-        let n_inputs = subscripts.inputs.len();
-        if n_inputs <= 1 {
+        let input_count = subscripts.inputs.len();
+        if input_count <= 1 {
             return Self::from_pairs(subscripts, shapes, &[]);
         }
 
@@ -188,25 +188,25 @@ impl ContractionTree {
         shapes: &[&[usize]],
         pairs: &[(usize, usize)],
     ) -> Result<Self> {
-        let n_inputs = subscripts.inputs.len();
-        let required_steps = n_inputs.saturating_sub(1);
+        let input_count = subscripts.inputs.len();
+        let required_steps = input_count.saturating_sub(1);
         if pairs.len() != required_steps {
             return Err(Error::InvalidArgument(format!(
-                "explicit contraction path for {n_inputs} operands must have {required_steps} steps, got {}",
+                "explicit contraction path for {input_count} operands must have {required_steps} steps, got {}",
                 pairs.len()
             )));
         }
         let size_dict = build_size_dict(subscripts, shapes, None)?;
 
         let mut operand_subs: Vec<Vec<u32>> = subscripts.inputs.clone();
-        let mut live = vec![false; n_inputs + pairs.len()];
-        for slot in live.iter_mut().take(n_inputs) {
+        let mut live = vec![false; input_count + pairs.len()];
+        for slot in live.iter_mut().take(input_count) {
             *slot = true;
         }
         let mut steps = Vec::new();
 
         for (step_idx, &(left, right)) in pairs.iter().enumerate() {
-            let next_idx = n_inputs + step_idx;
+            let next_idx = input_count + step_idx;
             if left == right {
                 return Err(Error::InvalidArgument(format!(
                     "pair ({left}, {right}) must reference two distinct live operands"
@@ -280,8 +280,8 @@ impl ContractionTree {
 
     /// Return the operand indices for a pairwise contraction step.
     ///
-    /// The returned indices refer to the original inputs (`0..n_inputs`) and
-    /// then to intermediates (`n_inputs..`) produced by earlier steps.
+    /// The returned indices refer to the original inputs (`0..input_count`) and
+    /// then to intermediates (`input_count..`) produced by earlier steps.
     ///
     /// # Examples
     ///
@@ -326,9 +326,9 @@ impl ContractionTree {
     /// ```
     #[must_use]
     pub fn step_subscripts(&self, step_idx: usize) -> Option<(&[u32], &[u32], &[u32])> {
-        let n_inputs = self.subscripts.inputs.len();
+        let input_count = self.subscripts.inputs.len();
         let step = self.steps.get(step_idx)?;
-        let result_idx = n_inputs + step_idx;
+        let result_idx = input_count + step_idx;
         let output_subs = if step_idx + 1 == self.steps.len() {
             &self.subscripts.output
         } else {
@@ -480,8 +480,8 @@ fn optimize_self_greedy_pairs(
     subscripts: &Subscripts,
     size_dict: &HashMap<u32, usize>,
 ) -> Result<Vec<(usize, usize)>> {
-    let n_inputs = subscripts.inputs.len();
-    let mut available: Vec<usize> = (0..n_inputs).collect();
+    let input_count = subscripts.inputs.len();
+    let mut available: Vec<usize> = (0..input_count).collect();
     let mut operand_subs: Vec<Vec<u32>> = subscripts.inputs.clone();
     let mut pairs: Vec<(usize, usize)> = Vec::new();
 

--- a/tenferro-einsum/src/subscripts.rs
+++ b/tenferro-einsum/src/subscripts.rs
@@ -42,10 +42,10 @@ impl EinsumSubscripts {
     ///
     /// let subscripts = EinsumSubscripts::new(&[&[0], &[0]], &[]);
     ///
-    /// assert_eq!(subscripts.n_inputs(), 2);
+    /// assert_eq!(subscripts.input_count(), 2);
     /// ```
     #[must_use]
-    pub fn n_inputs(&self) -> usize {
+    pub fn input_count(&self) -> usize {
         self.inputs.len()
     }
 }

--- a/tenferro-einsum/src/subscripts/tests.rs
+++ b/tenferro-einsum/src/subscripts/tests.rs
@@ -24,7 +24,7 @@ fn integer_subscripts_convert_to_and_from_raw_subscripts() {
     let owned = EinsumSubscripts::from(raw.clone());
 
     assert_eq!(borrowed, owned);
-    assert_eq!(borrowed.n_inputs(), 2);
+    assert_eq!(borrowed.input_count(), 2);
     assert_eq!(Subscripts::from(borrowed.clone()), raw);
     assert_eq!(Subscripts::from(&borrowed), raw);
 }

--- a/tenferro-einsum/src/tests/builder_tests.rs
+++ b/tenferro-einsum/src/tests/builder_tests.rs
@@ -1,10 +1,10 @@
-use computegraph::fragment::FragmentBuilder;
-use computegraph::types::ValRef;
+use computegraph::graph::GraphBuilder;
+use computegraph::types::ValueRef;
 
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 
-use crate::builder::build_einsum_fragment;
+use crate::builder::build_einsum_graph;
 use crate::planning::tree::ContractionTree;
 use crate::syntax::subscripts::Subscripts;
 use crate::{Error, Result};
@@ -18,10 +18,10 @@ fn make_tree(notation: &str, shapes: &[&[usize]]) -> ContractionTree {
     ContractionTree::optimize(&subscripts, shapes).expect("optimize failed")
 }
 
-fn unwrap_local(result: Result<ValRef<StdTensorOp>>) -> usize {
+fn unwrap_local(result: Result<ValueRef<StdTensorOp>>) -> usize {
     match result.expect("builder should succeed") {
-        ValRef::Local(id) => id,
-        ValRef::External(_) => panic!("expected local"),
+        ValueRef::Local(id) => id,
+        ValueRef::External(_) => panic!("expected local"),
     }
 }
 
@@ -29,11 +29,11 @@ fn unwrap_local(result: Result<ValRef<StdTensorOp>>) -> usize {
 fn builder_reports_missing_output_label_instead_of_panicking() {
     let mut tree = make_tree("i->i", &[&[3]]);
     tree.subscripts.output = vec![b'j' as u32];
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key(0));
 
     let err =
-        build_einsum_fragment(&mut builder, &tree, &[ValRef::Local(a)], &[vec![3]]).unwrap_err();
+        build_einsum_graph(&mut builder, &tree, &[ValueRef::Local(a)], &[vec![3]]).unwrap_err();
 
     assert!(matches!(
         err,
@@ -43,124 +43,129 @@ fn builder_reports_missing_output_label_instead_of_panicking() {
 }
 
 #[test]
-fn fragment_matmul_ij_jk_ik() {
+fn graph_matmul_ij_jk_ik() {
     let tree = make_tree("ij,jk->ik", &[&[2, 3], &[3, 4]]);
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key(0));
     let b = builder.add_input(input_key(1));
 
-    let result = build_einsum_fragment(
+    let result = build_einsum_graph(
         &mut builder,
         &tree,
-        &[ValRef::Local(a), ValRef::Local(b)],
+        &[ValueRef::Local(a), ValueRef::Local(b)],
         &[vec![2, 3], vec![3, 4]],
     );
 
     builder.set_outputs(vec![unwrap_local(result)]);
-    let fragment = builder.build();
-    assert!(!fragment.ops().is_empty());
+    let graph = builder.build();
+    assert!(!graph.operations().is_empty());
 }
 
 #[test]
-fn fragment_row_sum_ij_i() {
+fn graph_row_sum_ij_i() {
     let tree = make_tree("ij->i", &[&[3, 4]]);
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key(0));
 
-    let result = build_einsum_fragment(&mut builder, &tree, &[ValRef::Local(a)], &[vec![3, 4]]);
+    let result = build_einsum_graph(&mut builder, &tree, &[ValueRef::Local(a)], &[vec![3, 4]]);
 
     builder.set_outputs(vec![unwrap_local(result)]);
-    let fragment = builder.build();
+    let graph = builder.build();
     // Should have a reduce_sum op
-    assert!(!fragment.ops().is_empty());
+    assert!(!graph.operations().is_empty());
 }
 
 #[test]
-fn fragment_outer_product_i_j_ij() {
+fn graph_outer_product_i_j_ij() {
     let tree = make_tree("i,j->ij", &[&[3], &[4]]);
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key(0));
     let b = builder.add_input(input_key(1));
 
-    let result = build_einsum_fragment(
+    let result = build_einsum_graph(
         &mut builder,
         &tree,
-        &[ValRef::Local(a), ValRef::Local(b)],
+        &[ValueRef::Local(a), ValueRef::Local(b)],
         &[vec![3], vec![4]],
     );
 
     builder.set_outputs(vec![unwrap_local(result)]);
-    let fragment = builder.build();
-    assert!(!fragment.ops().is_empty());
+    let graph = builder.build();
+    assert!(!graph.operations().is_empty());
 }
 
 #[test]
-fn fragment_inner_product_i_i() {
+fn graph_inner_product_i_i() {
     let tree = make_tree("i,i->", &[&[3], &[3]]);
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key(0));
     let b = builder.add_input(input_key(1));
 
-    let result = build_einsum_fragment(
+    let result = build_einsum_graph(
         &mut builder,
         &tree,
-        &[ValRef::Local(a), ValRef::Local(b)],
+        &[ValueRef::Local(a), ValueRef::Local(b)],
         &[vec![3], vec![3]],
     );
 
     builder.set_outputs(vec![unwrap_local(result)]);
-    let fragment = builder.build();
-    assert!(!fragment.ops().is_empty());
+    let graph = builder.build();
+    assert!(!graph.operations().is_empty());
 }
 
 #[test]
-fn fragment_hadamard_ij_ij_ij() {
+fn graph_hadamard_ij_ij_ij() {
     let tree = make_tree("ij,ij->ij", &[&[3, 4], &[3, 4]]);
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key(0));
     let b = builder.add_input(input_key(1));
 
-    let result = build_einsum_fragment(
+    let result = build_einsum_graph(
         &mut builder,
         &tree,
-        &[ValRef::Local(a), ValRef::Local(b)],
+        &[ValueRef::Local(a), ValueRef::Local(b)],
         &[vec![3, 4], vec![3, 4]],
     );
 
     builder.set_outputs(vec![unwrap_local(result)]);
-    let fragment = builder.build();
-    assert!(!fragment.ops().is_empty());
+    let graph = builder.build();
+    assert!(!graph.operations().is_empty());
 }
 
 #[test]
-fn fragment_batched_chain_avoids_intermediate_transpose() {
+fn graph_batched_chain_avoids_intermediate_transpose() {
     let subs = Subscripts::parse("bik,bkj,bjl->bil").expect("bad notation");
     let shapes = [&[2, 3, 4][..], &[2, 4, 5][..], &[2, 5, 6][..]];
     let tree = ContractionTree::from_pairs(&subs, &shapes, &[(0, 1), (3, 2)]).unwrap();
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key(0));
     let b = builder.add_input(input_key(1));
     let c = builder.add_input(input_key(2));
 
-    let result = build_einsum_fragment(
+    let result = build_einsum_graph(
         &mut builder,
         &tree,
-        &[ValRef::Local(a), ValRef::Local(b), ValRef::Local(c)],
+        &[ValueRef::Local(a), ValueRef::Local(b), ValueRef::Local(c)],
         &[vec![2, 3, 4], vec![2, 4, 5], vec![2, 5, 6]],
     );
 
     builder.set_outputs(vec![unwrap_local(result)]);
-    let fragment = builder.build();
-    let transpose_count = fragment
-        .ops()
+    let graph = builder.build();
+    let transpose_count = graph
+        .operations()
         .iter()
-        .filter(|node| matches!(node.op, StdTensorOp::Transpose { .. }))
+        .filter(|node| matches!(node.operation, StdTensorOp::Transpose { .. }))
         .count();
 
     assert_eq!(transpose_count, 1, "expected only the final transpose");
-    match &fragment.ops().last().expect("fragment should have ops").op {
-        StdTensorOp::Transpose { perm } => assert_eq!(perm, &vec![2, 0, 1]),
+    match &graph
+        .operations()
+        .last()
+        .expect("graph should have ops")
+        .operation
+    {
+        StdTensorOp::Transpose { perm } => assert_eq!(perm.as_slice(), &[2, 0, 1]),
         other => panic!("expected final transpose, got {other:?}"),
     }
 }
@@ -186,16 +191,16 @@ fn tree_ternary() {
 
 #[test]
 fn test_diagonalize_repeated() {
-    // "ii->i" should produce an ExtractDiag in the fragment
+    // "ii->i" should produce an ExtractDiag in the graph
     let tree = make_tree("ii->i", &[&[3, 3]]);
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key(0));
 
-    let result = build_einsum_fragment(&mut builder, &tree, &[ValRef::Local(a)], &[vec![3, 3]]);
+    let result = build_einsum_graph(&mut builder, &tree, &[ValueRef::Local(a)], &[vec![3, 3]]);
 
     builder.set_outputs(vec![unwrap_local(result)]);
-    let fragment = builder.build();
-    let ops: Vec<_> = fragment.ops().iter().map(|n| &n.op).collect();
+    let graph = builder.build();
+    let ops: Vec<_> = graph.operations().iter().map(|n| &n.operation).collect();
     // Should contain exactly one ExtractDiag
     let extract_count = ops
         .iter()
@@ -214,17 +219,17 @@ fn test_diagonalize_repeated() {
 }
 
 #[test]
-fn test_trace_fragment() {
-    // "ii->" should produce ExtractDiag + ReduceSum in the fragment
+fn test_trace_graph() {
+    // "ii->" should produce ExtractDiag + ReduceSum in the graph
     let tree = make_tree("ii->", &[&[3, 3]]);
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let a = builder.add_input(input_key(0));
 
-    let result = build_einsum_fragment(&mut builder, &tree, &[ValRef::Local(a)], &[vec![3, 3]]);
+    let result = build_einsum_graph(&mut builder, &tree, &[ValueRef::Local(a)], &[vec![3, 3]]);
 
     builder.set_outputs(vec![unwrap_local(result)]);
-    let fragment = builder.build();
-    let ops: Vec<_> = fragment.ops().iter().map(|n| &n.op).collect();
+    let graph = builder.build();
+    let ops: Vec<_> = graph.operations().iter().map(|n| &n.operation).collect();
     // Should contain ExtractDiag followed by ReduceSum
     let extract_count = ops
         .iter()

--- a/tenferro-fft/src/lib.rs
+++ b/tenferro-fft/src/lib.rs
@@ -37,10 +37,7 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
-#[cfg(feature = "autodiff")]
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-#[cfg(feature = "autodiff")]
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use num_complex::Complex;
 use num_traits::{Float, FromPrimitive, Zero};
 use rustfft::{FftNum, FftPlanner};
@@ -49,6 +46,8 @@ use tenferro_ad::extension::ExtensionAdRuleTrait;
 use tenferro_extension_macros::define_extension_runtime;
 #[cfg(feature = "autodiff")]
 use tenferro_extension_macros::define_idempotent_rule_registration;
+#[cfg(feature = "autodiff")]
+use tenferro_ops::ad::PrimitiveRuleBuilder;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::std_tensor_op::StdTensorOp;
 #[cfg(feature = "autodiff")]
@@ -174,11 +173,11 @@ impl ExtensionOpTrait for FftOp {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -323,12 +322,12 @@ impl ExtensionAdRuleTrait for FftAdRule {
     fn linearize(
         &self,
         op: &dyn ExtensionOpTrait,
-        builder: &mut dyn OpEmitter<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let fft_op = fft_payload(op, ADRuleKind::Jvp)?;
         if !matches!(fft_op.kind, FftKind::C2C { .. }) {
             return Err(ADRuleError::unsupported(
@@ -339,10 +338,10 @@ impl ExtensionAdRuleTrait for FftAdRule {
 
         match tangent_in[0] {
             Some(dx) => {
-                let outputs = builder.add_op(
+                let outputs = builder.add_operation(
                     StdTensorOp::Extension(Arc::new(fft_op.clone())),
-                    vec![ValRef::Local(dx)],
-                    OpMode::Linear {
+                    vec![ValueRef::Local(dx)],
+                    OperationRole::Linearized {
                         active_mask: vec![true],
                     },
                 );
@@ -355,12 +354,12 @@ impl ExtensionAdRuleTrait for FftAdRule {
     fn transpose_rule(
         &self,
         op: &dyn ExtensionOpTrait,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        _inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
+        _mode: &OperationRole,
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let fft_op = fft_payload(op, ADRuleKind::Transpose)?;
         if !matches!(fft_op.kind, FftKind::C2C { .. }) {
             return Err(ADRuleError::unsupported(
@@ -371,10 +370,10 @@ impl ExtensionAdRuleTrait for FftAdRule {
 
         match cotangent_out[0] {
             Some(ct) => {
-                let outputs = emitter.add_op(
+                let outputs = builder.add_operation(
                     StdTensorOp::Extension(Arc::new(fft_op.clone())),
-                    vec![ValRef::Local(ct)],
-                    OpMode::Linear {
+                    vec![ValueRef::Local(ct)],
+                    OperationRole::Linearized {
                         active_mask: vec![true],
                     },
                 );

--- a/tenferro-gpu/src/cubecl/fusion/classify.rs
+++ b/tenferro-gpu/src/cubecl/fusion/classify.rs
@@ -18,7 +18,7 @@ pub(crate) fn classify<'a, T>(
 where
     T: FusionElement,
 {
-    if plan.dtype != T::DTYPE || plan.n_inputs != inputs.len() || plan.outputs.is_empty() {
+    if plan.dtype != T::DTYPE || plan.input_count != inputs.len() || plan.outputs.is_empty() {
         return Ok(None);
     }
     if !plan.ops.iter().all(|inst| T::supports_op(&inst.op)) {

--- a/tenferro-gpu/src/cubecl/fusion/codegen.rs
+++ b/tenferro-gpu/src/cubecl/fusion/codegen.rs
@@ -24,8 +24,8 @@ where
     address_type.register(&mut builder.scope);
 
     let item = T::as_type(&builder.scope);
-    let mut input_arrays = Vec::with_capacity(plan.n_inputs);
-    for _ in 0..plan.n_inputs {
+    let mut input_arrays = Vec::with_capacity(plan.input_count);
+    for _ in 0..plan.input_count {
         input_arrays.push(builder.input_array(item.clone()));
     }
     let mut output_arrays = Vec::with_capacity(plan.outputs.len());
@@ -76,7 +76,7 @@ fn build_body<T>(
 where
     T: CubeElement + CubePrimitive + Clone,
 {
-    let mut values = Vec::with_capacity(plan.n_inputs + plan.ops.len());
+    let mut values = Vec::with_capacity(plan.input_count + plan.ops.len());
     for array in input_arrays {
         values.push(load_array_element(
             scope,

--- a/tenferro-gpu/src/cubecl/tests/fusion_tests.rs
+++ b/tenferro-gpu/src/cubecl/tests/fusion_tests.rs
@@ -12,7 +12,7 @@ use super::{
 fn add_mul_plan() -> ElementwiseFusionPlan {
     ElementwiseFusionPlan {
         dtype: crate::DType::F64,
-        n_inputs: 2,
+        input_count: 2,
         outputs: vec![3], // value index of final result
         ops: vec![
             ElementwiseFusionInst {
@@ -54,7 +54,7 @@ fn test_fused_add_mul_matches_cpu() {
 fn complex_add_conj_mul_plan(dtype: crate::DType) -> ElementwiseFusionPlan {
     ElementwiseFusionPlan {
         dtype,
-        n_inputs: 2,
+        input_count: 2,
         outputs: vec![4],
         ops: vec![
             ElementwiseFusionInst {
@@ -115,7 +115,7 @@ fn test_fused_complex_c64_add_conj_mul_matches_cpu() {
 fn complex_div_neg_plan(dtype: crate::DType) -> ElementwiseFusionPlan {
     ElementwiseFusionPlan {
         dtype,
-        n_inputs: 2,
+        input_count: 2,
         outputs: vec![3],
         ops: vec![
             ElementwiseFusionInst {
@@ -172,7 +172,7 @@ fn test_fused_complex_c32_div_neg_matches_cpu() {
 fn add_neg_plan() -> ElementwiseFusionPlan {
     ElementwiseFusionPlan {
         dtype: crate::DType::F64,
-        n_inputs: 2,
+        input_count: 2,
         outputs: vec![3],
         ops: vec![
             ElementwiseFusionInst {
@@ -214,7 +214,7 @@ fn test_fused_add_neg() {
 fn multi_output_plan() -> ElementwiseFusionPlan {
     ElementwiseFusionPlan {
         dtype: crate::DType::F64,
-        n_inputs: 2,
+        input_count: 2,
         outputs: vec![2, 3], // sum and neg(sum)
         ops: vec![
             ElementwiseFusionInst {
@@ -257,7 +257,7 @@ fn test_fused_multi_output() {
 fn unary_chain_plan() -> ElementwiseFusionPlan {
     ElementwiseFusionPlan {
         dtype: crate::DType::F64,
-        n_inputs: 1,
+        input_count: 1,
         outputs: vec![3],
         ops: vec![
             ElementwiseFusionInst {

--- a/tenferro-internal-ops/src/ad/analytic.rs
+++ b/tenferro-internal-ops/src/ad/analytic.rs
@@ -1,123 +1,126 @@
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use crate::ad::PrimitiveRuleBuilder;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 
 use crate::std_tensor_op::StdTensorOp;
 
 fn emit_fixed_unary(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     op: StdTensorOp,
-    input: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emitter.add_op(
+    input: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    builder.add_operation(
         op,
         vec![input],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![false],
         },
     )[0]
 }
 
 fn emit_fixed_binary(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     op: StdTensorOp,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emitter.add_op(
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    builder.add_operation(
         op,
         vec![lhs, rhs],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![false, false],
         },
     )[0]
 }
 
 fn emit_fixed_neg(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emit_fixed_unary(emitter, StdTensorOp::Neg, input)
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    emit_fixed_unary(builder, StdTensorOp::Neg, input)
 }
 
 fn emit_fixed_add(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emit_fixed_binary(emitter, StdTensorOp::Add, lhs, rhs)
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    emit_fixed_binary(builder, StdTensorOp::Add, lhs, rhs)
 }
 
 fn emit_fixed_mul(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emit_fixed_binary(emitter, StdTensorOp::Mul, lhs, rhs)
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    emit_fixed_binary(builder, StdTensorOp::Mul, lhs, rhs)
 }
 
 fn emit_fixed_div(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emit_fixed_binary(emitter, StdTensorOp::Div, lhs, rhs)
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    emit_fixed_binary(builder, StdTensorOp::Div, lhs, rhs)
 }
 
 fn emit_one_like_fixed(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    anchor: ValRef<StdTensorOp>,
-) -> LocalValId {
-    let neg = emit_fixed_neg(emitter, anchor.clone());
-    let zero = emit_fixed_add(emitter, anchor, ValRef::Local(neg));
-    emit_fixed_unary(emitter, StdTensorOp::Exp, ValRef::Local(zero))
+    builder: &mut dyn PrimitiveRuleBuilder,
+    anchor: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    let neg = emit_fixed_neg(builder, anchor.clone());
+    let zero = emit_fixed_add(builder, anchor, ValueRef::Local(neg));
+    emit_fixed_unary(builder, StdTensorOp::Exp, ValueRef::Local(zero))
 }
 
 fn emit_linear_mul_fixed(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    fixed: ValRef<StdTensorOp>,
-    active: LocalValId,
-) -> LocalValId {
-    emitter.add_op(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    fixed: ValueRef<StdTensorOp>,
+    active: LocalValueId,
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::Mul,
-        vec![fixed, ValRef::Local(active)],
-        OpMode::Linear {
+        vec![fixed, ValueRef::Local(active)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0]
 }
 
 fn emit_linear_div_fixed_denominator(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    active: LocalValId,
-    denominator: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emitter.add_op(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    active: LocalValueId,
+    denominator: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::Div,
-        vec![ValRef::Local(active), denominator],
-        OpMode::Linear {
+        vec![ValueRef::Local(active), denominator],
+        OperationRole::Linearized {
             active_mask: vec![true, false],
         },
     )[0]
 }
 
-fn unary_is_active(mode: &OpMode) -> bool {
+fn unary_is_active(mode: &OperationRole) -> bool {
     match mode {
-        OpMode::Linear { active_mask } => active_mask[0],
-        OpMode::Primal => false,
+        OperationRole::Linearized { active_mask } => active_mask[0],
+        OperationRole::Primary => false,
     }
 }
 
 pub fn linearize_exp(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Mul,
-                vec![ValRef::External(primal_out[0].clone()), ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![
+                    ValueRef::External(primal_out[0].clone()),
+                    ValueRef::Local(dx),
+                ],
+                OperationRole::Linearized {
                     active_mask: vec![false, true],
                 },
             );
@@ -128,16 +131,19 @@ pub fn linearize_exp(
 }
 
 pub fn linearize_log(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Div,
-                vec![ValRef::Local(dx), ValRef::External(primal_in[0].clone())],
-                OpMode::Linear {
+                vec![
+                    ValueRef::Local(dx),
+                    ValueRef::External(primal_in[0].clone()),
+                ],
+                OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
             );
@@ -148,20 +154,20 @@ pub fn linearize_log(
 }
 
 pub fn linearize_sin(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
             let cos_x = emit_fixed_unary(
                 builder,
                 StdTensorOp::Cos,
-                ValRef::External(primal_in[0].clone()),
+                ValueRef::External(primal_in[0].clone()),
             );
             vec![Some(emit_linear_mul_fixed(
                 builder,
-                ValRef::Local(cos_x),
+                ValueRef::Local(cos_x),
                 dx,
             ))]
         }
@@ -170,21 +176,21 @@ pub fn linearize_sin(
 }
 
 pub fn linearize_cos(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
             let sin_x = emit_fixed_unary(
                 builder,
                 StdTensorOp::Sin,
-                ValRef::External(primal_in[0].clone()),
+                ValueRef::External(primal_in[0].clone()),
             );
-            let neg_sin_x = emit_fixed_neg(builder, ValRef::Local(sin_x));
+            let neg_sin_x = emit_fixed_neg(builder, ValueRef::Local(sin_x));
             vec![Some(emit_linear_mul_fixed(
                 builder,
-                ValRef::Local(neg_sin_x),
+                ValueRef::Local(neg_sin_x),
                 dx,
             ))]
         }
@@ -193,20 +199,20 @@ pub fn linearize_cos(
 }
 
 pub fn linearize_tanh(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let y = ValRef::External(primal_out[0].clone());
+            let y = ValueRef::External(primal_out[0].clone());
             let y_sq = emit_fixed_mul(builder, y.clone(), y.clone());
             let one = emit_one_like_fixed(builder, y);
-            let neg_y_sq = emit_fixed_neg(builder, ValRef::Local(y_sq));
-            let coeff = emit_fixed_add(builder, ValRef::Local(one), ValRef::Local(neg_y_sq));
+            let neg_y_sq = emit_fixed_neg(builder, ValueRef::Local(y_sq));
+            let coeff = emit_fixed_add(builder, ValueRef::Local(one), ValueRef::Local(neg_y_sq));
             vec![Some(emit_linear_mul_fixed(
                 builder,
-                ValRef::Local(coeff),
+                ValueRef::Local(coeff),
                 dx,
             ))]
         }
@@ -215,18 +221,18 @@ pub fn linearize_tanh(
 }
 
 pub fn linearize_sqrt(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let y = ValRef::External(primal_out[0].clone());
+            let y = ValueRef::External(primal_out[0].clone());
             let two_y = emit_fixed_add(builder, y.clone(), y);
             vec![Some(emit_linear_div_fixed_denominator(
                 builder,
                 dx,
-                ValRef::Local(two_y),
+                ValueRef::Local(two_y),
             ))]
         }
         None => vec![None],
@@ -234,20 +240,24 @@ pub fn linearize_sqrt(
 }
 
 pub fn linearize_rsqrt(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let neg_rsqrt_x = emit_fixed_neg(builder, ValRef::External(primal_out[0].clone()));
-            let x = ValRef::External(primal_in[0].clone());
+            let neg_rsqrt_x = emit_fixed_neg(builder, ValueRef::External(primal_out[0].clone()));
+            let x = ValueRef::External(primal_in[0].clone());
             let two_x = emit_fixed_add(builder, x.clone(), x);
-            let coeff = emit_fixed_div(builder, ValRef::Local(neg_rsqrt_x), ValRef::Local(two_x));
+            let coeff = emit_fixed_div(
+                builder,
+                ValueRef::Local(neg_rsqrt_x),
+                ValueRef::Local(two_x),
+            );
             vec![Some(emit_linear_mul_fixed(
                 builder,
-                ValRef::Local(coeff),
+                ValueRef::Local(coeff),
                 dx,
             ))]
         }
@@ -256,49 +266,49 @@ pub fn linearize_rsqrt(
 }
 
 pub fn linearize_pow(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     let mut terms = Vec::with_capacity(2);
 
     if let Some(dx) = tangent_in[0] {
         let pow_over_x = emit_fixed_div(
             builder,
-            ValRef::External(primal_out[0].clone()),
-            ValRef::External(primal_in[0].clone()),
+            ValueRef::External(primal_out[0].clone()),
+            ValueRef::External(primal_in[0].clone()),
         );
         let coeff = emit_fixed_mul(
             builder,
-            ValRef::External(primal_in[1].clone()),
-            ValRef::Local(pow_over_x),
+            ValueRef::External(primal_in[1].clone()),
+            ValueRef::Local(pow_over_x),
         );
-        terms.push(emit_linear_mul_fixed(builder, ValRef::Local(coeff), dx));
+        terms.push(emit_linear_mul_fixed(builder, ValueRef::Local(coeff), dx));
     }
 
     if let Some(dy) = tangent_in[1] {
         let log_x = emit_fixed_unary(
             builder,
             StdTensorOp::Log,
-            ValRef::External(primal_in[0].clone()),
+            ValueRef::External(primal_in[0].clone()),
         );
         let coeff = emit_fixed_mul(
             builder,
-            ValRef::Local(log_x),
-            ValRef::External(primal_out[0].clone()),
+            ValueRef::Local(log_x),
+            ValueRef::External(primal_out[0].clone()),
         );
-        terms.push(emit_linear_mul_fixed(builder, ValRef::Local(coeff), dy));
+        terms.push(emit_linear_mul_fixed(builder, ValueRef::Local(coeff), dy));
     }
 
     match terms.as_slice() {
         [] => vec![None],
         [only] => vec![Some(*only)],
         [lhs, rhs] => {
-            let sum = builder.add_op(
+            let sum = builder.add_operation(
                 StdTensorOp::Add,
-                vec![ValRef::Local(*lhs), ValRef::Local(*rhs)],
-                OpMode::Linear {
+                vec![ValueRef::Local(*lhs), ValueRef::Local(*rhs)],
+                OperationRole::Linearized {
                     active_mask: vec![true, true],
                 },
             );
@@ -309,18 +319,18 @@ pub fn linearize_pow(
 }
 
 pub fn linearize_expm1(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let y = ValRef::External(primal_out[0].clone());
+            let y = ValueRef::External(primal_out[0].clone());
             let one = emit_one_like_fixed(builder, y.clone());
-            let coeff = emit_fixed_add(builder, y, ValRef::Local(one));
+            let coeff = emit_fixed_add(builder, y, ValueRef::Local(one));
             vec![Some(emit_linear_mul_fixed(
                 builder,
-                ValRef::Local(coeff),
+                ValueRef::Local(coeff),
                 dx,
             ))]
         }
@@ -329,19 +339,19 @@ pub fn linearize_expm1(
 }
 
 pub fn linearize_log1p(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let x = ValRef::External(primal_in[0].clone());
+            let x = ValueRef::External(primal_in[0].clone());
             let one = emit_one_like_fixed(builder, x.clone());
-            let denom = emit_fixed_add(builder, x, ValRef::Local(one));
+            let denom = emit_fixed_add(builder, x, ValueRef::Local(one));
             vec![Some(emit_linear_div_fixed_denominator(
                 builder,
                 dx,
-                ValRef::Local(denom),
+                ValueRef::Local(denom),
             ))]
         }
         None => vec![None],
@@ -349,20 +359,20 @@ pub fn linearize_log1p(
 }
 
 pub fn transpose_exp(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let exp_x = emit_fixed_unary(emitter, StdTensorOp::Exp, inputs[0].clone());
+            let exp_x = emit_fixed_unary(builder, StdTensorOp::Exp, inputs[0].clone());
             vec![Some(emit_linear_mul_fixed(
-                emitter,
-                ValRef::Local(exp_x),
+                builder,
+                ValueRef::Local(exp_x),
                 ct,
             ))]
         }
@@ -371,20 +381,20 @@ pub fn transpose_exp(
 }
 
 pub fn transpose_log(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Div,
-                vec![ValRef::Local(ct), inputs[0].clone()],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct), inputs[0].clone()],
+                OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
             );
@@ -395,20 +405,20 @@ pub fn transpose_log(
 }
 
 pub fn transpose_sin(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let cos_x = emit_fixed_unary(emitter, StdTensorOp::Cos, inputs[0].clone());
+            let cos_x = emit_fixed_unary(builder, StdTensorOp::Cos, inputs[0].clone());
             vec![Some(emit_linear_mul_fixed(
-                emitter,
-                ValRef::Local(cos_x),
+                builder,
+                ValueRef::Local(cos_x),
                 ct,
             ))]
         }
@@ -417,21 +427,21 @@ pub fn transpose_sin(
 }
 
 pub fn transpose_cos(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let sin_x = emit_fixed_unary(emitter, StdTensorOp::Sin, inputs[0].clone());
-            let neg_sin_x = emit_fixed_neg(emitter, ValRef::Local(sin_x));
+            let sin_x = emit_fixed_unary(builder, StdTensorOp::Sin, inputs[0].clone());
+            let neg_sin_x = emit_fixed_neg(builder, ValueRef::Local(sin_x));
             vec![Some(emit_linear_mul_fixed(
-                emitter,
-                ValRef::Local(neg_sin_x),
+                builder,
+                ValueRef::Local(neg_sin_x),
                 ct,
             ))]
         }
@@ -440,24 +450,24 @@ pub fn transpose_cos(
 }
 
 pub fn transpose_tanh(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let tanh_x = emit_fixed_unary(emitter, StdTensorOp::Tanh, inputs[0].clone());
-            let tanh_sq = emit_fixed_mul(emitter, ValRef::Local(tanh_x), ValRef::Local(tanh_x));
-            let one = emit_one_like_fixed(emitter, inputs[0].clone());
-            let neg_tanh_sq = emit_fixed_neg(emitter, ValRef::Local(tanh_sq));
-            let coeff = emit_fixed_add(emitter, ValRef::Local(one), ValRef::Local(neg_tanh_sq));
+            let tanh_x = emit_fixed_unary(builder, StdTensorOp::Tanh, inputs[0].clone());
+            let tanh_sq = emit_fixed_mul(builder, ValueRef::Local(tanh_x), ValueRef::Local(tanh_x));
+            let one = emit_one_like_fixed(builder, inputs[0].clone());
+            let neg_tanh_sq = emit_fixed_neg(builder, ValueRef::Local(tanh_sq));
+            let coeff = emit_fixed_add(builder, ValueRef::Local(one), ValueRef::Local(neg_tanh_sq));
             vec![Some(emit_linear_mul_fixed(
-                emitter,
-                ValRef::Local(coeff),
+                builder,
+                ValueRef::Local(coeff),
                 ct,
             ))]
         }
@@ -466,22 +476,23 @@ pub fn transpose_tanh(
 }
 
 pub fn transpose_sqrt(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let sqrt_x = emit_fixed_unary(emitter, StdTensorOp::Sqrt, inputs[0].clone());
-            let two_sqrt_x = emit_fixed_add(emitter, ValRef::Local(sqrt_x), ValRef::Local(sqrt_x));
-            let out = emitter.add_op(
+            let sqrt_x = emit_fixed_unary(builder, StdTensorOp::Sqrt, inputs[0].clone());
+            let two_sqrt_x =
+                emit_fixed_add(builder, ValueRef::Local(sqrt_x), ValueRef::Local(sqrt_x));
+            let out = builder.add_operation(
                 StdTensorOp::Div,
-                vec![ValRef::Local(ct), ValRef::Local(two_sqrt_x)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct), ValueRef::Local(two_sqrt_x)],
+                OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
             );
@@ -492,23 +503,27 @@ pub fn transpose_sqrt(
 }
 
 pub fn transpose_rsqrt(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let rsqrt_x = emit_fixed_unary(emitter, StdTensorOp::Rsqrt, inputs[0].clone());
-            let neg_rsqrt_x = emit_fixed_neg(emitter, ValRef::Local(rsqrt_x));
-            let two_x = emit_fixed_add(emitter, inputs[0].clone(), inputs[0].clone());
-            let coeff = emit_fixed_div(emitter, ValRef::Local(neg_rsqrt_x), ValRef::Local(two_x));
+            let rsqrt_x = emit_fixed_unary(builder, StdTensorOp::Rsqrt, inputs[0].clone());
+            let neg_rsqrt_x = emit_fixed_neg(builder, ValueRef::Local(rsqrt_x));
+            let two_x = emit_fixed_add(builder, inputs[0].clone(), inputs[0].clone());
+            let coeff = emit_fixed_div(
+                builder,
+                ValueRef::Local(neg_rsqrt_x),
+                ValueRef::Local(two_x),
+            );
             vec![Some(emit_linear_mul_fixed(
-                emitter,
-                ValRef::Local(coeff),
+                builder,
+                ValueRef::Local(coeff),
                 ct,
             ))]
         }
@@ -517,65 +532,65 @@ pub fn transpose_rsqrt(
 }
 
 pub fn transpose_pow(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
         None => return vec![None, None],
     };
 
     let active_mask = match mode {
-        OpMode::Linear { active_mask } => active_mask,
-        OpMode::Primal => return vec![None, None],
+        OperationRole::Linearized { active_mask } => active_mask,
+        OperationRole::Primary => return vec![None, None],
     };
 
     let mut result = vec![None, None];
 
     if active_mask[0] {
         let pow_xy = emit_fixed_binary(
-            emitter,
+            builder,
             StdTensorOp::Pow,
             inputs[0].clone(),
             inputs[1].clone(),
         );
-        let pow_over_x = emit_fixed_div(emitter, ValRef::Local(pow_xy), inputs[0].clone());
-        let coeff = emit_fixed_mul(emitter, inputs[1].clone(), ValRef::Local(pow_over_x));
-        result[0] = Some(emit_linear_mul_fixed(emitter, ValRef::Local(coeff), ct));
+        let pow_over_x = emit_fixed_div(builder, ValueRef::Local(pow_xy), inputs[0].clone());
+        let coeff = emit_fixed_mul(builder, inputs[1].clone(), ValueRef::Local(pow_over_x));
+        result[0] = Some(emit_linear_mul_fixed(builder, ValueRef::Local(coeff), ct));
     }
 
     if active_mask[1] {
-        let log_x = emit_fixed_unary(emitter, StdTensorOp::Log, inputs[0].clone());
+        let log_x = emit_fixed_unary(builder, StdTensorOp::Log, inputs[0].clone());
         let pow_xy = emit_fixed_binary(
-            emitter,
+            builder,
             StdTensorOp::Pow,
             inputs[0].clone(),
             inputs[1].clone(),
         );
-        let coeff = emit_fixed_mul(emitter, ValRef::Local(log_x), ValRef::Local(pow_xy));
-        result[1] = Some(emit_linear_mul_fixed(emitter, ValRef::Local(coeff), ct));
+        let coeff = emit_fixed_mul(builder, ValueRef::Local(log_x), ValueRef::Local(pow_xy));
+        result[1] = Some(emit_linear_mul_fixed(builder, ValueRef::Local(coeff), ct));
     }
 
     result
 }
 
 pub fn transpose_expm1(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let exp_x = emit_fixed_unary(emitter, StdTensorOp::Exp, inputs[0].clone());
+            let exp_x = emit_fixed_unary(builder, StdTensorOp::Exp, inputs[0].clone());
             vec![Some(emit_linear_mul_fixed(
-                emitter,
-                ValRef::Local(exp_x),
+                builder,
+                ValueRef::Local(exp_x),
                 ct,
             ))]
         }
@@ -584,22 +599,22 @@ pub fn transpose_expm1(
 }
 
 pub fn transpose_log1p(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let one = emit_one_like_fixed(emitter, inputs[0].clone());
-            let denom = emit_fixed_add(emitter, inputs[0].clone(), ValRef::Local(one));
-            let out = emitter.add_op(
+            let one = emit_one_like_fixed(builder, inputs[0].clone());
+            let denom = emit_fixed_add(builder, inputs[0].clone(), ValueRef::Local(one));
+            let out = builder.add_operation(
                 StdTensorOp::Div,
-                vec![ValRef::Local(ct), ValRef::Local(denom)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct), ValueRef::Local(denom)],
+                OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
             );

--- a/tenferro-internal-ops/src/ad/context.rs
+++ b/tenferro-internal-ops/src/ad/context.rs
@@ -12,8 +12,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::{Mutex, OnceLock};
 
-use computegraph::fragment::Fragment;
-use computegraph::types::{GlobalValKey, ValRef};
+use computegraph::graph::Graph;
+use computegraph::types::{ValueKey, ValueRef};
 use tenferro_tensor::DType;
 
 use crate::dim_expr::DimExpr;
@@ -25,9 +25,9 @@ use crate::shape_extent::ShapeExtent;
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
 
-type MetadataMap = HashMap<GlobalValKey<StdTensorOp>, TensorMeta>;
+type MetadataMap = HashMap<ValueKey<StdTensorOp>, TensorMeta>;
 
-type GlobalMetadataMap = HashMap<GlobalValKey<StdTensorOp>, GlobalMetadataEntry>;
+type GlobalMetadataMap = HashMap<ValueKey<StdTensorOp>, GlobalMetadataEntry>;
 
 #[derive(Clone, Debug)]
 struct GlobalMetadataEntry {
@@ -55,11 +55,11 @@ fn global_metadata_registry() -> &'static Mutex<GlobalMetadataMap> {
 /// Lifetime token for graph-scoped global metadata.
 ///
 /// Dropping the last frontend owner of a traced graph drops this scope and
-/// releases the metadata keys that were registered for that graph fragment.
+/// releases the metadata keys that were registered for that graph graph.
 #[doc(hidden)]
 #[derive(Debug)]
 pub struct GlobalMetadataScope {
-    keys: Vec<GlobalValKey<StdTensorOp>>,
+    keys: Vec<ValueKey<StdTensorOp>>,
 }
 
 impl Drop for GlobalMetadataScope {
@@ -228,7 +228,7 @@ pub struct ShapeGuardContext {
     guards: Vec<ShapeGuard>,
     metadata: MetadataMap,
     use_global_registry: bool,
-    local_keys: Option<Vec<GlobalValKey<StdTensorOp>>>,
+    local_keys: Option<Vec<ValueKey<StdTensorOp>>>,
     #[cfg(feature = "autodiff")]
     extension_rules: Option<ExtensionRuleSet>,
 }
@@ -331,21 +331,21 @@ impl ShapeGuardContext {
     /// # Examples
     ///
     /// ```
-    /// use computegraph::types::{GlobalValKey, ValRef};
+    /// use computegraph::types::{ValueKey, ValueRef};
     /// use tenferro_ops::input_key::TensorInputKey;
     /// use tenferro_ops::std_tensor_op::StdTensorOp;
     /// use tenferro_ops::{ShapeGuardContext, SymDim, TensorMeta};
     /// use tenferro_tensor::DType;
     ///
-    /// let key = GlobalValKey::<StdTensorOp>::Input(TensorInputKey::User { id: 1 });
-    /// let value = ValRef::External(key.clone());
+    /// let key = ValueKey::<StdTensorOp>::Input(TensorInputKey::User { id: 1 });
+    /// let value = ValueRef::External(key.clone());
     /// let mut ctx = ShapeGuardContext::default();
     /// ctx.insert_metadata(key, TensorMeta::exact(DType::F64, vec![SymDim::from(4usize)]));
     ///
     /// let shape = ctx.shape_of(&value);
     /// assert_eq!(shape, &[SymDim::from(4usize)]);
     /// ```
-    pub fn shape_of(&mut self, val: &ValRef<StdTensorOp>) -> &[SymDim] {
+    pub fn shape_of(&mut self, val: &ValueRef<StdTensorOp>) -> &[SymDim] {
         &self.metadata_of(val).shape
     }
 
@@ -354,14 +354,14 @@ impl ShapeGuardContext {
     /// # Examples
     ///
     /// ```
-    /// use computegraph::types::{GlobalValKey, ValRef};
+    /// use computegraph::types::{ValueKey, ValueRef};
     /// use tenferro_ops::input_key::TensorInputKey;
     /// use tenferro_ops::std_tensor_op::StdTensorOp;
     /// use tenferro_ops::{ShapeExtent, ShapeGuardContext, SymDim, TensorMeta};
     /// use tenferro_tensor::DType;
     ///
-    /// let key = GlobalValKey::<StdTensorOp>::Input(TensorInputKey::User { id: 1 });
-    /// let value = ValRef::External(key.clone());
+    /// let key = ValueKey::<StdTensorOp>::Input(TensorInputKey::User { id: 1 });
+    /// let value = ValueRef::External(key.clone());
     /// let mut ctx = ShapeGuardContext::default();
     /// ctx.insert_metadata(
     ///     key,
@@ -371,7 +371,7 @@ impl ShapeGuardContext {
     /// let extents = ctx.extents_of(&value);
     /// assert_eq!(extents[0], ShapeExtent::upper_bound(SymDim::from(8usize)));
     /// ```
-    pub fn extents_of(&mut self, val: &ValRef<StdTensorOp>) -> &[ShapeExtent<SymDim>] {
+    pub fn extents_of(&mut self, val: &ValueRef<StdTensorOp>) -> &[ShapeExtent<SymDim>] {
         self.metadata_of(val).extents()
     }
 
@@ -380,14 +380,14 @@ impl ShapeGuardContext {
     /// # Examples
     ///
     /// ```
-    /// use computegraph::types::{GlobalValKey, ValRef};
+    /// use computegraph::types::{ValueKey, ValueRef};
     /// use tenferro_ops::input_key::TensorInputKey;
     /// use tenferro_ops::std_tensor_op::StdTensorOp;
     /// use tenferro_ops::{ShapeExtent, ShapeGuardContext, SymDim, TensorMeta};
     /// use tenferro_tensor::DType;
     ///
-    /// let key = GlobalValKey::<StdTensorOp>::Input(TensorInputKey::User { id: 1 });
-    /// let value = ValRef::External(key.clone());
+    /// let key = ValueKey::<StdTensorOp>::Input(TensorInputKey::User { id: 1 });
+    /// let value = ValueRef::External(key.clone());
     /// let mut ctx = ShapeGuardContext::default();
     /// ctx.insert_metadata(
     ///     key,
@@ -397,12 +397,12 @@ impl ShapeGuardContext {
     /// let maybe_shape = ctx.exact_shape_of(&value);
     /// assert_eq!(maybe_shape, None);
     /// ```
-    pub fn exact_shape_of(&mut self, val: &ValRef<StdTensorOp>) -> Option<Vec<SymDim>> {
+    pub fn exact_shape_of(&mut self, val: &ValueRef<StdTensorOp>) -> Option<Vec<SymDim>> {
         self.metadata_of(val).exact_shape()
     }
 
     #[doc(hidden)]
-    pub fn try_shape_of(&mut self, val: &ValRef<StdTensorOp>) -> Option<&[SymDim]> {
+    pub fn try_shape_of(&mut self, val: &ValueRef<StdTensorOp>) -> Option<&[SymDim]> {
         self.try_metadata_of(val).map(|meta| meta.shape.as_slice())
     }
 
@@ -411,21 +411,21 @@ impl ShapeGuardContext {
     /// # Examples
     ///
     /// ```
-    /// use computegraph::types::{GlobalValKey, ValRef};
+    /// use computegraph::types::{ValueKey, ValueRef};
     /// use tenferro_ops::input_key::TensorInputKey;
     /// use tenferro_ops::std_tensor_op::StdTensorOp;
     /// use tenferro_ops::{ShapeGuardContext, SymDim, TensorMeta};
     /// use tenferro_tensor::DType;
     ///
-    /// let key = GlobalValKey::<StdTensorOp>::Input(TensorInputKey::User { id: 1 });
-    /// let value = ValRef::External(key.clone());
+    /// let key = ValueKey::<StdTensorOp>::Input(TensorInputKey::User { id: 1 });
+    /// let value = ValueRef::External(key.clone());
     /// let mut ctx = ShapeGuardContext::default();
     /// ctx.insert_metadata(key, TensorMeta::exact(DType::F64, vec![SymDim::from(4usize)]));
     ///
     /// let dtype = ctx.dtype_of(&value);
     /// assert_eq!(dtype, DType::F64);
     /// ```
-    pub fn dtype_of(&mut self, val: &ValRef<StdTensorOp>) -> DType {
+    pub fn dtype_of(&mut self, val: &ValueRef<StdTensorOp>) -> DType {
         self.metadata_of(val).dtype
     }
 
@@ -434,21 +434,21 @@ impl ShapeGuardContext {
     /// # Examples
     ///
     /// ```
-    /// use computegraph::types::{GlobalValKey, ValRef};
+    /// use computegraph::types::{ValueKey, ValueRef};
     /// use tenferro_ops::input_key::TensorInputKey;
     /// use tenferro_ops::std_tensor_op::StdTensorOp;
     /// use tenferro_ops::{ShapeGuardContext, SymDim, TensorMeta};
     /// use tenferro_tensor::DType;
     ///
-    /// let key = GlobalValKey::<StdTensorOp>::Input(TensorInputKey::User { id: 1 });
-    /// let value = ValRef::External(key.clone());
+    /// let key = ValueKey::<StdTensorOp>::Input(TensorInputKey::User { id: 1 });
+    /// let value = ValueRef::External(key.clone());
     /// let mut ctx = ShapeGuardContext::default();
     /// ctx.insert_metadata(key, TensorMeta::exact(DType::F64, vec![SymDim::from(4usize)]));
     ///
     /// let meta = ctx.metadata_of(&value);
     /// assert_eq!(meta.dtype, DType::F64);
     /// ```
-    pub fn metadata_of(&mut self, val: &ValRef<StdTensorOp>) -> &TensorMeta {
+    pub fn metadata_of(&mut self, val: &ValueRef<StdTensorOp>) -> &TensorMeta {
         let key = self.resolve_key(val).clone();
         if !self.metadata.contains_key(&key) && self.use_global_registry {
             if let Some(meta) = lookup_global_metadata(&key) {
@@ -461,7 +461,7 @@ impl ShapeGuardContext {
     }
 
     #[doc(hidden)]
-    pub fn try_metadata_of(&mut self, val: &ValRef<StdTensorOp>) -> Option<&TensorMeta> {
+    pub fn try_metadata_of(&mut self, val: &ValueRef<StdTensorOp>) -> Option<&TensorMeta> {
         let key = self.resolve_key(val).clone();
         if !self.metadata.contains_key(&key) && self.use_global_registry {
             if let Some(meta) = lookup_global_metadata(&key) {
@@ -472,38 +472,32 @@ impl ShapeGuardContext {
     }
 
     #[doc(hidden)]
-    pub fn attach_fragment(&mut self, fragment: &Fragment<StdTensorOp>) {
-        self.local_keys = Some(
-            fragment
-                .vals()
-                .iter()
-                .map(|node| node.key.clone())
-                .collect(),
-        );
+    pub fn attach_graph(&mut self, graph: &Graph<StdTensorOp>) {
+        self.local_keys = Some(graph.values().iter().map(|node| node.key.clone()).collect());
     }
 
     #[doc(hidden)]
-    pub fn insert_metadata(&mut self, key: GlobalValKey<StdTensorOp>, meta: TensorMeta) {
+    pub fn insert_metadata(&mut self, key: ValueKey<StdTensorOp>, meta: TensorMeta) {
         self.metadata.insert(key, meta);
     }
 
     #[doc(hidden)]
     pub fn extend_metadata<I>(&mut self, entries: I)
     where
-        I: IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
+        I: IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
     {
         self.metadata.extend(entries);
     }
 
-    fn resolve_key<'a>(&'a self, val: &'a ValRef<StdTensorOp>) -> &'a GlobalValKey<StdTensorOp> {
+    fn resolve_key<'a>(&'a self, val: &'a ValueRef<StdTensorOp>) -> &'a ValueKey<StdTensorOp> {
         match val {
-            ValRef::External(key) => key,
-            ValRef::Local(local_id) => self
+            ValueRef::External(key) => key,
+            ValueRef::Local(local_id) => self
                 .local_keys
                 .as_ref()
                 .unwrap_or_else(|| {
                     panic!(
-                        "ShapeGuardContext: cannot resolve local value {local_id} without an attached fragment"
+                        "ShapeGuardContext: cannot resolve local value {local_id} without an attached graph"
                     )
                 })
                 .get(*local_id)
@@ -521,16 +515,16 @@ impl ShapeGuardContext {
 /// # Examples
 ///
 /// ```
-/// use computegraph::types::GlobalValKey;
+/// use computegraph::types::ValueKey;
 /// use tenferro_ops::ad::context::lookup_global_metadata;
 /// use tenferro_ops::input_key::TensorInputKey;
 /// use tenferro_ops::std_tensor_op::StdTensorOp;
 ///
-/// let key = GlobalValKey::<StdTensorOp>::Input(TensorInputKey::User { id: 99 });
+/// let key = ValueKey::<StdTensorOp>::Input(TensorInputKey::User { id: 99 });
 /// let meta = lookup_global_metadata(&key);
 /// assert!(meta.is_none());
 /// ```
-pub fn lookup_global_metadata(key: &GlobalValKey<StdTensorOp>) -> Option<TensorMeta> {
+pub fn lookup_global_metadata(key: &ValueKey<StdTensorOp>) -> Option<TensorMeta> {
     let guard = global_metadata_registry()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -540,7 +534,7 @@ pub fn lookup_global_metadata(key: &GlobalValKey<StdTensorOp>) -> Option<TensorM
 #[doc(hidden)]
 pub fn register_scoped_global_metadata_batch<I>(entries: I) -> GlobalMetadataScope
 where
-    I: IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
+    I: IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
 {
     let mut guard = global_metadata_registry()
         .lock()
@@ -558,7 +552,7 @@ where
     GlobalMetadataScope { keys }
 }
 
-fn release_scoped_global_metadata(keys: &[GlobalValKey<StdTensorOp>]) {
+fn release_scoped_global_metadata(keys: &[ValueKey<StdTensorOp>]) {
     let mut guard = global_metadata_registry()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());

--- a/tenferro-internal-ops/src/ad/contraction.rs
+++ b/tenferro-internal-ops/src/ad/contraction.rs
@@ -1,22 +1,26 @@
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{CompareDir, DType, DotGeneralConfig};
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::support::{conjugate_primal_if_complex, conjugate_primal_if_dtype_complex};
+use crate::ad::PrimitiveRuleBuilder;
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
 
 pub fn linearize_dot_general(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     config: &DotGeneralConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
-    let lhs_rank = ctx.shape_of(&ValRef::External(primal_in[0].clone())).len();
-    let rhs_rank = ctx.shape_of(&ValRef::External(primal_in[1].clone())).len();
+) -> Vec<Option<LocalValueId>> {
+    let lhs_rank = ctx
+        .shape_of(&ValueRef::External(primal_in[0].clone()))
+        .len();
+    let rhs_rank = ctx
+        .shape_of(&ValueRef::External(primal_in[1].clone()))
+        .len();
     config
         .validate_dims_with_ranks(lhs_rank, rhs_rank)
         .unwrap_or_else(|err| {
@@ -27,12 +31,15 @@ pub fn linearize_dot_general(
     let mut terms = Vec::with_capacity(2);
 
     if let Some(dx) = tangent_in[0] {
-        let term = builder.add_op(
+        let term = builder.add_operation(
             StdTensorOp::DotGeneral {
                 config: config.clone(),
             },
-            vec![ValRef::Local(dx), ValRef::External(primal_in[1].clone())],
-            OpMode::Linear {
+            vec![
+                ValueRef::Local(dx),
+                ValueRef::External(primal_in[1].clone()),
+            ],
+            OperationRole::Linearized {
                 active_mask: vec![true, false],
             },
         );
@@ -40,12 +47,15 @@ pub fn linearize_dot_general(
     }
 
     if let Some(dy) = tangent_in[1] {
-        let term = builder.add_op(
+        let term = builder.add_operation(
             StdTensorOp::DotGeneral {
                 config: config.clone(),
             },
-            vec![ValRef::External(primal_in[0].clone()), ValRef::Local(dy)],
-            OpMode::Linear {
+            vec![
+                ValueRef::External(primal_in[0].clone()),
+                ValueRef::Local(dy),
+            ],
+            OperationRole::Linearized {
                 active_mask: vec![false, true],
             },
         );
@@ -56,10 +66,10 @@ pub fn linearize_dot_general(
         [] => vec![None],
         [only] => vec![Some(*only)],
         [lhs, rhs] => {
-            let sum = builder.add_op(
+            let sum = builder.add_operation(
                 StdTensorOp::Add,
-                vec![ValRef::Local(*lhs), ValRef::Local(*rhs)],
-                OpMode::Linear {
+                vec![ValueRef::Local(*lhs), ValueRef::Local(*rhs)],
+                OperationRole::Linearized {
                     active_mask: vec![true, true],
                 },
             );
@@ -70,17 +80,17 @@ pub fn linearize_dot_general(
 }
 
 pub fn linearize_reduce_sum(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
     op: &StdTensorOp,
     _axes: &[usize],
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 op.clone(),
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -91,49 +101,49 @@ pub fn linearize_reduce_sum(
 }
 
 pub fn linearize_reduce_prod(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     axes: &[usize],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(dx) = tangent_in[0] else {
         return vec![None];
     };
 
     let input_shape = ctx
-        .shape_of(&ValRef::External(primal_in[0].clone()))
+        .shape_of(&ValueRef::External(primal_in[0].clone()))
         .to_vec();
     let kept_dims = kept_dims(input_shape.len(), axes);
     let prod_broadcast = broadcast_reduction_output(
         builder,
-        ValRef::External(primal_out[0].clone()),
-        ValRef::External(primal_in[0].clone()),
+        ValueRef::External(primal_out[0].clone()),
+        ValueRef::External(primal_in[0].clone()),
         &input_shape,
         &kept_dims,
     );
-    let coeff = builder.add_op(
+    let coeff = builder.add_operation(
         StdTensorOp::Div,
         vec![
-            ValRef::Local(prod_broadcast),
-            ValRef::External(primal_in[0].clone()),
+            ValueRef::Local(prod_broadcast),
+            ValueRef::External(primal_in[0].clone()),
         ],
-        OpMode::Primal,
+        OperationRole::Primary,
     )[0];
-    let scaled_tangent = builder.add_op(
+    let scaled_tangent = builder.add_operation(
         StdTensorOp::Mul,
-        vec![ValRef::Local(coeff), ValRef::Local(dx)],
-        OpMode::Linear {
+        vec![ValueRef::Local(coeff), ValueRef::Local(dx)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0];
-    let out = builder.add_op(
+    let out = builder.add_operation(
         StdTensorOp::ReduceSum {
             axes: axes.to_vec(),
         },
-        vec![ValRef::Local(scaled_tangent)],
-        OpMode::Linear {
+        vec![ValueRef::Local(scaled_tangent)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0];
@@ -141,56 +151,56 @@ pub fn linearize_reduce_prod(
 }
 
 pub fn linearize_reduce_chooser(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     axes: &[usize],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(dx) = tangent_in[0] else {
         return vec![None];
     };
 
     let input_shape = ctx
-        .shape_of(&ValRef::External(primal_in[0].clone()))
+        .shape_of(&ValueRef::External(primal_in[0].clone()))
         .to_vec();
     let kept_dims = kept_dims(input_shape.len(), axes);
     let answer_broadcast = broadcast_reduction_output(
         builder,
-        ValRef::External(primal_out[0].clone()),
-        ValRef::External(primal_in[0].clone()),
+        ValueRef::External(primal_out[0].clone()),
+        ValueRef::External(primal_in[0].clone()),
         &input_shape,
         &kept_dims,
     );
     let indicators = reduction_location_indicators(
         builder,
-        ValRef::External(primal_in[0].clone()),
-        ValRef::Local(answer_broadcast),
+        ValueRef::External(primal_in[0].clone()),
+        ValueRef::Local(answer_broadcast),
     );
-    let input_dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
+    let input_dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
     let numeric_indicators = numeric_indicators(builder, indicators, input_dtype);
-    let weighted_tangent = builder.add_op(
+    let weighted_tangent = builder.add_operation(
         StdTensorOp::Mul,
-        vec![ValRef::Local(numeric_indicators), ValRef::Local(dx)],
-        OpMode::Linear {
+        vec![ValueRef::Local(numeric_indicators), ValueRef::Local(dx)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0];
-    let tangent_sum = builder.add_op(
+    let tangent_sum = builder.add_operation(
         StdTensorOp::ReduceSum {
             axes: axes.to_vec(),
         },
-        vec![ValRef::Local(weighted_tangent)],
-        OpMode::Linear {
+        vec![ValueRef::Local(weighted_tangent)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0];
     let counts = reduction_location_counts(builder, numeric_indicators, axes);
-    let out = builder.add_op(
+    let out = builder.add_operation(
         StdTensorOp::Div,
-        vec![ValRef::Local(tangent_sum), ValRef::Local(counts)],
-        OpMode::Linear {
+        vec![ValueRef::Local(tangent_sum), ValueRef::Local(counts)],
+        OperationRole::Linearized {
             active_mask: vec![true, false],
         },
     )[0];
@@ -198,13 +208,13 @@ pub fn linearize_reduce_chooser(
 }
 
 pub fn transpose_dot_general(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     config: &DotGeneralConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
         None => return vec![None, None],
@@ -214,8 +224,8 @@ pub fn transpose_dot_general(
     let rhs_rank = ctx.shape_of(&inputs[1]).len();
 
     let active_mask = match mode {
-        OpMode::Linear { active_mask } => active_mask,
-        OpMode::Primal => return vec![None, None],
+        OperationRole::Linearized { active_mask } => active_mask,
+        OperationRole::Primary => return vec![None, None],
     };
 
     let lhs_free = compute_free_dims(
@@ -229,54 +239,54 @@ pub fn transpose_dot_general(
         &config.rhs_batch_dims,
     );
     let output_rank = config.lhs_batch_dims.len() + lhs_free.len() + rhs_free.len();
-    let cotangent = normalize_scalar_cotangent(emitter, ct, output_rank);
+    let cotangent = normalize_scalar_cotangent(builder, ct, output_rank);
 
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let rhs_conj = conjugate_primal_if_complex(emitter, inputs[1].clone(), ctx);
+        let rhs_conj = conjugate_primal_if_complex(builder, inputs[1].clone(), ctx);
         let (transpose_config, new_lhs_rank, new_rhs_rank, perm) =
             transpose_plan_for_lhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free);
-        let out = emitter.add_op(
+        let out = builder.add_operation(
             StdTensorOp::DotGeneral {
                 config: transpose_config,
             },
             vec![cotangent.clone(), rhs_conj],
-            OpMode::Linear {
+            OperationRole::Linearized {
                 active_mask: vec![true, false],
             },
         );
         let _ = (new_lhs_rank, new_rhs_rank);
-        result[0] = Some(add_transpose_if_needed(emitter, out[0], &perm));
+        result[0] = Some(add_transpose_if_needed(builder, out[0], &perm));
     }
 
     if active_mask[1] {
-        let lhs_conj = conjugate_primal_if_complex(emitter, inputs[0].clone(), ctx);
+        let lhs_conj = conjugate_primal_if_complex(builder, inputs[0].clone(), ctx);
         let (transpose_config, new_lhs_rank, new_rhs_rank, perm) =
             transpose_plan_for_rhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free);
-        let out = emitter.add_op(
+        let out = builder.add_operation(
             StdTensorOp::DotGeneral {
                 config: transpose_config,
             },
             vec![lhs_conj, cotangent],
-            OpMode::Linear {
+            OperationRole::Linearized {
                 active_mask: vec![false, true],
             },
         );
         let _ = (new_lhs_rank, new_rhs_rank);
-        result[1] = Some(add_transpose_if_needed(emitter, out[0], &perm));
+        result[1] = Some(add_transpose_if_needed(builder, out[0], &perm));
     }
 
     result
 }
 
 pub fn transpose_reduce_sum(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
     op: &StdTensorOp,
-    inputs: &[ValRef<StdTensorOp>],
+    inputs: &[ValueRef<StdTensorOp>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let StdTensorOp::ReduceSum { axes } = op else {
         unreachable!("transpose_reduce_sum expects ReduceSum");
     };
@@ -288,16 +298,16 @@ pub fn transpose_reduce_sum(
                 .filter(|dim| !axes.contains(dim))
                 .collect::<Vec<_>>();
             let cotangent = if kept_dims.is_empty() {
-                let scalar = emitter.add_op(
+                let scalar = builder.add_operation(
                     StdTensorOp::Reshape { to_shape: vec![] },
-                    vec![ValRef::Local(ct)],
-                    OpMode::Linear {
+                    vec![ValueRef::Local(ct)],
+                    OperationRole::Linearized {
                         active_mask: vec![true],
                     },
                 );
-                ValRef::Local(scalar[0])
+                ValueRef::Local(scalar[0])
             } else {
-                ValRef::Local(ct)
+                ValueRef::Local(ct)
             };
             let (shape, needs_shape_source) = sym_shape_to_dim_expr(&input_shape, 1);
             let mut op_inputs = vec![cotangent];
@@ -307,13 +317,13 @@ pub fn transpose_reduce_sum(
             } else {
                 vec![true]
             };
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::BroadcastInDim {
                     shape,
                     dims: kept_dims,
                 },
                 op_inputs,
-                OpMode::Linear { active_mask },
+                OperationRole::Linearized { active_mask },
             );
             vec![Some(out[0])]
         }
@@ -322,12 +332,12 @@ pub fn transpose_reduce_sum(
 }
 
 pub fn transpose_reduce_prod(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
     op: &StdTensorOp,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let StdTensorOp::ReduceProd { axes } = op else {
         unreachable!("transpose_reduce_prod expects ReduceProd");
     };
@@ -336,7 +346,7 @@ pub fn transpose_reduce_prod(
         Some(ct) => {
             let input_shape = ctx.shape_of(&inputs[0]).to_vec();
             let kept_dims = kept_dims(input_shape.len(), axes);
-            let cotangent = normalize_reduction_cotangent(emitter, ct, &kept_dims);
+            let cotangent = normalize_reduction_cotangent(builder, ct, &kept_dims);
             let (shape, needs_shape_source) = sym_shape_to_dim_expr(&input_shape, 1);
             let mut op_inputs = vec![cotangent];
             let active_mask = if needs_shape_source {
@@ -345,34 +355,36 @@ pub fn transpose_reduce_prod(
             } else {
                 vec![true]
             };
-            let cotangent = emitter.add_op(
+            let cotangent = builder.add_operation(
                 StdTensorOp::BroadcastInDim {
                     shape,
                     dims: kept_dims.clone(),
                 },
                 op_inputs,
-                OpMode::Linear { active_mask },
+                OperationRole::Linearized { active_mask },
             )[0];
-            let prod = emitter.add_op(op.clone(), vec![inputs[0].clone()], OpMode::Primal)[0];
+            let prod =
+                builder.add_operation(op.clone(), vec![inputs[0].clone()], OperationRole::Primary)
+                    [0];
             let prod_broadcast = broadcast_reduction_output(
-                emitter,
-                ValRef::Local(prod),
+                builder,
+                ValueRef::Local(prod),
                 inputs[0].clone(),
                 &input_shape,
                 &kept_dims,
             );
-            let coeff = emitter.add_op(
+            let coeff = builder.add_operation(
                 StdTensorOp::Div,
-                vec![ValRef::Local(prod_broadcast), inputs[0].clone()],
-                OpMode::Primal,
+                vec![ValueRef::Local(prod_broadcast), inputs[0].clone()],
+                OperationRole::Primary,
             )[0];
             let input_dtype = ctx.dtype_of(&inputs[0]);
             let coeff_conj =
-                conjugate_primal_if_dtype_complex(emitter, ValRef::Local(coeff), input_dtype);
-            let out = emitter.add_op(
+                conjugate_primal_if_dtype_complex(builder, ValueRef::Local(coeff), input_dtype);
+            let out = builder.add_operation(
                 StdTensorOp::Mul,
-                vec![coeff_conj, ValRef::Local(cotangent)],
-                OpMode::Linear {
+                vec![coeff_conj, ValueRef::Local(cotangent)],
+                OperationRole::Linearized {
                     active_mask: vec![false, true],
                 },
             )[0];
@@ -383,12 +395,12 @@ pub fn transpose_reduce_prod(
 }
 
 pub fn transpose_reduce_chooser(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
     op: &StdTensorOp,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let axes = match op {
         StdTensorOp::ReduceMax { axes } | StdTensorOp::ReduceMin { axes } => axes,
         _ => unreachable!("transpose_reduce_chooser expects ReduceMax or ReduceMin"),
@@ -398,7 +410,7 @@ pub fn transpose_reduce_chooser(
         Some(ct) => {
             let input_shape = ctx.shape_of(&inputs[0]).to_vec();
             let kept_dims = kept_dims(input_shape.len(), axes);
-            let cotangent = normalize_reduction_cotangent(emitter, ct, &kept_dims);
+            let cotangent = normalize_reduction_cotangent(builder, ct, &kept_dims);
             let (shape, needs_shape_source) = sym_shape_to_dim_expr(&input_shape, 1);
             let mut op_inputs = vec![cotangent];
             let active_mask = if needs_shape_source {
@@ -407,51 +419,53 @@ pub fn transpose_reduce_chooser(
             } else {
                 vec![true]
             };
-            let cotangent = emitter.add_op(
+            let cotangent = builder.add_operation(
                 StdTensorOp::BroadcastInDim {
                     shape,
                     dims: kept_dims.clone(),
                 },
                 op_inputs,
-                OpMode::Linear { active_mask },
+                OperationRole::Linearized { active_mask },
             )[0];
-            let answer = emitter.add_op(op.clone(), vec![inputs[0].clone()], OpMode::Primal)[0];
+            let answer =
+                builder.add_operation(op.clone(), vec![inputs[0].clone()], OperationRole::Primary)
+                    [0];
             let answer_broadcast = broadcast_reduction_output(
-                emitter,
-                ValRef::Local(answer),
+                builder,
+                ValueRef::Local(answer),
                 inputs[0].clone(),
                 &input_shape,
                 &kept_dims,
             );
             let indicators = reduction_location_indicators(
-                emitter,
+                builder,
                 inputs[0].clone(),
-                ValRef::Local(answer_broadcast),
+                ValueRef::Local(answer_broadcast),
             );
             let input_dtype = ctx.dtype_of(&inputs[0]);
-            let numeric_indicators = numeric_indicators(emitter, indicators, input_dtype);
-            let counts = reduction_location_counts(emitter, numeric_indicators, axes);
+            let numeric_indicators = numeric_indicators(builder, indicators, input_dtype);
+            let counts = reduction_location_counts(builder, numeric_indicators, axes);
             let counts_broadcast = broadcast_reduction_output(
-                emitter,
-                ValRef::Local(counts),
+                builder,
+                ValueRef::Local(counts),
                 inputs[0].clone(),
                 &input_shape,
                 &kept_dims,
             );
-            let weights = emitter.add_op(
+            let weights = builder.add_operation(
                 StdTensorOp::Div,
                 vec![
-                    ValRef::Local(numeric_indicators),
-                    ValRef::Local(counts_broadcast),
+                    ValueRef::Local(numeric_indicators),
+                    ValueRef::Local(counts_broadcast),
                 ],
-                OpMode::Primal,
+                OperationRole::Primary,
             )[0];
             let weights_conj =
-                conjugate_primal_if_dtype_complex(emitter, ValRef::Local(weights), input_dtype);
-            let out = emitter.add_op(
+                conjugate_primal_if_dtype_complex(builder, ValueRef::Local(weights), input_dtype);
+            let out = builder.add_operation(
                 StdTensorOp::Mul,
-                vec![weights_conj, ValRef::Local(cotangent)],
-                OpMode::Linear {
+                vec![weights_conj, ValueRef::Local(cotangent)],
+                OperationRole::Linearized {
                     active_mask: vec![false, true],
                 },
             )[0];
@@ -502,104 +516,104 @@ fn sym_shape_to_dim_expr(shape: &[SymDim], source_idx: usize) -> (Vec<DimExpr>, 
 }
 
 fn normalize_reduction_cotangent(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent: LocalValueId,
     kept_dims: &[usize],
-) -> ValRef<StdTensorOp> {
+) -> ValueRef<StdTensorOp> {
     if kept_dims.is_empty() {
-        let scalar = emitter.add_op(
+        let scalar = builder.add_operation(
             StdTensorOp::Reshape { to_shape: vec![] },
-            vec![ValRef::Local(cotangent)],
-            OpMode::Linear {
+            vec![ValueRef::Local(cotangent)],
+            OperationRole::Linearized {
                 active_mask: vec![true],
             },
         );
-        ValRef::Local(scalar[0])
+        ValueRef::Local(scalar[0])
     } else {
-        ValRef::Local(cotangent)
+        ValueRef::Local(cotangent)
     }
 }
 
 fn broadcast_reduction_output(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    output: ValRef<StdTensorOp>,
-    shape_source: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    output: ValueRef<StdTensorOp>,
+    shape_source: ValueRef<StdTensorOp>,
     input_shape: &[SymDim],
     kept_dims: &[usize],
-) -> LocalValId {
+) -> LocalValueId {
     let (shape, needs_shape_source) = sym_shape_to_dim_expr(input_shape, 1);
     let inputs = if needs_shape_source {
         vec![output, shape_source]
     } else {
         vec![output]
     };
-    emitter.add_op(
+    builder.add_operation(
         StdTensorOp::BroadcastInDim {
             shape,
             dims: kept_dims.to_vec(),
         },
         inputs,
-        OpMode::Primal,
+        OperationRole::Primary,
     )[0]
 }
 
 fn reduction_location_indicators(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
-    answer_broadcast: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emitter.add_op(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+    answer_broadcast: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::Compare(CompareDir::Eq),
         vec![input, answer_broadcast],
-        OpMode::Primal,
+        OperationRole::Primary,
     )[0]
 }
 
 fn reduction_location_counts(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    indicators: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    indicators: LocalValueId,
     axes: &[usize],
-) -> LocalValId {
-    emitter.add_op(
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::ReduceSum {
             axes: axes.to_vec(),
         },
-        vec![ValRef::Local(indicators)],
-        OpMode::Primal,
+        vec![ValueRef::Local(indicators)],
+        OperationRole::Primary,
     )[0]
 }
 
 fn numeric_indicators(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    indicators: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    indicators: LocalValueId,
     dtype: DType,
-) -> LocalValId {
-    emitter.add_op(
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::Convert {
             from: DType::Bool,
             to: dtype,
         },
-        vec![ValRef::Local(indicators)],
-        OpMode::Primal,
+        vec![ValueRef::Local(indicators)],
+        OperationRole::Primary,
     )[0]
 }
 
 fn normalize_scalar_cotangent(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent: LocalValueId,
     output_rank: usize,
-) -> ValRef<StdTensorOp> {
+) -> ValueRef<StdTensorOp> {
     if output_rank == 0 {
-        let scalar = emitter.add_op(
+        let scalar = builder.add_operation(
             StdTensorOp::Reshape { to_shape: vec![] },
-            vec![ValRef::Local(cotangent)],
-            OpMode::Linear {
+            vec![ValueRef::Local(cotangent)],
+            OperationRole::Linearized {
                 active_mask: vec![true],
             },
         );
-        ValRef::Local(scalar[0])
+        ValueRef::Local(scalar[0])
     } else {
-        ValRef::Local(cotangent)
+        ValueRef::Local(cotangent)
     }
 }
 
@@ -699,20 +713,20 @@ fn permutation_to_original_order(rank: usize, result_order: &[usize]) -> Vec<usi
 }
 
 fn add_transpose_if_needed(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    input: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
     perm: &[usize],
-) -> LocalValId {
+) -> LocalValueId {
     if perm.iter().enumerate().all(|(dim, &axis)| dim == axis) {
         return input;
     }
 
-    let out = emitter.add_op(
+    let out = builder.add_operation(
         StdTensorOp::Transpose {
             perm: perm.to_vec(),
         },
-        vec![ValRef::Local(input)],
-        OpMode::Linear {
+        vec![ValueRef::Local(input)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     );

--- a/tenferro-internal-ops/src/ad/diagonal.rs
+++ b/tenferro-internal-ops/src/ad/diagonal.rs
@@ -1,21 +1,21 @@
-use computegraph::types::{LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use crate::ad::PrimitiveRuleBuilder;
+use computegraph::types::{LocalValueId, OperationRole, ValueRef};
 
 use crate::std_tensor_op::StdTensorOp;
 
 pub fn linearize_extract_diag(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
     axis_a: usize,
     axis_b: usize,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     // TODO: ExtractDiag/EmbedDiag could be replaced by Gather/Scatter
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::ExtractDiag { axis_a, axis_b },
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -26,18 +26,18 @@ pub fn linearize_extract_diag(
 }
 
 pub fn linearize_embed_diag(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
     axis_a: usize,
     axis_b: usize,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     // TODO: ExtractDiag/EmbedDiag could be replaced by Gather/Scatter
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::EmbedDiag { axis_a, axis_b },
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -48,18 +48,18 @@ pub fn linearize_embed_diag(
 }
 
 pub fn transpose_extract_diag(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
     axis_a: usize,
     axis_b: usize,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     // TODO: ExtractDiag/EmbedDiag could be replaced by Gather/Scatter
     match cotangent_out[0] {
         Some(ct) => {
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::EmbedDiag { axis_a, axis_b },
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -70,18 +70,18 @@ pub fn transpose_extract_diag(
 }
 
 pub fn transpose_embed_diag(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
     axis_a: usize,
     axis_b: usize,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     // TODO: ExtractDiag/EmbedDiag could be replaced by Gather/Scatter
     match cotangent_out[0] {
         Some(ct) => {
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::ExtractDiag { axis_a, axis_b },
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );

--- a/tenferro-internal-ops/src/ad/dynamic.rs
+++ b/tenferro-internal-ops/src/ad/dynamic.rs
@@ -1,18 +1,18 @@
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::SliceConfig;
 
 use crate::ad::context::ShapeGuardContext;
+use crate::ad::PrimitiveRuleBuilder;
 use crate::std_tensor_op::StdTensorOp;
 
 pub fn linearize_dynamic_truncate(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     axis: usize,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
             // Checkpointed dynamic truncation records the concrete runtime
@@ -21,24 +21,27 @@ pub fn linearize_dynamic_truncate(
             // shape instead of the pre-truncation static upper bound.
             if let Some(limits) = static_truncated_shape(primal_in, primal_out, axis, ctx) {
                 let rank = limits.len();
-                let out = builder.add_op(
+                let out = builder.add_operation(
                     StdTensorOp::Slice(SliceConfig {
                         starts: vec![0; rank],
                         limits,
                         strides: vec![1; rank],
                     }),
-                    vec![ValRef::Local(dx)],
-                    OpMode::Linear {
+                    vec![ValueRef::Local(dx)],
+                    OperationRole::Linearized {
                         active_mask: vec![true],
                     },
                 );
                 return vec![Some(out[0])];
             }
 
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::DynamicTruncate { axis },
-                vec![ValRef::Local(dx), ValRef::External(primal_in[1].clone())],
-                OpMode::Linear {
+                vec![
+                    ValueRef::Local(dx),
+                    ValueRef::External(primal_in[1].clone()),
+                ],
+                OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
             );
@@ -49,17 +52,17 @@ pub fn linearize_dynamic_truncate(
 }
 
 pub fn transpose_dynamic_truncate(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
     axis: usize,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match cotangent_out[0] {
         Some(ct) => {
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::PadToMatch { axis },
-                vec![ValRef::Local(ct), inputs[0].clone()],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct), inputs[0].clone()],
+                OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
             );
@@ -70,17 +73,20 @@ pub fn transpose_dynamic_truncate(
 }
 
 pub fn linearize_pad_to_match(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     axis: usize,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::PadToMatch { axis },
-                vec![ValRef::Local(dx), ValRef::External(primal_in[1].clone())],
-                OpMode::Linear {
+                vec![
+                    ValueRef::Local(dx),
+                    ValueRef::External(primal_in[1].clone()),
+                ],
+                OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
             );
@@ -91,13 +97,13 @@ pub fn linearize_pad_to_match(
 }
 
 pub fn transpose_pad_to_match(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     axis: usize,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None, None];
     };
@@ -120,14 +126,14 @@ pub fn transpose_pad_to_match(
             .collect::<Option<Vec<_>>>()
         {
             let rank = limits.len();
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Slice(SliceConfig {
                     starts: vec![0; rank],
                     limits,
                     strides: vec![1; rank],
                 }),
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -135,41 +141,41 @@ pub fn transpose_pad_to_match(
         }
     }
 
-    let size = emitter.add_op(
+    let size = builder.add_operation(
         StdTensorOp::ShapeOf { axis },
         vec![inputs[0].clone()],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![false],
         },
     );
-    let out = emitter.add_op(
+    let out = builder.add_operation(
         StdTensorOp::DynamicTruncate { axis },
-        vec![ValRef::Local(ct), ValRef::Local(size[0])],
-        OpMode::Linear {
+        vec![ValueRef::Local(ct), ValueRef::Local(size[0])],
+        OperationRole::Linearized {
             active_mask: vec![true, false],
         },
     );
     vec![Some(out[0]), None]
 }
 
-fn first_input_active(mode: &OpMode) -> bool {
+fn first_input_active(mode: &OperationRole) -> bool {
     matches!(
         mode,
-        OpMode::Linear { active_mask } if active_mask.first().copied().unwrap_or(false)
+        OperationRole::Linearized { active_mask } if active_mask.first().copied().unwrap_or(false)
     )
 }
 
 fn static_truncated_shape(
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
     axis: usize,
     ctx: &mut ShapeGuardContext,
 ) -> Option<Vec<usize>> {
     let input_shape = ctx
-        .try_shape_of(&ValRef::External(primal_in[0].clone()))?
+        .try_shape_of(&ValueRef::External(primal_in[0].clone()))?
         .to_vec();
     let output_shape = ctx
-        .try_shape_of(&ValRef::External(primal_out[0].clone()))?
+        .try_shape_of(&ValueRef::External(primal_out[0].clone()))?
         .to_vec();
     if axis >= input_shape.len() || input_shape.len() != output_shape.len() {
         return None;

--- a/tenferro-internal-ops/src/ad/elementwise.rs
+++ b/tenferro-internal-ops/src/ad/elementwise.rs
@@ -1,176 +1,183 @@
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use crate::ad::PrimitiveRuleBuilder;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::CompareDir;
 
 use crate::std_tensor_op::StdTensorOp;
 
 fn emit_fixed_unary(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     op: StdTensorOp,
-    input: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emitter.add_op(
+    input: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    builder.add_operation(
         op,
         vec![input],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![false],
         },
     )[0]
 }
 
 fn emit_fixed_binary(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     op: StdTensorOp,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emitter.add_op(
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    builder.add_operation(
         op,
         vec![lhs, rhs],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![false, false],
         },
     )[0]
 }
 
 fn emit_fixed_neg(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emit_fixed_unary(emitter, StdTensorOp::Neg, input)
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    emit_fixed_unary(builder, StdTensorOp::Neg, input)
 }
 
 fn emit_fixed_div(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emit_fixed_binary(emitter, StdTensorOp::Div, lhs, rhs)
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    emit_fixed_binary(builder, StdTensorOp::Div, lhs, rhs)
 }
 
 fn emit_fixed_compare(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     dir: CompareDir,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emit_fixed_binary(emitter, StdTensorOp::Compare(dir), lhs, rhs)
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    emit_fixed_binary(builder, StdTensorOp::Compare(dir), lhs, rhs)
 }
 
 fn emit_linear_mul_fixed(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    fixed: ValRef<StdTensorOp>,
-    active: LocalValId,
-) -> LocalValId {
-    emitter.add_op(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    fixed: ValueRef<StdTensorOp>,
+    active: LocalValueId,
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::Mul,
-        vec![fixed, ValRef::Local(active)],
-        OpMode::Linear {
+        vec![fixed, ValueRef::Local(active)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0]
 }
 
 fn emit_linear_select(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    condition: ValRef<StdTensorOp>,
-    on_true: LocalValId,
-    on_false: LocalValId,
-) -> LocalValId {
-    emitter.add_op(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    condition: ValueRef<StdTensorOp>,
+    on_true: LocalValueId,
+    on_false: LocalValueId,
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::Select,
-        vec![condition, ValRef::Local(on_true), ValRef::Local(on_false)],
-        OpMode::Linear {
+        vec![
+            condition,
+            ValueRef::Local(on_true),
+            ValueRef::Local(on_false),
+        ],
+        OperationRole::Linearized {
             active_mask: vec![false, true, true],
         },
     )[0]
 }
 
 fn emit_zero_from_active(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    active: LocalValId,
-) -> LocalValId {
-    let neg = emitter.add_op(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    active: LocalValueId,
+) -> LocalValueId {
+    let neg = builder.add_operation(
         StdTensorOp::Neg,
-        vec![ValRef::Local(active)],
-        OpMode::Linear {
+        vec![ValueRef::Local(active)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     );
-    emitter.add_op(
+    builder.add_operation(
         StdTensorOp::Add,
-        vec![ValRef::Local(active), ValRef::Local(neg[0])],
-        OpMode::Linear {
+        vec![ValueRef::Local(active), ValueRef::Local(neg[0])],
+        OperationRole::Linearized {
             active_mask: vec![true, true],
         },
     )[0]
 }
 
 fn select_tangents(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    condition: ValRef<StdTensorOp>,
-    on_true: Option<LocalValId>,
-    on_false: Option<LocalValId>,
-) -> Option<LocalValId> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    condition: ValueRef<StdTensorOp>,
+    on_true: Option<LocalValueId>,
+    on_false: Option<LocalValueId>,
+) -> Option<LocalValueId> {
     match (on_true, on_false) {
-        (Some(t), Some(f)) => Some(emit_linear_select(emitter, condition, t, f)),
+        (Some(t), Some(f)) => Some(emit_linear_select(builder, condition, t, f)),
         (Some(t), None) => {
-            let zero = emit_zero_from_active(emitter, t);
-            Some(emit_linear_select(emitter, condition, t, zero))
+            let zero = emit_zero_from_active(builder, t);
+            Some(emit_linear_select(builder, condition, t, zero))
         }
         (None, Some(f)) => {
-            let zero = emit_zero_from_active(emitter, f);
-            Some(emit_linear_select(emitter, condition, zero, f))
+            let zero = emit_zero_from_active(builder, f);
+            Some(emit_linear_select(builder, condition, zero, f))
         }
         (None, None) => None,
     }
 }
 
 fn split_cotangent_by_mask(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    condition: ValRef<StdTensorOp>,
-    cotangent: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    condition: ValueRef<StdTensorOp>,
+    cotangent: LocalValueId,
     true_active: bool,
     false_active: bool,
-) -> (Option<LocalValId>, Option<LocalValId>) {
+) -> (Option<LocalValueId>, Option<LocalValueId>) {
     if !true_active && !false_active {
         return (None, None);
     }
 
-    let zero = emit_zero_from_active(emitter, cotangent);
+    let zero = emit_zero_from_active(builder, cotangent);
     let true_ct =
-        true_active.then(|| emit_linear_select(emitter, condition.clone(), cotangent, zero));
-    let false_ct = false_active.then(|| emit_linear_select(emitter, condition, zero, cotangent));
+        true_active.then(|| emit_linear_select(builder, condition.clone(), cotangent, zero));
+    let false_ct = false_active.then(|| emit_linear_select(builder, condition, zero, cotangent));
     (true_ct, false_ct)
 }
 
-fn unary_is_active(mode: &OpMode) -> bool {
+fn unary_is_active(mode: &OperationRole) -> bool {
     match mode {
-        OpMode::Linear { active_mask } => active_mask[0],
-        OpMode::Primal => false,
+        OperationRole::Linearized { active_mask } => active_mask[0],
+        OperationRole::Primary => false,
     }
 }
 
-fn active_mask(mode: &OpMode, len: usize) -> Vec<bool> {
+fn active_mask(mode: &OperationRole, len: usize) -> Vec<bool> {
     match mode {
-        OpMode::Linear { active_mask } => active_mask.clone(),
-        OpMode::Primal => vec![false; len],
+        OperationRole::Linearized { active_mask } => active_mask.clone(),
+        OperationRole::Primary => vec![false; len],
     }
 }
 
 pub fn linearize_div(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     let mut terms = Vec::with_capacity(2);
 
     if let Some(dx) = tangent_in[0] {
-        let out = builder.add_op(
+        let out = builder.add_operation(
             StdTensorOp::Div,
-            vec![ValRef::Local(dx), ValRef::External(primal_in[1].clone())],
-            OpMode::Linear {
+            vec![
+                ValueRef::Local(dx),
+                ValueRef::External(primal_in[1].clone()),
+            ],
+            OperationRole::Linearized {
                 active_mask: vec![true, false],
             },
         );
@@ -180,21 +187,25 @@ pub fn linearize_div(
     if let Some(dy) = tangent_in[1] {
         let quotient_over_rhs = emit_fixed_div(
             builder,
-            ValRef::External(primal_out[0].clone()),
-            ValRef::External(primal_in[1].clone()),
+            ValueRef::External(primal_out[0].clone()),
+            ValueRef::External(primal_in[1].clone()),
         );
-        let neg_coeff = emit_fixed_neg(builder, ValRef::Local(quotient_over_rhs));
-        terms.push(emit_linear_mul_fixed(builder, ValRef::Local(neg_coeff), dy));
+        let neg_coeff = emit_fixed_neg(builder, ValueRef::Local(quotient_over_rhs));
+        terms.push(emit_linear_mul_fixed(
+            builder,
+            ValueRef::Local(neg_coeff),
+            dy,
+        ));
     }
 
     match terms.as_slice() {
         [] => vec![None],
         [only] => vec![Some(*only)],
         [lhs, rhs] => {
-            let sum = builder.add_op(
+            let sum = builder.add_operation(
                 StdTensorOp::Add,
-                vec![ValRef::Local(*lhs), ValRef::Local(*rhs)],
-                OpMode::Linear {
+                vec![ValueRef::Local(*lhs), ValueRef::Local(*rhs)],
+                OperationRole::Linearized {
                     active_mask: vec![true, true],
                 },
             );
@@ -205,20 +216,20 @@ pub fn linearize_div(
 }
 
 pub fn linearize_abs(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
             let sign_x = emit_fixed_unary(
                 builder,
                 StdTensorOp::Sign,
-                ValRef::External(primal_in[0].clone()),
+                ValueRef::External(primal_in[0].clone()),
             );
             vec![Some(emit_linear_mul_fixed(
                 builder,
-                ValRef::Local(sign_x),
+                ValueRef::Local(sign_x),
                 dx,
             ))]
         }
@@ -227,9 +238,9 @@ pub fn linearize_abs(
 }
 
 pub fn linearize_sign(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => vec![Some(emit_zero_from_active(builder, dx))],
         None => vec![None],
@@ -237,10 +248,10 @@ pub fn linearize_sign(
 }
 
 pub fn linearize_maximum(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     if tangent_in[0].is_none() && tangent_in[1].is_none() {
         return vec![None];
     }
@@ -248,22 +259,22 @@ pub fn linearize_maximum(
     let mask = emit_fixed_compare(
         builder,
         CompareDir::Ge,
-        ValRef::External(primal_in[0].clone()),
-        ValRef::External(primal_in[1].clone()),
+        ValueRef::External(primal_in[0].clone()),
+        ValueRef::External(primal_in[1].clone()),
     );
     vec![select_tangents(
         builder,
-        ValRef::Local(mask),
+        ValueRef::Local(mask),
         tangent_in[0],
         tangent_in[1],
     )]
 }
 
 pub fn linearize_minimum(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     if tangent_in[0].is_none() && tangent_in[1].is_none() {
         return vec![None];
     }
@@ -271,35 +282,35 @@ pub fn linearize_minimum(
     let mask = emit_fixed_compare(
         builder,
         CompareDir::Le,
-        ValRef::External(primal_in[0].clone()),
-        ValRef::External(primal_in[1].clone()),
+        ValueRef::External(primal_in[0].clone()),
+        ValueRef::External(primal_in[1].clone()),
     );
     vec![select_tangents(
         builder,
-        ValRef::Local(mask),
+        ValueRef::Local(mask),
         tangent_in[0],
         tangent_in[1],
     )]
 }
 
 pub fn linearize_select(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     vec![select_tangents(
         builder,
-        ValRef::External(primal_in[0].clone()),
+        ValueRef::External(primal_in[0].clone()),
         tangent_in[1],
         tangent_in[2],
     )]
 }
 
 pub fn linearize_clamp(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     if tangent_in.iter().all(Option::is_none) {
         return vec![None];
     }
@@ -307,12 +318,12 @@ pub fn linearize_clamp(
     let upper_mask = emit_fixed_compare(
         builder,
         CompareDir::Le,
-        ValRef::External(primal_in[0].clone()),
-        ValRef::External(primal_in[2].clone()),
+        ValueRef::External(primal_in[0].clone()),
+        ValueRef::External(primal_in[2].clone()),
     );
     let inner_tangent = select_tangents(
         builder,
-        ValRef::Local(upper_mask),
+        ValueRef::Local(upper_mask),
         tangent_in[0],
         tangent_in[2],
     );
@@ -320,47 +331,47 @@ pub fn linearize_clamp(
     let inner_primal = emit_fixed_binary(
         builder,
         StdTensorOp::Minimum,
-        ValRef::External(primal_in[0].clone()),
-        ValRef::External(primal_in[2].clone()),
+        ValueRef::External(primal_in[0].clone()),
+        ValueRef::External(primal_in[2].clone()),
     );
     let lower_mask = emit_fixed_compare(
         builder,
         CompareDir::Ge,
-        ValRef::External(primal_in[1].clone()),
-        ValRef::Local(inner_primal),
+        ValueRef::External(primal_in[1].clone()),
+        ValueRef::Local(inner_primal),
     );
 
     vec![select_tangents(
         builder,
-        ValRef::Local(lower_mask),
+        ValueRef::Local(lower_mask),
         tangent_in[1],
         inner_tangent,
     )]
 }
 
 pub fn transpose_div(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
         None => return vec![None, None],
     };
 
     let active_mask = match mode {
-        OpMode::Linear { active_mask } => active_mask,
-        OpMode::Primal => return vec![None, None],
+        OperationRole::Linearized { active_mask } => active_mask,
+        OperationRole::Primary => return vec![None, None],
     };
 
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let out = emitter.add_op(
+        let out = builder.add_operation(
             StdTensorOp::Div,
-            vec![ValRef::Local(ct), inputs[1].clone()],
-            OpMode::Linear {
+            vec![ValueRef::Local(ct), inputs[1].clone()],
+            OperationRole::Linearized {
                 active_mask: vec![true, false],
             },
         );
@@ -368,30 +379,30 @@ pub fn transpose_div(
     }
 
     if active_mask[1] {
-        let quotient = emit_fixed_div(emitter, inputs[0].clone(), inputs[1].clone());
-        let neg_quotient = emit_fixed_neg(emitter, ValRef::Local(quotient));
-        let coeff = emit_fixed_div(emitter, ValRef::Local(neg_quotient), inputs[1].clone());
-        result[1] = Some(emit_linear_mul_fixed(emitter, ValRef::Local(coeff), ct));
+        let quotient = emit_fixed_div(builder, inputs[0].clone(), inputs[1].clone());
+        let neg_quotient = emit_fixed_neg(builder, ValueRef::Local(quotient));
+        let coeff = emit_fixed_div(builder, ValueRef::Local(neg_quotient), inputs[1].clone());
+        result[1] = Some(emit_linear_mul_fixed(builder, ValueRef::Local(coeff), ct));
     }
 
     result
 }
 
 pub fn transpose_abs(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let sign_x = emit_fixed_unary(emitter, StdTensorOp::Sign, inputs[0].clone());
+            let sign_x = emit_fixed_unary(builder, StdTensorOp::Sign, inputs[0].clone());
             vec![Some(emit_linear_mul_fixed(
-                emitter,
-                ValRef::Local(sign_x),
+                builder,
+                ValueRef::Local(sign_x),
                 ct,
             ))]
         }
@@ -400,25 +411,25 @@ pub fn transpose_abs(
 }
 
 pub fn transpose_sign(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
-        Some(ct) => vec![Some(emit_zero_from_active(emitter, ct))],
+        Some(ct) => vec![Some(emit_zero_from_active(builder, ct))],
         None => vec![None],
     }
 }
 
 pub fn transpose_maximum(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None, None];
     };
@@ -427,7 +438,7 @@ pub fn transpose_maximum(
         return vec![None, None];
     }
     let mask = emit_fixed_compare(
-        emitter,
+        builder,
         CompareDir::Ge,
         inputs[0].clone(),
         inputs[1].clone(),
@@ -435,16 +446,16 @@ pub fn transpose_maximum(
     let lhs_active = active.first().copied().unwrap_or(false);
     let rhs_active = active.get(1).copied().unwrap_or(false);
     let (lhs, rhs) =
-        split_cotangent_by_mask(emitter, ValRef::Local(mask), ct, lhs_active, rhs_active);
+        split_cotangent_by_mask(builder, ValueRef::Local(mask), ct, lhs_active, rhs_active);
     vec![lhs, rhs]
 }
 
 pub fn transpose_minimum(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None, None];
     };
@@ -453,7 +464,7 @@ pub fn transpose_minimum(
         return vec![None, None];
     }
     let mask = emit_fixed_compare(
-        emitter,
+        builder,
         CompareDir::Le,
         inputs[0].clone(),
         inputs[1].clone(),
@@ -461,16 +472,16 @@ pub fn transpose_minimum(
     let lhs_active = active.first().copied().unwrap_or(false);
     let rhs_active = active.get(1).copied().unwrap_or(false);
     let (lhs, rhs) =
-        split_cotangent_by_mask(emitter, ValRef::Local(mask), ct, lhs_active, rhs_active);
+        split_cotangent_by_mask(builder, ValueRef::Local(mask), ct, lhs_active, rhs_active);
     vec![lhs, rhs]
 }
 
 pub fn transpose_select(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None, None, None];
     };
@@ -481,16 +492,16 @@ pub fn transpose_select(
         return vec![None, None, None];
     }
     let (on_true, on_false) =
-        split_cotangent_by_mask(emitter, inputs[0].clone(), ct, true_active, false_active);
+        split_cotangent_by_mask(builder, inputs[0].clone(), ct, true_active, false_active);
     vec![None, on_true, on_false]
 }
 
 pub fn transpose_clamp(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None, None, None];
     };
@@ -503,20 +514,20 @@ pub fn transpose_clamp(
     let upper_active = active.get(2).copied().unwrap_or(false);
 
     let inner_primal = emit_fixed_binary(
-        emitter,
+        builder,
         StdTensorOp::Minimum,
         inputs[0].clone(),
         inputs[2].clone(),
     );
     let lower_mask = emit_fixed_compare(
-        emitter,
+        builder,
         CompareDir::Ge,
         inputs[1].clone(),
-        ValRef::Local(inner_primal),
+        ValueRef::Local(inner_primal),
     );
     let (lower_ct, inner_ct) = split_cotangent_by_mask(
-        emitter,
-        ValRef::Local(lower_mask),
+        builder,
+        ValueRef::Local(lower_mask),
         ct,
         lower_active,
         input_active || upper_active,
@@ -525,14 +536,14 @@ pub fn transpose_clamp(
     let (input_ct, upper_ct) = match inner_ct {
         Some(inner_ct) => {
             let upper_mask = emit_fixed_compare(
-                emitter,
+                builder,
                 CompareDir::Le,
                 inputs[0].clone(),
                 inputs[2].clone(),
             );
             split_cotangent_by_mask(
-                emitter,
-                ValRef::Local(upper_mask),
+                builder,
+                ValueRef::Local(upper_mask),
                 inner_ct,
                 input_active,
                 upper_active,

--- a/tenferro-internal-ops/src/ad/indexing.rs
+++ b/tenferro-internal-ops/src/ad/indexing.rs
@@ -24,12 +24,12 @@
 //! Closing the core op vocabulary under AD is a Stage 7 prerequisite (the
 //! tropical fused backward emits `Gather` / `Scatter` on this vocabulary).
 
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{GatherConfig, ScatterConfig};
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::zeros::build_zero_like;
+use crate::ad::PrimitiveRuleBuilder;
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
@@ -40,20 +40,20 @@ use crate::sym_dim::SymDim;
 /// is ignored. The output tangent is the same gather applied to the
 /// operand's tangent, reusing the primal indices.
 pub fn linearize_gather(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     config: &GatherConfig,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(d_operand) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Gather(config.clone()),
                 vec![
-                    ValRef::Local(d_operand),
-                    ValRef::External(primal_in[1].clone()),
+                    ValueRef::Local(d_operand),
+                    ValueRef::External(primal_in[1].clone()),
                 ],
-                OpMode::Linear {
+                OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
             );
@@ -69,25 +69,25 @@ pub fn linearize_gather(
 /// shape-source inputs are non-differentiable and are reused from the primal.
 #[allow(clippy::too_many_arguments)]
 pub fn linearize_gather_dynamic_slice_sizes(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     offset_dims: &[usize],
     collapsed_slice_dims: &[usize],
     start_index_map: &[usize],
     index_vector_dim: usize,
     slice_sizes: &[DimExpr],
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(d_operand) => {
             let mut inputs = Vec::with_capacity(primal_in.len());
-            inputs.push(ValRef::Local(d_operand));
-            inputs.extend(primal_in.iter().skip(1).cloned().map(ValRef::External));
+            inputs.push(ValueRef::Local(d_operand));
+            inputs.extend(primal_in.iter().skip(1).cloned().map(ValueRef::External));
 
             let mut active_mask = vec![false; primal_in.len()];
             active_mask[0] = true;
 
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::GatherDynamicSliceSizes {
                     offset_dims: offset_dims.to_vec(),
                     collapsed_slice_dims: collapsed_slice_dims.to_vec(),
@@ -96,7 +96,7 @@ pub fn linearize_gather_dynamic_slice_sizes(
                     slice_sizes: slice_sizes.to_vec(),
                 },
                 inputs,
-                OpMode::Linear { active_mask },
+                OperationRole::Linearized { active_mask },
             );
             vec![Some(out[0])]
         }
@@ -109,22 +109,22 @@ pub fn linearize_gather_dynamic_slice_sizes(
 /// The source tensor tangent flows through the same dynamic slice. Runtime
 /// start indices are integer-valued and non-differentiable.
 pub fn linearize_dynamic_slice(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     slice_sizes: &[usize],
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(d_operand) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::DynamicSlice {
                     slice_sizes: slice_sizes.to_vec(),
                 },
                 vec![
-                    ValRef::Local(d_operand),
-                    ValRef::External(primal_in[1].clone()),
+                    ValueRef::Local(d_operand),
+                    ValueRef::External(primal_in[1].clone()),
                 ],
-                OpMode::Linear {
+                OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
             );
@@ -139,17 +139,17 @@ pub fn linearize_dynamic_slice(
 /// The operand and update inputs are differentiable. Runtime start indices are
 /// integer-valued and non-differentiable.
 pub fn linearize_dynamic_update_slice(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     if tangent_in[0].is_none() && tangent_in[1].is_none() {
         return vec![None];
     }
 
-    let operand = ValRef::External(primal_in[0].clone());
-    let update = ValRef::External(primal_in[1].clone());
+    let operand = ValueRef::External(primal_in[0].clone());
+    let update = ValueRef::External(primal_in[1].clone());
     let d_operand = tangent_in[0].unwrap_or_else(|| {
         let meta = ctx.metadata_of(&operand);
         build_zero_like(builder, meta.dtype, operand, meta.shape.len())
@@ -159,14 +159,14 @@ pub fn linearize_dynamic_update_slice(
         build_zero_like(builder, meta.dtype, update, meta.shape.len())
     });
 
-    let out = builder.add_op(
+    let out = builder.add_operation(
         StdTensorOp::DynamicUpdateSlice,
         vec![
-            ValRef::Local(d_operand),
-            ValRef::Local(d_update),
-            ValRef::External(primal_in[2].clone()),
+            ValueRef::Local(d_operand),
+            ValueRef::Local(d_update),
+            ValueRef::External(primal_in[2].clone()),
         ],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![tangent_in[0].is_some(), tangent_in[1].is_some(), false],
         },
     );
@@ -184,21 +184,21 @@ pub fn linearize_dynamic_update_slice(
 /// use a zero operand so the operand cotangent is only the sum over
 /// gather reads, not `original operand + sum over gather reads`.
 pub fn transpose_gather(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     config: &GatherConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
         None => return vec![None, None],
     };
 
     let active_mask = match mode {
-        OpMode::Linear { active_mask } => active_mask.clone(),
-        OpMode::Primal => return vec![None, None],
+        OperationRole::Linearized { active_mask } => active_mask.clone(),
+        OperationRole::Primary => return vec![None, None],
     };
 
     if !active_mask.first().copied().unwrap_or(false) {
@@ -215,16 +215,16 @@ pub fn transpose_gather(
     let operand_meta = ctx.metadata_of(&inputs[0]);
     let operand_rank = operand_meta.shape.len();
     let operand_dtype = operand_meta.dtype;
-    let zero_operand = build_zero_like(emitter, operand_dtype, inputs[0].clone(), operand_rank);
+    let zero_operand = build_zero_like(builder, operand_dtype, inputs[0].clone(), operand_rank);
 
-    let out = emitter.add_op(
+    let out = builder.add_operation(
         StdTensorOp::Scatter(inverse_config),
         vec![
-            ValRef::Local(zero_operand),
+            ValueRef::Local(zero_operand),
             inputs[1].clone(),
-            ValRef::Local(ct),
+            ValueRef::Local(ct),
         ],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![false, false, true],
         },
     );
@@ -239,16 +239,16 @@ pub fn transpose_gather(
 /// their cotangents are always inactive.
 #[allow(clippy::too_many_arguments)]
 pub fn transpose_gather_dynamic_slice_sizes(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     offset_dims: &[usize],
     collapsed_slice_dims: &[usize],
     start_index_map: &[usize],
     index_vector_dim: usize,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let mut result = vec![None; inputs.len()];
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
@@ -256,8 +256,8 @@ pub fn transpose_gather_dynamic_slice_sizes(
     };
 
     let active_mask = match mode {
-        OpMode::Linear { active_mask } => active_mask,
-        OpMode::Primal => return result,
+        OperationRole::Linearized { active_mask } => active_mask,
+        OperationRole::Primary => return result,
     };
 
     if !active_mask.first().copied().unwrap_or(false) {
@@ -274,16 +274,16 @@ pub fn transpose_gather_dynamic_slice_sizes(
     let operand_meta = ctx.metadata_of(&inputs[0]);
     let operand_rank = operand_meta.shape.len();
     let operand_dtype = operand_meta.dtype;
-    let zero_operand = build_zero_like(emitter, operand_dtype, inputs[0].clone(), operand_rank);
+    let zero_operand = build_zero_like(builder, operand_dtype, inputs[0].clone(), operand_rank);
 
-    let out = emitter.add_op(
+    let out = builder.add_operation(
         StdTensorOp::Scatter(inverse_config),
         vec![
-            ValRef::Local(zero_operand),
+            ValueRef::Local(zero_operand),
             inputs[1].clone(),
-            ValRef::Local(ct),
+            ValueRef::Local(ct),
         ],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![false, false, true],
         },
     );
@@ -297,20 +297,20 @@ pub fn transpose_gather_dynamic_slice_sizes(
 /// The transpose of `DynamicSlice(x, starts, sizes)` writes the cotangent back
 /// into a zero tensor shaped like `x` using the same start-adjustment semantics.
 pub fn transpose_dynamic_slice(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
         None => return vec![None, None],
     };
 
     let active_mask = match mode {
-        OpMode::Linear { active_mask } => active_mask,
-        OpMode::Primal => return vec![None, None],
+        OperationRole::Linearized { active_mask } => active_mask,
+        OperationRole::Primary => return vec![None, None],
     };
     if !active_mask.first().copied().unwrap_or(false) {
         return vec![None, None];
@@ -318,19 +318,19 @@ pub fn transpose_dynamic_slice(
 
     let operand_meta = ctx.metadata_of(&inputs[0]);
     let zero_operand = build_zero_like(
-        emitter,
+        builder,
         operand_meta.dtype,
         inputs[0].clone(),
         operand_meta.shape.len(),
     );
-    let out = emitter.add_op(
+    let out = builder.add_operation(
         StdTensorOp::DynamicUpdateSlice,
         vec![
-            ValRef::Local(zero_operand),
-            ValRef::Local(ct),
+            ValueRef::Local(zero_operand),
+            ValueRef::Local(ct),
             inputs[1].clone(),
         ],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![false, true, false],
         },
     );
@@ -343,39 +343,39 @@ pub fn transpose_dynamic_slice(
 /// zeros the updated window. Update cotangent is the matching dynamic slice of
 /// the output cotangent.
 pub fn transpose_dynamic_update_slice(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
         None => return vec![None, None, None],
     };
 
     let active_mask = match mode {
-        OpMode::Linear { active_mask } => active_mask,
-        OpMode::Primal => return vec![None, None, None],
+        OperationRole::Linearized { active_mask } => active_mask,
+        OperationRole::Primary => return vec![None, None, None],
     };
 
     let mut result = vec![None, None, None];
     if active_mask.first().copied().unwrap_or(false) {
         let update_meta = ctx.metadata_of(&inputs[1]);
         let zero_update = build_zero_like(
-            emitter,
+            builder,
             update_meta.dtype,
             inputs[1].clone(),
             update_meta.shape.len(),
         );
-        let operand_ct = emitter.add_op(
+        let operand_ct = builder.add_operation(
             StdTensorOp::DynamicUpdateSlice,
             vec![
-                ValRef::Local(ct),
-                ValRef::Local(zero_update),
+                ValueRef::Local(ct),
+                ValueRef::Local(zero_update),
                 inputs[2].clone(),
             ],
-            OpMode::Linear {
+            OperationRole::Linearized {
                 active_mask: vec![true, false, false],
             },
         )[0];
@@ -384,12 +384,12 @@ pub fn transpose_dynamic_update_slice(
 
     if active_mask.get(1).copied().unwrap_or(false) {
         let update_shape = exact_usize_shape(ctx, &inputs[1], "DynamicUpdateSlice transpose");
-        let update_ct = emitter.add_op(
+        let update_ct = builder.add_operation(
             StdTensorOp::DynamicSlice {
                 slice_sizes: update_shape,
             },
-            vec![ValRef::Local(ct), inputs[2].clone()],
-            OpMode::Linear {
+            vec![ValueRef::Local(ct), inputs[2].clone()],
+            OperationRole::Linearized {
                 active_mask: vec![true, false],
             },
         )[0];
@@ -419,12 +419,12 @@ pub fn transpose_dynamic_update_slice(
 ///   `Scatter(operand_dot, indices, updates_dot, config)`; by linearity
 ///   this captures both contributions in a single scatter.
 pub fn linearize_scatter(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     config: &ScatterConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let d_operand = tangent_in[0];
     let d_updates = tangent_in[2];
 
@@ -432,34 +432,34 @@ pub fn linearize_scatter(
         (None, None) => vec![None],
         (Some(d_op), None) => vec![Some(d_op)],
         (None, Some(d_up)) => {
-            let operand_key = ValRef::External(primal_in[0].clone());
+            let operand_key = ValueRef::External(primal_in[0].clone());
             let operand_meta = ctx.metadata_of(&operand_key);
             let operand_rank = operand_meta.shape.len();
             let operand_dtype = operand_meta.dtype;
             let zero_operand =
                 build_zero_like(builder, operand_dtype, operand_key.clone(), operand_rank);
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Scatter(config.clone()),
                 vec![
-                    ValRef::Local(zero_operand),
-                    ValRef::External(primal_in[1].clone()),
-                    ValRef::Local(d_up),
+                    ValueRef::Local(zero_operand),
+                    ValueRef::External(primal_in[1].clone()),
+                    ValueRef::Local(d_up),
                 ],
-                OpMode::Linear {
+                OperationRole::Linearized {
                     active_mask: vec![false, false, true],
                 },
             );
             vec![Some(out[0])]
         }
         (Some(d_op), Some(d_up)) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Scatter(config.clone()),
                 vec![
-                    ValRef::Local(d_op),
-                    ValRef::External(primal_in[1].clone()),
-                    ValRef::Local(d_up),
+                    ValueRef::Local(d_op),
+                    ValueRef::External(primal_in[1].clone()),
+                    ValueRef::Local(d_up),
                 ],
-                OpMode::Linear {
+                OperationRole::Linearized {
                     active_mask: vec![true, false, true],
                 },
             );
@@ -482,21 +482,21 @@ pub fn linearize_scatter(
 ///   with `slice_sizes` derived from the primal `updates`' shape. The
 ///   third entry of the active mask gates whether it is returned.
 pub fn transpose_scatter(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     config: &ScatterConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
         None => return vec![None, None, None],
     };
 
     let active_mask = match mode {
-        OpMode::Linear { active_mask } => active_mask.clone(),
-        OpMode::Primal => return vec![None, None, None],
+        OperationRole::Linearized { active_mask } => active_mask.clone(),
+        OperationRole::Primary => return vec![None, None, None],
     };
 
     let operand_active = active_mask.first().copied().unwrap_or(false);
@@ -514,10 +514,10 @@ pub fn transpose_scatter(
         let inverse = compute_inverse_gather(&operand_shape, &updates_shape, config, &inputs[2]);
 
         let out = match inverse {
-            InverseGather::Concrete(config) => emitter.add_op(
+            InverseGather::Concrete(config) => builder.add_operation(
                 StdTensorOp::Gather(config),
-                vec![ValRef::Local(ct), inputs[1].clone()],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct), inputs[1].clone()],
+                OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
             ),
@@ -529,13 +529,13 @@ pub fn transpose_scatter(
                 slice_sizes,
                 shape_sources,
             } => {
-                let mut gather_inputs = vec![ValRef::Local(ct), inputs[1].clone()];
+                let mut gather_inputs = vec![ValueRef::Local(ct), inputs[1].clone()];
                 let mut active_mask = vec![true, false];
                 for shape_source in shape_sources {
                     gather_inputs.push(shape_source);
                     active_mask.push(false);
                 }
-                emitter.add_op(
+                builder.add_operation(
                     StdTensorOp::GatherDynamicSliceSizes {
                         offset_dims,
                         collapsed_slice_dims,
@@ -544,7 +544,7 @@ pub fn transpose_scatter(
                         slice_sizes,
                     },
                     gather_inputs,
-                    OpMode::Linear { active_mask },
+                    OperationRole::Linearized { active_mask },
                 )
             }
         };
@@ -562,7 +562,7 @@ enum InverseGather {
         start_index_map: Vec<usize>,
         index_vector_dim: usize,
         slice_sizes: Vec<DimExpr>,
-        shape_sources: Vec<ValRef<StdTensorOp>>,
+        shape_sources: Vec<ValueRef<StdTensorOp>>,
     },
 }
 
@@ -578,7 +578,7 @@ fn compute_inverse_gather(
     operand_shape: &[SymDim],
     updates_shape: &[SymDim],
     config: &ScatterConfig,
-    updates_ref: &ValRef<StdTensorOp>,
+    updates_ref: &ValueRef<StdTensorOp>,
 ) -> InverseGather {
     let rank = operand_shape.len();
     let operand_window_dims: Vec<usize> = (0..rank)
@@ -639,7 +639,7 @@ fn compute_inverse_gather(
 
 fn exact_usize_shape(
     ctx: &mut ShapeGuardContext,
-    value: &ValRef<StdTensorOp>,
+    value: &ValueRef<StdTensorOp>,
     op_name: &'static str,
 ) -> Vec<usize> {
     ctx.exact_shape_of(value)

--- a/tenferro-internal-ops/src/ad/mod.rs
+++ b/tenferro-internal-ops/src/ad/mod.rs
@@ -31,10 +31,9 @@ pub mod support;
 mod zeros;
 
 #[cfg(feature = "autodiff")]
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
+use computegraph::graph::GraphBuilder;
 #[cfg(feature = "autodiff")]
-use computegraph::OpEmitter;
-
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleKind, ADRuleResult, PrimitiveBuilder, PrimitiveValue};
 
@@ -43,36 +42,68 @@ use crate::ext_op::{linearize_extension_rule, transpose_extension_rule};
 #[cfg(feature = "autodiff")]
 use crate::std_tensor_op::StdTensorOp;
 
+/// Builder interface used by tenferro AD rules.
+///
+/// # Examples
+///
+/// ```
+/// use computegraph::graph::GraphBuilder;
+/// use computegraph::{OperationRole, ValueRef};
+/// use tenferro_ops::ad::PrimitiveRuleBuilder;
+/// use tenferro_ops::input_key::TensorInputKey;
+/// use tenferro_ops::std_tensor_op::StdTensorOp;
+///
+/// let mut builder = GraphBuilder::<StdTensorOp>::new();
+/// let x = builder.add_input(TensorInputKey::User { id: 1 });
+/// let out = PrimitiveRuleBuilder::add_operation(
+///     &mut builder,
+///     StdTensorOp::Neg,
+///     vec![ValueRef::Local(x)],
+///     OperationRole::Primary,
+/// );
+/// assert_eq!(out.len(), 1);
+/// ```
 #[cfg(feature = "autodiff")]
-pub(crate) struct PrimitiveBuilderEmitter<'a, B: ?Sized> {
-    inner: &'a mut B,
+pub trait PrimitiveRuleBuilder {
+    /// Add one primitive graph operation and return local ids for its outputs.
+    fn add_operation(
+        &mut self,
+        operation: StdTensorOp,
+        inputs: Vec<ValueRef<StdTensorOp>>,
+        role: OperationRole,
+    ) -> Vec<LocalValueId>;
 }
 
 #[cfg(feature = "autodiff")]
-impl<'a, B: ?Sized> PrimitiveBuilderEmitter<'a, B> {
-    pub(crate) fn new(inner: &'a mut B) -> Self {
-        Self { inner }
+impl<B> PrimitiveRuleBuilder for B
+where
+    B: PrimitiveBuilder<StdTensorOp> + ?Sized,
+{
+    fn add_operation(
+        &mut self,
+        operation: StdTensorOp,
+        inputs: Vec<ValueRef<StdTensorOp>>,
+        role: OperationRole,
+    ) -> Vec<LocalValueId> {
+        let inputs = inputs.into_iter().map(PrimitiveValue::from).collect();
+        PrimitiveBuilder::add_primitive(self, operation, inputs, role)
     }
 }
 
 #[cfg(feature = "autodiff")]
-impl<B> OpEmitter<StdTensorOp> for PrimitiveBuilderEmitter<'_, B>
-where
-    B: PrimitiveBuilder<StdTensorOp> + ?Sized,
-{
-    fn add_op(
+impl PrimitiveRuleBuilder for GraphBuilder<StdTensorOp> {
+    fn add_operation(
         &mut self,
-        op: StdTensorOp,
-        inputs: Vec<ValRef<StdTensorOp>>,
-        mode: OpMode,
-    ) -> Vec<LocalValId> {
-        let inputs = inputs.into_iter().map(PrimitiveValue::from).collect();
-        self.inner.add_primitive(op, inputs, mode)
+        operation: StdTensorOp,
+        inputs: Vec<ValueRef<StdTensorOp>>,
+        role: OperationRole,
+    ) -> Vec<LocalValueId> {
+        GraphBuilder::add_operation(self, operation, inputs, role)
     }
 }
 
 /// Forward-mode AD (JVP) for `StdTensorOp`: given the primal op and its
-/// tangent inputs, emit the linearized fragment into `builder` and return
+/// tangent inputs, emit the linearized graph into `builder` and return
 /// the output tangents.
 ///
 /// Rules per op live in the category submodules (`semiring`, `analytic`,
@@ -81,12 +112,12 @@ where
 #[cfg(feature = "autodiff")]
 pub fn linearize(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut context::ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match try_linearize(op, builder, primal_in, primal_out, tangent_in, ctx) {
         Ok(tangents) => tangents,
         Err(err) => panic!("{err}"),
@@ -97,12 +128,12 @@ pub fn linearize(
 #[cfg(feature = "autodiff")]
 pub fn try_linearize(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut context::ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     if let StdTensorOp::Extension(ext) = op {
         return linearize_extension_rule(
             ext.as_ref(),
@@ -123,7 +154,7 @@ pub fn try_linearize(
 }
 
 /// Reverse-mode AD (VJP) for `StdTensorOp`: given the primal op, its
-/// inputs, and the output cotangent, emit the transposed fragment and
+/// inputs, and the output cotangent, emit the transposed graph and
 /// return the input cotangents.
 ///
 /// See [`linearize`] for the category split; the same categories appear
@@ -131,13 +162,13 @@ pub fn try_linearize(
 #[cfg(feature = "autodiff")]
 pub fn transpose_rule(
     op: &StdTensorOp,
-    emitter: &mut impl OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut impl PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut context::ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
-    match try_transpose_rule(op, emitter, cotangent_out, inputs, mode, ctx) {
+) -> Vec<Option<LocalValueId>> {
+    match try_transpose_rule(op, builder, cotangent_out, inputs, mode, ctx) {
         Ok(cotangents) => cotangents,
         Err(err) => panic!("{err}"),
     }
@@ -147,17 +178,17 @@ pub fn transpose_rule(
 #[cfg(feature = "autodiff")]
 pub fn try_transpose_rule(
     op: &StdTensorOp,
-    emitter: &mut impl OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut impl PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut context::ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     if let StdTensorOp::Extension(ext) = op {
-        let emitter_dyn: &mut dyn OpEmitter<StdTensorOp> = emitter;
+        let builder_dyn: &mut dyn PrimitiveRuleBuilder = builder;
         return transpose_extension_rule(
             ext.as_ref(),
-            emitter_dyn,
+            builder_dyn,
             cotangent_out,
             inputs,
             mode,
@@ -170,8 +201,8 @@ pub fn try_transpose_rule(
         .expect("non-extension StdTensorOp must have a primitive kind");
     let rule = registry::primitive_ad_rule(kind)
         .ok_or_else(|| registry::missing_rule(kind, ADRuleKind::Transpose))?;
-    let emitter_dyn: &mut dyn OpEmitter<StdTensorOp> = emitter;
-    rule.transpose_rule(op, emitter_dyn, cotangent_out, inputs, mode, ctx)
+    let builder_dyn: &mut dyn PrimitiveRuleBuilder = builder;
+    rule.transpose_rule(op, builder_dyn, cotangent_out, inputs, mode, ctx)
 }
 
 #[cfg(test)]

--- a/tenferro-internal-ops/src/ad/registry.rs
+++ b/tenferro-internal-ops/src/ad/registry.rs
@@ -1,5 +1,5 @@
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use crate::ad::PrimitiveRuleBuilder;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_core_ops::PrimitiveOpKind;
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
@@ -11,21 +11,21 @@ use crate::std_tensor_op::StdTensorOp;
 
 pub(crate) type LinearizeFn = fn(
     &StdTensorOp,
-    &mut dyn OpEmitter<StdTensorOp>,
-    &[GlobalValKey<StdTensorOp>],
-    &[GlobalValKey<StdTensorOp>],
-    &[Option<LocalValId>],
+    &mut dyn PrimitiveRuleBuilder,
+    &[ValueKey<StdTensorOp>],
+    &[ValueKey<StdTensorOp>],
+    &[Option<LocalValueId>],
     &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>>;
+) -> ADRuleResult<Vec<Option<LocalValueId>>>;
 
 pub(crate) type TransposeFn = fn(
     &StdTensorOp,
-    &mut dyn OpEmitter<StdTensorOp>,
-    &[Option<LocalValId>],
-    &[ValRef<StdTensorOp>],
-    &OpMode,
+    &mut dyn PrimitiveRuleBuilder,
+    &[Option<LocalValueId>],
+    &[ValueRef<StdTensorOp>],
+    &OperationRole,
     &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>>;
+) -> ADRuleResult<Vec<Option<LocalValueId>>>;
 
 pub(crate) trait PrimitiveAdRule: Send + Sync {
     fn kind(&self) -> PrimitiveOpKind;
@@ -33,22 +33,22 @@ pub(crate) trait PrimitiveAdRule: Send + Sync {
     fn linearize(
         &self,
         op: &StdTensorOp,
-        builder: &mut dyn OpEmitter<StdTensorOp>,
-        primal_in: &[GlobalValKey<StdTensorOp>],
-        primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut dyn PrimitiveRuleBuilder,
+        primal_in: &[ValueKey<StdTensorOp>],
+        primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>>;
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
 
     fn transpose_rule(
         &self,
         op: &StdTensorOp,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<StdTensorOp>],
-        mode: &OpMode,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
+        mode: &OperationRole,
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>>;
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
 }
 
 struct FunctionPrimitiveAdRule {
@@ -65,25 +65,25 @@ impl PrimitiveAdRule for FunctionPrimitiveAdRule {
     fn linearize(
         &self,
         op: &StdTensorOp,
-        builder: &mut dyn OpEmitter<StdTensorOp>,
-        primal_in: &[GlobalValKey<StdTensorOp>],
-        primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut dyn PrimitiveRuleBuilder,
+        primal_in: &[ValueKey<StdTensorOp>],
+        primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         (self.linearize)(op, builder, primal_in, primal_out, tangent_in, ctx)
     }
 
     fn transpose_rule(
         &self,
         op: &StdTensorOp,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<StdTensorOp>],
-        mode: &OpMode,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
+        mode: &OperationRole,
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
-        (self.transpose_rule)(op, emitter, cotangent_out, inputs, mode, ctx)
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        (self.transpose_rule)(op, builder, cotangent_out, inputs, mode, ctx)
     }
 }
 
@@ -342,47 +342,47 @@ static PRIMITIVE_AD_RULES: [&'static dyn PrimitiveAdRule; PrimitiveOpKind::COUNT
 
 fn linearize_add(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(semiring::linearize_add(builder, tangent_in))
 }
 
 fn transpose_add(
     _op: &StdTensorOp,
-    _emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    _inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    _builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    _inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(semiring::transpose_add(cotangent_out))
 }
 
 fn linearize_mul(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(semiring::linearize_mul(builder, primal_in, tangent_in))
 }
 
 fn transpose_mul(
     _op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(semiring::transpose_mul(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -392,34 +392,34 @@ fn transpose_mul(
 
 fn linearize_neg(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(semiring::linearize_neg(builder, tangent_in))
 }
 
 fn transpose_neg(
     _op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    _inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    _inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
-    Ok(semiring::transpose_neg(emitter, cotangent_out))
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    Ok(semiring::transpose_neg(builder, cotangent_out))
 }
 
 fn linearize_conj(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(semiring::linearize_conj(
         builder, primal_in, tangent_in, ctx,
     ))
@@ -427,14 +427,14 @@ fn linearize_conj(
 
 fn transpose_conj(
     _op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(semiring::transpose_conj(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         ctx,
@@ -443,12 +443,12 @@ fn transpose_conj(
 
 fn linearize_div(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(elementwise::linearize_div(
         builder, primal_in, primal_out, tangent_in,
     ))
@@ -456,34 +456,34 @@ fn linearize_div(
 
 fn linearize_abs(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(elementwise::linearize_abs(builder, primal_in, tangent_in))
 }
 
 fn linearize_sign(
     _op: &StdTensorOp,
-    _builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    _builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(elementwise::linearize_sign(_builder, tangent_in))
 }
 
 fn linearize_maximum(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(elementwise::linearize_maximum(
         builder, primal_in, tangent_in,
     ))
@@ -491,12 +491,12 @@ fn linearize_maximum(
 
 fn linearize_minimum(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(elementwise::linearize_minimum(
         builder, primal_in, tangent_in,
     ))
@@ -504,23 +504,23 @@ fn linearize_minimum(
 
 fn linearize_compare(
     _op: &StdTensorOp,
-    _builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    _tangent_in: &[Option<LocalValId>],
+    _builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    _tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(vec![None])
 }
 
 fn linearize_select(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(elementwise::linearize_select(
         builder, primal_in, tangent_in,
     ))
@@ -528,12 +528,12 @@ fn linearize_select(
 
 fn linearize_clamp(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(elementwise::linearize_clamp(builder, primal_in, tangent_in))
 }
 
@@ -541,13 +541,13 @@ macro_rules! transpose_elementwise {
     ($name:ident, $callee:path) => {
         fn $name(
             _op: &StdTensorOp,
-            emitter: &mut dyn OpEmitter<StdTensorOp>,
-            cotangent_out: &[Option<LocalValId>],
-            inputs: &[ValRef<StdTensorOp>],
-            mode: &OpMode,
+            builder: &mut dyn PrimitiveRuleBuilder,
+            cotangent_out: &[Option<LocalValueId>],
+            inputs: &[ValueRef<StdTensorOp>],
+            mode: &OperationRole,
             _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
-            Ok($callee(emitter, cotangent_out, inputs, mode))
+        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+            Ok($callee(builder, cotangent_out, inputs, mode))
         }
     };
 }
@@ -556,13 +556,13 @@ transpose_elementwise!(transpose_div, elementwise::transpose_div);
 transpose_elementwise!(transpose_abs, elementwise::transpose_abs);
 fn transpose_sign(
     _op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    _inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    _inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
-    Ok(elementwise::transpose_sign(emitter, cotangent_out, mode))
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    Ok(elementwise::transpose_sign(builder, cotangent_out, mode))
 }
 transpose_elementwise!(transpose_maximum, elementwise::transpose_maximum);
 transpose_elementwise!(transpose_minimum, elementwise::transpose_minimum);
@@ -570,12 +570,12 @@ transpose_elementwise!(transpose_select, elementwise::transpose_select);
 transpose_elementwise!(transpose_clamp, elementwise::transpose_clamp);
 fn transpose_compare(
     _op: &StdTensorOp,
-    _emitter: &mut dyn OpEmitter<StdTensorOp>,
-    _cotangent_out: &[Option<LocalValId>],
-    _inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    _builder: &mut dyn PrimitiveRuleBuilder,
+    _cotangent_out: &[Option<LocalValueId>],
+    _inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(vec![None, None])
 }
 
@@ -583,24 +583,24 @@ macro_rules! analytic_linearize {
     ($name:ident, $callee:path, primal_in) => {
         fn $name(
             _op: &StdTensorOp,
-            builder: &mut dyn OpEmitter<StdTensorOp>,
-            primal_in: &[GlobalValKey<StdTensorOp>],
-            _primal_out: &[GlobalValKey<StdTensorOp>],
-            tangent_in: &[Option<LocalValId>],
+            builder: &mut dyn PrimitiveRuleBuilder,
+            primal_in: &[ValueKey<StdTensorOp>],
+            _primal_out: &[ValueKey<StdTensorOp>],
+            tangent_in: &[Option<LocalValueId>],
             _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             Ok($callee(builder, primal_in, tangent_in))
         }
     };
     ($name:ident, $callee:path, primal_out) => {
         fn $name(
             _op: &StdTensorOp,
-            builder: &mut dyn OpEmitter<StdTensorOp>,
-            _primal_in: &[GlobalValKey<StdTensorOp>],
-            primal_out: &[GlobalValKey<StdTensorOp>],
-            tangent_in: &[Option<LocalValId>],
+            builder: &mut dyn PrimitiveRuleBuilder,
+            _primal_in: &[ValueKey<StdTensorOp>],
+            primal_out: &[ValueKey<StdTensorOp>],
+            tangent_in: &[Option<LocalValueId>],
             _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             Ok($callee(builder, primal_out, tangent_in))
         }
     };
@@ -614,24 +614,24 @@ analytic_linearize!(linearize_tanh, analytic::linearize_tanh, primal_out);
 analytic_linearize!(linearize_sqrt, analytic::linearize_sqrt, primal_out);
 fn linearize_rsqrt(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(analytic::linearize_rsqrt(
         builder, primal_in, primal_out, tangent_in,
     ))
 }
 fn linearize_pow(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(analytic::linearize_pow(
         builder, primal_in, primal_out, tangent_in,
     ))
@@ -643,13 +643,13 @@ macro_rules! analytic_transpose {
     ($name:ident, $callee:path) => {
         fn $name(
             _op: &StdTensorOp,
-            emitter: &mut dyn OpEmitter<StdTensorOp>,
-            cotangent_out: &[Option<LocalValId>],
-            inputs: &[ValRef<StdTensorOp>],
-            mode: &OpMode,
+            builder: &mut dyn PrimitiveRuleBuilder,
+            cotangent_out: &[Option<LocalValueId>],
+            inputs: &[ValueRef<StdTensorOp>],
+            mode: &OperationRole,
             _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
-            Ok($callee(emitter, cotangent_out, inputs, mode))
+        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+            Ok($callee(builder, cotangent_out, inputs, mode))
         }
     };
 }
@@ -667,12 +667,12 @@ analytic_transpose!(transpose_log1p, analytic::transpose_log1p);
 
 fn linearize_dot_general(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::DotGeneral { config } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -683,17 +683,17 @@ fn linearize_dot_general(
 
 fn transpose_dot_general(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::DotGeneral { config } = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(contraction::transpose_dot_general(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -704,12 +704,12 @@ fn transpose_dot_general(
 
 fn linearize_reduce_sum(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::ReduceSum { axes } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -720,14 +720,14 @@ fn linearize_reduce_sum(
 
 fn transpose_reduce_sum(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(contraction::transpose_reduce_sum(
-        emitter,
+        builder,
         cotangent_out,
         op,
         inputs,
@@ -737,12 +737,12 @@ fn transpose_reduce_sum(
 
 fn linearize_reduce_prod(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::ReduceProd { axes } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -753,14 +753,14 @@ fn linearize_reduce_prod(
 
 fn transpose_reduce_prod(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(contraction::transpose_reduce_prod(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         op,
@@ -770,12 +770,12 @@ fn transpose_reduce_prod(
 
 fn linearize_reduce_max(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::ReduceMax { axes } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -786,12 +786,12 @@ fn linearize_reduce_max(
 
 fn linearize_reduce_min(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::ReduceMin { axes } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -802,14 +802,14 @@ fn linearize_reduce_min(
 
 fn transpose_reduce_max(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(contraction::transpose_reduce_chooser(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         op,
@@ -819,14 +819,14 @@ fn transpose_reduce_max(
 
 fn transpose_reduce_min(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(contraction::transpose_reduce_chooser(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         op,
@@ -836,12 +836,12 @@ fn transpose_reduce_min(
 
 fn linearize_transpose(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Transpose { perm } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -850,17 +850,17 @@ fn linearize_transpose(
 
 fn transpose_transpose(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    _inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    _inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Transpose { perm } = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(structural::transpose_transpose(
-        emitter,
+        builder,
         cotangent_out,
         perm,
     ))
@@ -868,12 +868,12 @@ fn transpose_transpose(
 
 fn linearize_reshape(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(structural::linearize_reshape(
         builder, primal_in, tangent_in, op, ctx,
     ))
@@ -881,14 +881,14 @@ fn linearize_reshape(
 
 fn transpose_reshape(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(structural::transpose_reshape(
-        emitter,
+        builder,
         cotangent_out,
         op,
         inputs,
@@ -898,12 +898,12 @@ fn transpose_reshape(
 
 fn linearize_broadcast_in_dim(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::BroadcastInDim { shape, dims } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -914,17 +914,17 @@ fn linearize_broadcast_in_dim(
 
 fn transpose_broadcast_in_dim(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    _inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    _inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::BroadcastInDim { shape, dims } = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(structural::transpose_broadcast_in_dim(
-        emitter,
+        builder,
         cotangent_out,
         shape,
         dims,
@@ -933,12 +933,12 @@ fn transpose_broadcast_in_dim(
 
 fn linearize_convert(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Convert { from, to } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -949,17 +949,17 @@ fn linearize_convert(
 
 fn transpose_convert(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    _inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    _inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Convert { from, to } = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(structural::transpose_convert(
-        emitter,
+        builder,
         cotangent_out,
         mode,
         *from,
@@ -971,12 +971,12 @@ macro_rules! diagonal_rule {
     ($lin:ident, $trans:ident, $variant:ident, $lin_call:path, $trans_call:path) => {
         fn $lin(
             op: &StdTensorOp,
-            builder: &mut dyn OpEmitter<StdTensorOp>,
-            _primal_in: &[GlobalValKey<StdTensorOp>],
-            _primal_out: &[GlobalValKey<StdTensorOp>],
-            tangent_in: &[Option<LocalValId>],
+            builder: &mut dyn PrimitiveRuleBuilder,
+            _primal_in: &[ValueKey<StdTensorOp>],
+            _primal_out: &[ValueKey<StdTensorOp>],
+            tangent_in: &[Option<LocalValueId>],
             _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             let StdTensorOp::$variant { axis_a, axis_b } = op else {
                 unreachable!("catalog kind mismatch")
             };
@@ -985,16 +985,16 @@ macro_rules! diagonal_rule {
 
         fn $trans(
             op: &StdTensorOp,
-            emitter: &mut dyn OpEmitter<StdTensorOp>,
-            cotangent_out: &[Option<LocalValId>],
-            _inputs: &[ValRef<StdTensorOp>],
-            _mode: &OpMode,
+            builder: &mut dyn PrimitiveRuleBuilder,
+            cotangent_out: &[Option<LocalValueId>],
+            _inputs: &[ValueRef<StdTensorOp>],
+            _mode: &OperationRole,
             _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             let StdTensorOp::$variant { axis_a, axis_b } = op else {
                 unreachable!("catalog kind mismatch")
             };
-            Ok($trans_call(emitter, cotangent_out, *axis_a, *axis_b))
+            Ok($trans_call(builder, cotangent_out, *axis_a, *axis_b))
         }
     };
 }
@@ -1018,12 +1018,12 @@ macro_rules! triangular_rule {
     ($lin:ident, $trans:ident, $variant:ident, $lin_call:path, $trans_call:path) => {
         fn $lin(
             op: &StdTensorOp,
-            builder: &mut dyn OpEmitter<StdTensorOp>,
-            _primal_in: &[GlobalValKey<StdTensorOp>],
-            _primal_out: &[GlobalValKey<StdTensorOp>],
-            tangent_in: &[Option<LocalValId>],
+            builder: &mut dyn PrimitiveRuleBuilder,
+            _primal_in: &[ValueKey<StdTensorOp>],
+            _primal_out: &[ValueKey<StdTensorOp>],
+            tangent_in: &[Option<LocalValueId>],
             _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             let StdTensorOp::$variant { k } = op else {
                 unreachable!("catalog kind mismatch")
             };
@@ -1032,16 +1032,16 @@ macro_rules! triangular_rule {
 
         fn $trans(
             op: &StdTensorOp,
-            emitter: &mut dyn OpEmitter<StdTensorOp>,
-            cotangent_out: &[Option<LocalValId>],
-            _inputs: &[ValRef<StdTensorOp>],
-            _mode: &OpMode,
+            builder: &mut dyn PrimitiveRuleBuilder,
+            cotangent_out: &[Option<LocalValueId>],
+            _inputs: &[ValueRef<StdTensorOp>],
+            _mode: &OperationRole,
             _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             let StdTensorOp::$variant { k } = op else {
                 unreachable!("catalog kind mismatch")
             };
-            Ok($trans_call(emitter, cotangent_out, *k))
+            Ok($trans_call(builder, cotangent_out, *k))
         }
     };
 }
@@ -1063,12 +1063,12 @@ triangular_rule!(
 
 fn linearize_gather(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Gather(config) = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -1079,17 +1079,17 @@ fn linearize_gather(
 
 fn transpose_gather(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Gather(config) = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(indexing::transpose_gather(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -1100,12 +1100,12 @@ fn transpose_gather(
 
 fn linearize_gather_dynamic_slice_sizes(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::GatherDynamicSliceSizes {
         offset_dims,
         collapsed_slice_dims,
@@ -1130,12 +1130,12 @@ fn linearize_gather_dynamic_slice_sizes(
 
 fn transpose_gather_dynamic_slice_sizes(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::GatherDynamicSliceSizes {
         offset_dims,
         collapsed_slice_dims,
@@ -1147,7 +1147,7 @@ fn transpose_gather_dynamic_slice_sizes(
         unreachable!("catalog kind mismatch")
     };
     Ok(indexing::transpose_gather_dynamic_slice_sizes(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -1161,12 +1161,12 @@ fn transpose_gather_dynamic_slice_sizes(
 
 fn linearize_scatter(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Scatter(config) = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -1177,17 +1177,17 @@ fn linearize_scatter(
 
 fn transpose_scatter(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Scatter(config) = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(indexing::transpose_scatter(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -1198,12 +1198,12 @@ fn transpose_scatter(
 
 fn linearize_slice(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Slice(config) = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -1212,17 +1212,17 @@ fn linearize_slice(
 
 fn transpose_slice(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Slice(config) = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(structural::transpose_slice(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -1233,12 +1233,12 @@ fn transpose_slice(
 
 fn linearize_dynamic_slice(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::DynamicSlice { slice_sizes } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -1252,14 +1252,14 @@ fn linearize_dynamic_slice(
 
 fn transpose_dynamic_slice(
     _op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(indexing::transpose_dynamic_slice(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -1269,12 +1269,12 @@ fn transpose_dynamic_slice(
 
 fn linearize_dynamic_update_slice(
     _op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(indexing::linearize_dynamic_update_slice(
         builder, primal_in, tangent_in, ctx,
     ))
@@ -1282,14 +1282,14 @@ fn linearize_dynamic_update_slice(
 
 fn transpose_dynamic_update_slice(
     _op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(indexing::transpose_dynamic_update_slice(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -1299,12 +1299,12 @@ fn transpose_dynamic_update_slice(
 
 fn linearize_pad(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Pad(config) = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -1313,17 +1313,17 @@ fn linearize_pad(
 
 fn transpose_pad(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Pad(config) = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(structural::transpose_pad(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -1334,50 +1334,55 @@ fn transpose_pad(
 
 fn linearize_concatenate(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
-    let StdTensorOp::Concatenate { axis, n_inputs } = op else {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    let StdTensorOp::Concatenate { axis, input_count } = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(structural::linearize_concatenate(
-        builder, primal_in, tangent_in, *axis, *n_inputs, ctx,
+        builder,
+        primal_in,
+        tangent_in,
+        *axis,
+        *input_count,
+        ctx,
     ))
 }
 
 fn transpose_concatenate(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
-    let StdTensorOp::Concatenate { axis, n_inputs } = op else {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    let StdTensorOp::Concatenate { axis, input_count } = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(structural::transpose_concatenate(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
         *axis,
-        *n_inputs,
+        *input_count,
         ctx,
     ))
 }
 
 fn linearize_reverse(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Reverse { axes } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -1386,17 +1391,17 @@ fn linearize_reverse(
 
 fn transpose_reverse(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    _inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    _inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Reverse { axes } = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(structural::transpose_reverse(
-        emitter,
+        builder,
         cotangent_out,
         mode,
         axes,
@@ -1405,34 +1410,34 @@ fn transpose_reverse(
 
 fn linearize_shape_of(
     _op: &StdTensorOp,
-    _builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    _tangent_in: &[Option<LocalValId>],
+    _builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    _tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(vec![None])
 }
 
 fn transpose_shape_of(
     _op: &StdTensorOp,
-    _emitter: &mut dyn OpEmitter<StdTensorOp>,
-    _cotangent_out: &[Option<LocalValId>],
-    _inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    _builder: &mut dyn PrimitiveRuleBuilder,
+    _cotangent_out: &[Option<LocalValueId>],
+    _inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(vec![None])
 }
 
 fn linearize_dynamic_truncate(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::DynamicTruncate { axis } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -1443,17 +1448,17 @@ fn linearize_dynamic_truncate(
 
 fn transpose_dynamic_truncate(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::DynamicTruncate { axis } = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(dynamic::transpose_dynamic_truncate(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         *axis,
@@ -1462,12 +1467,12 @@ fn transpose_dynamic_truncate(
 
 fn linearize_pad_to_match(
     op: &StdTensorOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::PadToMatch { axis } = op else {
         unreachable!("catalog kind mismatch")
     };
@@ -1478,17 +1483,17 @@ fn linearize_pad_to_match(
 
 fn transpose_pad_to_match(
     op: &StdTensorOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::PadToMatch { axis } = op else {
         unreachable!("catalog kind mismatch")
     };
     Ok(dynamic::transpose_pad_to_match(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -1499,22 +1504,22 @@ fn transpose_pad_to_match(
 
 fn linearize_constant(
     _op: &StdTensorOp,
-    _builder: &mut dyn OpEmitter<StdTensorOp>,
-    _primal_in: &[GlobalValKey<StdTensorOp>],
-    _primal_out: &[GlobalValKey<StdTensorOp>],
-    _tangent_in: &[Option<LocalValId>],
+    _builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    _tangent_in: &[Option<LocalValueId>],
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(vec![None])
 }
 
 fn transpose_constant(
     _op: &StdTensorOp,
-    _emitter: &mut dyn OpEmitter<StdTensorOp>,
-    _cotangent_out: &[Option<LocalValId>],
-    _inputs: &[ValRef<StdTensorOp>],
-    _mode: &OpMode,
+    _builder: &mut dyn PrimitiveRuleBuilder,
+    _cotangent_out: &[Option<LocalValueId>],
+    _inputs: &[ValueRef<StdTensorOp>],
+    _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     Ok(vec![])
 }

--- a/tenferro-internal-ops/src/ad/semiring.rs
+++ b/tenferro-internal-ops/src/ad/semiring.rs
@@ -1,20 +1,20 @@
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::support::{conjugate_linear_if_dtype_complex, conjugate_primal_if_complex};
+use crate::ad::PrimitiveRuleBuilder;
 use crate::std_tensor_op::StdTensorOp;
 
 pub fn linearize_add(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match (tangent_in[0], tangent_in[1]) {
         (Some(dx), Some(dy)) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Add,
-                vec![ValRef::Local(dx), ValRef::Local(dy)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx), ValueRef::Local(dy)],
+                OperationRole::Linearized {
                     active_mask: vec![true, true],
                 },
             );
@@ -27,17 +27,20 @@ pub fn linearize_add(
 }
 
 pub fn linearize_mul(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     let mut terms = Vec::with_capacity(2);
 
     if let Some(dx) = tangent_in[0] {
-        let term = builder.add_op(
+        let term = builder.add_operation(
             StdTensorOp::Mul,
-            vec![ValRef::Local(dx), ValRef::External(primal_in[1].clone())],
-            OpMode::Linear {
+            vec![
+                ValueRef::Local(dx),
+                ValueRef::External(primal_in[1].clone()),
+            ],
+            OperationRole::Linearized {
                 active_mask: vec![true, false],
             },
         );
@@ -45,10 +48,13 @@ pub fn linearize_mul(
     }
 
     if let Some(dy) = tangent_in[1] {
-        let term = builder.add_op(
+        let term = builder.add_operation(
             StdTensorOp::Mul,
-            vec![ValRef::External(primal_in[0].clone()), ValRef::Local(dy)],
-            OpMode::Linear {
+            vec![
+                ValueRef::External(primal_in[0].clone()),
+                ValueRef::Local(dy),
+            ],
+            OperationRole::Linearized {
                 active_mask: vec![false, true],
             },
         );
@@ -59,10 +65,10 @@ pub fn linearize_mul(
         [] => vec![None],
         [only] => vec![Some(*only)],
         [lhs, rhs] => {
-            let sum = builder.add_op(
+            let sum = builder.add_operation(
                 StdTensorOp::Add,
-                vec![ValRef::Local(*lhs), ValRef::Local(*rhs)],
-                OpMode::Linear {
+                vec![ValueRef::Local(*lhs), ValueRef::Local(*rhs)],
+                OperationRole::Linearized {
                     active_mask: vec![true, true],
                 },
             );
@@ -73,15 +79,15 @@ pub fn linearize_mul(
 }
 
 pub fn linearize_neg(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Neg,
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -92,21 +98,21 @@ pub fn linearize_neg(
 }
 
 pub fn linearize_conj(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
+            let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
             vec![Some(conjugate_linear_if_dtype_complex(builder, dx, dtype))]
         }
         None => vec![None],
     }
 }
 
-pub fn transpose_add(cotangent_out: &[Option<LocalValId>]) -> Vec<Option<LocalValId>> {
+pub fn transpose_add(cotangent_out: &[Option<LocalValueId>]) -> Vec<Option<LocalValueId>> {
     match cotangent_out[0] {
         Some(ct) => vec![Some(ct), Some(ct)],
         None => vec![None, None],
@@ -114,30 +120,30 @@ pub fn transpose_add(cotangent_out: &[Option<LocalValId>]) -> Vec<Option<LocalVa
 }
 
 pub fn transpose_mul(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
         None => return vec![None, None],
     };
 
     let active_mask = match mode {
-        OpMode::Linear { active_mask } => active_mask,
-        OpMode::Primal => return vec![None, None],
+        OperationRole::Linearized { active_mask } => active_mask,
+        OperationRole::Primary => return vec![None, None],
     };
 
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let rhs_conj = conjugate_primal_if_complex(emitter, inputs[1].clone(), ctx);
-        let out = emitter.add_op(
+        let rhs_conj = conjugate_primal_if_complex(builder, inputs[1].clone(), ctx);
+        let out = builder.add_operation(
             StdTensorOp::Mul,
-            vec![rhs_conj, ValRef::Local(ct)],
-            OpMode::Linear {
+            vec![rhs_conj, ValueRef::Local(ct)],
+            OperationRole::Linearized {
                 active_mask: vec![false, true],
             },
         );
@@ -145,11 +151,11 @@ pub fn transpose_mul(
     }
 
     if active_mask[1] {
-        let lhs_conj = conjugate_primal_if_complex(emitter, inputs[0].clone(), ctx);
-        let out = emitter.add_op(
+        let lhs_conj = conjugate_primal_if_complex(builder, inputs[0].clone(), ctx);
+        let out = builder.add_operation(
             StdTensorOp::Mul,
-            vec![lhs_conj, ValRef::Local(ct)],
-            OpMode::Linear {
+            vec![lhs_conj, ValueRef::Local(ct)],
+            OperationRole::Linearized {
                 active_mask: vec![false, true],
             },
         );
@@ -160,15 +166,15 @@ pub fn transpose_mul(
 }
 
 pub fn transpose_neg(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-) -> Vec<Option<LocalValId>> {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+) -> Vec<Option<LocalValueId>> {
     match cotangent_out[0] {
         Some(ct) => {
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Neg,
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -179,15 +185,15 @@ pub fn transpose_neg(
 }
 
 pub fn transpose_conj(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match cotangent_out[0] {
         Some(ct) => {
             let dtype = ctx.dtype_of(&inputs[0]);
-            vec![Some(conjugate_linear_if_dtype_complex(emitter, ct, dtype))]
+            vec![Some(conjugate_linear_if_dtype_complex(builder, ct, dtype))]
         }
         None => vec![None],
     }

--- a/tenferro-internal-ops/src/ad/structural.rs
+++ b/tenferro-internal-ops/src/ad/structural.rs
@@ -1,9 +1,9 @@
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{PadConfig, SliceConfig};
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::zeros::build_zero_like;
+use crate::ad::PrimitiveRuleBuilder;
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
@@ -16,7 +16,7 @@ fn is_identity_perm(perm: &[usize]) -> bool {
 
 fn shape_exprs_match_primal_input(
     ctx: &mut ShapeGuardContext,
-    primal_in: &[GlobalValKey<StdTensorOp>],
+    primal_in: &[ValueKey<StdTensorOp>],
     shape: &[DimExpr],
 ) -> bool {
     if primal_in.is_empty() || DimExpr::max_input_idx_all(shape).is_some_and(|idx| idx > 0) {
@@ -24,7 +24,7 @@ fn shape_exprs_match_primal_input(
     }
 
     let input_shape = ctx
-        .shape_of(&ValRef::External(primal_in[0].clone()))
+        .shape_of(&ValueRef::External(primal_in[0].clone()))
         .to_vec();
     if input_shape.len() != shape.len() {
         return false;
@@ -38,21 +38,21 @@ fn shape_exprs_match_primal_input(
 }
 
 pub fn linearize_transpose(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
     perm: &[usize],
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
             if is_identity_perm(perm) {
                 return vec![Some(dx)];
             }
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Transpose {
                     perm: perm.to_vec(),
                 },
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -63,12 +63,12 @@ pub fn linearize_transpose(
 }
 
 pub fn linearize_reshape(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     op: &StdTensorOp,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let StdTensorOp::Reshape { to_shape } = op else {
         unreachable!("linearize_reshape expects Reshape");
     };
@@ -80,19 +80,19 @@ pub fn linearize_reshape(
             }
             let needs_shape_source =
                 DimExpr::max_input_idx_all(to_shape).is_some_and(|idx| idx > 0);
-            let mut op_inputs = vec![ValRef::Local(dx)];
+            let mut op_inputs = vec![ValueRef::Local(dx)];
             let active_mask = if needs_shape_source {
-                op_inputs.push(ValRef::External(primal_in[1].clone()));
+                op_inputs.push(ValueRef::External(primal_in[1].clone()));
                 vec![true, false]
             } else {
                 vec![true]
             };
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Reshape {
                     to_shape: to_shape.clone(),
                 },
                 op_inputs,
-                OpMode::Linear { active_mask },
+                OperationRole::Linearized { active_mask },
             );
             vec![Some(out[0])]
         }
@@ -101,13 +101,13 @@ pub fn linearize_reshape(
 }
 
 pub fn linearize_broadcast_in_dim(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     shape: &[DimExpr],
     dims: &[usize],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
             if dims.iter().copied().eq(0..dims.len())
@@ -116,20 +116,20 @@ pub fn linearize_broadcast_in_dim(
                 return vec![Some(dx)];
             }
             let needs_shape_source = DimExpr::max_input_idx_all(shape).is_some_and(|idx| idx > 0);
-            let mut op_inputs = vec![ValRef::Local(dx)];
+            let mut op_inputs = vec![ValueRef::Local(dx)];
             let active_mask = if needs_shape_source {
-                op_inputs.push(ValRef::External(primal_in[1].clone()));
+                op_inputs.push(ValueRef::External(primal_in[1].clone()));
                 vec![true, false]
             } else {
                 vec![true]
             };
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::BroadcastInDim {
                     shape: shape.to_vec(),
                     dims: dims.to_vec(),
                 },
                 op_inputs,
-                OpMode::Linear { active_mask },
+                OperationRole::Linearized { active_mask },
             );
             vec![Some(out[0])]
         }
@@ -138,17 +138,17 @@ pub fn linearize_broadcast_in_dim(
 }
 
 pub fn linearize_convert(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
     from: tenferro_tensor::DType,
     to: tenferro_tensor::DType,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dt) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Convert { from, to },
-                vec![ValRef::Local(dt)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dt)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -159,16 +159,16 @@ pub fn linearize_convert(
 }
 
 pub fn linearize_tril(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
     k: i64,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Tril { k },
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -179,16 +179,16 @@ pub fn linearize_tril(
 }
 
 pub fn linearize_triu(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
     k: i64,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Triu { k },
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -199,16 +199,16 @@ pub fn linearize_triu(
 }
 
 pub fn linearize_slice(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
     config: &SliceConfig,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Slice(config.clone()),
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -219,16 +219,16 @@ pub fn linearize_slice(
 }
 
 pub fn linearize_pad(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
     config: &PadConfig,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Pad(config.clone()),
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -239,59 +239,59 @@ pub fn linearize_pad(
 }
 
 pub fn linearize_concatenate(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     axis: usize,
-    n_inputs: usize,
+    input_count: usize,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     if tangent_in.iter().all(Option::is_none) {
         return vec![None];
     }
-    if n_inputs == 1 {
+    if input_count == 1 {
         return vec![tangent_in[0]];
     }
 
-    let mut inputs = Vec::with_capacity(n_inputs);
-    let mut active_mask = Vec::with_capacity(n_inputs);
-    for input_index in 0..n_inputs {
+    let mut inputs = Vec::with_capacity(input_count);
+    let mut active_mask = Vec::with_capacity(input_count);
+    for input_index in 0..input_count {
         match tangent_in[input_index] {
             Some(tangent) => {
-                inputs.push(ValRef::Local(tangent));
+                inputs.push(ValueRef::Local(tangent));
                 active_mask.push(true);
             }
             None => {
-                let anchor = ValRef::External(primal_in[input_index].clone());
+                let anchor = ValueRef::External(primal_in[input_index].clone());
                 let meta = ctx.metadata_of(&anchor);
                 let zero = build_zero_like(builder, meta.dtype, anchor, meta.shape.len());
-                inputs.push(ValRef::Local(zero));
+                inputs.push(ValueRef::Local(zero));
                 active_mask.push(false);
             }
         }
     }
 
-    let out = builder.add_op(
-        StdTensorOp::Concatenate { axis, n_inputs },
+    let out = builder.add_operation(
+        StdTensorOp::Concatenate { axis, input_count },
         inputs,
-        OpMode::Linear { active_mask },
+        OperationRole::Linearized { active_mask },
     );
     vec![Some(out[0])]
 }
 
 pub fn linearize_reverse(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    tangent_in: &[Option<LocalValueId>],
     axes: &[usize],
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match tangent_in[0] {
         Some(dx) => {
-            let out = builder.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Reverse {
                     axes: axes.to_vec(),
                 },
-                vec![ValRef::Local(dx)],
-                OpMode::Linear {
+                vec![ValueRef::Local(dx)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -302,10 +302,10 @@ pub fn linearize_reverse(
 }
 
 pub fn transpose_transpose(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
     perm: &[usize],
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let mut inv = vec![0; perm.len()];
     for (index, &value) in perm.iter().enumerate() {
         inv[value] = index;
@@ -316,10 +316,10 @@ pub fn transpose_transpose(
             if is_identity_perm(&inv) {
                 return vec![Some(ct)];
             }
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Transpose { perm: inv },
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -330,12 +330,12 @@ pub fn transpose_transpose(
 }
 
 pub fn transpose_reshape(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
     op: &StdTensorOp,
-    inputs: &[ValRef<StdTensorOp>],
+    inputs: &[ValueRef<StdTensorOp>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let StdTensorOp::Reshape { to_shape: _ } = op else {
         unreachable!("transpose_reshape expects Reshape");
     };
@@ -346,19 +346,19 @@ pub fn transpose_reshape(
             let remapped_to_shape = DimExpr::input_shape(1, input_rank);
             let needs_shape_source =
                 DimExpr::max_input_idx_all(&remapped_to_shape).is_some_and(|idx| idx > 0);
-            let mut op_inputs = vec![ValRef::Local(ct)];
+            let mut op_inputs = vec![ValueRef::Local(ct)];
             let active_mask = if needs_shape_source {
                 op_inputs.push(inputs[0].clone());
                 vec![true, false]
             } else {
                 vec![true]
             };
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Reshape {
                     to_shape: remapped_to_shape,
                 },
                 op_inputs,
-                OpMode::Linear { active_mask },
+                OperationRole::Linearized { active_mask },
             );
             vec![Some(out[0])]
         }
@@ -367,11 +367,11 @@ pub fn transpose_reshape(
 }
 
 pub fn transpose_broadcast_in_dim(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
     shape: &[DimExpr],
     dims: &[usize],
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let output_rank = shape.len();
     let broadcast_axes: Vec<usize> = (0..output_rank).filter(|dim| !dims.contains(dim)).collect();
 
@@ -384,12 +384,12 @@ pub fn transpose_broadcast_in_dim(
     let primary = match cotangent_out[0] {
         Some(ct) if broadcast_axes.is_empty() => Some(ct),
         Some(ct) => {
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::ReduceSum {
                     axes: broadcast_axes,
                 },
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -407,15 +407,15 @@ pub fn transpose_broadcast_in_dim(
 }
 
 pub fn transpose_convert(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    mode: &OperationRole,
     from: tenferro_tensor::DType,
     to: tenferro_tensor::DType,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let is_active = matches!(
         mode,
-        OpMode::Linear { active_mask } if active_mask.first().copied().unwrap_or(false)
+        OperationRole::Linearized { active_mask } if active_mask.first().copied().unwrap_or(false)
     );
     if !is_active {
         return vec![None];
@@ -423,10 +423,10 @@ pub fn transpose_convert(
 
     match cotangent_out[0] {
         Some(ct) => {
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Convert { from: to, to: from },
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -437,16 +437,16 @@ pub fn transpose_convert(
 }
 
 pub fn transpose_tril(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
     k: i64,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match cotangent_out[0] {
         Some(ct) => {
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Tril { k },
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -457,16 +457,16 @@ pub fn transpose_tril(
 }
 
 pub fn transpose_triu(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
     k: i64,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     match cotangent_out[0] {
         Some(ct) => {
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Triu { k },
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -477,13 +477,13 @@ pub fn transpose_triu(
 }
 
 pub fn transpose_slice(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     config: &SliceConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None];
     };
@@ -544,14 +544,14 @@ pub fn transpose_slice(
         interior_padding.push(usize_to_i64(stride - 1, "transpose_slice"));
     }
 
-    let out = emitter.add_op(
+    let out = builder.add_operation(
         StdTensorOp::Pad(PadConfig {
             edge_padding_low,
             edge_padding_high,
             interior_padding,
         }),
-        vec![ValRef::Local(ct)],
-        OpMode::Linear {
+        vec![ValueRef::Local(ct)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     );
@@ -559,13 +559,13 @@ pub fn transpose_slice(
 }
 
 pub fn transpose_pad(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     config: &PadConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None];
     };
@@ -651,14 +651,14 @@ pub fn transpose_pad(
         edge_padding_high.push(i128_to_i64(input_extent_i - j_end, "transpose_pad"));
     }
 
-    let sliced = emitter.add_op(
+    let sliced = builder.add_operation(
         StdTensorOp::Slice(SliceConfig {
             starts,
             limits,
             strides,
         }),
-        vec![ValRef::Local(ct)],
-        OpMode::Linear {
+        vec![ValueRef::Local(ct)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0];
@@ -668,14 +668,14 @@ pub fn transpose_pad(
         return vec![Some(sliced)];
     }
 
-    let out = emitter.add_op(
+    let out = builder.add_operation(
         StdTensorOp::Pad(PadConfig {
             edge_padding_low,
             edge_padding_high,
             interior_padding: vec![0; rank],
         }),
-        vec![ValRef::Local(sliced)],
-        OpMode::Linear {
+        vec![ValueRef::Local(sliced)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     );
@@ -683,11 +683,11 @@ pub fn transpose_pad(
 }
 
 pub fn transpose_reverse(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    mode: &OperationRole,
     axes: &[usize],
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None];
     };
@@ -695,12 +695,12 @@ pub fn transpose_reverse(
         return vec![None];
     }
 
-    let out = emitter.add_op(
+    let out = builder.add_operation(
         StdTensorOp::Reverse {
             axes: axes.to_vec(),
         },
-        vec![ValRef::Local(ct)],
-        OpMode::Linear {
+        vec![ValueRef::Local(ct)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     );
@@ -708,25 +708,25 @@ pub fn transpose_reverse(
 }
 
 pub fn transpose_concatenate(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     axis: usize,
-    n_inputs: usize,
+    input_count: usize,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
-        return vec![None; n_inputs];
+        return vec![None; input_count];
     };
     let active_mask = match mode {
-        OpMode::Linear { active_mask } => active_mask,
-        OpMode::Primal => return vec![None; n_inputs],
+        OperationRole::Linearized { active_mask } => active_mask,
+        OperationRole::Primary => return vec![None; input_count],
     };
 
-    let mut result = vec![None; n_inputs];
+    let mut result = vec![None; input_count];
     let mut axis_offset = 0usize;
-    for input_index in 0..n_inputs {
+    for input_index in 0..input_count {
         let input_shape = ctx.shape_of(&inputs[input_index]);
         let rank = input_shape.len();
         assert!(
@@ -747,14 +747,14 @@ pub fn transpose_concatenate(
                     }
                 })
                 .collect();
-            let out = emitter.add_op(
+            let out = builder.add_operation(
                 StdTensorOp::Slice(SliceConfig {
                     starts,
                     limits,
                     strides: vec![1; rank],
                 }),
-                vec![ValRef::Local(ct)],
-                OpMode::Linear {
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
                     active_mask: vec![true],
                 },
             );
@@ -766,10 +766,10 @@ pub fn transpose_concatenate(
     result
 }
 
-fn first_input_active(mode: &OpMode) -> bool {
+fn first_input_active(mode: &OperationRole) -> bool {
     matches!(
         mode,
-        OpMode::Linear { active_mask } if active_mask.first().copied().unwrap_or(false)
+        OperationRole::Linearized { active_mask } if active_mask.first().copied().unwrap_or(false)
     )
 }
 

--- a/tenferro-internal-ops/src/ad/support.rs
+++ b/tenferro-internal-ops/src/ad/support.rs
@@ -1,8 +1,8 @@
-use computegraph::types::{LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueRef};
 use tenferro_tensor::DType;
 
 use crate::ad::context::ShapeGuardContext;
+use crate::ad::PrimitiveRuleBuilder;
 use crate::std_tensor_op::StdTensorOp;
 
 pub fn is_real_dtype(dtype: DType) -> bool {
@@ -10,38 +10,40 @@ pub fn is_real_dtype(dtype: DType) -> bool {
 }
 
 pub fn conjugate_primal_if_complex(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
     ctx: &mut ShapeGuardContext,
-) -> ValRef<StdTensorOp> {
+) -> ValueRef<StdTensorOp> {
     let dtype = ctx.dtype_of(&input);
-    conjugate_primal_if_dtype_complex(emitter, input, dtype)
+    conjugate_primal_if_dtype_complex(builder, input, dtype)
 }
 
 pub fn conjugate_primal_if_dtype_complex(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
     dtype: DType,
-) -> ValRef<StdTensorOp> {
+) -> ValueRef<StdTensorOp> {
     if is_real_dtype(dtype) {
         input
     } else {
-        ValRef::Local(emitter.add_op(StdTensorOp::Conj, vec![input], OpMode::Primal)[0])
+        ValueRef::Local(
+            builder.add_operation(StdTensorOp::Conj, vec![input], OperationRole::Primary)[0],
+        )
     }
 }
 
 pub fn conjugate_linear_if_dtype_complex(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    input: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
     dtype: DType,
-) -> LocalValId {
+) -> LocalValueId {
     if is_real_dtype(dtype) {
         input
     } else {
-        emitter.add_op(
+        builder.add_operation(
             StdTensorOp::Conj,
-            vec![ValRef::Local(input)],
-            OpMode::Linear {
+            vec![ValueRef::Local(input)],
+            OperationRole::Linearized {
                 active_mask: vec![true],
             },
         )[0]

--- a/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
+++ b/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for elementwise AD helper rules.
 
-use computegraph::fragment::FragmentBuilder;
-use computegraph::types::{GlobalValKey, OpMode, ValRef};
+use computegraph::graph::GraphBuilder;
+use computegraph::types::{OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{CompareDir, DType};
 
 use crate::ad::context::ShapeGuardContext;
@@ -12,13 +12,13 @@ fn tensor_input(id: u64) -> TensorInputKey {
     TensorInputKey::User { id }
 }
 
-fn input_key(id: u64) -> GlobalValKey<StdTensorOp> {
-    GlobalValKey::Input(tensor_input(id))
+fn input_key(id: u64) -> ValueKey<StdTensorOp> {
+    ValueKey::Input(tensor_input(id))
 }
 
 #[test]
 fn zero_like_covers_scalar_and_broadcasted_dtype_paths() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let anchor = builder.add_input(tensor_input(1));
 
     let dtype_cases = [
@@ -31,20 +31,20 @@ fn zero_like_covers_scalar_and_broadcasted_dtype_paths() {
     let mut scalar_zeros = Vec::new();
     for (dtype, byte_len) in dtype_cases {
         let zero =
-            super::super::zeros::build_zero_like(&mut builder, dtype, ValRef::Local(anchor), 0);
+            super::super::zeros::build_zero_like(&mut builder, dtype, ValueRef::Local(anchor), 0);
         scalar_zeros.push((zero, dtype, byte_len));
     }
 
     let vector_zero =
-        super::super::zeros::build_zero_like(&mut builder, DType::F64, ValRef::Local(anchor), 2);
-    let fragment = builder.build();
+        super::super::zeros::build_zero_like(&mut builder, DType::F64, ValueRef::Local(anchor), 2);
+    let graph = builder.build();
 
     for (zero, dtype, byte_len) in scalar_zeros {
-        let (op_id, _) = fragment.vals()[zero]
+        let (op_id, _) = graph.values()[zero]
             .producer
             .expect("zero scalar must be produced by a constant op");
-        let op = &fragment.ops()[op_id];
-        match &op.op {
+        let op = &graph.operations()[op_id];
+        match &op.operation {
             StdTensorOp::Constant { dtype: got, bytes } => {
                 assert_eq!(*got, dtype);
                 assert_eq!(bytes.len(), byte_len);
@@ -54,12 +54,12 @@ fn zero_like_covers_scalar_and_broadcasted_dtype_paths() {
         }
     }
 
-    let (broadcast, _) = fragment.vals()[vector_zero]
+    let (broadcast, _) = graph.values()[vector_zero]
         .producer
         .expect("ranked zero must be produced by broadcast");
-    let op = &fragment.ops()[broadcast];
+    let op = &graph.operations()[broadcast];
     assert_eq!(
-        op.op,
+        op.operation,
         StdTensorOp::BroadcastInDim {
             shape: vec![
                 crate::dim_expr::DimExpr::InputDim {
@@ -74,7 +74,7 @@ fn zero_like_covers_scalar_and_broadcasted_dtype_paths() {
             dims: vec![],
         }
     );
-    assert_eq!(op.inputs[1], ValRef::Local(anchor));
+    assert_eq!(op.inputs[1], ValueRef::Local(anchor));
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn linearize_elementwise_inactive_inputs_return_none_without_ops() {
         StdTensorOp::Select,
         StdTensorOp::Clamp,
     ] {
-        let mut builder = FragmentBuilder::<StdTensorOp>::new();
+        let mut builder = GraphBuilder::<StdTensorOp>::new();
         let result = op.jvp_rule(
             &mut builder,
             &keys,
@@ -101,7 +101,7 @@ fn linearize_elementwise_inactive_inputs_return_none_without_ops() {
         );
         assert_eq!(result, vec![None], "{op:?}");
         assert!(
-            builder.build().ops().is_empty(),
+            builder.build().operations().is_empty(),
             "inactive {op:?} should not emit linearized ops"
         );
     }
@@ -109,7 +109,7 @@ fn linearize_elementwise_inactive_inputs_return_none_without_ops() {
 
 #[test]
 fn linearize_div_with_two_active_inputs_sums_both_terms() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let dx = builder.add_input(tensor_input(10));
     let dy = builder.add_input(tensor_input(11));
     let mut ctx = ShapeGuardContext::default();
@@ -124,9 +124,9 @@ fn linearize_div_with_two_active_inputs_sums_both_terms() {
     );
 
     assert!(result[0].is_some());
-    let fragment = builder.build();
+    let graph = builder.build();
     assert_eq!(
-        fragment.ops().last().map(|op| &op.op),
+        graph.operations().last().map(|op| &op.operation),
         Some(&StdTensorOp::Add)
     );
 }
@@ -135,7 +135,7 @@ fn linearize_div_with_two_active_inputs_sums_both_terms() {
 fn linearize_extrema_and_select_emit_zero_fill_for_one_sided_tangents() {
     let mut ctx = ShapeGuardContext::default();
 
-    let mut max_builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut max_builder = GraphBuilder::<StdTensorOp>::new();
     let dx = max_builder.add_input(tensor_input(20));
     let result = StdTensorOp::Maximum.jvp_rule(
         &mut max_builder,
@@ -145,11 +145,17 @@ fn linearize_extrema_and_select_emit_zero_fill_for_one_sided_tangents() {
         &mut ctx,
     );
     assert!(result[0].is_some());
-    let fragment = max_builder.build();
-    assert_eq!(fragment.ops()[0].op, StdTensorOp::Compare(CompareDir::Ge));
-    assert!(fragment.ops().iter().any(|op| op.op == StdTensorOp::Select));
+    let graph = max_builder.build();
+    assert_eq!(
+        graph.operations()[0].operation,
+        StdTensorOp::Compare(CompareDir::Ge)
+    );
+    assert!(graph
+        .operations()
+        .iter()
+        .any(|op| op.operation == StdTensorOp::Select));
 
-    let mut min_builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut min_builder = GraphBuilder::<StdTensorOp>::new();
     let dy = min_builder.add_input(tensor_input(23));
     let result = StdTensorOp::Minimum.jvp_rule(
         &mut min_builder,
@@ -159,14 +165,20 @@ fn linearize_extrema_and_select_emit_zero_fill_for_one_sided_tangents() {
         &mut ctx,
     );
     assert!(result[0].is_some());
-    let fragment = min_builder.build();
-    assert_eq!(fragment.ops()[0].op, StdTensorOp::Compare(CompareDir::Le));
-    assert!(fragment.ops().iter().any(|op| op.op == StdTensorOp::Select));
+    let graph = min_builder.build();
+    assert_eq!(
+        graph.operations()[0].operation,
+        StdTensorOp::Compare(CompareDir::Le)
+    );
+    assert!(graph
+        .operations()
+        .iter()
+        .any(|op| op.operation == StdTensorOp::Select));
 }
 
 #[test]
 fn linearize_clamp_builds_nested_selects_for_active_bounds() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let dx = builder.add_input(tensor_input(30));
     let dlower = builder.add_input(tensor_input(31));
     let dupper = builder.add_input(tensor_input(32));
@@ -181,12 +193,12 @@ fn linearize_clamp_builds_nested_selects_for_active_bounds() {
     );
 
     assert!(result[0].is_some());
-    let fragment = builder.build();
+    let graph = builder.build();
     assert!(
-        fragment
-            .ops()
+        graph
+            .operations()
             .iter()
-            .filter(|op| op.op == StdTensorOp::Select)
+            .filter(|op| op.operation == StdTensorOp::Select)
             .count()
             >= 2
     );
@@ -194,15 +206,21 @@ fn linearize_clamp_builds_nested_selects_for_active_bounds() {
 
 #[test]
 fn transpose_elementwise_handles_missing_or_inactive_cotangents() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let inputs = vec![
-        ValRef::External(input_key(40)),
-        ValRef::External(input_key(41)),
+        ValueRef::External(input_key(40)),
+        ValueRef::External(input_key(41)),
     ];
 
     assert_eq!(
-        StdTensorOp::Div.transpose_rule(&mut builder, &[None], &inputs, &OpMode::Primal, &mut ctx),
+        StdTensorOp::Div.transpose_rule(
+            &mut builder,
+            &[None],
+            &inputs,
+            &OperationRole::Primary,
+            &mut ctx
+        ),
         vec![None, None]
     );
     let abs_ct = builder.add_input(tensor_input(42));
@@ -211,7 +229,7 @@ fn transpose_elementwise_handles_missing_or_inactive_cotangents() {
             &mut builder,
             &[Some(abs_ct)],
             &[inputs[0].clone()],
-            &OpMode::Primal,
+            &OperationRole::Primary,
             &mut ctx,
         ),
         vec![None]
@@ -221,7 +239,7 @@ fn transpose_elementwise_handles_missing_or_inactive_cotangents() {
             &mut builder,
             &[None],
             &inputs,
-            &OpMode::Linear {
+            &OperationRole::Linearized {
                 active_mask: vec![true, true],
             },
             &mut ctx,
@@ -232,20 +250,20 @@ fn transpose_elementwise_handles_missing_or_inactive_cotangents() {
 
 #[test]
 fn transpose_select_splits_cotangent_only_to_active_value_inputs() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let ct = builder.add_input(tensor_input(50));
     let mut ctx = ShapeGuardContext::default();
     let inputs = vec![
-        ValRef::External(input_key(51)),
-        ValRef::External(input_key(52)),
-        ValRef::External(input_key(53)),
+        ValueRef::External(input_key(51)),
+        ValueRef::External(input_key(52)),
+        ValueRef::External(input_key(53)),
     ];
 
     let result = StdTensorOp::Select.transpose_rule(
         &mut builder,
         &[Some(ct)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![false, true, false],
         },
         &mut ctx,
@@ -254,26 +272,29 @@ fn transpose_select_splits_cotangent_only_to_active_value_inputs() {
     assert_eq!(result[0], None);
     assert!(result[1].is_some());
     assert_eq!(result[2], None);
-    let fragment = builder.build();
-    assert!(fragment.ops().iter().any(|op| op.op == StdTensorOp::Select));
+    let graph = builder.build();
+    assert!(graph
+        .operations()
+        .iter()
+        .any(|op| op.operation == StdTensorOp::Select));
 }
 
 #[test]
 fn transpose_clamp_covers_lower_only_and_inner_paths() {
     let mut ctx = ShapeGuardContext::default();
     let inputs = vec![
-        ValRef::External(input_key(60)),
-        ValRef::External(input_key(61)),
-        ValRef::External(input_key(62)),
+        ValueRef::External(input_key(60)),
+        ValueRef::External(input_key(61)),
+        ValueRef::External(input_key(62)),
     ];
 
-    let mut lower_builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut lower_builder = GraphBuilder::<StdTensorOp>::new();
     let lower_ct = lower_builder.add_input(tensor_input(63));
     let result = StdTensorOp::Clamp.transpose_rule(
         &mut lower_builder,
         &[Some(lower_ct)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![false, true, false],
         },
         &mut ctx,
@@ -282,13 +303,13 @@ fn transpose_clamp_covers_lower_only_and_inner_paths() {
     assert!(result[1].is_some());
     assert_eq!(result[2], None);
 
-    let mut full_builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut full_builder = GraphBuilder::<StdTensorOp>::new();
     let full_ct = full_builder.add_input(tensor_input(64));
     let result = StdTensorOp::Clamp.transpose_rule(
         &mut full_builder,
         &[Some(full_ct)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![true, true, true],
         },
         &mut ctx,

--- a/tenferro-internal-ops/src/ad/tests/indexing_tests.rs
+++ b/tenferro-internal-ops/src/ad/tests/indexing_tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for the `Gather` / `Scatter` AD rules in `ad::indexing`.
 
-use computegraph::fragment::FragmentBuilder;
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
+use computegraph::graph::GraphBuilder;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{DType, GatherConfig, ScatterConfig};
 
 use crate::ad::context::ShapeGuardContext;
@@ -16,15 +16,15 @@ fn tensor_input(id: u64) -> TensorInputKey {
     TensorInputKey::User { id }
 }
 
-fn input_key(id: u64) -> GlobalValKey<StdTensorOp> {
-    GlobalValKey::Input(tensor_input(id))
+fn input_key(id: u64) -> ValueKey<StdTensorOp> {
+    ValueKey::Input(tensor_input(id))
 }
 
 fn meta(shape: &[usize]) -> TensorMeta {
     TensorMeta::exact(DType::F64, shape.iter().copied().map(Into::into).collect())
 }
 
-fn seed_metadata(ctx: &mut ShapeGuardContext, entries: &[(GlobalValKey<StdTensorOp>, &[usize])]) {
+fn seed_metadata(ctx: &mut ShapeGuardContext, entries: &[(ValueKey<StdTensorOp>, &[usize])]) {
     for (key, shape) in entries {
         ctx.insert_metadata(key.clone(), meta(shape));
     }
@@ -54,7 +54,7 @@ fn rank1_scatter_config() -> ScatterConfig {
 
 #[test]
 fn linearize_gather_reuses_primal_indices_and_emits_gather() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(1);
     let indices_key = input_key(2);
@@ -69,42 +69,42 @@ fn linearize_gather_reuses_primal_indices_and_emits_gather() {
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
-    let fragment = builder.build();
+    let graph = builder.build();
 
-    assert_eq!(fragment.ops().len(), 1);
-    let gather_op = &fragment.ops()[0];
-    assert_eq!(gather_op.op, StdTensorOp::Gather(config));
+    assert_eq!(graph.operations().len(), 1);
+    let gather_op = &graph.operations()[0];
+    assert_eq!(gather_op.operation, StdTensorOp::Gather(config));
     assert_eq!(
-        gather_op.mode,
-        OpMode::Linear {
+        gather_op.role,
+        OperationRole::Linearized {
             active_mask: vec![true, false],
         }
     );
     // The second operand of the linearised Gather must be the *primal* indices.
-    assert_eq!(gather_op.inputs[1], ValRef::External(indices_key),);
+    assert_eq!(gather_op.inputs[1], ValueRef::External(indices_key),);
     // The returned local id must be one of the emitted gather's outputs.
     assert!(gather_op.outputs.contains(&tangent_out));
 }
 
 #[test]
 fn linearize_gather_inactive_tangent_returns_none() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(10);
     let indices_key = input_key(11);
 
     let op = StdTensorOp::Gather(rank1_gather_config());
     let primal_in = vec![operand_key, indices_key];
-    let tangent_in: [Option<LocalValId>; 2] = [None, None];
+    let tangent_in: [Option<LocalValueId>; 2] = [None, None];
 
     let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
     assert_eq!(result, vec![None]);
-    assert!(builder.build().ops().is_empty());
+    assert!(builder.build().operations().is_empty());
 }
 
 #[test]
 fn linearize_dynamic_gather_reuses_primal_indices_and_shape_sources() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(101);
     let indices_key = input_key(102);
@@ -132,17 +132,17 @@ fn linearize_dynamic_gather_reuses_primal_indices_and_shape_sources() {
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
-    let fragment = builder.build();
+    let graph = builder.build();
 
-    assert_eq!(fragment.ops().len(), 1);
-    let gather = &fragment.ops()[0];
-    assert_eq!(gather.op, op);
-    assert_eq!(gather.inputs[0], ValRef::Local(operand_tangent));
-    assert_eq!(gather.inputs[1], ValRef::External(indices_key));
-    assert_eq!(gather.inputs[2], ValRef::External(shape_source_key));
+    assert_eq!(graph.operations().len(), 1);
+    let gather = &graph.operations()[0];
+    assert_eq!(gather.operation, op);
+    assert_eq!(gather.inputs[0], ValueRef::Local(operand_tangent));
+    assert_eq!(gather.inputs[1], ValueRef::External(indices_key));
+    assert_eq!(gather.inputs[2], ValueRef::External(shape_source_key));
     assert_eq!(
-        gather.mode,
-        OpMode::Linear {
+        gather.role,
+        OperationRole::Linearized {
             active_mask: vec![true, false, false],
         }
     );
@@ -151,7 +151,7 @@ fn linearize_dynamic_gather_reuses_primal_indices_and_shape_sources() {
 
 #[test]
 fn linearize_dynamic_slice_reuses_primal_starts() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(105);
     let starts_key = input_key(106);
@@ -168,16 +168,19 @@ fn linearize_dynamic_slice_reuses_primal_starts() {
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
-    let fragment = builder.build();
+    let graph = builder.build();
 
-    assert_eq!(fragment.ops().len(), 1);
-    let dynamic_slice = &fragment.ops()[0];
-    assert_eq!(dynamic_slice.op, StdTensorOp::DynamicSlice { slice_sizes });
-    assert_eq!(dynamic_slice.inputs[0], ValRef::Local(operand_tangent));
-    assert_eq!(dynamic_slice.inputs[1], ValRef::External(starts_key));
+    assert_eq!(graph.operations().len(), 1);
+    let dynamic_slice = &graph.operations()[0];
     assert_eq!(
-        dynamic_slice.mode,
-        OpMode::Linear {
+        dynamic_slice.operation,
+        StdTensorOp::DynamicSlice { slice_sizes }
+    );
+    assert_eq!(dynamic_slice.inputs[0], ValueRef::Local(operand_tangent));
+    assert_eq!(dynamic_slice.inputs[1], ValueRef::External(starts_key));
+    assert_eq!(
+        dynamic_slice.role,
+        OperationRole::Linearized {
             active_mask: vec![true, false],
         }
     );
@@ -186,7 +189,7 @@ fn linearize_dynamic_slice_reuses_primal_starts() {
 
 #[test]
 fn linearize_dynamic_slice_inactive_tangent_returns_none() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(108);
     let starts_key = input_key(109);
@@ -195,16 +198,16 @@ fn linearize_dynamic_slice_inactive_tangent_returns_none() {
         slice_sizes: vec![3],
     };
     let primal_in = vec![operand_key, starts_key];
-    let tangent_in: [Option<LocalValId>; 2] = [None, None];
+    let tangent_in: [Option<LocalValueId>; 2] = [None, None];
 
     let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
     assert_eq!(result, vec![None]);
-    assert!(builder.build().ops().is_empty());
+    assert!(builder.build().operations().is_empty());
 }
 
 #[test]
 fn linearize_dynamic_update_slice_reuses_primal_starts() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(110);
     let update_key = input_key(111);
@@ -220,17 +223,17 @@ fn linearize_dynamic_update_slice_reuses_primal_starts() {
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
-    let fragment = builder.build();
+    let graph = builder.build();
 
-    assert_eq!(fragment.ops().len(), 1);
-    let update_slice = &fragment.ops()[0];
-    assert_eq!(update_slice.op, StdTensorOp::DynamicUpdateSlice);
-    assert_eq!(update_slice.inputs[0], ValRef::Local(operand_tangent));
-    assert_eq!(update_slice.inputs[1], ValRef::Local(update_tangent));
-    assert_eq!(update_slice.inputs[2], ValRef::External(starts_key));
+    assert_eq!(graph.operations().len(), 1);
+    let update_slice = &graph.operations()[0];
+    assert_eq!(update_slice.operation, StdTensorOp::DynamicUpdateSlice);
+    assert_eq!(update_slice.inputs[0], ValueRef::Local(operand_tangent));
+    assert_eq!(update_slice.inputs[1], ValueRef::Local(update_tangent));
+    assert_eq!(update_slice.inputs[2], ValueRef::External(starts_key));
     assert_eq!(
-        update_slice.mode,
-        OpMode::Linear {
+        update_slice.role,
+        OperationRole::Linearized {
             active_mask: vec![true, true, false],
         }
     );
@@ -239,7 +242,7 @@ fn linearize_dynamic_update_slice_reuses_primal_starts() {
 
 #[test]
 fn transpose_dynamic_slice_emits_dynamic_update_slice() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cot = builder.add_input(tensor_input(115));
     let operand_key = input_key(116);
@@ -250,8 +253,8 @@ fn transpose_dynamic_slice_emits_dynamic_update_slice() {
     );
 
     let inputs = vec![
-        ValRef::External(operand_key.clone()),
-        ValRef::External(starts_key.clone()),
+        ValueRef::External(operand_key.clone()),
+        ValueRef::External(starts_key.clone()),
     ];
     let result = (StdTensorOp::DynamicSlice {
         slice_sizes: vec![3],
@@ -260,7 +263,7 @@ fn transpose_dynamic_slice_emits_dynamic_update_slice() {
         &mut builder,
         &[Some(cot)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![true, false],
         },
         &mut ctx,
@@ -269,19 +272,19 @@ fn transpose_dynamic_slice_emits_dynamic_update_slice() {
     assert!(result[0].is_some(), "operand cotangent must be active");
     assert_eq!(result[1], None, "starts cotangent must stay None");
 
-    let fragment = builder.build();
-    let update_slice = fragment
-        .ops()
+    let graph = builder.build();
+    let update_slice = graph
+        .operations()
         .iter()
-        .find(|op_node| matches!(op_node.op, StdTensorOp::DynamicUpdateSlice))
+        .find(|op_node| matches!(op_node.operation, StdTensorOp::DynamicUpdateSlice))
         .expect("expected a DynamicUpdateSlice op");
-    assert!(matches!(update_slice.inputs[0], ValRef::Local(_)));
-    assert_ne!(update_slice.inputs[0], ValRef::External(operand_key));
-    assert_eq!(update_slice.inputs[1], ValRef::Local(cot));
-    assert_eq!(update_slice.inputs[2], ValRef::External(starts_key));
+    assert!(matches!(update_slice.inputs[0], ValueRef::Local(_)));
+    assert_ne!(update_slice.inputs[0], ValueRef::External(operand_key));
+    assert_eq!(update_slice.inputs[1], ValueRef::Local(cot));
+    assert_eq!(update_slice.inputs[2], ValueRef::External(starts_key));
     assert_eq!(
-        update_slice.mode,
-        OpMode::Linear {
+        update_slice.role,
+        OperationRole::Linearized {
             active_mask: vec![false, true, false],
         }
     );
@@ -289,7 +292,7 @@ fn transpose_dynamic_slice_emits_dynamic_update_slice() {
 
 #[test]
 fn transpose_dynamic_update_slice_returns_operand_and_update_cotangents() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cot = builder.add_input(tensor_input(118));
     let operand_key = input_key(119);
@@ -305,15 +308,15 @@ fn transpose_dynamic_update_slice_returns_operand_and_update_cotangents() {
     );
 
     let inputs = vec![
-        ValRef::External(operand_key),
-        ValRef::External(update_key),
-        ValRef::External(starts_key.clone()),
+        ValueRef::External(operand_key),
+        ValueRef::External(update_key),
+        ValueRef::External(starts_key.clone()),
     ];
     let result = StdTensorOp::DynamicUpdateSlice.transpose_rule(
         &mut builder,
         &[Some(cot)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![true, true, false],
         },
         &mut ctx,
@@ -323,32 +326,32 @@ fn transpose_dynamic_update_slice_returns_operand_and_update_cotangents() {
     assert!(result[1].is_some(), "update cotangent must be active");
     assert_eq!(result[2], None, "starts cotangent must stay None");
 
-    let fragment = builder.build();
+    let graph = builder.build();
     assert!(
-        fragment
-            .ops()
+        graph
+            .operations()
             .iter()
-            .any(|op_node| matches!(op_node.op, StdTensorOp::DynamicUpdateSlice)),
+            .any(|op_node| matches!(op_node.operation, StdTensorOp::DynamicUpdateSlice)),
         "operand cotangent should be masked by DynamicUpdateSlice"
     );
-    let update_ct = fragment
-        .ops()
+    let update_ct = graph
+        .operations()
         .iter()
-        .find(|op_node| matches!(op_node.op, StdTensorOp::DynamicSlice { .. }))
+        .find(|op_node| matches!(op_node.operation, StdTensorOp::DynamicSlice { .. }))
         .expect("expected a DynamicSlice op for update cotangent");
     assert_eq!(
-        update_ct.op,
+        update_ct.operation,
         StdTensorOp::DynamicSlice {
             slice_sizes: vec![3],
         }
     );
-    assert_eq!(update_ct.inputs[0], ValRef::Local(cot));
-    assert_eq!(update_ct.inputs[1], ValRef::External(starts_key));
+    assert_eq!(update_ct.inputs[0], ValueRef::Local(cot));
+    assert_eq!(update_ct.inputs[1], ValueRef::External(starts_key));
 }
 
 #[test]
 fn transpose_gather_emits_scatter_with_inverted_config() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cot = builder.add_input(tensor_input(20));
     let operand_key = input_key(21);
@@ -361,15 +364,15 @@ fn transpose_gather_emits_scatter_with_inverted_config() {
     let config = rank1_gather_config();
     let op = StdTensorOp::Gather(config.clone());
     let inputs = vec![
-        ValRef::External(operand_key.clone()),
-        ValRef::External(indices_key.clone()),
+        ValueRef::External(operand_key.clone()),
+        ValueRef::External(indices_key.clone()),
     ];
 
     let result = op.transpose_rule(
         &mut builder,
         &[Some(cot)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![true, false],
         },
         &mut ctx,
@@ -377,18 +380,18 @@ fn transpose_gather_emits_scatter_with_inverted_config() {
     assert!(result[0].is_some(), "operand cotangent must be active");
     assert_eq!(result[1], None, "indices cotangent must stay None");
 
-    let fragment = builder.build();
+    let graph = builder.build();
     // Under StableHLO add-scatter semantics the inverse scatter must use
-    // a zero operand built from Constant + BroadcastInDim, so the fragment
+    // a zero operand built from Constant + BroadcastInDim, so the graph
     // contains [Constant, BroadcastInDim, Scatter].
-    assert_eq!(fragment.ops().len(), 3);
-    let scatter = fragment
-        .ops()
+    assert_eq!(graph.operations().len(), 3);
+    let scatter = graph
+        .operations()
         .iter()
-        .find(|op_node| matches!(op_node.op, StdTensorOp::Scatter(_)))
-        .expect("expected a Scatter op in the fragment");
-    let StdTensorOp::Scatter(scatter_cfg) = &scatter.op else {
-        panic!("expected Scatter op, got {:?}", scatter.op);
+        .find(|op_node| matches!(op_node.operation, StdTensorOp::Scatter(_)))
+        .expect("expected a Scatter op in the graph");
+    let StdTensorOp::Scatter(scatter_cfg) = &scatter.operation else {
+        panic!("expected Scatter op, got {:?}", scatter.operation);
     };
     assert_eq!(scatter_cfg.update_window_dims, config.offset_dims);
     assert_eq!(
@@ -402,14 +405,14 @@ fn transpose_gather_emits_scatter_with_inverted_config() {
     assert_eq!(scatter_cfg.index_vector_dim, config.index_vector_dim);
     // The scatter's first input (operand) must be the broadcast zero
     // local, not the primal forward-gather operand.
-    assert!(matches!(scatter.inputs[0], ValRef::Local(_)));
-    assert_ne!(scatter.inputs[0], ValRef::External(operand_key));
+    assert!(matches!(scatter.inputs[0], ValueRef::Local(_)));
+    assert_ne!(scatter.inputs[0], ValueRef::External(operand_key));
     // Indices are reused from the primal; updates are the cotangent.
-    assert_eq!(scatter.inputs[1], ValRef::External(indices_key));
-    assert_eq!(scatter.inputs[2], ValRef::Local(cot));
+    assert_eq!(scatter.inputs[1], ValueRef::External(indices_key));
+    assert_eq!(scatter.inputs[2], ValueRef::Local(cot));
     assert_eq!(
-        scatter.mode,
-        OpMode::Linear {
+        scatter.role,
+        OperationRole::Linearized {
             active_mask: vec![false, false, true],
         }
     );
@@ -417,11 +420,14 @@ fn transpose_gather_emits_scatter_with_inverted_config() {
 
 #[test]
 fn transpose_gather_inactive_path_returns_all_none() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(30);
     let indices_key = input_key(31);
-    let inputs = vec![ValRef::External(operand_key), ValRef::External(indices_key)];
+    let inputs = vec![
+        ValueRef::External(operand_key),
+        ValueRef::External(indices_key),
+    ];
 
     let op = StdTensorOp::Gather(rank1_gather_config());
 
@@ -429,18 +435,18 @@ fn transpose_gather_inactive_path_returns_all_none() {
         &mut builder,
         &[None],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![true, false],
         },
         &mut ctx,
     );
     assert_eq!(result, vec![None, None]);
-    assert!(builder.build().ops().is_empty());
+    assert!(builder.build().operations().is_empty());
 }
 
 #[test]
 fn transpose_dynamic_gather_emits_scatter_and_ignores_shape_sources() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cot = builder.add_input(tensor_input(120));
     let operand_key = input_key(121);
@@ -469,16 +475,16 @@ fn transpose_dynamic_gather_emits_scatter_and_ignores_shape_sources() {
         ],
     };
     let inputs = vec![
-        ValRef::External(operand_key.clone()),
-        ValRef::External(indices_key.clone()),
-        ValRef::External(shape_source_key),
+        ValueRef::External(operand_key.clone()),
+        ValueRef::External(indices_key.clone()),
+        ValueRef::External(shape_source_key),
     ];
 
     let result = op.transpose_rule(
         &mut builder,
         &[Some(cot)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![true, false, false],
         },
         &mut ctx,
@@ -488,21 +494,21 @@ fn transpose_dynamic_gather_emits_scatter_and_ignores_shape_sources() {
     assert_eq!(result[1], None, "indices cotangent must stay None");
     assert_eq!(result[2], None, "shape source cotangent must stay None");
 
-    let fragment = builder.build();
-    let scatter = fragment
-        .ops()
+    let graph = builder.build();
+    let scatter = graph
+        .operations()
         .iter()
-        .find(|op_node| matches!(op_node.op, StdTensorOp::Scatter(_)))
-        .expect("expected a Scatter op in the fragment");
-    let StdTensorOp::Scatter(scatter_cfg) = &scatter.op else {
-        panic!("expected Scatter op, got {:?}", scatter.op);
+        .find(|op_node| matches!(op_node.operation, StdTensorOp::Scatter(_)))
+        .expect("expected a Scatter op in the graph");
+    let StdTensorOp::Scatter(scatter_cfg) = &scatter.operation else {
+        panic!("expected Scatter op, got {:?}", scatter.operation);
     };
     assert_eq!(scatter_cfg.update_window_dims, vec![1]);
     assert_eq!(scatter_cfg.inserted_window_dims, vec![0]);
     assert_eq!(scatter_cfg.scatter_dims_to_operand_dims, vec![0]);
     assert_eq!(scatter_cfg.index_vector_dim, 1);
-    assert!(matches!(scatter.inputs[0], ValRef::Local(_)));
-    assert_ne!(scatter.inputs[0], ValRef::External(operand_key));
-    assert_eq!(scatter.inputs[1], ValRef::External(indices_key));
-    assert_eq!(scatter.inputs[2], ValRef::Local(cot));
+    assert!(matches!(scatter.inputs[0], ValueRef::Local(_)));
+    assert_ne!(scatter.inputs[0], ValueRef::External(operand_key));
+    assert_eq!(scatter.inputs[1], ValueRef::External(indices_key));
+    assert_eq!(scatter.inputs[2], ValueRef::Local(cot));
 }

--- a/tenferro-internal-ops/src/ad/tests/indexing_tests/scatter.rs
+++ b/tenferro-internal-ops/src/ad/tests/indexing_tests/scatter.rs
@@ -3,24 +3,24 @@ use super::*;
 #[test]
 fn linearize_scatter_inactive_tangents_returns_none() {
     // Both operand_dot = None and updates_dot = None => [None] with no ops.
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(50);
     let indices_key = input_key(51);
     let updates_key = input_key(52);
     let op = StdTensorOp::Scatter(rank1_scatter_config());
     let primal_in = vec![operand_key, indices_key, updates_key];
-    let tangent_in: [Option<LocalValId>; 3] = [None, None, None];
+    let tangent_in: [Option<LocalValueId>; 3] = [None, None, None];
     let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
     assert_eq!(result, vec![None]);
-    assert!(builder.build().ops().is_empty());
+    assert!(builder.build().operations().is_empty());
 }
 
 #[test]
 fn linearize_scatter_operand_only_is_identity_passthrough() {
     // Only operand_dot is active: the output tangent is the operand
     // tangent itself, with no ops emitted.
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(40);
     let indices_key = input_key(41);
@@ -46,9 +46,9 @@ fn linearize_scatter_operand_only_is_identity_passthrough() {
         vec![Some(operand_tangent)],
         "operand-only scatter tangent must be the operand tangent itself"
     );
-    let fragment = builder.build();
+    let graph = builder.build();
     assert!(
-        fragment.ops().is_empty(),
+        graph.operations().is_empty(),
         "identity passthrough must not emit any ops"
     );
 }
@@ -57,7 +57,7 @@ fn linearize_scatter_operand_only_is_identity_passthrough() {
 fn linearize_scatter_updates_only_uses_zero_operand() {
     // Only updates_dot is active: emit Scatter(zeros_like(operand), ..., d_updates)
     // via Constant + BroadcastInDim + Scatter.
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(40);
     let indices_key = input_key(41);
@@ -85,43 +85,43 @@ fn linearize_scatter_updates_only_uses_zero_operand() {
     assert_eq!(result.len(), 1);
     let _ = result[0].expect("output tangent must be active");
 
-    let fragment = builder.build();
-    // Fragment: [Constant, BroadcastInDim, Scatter]
+    let graph = builder.build();
+    // Graph: [Constant, BroadcastInDim, Scatter]
     assert_eq!(
-        fragment.ops().len(),
+        graph.operations().len(),
         3,
-        "expected Constant + BroadcastInDim + Scatter in the fragment"
+        "expected Constant + BroadcastInDim + Scatter in the graph"
     );
-    let scatter = fragment
-        .ops()
+    let scatter = graph
+        .operations()
         .iter()
-        .find(|op_node| matches!(op_node.op, StdTensorOp::Scatter(_)))
+        .find(|op_node| matches!(op_node.operation, StdTensorOp::Scatter(_)))
         .expect("expected a Scatter op");
-    assert_eq!(scatter.op, StdTensorOp::Scatter(config));
+    assert_eq!(scatter.operation, StdTensorOp::Scatter(config));
     assert_eq!(
-        scatter.mode,
-        OpMode::Linear {
+        scatter.role,
+        OperationRole::Linearized {
             active_mask: vec![false, false, true],
         }
     );
     // The scatter's operand must be a freshly built zero local, not the
     // primal operand.
-    assert!(matches!(scatter.inputs[0], ValRef::Local(_)));
-    assert_ne!(scatter.inputs[0], ValRef::External(operand_key));
-    assert_eq!(scatter.inputs[1], ValRef::External(indices_key));
-    assert_eq!(scatter.inputs[2], ValRef::Local(updates_tangent));
+    assert!(matches!(scatter.inputs[0], ValueRef::Local(_)));
+    assert_ne!(scatter.inputs[0], ValueRef::External(operand_key));
+    assert_eq!(scatter.inputs[1], ValueRef::External(indices_key));
+    assert_eq!(scatter.inputs[2], ValueRef::Local(updates_tangent));
 
-    // And the fragment should contain a matching Constant + BroadcastInDim
+    // And the graph should contain a matching Constant + BroadcastInDim
     // pair feeding the scatter's operand.
-    let constant_count = fragment
-        .ops()
+    let constant_count = graph
+        .operations()
         .iter()
-        .filter(|op_node| matches!(op_node.op, StdTensorOp::Constant { .. }))
+        .filter(|op_node| matches!(op_node.operation, StdTensorOp::Constant { .. }))
         .count();
-    let broadcast_count = fragment
-        .ops()
+    let broadcast_count = graph
+        .operations()
         .iter()
-        .filter(|op_node| matches!(op_node.op, StdTensorOp::BroadcastInDim { .. }))
+        .filter(|op_node| matches!(op_node.operation, StdTensorOp::BroadcastInDim { .. }))
         .count();
     assert_eq!(constant_count, 1, "exactly one Constant(zero) expected");
     assert_eq!(broadcast_count, 1, "exactly one BroadcastInDim expected");
@@ -131,7 +131,7 @@ fn linearize_scatter_updates_only_uses_zero_operand() {
 fn linearize_scatter_both_tangents_emit_single_scatter() {
     // Both operand_dot and updates_dot active => single Scatter with
     // active_mask [true, false, true], no zero-operand plumbing.
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let operand_key = input_key(40);
     let indices_key = input_key(41);
@@ -156,28 +156,28 @@ fn linearize_scatter_both_tangents_emit_single_scatter() {
     assert_eq!(result.len(), 1);
     let _ = result[0].expect("output tangent must be active");
 
-    let fragment = builder.build();
+    let graph = builder.build();
     assert_eq!(
-        fragment.ops().len(),
+        graph.operations().len(),
         1,
         "both-tangents case must emit exactly one Scatter"
     );
-    let scatter = &fragment.ops()[0];
-    assert_eq!(scatter.op, StdTensorOp::Scatter(config));
+    let scatter = &graph.operations()[0];
+    assert_eq!(scatter.operation, StdTensorOp::Scatter(config));
     assert_eq!(
-        scatter.mode,
-        OpMode::Linear {
+        scatter.role,
+        OperationRole::Linearized {
             active_mask: vec![true, false, true],
         }
     );
-    assert_eq!(scatter.inputs[0], ValRef::Local(operand_tangent));
-    assert_eq!(scatter.inputs[1], ValRef::External(indices_key));
-    assert_eq!(scatter.inputs[2], ValRef::Local(updates_tangent));
+    assert_eq!(scatter.inputs[0], ValueRef::Local(operand_tangent));
+    assert_eq!(scatter.inputs[1], ValueRef::External(indices_key));
+    assert_eq!(scatter.inputs[2], ValueRef::Local(updates_tangent));
 }
 
 #[test]
 fn transpose_scatter_emits_identity_for_operand_and_gather_for_updates() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cot = builder.add_input(tensor_input(60));
     let operand_key = input_key(61);
@@ -195,16 +195,16 @@ fn transpose_scatter_emits_identity_for_operand_and_gather_for_updates() {
     let config = rank1_scatter_config();
     let op = StdTensorOp::Scatter(config.clone());
     let inputs = vec![
-        ValRef::External(operand_key),
-        ValRef::External(indices_key.clone()),
-        ValRef::External(updates_key),
+        ValueRef::External(operand_key),
+        ValueRef::External(indices_key.clone()),
+        ValueRef::External(updates_key),
     ];
 
     let result = op.transpose_rule(
         &mut builder,
         &[Some(cot)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![true, false, true],
         },
         &mut ctx,
@@ -217,15 +217,15 @@ fn transpose_scatter_emits_identity_for_operand_and_gather_for_updates() {
     assert_eq!(result[1], None, "indices cotangent must stay None");
     assert!(result[2].is_some(), "updates cotangent must be active");
 
-    let fragment = builder.build();
+    let graph = builder.build();
     assert_eq!(
-        fragment.ops().len(),
+        graph.operations().len(),
         1,
         "identity passthrough must not emit extra ops; only the Gather"
     );
-    let gather = &fragment.ops()[0];
-    let StdTensorOp::Gather(gather_cfg) = &gather.op else {
-        panic!("expected Gather op, got {:?}", gather.op);
+    let gather = &graph.operations()[0];
+    let StdTensorOp::Gather(gather_cfg) = &gather.operation else {
+        panic!("expected Gather op, got {:?}", gather.operation);
     };
     assert_eq!(gather_cfg.offset_dims, config.update_window_dims);
     assert_eq!(gather_cfg.collapsed_slice_dims, config.inserted_window_dims);
@@ -239,15 +239,15 @@ fn transpose_scatter_emits_identity_for_operand_and_gather_for_updates() {
         vec![1],
         "all operand dims are inserted_window_dims => slice_sizes = [1]"
     );
-    assert_eq!(gather.inputs[0], ValRef::Local(cot));
-    assert_eq!(gather.inputs[1], ValRef::External(indices_key));
+    assert_eq!(gather.inputs[0], ValueRef::Local(cot));
+    assert_eq!(gather.inputs[1], ValueRef::External(indices_key));
 }
 
 #[test]
 fn transpose_scatter_updates_only_emits_only_gather() {
     // active_mask[0] = false, active_mask[2] = true → only the updates
     // cotangent comes back, via a single Gather.
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cot = builder.add_input(tensor_input(60));
     let operand_key = input_key(61);
@@ -265,16 +265,16 @@ fn transpose_scatter_updates_only_emits_only_gather() {
     let config = rank1_scatter_config();
     let op = StdTensorOp::Scatter(config);
     let inputs = vec![
-        ValRef::External(operand_key),
-        ValRef::External(indices_key.clone()),
-        ValRef::External(updates_key),
+        ValueRef::External(operand_key),
+        ValueRef::External(indices_key.clone()),
+        ValueRef::External(updates_key),
     ];
 
     let result = op.transpose_rule(
         &mut builder,
         &[Some(cot)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![false, false, true],
         },
         &mut ctx,
@@ -286,21 +286,21 @@ fn transpose_scatter_updates_only_emits_only_gather() {
     assert_eq!(result[1], None, "indices cotangent must stay None");
     assert!(result[2].is_some(), "updates cotangent must be active");
 
-    let fragment = builder.build();
-    assert_eq!(fragment.ops().len(), 1);
-    let gather = &fragment.ops()[0];
-    let StdTensorOp::Gather(_) = &gather.op else {
-        panic!("expected Gather op, got {:?}", gather.op);
+    let graph = builder.build();
+    assert_eq!(graph.operations().len(), 1);
+    let gather = &graph.operations()[0];
+    let StdTensorOp::Gather(_) = &gather.operation else {
+        panic!("expected Gather op, got {:?}", gather.operation);
     };
-    assert_eq!(gather.inputs[0], ValRef::Local(cot));
-    assert_eq!(gather.inputs[1], ValRef::External(indices_key));
+    assert_eq!(gather.inputs[0], ValueRef::Local(cot));
+    assert_eq!(gather.inputs[1], ValueRef::External(indices_key));
 }
 
 #[test]
 fn transpose_scatter_operand_only_is_identity_and_no_ops() {
     // active_mask[0] = true, active_mask[2] = false → operand cotangent is
     // cot_out (identity passthrough); no ops emitted.
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cot = builder.add_input(tensor_input(60));
     let operand_key = input_key(61);
@@ -318,16 +318,16 @@ fn transpose_scatter_operand_only_is_identity_and_no_ops() {
     let config = rank1_scatter_config();
     let op = StdTensorOp::Scatter(config);
     let inputs = vec![
-        ValRef::External(operand_key),
-        ValRef::External(indices_key),
-        ValRef::External(updates_key),
+        ValueRef::External(operand_key),
+        ValueRef::External(indices_key),
+        ValueRef::External(updates_key),
     ];
 
     let result = op.transpose_rule(
         &mut builder,
         &[Some(cot)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![true, false, false],
         },
         &mut ctx,
@@ -337,12 +337,12 @@ fn transpose_scatter_operand_only_is_identity_and_no_ops() {
         vec![Some(cot), None, None],
         "operand-only transpose must be identity passthrough and no-op"
     );
-    assert!(builder.build().ops().is_empty());
+    assert!(builder.build().operations().is_empty());
 }
 
 #[test]
 fn transpose_scatter_inactive_updates_returns_all_none() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cot = builder.add_input(tensor_input(70));
     let operand_key = input_key(71);
@@ -357,9 +357,9 @@ fn transpose_scatter_inactive_updates_returns_all_none() {
         ],
     );
     let inputs = vec![
-        ValRef::External(operand_key),
-        ValRef::External(indices_key),
-        ValRef::External(updates_key),
+        ValueRef::External(operand_key),
+        ValueRef::External(indices_key),
+        ValueRef::External(updates_key),
     ];
 
     let op = StdTensorOp::Scatter(rank1_scatter_config());
@@ -367,20 +367,20 @@ fn transpose_scatter_inactive_updates_returns_all_none() {
         &mut builder,
         &[Some(cot)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![false, false, false],
         },
         &mut ctx,
     );
     assert_eq!(result, vec![None, None, None]);
-    assert!(builder.build().ops().is_empty());
+    assert!(builder.build().operations().is_empty());
 }
 
 #[test]
 fn transpose_scatter_window_dims_derive_slice_sizes_from_updates_shape() {
     // Scatter 2-slabs into a rank-2 operand, along axis 0. The inverse
     // Gather must read a window of 2 along operand axis 1.
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cot = builder.add_input(tensor_input(80));
     let operand_key = input_key(81);
@@ -404,24 +404,24 @@ fn transpose_scatter_window_dims_derive_slice_sizes_from_updates_shape() {
     };
     let op = StdTensorOp::Scatter(config);
     let inputs = vec![
-        ValRef::External(operand_key),
-        ValRef::External(indices_key),
-        ValRef::External(updates_key),
+        ValueRef::External(operand_key),
+        ValueRef::External(indices_key),
+        ValueRef::External(updates_key),
     ];
 
     let result = op.transpose_rule(
         &mut builder,
         &[Some(cot)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![false, false, true],
         },
         &mut ctx,
     );
     assert!(result[2].is_some());
 
-    let fragment = builder.build();
-    let StdTensorOp::Gather(cfg) = &fragment.ops()[0].op else {
+    let graph = builder.build();
+    let StdTensorOp::Gather(cfg) = &graph.operations()[0].operation else {
         panic!("expected Gather op");
     };
     // operand rank = 2, inserted_window_dims = [0] -> window dim is operand
@@ -436,7 +436,7 @@ fn transpose_scatter_window_dims_derive_slice_sizes_from_updates_shape() {
 
 #[test]
 fn transpose_scatter_symbolic_window_dim_emits_dynamic_gather() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cot = builder.add_input(tensor_input(900));
     let operand_key = input_key(901);
@@ -468,24 +468,24 @@ fn transpose_scatter_symbolic_window_dim_emits_dynamic_gather() {
 
     let op = StdTensorOp::Scatter(config);
     let inputs = vec![
-        ValRef::External(operand_key),
-        ValRef::External(indices_key),
-        ValRef::External(updates_key.clone()),
+        ValueRef::External(operand_key),
+        ValueRef::External(indices_key),
+        ValueRef::External(updates_key.clone()),
     ];
     let result = op.transpose_rule(
         &mut builder,
         &[Some(cot)],
         &inputs,
-        &OpMode::Linear {
+        &OperationRole::Linearized {
             active_mask: vec![false, false, true],
         },
         &mut ctx,
     );
 
     assert!(result[2].is_some());
-    let fragment = builder.build();
-    let gather = fragment.ops().last().expect("expected gather op");
-    match &gather.op {
+    let graph = builder.build();
+    let gather = graph.operations().last().expect("expected gather op");
+    match &gather.operation {
         StdTensorOp::GatherDynamicSliceSizes { slice_sizes, .. } => {
             assert_eq!(
                 slice_sizes[1],
@@ -494,7 +494,7 @@ fn transpose_scatter_symbolic_window_dim_emits_dynamic_gather() {
                     axis: 1,
                 }
             );
-            assert_eq!(gather.inputs[2], ValRef::External(updates_key));
+            assert_eq!(gather.inputs[2], ValueRef::External(updates_key));
         }
         other => panic!("expected GatherDynamicSliceSizes, got {other:?}"),
     }

--- a/tenferro-internal-ops/src/ad/tests/mod.rs
+++ b/tenferro-internal-ops/src/ad/tests/mod.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
-use computegraph::fragment::FragmentBuilder;
-use computegraph::types::{GlobalValKey, OpMode, ValRef};
+use computegraph::graph::GraphBuilder;
+use computegraph::types::{OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{DType, DotGeneralConfig};
 
 use crate::ad::context::{resolve_and_guard, resolve_dim, ShapeGuard, ShapeGuardContext};
@@ -22,8 +22,8 @@ fn tensor_input(id: u64) -> TensorInputKey {
     TensorInputKey::User { id }
 }
 
-fn input_key(id: u64) -> GlobalValKey<StdTensorOp> {
-    GlobalValKey::Input(tensor_input(id))
+fn input_key(id: u64) -> ValueKey<StdTensorOp> {
+    ValueKey::Input(tensor_input(id))
 }
 
 fn meta(dtype: DType, shape: &[usize]) -> TensorMeta {
@@ -96,7 +96,7 @@ fn shape_and_dtype_queries_work_for_concrete_input_values() {
     let key = input_key(1);
     ctx.insert_metadata(key.clone(), meta(DType::F64, &[2, 3]));
 
-    let val = ValRef::External(key);
+    let val = ValueRef::External(key);
     assert_eq!(ctx.dtype_of(&val), DType::F64);
     assert_eq!(
         ctx.shape_of(&val),
@@ -115,7 +115,7 @@ fn shape_queries_work_for_symbolic_input_values() {
     );
 
     assert_eq!(
-        ctx.shape_of(&ValRef::External(key)),
+        ctx.shape_of(&ValueRef::External(key)),
         symbolic_shape.as_slice()
     );
 }
@@ -127,7 +127,7 @@ fn metadata_exposes_exact_extents() {
     let meta = TensorMeta::exact(DType::F64, vec![SymDim::from(2usize), SymDim::from(3usize)]);
     ctx.insert_metadata(key.clone(), meta.clone());
 
-    let val = ValRef::External(key);
+    let val = ValueRef::External(key);
     assert_eq!(ctx.extents_of(&val), meta.extents());
     assert_eq!(ctx.exact_shape_of(&val), Some(meta.shape.clone()));
 }
@@ -143,29 +143,29 @@ fn metadata_exact_shape_rejects_upper_bound() {
     };
     ctx.insert_metadata(key.clone(), meta);
 
-    assert_eq!(ctx.exact_shape_of(&ValRef::External(key)), None);
+    assert_eq!(ctx.exact_shape_of(&ValueRef::External(key)), None);
 }
 
 #[test]
-fn metadata_queries_resolve_local_values_through_attached_fragment() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+fn metadata_queries_resolve_local_values_through_attached_graph() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let lhs = builder.add_input(tensor_input(10));
     let rhs = builder.add_input(tensor_input(11));
-    let sum = builder.add_op(
+    let sum = builder.add_operation(
         StdTensorOp::Add,
-        vec![ValRef::Local(lhs), ValRef::Local(rhs)],
-        OpMode::Primal,
+        vec![ValueRef::Local(lhs), ValueRef::Local(rhs)],
+        OperationRole::Primary,
     )[0];
     builder.set_outputs(vec![sum]);
-    let fragment = builder.build();
+    let graph = builder.build();
 
     let mut ctx = ShapeGuardContext::default();
-    ctx.attach_fragment(&fragment);
-    ctx.insert_metadata(fragment.vals()[lhs].key.clone(), meta(DType::F64, &[2, 3]));
-    ctx.insert_metadata(fragment.vals()[rhs].key.clone(), meta(DType::F64, &[2, 3]));
-    ctx.insert_metadata(fragment.vals()[sum].key.clone(), meta(DType::F64, &[2, 3]));
+    ctx.attach_graph(&graph);
+    ctx.insert_metadata(graph.values()[lhs].key.clone(), meta(DType::F64, &[2, 3]));
+    ctx.insert_metadata(graph.values()[rhs].key.clone(), meta(DType::F64, &[2, 3]));
+    ctx.insert_metadata(graph.values()[sum].key.clone(), meta(DType::F64, &[2, 3]));
 
-    let local_sum = ValRef::Local(sum);
+    let local_sum = ValueRef::Local(sum);
     assert_eq!(ctx.dtype_of(&local_sum), DType::F64);
     assert_eq!(
         ctx.shape_of(&local_sum),
@@ -174,22 +174,22 @@ fn metadata_queries_resolve_local_values_through_attached_fragment() {
 }
 
 #[test]
-fn representative_fragment_values_all_have_queryable_tensor_metadata() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+fn representative_graph_values_all_have_queryable_tensor_metadata() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let lhs = builder.add_input(tensor_input(20));
     let rhs = builder.add_input(tensor_input(21));
-    let add = builder.add_op(
+    let add = builder.add_operation(
         StdTensorOp::Add,
-        vec![ValRef::Local(lhs), ValRef::Local(rhs)],
-        OpMode::Primal,
+        vec![ValueRef::Local(lhs), ValueRef::Local(rhs)],
+        OperationRole::Primary,
     )[0];
-    let mul = builder.add_op(
+    let mul = builder.add_operation(
         StdTensorOp::Mul,
-        vec![ValRef::Local(add), ValRef::Local(rhs)],
-        OpMode::Primal,
+        vec![ValueRef::Local(add), ValueRef::Local(rhs)],
+        OperationRole::Primary,
     )[0];
     let dot_rhs = builder.add_input(tensor_input(22));
-    let dot = builder.add_op(
+    let dot = builder.add_operation(
         StdTensorOp::DotGeneral {
             config: DotGeneralConfig {
                 lhs_contracting_dims: vec![1],
@@ -198,55 +198,55 @@ fn representative_fragment_values_all_have_queryable_tensor_metadata() {
                 rhs_batch_dims: vec![],
             },
         },
-        vec![ValRef::Local(mul), ValRef::Local(dot_rhs)],
-        OpMode::Primal,
+        vec![ValueRef::Local(mul), ValueRef::Local(dot_rhs)],
+        OperationRole::Primary,
     )[0];
-    let reduce = builder.add_op(
+    let reduce = builder.add_operation(
         StdTensorOp::ReduceSum { axes: vec![1] },
-        vec![ValRef::Local(dot)],
-        OpMode::Primal,
+        vec![ValueRef::Local(dot)],
+        OperationRole::Primary,
     )[0];
-    let reshape = builder.add_op(
+    let reshape = builder.add_operation(
         StdTensorOp::Reshape {
             to_shape: DimExpr::from_concrete(&[1, 2]),
         },
-        vec![ValRef::Local(reduce)],
-        OpMode::Primal,
+        vec![ValueRef::Local(reduce)],
+        OperationRole::Primary,
     )[0];
-    let broadcast = builder.add_op(
+    let broadcast = builder.add_operation(
         StdTensorOp::BroadcastInDim {
             shape: DimExpr::from_concrete(&[3, 1, 2]),
             dims: vec![1, 2],
         },
-        vec![ValRef::Local(reshape)],
-        OpMode::Primal,
+        vec![ValueRef::Local(reshape)],
+        OperationRole::Primary,
     )[0];
     builder.set_outputs(vec![broadcast]);
-    let fragment = builder.build();
+    let graph = builder.build();
 
     let mut ctx = ShapeGuardContext::default();
-    ctx.attach_fragment(&fragment);
-    ctx.insert_metadata(fragment.vals()[lhs].key.clone(), meta(DType::F64, &[2, 3]));
-    ctx.insert_metadata(fragment.vals()[rhs].key.clone(), meta(DType::F64, &[2, 3]));
-    ctx.insert_metadata(fragment.vals()[add].key.clone(), meta(DType::F64, &[2, 3]));
-    ctx.insert_metadata(fragment.vals()[mul].key.clone(), meta(DType::F64, &[2, 3]));
+    ctx.attach_graph(&graph);
+    ctx.insert_metadata(graph.values()[lhs].key.clone(), meta(DType::F64, &[2, 3]));
+    ctx.insert_metadata(graph.values()[rhs].key.clone(), meta(DType::F64, &[2, 3]));
+    ctx.insert_metadata(graph.values()[add].key.clone(), meta(DType::F64, &[2, 3]));
+    ctx.insert_metadata(graph.values()[mul].key.clone(), meta(DType::F64, &[2, 3]));
     ctx.insert_metadata(
-        fragment.vals()[dot_rhs].key.clone(),
+        graph.values()[dot_rhs].key.clone(),
         meta(DType::F64, &[3, 4]),
     );
-    ctx.insert_metadata(fragment.vals()[dot].key.clone(), meta(DType::F64, &[2, 4]));
-    ctx.insert_metadata(fragment.vals()[reduce].key.clone(), meta(DType::F64, &[2]));
+    ctx.insert_metadata(graph.values()[dot].key.clone(), meta(DType::F64, &[2, 4]));
+    ctx.insert_metadata(graph.values()[reduce].key.clone(), meta(DType::F64, &[2]));
     ctx.insert_metadata(
-        fragment.vals()[reshape].key.clone(),
+        graph.values()[reshape].key.clone(),
         meta(DType::F64, &[1, 2]),
     );
     ctx.insert_metadata(
-        fragment.vals()[broadcast].key.clone(),
+        graph.values()[broadcast].key.clone(),
         meta(DType::F64, &[3, 1, 2]),
     );
 
-    for local_id in 0..fragment.vals().len() {
-        let value = ValRef::Local(local_id);
+    for local_id in 0..graph.values().len() {
+        let value = ValueRef::Local(local_id);
         let metadata = ctx.metadata_of(&value);
         assert_eq!(metadata.dtype, DType::F64);
         assert!(

--- a/tenferro-internal-ops/src/ad/zeros.rs
+++ b/tenferro-internal-ops/src/ad/zeros.rs
@@ -1,23 +1,23 @@
-use computegraph::types::{LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use crate::ad::PrimitiveRuleBuilder;
+use computegraph::types::{LocalValueId, OperationRole, ValueRef};
 use tenferro_tensor::DType;
 
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 
 pub(super) fn build_zero_like(
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     dtype: DType,
-    anchor: ValRef<StdTensorOp>,
+    anchor: ValueRef<StdTensorOp>,
     anchor_rank: usize,
-) -> LocalValId {
-    let zero_scalar = emitter.add_op(
+) -> LocalValueId {
+    let zero_scalar = builder.add_operation(
         StdTensorOp::Constant {
             dtype,
             bytes: zero_bytes(dtype),
         },
         vec![],
-        OpMode::Primal,
+        OperationRole::Primary,
     )[0];
     if anchor_rank == 0 {
         return zero_scalar;
@@ -26,13 +26,13 @@ pub(super) fn build_zero_like(
     let shape: Vec<DimExpr> = (0..anchor_rank)
         .map(|axis| DimExpr::InputDim { input_idx: 1, axis })
         .collect();
-    let out = emitter.add_op(
+    let out = builder.add_operation(
         StdTensorOp::BroadcastInDim {
             shape,
             dims: vec![],
         },
-        vec![ValRef::Local(zero_scalar), anchor],
-        OpMode::Primal,
+        vec![ValueRef::Local(zero_scalar), anchor],
+        OperationRole::Primary,
     );
     out[0]
 }

--- a/tenferro-internal-ops/src/ext_op.rs
+++ b/tenferro-internal-ops/src/ext_op.rs
@@ -11,7 +11,7 @@
 //! - Identity / hashing / equality are expressed on the trait so the
 //!   type-erased `Arc<dyn ExtensionOp>` carrier can satisfy
 //!   `Clone + Hash + Eq + Send + Sync + 'static` (computegraph's
-//!   `GraphOp` requirements).
+//!   `GraphOperation` requirements).
 //! - AD rules are registered separately through [`ExtensionAdRule`] and
 //!   [`register_extension_rule`]. A rule may emit core [`StdTensorOp`] values
 //!   and registered `Extension` values so out-of-tree operations remain in the
@@ -25,16 +25,16 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 #[cfg(feature = "autodiff")]
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-#[cfg(feature = "autodiff")]
-use computegraph::OpEmitter;
 use tenferro_tensor::{DType, Tensor};
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 #[cfg(feature = "autodiff")]
 use crate::ad::context::ShapeGuardContext;
+#[cfg(feature = "autodiff")]
+use crate::ad::PrimitiveRuleBuilder;
 #[cfg(feature = "autodiff")]
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
@@ -51,7 +51,7 @@ use std::sync::{OnceLock, RwLock};
 ///
 /// - identity via [`family_id`][Self::family_id] + [`payload_hash`][Self::payload_hash]
 ///   + [`payload_eq`][Self::payload_eq];
-/// - fixed arity via [`n_inputs`][Self::n_inputs] / [`n_outputs`][Self::n_outputs];
+/// - fixed arity via [`input_count`][Self::input_count] / [`output_count`][Self::output_count];
 /// - shape / dtype inference via [`infer_output_meta`][Self::infer_output_meta];
 /// - forward dispatch via [`eager_execute`][Self::eager_execute] (used by both
 ///   the eager and compiled paths);
@@ -85,8 +85,8 @@ use std::sync::{OnceLock, RwLock};
 ///     }
 ///     fn clone_arc(&self) -> Arc<dyn ExtensionOp> { Arc::new(self.clone()) }
 ///     fn as_any(&self) -> &dyn Any { self }
-///     fn n_inputs(&self) -> usize { 1 }
-///     fn n_outputs(&self) -> usize { 1 }
+///     fn input_count(&self) -> usize { 1 }
+///     fn output_count(&self) -> usize { 1 }
 ///     fn infer_output_meta(
 ///         &self,
 ///         dtypes: &[DType],
@@ -100,7 +100,7 @@ use std::sync::{OnceLock, RwLock};
 /// }
 ///
 /// let op: Arc<dyn ExtensionOp> = Arc::new(IdentityExt);
-/// assert_eq!(op.n_inputs(), 1);
+/// assert_eq!(op.input_count(), 1);
 /// ```
 pub trait ExtensionOp: Debug + Send + Sync + 'static {
     // ----- Identity, hashing, equality (spec Section 5) -----
@@ -146,19 +146,19 @@ pub trait ExtensionOp: Debug + Send + Sync + 'static {
 
     /// Number of primal inputs. MUST be constant for any given
     /// `Arc<dyn ExtensionOp>` value.
-    fn n_inputs(&self) -> usize;
+    fn input_count(&self) -> usize;
 
     /// Number of outputs. MUST match the length of the vector returned by
     /// [`Self::infer_output_meta`].
-    fn n_outputs(&self) -> usize;
+    fn output_count(&self) -> usize;
 
     // ----- Shape and dtype inference (spec Section 7) -----
 
     /// Infer output dtypes and shapes for each output slot.
     ///
     /// `input_dtypes.len()` and `input_shapes.len()` both equal
-    /// `self.n_inputs()`. The returned vector MUST have length
-    /// `self.n_outputs()`, one `(dtype, shape)` entry per output slot.
+    /// `self.input_count()`. The returned vector MUST have length
+    /// `self.output_count()`, one `(dtype, shape)` entry per output slot.
     /// Shapes use [`SymDim`] so extension ops compose with graph-global
     /// symbolic metadata.
     fn infer_output_meta(
@@ -196,23 +196,23 @@ pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut dyn OpEmitter<StdTensorOp>,
-        primal_in: &[GlobalValKey<StdTensorOp>],
-        primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut dyn PrimitiveRuleBuilder,
+        primal_in: &[ValueKey<StdTensorOp>],
+        primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>>;
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
 
     /// Emit the transpose (VJP) rule.
     fn transpose_rule(
         &self,
         op: &dyn ExtensionOp,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<StdTensorOp>],
-        mode: &OpMode,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
+        mode: &OperationRole,
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>>;
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
 }
 
 /// Errors returned from extension registries.
@@ -276,9 +276,8 @@ impl ExtensionRuleSet {
     /// ```
     /// use std::sync::Arc;
     /// use tidu::ADRuleResult;
-    /// use computegraph::fragment::FragmentBuilder;
-    /// use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-    /// use computegraph::OpEmitter;
+    /// use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
+    /// use tenferro_ops::ad::PrimitiveRuleBuilder;
     /// use tenferro_ops::ext_op::{ExtensionAdRule, ExtensionOp};
     /// use tenferro_ops::{ExtensionRuleSet, ShapeGuardContext};
     /// use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -291,23 +290,23 @@ impl ExtensionRuleSet {
     ///     fn linearize(
     ///         &self,
     ///         _op: &dyn ExtensionOp,
-    ///         _builder: &mut dyn OpEmitter<StdTensorOp>,
-    ///         _primal_in: &[GlobalValKey<StdTensorOp>],
-    ///         _primal_out: &[GlobalValKey<StdTensorOp>],
-    ///         tangent_in: &[Option<LocalValId>],
+    ///         _builder: &mut dyn PrimitiveRuleBuilder,
+    ///         _primal_in: &[ValueKey<StdTensorOp>],
+    ///         _primal_out: &[ValueKey<StdTensorOp>],
+    ///         tangent_in: &[Option<LocalValueId>],
     ///         _ctx: &mut ShapeGuardContext,
-    ///     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ///     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     ///         Ok(tangent_in.to_vec())
     ///     }
     ///     fn transpose_rule(
     ///         &self,
     ///         _op: &dyn ExtensionOp,
-    ///         _emitter: &mut dyn OpEmitter<StdTensorOp>,
-    ///         cotangent_out: &[Option<LocalValId>],
-    ///         _inputs: &[ValRef<StdTensorOp>],
-    ///         _mode: &OpMode,
+    ///         _builder: &mut dyn PrimitiveRuleBuilder,
+    ///         cotangent_out: &[Option<LocalValueId>],
+    ///         _inputs: &[ValueRef<StdTensorOp>],
+    ///         _mode: &OperationRole,
     ///         _ctx: &mut ShapeGuardContext,
-    ///     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ///     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     ///         Ok(cotangent_out.to_vec())
     ///     }
     /// }
@@ -334,9 +333,8 @@ impl ExtensionRuleSet {
     /// ```
     /// use std::sync::Arc;
     /// use tidu::ADRuleResult;
-    /// use computegraph::fragment::FragmentBuilder;
-    /// use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-    /// use computegraph::OpEmitter;
+    /// use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
+    /// use tenferro_ops::ad::PrimitiveRuleBuilder;
     /// use tenferro_ops::ext_op::{ExtensionAdRule, ExtensionOp};
     /// use tenferro_ops::{ExtensionRuleSet, ShapeGuardContext};
     /// use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -349,23 +347,23 @@ impl ExtensionRuleSet {
     ///     fn linearize(
     ///         &self,
     ///         _op: &dyn ExtensionOp,
-    ///         _builder: &mut dyn OpEmitter<StdTensorOp>,
-    ///         _primal_in: &[GlobalValKey<StdTensorOp>],
-    ///         _primal_out: &[GlobalValKey<StdTensorOp>],
-    ///         tangent_in: &[Option<LocalValId>],
+    ///         _builder: &mut dyn PrimitiveRuleBuilder,
+    ///         _primal_in: &[ValueKey<StdTensorOp>],
+    ///         _primal_out: &[ValueKey<StdTensorOp>],
+    ///         tangent_in: &[Option<LocalValueId>],
     ///         _ctx: &mut ShapeGuardContext,
-    ///     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ///     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     ///         Ok(tangent_in.to_vec())
     ///     }
     ///     fn transpose_rule(
     ///         &self,
     ///         _op: &dyn ExtensionOp,
-    ///         _emitter: &mut dyn OpEmitter<StdTensorOp>,
-    ///         cotangent_out: &[Option<LocalValId>],
-    ///         _inputs: &[ValRef<StdTensorOp>],
-    ///         _mode: &OpMode,
+    ///         _builder: &mut dyn PrimitiveRuleBuilder,
+    ///         cotangent_out: &[Option<LocalValueId>],
+    ///         _inputs: &[ValueRef<StdTensorOp>],
+    ///         _mode: &OperationRole,
     ///         _ctx: &mut ShapeGuardContext,
-    ///     ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ///     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     ///         Ok(cotangent_out.to_vec())
     ///     }
     /// }
@@ -530,12 +528,12 @@ pub fn lookup_extension_rule(family_id: &str) -> Option<Arc<dyn ExtensionAdRule>
 #[cfg(feature = "autodiff")]
 pub fn linearize_extension_rule(
     op: &dyn ExtensionOp,
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     match ctx.lookup_extension_rule(op.family_id()) {
         Some(rule) => rule.linearize(op, builder, primal_in, primal_out, tangent_in, ctx),
         None => Err(ADRuleError::unsupported(op.family_id(), ADRuleKind::Jvp)),
@@ -546,14 +544,14 @@ pub fn linearize_extension_rule(
 #[cfg(feature = "autodiff")]
 pub fn transpose_extension_rule(
     op: &dyn ExtensionOp,
-    emitter: &mut dyn OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> ADRuleResult<Vec<Option<LocalValId>>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     match ctx.lookup_extension_rule(op.family_id()) {
-        Some(rule) => rule.transpose_rule(op, emitter, cotangent_out, inputs, mode, ctx),
+        Some(rule) => rule.transpose_rule(op, builder, cotangent_out, inputs, mode, ctx),
         None => Err(ADRuleError::unsupported(
             op.family_id(),
             ADRuleKind::Transpose,

--- a/tenferro-internal-ops/src/std_tensor_op.rs
+++ b/tenferro-internal-ops/src/std_tensor_op.rs
@@ -2,8 +2,8 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
-use computegraph::types::{GlobalValKey, LocalValId, OpMode};
-use computegraph::GraphOp;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey};
+use computegraph::GraphOperation;
 use num_complex::{Complex32, Complex64};
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleResult, Primitive, PrimitiveBuilder, PrimitiveValue};
@@ -247,11 +247,11 @@ impl PartialEq for StdTensorOp {
             (
                 Self::Concatenate {
                     axis: a,
-                    n_inputs: na,
+                    input_count: na,
                 },
                 Self::Concatenate {
                     axis: b,
-                    n_inputs: nb,
+                    input_count: nb,
                 },
             ) => a == b && na == nb,
             (Self::ShapeOf { axis: a }, Self::ShapeOf { axis: b })
@@ -337,9 +337,9 @@ impl Hash for StdTensorOp {
             Self::DynamicSlice { slice_sizes } => slice_sizes.hash(state),
             Self::DynamicUpdateSlice => {}
             Self::Pad(config) => config.hash(state),
-            Self::Concatenate { axis, n_inputs } => {
+            Self::Concatenate { axis, input_count } => {
                 axis.hash(state);
-                n_inputs.hash(state);
+                input_count.hash(state);
             }
             Self::Reverse { axes } => axes.hash(state),
             Self::ShapeOf { axis } | Self::DynamicTruncate { axis } | Self::PadToMatch { axis } => {
@@ -363,12 +363,12 @@ fn n_inputs_from_dim_exprs(min_inputs: usize, exprs: &[&[DimExpr]]) -> usize {
     max_idx.max(min_inputs)
 }
 
-impl GraphOp for StdTensorOp {
+impl GraphOperation for StdTensorOp {
     type Operand = tenferro_tensor::Tensor;
     type Context = ();
     type InputKey = TensorInputKey;
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         match self {
             Self::Add | Self::Mul | Self::DotGeneral { .. } | Self::Gather(_) => 2,
             Self::GatherDynamicSliceSizes { slice_sizes, .. } => {
@@ -396,7 +396,7 @@ impl GraphOp for StdTensorOp {
             Self::Div | Self::Maximum | Self::Minimum | Self::Pow | Self::DynamicSlice { .. } => 2,
             Self::Constant { .. } => 0,
             Self::Scatter(_) | Self::DynamicUpdateSlice => 3,
-            Self::Concatenate { n_inputs, .. } => *n_inputs,
+            Self::Concatenate { input_count, .. } => *input_count,
             Self::Abs
             | Self::Sign
             | Self::Exp
@@ -410,11 +410,11 @@ impl GraphOp for StdTensorOp {
             | Self::Log1p => 1,
             Self::Select | Self::Clamp => 3,
             Self::Compare(_) => 2,
-            Self::Extension(op) => ExtensionOp::n_inputs(op.as_ref()),
+            Self::Extension(op) => ExtensionOp::input_count(op.as_ref()),
         }
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         match self {
             Self::Add
             | Self::Mul
@@ -464,7 +464,7 @@ impl GraphOp for StdTensorOp {
             | Self::ReduceMax { .. }
             | Self::ReduceMin { .. } => 1,
             Self::Concatenate { .. } => 1,
-            Self::Extension(op) => ExtensionOp::n_outputs(op.as_ref()),
+            Self::Extension(op) => ExtensionOp::output_count(op.as_ref()),
         }
     }
 }
@@ -480,51 +480,47 @@ impl Primitive for StdTensorOp {
     fn jvp_rule(
         &self,
         builder: &mut impl PrimitiveBuilder<Self>,
-        primal_in: &[GlobalValKey<Self>],
-        primal_out: &[GlobalValKey<Self>],
-        tangent_in: &[Option<LocalValId>],
+        primal_in: &[ValueKey<Self>],
+        primal_out: &[ValueKey<Self>],
+        tangent_in: &[Option<LocalValueId>],
         ctx: &mut Self::ADContext,
-    ) -> Vec<Option<LocalValId>> {
-        let mut emitter = crate::ad::PrimitiveBuilderEmitter::new(builder);
-        crate::ad::linearize(self, &mut emitter, primal_in, primal_out, tangent_in, ctx)
+    ) -> Vec<Option<LocalValueId>> {
+        crate::ad::linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
     }
 
     fn try_jvp_rule(
         &self,
         builder: &mut impl PrimitiveBuilder<Self>,
-        primal_in: &[GlobalValKey<Self>],
-        primal_out: &[GlobalValKey<Self>],
-        tangent_in: &[Option<LocalValId>],
+        primal_in: &[ValueKey<Self>],
+        primal_out: &[ValueKey<Self>],
+        tangent_in: &[Option<LocalValueId>],
         ctx: &mut Self::ADContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
-        let mut emitter = crate::ad::PrimitiveBuilderEmitter::new(builder);
-        crate::ad::try_linearize(self, &mut emitter, primal_in, primal_out, tangent_in, ctx)
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        crate::ad::try_linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
     }
 
     fn transpose_rule(
         &self,
         builder: &mut impl PrimitiveBuilder<Self>,
-        cotangent_out: &[Option<LocalValId>],
+        cotangent_out: &[Option<LocalValueId>],
         inputs: &[PrimitiveValue<Self>],
-        mode: &OpMode,
+        mode: &OperationRole,
         ctx: &mut Self::ADContext,
-    ) -> Vec<Option<LocalValId>> {
+    ) -> Vec<Option<LocalValueId>> {
         let inputs = inputs.iter().cloned().map(Into::into).collect::<Vec<_>>();
-        let mut emitter = crate::ad::PrimitiveBuilderEmitter::new(builder);
-        crate::ad::transpose_rule(self, &mut emitter, cotangent_out, &inputs, mode, ctx)
+        crate::ad::transpose_rule(self, builder, cotangent_out, &inputs, mode, ctx)
     }
 
     fn try_linear_transpose_rule(
         &self,
         builder: &mut impl PrimitiveBuilder<Self>,
-        cotangent_out: &[Option<LocalValId>],
+        cotangent_out: &[Option<LocalValueId>],
         inputs: &[PrimitiveValue<Self>],
-        mode: &OpMode,
+        mode: &OperationRole,
         ctx: &mut Self::ADContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let inputs = inputs.iter().cloned().map(Into::into).collect::<Vec<_>>();
-        let mut emitter = crate::ad::PrimitiveBuilderEmitter::new(builder);
-        crate::ad::try_transpose_rule(self, &mut emitter, cotangent_out, &inputs, mode, ctx)
+        crate::ad::try_transpose_rule(self, builder, cotangent_out, &inputs, mode, ctx)
     }
 }
 
@@ -532,45 +528,45 @@ impl Primitive for StdTensorOp {
 impl StdTensorOp {
     pub(crate) fn jvp_rule(
         &self,
-        builder: &mut computegraph::fragment::FragmentBuilder<Self>,
-        primal_in: &[GlobalValKey<Self>],
-        primal_out: &[GlobalValKey<Self>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut computegraph::graph::GraphBuilder<Self>,
+        primal_in: &[ValueKey<Self>],
+        primal_out: &[ValueKey<Self>],
+        tangent_in: &[Option<LocalValueId>],
         ctx: &mut crate::ad::context::ShapeGuardContext,
-    ) -> Vec<Option<LocalValId>> {
+    ) -> Vec<Option<LocalValueId>> {
         crate::ad::linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
     }
 
     pub(crate) fn try_jvp_rule(
         &self,
-        builder: &mut computegraph::fragment::FragmentBuilder<Self>,
-        primal_in: &[GlobalValKey<Self>],
-        primal_out: &[GlobalValKey<Self>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut computegraph::graph::GraphBuilder<Self>,
+        primal_in: &[ValueKey<Self>],
+        primal_out: &[ValueKey<Self>],
+        tangent_in: &[Option<LocalValueId>],
         ctx: &mut crate::ad::context::ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         crate::ad::try_linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
     }
 
     pub(crate) fn transpose_rule(
         &self,
-        emitter: &mut impl computegraph::OpEmitter<Self>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[computegraph::ValRef<Self>],
-        mode: &OpMode,
+        builder: &mut impl crate::ad::PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[computegraph::ValueRef<Self>],
+        mode: &OperationRole,
         ctx: &mut crate::ad::context::ShapeGuardContext,
-    ) -> Vec<Option<LocalValId>> {
-        crate::ad::transpose_rule(self, emitter, cotangent_out, inputs, mode, ctx)
+    ) -> Vec<Option<LocalValueId>> {
+        crate::ad::transpose_rule(self, builder, cotangent_out, inputs, mode, ctx)
     }
 
     pub(crate) fn try_linear_transpose_rule(
         &self,
-        emitter: &mut impl computegraph::OpEmitter<Self>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[computegraph::ValRef<Self>],
-        mode: &OpMode,
+        builder: &mut impl crate::ad::PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[computegraph::ValueRef<Self>],
+        mode: &OperationRole,
         ctx: &mut crate::ad::context::ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
-        crate::ad::try_transpose_rule(self, emitter, cotangent_out, inputs, mode, ctx)
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        crate::ad::try_transpose_rule(self, builder, cotangent_out, inputs, mode, ctx)
     }
 }

--- a/tenferro-internal-ops/src/tests/catalog_kind_tests.rs
+++ b/tenferro-internal-ops/src/tests/catalog_kind_tests.rs
@@ -31,11 +31,11 @@ impl ExtensionOp for CatalogExt {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 

--- a/tenferro-internal-ops/src/tests/ext_op_tests.rs
+++ b/tenferro-internal-ops/src/tests/ext_op_tests.rs
@@ -4,12 +4,12 @@ use std::any::Any;
 use std::hash::Hasher;
 use std::sync::Arc;
 
-use computegraph::fragment::FragmentBuilder;
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::graph::GraphBuilder;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tidu::{ADRuleKind, ADRuleResult};
 
 use crate::ad::context::ShapeGuardContext;
+use crate::ad::PrimitiveRuleBuilder;
 use crate::ext_op::{
     is_extension_rule_registered, linearize_extension_rule, lookup_extension_rule,
     register_extension_rule, transpose_extension_rule, ExtensionAdRule, ExtensionOp,
@@ -56,11 +56,11 @@ impl ExtensionOp for NoInlineRuleOp {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -101,11 +101,11 @@ impl ExtensionOp for FamilyOnlyOp {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -130,24 +130,24 @@ impl ExtensionAdRule for CoverageRule {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        _builder: &mut dyn OpEmitter<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![tangent_in[0]])
     }
 
     fn transpose_rule(
         &self,
         _op: &dyn ExtensionOp,
-        _emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        _inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
+        _mode: &OperationRole,
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![cotangent_out[0]])
     }
 }
@@ -203,7 +203,7 @@ fn explicit_empty_rule_set_does_not_fallback_to_global_registry() {
         .expect("global sentinel rule should register");
 
     let op = FamilyOnlyOp { family };
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let dx = builder.add_input(TensorInputKey::User { id: 10_201 });
     let mut ctx = ShapeGuardContext::default().with_extension_rules(ExtensionRuleSet::new());
     let err = linearize_extension_rule(&op, &mut builder, &[], &[], &[Some(dx)], &mut ctx)
@@ -271,18 +271,24 @@ fn owned_rule_set_rejects_duplicate_and_malformed_rules() {
 fn missing_registered_rule_helpers_return_ad_rule_errors() {
     let op = NoInlineRuleOp;
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let linearize_err =
         linearize_extension_rule(&op, &mut builder, &[], &[], &[], &mut ctx).unwrap_err();
     assert_eq!(linearize_err.rule(), ADRuleKind::Jvp);
     assert!(linearize_err.to_string().contains(op.family_id()));
 
-    let mut emitter = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
-    let transpose_err =
-        transpose_extension_rule(&op, &mut emitter, &[], &[], &OpMode::Primal, &mut ctx)
-            .unwrap_err();
+    let transpose_err = transpose_extension_rule(
+        &op,
+        &mut builder,
+        &[],
+        &[],
+        &OperationRole::Primary,
+        &mut ctx,
+    )
+    .unwrap_err();
     assert_eq!(transpose_err.rule(), ADRuleKind::Transpose);
     assert!(transpose_err.to_string().contains(op.family_id()));
 }
@@ -291,15 +297,15 @@ fn missing_registered_rule_helpers_return_ad_rule_errors() {
 fn register_rule_rejects_malformed_family_ids() {
     // Each case targets a different reject branch in `is_valid_family_id`.
     let cases = [
-        "noversion",     // rsplitn(2, '.').next() returns None on second call
-        "foo.v1",        // prefix has no '.', split_once returns None
-        "foo.bar",       // version segment "bar" fails starts_with('v')
-        "foo.bar.v",     // empty digit string after 'v'
-        "foo.bar.vabc",  // non-digit version
-        ".op.v1",        // empty crate name
-        "foo..v1",       // empty op name
-        "foo bar.op.v1", // whitespace in crate
-        "fooあ.op.v1",   // non-ASCII in crate
+        "noversion",            // rsplitn(2, '.').next() returns None on second call
+        "foo.v1",               // prefix has no '.', split_once returns None
+        "foo.bar",              // version segment "bar" fails starts_with('v')
+        "foo.bar.v",            // empty digit string after 'v'
+        "foo.bar.vabc",         // non-digit version
+        ".operation.v1",        // empty crate name
+        "foo..v1",              // empty op name
+        "foo bar.operation.v1", // whitespace in crate
+        "fooあ.operation.v1",   // non-ASCII in crate
     ];
     for bad in cases {
         let rule: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family: bad });

--- a/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
+++ b/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
@@ -3,9 +3,9 @@ use crate::dim_expr::DimExpr;
 use crate::ext_op::{register_extension_rule, ExtensionAdRule, ExtensionOp};
 use crate::std_tensor_op::StdTensorOp;
 use crate::{SymDim, TensorMeta};
-use computegraph::fragment::{Fragment, FragmentBuilder};
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::{GraphOp, OpEmitter};
+use computegraph::graph::{Graph, GraphBuilder};
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
+use computegraph::GraphOperation;
 use num_complex::{Complex32, Complex64};
 use std::any::Any;
 use std::hash::Hasher;
@@ -34,10 +34,10 @@ fn tensor_input_key(id: u64) -> TensorInputKey {
 }
 
 fn add_input_keys(
-    builder: &mut FragmentBuilder<StdTensorOp>,
+    builder: &mut GraphBuilder<StdTensorOp>,
     start_id: u64,
     count: usize,
-) -> Vec<GlobalValKey<StdTensorOp>> {
+) -> Vec<ValueKey<StdTensorOp>> {
     (0..count)
         .map(|offset| {
             let local = builder.add_input(tensor_input_key(start_id + offset as u64));
@@ -46,26 +46,21 @@ fn add_input_keys(
         .collect()
 }
 
-fn external_inputs(start_id: u64, count: usize) -> Vec<ValRef<StdTensorOp>> {
+fn external_inputs(start_id: u64, count: usize) -> Vec<ValueRef<StdTensorOp>> {
     (0..count)
         .map(|offset| {
-            ValRef::External(GlobalValKey::Input(tensor_input_key(
-                start_id + offset as u64,
-            )))
+            ValueRef::External(ValueKey::Input(tensor_input_key(start_id + offset as u64)))
         })
         .collect()
 }
 
-fn linear_mode(active_mask: &[bool]) -> OpMode {
-    OpMode::Linear {
+fn linear_mode(active_mask: &[bool]) -> OperationRole {
+    OperationRole::Linearized {
         active_mask: active_mask.to_vec(),
     }
 }
 
-fn seed_dot_general_input_metadata(
-    ctx: &mut ShapeGuardContext,
-    keys: &[GlobalValKey<StdTensorOp>],
-) {
+fn seed_dot_general_input_metadata(ctx: &mut ShapeGuardContext, keys: &[ValueKey<StdTensorOp>]) {
     let shapes = [
         vec![SymDim::from(2usize), SymDim::from(3usize)],
         vec![SymDim::from(3usize), SymDim::from(4usize)],
@@ -75,12 +70,12 @@ fn seed_dot_general_input_metadata(
     }
 }
 
-fn seed_dot_general_ref_metadata(ctx: &mut ShapeGuardContext, inputs: &[ValRef<StdTensorOp>]) {
+fn seed_dot_general_ref_metadata(ctx: &mut ShapeGuardContext, inputs: &[ValueRef<StdTensorOp>]) {
     let keys: Vec<_> = inputs
         .iter()
         .map(|input| match input {
-            ValRef::External(key) => key.clone(),
-            ValRef::Local(local_id) => {
+            ValueRef::External(key) => key.clone(),
+            ValueRef::Local(local_id) => {
                 panic!("expected external input in test helper, got local {local_id}")
             }
         })
@@ -90,7 +85,7 @@ fn seed_dot_general_ref_metadata(ctx: &mut ShapeGuardContext, inputs: &[ValRef<S
 
 fn seed_uniform_ref_metadata(
     ctx: &mut ShapeGuardContext,
-    inputs: &[ValRef<StdTensorOp>],
+    inputs: &[ValueRef<StdTensorOp>],
     shape: Vec<SymDim>,
 ) {
     seed_uniform_ref_metadata_with_dtype(ctx, inputs, DType::F64, shape);
@@ -98,14 +93,14 @@ fn seed_uniform_ref_metadata(
 
 fn seed_uniform_ref_metadata_with_dtype(
     ctx: &mut ShapeGuardContext,
-    inputs: &[ValRef<StdTensorOp>],
+    inputs: &[ValueRef<StdTensorOp>],
     dtype: DType,
     shape: Vec<SymDim>,
 ) {
     for input in inputs {
         let key = match input {
-            ValRef::External(key) => key.clone(),
-            ValRef::Local(local_id) => {
+            ValueRef::External(key) => key.clone(),
+            ValueRef::Local(local_id) => {
                 panic!("expected external input in test helper, got local {local_id}")
             }
         };
@@ -118,15 +113,15 @@ fn run_linearize_case(
     n_primal_in: usize,
     n_primal_out: usize,
     tangent_mask: &[bool],
-) -> (Vec<Option<LocalValId>>, Fragment<StdTensorOp>) {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+) -> (Vec<Option<LocalValueId>>, Graph<StdTensorOp>) {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let primal_in = add_input_keys(&mut builder, 100, n_primal_in);
     let primal_out = add_input_keys(&mut builder, 200, n_primal_out);
     if matches!(&op, StdTensorOp::DotGeneral { .. }) {
         seed_dot_general_input_metadata(&mut ad_ctx, &primal_in);
     }
-    let tangent_in: Vec<Option<LocalValId>> = tangent_mask
+    let tangent_in: Vec<Option<LocalValueId>> = tangent_mask
         .iter()
         .enumerate()
         .map(|(offset, &active)| {
@@ -145,32 +140,32 @@ fn run_linearize_case(
 
 fn run_transpose_case(
     op: StdTensorOp,
-    n_inputs: usize,
+    input_count: usize,
     active_mask: &[bool],
     cotangent_present: bool,
 ) -> (
-    Vec<Option<LocalValId>>,
-    Option<LocalValId>,
-    Fragment<StdTensorOp>,
+    Vec<Option<LocalValueId>>,
+    Option<LocalValueId>,
+    Graph<StdTensorOp>,
 ) {
-    run_transpose_case_with_input_shape(op, n_inputs, active_mask, cotangent_present, None)
+    run_transpose_case_with_input_shape(op, input_count, active_mask, cotangent_present, None)
 }
 
 fn run_transpose_case_with_input_shape(
     op: StdTensorOp,
-    n_inputs: usize,
+    input_count: usize,
     active_mask: &[bool],
     cotangent_present: bool,
     input_shape: Option<Vec<SymDim>>,
 ) -> (
-    Vec<Option<LocalValId>>,
-    Option<LocalValId>,
-    Fragment<StdTensorOp>,
+    Vec<Option<LocalValueId>>,
+    Option<LocalValueId>,
+    Graph<StdTensorOp>,
 ) {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let cotangent = cotangent_present.then(|| builder.add_input(tensor_input_key(400)));
-    let inputs = external_inputs(500, n_inputs);
+    let inputs = external_inputs(500, input_count);
     if matches!(&op, StdTensorOp::DotGeneral { .. }) {
         seed_dot_general_ref_metadata(&mut ad_ctx, &inputs);
     } else if let Some(shape) = input_shape {
@@ -190,26 +185,26 @@ fn run_transpose_case_with_input_shape(
 /// op kinds whose transpose rules query `ctx.shape_of`.
 fn run_transpose_case_with_input_shapes(
     op: StdTensorOp,
-    n_inputs: usize,
+    input_count: usize,
     active_mask: &[bool],
     cotangent_present: bool,
     input_shapes: &[&[usize]],
 ) -> (
-    Vec<Option<LocalValId>>,
-    Option<LocalValId>,
-    Fragment<StdTensorOp>,
+    Vec<Option<LocalValueId>>,
+    Option<LocalValueId>,
+    Graph<StdTensorOp>,
 ) {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let cotangent = cotangent_present.then(|| builder.add_input(tensor_input_key(400)));
-    let inputs = external_inputs(500, n_inputs);
+    let inputs = external_inputs(500, input_count);
     assert_eq!(
         input_shapes.len(),
-        n_inputs,
+        input_count,
         "seed shapes must match input count",
     );
     for (input, shape) in inputs.iter().zip(input_shapes.iter()) {
-        let ValRef::External(key) = input else {
+        let ValueRef::External(key) = input else {
             panic!("expected external input reference");
         };
         ad_ctx.insert_metadata(
@@ -232,10 +227,10 @@ fn run_transpose_case_with_input_shapes(
 
 #[test]
 fn test_std_tensor_op_input_output_counts() {
-    assert_eq!(StdTensorOp::Add.n_inputs(), 2);
-    assert_eq!(StdTensorOp::Mul.n_inputs(), 2);
-    assert_eq!(StdTensorOp::Neg.n_inputs(), 1);
-    assert_eq!(StdTensorOp::Conj.n_inputs(), 1);
+    assert_eq!(StdTensorOp::Add.input_count(), 2);
+    assert_eq!(StdTensorOp::Mul.input_count(), 2);
+    assert_eq!(StdTensorOp::Neg.input_count(), 1);
+    assert_eq!(StdTensorOp::Conj.input_count(), 1);
     assert_eq!(
         StdTensorOp::DotGeneral {
             config: DotGeneralConfig {
@@ -245,17 +240,17 @@ fn test_std_tensor_op_input_output_counts() {
                 rhs_batch_dims: vec![],
             },
         }
-        .n_inputs(),
+        .input_count(),
         2
     );
-    assert_eq!(StdTensorOp::ReduceSum { axes: vec![0] }.n_inputs(), 1);
-    assert_eq!(StdTensorOp::constant_f64(1.0).n_inputs(), 0);
+    assert_eq!(StdTensorOp::ReduceSum { axes: vec![0] }.input_count(), 1);
+    assert_eq!(StdTensorOp::constant_f64(1.0).input_count(), 0);
     assert_eq!(
         StdTensorOp::ExtractDiag {
             axis_a: 0,
             axis_b: 1
         }
-        .n_inputs(),
+        .input_count(),
         1
     );
     assert_eq!(
@@ -263,7 +258,7 @@ fn test_std_tensor_op_input_output_counts() {
             axis_a: 0,
             axis_b: 1
         }
-        .n_inputs(),
+        .input_count(),
         1
     );
     assert_eq!(
@@ -274,7 +269,7 @@ fn test_std_tensor_op_input_output_counts() {
             index_vector_dim: 1,
             slice_sizes: vec![1],
         })
-        .n_inputs(),
+        .input_count(),
         2
     );
     assert_eq!(
@@ -284,44 +279,44 @@ fn test_std_tensor_op_input_output_counts() {
             scatter_dims_to_operand_dims: vec![0],
             index_vector_dim: 1,
         })
-        .n_inputs(),
+        .input_count(),
         3
     );
     assert_eq!(
         StdTensorOp::DynamicSlice {
             slice_sizes: vec![1]
         }
-        .n_inputs(),
+        .input_count(),
         2
     );
-    assert_eq!(StdTensorOp::DynamicUpdateSlice.n_inputs(), 3);
+    assert_eq!(StdTensorOp::DynamicUpdateSlice.input_count(), 3);
     assert_eq!(
         StdTensorOp::Pad(PadConfig {
             edge_padding_low: vec![1],
             edge_padding_high: vec![1],
             interior_padding: vec![0],
         })
-        .n_inputs(),
+        .input_count(),
         1
     );
 
-    assert_eq!(StdTensorOp::Add.n_outputs(), 1);
-    assert_eq!(StdTensorOp::Neg.n_outputs(), 1);
-    assert_eq!(StdTensorOp::Compare(CompareDir::Eq).n_inputs(), 2);
-    assert_eq!(StdTensorOp::Select.n_inputs(), 3);
-    assert_eq!(StdTensorOp::Clamp.n_inputs(), 3);
-    assert_eq!(StdTensorOp::Div.n_inputs(), 2);
-    assert_eq!(StdTensorOp::Pow.n_inputs(), 2);
-    assert_eq!(StdTensorOp::Abs.n_inputs(), 1);
-    assert_eq!(StdTensorOp::Exp.n_inputs(), 1);
-    assert_eq!(StdTensorOp::Log1p.n_inputs(), 1);
-    assert_eq!(StdTensorOp::constant_f64(1.0).n_outputs(), 1);
+    assert_eq!(StdTensorOp::Add.output_count(), 1);
+    assert_eq!(StdTensorOp::Neg.output_count(), 1);
+    assert_eq!(StdTensorOp::Compare(CompareDir::Eq).input_count(), 2);
+    assert_eq!(StdTensorOp::Select.input_count(), 3);
+    assert_eq!(StdTensorOp::Clamp.input_count(), 3);
+    assert_eq!(StdTensorOp::Div.input_count(), 2);
+    assert_eq!(StdTensorOp::Pow.input_count(), 2);
+    assert_eq!(StdTensorOp::Abs.input_count(), 1);
+    assert_eq!(StdTensorOp::Exp.input_count(), 1);
+    assert_eq!(StdTensorOp::Log1p.input_count(), 1);
+    assert_eq!(StdTensorOp::constant_f64(1.0).output_count(), 1);
     assert_eq!(
         StdTensorOp::EmbedDiag {
             axis_a: 0,
             axis_b: 1
         }
-        .n_outputs(),
+        .output_count(),
         1
     );
     assert_eq!(
@@ -332,7 +327,7 @@ fn test_std_tensor_op_input_output_counts() {
             index_vector_dim: 1,
             slice_sizes: vec![1],
         })
-        .n_outputs(),
+        .output_count(),
         1
     );
     assert_eq!(
@@ -342,30 +337,30 @@ fn test_std_tensor_op_input_output_counts() {
             scatter_dims_to_operand_dims: vec![0],
             index_vector_dim: 1,
         })
-        .n_outputs(),
+        .output_count(),
         1
     );
     assert_eq!(
         StdTensorOp::DynamicSlice {
             slice_sizes: vec![1]
         }
-        .n_outputs(),
+        .output_count(),
         1
     );
-    assert_eq!(StdTensorOp::DynamicUpdateSlice.n_outputs(), 1);
+    assert_eq!(StdTensorOp::DynamicUpdateSlice.output_count(), 1);
     assert_eq!(
         StdTensorOp::Pad(PadConfig {
             edge_padding_low: vec![1],
             edge_padding_high: vec![1],
             interior_padding: vec![0],
         })
-        .n_outputs(),
+        .output_count(),
         1
     );
-    assert_eq!(StdTensorOp::Tril { k: -1 }.n_inputs(), 1);
-    assert_eq!(StdTensorOp::Tril { k: -1 }.n_outputs(), 1);
-    assert_eq!(StdTensorOp::Triu { k: 1 }.n_inputs(), 1);
-    assert_eq!(StdTensorOp::Triu { k: 1 }.n_outputs(), 1);
+    assert_eq!(StdTensorOp::Tril { k: -1 }.input_count(), 1);
+    assert_eq!(StdTensorOp::Tril { k: -1 }.output_count(), 1);
+    assert_eq!(StdTensorOp::Triu { k: 1 }.input_count(), 1);
+    assert_eq!(StdTensorOp::Triu { k: 1 }.output_count(), 1);
 }
 
 #[test]
@@ -376,16 +371,16 @@ fn test_std_tensor_op_remaining_input_output_counts() {
         strides: vec![1, 1],
     };
 
-    assert_eq!(StdTensorOp::Maximum.n_inputs(), 2);
-    assert_eq!(StdTensorOp::Maximum.n_outputs(), 1);
-    assert_eq!(StdTensorOp::Minimum.n_inputs(), 2);
-    assert_eq!(StdTensorOp::Minimum.n_outputs(), 1);
+    assert_eq!(StdTensorOp::Maximum.input_count(), 2);
+    assert_eq!(StdTensorOp::Maximum.output_count(), 1);
+    assert_eq!(StdTensorOp::Minimum.input_count(), 2);
+    assert_eq!(StdTensorOp::Minimum.output_count(), 1);
     assert_eq!(
         StdTensorOp::Convert {
             from: DType::F64,
             to: DType::C64,
         }
-        .n_inputs(),
+        .input_count(),
         1
     );
     assert_eq!(
@@ -393,45 +388,48 @@ fn test_std_tensor_op_remaining_input_output_counts() {
             from: DType::F64,
             to: DType::C64,
         }
-        .n_outputs(),
+        .output_count(),
         1
     );
-    assert_eq!(StdTensorOp::Slice(slice.clone()).n_inputs(), 1);
-    assert_eq!(StdTensorOp::Slice(slice).n_outputs(), 1);
-    assert_eq!(StdTensorOp::Reverse { axes: vec![0, 2] }.n_inputs(), 1);
-    assert_eq!(StdTensorOp::Reverse { axes: vec![0, 2] }.n_outputs(), 1);
-    assert_eq!(StdTensorOp::ShapeOf { axis: 1 }.n_inputs(), 1);
-    assert_eq!(StdTensorOp::ShapeOf { axis: 1 }.n_outputs(), 1);
-    assert_eq!(StdTensorOp::DynamicTruncate { axis: 0 }.n_inputs(), 2);
-    assert_eq!(StdTensorOp::DynamicTruncate { axis: 0 }.n_outputs(), 1);
-    assert_eq!(StdTensorOp::PadToMatch { axis: 0 }.n_inputs(), 2);
-    assert_eq!(StdTensorOp::PadToMatch { axis: 0 }.n_outputs(), 1);
+    assert_eq!(StdTensorOp::Slice(slice.clone()).input_count(), 1);
+    assert_eq!(StdTensorOp::Slice(slice).output_count(), 1);
+    assert_eq!(StdTensorOp::Reverse { axes: vec![0, 2] }.input_count(), 1);
+    assert_eq!(StdTensorOp::Reverse { axes: vec![0, 2] }.output_count(), 1);
+    assert_eq!(StdTensorOp::ShapeOf { axis: 1 }.input_count(), 1);
+    assert_eq!(StdTensorOp::ShapeOf { axis: 1 }.output_count(), 1);
+    assert_eq!(StdTensorOp::DynamicTruncate { axis: 0 }.input_count(), 2);
+    assert_eq!(StdTensorOp::DynamicTruncate { axis: 0 }.output_count(), 1);
+    assert_eq!(StdTensorOp::PadToMatch { axis: 0 }.input_count(), 2);
+    assert_eq!(StdTensorOp::PadToMatch { axis: 0 }.output_count(), 1);
 }
 
 #[test]
 fn test_std_tensor_op_concatenate_counts_use_recorded_arity() {
     let op = StdTensorOp::Concatenate {
         axis: 0,
-        n_inputs: 3,
+        input_count: 3,
     };
 
-    assert_eq!(op.n_inputs(), 3);
-    assert_eq!(op.n_outputs(), 1);
+    assert_eq!(op.input_count(), 3);
+    assert_eq!(op.output_count(), 1);
 }
 
 #[test]
 fn test_std_tensor_op_reduction_counts_cover_remaining_variants() {
-    assert_eq!(StdTensorOp::ReduceProd { axes: vec![1] }.n_inputs(), 1);
-    assert_eq!(StdTensorOp::ReduceProd { axes: vec![1] }.n_outputs(), 1);
-    assert_eq!(StdTensorOp::ReduceMax { axes: vec![0] }.n_inputs(), 1);
-    assert_eq!(StdTensorOp::ReduceMax { axes: vec![0] }.n_outputs(), 1);
-    assert_eq!(StdTensorOp::ReduceMin { axes: vec![0, 1] }.n_inputs(), 1);
-    assert_eq!(StdTensorOp::ReduceMin { axes: vec![0, 1] }.n_outputs(), 1);
+    assert_eq!(StdTensorOp::ReduceProd { axes: vec![1] }.input_count(), 1);
+    assert_eq!(StdTensorOp::ReduceProd { axes: vec![1] }.output_count(), 1);
+    assert_eq!(StdTensorOp::ReduceMax { axes: vec![0] }.input_count(), 1);
+    assert_eq!(StdTensorOp::ReduceMax { axes: vec![0] }.output_count(), 1);
+    assert_eq!(StdTensorOp::ReduceMin { axes: vec![0, 1] }.input_count(), 1);
+    assert_eq!(
+        StdTensorOp::ReduceMin { axes: vec![0, 1] }.output_count(),
+        1
+    );
 }
 
 #[test]
 fn test_std_tensor_op_linearize_add_delegates_to_ad_module() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let dx = builder.add_input(TensorInputKey::User { id: 1 });
     let dy = builder.add_input(TensorInputKey::User { id: 2 });
@@ -441,12 +439,12 @@ fn test_std_tensor_op_linearize_add_delegates_to_ad_module() {
 
     assert_eq!(result.len(), 1);
     assert!(result[0].is_some());
-    let fragment = builder.build();
-    assert_eq!(fragment.ops().len(), 1);
-    assert_eq!(fragment.ops()[0].op, StdTensorOp::Add);
+    let graph = builder.build();
+    assert_eq!(graph.operations().len(), 1);
+    assert_eq!(graph.operations()[0].operation, StdTensorOp::Add);
     assert_eq!(
-        fragment.ops()[0].mode,
-        OpMode::Linear {
+        graph.operations()[0].role,
+        OperationRole::Linearized {
             active_mask: vec![true, true],
         }
     );
@@ -454,30 +452,30 @@ fn test_std_tensor_op_linearize_add_delegates_to_ad_module() {
 
 #[test]
 fn test_std_tensor_op_transpose_rule_add_fans_out_cotangent() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let ct = builder.add_input(TensorInputKey::User { id: 3 });
     let inputs = vec![
-        ValRef::External(GlobalValKey::Input(TensorInputKey::User { id: 10 })),
-        ValRef::External(GlobalValKey::Input(TensorInputKey::User { id: 11 })),
+        ValueRef::External(ValueKey::Input(TensorInputKey::User { id: 10 })),
+        ValueRef::External(ValueKey::Input(TensorInputKey::User { id: 11 })),
     ];
 
     let result = StdTensorOp::add().transpose_rule(
         &mut builder,
         &[Some(ct)],
         &inputs,
-        &OpMode::Primal,
+        &OperationRole::Primary,
         &mut ad_ctx,
     );
 
     assert_eq!(result, vec![Some(ct), Some(ct)]);
-    let fragment = builder.build();
-    assert!(fragment.ops().is_empty());
+    let graph = builder.build();
+    assert!(graph.operations().is_empty());
 }
 
 #[test]
 fn test_std_tensor_op_mul_transpose_skips_real_conjugates_and_keeps_complex_conjugates() {
-    let (real_result, _, real_fragment) = run_transpose_case_with_input_shape(
+    let (real_result, _, real_graph) = run_transpose_case_with_input_shape(
         StdTensorOp::Mul,
         2,
         &[true, true],
@@ -487,14 +485,14 @@ fn test_std_tensor_op_mul_transpose_skips_real_conjugates_and_keeps_complex_conj
 
     assert!(real_result.iter().all(Option::is_some));
     assert!(
-        real_fragment
-            .ops()
+        real_graph
+            .operations()
             .iter()
-            .all(|op| op.op != StdTensorOp::Conj),
+            .all(|op| op.operation != StdTensorOp::Conj),
         "real mul transpose should not emit no-op Conj nodes"
     );
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let cotangent = builder.add_input(tensor_input_key(401));
     let inputs = external_inputs(510, 2);
@@ -506,21 +504,21 @@ fn test_std_tensor_op_mul_transpose_skips_real_conjugates_and_keeps_complex_conj
         &linear_mode(&[true, true]),
         &mut ad_ctx,
     );
-    let complex_fragment = builder.build();
+    let complex_graph = builder.build();
 
     assert!(complex_result.iter().all(Option::is_some));
     assert!(
-        complex_fragment
-            .ops()
+        complex_graph
+            .operations()
             .iter()
-            .any(|op| op.op == StdTensorOp::Conj),
+            .any(|op| op.operation == StdTensorOp::Conj),
         "complex mul transpose must still conjugate inactive primal factors"
     );
 }
 
 #[test]
 fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let primal_in = add_input_keys(&mut builder, 530, 1);
     ad_ctx.insert_metadata(
@@ -530,13 +528,13 @@ fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation(
     let tangent = builder.add_input(tensor_input_key(540));
     let real_linearized =
         StdTensorOp::Conj.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
-    let real_linear_fragment = builder.build();
+    let real_linear_graph = builder.build();
     assert_eq!(real_linearized, vec![Some(tangent)]);
-    assert!(real_linear_fragment.ops().is_empty());
+    assert!(real_linear_graph.operations().is_empty());
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
-    let input = ValRef::External(GlobalValKey::Input(tensor_input_key(541)));
+    let input = ValueRef::External(ValueKey::Input(tensor_input_key(541)));
     seed_uniform_ref_metadata_with_dtype(
         &mut ad_ctx,
         std::slice::from_ref(&input),
@@ -551,11 +549,11 @@ fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation(
         &linear_mode(&[true]),
         &mut ad_ctx,
     );
-    let real_transpose_fragment = builder.build();
+    let real_transpose_graph = builder.build();
     assert_eq!(real_transposed, vec![Some(cotangent)]);
-    assert!(real_transpose_fragment.ops().is_empty());
+    assert!(real_transpose_graph.operations().is_empty());
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let primal_in = add_input_keys(&mut builder, 550, 1);
     ad_ctx.insert_metadata(
@@ -565,14 +563,17 @@ fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation(
     let tangent = builder.add_input(tensor_input_key(560));
     let complex_linearized =
         StdTensorOp::Conj.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
-    let complex_linear_fragment = builder.build();
+    let complex_linear_graph = builder.build();
     assert!(complex_linearized[0].is_some());
-    assert_eq!(complex_linear_fragment.ops().len(), 1);
-    assert_eq!(complex_linear_fragment.ops()[0].op, StdTensorOp::Conj);
+    assert_eq!(complex_linear_graph.operations().len(), 1);
+    assert_eq!(
+        complex_linear_graph.operations()[0].operation,
+        StdTensorOp::Conj
+    );
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
-    let input = ValRef::External(GlobalValKey::Input(tensor_input_key(561)));
+    let input = ValueRef::External(ValueKey::Input(tensor_input_key(561)));
     seed_uniform_ref_metadata_with_dtype(
         &mut ad_ctx,
         std::slice::from_ref(&input),
@@ -587,10 +588,13 @@ fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation(
         &linear_mode(&[true]),
         &mut ad_ctx,
     );
-    let complex_transpose_fragment = builder.build();
+    let complex_transpose_graph = builder.build();
     assert!(complex_transposed[0].is_some());
-    assert_eq!(complex_transpose_fragment.ops().len(), 1);
-    assert_eq!(complex_transpose_fragment.ops()[0].op, StdTensorOp::Conj);
+    assert_eq!(complex_transpose_graph.operations().len(), 1);
+    assert_eq!(
+        complex_transpose_graph.operations()[0].operation,
+        StdTensorOp::Conj
+    );
 }
 
 #[test]
@@ -635,7 +639,7 @@ fn test_std_tensor_op_hash_covers_remaining_variants() {
         },
         StdTensorOp::Concatenate {
             axis: 1,
-            n_inputs: 3,
+            input_count: 3,
         },
         StdTensorOp::Reverse { axes: vec![0] },
         StdTensorOp::ShapeOf { axis: 0 },
@@ -661,7 +665,7 @@ fn test_std_tensor_op_hash_covers_remaining_variants() {
 
 #[test]
 fn test_std_tensor_op_reduce_prod_transpose_emits_product_rule() {
-    let (result, _, fragment) = run_transpose_case_with_input_shape(
+    let (result, _, graph) = run_transpose_case_with_input_shape(
         StdTensorOp::ReduceProd { axes: vec![0] },
         1,
         &[true],
@@ -670,24 +674,27 @@ fn test_std_tensor_op_reduce_prod_transpose_emits_product_rule() {
     );
 
     assert!(result[0].is_some());
-    assert!(fragment.ops().iter().any(|instr| matches!(
-        &instr.op,
+    assert!(graph.operations().iter().any(|instr| matches!(
+        &instr.operation,
         StdTensorOp::BroadcastInDim { dims, .. } if dims.as_slice() == [1]
     )));
-    assert!(fragment.ops().iter().any(|instr| matches!(
-        &instr.op,
+    assert!(graph.operations().iter().any(|instr| matches!(
+        &instr.operation,
         StdTensorOp::ReduceProd { axes } if axes.as_slice() == [0]
     )));
-    assert!(fragment
-        .ops()
+    assert!(graph
+        .operations()
         .iter()
-        .any(|instr| instr.op == StdTensorOp::Div));
-    assert_eq!(fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+        .any(|instr| instr.operation == StdTensorOp::Div));
+    assert_eq!(
+        graph.operations().last().unwrap().operation,
+        StdTensorOp::Mul
+    );
 }
 
 #[test]
 fn test_std_tensor_op_reduce_chooser_transpose_emits_tie_split_rule() {
-    let (result, _, fragment) = run_transpose_case_with_input_shape(
+    let (result, _, graph) = run_transpose_case_with_input_shape(
         StdTensorOp::ReduceMax { axes: vec![0, 1] },
         1,
         &[true],
@@ -696,31 +703,34 @@ fn test_std_tensor_op_reduce_chooser_transpose_emits_tie_split_rule() {
     );
 
     assert!(result[0].is_some());
-    assert!(fragment.ops().iter().any(|instr| matches!(
-        &instr.op,
+    assert!(graph.operations().iter().any(|instr| matches!(
+        &instr.operation,
         StdTensorOp::Reshape { to_shape } if to_shape.is_empty()
     )));
-    assert!(fragment
-        .ops()
+    assert!(graph
+        .operations()
         .iter()
-        .any(|instr| instr.op == StdTensorOp::Compare(CompareDir::Eq)));
-    assert!(fragment.ops().iter().any(|instr| matches!(
-        &instr.op,
+        .any(|instr| instr.operation == StdTensorOp::Compare(CompareDir::Eq)));
+    assert!(graph.operations().iter().any(|instr| matches!(
+        &instr.operation,
         StdTensorOp::ReduceSum { axes } if axes.as_slice() == [0, 1]
     )));
-    assert!(fragment.ops().iter().any(|instr| {
-        instr.op
+    assert!(graph.operations().iter().any(|instr| {
+        instr.operation
             == StdTensorOp::Convert {
                 from: DType::Bool,
                 to: DType::F64,
             }
     }));
-    assert_eq!(fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+    assert_eq!(
+        graph.operations().last().unwrap().operation,
+        StdTensorOp::Mul
+    );
 }
 
 #[test]
 fn test_std_tensor_op_pad_to_match_transpose_uses_static_slice_for_concrete_shape() {
-    let (result, _, fragment) = run_transpose_case_with_input_shapes(
+    let (result, _, graph) = run_transpose_case_with_input_shapes(
         StdTensorOp::PadToMatch { axis: 0 },
         2,
         &[true, false],
@@ -730,9 +740,9 @@ fn test_std_tensor_op_pad_to_match_transpose_uses_static_slice_for_concrete_shap
 
     assert!(result[0].is_some());
     assert_eq!(result[1], None);
-    assert_eq!(fragment.ops().len(), 1);
+    assert_eq!(graph.operations().len(), 1);
     assert_eq!(
-        fragment.ops()[0].op,
+        graph.operations()[0].operation,
         StdTensorOp::Slice(tenferro_tensor::SliceConfig {
             starts: vec![0],
             limits: vec![2],
@@ -743,7 +753,7 @@ fn test_std_tensor_op_pad_to_match_transpose_uses_static_slice_for_concrete_shap
 
 #[test]
 fn test_std_tensor_op_dynamic_truncate_linearize_uses_static_slice_for_narrowed_metadata() {
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let primal_in = add_input_keys(&mut builder, 960, 2);
     let primal_out = add_input_keys(&mut builder, 970, 1);
@@ -765,12 +775,12 @@ fn test_std_tensor_op_dynamic_truncate_linearize_uses_static_slice_for_narrowed_
         &[Some(tangent), None],
         &mut ad_ctx,
     );
-    let fragment = builder.build();
+    let graph = builder.build();
 
     assert!(result[0].is_some());
-    assert_eq!(fragment.ops().len(), 1);
+    assert_eq!(graph.operations().len(), 1);
     assert_eq!(
-        fragment.ops()[0].op,
+        graph.operations()[0].operation,
         StdTensorOp::Slice(tenferro_tensor::SliceConfig {
             starts: vec![0],
             limits: vec![2],
@@ -830,194 +840,243 @@ fn test_std_tensor_op_linearize_none_tangent_paths_return_none() {
         StdTensorOp::Abs,
     ];
     for op in unary_primal_in {
-        let (result, fragment) = run_linearize_case(op.clone(), 1, 0, &[false]);
+        let (result, graph) = run_linearize_case(op.clone(), 1, 0, &[false]);
         assert_eq!(result, vec![None], "unexpected result for {op:?}");
-        assert!(fragment.ops().is_empty(), "expected no ops for {op:?}");
+        assert!(graph.operations().is_empty(), "expected no ops for {op:?}");
     }
 
     let unary_primal_out = [StdTensorOp::Tanh, StdTensorOp::Sqrt, StdTensorOp::Expm1];
     for op in unary_primal_out {
-        let (result, fragment) = run_linearize_case(op.clone(), 0, 1, &[false]);
+        let (result, graph) = run_linearize_case(op.clone(), 0, 1, &[false]);
         assert_eq!(result, vec![None], "unexpected result for {op:?}");
-        assert!(fragment.ops().is_empty(), "expected no ops for {op:?}");
+        assert!(graph.operations().is_empty(), "expected no ops for {op:?}");
     }
 
-    let (result, fragment) = run_linearize_case(StdTensorOp::Rsqrt, 1, 1, &[false]);
+    let (result, graph) = run_linearize_case(StdTensorOp::Rsqrt, 1, 1, &[false]);
     assert_eq!(result, vec![None]);
-    assert!(fragment.ops().is_empty());
+    assert!(graph.operations().is_empty());
 
-    let (result, fragment) = run_linearize_case(StdTensorOp::Pow, 2, 1, &[false, false]);
+    let (result, graph) = run_linearize_case(StdTensorOp::Pow, 2, 1, &[false, false]);
     assert_eq!(result, vec![None]);
-    assert!(fragment.ops().is_empty());
+    assert!(graph.operations().is_empty());
 
-    let (constant_result, constant_fragment) =
+    let (constant_result, constant_graph) =
         run_linearize_case(StdTensorOp::constant_f64(1.0), 0, 0, &[]);
     assert_eq!(constant_result, vec![None]);
-    assert!(constant_fragment.ops().is_empty());
+    assert!(constant_graph.operations().is_empty());
 }
 
 #[test]
 fn test_std_tensor_op_analytic_linearize_emits_ops_for_remaining_variants() {
-    let (sin_result, sin_fragment) = run_linearize_case(StdTensorOp::Sin, 1, 0, &[true]);
+    let (sin_result, sin_graph) = run_linearize_case(StdTensorOp::Sin, 1, 0, &[true]);
     assert!(sin_result[0].is_some());
-    assert_eq!(sin_fragment.ops().len(), 2);
-    assert_eq!(sin_fragment.ops()[0].op, StdTensorOp::Cos);
-    assert_eq!(sin_fragment.ops()[1].op, StdTensorOp::Mul);
+    assert_eq!(sin_graph.operations().len(), 2);
+    assert_eq!(sin_graph.operations()[0].operation, StdTensorOp::Cos);
+    assert_eq!(sin_graph.operations()[1].operation, StdTensorOp::Mul);
 
-    let (cos_result, cos_fragment) = run_linearize_case(StdTensorOp::Cos, 1, 0, &[true]);
+    let (cos_result, cos_graph) = run_linearize_case(StdTensorOp::Cos, 1, 0, &[true]);
     assert!(cos_result[0].is_some());
-    assert_eq!(cos_fragment.ops().len(), 3);
-    assert_eq!(cos_fragment.ops()[0].op, StdTensorOp::Sin);
-    assert_eq!(cos_fragment.ops()[1].op, StdTensorOp::Neg);
-    assert_eq!(cos_fragment.ops()[2].op, StdTensorOp::Mul);
+    assert_eq!(cos_graph.operations().len(), 3);
+    assert_eq!(cos_graph.operations()[0].operation, StdTensorOp::Sin);
+    assert_eq!(cos_graph.operations()[1].operation, StdTensorOp::Neg);
+    assert_eq!(cos_graph.operations()[2].operation, StdTensorOp::Mul);
 
-    let (tanh_result, tanh_fragment) = run_linearize_case(StdTensorOp::Tanh, 0, 1, &[true]);
+    let (tanh_result, tanh_graph) = run_linearize_case(StdTensorOp::Tanh, 0, 1, &[true]);
     assert!(tanh_result[0].is_some());
-    assert_eq!(tanh_fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+    assert_eq!(
+        tanh_graph.operations().last().unwrap().operation,
+        StdTensorOp::Mul
+    );
 
-    let (sqrt_result, sqrt_fragment) = run_linearize_case(StdTensorOp::Sqrt, 0, 1, &[true]);
+    let (sqrt_result, sqrt_graph) = run_linearize_case(StdTensorOp::Sqrt, 0, 1, &[true]);
     assert!(sqrt_result[0].is_some());
-    assert_eq!(sqrt_fragment.ops().last().unwrap().op, StdTensorOp::Div);
+    assert_eq!(
+        sqrt_graph.operations().last().unwrap().operation,
+        StdTensorOp::Div
+    );
 
-    let (rsqrt_result, rsqrt_fragment) = run_linearize_case(StdTensorOp::Rsqrt, 1, 1, &[true]);
+    let (rsqrt_result, rsqrt_graph) = run_linearize_case(StdTensorOp::Rsqrt, 1, 1, &[true]);
     assert!(rsqrt_result[0].is_some());
-    assert_eq!(rsqrt_fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+    assert_eq!(
+        rsqrt_graph.operations().last().unwrap().operation,
+        StdTensorOp::Mul
+    );
 
-    let (pow_result, pow_fragment) = run_linearize_case(StdTensorOp::Pow, 2, 1, &[true, true]);
+    let (pow_result, pow_graph) = run_linearize_case(StdTensorOp::Pow, 2, 1, &[true, true]);
     assert!(pow_result[0].is_some());
-    assert_eq!(pow_fragment.ops().last().unwrap().op, StdTensorOp::Add);
+    assert_eq!(
+        pow_graph.operations().last().unwrap().operation,
+        StdTensorOp::Add
+    );
 
-    let (expm1_result, expm1_fragment) = run_linearize_case(StdTensorOp::Expm1, 0, 1, &[true]);
+    let (expm1_result, expm1_graph) = run_linearize_case(StdTensorOp::Expm1, 0, 1, &[true]);
     assert!(expm1_result[0].is_some());
-    assert_eq!(expm1_fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+    assert_eq!(
+        expm1_graph.operations().last().unwrap().operation,
+        StdTensorOp::Mul
+    );
 
-    let (log1p_result, log1p_fragment) = run_linearize_case(StdTensorOp::Log1p, 1, 0, &[true]);
+    let (log1p_result, log1p_graph) = run_linearize_case(StdTensorOp::Log1p, 1, 0, &[true]);
     assert!(log1p_result[0].is_some());
-    assert_eq!(log1p_fragment.ops().last().unwrap().op, StdTensorOp::Div);
+    assert_eq!(
+        log1p_graph.operations().last().unwrap().operation,
+        StdTensorOp::Div
+    );
 }
 
 #[test]
 fn test_std_tensor_op_elementwise_special_cases_are_covered() {
-    let (div_sum_result, div_sum_fragment) =
-        run_linearize_case(StdTensorOp::Div, 2, 1, &[true, true]);
+    let (div_sum_result, div_sum_graph) = run_linearize_case(StdTensorOp::Div, 2, 1, &[true, true]);
     assert!(div_sum_result[0].is_some());
-    assert_eq!(div_sum_fragment.ops().last().unwrap().op, StdTensorOp::Add);
+    assert_eq!(
+        div_sum_graph.operations().last().unwrap().operation,
+        StdTensorOp::Add
+    );
 
-    let (div_result, div_fragment) = run_linearize_case(StdTensorOp::Div, 2, 1, &[false, true]);
+    let (div_result, div_graph) = run_linearize_case(StdTensorOp::Div, 2, 1, &[false, true]);
     assert!(div_result[0].is_some());
-    assert_eq!(div_fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+    assert_eq!(
+        div_graph.operations().last().unwrap().operation,
+        StdTensorOp::Mul
+    );
 
-    let (abs_result, abs_fragment) = run_linearize_case(StdTensorOp::Abs, 1, 0, &[true]);
+    let (abs_result, abs_graph) = run_linearize_case(StdTensorOp::Abs, 1, 0, &[true]);
     assert!(abs_result[0].is_some());
-    assert_eq!(abs_fragment.ops()[0].op, StdTensorOp::Sign);
-    assert_eq!(abs_fragment.ops()[1].op, StdTensorOp::Mul);
+    assert_eq!(abs_graph.operations()[0].operation, StdTensorOp::Sign);
+    assert_eq!(abs_graph.operations()[1].operation, StdTensorOp::Mul);
 
-    let (sign_result, sign_fragment) = run_linearize_case(StdTensorOp::Sign, 0, 0, &[true]);
+    let (sign_result, sign_graph) = run_linearize_case(StdTensorOp::Sign, 0, 0, &[true]);
     assert!(sign_result[0].is_some());
-    assert_eq!(sign_fragment.ops().len(), 2);
-    assert_eq!(sign_fragment.ops()[0].op, StdTensorOp::Neg);
-    assert_eq!(sign_fragment.ops()[1].op, StdTensorOp::Add);
+    assert_eq!(sign_graph.operations().len(), 2);
+    assert_eq!(sign_graph.operations()[0].operation, StdTensorOp::Neg);
+    assert_eq!(sign_graph.operations()[1].operation, StdTensorOp::Add);
 
-    let (transpose_div_result, _, transpose_div_fragment) =
+    let (transpose_div_result, _, transpose_div_graph) =
         run_transpose_case(StdTensorOp::Div, 2, &[false, true], true);
     assert_eq!(transpose_div_result[0], None);
     assert!(transpose_div_result[1].is_some());
     assert_eq!(
-        transpose_div_fragment.ops().last().unwrap().op,
+        transpose_div_graph.operations().last().unwrap().operation,
         StdTensorOp::Mul
     );
 
-    let (transpose_sign_result, _, transpose_sign_fragment) =
+    let (transpose_sign_result, _, transpose_sign_graph) =
         run_transpose_case(StdTensorOp::Sign, 1, &[true], true);
     assert!(transpose_sign_result[0].is_some());
-    assert_eq!(transpose_sign_fragment.ops().len(), 2);
-    assert_eq!(transpose_sign_fragment.ops()[0].op, StdTensorOp::Neg);
-    assert_eq!(transpose_sign_fragment.ops()[1].op, StdTensorOp::Add);
+    assert_eq!(transpose_sign_graph.operations().len(), 2);
+    assert_eq!(
+        transpose_sign_graph.operations()[0].operation,
+        StdTensorOp::Neg
+    );
+    assert_eq!(
+        transpose_sign_graph.operations()[1].operation,
+        StdTensorOp::Add
+    );
 
-    let (transpose_div_none_result, _, transpose_div_none_fragment) =
+    let (transpose_div_none_result, _, transpose_div_none_graph) =
         run_transpose_case(StdTensorOp::Div, 2, &[true, true], false);
     assert_eq!(transpose_div_none_result, vec![None, None]);
-    assert!(transpose_div_none_fragment.ops().is_empty());
+    assert!(transpose_div_none_graph.operations().is_empty());
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let cotangent = builder.add_input(tensor_input_key(920));
     let div_primal_mode = StdTensorOp::Div.transpose_rule(
         &mut builder,
         &[Some(cotangent)],
         &external_inputs(921, 2),
-        &OpMode::Primal,
+        &OperationRole::Primary,
         &mut ad_ctx,
     );
     assert_eq!(div_primal_mode, vec![None, None]);
-    assert!(builder.build().ops().is_empty());
+    assert!(builder.build().operations().is_empty());
 
-    let (transpose_abs_result, _, transpose_abs_fragment) =
+    let (transpose_abs_result, _, transpose_abs_graph) =
         run_transpose_case(StdTensorOp::Abs, 1, &[true], true);
     assert!(transpose_abs_result[0].is_some());
-    assert_eq!(transpose_abs_fragment.ops()[0].op, StdTensorOp::Sign);
-    assert_eq!(transpose_abs_fragment.ops()[1].op, StdTensorOp::Mul);
+    assert_eq!(
+        transpose_abs_graph.operations()[0].operation,
+        StdTensorOp::Sign
+    );
+    assert_eq!(
+        transpose_abs_graph.operations()[1].operation,
+        StdTensorOp::Mul
+    );
 }
 
 #[test]
 fn test_std_tensor_op_constant_transpose_rule_has_no_inputs_or_ops() {
-    let (result, _, fragment) = run_transpose_case(StdTensorOp::constant_f64(1.0), 0, &[], true);
+    let (result, _, graph) = run_transpose_case(StdTensorOp::constant_f64(1.0), 0, &[], true);
     assert!(result.is_empty());
-    assert!(fragment.ops().is_empty());
+    assert!(graph.operations().is_empty());
 }
 
 #[test]
 fn test_std_tensor_op_analytic_transpose_rule_emits_ops_for_remaining_variants() {
-    let (exp_result, _, exp_fragment) = run_transpose_case(StdTensorOp::Exp, 1, &[true], true);
+    let (exp_result, _, exp_graph) = run_transpose_case(StdTensorOp::Exp, 1, &[true], true);
     assert!(exp_result[0].is_some());
-    assert_eq!(exp_fragment.ops()[0].op, StdTensorOp::Exp);
-    assert_eq!(exp_fragment.ops()[1].op, StdTensorOp::Mul);
+    assert_eq!(exp_graph.operations()[0].operation, StdTensorOp::Exp);
+    assert_eq!(exp_graph.operations()[1].operation, StdTensorOp::Mul);
 
-    let (log_result, _, log_fragment) = run_transpose_case(StdTensorOp::Log, 1, &[true], true);
+    let (log_result, _, log_graph) = run_transpose_case(StdTensorOp::Log, 1, &[true], true);
     assert!(log_result[0].is_some());
-    assert_eq!(log_fragment.ops()[0].op, StdTensorOp::Div);
+    assert_eq!(log_graph.operations()[0].operation, StdTensorOp::Div);
 
-    let (sin_result, _, sin_fragment) = run_transpose_case(StdTensorOp::Sin, 1, &[true], true);
+    let (sin_result, _, sin_graph) = run_transpose_case(StdTensorOp::Sin, 1, &[true], true);
     assert!(sin_result[0].is_some());
-    assert_eq!(sin_fragment.ops().len(), 2);
-    assert_eq!(sin_fragment.ops()[0].op, StdTensorOp::Cos);
-    assert_eq!(sin_fragment.ops()[1].op, StdTensorOp::Mul);
+    assert_eq!(sin_graph.operations().len(), 2);
+    assert_eq!(sin_graph.operations()[0].operation, StdTensorOp::Cos);
+    assert_eq!(sin_graph.operations()[1].operation, StdTensorOp::Mul);
 
-    let (cos_result, _, cos_fragment) = run_transpose_case(StdTensorOp::Cos, 1, &[true], true);
+    let (cos_result, _, cos_graph) = run_transpose_case(StdTensorOp::Cos, 1, &[true], true);
     assert!(cos_result[0].is_some());
-    assert_eq!(cos_fragment.ops().len(), 3);
-    assert_eq!(cos_fragment.ops()[0].op, StdTensorOp::Sin);
-    assert_eq!(cos_fragment.ops()[1].op, StdTensorOp::Neg);
-    assert_eq!(cos_fragment.ops()[2].op, StdTensorOp::Mul);
+    assert_eq!(cos_graph.operations().len(), 3);
+    assert_eq!(cos_graph.operations()[0].operation, StdTensorOp::Sin);
+    assert_eq!(cos_graph.operations()[1].operation, StdTensorOp::Neg);
+    assert_eq!(cos_graph.operations()[2].operation, StdTensorOp::Mul);
 
-    let (tanh_result, _, tanh_fragment) = run_transpose_case(StdTensorOp::Tanh, 1, &[true], true);
+    let (tanh_result, _, tanh_graph) = run_transpose_case(StdTensorOp::Tanh, 1, &[true], true);
     assert!(tanh_result[0].is_some());
-    assert_eq!(tanh_fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+    assert_eq!(
+        tanh_graph.operations().last().unwrap().operation,
+        StdTensorOp::Mul
+    );
 
-    let (sqrt_result, _, sqrt_fragment) = run_transpose_case(StdTensorOp::Sqrt, 1, &[true], true);
+    let (sqrt_result, _, sqrt_graph) = run_transpose_case(StdTensorOp::Sqrt, 1, &[true], true);
     assert!(sqrt_result[0].is_some());
-    assert_eq!(sqrt_fragment.ops().last().unwrap().op, StdTensorOp::Div);
+    assert_eq!(
+        sqrt_graph.operations().last().unwrap().operation,
+        StdTensorOp::Div
+    );
 
-    let (rsqrt_result, _, rsqrt_fragment) =
-        run_transpose_case(StdTensorOp::Rsqrt, 1, &[true], true);
+    let (rsqrt_result, _, rsqrt_graph) = run_transpose_case(StdTensorOp::Rsqrt, 1, &[true], true);
     assert!(rsqrt_result[0].is_some());
-    assert_eq!(rsqrt_fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+    assert_eq!(
+        rsqrt_graph.operations().last().unwrap().operation,
+        StdTensorOp::Mul
+    );
 
-    let (pow_result, _, pow_fragment) =
-        run_transpose_case(StdTensorOp::Pow, 2, &[true, true], true);
+    let (pow_result, _, pow_graph) = run_transpose_case(StdTensorOp::Pow, 2, &[true, true], true);
     assert!(pow_result[0].is_some());
     assert!(pow_result[1].is_some());
-    assert_eq!(pow_fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+    assert_eq!(
+        pow_graph.operations().last().unwrap().operation,
+        StdTensorOp::Mul
+    );
 
-    let (expm1_result, _, expm1_fragment) =
-        run_transpose_case(StdTensorOp::Expm1, 1, &[true], true);
+    let (expm1_result, _, expm1_graph) = run_transpose_case(StdTensorOp::Expm1, 1, &[true], true);
     assert!(expm1_result[0].is_some());
-    assert_eq!(expm1_fragment.ops().last().unwrap().op, StdTensorOp::Mul);
+    assert_eq!(
+        expm1_graph.operations().last().unwrap().operation,
+        StdTensorOp::Mul
+    );
 
-    let (log1p_result, _, log1p_fragment) =
-        run_transpose_case(StdTensorOp::Log1p, 1, &[true], true);
+    let (log1p_result, _, log1p_graph) = run_transpose_case(StdTensorOp::Log1p, 1, &[true], true);
     assert!(log1p_result[0].is_some());
-    assert_eq!(log1p_fragment.ops().last().unwrap().op, StdTensorOp::Div);
+    assert_eq!(
+        log1p_graph.operations().last().unwrap().operation,
+        StdTensorOp::Div
+    );
 }
 
 #[test]
@@ -1035,23 +1094,26 @@ fn test_std_tensor_op_transpose_none_or_inactive_paths_return_none() {
     ];
 
     for op in unary_ops {
-        let (none_result, _, none_fragment) = run_transpose_case(op.clone(), 1, &[true], false);
+        let (none_result, _, none_graph) = run_transpose_case(op.clone(), 1, &[true], false);
         assert_eq!(none_result, vec![None], "unexpected None path for {op:?}");
-        assert!(none_fragment.ops().is_empty(), "expected no ops for {op:?}");
+        assert!(
+            none_graph.operations().is_empty(),
+            "expected no ops for {op:?}"
+        );
 
-        let mut builder = FragmentBuilder::<StdTensorOp>::new();
+        let mut builder = GraphBuilder::<StdTensorOp>::new();
         let mut ad_ctx = ShapeGuardContext::default();
         let cotangent = builder.add_input(tensor_input_key(900));
         let result = op.transpose_rule(
             &mut builder,
             &[Some(cotangent)],
             &external_inputs(901, 1),
-            &OpMode::Primal,
+            &OperationRole::Primary,
             &mut ad_ctx,
         );
         assert_eq!(result, vec![None], "unexpected inactive path for {op:?}");
         assert!(
-            builder.build().ops().is_empty(),
+            builder.build().operations().is_empty(),
             "expected no ops for {op:?}"
         );
     }

--- a/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
+++ b/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
@@ -1,27 +1,28 @@
 use super::*;
+use crate::ad::PrimitiveRuleBuilder;
 
 #[test]
 fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
-    let (transpose_none_result, transpose_none_fragment) =
+    let (transpose_none_result, transpose_none_graph) =
         run_linearize_case(StdTensorOp::Transpose { perm: vec![1, 0] }, 0, 0, &[false]);
     assert_eq!(transpose_none_result, vec![None]);
-    assert!(transpose_none_fragment.ops().is_empty());
+    assert!(transpose_none_graph.operations().is_empty());
 
-    let (identity_transpose_result, identity_transpose_fragment) =
+    let (identity_transpose_result, identity_transpose_graph) =
         run_linearize_case(StdTensorOp::Transpose { perm: vec![0, 1] }, 0, 0, &[true]);
     assert!(identity_transpose_result[0].is_some());
-    assert!(identity_transpose_fragment.ops().is_empty());
+    assert!(identity_transpose_graph.operations().is_empty());
 
     let reshape = StdTensorOp::Reshape {
         to_shape: shape![2, 2],
     };
-    let (reshape_linear_result, reshape_linear_fragment) =
+    let (reshape_linear_result, reshape_linear_graph) =
         run_linearize_case(reshape.clone(), 0, 0, &[true]);
     assert!(reshape_linear_result[0].is_some());
-    assert_eq!(reshape_linear_fragment.ops().len(), 1);
-    assert_eq!(reshape_linear_fragment.ops()[0].op, reshape);
+    assert_eq!(reshape_linear_graph.operations().len(), 1);
+    assert_eq!(reshape_linear_graph.operations()[0].operation, reshape);
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let primal_in = add_input_keys(&mut builder, 904, 1);
     ad_ctx.insert_metadata(
@@ -34,20 +35,20 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
     };
     let identity_reshape_result =
         identity_reshape.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
-    let identity_reshape_fragment = builder.build();
+    let identity_reshape_graph = builder.build();
     assert_eq!(identity_reshape_result, vec![Some(tangent)]);
-    assert!(identity_reshape_fragment.ops().is_empty());
+    assert!(identity_reshape_graph.operations().is_empty());
 
-    let (transpose_result, _, transpose_fragment) = run_transpose_case(
+    let (transpose_result, _, transpose_graph) = run_transpose_case(
         StdTensorOp::Transpose { perm: vec![0, 1] },
         1,
         &[true],
         true,
     );
     assert!(transpose_result[0].is_some());
-    assert!(transpose_fragment.ops().is_empty());
+    assert!(transpose_graph.operations().is_empty());
 
-    let (broadcast_linear_result, broadcast_linear_fragment) = run_linearize_case(
+    let (broadcast_linear_result, broadcast_linear_graph) = run_linearize_case(
         StdTensorOp::BroadcastInDim {
             shape: shape![2, 2, 3],
             dims: vec![0, 2],
@@ -58,14 +59,14 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
     );
     assert!(broadcast_linear_result[0].is_some());
     assert_eq!(
-        broadcast_linear_fragment.ops()[0].op,
+        broadcast_linear_graph.operations()[0].operation,
         StdTensorOp::BroadcastInDim {
             shape: shape![2, 2, 3],
             dims: vec![0, 2],
         }
     );
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let primal_in = add_input_keys(&mut builder, 906, 1);
     ad_ctx.insert_metadata(
@@ -79,11 +80,11 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
     };
     let identity_broadcast_result =
         identity_broadcast.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
-    let identity_broadcast_fragment = builder.build();
+    let identity_broadcast_graph = builder.build();
     assert_eq!(identity_broadcast_result, vec![Some(tangent)]);
-    assert!(identity_broadcast_fragment.ops().is_empty());
+    assert!(identity_broadcast_graph.operations().is_empty());
 
-    let (broadcast_none_result, broadcast_none_fragment) = run_linearize_case(
+    let (broadcast_none_result, broadcast_none_graph) = run_linearize_case(
         StdTensorOp::BroadcastInDim {
             shape: shape![2, 2, 3],
             dims: vec![0, 2],
@@ -93,9 +94,9 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         &[false],
     );
     assert_eq!(broadcast_none_result, vec![None]);
-    assert!(broadcast_none_fragment.ops().is_empty());
+    assert!(broadcast_none_graph.operations().is_empty());
 
-    let (reshape_transpose_result, _, reshape_transpose_fragment) =
+    let (reshape_transpose_result, _, reshape_transpose_graph) =
         run_transpose_case_with_input_shape(
             reshape,
             1,
@@ -104,15 +105,15 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
             Some(vec![SymDim::from(4usize)]),
         );
     assert!(reshape_transpose_result[0].is_some());
-    assert_eq!(reshape_transpose_fragment.ops().len(), 1);
+    assert_eq!(reshape_transpose_graph.operations().len(), 1);
     assert_eq!(
-        reshape_transpose_fragment.ops()[0].op,
+        reshape_transpose_graph.operations()[0].operation,
         StdTensorOp::Reshape {
             to_shape: DimExpr::input_shape(1, 1),
         }
     );
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let cotangent = builder.add_input(tensor_input_key(910));
     let result = StdTensorOp::BroadcastInDim {
@@ -127,33 +128,37 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         &mut ad_ctx,
     );
     assert_eq!(result, vec![Some(cotangent)]);
-    assert!(builder.build().ops().is_empty());
+    assert!(builder.build().operations().is_empty());
 
-    let (tril_result, tril_fragment) =
-        run_linearize_case(StdTensorOp::Tril { k: -1 }, 0, 0, &[true]);
+    let (tril_result, tril_graph) = run_linearize_case(StdTensorOp::Tril { k: -1 }, 0, 0, &[true]);
     assert!(tril_result[0].is_some());
-    assert_eq!(tril_fragment.ops()[0].op, StdTensorOp::Tril { k: -1 });
+    assert_eq!(
+        tril_graph.operations()[0].operation,
+        StdTensorOp::Tril { k: -1 }
+    );
 
-    let (triu_result, triu_fragment) =
-        run_linearize_case(StdTensorOp::Triu { k: 2 }, 0, 0, &[true]);
+    let (triu_result, triu_graph) = run_linearize_case(StdTensorOp::Triu { k: 2 }, 0, 0, &[true]);
     assert!(triu_result[0].is_some());
-    assert_eq!(triu_fragment.ops()[0].op, StdTensorOp::Triu { k: 2 });
+    assert_eq!(
+        triu_graph.operations()[0].operation,
+        StdTensorOp::Triu { k: 2 }
+    );
 
     let slice = StdTensorOp::Slice(tenferro_tensor::SliceConfig {
         starts: vec![1],
         limits: vec![5],
         strides: vec![2],
     });
-    let (slice_result, slice_fragment) = run_linearize_case(slice.clone(), 0, 0, &[true]);
+    let (slice_result, slice_graph) = run_linearize_case(slice.clone(), 0, 0, &[true]);
     assert!(slice_result[0].is_some());
-    assert_eq!(slice_fragment.ops()[0].op, slice.clone());
+    assert_eq!(slice_graph.operations()[0].operation, slice.clone());
 
-    let (transpose_slice_result, _, transpose_slice_fragment) =
+    let (transpose_slice_result, _, transpose_slice_graph) =
         run_transpose_case_with_input_shapes(slice, 1, &[true], true, &[&[5]]);
     assert!(transpose_slice_result[0].is_some());
-    assert_eq!(transpose_slice_fragment.ops().len(), 1);
+    assert_eq!(transpose_slice_graph.operations().len(), 1);
     assert_eq!(
-        transpose_slice_fragment.ops()[0].op,
+        transpose_slice_graph.operations()[0].operation,
         StdTensorOp::Pad(PadConfig {
             edge_padding_low: vec![1],
             edge_padding_high: vec![1],
@@ -166,12 +171,12 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         edge_padding_high: vec![2],
         interior_padding: vec![1],
     });
-    let (transpose_pad_result, _, transpose_pad_fragment) =
+    let (transpose_pad_result, _, transpose_pad_graph) =
         run_transpose_case_with_input_shapes(pad, 1, &[true], true, &[&[3]]);
     assert!(transpose_pad_result[0].is_some());
-    assert_eq!(transpose_pad_fragment.ops().len(), 1);
+    assert_eq!(transpose_pad_graph.operations().len(), 1);
     assert_eq!(
-        transpose_pad_fragment.ops()[0].op,
+        transpose_pad_graph.operations()[0].operation,
         StdTensorOp::Slice(tenferro_tensor::SliceConfig {
             starts: vec![1],
             limits: vec![6],
@@ -184,12 +189,12 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         edge_padding_high: vec![0],
         interior_padding: vec![0],
     });
-    let (cropped_pad_result, _, cropped_pad_fragment) =
+    let (cropped_pad_result, _, cropped_pad_graph) =
         run_transpose_case_with_input_shapes(cropped_pad, 1, &[true], true, &[&[4]]);
     assert!(cropped_pad_result[0].is_some());
-    assert_eq!(cropped_pad_fragment.ops().len(), 2);
+    assert_eq!(cropped_pad_graph.operations().len(), 2);
     assert_eq!(
-        cropped_pad_fragment.ops()[0].op,
+        cropped_pad_graph.operations()[0].operation,
         StdTensorOp::Slice(tenferro_tensor::SliceConfig {
             starts: vec![0],
             limits: vec![3],
@@ -197,7 +202,7 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         })
     );
     assert_eq!(
-        cropped_pad_fragment.ops()[1].op,
+        cropped_pad_graph.operations()[1].operation,
         StdTensorOp::Pad(PadConfig {
             edge_padding_low: vec![1],
             edge_padding_high: vec![0],
@@ -206,44 +211,43 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
     );
 
     let reverse = StdTensorOp::Reverse { axes: vec![0, 2] };
-    let (reverse_result, reverse_fragment) = run_linearize_case(reverse.clone(), 0, 0, &[true]);
+    let (reverse_result, reverse_graph) = run_linearize_case(reverse.clone(), 0, 0, &[true]);
     assert!(reverse_result[0].is_some());
-    assert_eq!(reverse_fragment.ops()[0].op, reverse.clone());
+    assert_eq!(reverse_graph.operations()[0].operation, reverse.clone());
 
-    let (transpose_reverse_result, _, transpose_reverse_fragment) =
+    let (transpose_reverse_result, _, transpose_reverse_graph) =
         run_transpose_case(reverse.clone(), 1, &[true], true);
     assert!(transpose_reverse_result[0].is_some());
-    assert_eq!(transpose_reverse_fragment.ops()[0].op, reverse);
+    assert_eq!(transpose_reverse_graph.operations()[0].operation, reverse);
 
-    let (transpose_tril_result, _, transpose_tril_fragment) =
+    let (transpose_tril_result, _, transpose_tril_graph) =
         run_transpose_case(StdTensorOp::Tril { k: 0 }, 1, &[true], true);
     assert!(transpose_tril_result[0].is_some());
     assert_eq!(
-        transpose_tril_fragment.ops()[0].op,
+        transpose_tril_graph.operations()[0].operation,
         StdTensorOp::Tril { k: 0 }
     );
 
-    let (transpose_triu_result, _, transpose_triu_fragment) =
+    let (transpose_triu_result, _, transpose_triu_graph) =
         run_transpose_case(StdTensorOp::Triu { k: 1 }, 1, &[true], true);
     assert!(transpose_triu_result[0].is_some());
     assert_eq!(
-        transpose_triu_fragment.ops()[0].op,
+        transpose_triu_graph.operations()[0].operation,
         StdTensorOp::Triu { k: 1 }
     );
 
-    let (transpose_transpose_none_result, _, transpose_transpose_none_fragment) =
-        run_transpose_case(
-            StdTensorOp::Transpose {
-                perm: vec![2, 0, 1],
-            },
-            1,
-            &[true],
-            false,
-        );
+    let (transpose_transpose_none_result, _, transpose_transpose_none_graph) = run_transpose_case(
+        StdTensorOp::Transpose {
+            perm: vec![2, 0, 1],
+        },
+        1,
+        &[true],
+        false,
+    );
     assert_eq!(transpose_transpose_none_result, vec![None]);
-    assert!(transpose_transpose_none_fragment.ops().is_empty());
+    assert!(transpose_transpose_none_graph.operations().is_empty());
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let none_broadcast = StdTensorOp::BroadcastInDim {
         shape: shape![2, 2, 3],
@@ -257,7 +261,7 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         &mut ad_ctx,
     );
     assert_eq!(none_broadcast, vec![None]);
-    assert!(builder.build().ops().is_empty());
+    assert!(builder.build().operations().is_empty());
 }
 
 #[test]
@@ -267,32 +271,32 @@ fn test_std_tensor_op_convert_linearize_and_transpose_swap_dtypes() {
         to: DType::C64,
     };
 
-    let (linear_result, linear_fragment) = run_linearize_case(convert.clone(), 0, 0, &[true]);
+    let (linear_result, linear_graph) = run_linearize_case(convert.clone(), 0, 0, &[true]);
     assert!(linear_result[0].is_some());
-    assert_eq!(linear_fragment.ops().len(), 1);
-    assert_eq!(linear_fragment.ops()[0].op, convert);
+    assert_eq!(linear_graph.operations().len(), 1);
+    assert_eq!(linear_graph.operations()[0].operation, convert);
 
-    let (linear_none_result, linear_none_fragment) =
+    let (linear_none_result, linear_none_graph) =
         run_linearize_case(convert.clone(), 0, 0, &[false]);
     assert_eq!(linear_none_result, vec![None]);
-    assert!(linear_none_fragment.ops().is_empty());
+    assert!(linear_none_graph.operations().is_empty());
 
-    let (transpose_result, _, transpose_fragment) =
+    let (transpose_result, _, transpose_graph) =
         run_transpose_case(convert.clone(), 1, &[true], true);
     assert!(transpose_result[0].is_some());
-    assert_eq!(transpose_fragment.ops().len(), 1);
+    assert_eq!(transpose_graph.operations().len(), 1);
     assert_eq!(
-        transpose_fragment.ops()[0].op,
+        transpose_graph.operations()[0].operation,
         StdTensorOp::Convert {
             from: DType::C64,
             to: DType::F64,
         }
     );
 
-    let (transpose_inactive_result, _, transpose_inactive_fragment) =
+    let (transpose_inactive_result, _, transpose_inactive_graph) =
         run_transpose_case(convert, 1, &[false], true);
     assert_eq!(transpose_inactive_result, vec![None]);
-    assert!(transpose_inactive_fragment.ops().is_empty());
+    assert!(transpose_inactive_graph.operations().is_empty());
 }
 
 #[test]
@@ -305,17 +309,17 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
             rhs_batch_dims: vec![],
         },
     };
-    let (linearize_none_result, linearize_none_fragment) =
+    let (linearize_none_result, linearize_none_graph) =
         run_linearize_case(matmul.clone(), 2, 0, &[false, false]);
     assert_eq!(linearize_none_result, vec![None]);
-    assert!(linearize_none_fragment.ops().is_empty());
+    assert!(linearize_none_graph.operations().is_empty());
 
-    let (transpose_none_result, _, transpose_none_fragment) =
+    let (transpose_none_result, _, transpose_none_graph) =
         run_transpose_case(matmul.clone(), 2, &[true, true], false);
     assert_eq!(transpose_none_result, vec![None, None]);
-    assert!(transpose_none_fragment.ops().is_empty());
+    assert!(transpose_none_graph.operations().is_empty());
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let cotangent = builder.add_input(tensor_input_key(980));
     seed_dot_general_ref_metadata(&mut ad_ctx, &external_inputs(981, 2));
@@ -323,27 +327,27 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
         &mut builder,
         &[Some(cotangent)],
         &external_inputs(981, 2),
-        &OpMode::Primal,
+        &OperationRole::Primary,
         &mut ad_ctx,
     );
     assert_eq!(primal_mode_result, vec![None, None]);
-    assert!(builder.build().ops().is_empty());
+    assert!(builder.build().operations().is_empty());
 
     let reduce = StdTensorOp::ReduceSum { axes: vec![1] };
-    let (reduce_linearize_none_result, reduce_linearize_none_fragment) =
+    let (reduce_linearize_none_result, reduce_linearize_none_graph) =
         run_linearize_case(reduce.clone(), 0, 0, &[false]);
     assert_eq!(reduce_linearize_none_result, vec![None]);
-    assert!(reduce_linearize_none_fragment.ops().is_empty());
+    assert!(reduce_linearize_none_graph.operations().is_empty());
 
-    let (reduce_transpose_result, _, reduce_transpose_fragment) =
+    let (reduce_transpose_result, _, reduce_transpose_graph) =
         run_transpose_case_with_input_shapes(reduce.clone(), 1, &[true], true, &[&[2, 3]]);
     assert!(reduce_transpose_result[0].is_some());
-    assert_eq!(reduce_transpose_fragment.ops().len(), 1);
+    assert_eq!(reduce_transpose_graph.operations().len(), 1);
     // The transpose rule reads input shape via `ctx.shape_of` and emits
     // `BroadcastInDim` with `InputDim` references into the primal input
     // (which sits at op input index 1 after the cotangent at index 0).
     assert_eq!(
-        reduce_transpose_fragment.ops()[0].op,
+        reduce_transpose_graph.operations()[0].operation,
         StdTensorOp::BroadcastInDim {
             shape: vec![
                 DimExpr::InputDim {
@@ -359,10 +363,10 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
         }
     );
 
-    let (reduce_transpose_none_result, _, reduce_transpose_none_fragment) =
+    let (reduce_transpose_none_result, _, reduce_transpose_none_graph) =
         run_transpose_case(reduce, 1, &[true], false);
     assert_eq!(reduce_transpose_none_result, vec![None]);
-    assert!(reduce_transpose_none_fragment.ops().is_empty());
+    assert!(reduce_transpose_none_graph.operations().is_empty());
 
     let scalar_contract = StdTensorOp::DotGeneral {
         config: DotGeneralConfig {
@@ -372,33 +376,37 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
             rhs_batch_dims: vec![],
         },
     };
-    let (scalar_transpose_result, _, scalar_transpose_fragment) =
+    let (scalar_transpose_result, _, scalar_transpose_graph) =
         run_transpose_case(scalar_contract.clone(), 2, &[true, false], true);
     assert!(scalar_transpose_result[0].is_some());
     assert_eq!(scalar_transpose_result[1], None);
     assert_eq!(
-        scalar_transpose_fragment.ops()[0].op,
+        scalar_transpose_graph.operations()[0].operation,
         StdTensorOp::Reshape { to_shape: shape![] }
     );
-    assert!(scalar_transpose_fragment
-        .ops()
+    assert!(scalar_transpose_graph
+        .operations()
         .iter()
-        .all(|node| node.op != StdTensorOp::Conj));
+        .all(|node| node.operation != StdTensorOp::Conj));
     assert!(matches!(
-        scalar_transpose_fragment.ops()[1].op,
+        scalar_transpose_graph.operations()[1].operation,
         StdTensorOp::DotGeneral { .. }
     ));
     assert_eq!(
-        scalar_transpose_fragment.ops().last().unwrap().op,
+        scalar_transpose_graph
+            .operations()
+            .last()
+            .unwrap()
+            .operation,
         StdTensorOp::Transpose { perm: vec![1, 0] }
     );
 
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let cotangent = builder.add_input(tensor_input_key(990));
     let inputs = external_inputs(991, 2);
     for (input, shape) in inputs.iter().zip([&[2, 3][..], &[3, 2][..]]) {
-        let ValRef::External(key) = input else {
+        let ValueRef::External(key) = input else {
             unreachable!("external_inputs returns external refs")
         };
         ad_ctx.insert_metadata(
@@ -416,13 +424,13 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
         &linear_mode(&[true, false]),
         &mut ad_ctx,
     );
-    let complex_transpose_fragment = builder.build();
+    let complex_transpose_graph = builder.build();
     assert!(complex_transpose_result[0].is_some());
     assert_eq!(complex_transpose_result[1], None);
-    assert!(complex_transpose_fragment
-        .ops()
+    assert!(complex_transpose_graph
+        .operations()
         .iter()
-        .any(|node| node.op == StdTensorOp::Conj));
+        .any(|node| node.operation == StdTensorOp::Conj));
 }
 
 #[derive(Clone, Debug)]
@@ -452,11 +460,11 @@ impl ExtensionOp for RuleOnlyExt {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 
@@ -489,24 +497,24 @@ impl ExtensionAdRule for RuleOnlyIdentityAd {
     fn linearize(
         &self,
         _op: &dyn ExtensionOp,
-        _builder: &mut dyn OpEmitter<StdTensorOp>,
-        _primal_in: &[GlobalValKey<StdTensorOp>],
-        _primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![tangent_in[0]])
     }
 
     fn transpose_rule(
         &self,
         _op: &dyn ExtensionOp,
-        _emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        _inputs: &[ValRef<StdTensorOp>],
-        _mode: &OpMode,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
+        _mode: &OperationRole,
         _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![cotangent_out[0]])
     }
 }
@@ -516,7 +524,7 @@ fn extension_try_linearize_uses_registered_rule() {
     let family = "stdtensor.rule_only_identity.v1";
     let _ = register_extension_rule(Arc::new(RuleOnlyIdentityAd { family }));
     let op = StdTensorOp::Extension(Arc::new(RuleOnlyExt { family }));
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let dx = builder.add_input(tensor_input_key(900));
     let result = op
@@ -531,7 +539,7 @@ fn extension_try_transpose_uses_registered_rule() {
     let family = "stdtensor.rule_only_transpose.v1";
     let _ = register_extension_rule(Arc::new(RuleOnlyIdentityAd { family }));
     let op = StdTensorOp::Extension(Arc::new(RuleOnlyExt { family }));
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let ct = builder.add_input(tensor_input_key(901));
     let result = op
@@ -551,7 +559,7 @@ fn extension_try_transpose_uses_registered_rule() {
 fn extension_try_linearize_reports_missing_rule() {
     let family = "stdtensor.missing_rule.v1";
     let op = StdTensorOp::Extension(Arc::new(RuleOnlyExt { family }));
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let dx = builder.add_input(tensor_input_key(920));
     let err = op

--- a/tenferro-linalg/src/ad.rs
+++ b/tenferro-linalg/src/ad.rs
@@ -22,13 +22,12 @@
 
 use std::sync::Arc;
 
-use computegraph::fragment::FragmentBuilder;
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_ad::extension::{
     is_extension_rule_registered, register_extension_rule as register_rule, ExtensionAdRuleTrait,
     ExtensionOpTrait, ExtensionRegistryError, ExtensionRuleSet,
 };
+use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
@@ -85,12 +84,12 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
     fn linearize(
         &self,
         op: &dyn ExtensionOpTrait,
-        builder: &mut dyn OpEmitter<StdTensorOp>,
-        primal_in: &[GlobalValKey<StdTensorOp>],
-        primal_out: &[GlobalValKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValId>],
+        builder: &mut dyn PrimitiveRuleBuilder,
+        primal_in: &[ValueKey<StdTensorOp>],
+        primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_ad_op(op, ADRuleKind::Jvp)?;
         let tangents = match op.op() {
             LinalgOp::Lu => rules::linearize_lu(builder, primal_in, primal_out, tangent_in, ctx),
@@ -144,14 +143,14 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
     fn transpose_rule(
         &self,
         op: &dyn ExtensionOpTrait,
-        emitter: &mut dyn OpEmitter<StdTensorOp>,
-        cotangent_out: &[Option<LocalValId>],
-        inputs: &[ValRef<StdTensorOp>],
-        mode: &OpMode,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
+        mode: &OperationRole,
         ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValId>>> {
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_ad_op(op, ADRuleKind::Transpose)?;
-        let mut emitter = DynEmitter(emitter);
+        let mut builder = DynBuilder(builder);
         let cotangents = match op.op() {
             LinalgOp::TriangularSolve {
                 left_side,
@@ -159,7 +158,7 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
                 transpose_a,
                 unit_diagonal,
             } => rules::transpose_triangular_solve(
-                &mut emitter,
+                &mut builder,
                 cotangent_out,
                 inputs,
                 mode,
@@ -170,10 +169,10 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
                 ctx,
             ),
             LinalgOp::Solve { transpose_a } => {
-                rules::transpose_solve(&mut emitter, cotangent_out, inputs, mode, transpose_a, ctx)
+                rules::transpose_solve(&mut builder, cotangent_out, inputs, mode, transpose_a, ctx)
             }
             LinalgOp::FullPivLuSolve { transpose_a } => rules::transpose_full_piv_lu_solve(
-                &mut emitter,
+                &mut builder,
                 cotangent_out,
                 inputs,
                 mode,
@@ -186,22 +185,22 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
             | LinalgOp::Svd { .. }
             | LinalgOp::Qr
             | LinalgOp::Eigh { .. }
-            | LinalgOp::Eig { .. } => vec![None; op.n_inputs()],
+            | LinalgOp::Eig { .. } => vec![None; op.input_count()],
         };
         Ok(cotangents)
     }
 }
 
-struct DynEmitter<'a>(&'a mut dyn OpEmitter<StdTensorOp>);
+struct DynBuilder<'a>(&'a mut dyn PrimitiveRuleBuilder);
 
-impl OpEmitter<StdTensorOp> for DynEmitter<'_> {
-    fn add_op(
+impl PrimitiveRuleBuilder for DynBuilder<'_> {
+    fn add_operation(
         &mut self,
         op: StdTensorOp,
-        inputs: Vec<ValRef<StdTensorOp>>,
-        mode: OpMode,
-    ) -> Vec<LocalValId> {
-        self.0.add_op(op, inputs, mode)
+        inputs: Vec<ValueRef<StdTensorOp>>,
+        mode: OperationRole,
+    ) -> Vec<LocalValueId> {
+        self.0.add_operation(op, inputs, mode)
     }
 }
 

--- a/tenferro-linalg/src/ad/rules/mod.rs
+++ b/tenferro-linalg/src/ad/rules/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
+use tenferro_ops::ad::PrimitiveRuleBuilder;
 
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 
 use crate::ad_support::{LinalgExtensionOp, LinalgOp};
 use tenferro_ops::ad::context::{resolve_and_guard, ShapeGuardContext};
@@ -30,9 +31,9 @@ use support::*;
 /// `TriangularSolve`) see a well-formed shape expression.
 fn primal_input_shape(
     ctx: &mut ShapeGuardContext,
-    primal_in: &[GlobalValKey<StdTensorOp>],
+    primal_in: &[ValueKey<StdTensorOp>],
 ) -> Vec<DimExpr> {
-    let shape = ctx.shape_of(&ValRef::External(primal_in[0].clone()));
+    let shape = ctx.shape_of(&ValueRef::External(primal_in[0].clone()));
     if let Some(concrete) = shape
         .iter()
         .map(|dim| dim.constant_value())
@@ -49,12 +50,12 @@ fn linalg_std_op(op: LinalgOp) -> StdTensorOp {
 }
 
 pub(crate) fn linearize_lu(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(da) = tangent_in[0] else {
         return vec![None, None, None, None];
     };
@@ -68,9 +69,9 @@ pub(crate) fn linearize_lu(
     let rank = input_shape.len();
     let l_shape = matrix_shape(m, &k, batch_shape);
     let u_shape = matrix_shape(&k, n, batch_shape);
-    let p = ValRef::External(primal_out[0].clone());
-    let l = ValRef::External(primal_out[1].clone());
-    let u = ValRef::External(primal_out[2].clone());
+    let p = ValueRef::External(primal_out[0].clone());
+    let l = ValueRef::External(primal_out[1].clone());
+    let u = ValueRef::External(primal_out[2].clone());
     let l_square = augment_unit_lower_to_square_fixed(
         builder,
         l.clone(),
@@ -90,28 +91,28 @@ pub(crate) fn linearize_lu(
         rank,
     );
 
-    let pd_a = matmul_linear(builder, p, ValRef::Local(da), vec![false, true], rank);
-    let la = builder.add_op(
+    let pd_a = matmul_linear(builder, p, ValueRef::Local(da), vec![false, true], rank);
+    let la = builder.add_operation(
         linalg_std_op(LinalgOp::TriangularSolve {
             left_side: true,
             lower: true,
             transpose_a: false,
             unit_diagonal: true,
         }),
-        vec![ValRef::Local(l_square), ValRef::Local(pd_a)],
-        OpMode::Linear {
+        vec![ValueRef::Local(l_square), ValueRef::Local(pd_a)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0];
-    let x = builder.add_op(
+    let x = builder.add_operation(
         linalg_std_op(LinalgOp::TriangularSolve {
             left_side: false,
             lower: false,
             transpose_a: false,
             unit_diagonal: false,
         }),
-        vec![ValRef::Local(u_square), ValRef::Local(la)],
-        OpMode::Linear {
+        vec![ValueRef::Local(u_square), ValueRef::Local(la)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0];
@@ -120,15 +121,15 @@ pub(crate) fn linearize_lu(
     let x_upper = linear_unary(builder, StdTensorOp::Triu { k: 0 }, x);
     let dl_full = matmul_linear(
         builder,
-        ValRef::Local(l_square),
-        ValRef::Local(x_lower),
+        ValueRef::Local(l_square),
+        ValueRef::Local(x_lower),
         vec![false, true],
         rank,
     );
     let du_full = matmul_linear(
         builder,
-        ValRef::Local(x_upper),
-        ValRef::Local(u_square),
+        ValueRef::Local(x_upper),
+        ValueRef::Local(u_square),
         vec![true, false],
         rank,
     );
@@ -165,12 +166,12 @@ pub(crate) fn linearize_lu(
 }
 
 pub(crate) fn linearize_full_piv_lu(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(da) = tangent_in[0] else {
         return vec![None, None, None, None, None];
     };
@@ -185,61 +186,73 @@ pub(crate) fn linearize_full_piv_lu(
     );
 
     let rank = input_shape.len();
-    let p = ValRef::External(primal_out[0].clone());
-    let l = ValRef::External(primal_out[1].clone());
-    let u = ValRef::External(primal_out[2].clone());
-    let q = ValRef::External(primal_out[3].clone());
+    let p = ValueRef::External(primal_out[0].clone());
+    let l = ValueRef::External(primal_out[1].clone());
+    let u = ValueRef::External(primal_out[2].clone());
+    let q = ValueRef::External(primal_out[3].clone());
     let q_t = transpose_matrix_fixed(builder, q, rank);
 
-    let pd_a = matmul_linear(builder, p, ValRef::Local(da), vec![false, true], rank);
+    let pd_a = matmul_linear(builder, p, ValueRef::Local(da), vec![false, true], rank);
     let pd_a_qt = matmul_linear(
         builder,
-        ValRef::Local(pd_a),
-        ValRef::Local(q_t),
+        ValueRef::Local(pd_a),
+        ValueRef::Local(q_t),
         vec![true, false],
         rank,
     );
-    let la = builder.add_op(
+    let la = builder.add_operation(
         linalg_std_op(LinalgOp::TriangularSolve {
             left_side: true,
             lower: true,
             transpose_a: false,
             unit_diagonal: true,
         }),
-        vec![l.clone(), ValRef::Local(pd_a_qt)],
-        OpMode::Linear {
+        vec![l.clone(), ValueRef::Local(pd_a_qt)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0];
-    let x = builder.add_op(
+    let x = builder.add_operation(
         linalg_std_op(LinalgOp::TriangularSolve {
             left_side: false,
             lower: false,
             transpose_a: false,
             unit_diagonal: false,
         }),
-        vec![u.clone(), ValRef::Local(la)],
-        OpMode::Linear {
+        vec![u.clone(), ValueRef::Local(la)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0];
 
     let x_lower = linear_unary(builder, StdTensorOp::Tril { k: -1 }, x);
     let x_upper = linear_unary(builder, StdTensorOp::Triu { k: 0 }, x);
-    let dl = matmul_linear(builder, l, ValRef::Local(x_lower), vec![false, true], rank);
-    let du = matmul_linear(builder, ValRef::Local(x_upper), u, vec![true, false], rank);
+    let dl = matmul_linear(
+        builder,
+        l,
+        ValueRef::Local(x_lower),
+        vec![false, true],
+        rank,
+    );
+    let du = matmul_linear(
+        builder,
+        ValueRef::Local(x_upper),
+        u,
+        vec![true, false],
+        rank,
+    );
 
     vec![None, Some(dl), Some(du), None, None]
 }
 
 pub(crate) fn linearize_eig(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     input_dtype: DType,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(da) = tangent_in[0] else {
         return vec![None, None];
     };
@@ -247,9 +260,9 @@ pub(crate) fn linearize_eig(
     let input_shape = primal_input_shape(ctx, primal_in);
     let input_shape = input_shape.as_slice();
     let rank = input_shape.len();
-    let v = ValRef::External(primal_out[1].clone());
+    let v = ValueRef::External(primal_out[1].clone());
     let da_complex = match input_dtype {
-        DType::F64 | DType::F32 => builder.add_op(
+        DType::F64 | DType::F32 => builder.add_operation(
             StdTensorOp::Convert {
                 from: input_dtype,
                 to: match input_dtype {
@@ -258,8 +271,8 @@ pub(crate) fn linearize_eig(
                     _ => unreachable!("real dtype branch"),
                 },
             },
-            vec![ValRef::Local(da)],
-            OpMode::Linear {
+            vec![ValueRef::Local(da)],
+            OperationRole::Linearized {
                 active_mask: vec![true],
             },
         )[0],
@@ -269,24 +282,24 @@ pub(crate) fn linearize_eig(
 
     let dav = matmul_linear(
         builder,
-        ValRef::Local(da_complex),
+        ValueRef::Local(da_complex),
         v.clone(),
         vec![true, false],
         rank,
     );
-    let projected = solve_in_graph(builder, v, ValRef::Local(dav), rank);
+    let projected = solve_in_graph(builder, v, ValueRef::Local(dav), rank);
     let dw = extract_diag_linear(builder, projected);
     vec![Some(dw), None]
 }
 
 pub(crate) fn linearize_svd(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     eps: f64,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(da) = tangent_in[0] else {
         return vec![None, None, None];
     };
@@ -296,86 +309,86 @@ pub(crate) fn linearize_svd(
     let (m, n, batch_shape) = matrix_shape_parts(input_shape, "linearize_svd");
     let (m_size, n_size) = resolve_and_guard(m, n, ctx);
     let matrix_rank = input_shape.len();
-    let dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
     let k = DimExpr::min(m.clone(), n.clone());
-    let u = ValRef::External(primal_out[0].clone());
-    let s = ValRef::External(primal_out[1].clone());
-    let vt = ValRef::External(primal_out[2].clone());
+    let u = ValueRef::External(primal_out[0].clone());
+    let s = ValueRef::External(primal_out[1].clone());
+    let vt = ValueRef::External(primal_out[2].clone());
 
     let uh = adjoint_matrix_fixed(builder, u.clone(), matrix_rank, dtype);
     let v = adjoint_matrix_fixed(builder, vt.clone(), matrix_rank, dtype);
     let tmp = matmul_linear(
         builder,
-        ValRef::Local(uh),
-        ValRef::Local(da),
+        ValueRef::Local(uh),
+        ValueRef::Local(da),
         vec![false, true],
         matrix_rank,
     );
     let ds_mat = matmul_linear(
         builder,
-        ValRef::Local(tmp),
-        ValRef::Local(v),
+        ValueRef::Local(tmp),
+        ValueRef::Local(v),
         vec![true, false],
         matrix_rank,
     );
     let ds = extract_diag_linear(builder, ds_mat);
 
     let diag_s = embed_diag_fixed(builder, s.clone());
-    let ones_mat = one_like_fixed(builder, ValRef::Local(diag_s));
+    let ones_mat = one_like_fixed(builder, ValueRef::Local(diag_s));
     let s_dim = matmul_fixed(
         builder,
-        ValRef::Local(ones_mat),
-        ValRef::Local(diag_s),
+        ValueRef::Local(ones_mat),
+        ValueRef::Local(diag_s),
         matrix_rank,
     );
     let s_dim_t = matmul_fixed(
         builder,
-        ValRef::Local(diag_s),
-        ValRef::Local(ones_mat),
+        ValueRef::Local(diag_s),
+        ValueRef::Local(ones_mat),
         matrix_rank,
     );
-    let s_sum = fixed_add(builder, ValRef::Local(s_dim), ValRef::Local(s_dim_t));
-    let s_diff = fixed_sub(builder, ValRef::Local(s_dim), ValRef::Local(s_dim_t));
-    let s_gap = fixed_mul(builder, ValRef::Local(s_sum), ValRef::Local(s_diff));
-    let s_gap_sq = fixed_mul(builder, ValRef::Local(s_gap), ValRef::Local(s_gap));
-    let eps_sq = fixed_scale(builder, ValRef::Local(ones_mat), eps * eps);
-    let safe_gap = fixed_add(builder, ValRef::Local(s_gap_sq), ValRef::Local(eps_sq));
-    let f = fixed_div(builder, ValRef::Local(s_gap), ValRef::Local(safe_gap));
+    let s_sum = fixed_add(builder, ValueRef::Local(s_dim), ValueRef::Local(s_dim_t));
+    let s_diff = fixed_sub(builder, ValueRef::Local(s_dim), ValueRef::Local(s_dim_t));
+    let s_gap = fixed_mul(builder, ValueRef::Local(s_sum), ValueRef::Local(s_diff));
+    let s_gap_sq = fixed_mul(builder, ValueRef::Local(s_gap), ValueRef::Local(s_gap));
+    let eps_sq = fixed_scale(builder, ValueRef::Local(ones_mat), eps * eps);
+    let safe_gap = fixed_add(builder, ValueRef::Local(s_gap_sq), ValueRef::Local(eps_sq));
+    let f = fixed_div(builder, ValueRef::Local(s_gap), ValueRef::Local(safe_gap));
 
     let s_ones = one_like_fixed(builder, s.clone());
     let s_sq = fixed_mul(builder, s.clone(), s.clone());
-    let s_eps_sq = fixed_scale(builder, ValRef::Local(s_ones), eps * eps);
-    let safe_s_sq = fixed_add(builder, ValRef::Local(s_sq), ValRef::Local(s_eps_sq));
-    let s_inv = fixed_div(builder, s.clone(), ValRef::Local(safe_s_sq));
-    let s_inv_mat = embed_diag_fixed(builder, ValRef::Local(s_inv));
+    let s_eps_sq = fixed_scale(builder, ValueRef::Local(s_ones), eps * eps);
+    let safe_s_sq = fixed_add(builder, ValueRef::Local(s_sq), ValueRef::Local(s_eps_sq));
+    let s_inv = fixed_div(builder, s.clone(), ValueRef::Local(safe_s_sq));
+    let s_inv_mat = embed_diag_fixed(builder, ValueRef::Local(s_inv));
 
     let ds_h = adjoint_matrix_linear(builder, ds_mat, matrix_rank, dtype);
     let anti_hermitian = linear_sub(builder, ds_mat, ds_h);
     // Matches JAX's complex gauge correction: 0.5 * (dS - dS^H) * diag(1 / s).
-    let d_udv_diag = hadamard_fixed_linear(builder, ValRef::Local(s_inv_mat), anti_hermitian);
+    let d_udv_diag = hadamard_fixed_linear(builder, ValueRef::Local(s_inv_mat), anti_hermitian);
     let d_udv_diag = linear_scale(builder, d_udv_diag, 0.5);
 
-    let dss = hadamard_fixed_linear(builder, ValRef::Local(s_dim), ds_mat);
+    let dss = hadamard_fixed_linear(builder, ValueRef::Local(s_dim), ds_mat);
     let dss_h = adjoint_matrix_linear(builder, dss, matrix_rank, dtype);
     let du_inner_sum = linear_add(builder, dss, dss_h);
-    let du_inner = hadamard_fixed_linear(builder, ValRef::Local(f), du_inner_sum);
+    let du_inner = hadamard_fixed_linear(builder, ValueRef::Local(f), du_inner_sum);
     let du_inner = linear_add(builder, du_inner, d_udv_diag);
     let mut du = matmul_linear(
         builder,
         u.clone(),
-        ValRef::Local(du_inner),
+        ValueRef::Local(du_inner),
         vec![false, true],
         matrix_rank,
     );
 
-    let sds = hadamard_fixed_linear(builder, ValRef::Local(s_dim_t), ds_mat);
+    let sds = hadamard_fixed_linear(builder, ValueRef::Local(s_dim_t), ds_mat);
     let sds_h = adjoint_matrix_linear(builder, sds, matrix_rank, dtype);
     let dv_inner_sum = linear_add(builder, sds, sds_h);
-    let dv_inner = hadamard_fixed_linear(builder, ValRef::Local(f), dv_inner_sum);
+    let dv_inner = hadamard_fixed_linear(builder, ValueRef::Local(f), dv_inner_sum);
     let mut dv = matmul_linear(
         builder,
-        ValRef::Local(v),
-        ValRef::Local(dv_inner),
+        ValueRef::Local(v),
+        ValueRef::Local(dv_inner),
         vec![false, true],
         matrix_rank,
     );
@@ -383,22 +396,22 @@ pub(crate) fn linearize_svd(
     if m_size > n_size {
         let d_av = matmul_linear(
             builder,
-            ValRef::Local(da),
-            ValRef::Local(v),
+            ValueRef::Local(da),
+            ValueRef::Local(v),
             vec![true, false],
             matrix_rank,
         );
         let ut_d_av = matmul_linear(
             builder,
-            ValRef::Local(uh),
-            ValRef::Local(d_av),
+            ValueRef::Local(uh),
+            ValueRef::Local(d_av),
             vec![false, true],
             matrix_rank,
         );
         let u_ut_d_av = matmul_linear(
             builder,
             u.clone(),
-            ValRef::Local(ut_d_av),
+            ValueRef::Local(ut_d_av),
             vec![false, true],
             matrix_rank,
         );
@@ -409,7 +422,7 @@ pub(crate) fn linearize_svd(
             matrix_shape(m, &k, batch_shape),
             vector_to_matrix_broadcast_dims(batch_shape.len()),
         );
-        let correction = linear_div_fixed(builder, proj, ValRef::Local(s_broadcast));
+        let correction = linear_div_fixed(builder, proj, ValueRef::Local(s_broadcast));
         du = linear_add(builder, du, correction);
     }
 
@@ -417,7 +430,7 @@ pub(crate) fn linearize_svd(
         let da_h = adjoint_matrix_linear(builder, da, matrix_rank, dtype);
         let d_ahu = matmul_linear(
             builder,
-            ValRef::Local(da_h),
+            ValueRef::Local(da_h),
             u.clone(),
             vec![true, false],
             matrix_rank,
@@ -425,14 +438,14 @@ pub(crate) fn linearize_svd(
         let vt_d_ahu = matmul_linear(
             builder,
             vt.clone(),
-            ValRef::Local(d_ahu),
+            ValueRef::Local(d_ahu),
             vec![false, true],
             matrix_rank,
         );
         let v_vt_d_ahu = matmul_linear(
             builder,
-            ValRef::Local(v),
-            ValRef::Local(vt_d_ahu),
+            ValueRef::Local(v),
+            ValueRef::Local(vt_d_ahu),
             vec![false, true],
             matrix_rank,
         );
@@ -443,7 +456,7 @@ pub(crate) fn linearize_svd(
             matrix_shape(n, &k, batch_shape),
             vector_to_matrix_broadcast_dims(batch_shape.len()),
         );
-        let correction = linear_div_fixed(builder, proj, ValRef::Local(s_broadcast));
+        let correction = linear_div_fixed(builder, proj, ValueRef::Local(s_broadcast));
         dv = linear_add(builder, dv, correction);
     }
 
@@ -453,13 +466,13 @@ pub(crate) fn linearize_svd(
 }
 
 pub(crate) fn linearize_eigh(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     eps: f64,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(da) = tangent_in[0] else {
         return vec![None, None];
     };
@@ -467,22 +480,22 @@ pub(crate) fn linearize_eigh(
     let input_shape = primal_input_shape(ctx, primal_in);
     let input_shape = input_shape.as_slice();
     let matrix_rank = input_shape.len();
-    let dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
-    let w = ValRef::External(primal_out[0].clone());
-    let v = ValRef::External(primal_out[1].clone());
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let w = ValueRef::External(primal_out[0].clone());
+    let v = ValueRef::External(primal_out[1].clone());
     let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
 
     let vh = adjoint_matrix_fixed(builder, v.clone(), matrix_rank, dtype);
     let tmp = matmul_linear(
         builder,
-        ValRef::Local(vh),
-        ValRef::Local(da_self_adjoint),
+        ValueRef::Local(vh),
+        ValueRef::Local(da_self_adjoint),
         vec![false, true],
         matrix_rank,
     );
     let projected = matmul_linear(
         builder,
-        ValRef::Local(tmp),
+        ValueRef::Local(tmp),
         v.clone(),
         vec![true, false],
         matrix_rank,
@@ -490,29 +503,29 @@ pub(crate) fn linearize_eigh(
     let dw = extract_diag_linear(builder, projected);
 
     let diag_w = embed_diag_fixed(builder, w.clone());
-    let ones_mat = one_like_fixed(builder, ValRef::Local(diag_w));
+    let ones_mat = one_like_fixed(builder, ValueRef::Local(diag_w));
     let w_col = matmul_fixed(
         builder,
-        ValRef::Local(diag_w),
-        ValRef::Local(ones_mat),
+        ValueRef::Local(diag_w),
+        ValueRef::Local(ones_mat),
         matrix_rank,
     );
     let w_row = matmul_fixed(
         builder,
-        ValRef::Local(ones_mat),
-        ValRef::Local(diag_w),
+        ValueRef::Local(ones_mat),
+        ValueRef::Local(diag_w),
         matrix_rank,
     );
-    let diff = fixed_sub(builder, ValRef::Local(w_row), ValRef::Local(w_col));
-    let diff_sq = fixed_mul(builder, ValRef::Local(diff), ValRef::Local(diff));
-    let eps_sq = fixed_scale(builder, ValRef::Local(ones_mat), eps * eps);
-    let safe_diff = fixed_add(builder, ValRef::Local(diff_sq), ValRef::Local(eps_sq));
-    let f = fixed_div(builder, ValRef::Local(diff), ValRef::Local(safe_diff));
-    let fm = hadamard_fixed_linear(builder, ValRef::Local(f), projected);
+    let diff = fixed_sub(builder, ValueRef::Local(w_row), ValueRef::Local(w_col));
+    let diff_sq = fixed_mul(builder, ValueRef::Local(diff), ValueRef::Local(diff));
+    let eps_sq = fixed_scale(builder, ValueRef::Local(ones_mat), eps * eps);
+    let safe_diff = fixed_add(builder, ValueRef::Local(diff_sq), ValueRef::Local(eps_sq));
+    let f = fixed_div(builder, ValueRef::Local(diff), ValueRef::Local(safe_diff));
+    let fm = hadamard_fixed_linear(builder, ValueRef::Local(f), projected);
     let dv = matmul_linear(
         builder,
         v,
-        ValRef::Local(fm),
+        ValueRef::Local(fm),
         vec![false, true],
         matrix_rank,
     );
@@ -521,12 +534,12 @@ pub(crate) fn linearize_eigh(
 }
 
 pub(crate) fn linearize_cholesky(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(da) = tangent_in[0] else {
         return vec![None];
     };
@@ -534,40 +547,40 @@ pub(crate) fn linearize_cholesky(
     let input_shape = primal_input_shape(ctx, primal_in);
     let input_shape = input_shape.as_slice();
     let matrix_rank = input_shape.len();
-    let dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
-    let l = ValRef::External(primal_out[0].clone());
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let l = ValueRef::External(primal_out[0].clone());
     let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
     let l_conj = conjugate_primal_if_dtype_complex(builder, l.clone(), dtype);
 
-    let tmp = builder.add_op(
+    let tmp = builder.add_operation(
         linalg_std_op(LinalgOp::TriangularSolve {
             left_side: false,
             lower: true,
             transpose_a: true,
             unit_diagonal: false,
         }),
-        vec![l_conj, ValRef::Local(da_self_adjoint)],
-        OpMode::Linear {
+        vec![l_conj, ValueRef::Local(da_self_adjoint)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0];
-    let s = builder.add_op(
+    let s = builder.add_operation(
         linalg_std_op(LinalgOp::TriangularSolve {
             left_side: true,
             lower: true,
             transpose_a: false,
             unit_diagonal: false,
         }),
-        vec![l.clone(), ValRef::Local(tmp)],
-        OpMode::Linear {
+        vec![l.clone(), ValueRef::Local(tmp)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0];
 
-    let strict_lower = builder.add_op(
+    let strict_lower = builder.add_operation(
         StdTensorOp::Tril { k: -1 },
-        vec![ValRef::Local(s)],
-        OpMode::Linear {
+        vec![ValueRef::Local(s)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0];
@@ -578,7 +591,7 @@ pub(crate) fn linearize_cholesky(
     let dl = matmul_linear(
         builder,
         l,
-        ValRef::Local(phi_s),
+        ValueRef::Local(phi_s),
         vec![false, true],
         matrix_rank,
     );
@@ -587,12 +600,12 @@ pub(crate) fn linearize_cholesky(
 }
 
 pub(crate) fn linearize_qr(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(da) = tangent_in[0] else {
         return vec![None, None];
     };
@@ -602,9 +615,9 @@ pub(crate) fn linearize_qr(
     let (m, n, batch_shape) = matrix_shape_parts(input_shape, "linearize_qr");
     let (m_size, n_size) = resolve_and_guard(m, n, ctx);
     let matrix_rank = input_shape.len();
-    let dtype = ctx.dtype_of(&ValRef::External(primal_in[0].clone()));
-    let q = ValRef::External(primal_out[0].clone());
-    let r = ValRef::External(primal_out[1].clone());
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let q = ValueRef::External(primal_out[0].clone());
+    let r = ValueRef::External(primal_out[1].clone());
 
     if n_size > m_size {
         let qh = adjoint_matrix_fixed(builder, q.clone(), matrix_rank, dtype);
@@ -617,49 +630,49 @@ pub(crate) fn linearize_qr(
             input_shape,
         );
         let leading_selector_t =
-            transpose_matrix_fixed(builder, ValRef::Local(leading_selector), matrix_rank);
+            transpose_matrix_fixed(builder, ValueRef::Local(leading_selector), matrix_rank);
         let da_leading = matmul_linear(
             builder,
-            ValRef::Local(da),
-            ValRef::Local(leading_selector_t),
+            ValueRef::Local(da),
+            ValueRef::Local(leading_selector_t),
             vec![true, false],
             matrix_rank,
         );
         let r_leading = matmul_fixed(
             builder,
             r.clone(),
-            ValRef::Local(leading_selector_t),
+            ValueRef::Local(leading_selector_t),
             matrix_rank,
         );
         let r_leading_h =
-            adjoint_matrix_fixed(builder, ValRef::Local(r_leading), matrix_rank, dtype);
+            adjoint_matrix_fixed(builder, ValueRef::Local(r_leading), matrix_rank, dtype);
         let da_leading_h = adjoint_matrix_linear(builder, da_leading, matrix_rank, dtype);
-        let dx_rinv_h = builder.add_op(
+        let dx_rinv_h = builder.add_operation(
             linalg_std_op(LinalgOp::TriangularSolve {
                 left_side: true,
                 lower: true,
                 transpose_a: false,
                 unit_diagonal: false,
             }),
-            vec![ValRef::Local(r_leading_h), ValRef::Local(da_leading_h)],
-            OpMode::Linear {
+            vec![ValueRef::Local(r_leading_h), ValueRef::Local(da_leading_h)],
+            OperationRole::Linearized {
                 active_mask: vec![false, true],
             },
         )[0];
         let dx_rinv = adjoint_matrix_linear(builder, dx_rinv_h, matrix_rank, dtype);
         let qt_dx_rinv = matmul_linear(
             builder,
-            ValRef::Local(qh),
-            ValRef::Local(dx_rinv),
+            ValueRef::Local(qh),
+            ValueRef::Local(dx_rinv),
             vec![false, true],
             matrix_rank,
         );
         let qt_dx_rinv_h = adjoint_matrix_linear(builder, qt_dx_rinv, matrix_rank, dtype);
         let sym = linear_add(builder, qt_dx_rinv, qt_dx_rinv_h);
-        let upper = builder.add_op(
+        let upper = builder.add_operation(
             StdTensorOp::Triu { k: 1 },
-            vec![ValRef::Local(sym)],
-            OpMode::Linear {
+            vec![ValueRef::Local(sym)],
+            OperationRole::Linearized {
                 active_mask: vec![true],
             },
         )[0];
@@ -671,22 +684,22 @@ pub(crate) fn linearize_qr(
         let q_dr_leading_hat = matmul_linear(
             builder,
             q.clone(),
-            ValRef::Local(dr_leading_hat),
+            ValueRef::Local(dr_leading_hat),
             vec![false, true],
             matrix_rank,
         );
         let dq = linear_sub(builder, dx_rinv, q_dr_leading_hat);
         let dr_leading = matmul_linear(
             builder,
-            ValRef::Local(dr_leading_hat),
-            ValRef::Local(r_leading),
+            ValueRef::Local(dr_leading_hat),
+            ValueRef::Local(r_leading),
             vec![true, false],
             matrix_rank,
         );
         let mut dr = matmul_linear(
             builder,
-            ValRef::Local(dr_leading),
-            ValRef::Local(leading_selector),
+            ValueRef::Local(dr_leading),
+            ValueRef::Local(leading_selector),
             vec![true, false],
             matrix_rank,
         );
@@ -702,40 +715,40 @@ pub(crate) fn linearize_qr(
                 input_shape,
             );
             let trailing_selector_t =
-                transpose_matrix_fixed(builder, ValRef::Local(trailing_selector), matrix_rank);
+                transpose_matrix_fixed(builder, ValueRef::Local(trailing_selector), matrix_rank);
             let da_trailing = matmul_linear(
                 builder,
-                ValRef::Local(da),
-                ValRef::Local(trailing_selector_t),
+                ValueRef::Local(da),
+                ValueRef::Local(trailing_selector_t),
                 vec![true, false],
                 matrix_rank,
             );
             let r_trailing = matmul_fixed(
                 builder,
                 r.clone(),
-                ValRef::Local(trailing_selector_t),
+                ValueRef::Local(trailing_selector_t),
                 matrix_rank,
             );
             let qt_da_trailing = matmul_linear(
                 builder,
-                ValRef::Local(qh),
-                ValRef::Local(da_trailing),
+                ValueRef::Local(qh),
+                ValueRef::Local(da_trailing),
                 vec![false, true],
                 matrix_rank,
             );
             let omega = linear_sub(builder, qt_dx_rinv, dr_leading_hat);
             let omega_r_trailing = matmul_linear(
                 builder,
-                ValRef::Local(omega),
-                ValRef::Local(r_trailing),
+                ValueRef::Local(omega),
+                ValueRef::Local(r_trailing),
                 vec![true, false],
                 matrix_rank,
             );
             let dr_trailing = linear_sub(builder, qt_da_trailing, omega_r_trailing);
             let dr_trailing_full = matmul_linear(
                 builder,
-                ValRef::Local(dr_trailing),
-                ValRef::Local(trailing_selector),
+                ValueRef::Local(dr_trailing),
+                ValueRef::Local(trailing_selector),
                 vec![true, false],
                 matrix_rank,
             );
@@ -747,15 +760,15 @@ pub(crate) fn linearize_qr(
 
     let r_h = adjoint_matrix_fixed(builder, r.clone(), matrix_rank, dtype);
     let da_h = adjoint_matrix_linear(builder, da, matrix_rank, dtype);
-    let dx_rinv_h = builder.add_op(
+    let dx_rinv_h = builder.add_operation(
         linalg_std_op(LinalgOp::TriangularSolve {
             left_side: true,
             lower: true,
             transpose_a: false,
             unit_diagonal: false,
         }),
-        vec![ValRef::Local(r_h), ValRef::Local(da_h)],
-        OpMode::Linear {
+        vec![ValueRef::Local(r_h), ValueRef::Local(da_h)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0];
@@ -763,17 +776,17 @@ pub(crate) fn linearize_qr(
     let qh = adjoint_matrix_fixed(builder, q.clone(), matrix_rank, dtype);
     let qt_dx_rinv = matmul_linear(
         builder,
-        ValRef::Local(qh),
-        ValRef::Local(dx_rinv),
+        ValueRef::Local(qh),
+        ValueRef::Local(dx_rinv),
         vec![false, true],
         matrix_rank,
     );
     let qt_dx_rinv_h = adjoint_matrix_linear(builder, qt_dx_rinv, matrix_rank, dtype);
     let sym = linear_add(builder, qt_dx_rinv, qt_dx_rinv_h);
-    let upper = builder.add_op(
+    let upper = builder.add_operation(
         StdTensorOp::Triu { k: 1 },
-        vec![ValRef::Local(sym)],
-        OpMode::Linear {
+        vec![ValueRef::Local(sym)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0];
@@ -785,14 +798,14 @@ pub(crate) fn linearize_qr(
     let q_dr_hat = matmul_linear(
         builder,
         q.clone(),
-        ValRef::Local(dr_hat),
+        ValueRef::Local(dr_hat),
         vec![false, true],
         matrix_rank,
     );
     let dq = linear_sub(builder, dx_rinv, q_dr_hat);
     let dr = matmul_linear(
         builder,
-        ValRef::Local(dr_hat),
+        ValueRef::Local(dr_hat),
         r,
         vec![true, false],
         matrix_rank,

--- a/tenferro-linalg/src/ad/rules/solve.rs
+++ b/tenferro-linalg/src/ad/rules/solve.rs
@@ -1,6 +1,6 @@
-use computegraph::types::{GlobalValKey, LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_ops::ad::context::ShapeGuardContext;
+use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 
 use crate::ad_support::LinalgOp;
@@ -9,16 +9,16 @@ use super::support::*;
 use super::{conjugate_primal_if_dtype_complex, linalg_std_op};
 
 pub(crate) fn linearize_triangular_solve(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     left_side: bool,
     lower: bool,
     transpose_a: bool,
     unit_diagonal: bool,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     // Equation: op(A) @ X = B  (left_side=true)
     //       or  X @ op(A) = B  (left_side=false)
     // where op = identity (transpose_a=false) or transpose (transpose_a=true).
@@ -28,8 +28,12 @@ pub(crate) fn linearize_triangular_solve(
     //
     // When tangent_in[0] (dA) is present, we compute the correction:
     //   -d(op(A)) @ X  or  -X @ d(op(A))
-    let lhs_rank = ctx.shape_of(&ValRef::External(primal_in[0].clone())).len();
-    let rhs_rank = ctx.shape_of(&ValRef::External(primal_in[1].clone())).len();
+    let lhs_rank = ctx
+        .shape_of(&ValueRef::External(primal_in[0].clone()))
+        .len();
+    let rhs_rank = ctx
+        .shape_of(&ValueRef::External(primal_in[1].clone()))
+        .len();
     assert!(
         lhs_rank >= 2 && rhs_rank >= 2,
         "linearize_triangular_solve: expected matrix operands"
@@ -53,7 +57,7 @@ pub(crate) fn linearize_triangular_solve(
         return vec![None];
     };
 
-    let out = builder.add_op(
+    let out = builder.add_operation(
         linalg_std_op(LinalgOp::TriangularSolve {
             left_side,
             lower,
@@ -61,10 +65,10 @@ pub(crate) fn linearize_triangular_solve(
             unit_diagonal,
         }),
         vec![
-            ValRef::External(primal_in[0].clone()),
-            ValRef::Local(rhs_tangent),
+            ValueRef::External(primal_in[0].clone()),
+            ValueRef::Local(rhs_tangent),
         ],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     );
@@ -92,16 +96,20 @@ fn linear_solve_op_name(kind: LinearSolveOp) -> &'static str {
 }
 
 fn linearize_linear_solve(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
     kind: LinearSolveOp,
-) -> Vec<Option<LocalValId>> {
-    let lhs_rank = ctx.shape_of(&ValRef::External(primal_in[0].clone())).len();
-    let rhs_rank = ctx.shape_of(&ValRef::External(primal_in[1].clone())).len();
+) -> Vec<Option<LocalValueId>> {
+    let lhs_rank = ctx
+        .shape_of(&ValueRef::External(primal_in[0].clone()))
+        .len();
+    let rhs_rank = ctx
+        .shape_of(&ValueRef::External(primal_in[1].clone()))
+        .len();
     let op_name = linear_solve_op_name(kind);
     assert!(
         lhs_rank >= 2 && rhs_rank >= 2,
@@ -120,8 +128,9 @@ fn linearize_linear_solve(
         } else {
             da
         };
-        let x = ValRef::External(primal_out[0].clone());
-        let correction = matmul_linear(builder, ValRef::Local(d_op_a), x, vec![true, false], rank);
+        let x = ValueRef::External(primal_out[0].clone());
+        let correction =
+            matmul_linear(builder, ValueRef::Local(d_op_a), x, vec![true, false], rank);
         let neg_correction = linear_neg(builder, correction);
         rhs_tangent = Some(match rhs_tangent {
             Some(db) => linear_add(builder, db, neg_correction),
@@ -133,13 +142,13 @@ fn linearize_linear_solve(
         return vec![None];
     };
 
-    let out = builder.add_op(
+    let out = builder.add_operation(
         linear_solve_op(kind, transpose_a),
         vec![
-            ValRef::External(primal_in[0].clone()),
-            ValRef::Local(rhs_tangent),
+            ValueRef::External(primal_in[0].clone()),
+            ValueRef::Local(rhs_tangent),
         ],
-        OpMode::Linear {
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     );
@@ -147,13 +156,13 @@ fn linearize_linear_solve(
 }
 
 pub(crate) fn linearize_solve(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     linearize_linear_solve(
         builder,
         primal_in,
@@ -166,13 +175,13 @@ pub(crate) fn linearize_solve(
 }
 
 pub(crate) fn linearize_full_piv_lu_solve(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_in: &[GlobalValKey<StdTensorOp>],
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     linearize_linear_solve(
         builder,
         primal_in,
@@ -185,15 +194,15 @@ pub(crate) fn linearize_full_piv_lu_solve(
 }
 
 fn triangular_solve_rhs_tangent(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    primal_out: &[GlobalValKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValId>],
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
     left_side: bool,
     lower: bool,
     transpose_a: bool,
     unit_diagonal: bool,
     rank: usize,
-) -> Option<LocalValId> {
+) -> Option<LocalValueId> {
     let mut rhs_tangent = tangent_in[1];
 
     if let Some(da) = tangent_in[0] {
@@ -206,11 +215,11 @@ fn triangular_solve_rhs_tangent(
         };
 
         // Correction = d(op(A)) @ X  or  X @ d(op(A))
-        let x = ValRef::External(primal_out[0].clone());
+        let x = ValueRef::External(primal_out[0].clone());
         let correction = if left_side {
-            matmul_linear(builder, ValRef::Local(d_op_a), x, vec![true, false], rank)
+            matmul_linear(builder, ValueRef::Local(d_op_a), x, vec![true, false], rank)
         } else {
-            matmul_linear(builder, x, ValRef::Local(d_op_a), vec![false, true], rank)
+            matmul_linear(builder, x, ValueRef::Local(d_op_a), vec![false, true], rank)
         };
         let neg_correction = linear_neg(builder, correction);
         rhs_tangent = Some(match rhs_tangent {
@@ -223,43 +232,43 @@ fn triangular_solve_rhs_tangent(
 }
 
 pub(crate) fn transpose_triangular_solve(
-    emitter: &mut impl OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     left_side: bool,
     lower: bool,
     transpose_a: bool,
     unit_diagonal: bool,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None, None];
     };
-    let OpMode::Linear { active_mask } = mode else {
+    let OperationRole::Linearized { active_mask } = mode else {
         return vec![None, None];
     };
 
     let mut result = vec![None, None];
     if active_mask[0] || active_mask[1] {
         let dtype = ctx.dtype_of(&inputs[0]);
-        let conjugated_a = conjugate_primal_if_dtype_complex(emitter, inputs[0].clone(), dtype);
-        let out = emitter.add_op(
+        let conjugated_a = conjugate_primal_if_dtype_complex(builder, inputs[0].clone(), dtype);
+        let out = builder.add_operation(
             linalg_std_op(LinalgOp::TriangularSolve {
                 left_side,
                 lower,
                 transpose_a: !transpose_a,
                 unit_diagonal,
             }),
-            vec![conjugated_a, ValRef::Local(ct)],
-            OpMode::Linear {
+            vec![conjugated_a, ValueRef::Local(ct)],
+            OperationRole::Linearized {
                 active_mask: vec![false, true],
             },
         );
         let rhs_cotangent = out[0];
         if active_mask[0] {
             let rank = ctx.shape_of(&inputs[0]).len();
-            let solution = emitter.add_op(
+            let solution = builder.add_operation(
                 linalg_std_op(LinalgOp::TriangularSolve {
                     left_side,
                     lower,
@@ -267,19 +276,19 @@ pub(crate) fn transpose_triangular_solve(
                     unit_diagonal,
                 }),
                 inputs.to_vec(),
-                OpMode::Primal,
+                OperationRole::Primary,
             )[0];
             let matrix_cotangent = solve_matrix_cotangent(
-                emitter,
+                builder,
                 rhs_cotangent,
-                ValRef::Local(solution),
+                ValueRef::Local(solution),
                 left_side,
                 transpose_a,
                 rank,
                 dtype,
             );
             let matrix_cotangent =
-                project_triangular_operand_linear(emitter, matrix_cotangent, lower, unit_diagonal);
+                project_triangular_operand_linear(builder, matrix_cotangent, lower, unit_diagonal);
             result[0] = Some(matrix_cotangent);
         }
         if active_mask[1] {
@@ -291,44 +300,44 @@ pub(crate) fn transpose_triangular_solve(
 }
 
 fn transpose_linear_solve(
-    emitter: &mut impl OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
     kind: LinearSolveOp,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
         return vec![None, None];
     };
-    let OpMode::Linear { active_mask } = mode else {
+    let OperationRole::Linearized { active_mask } = mode else {
         return vec![None, None];
     };
 
     let mut result = vec![None, None];
     if active_mask[0] || active_mask[1] {
         let dtype = ctx.dtype_of(&inputs[0]);
-        let conjugated_a = conjugate_primal_if_dtype_complex(emitter, inputs[0].clone(), dtype);
-        let out = emitter.add_op(
+        let conjugated_a = conjugate_primal_if_dtype_complex(builder, inputs[0].clone(), dtype);
+        let out = builder.add_operation(
             linear_solve_op(kind, !transpose_a),
-            vec![conjugated_a, ValRef::Local(ct)],
-            OpMode::Linear {
+            vec![conjugated_a, ValueRef::Local(ct)],
+            OperationRole::Linearized {
                 active_mask: vec![false, true],
             },
         );
         let rhs_cotangent = out[0];
         if active_mask[0] {
             let rank = ctx.shape_of(&inputs[0]).len();
-            let solution = emitter.add_op(
+            let solution = builder.add_operation(
                 linear_solve_op(kind, transpose_a),
                 inputs.to_vec(),
-                OpMode::Primal,
+                OperationRole::Primary,
             )[0];
             result[0] = Some(solve_matrix_cotangent(
-                emitter,
+                builder,
                 rhs_cotangent,
-                ValRef::Local(solution),
+                ValueRef::Local(solution),
                 true,
                 transpose_a,
                 rank,
@@ -344,15 +353,15 @@ fn transpose_linear_solve(
 }
 
 pub(crate) fn transpose_solve(
-    emitter: &mut impl OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     transpose_linear_solve(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,
@@ -363,15 +372,15 @@ pub(crate) fn transpose_solve(
 }
 
 pub(crate) fn transpose_full_piv_lu_solve(
-    emitter: &mut impl OpEmitter<StdTensorOp>,
-    cotangent_out: &[Option<LocalValId>],
-    inputs: &[ValRef<StdTensorOp>],
-    mode: &OpMode,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValId>> {
+) -> Vec<Option<LocalValueId>> {
     transpose_linear_solve(
-        emitter,
+        builder,
         cotangent_out,
         inputs,
         mode,

--- a/tenferro-linalg/src/ad/rules/support.rs
+++ b/tenferro-linalg/src/ad/rules/support.rs
@@ -1,5 +1,5 @@
-use computegraph::types::{LocalValId, OpMode, ValRef};
-use computegraph::OpEmitter;
+use computegraph::types::{LocalValueId, OperationRole, ValueRef};
+use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{DType, DotGeneralConfig, PadConfig};
@@ -9,184 +9,189 @@ use crate::ad_support::LinalgOp;
 use super::{conjugate_linear_if_dtype_complex, conjugate_primal_if_dtype_complex, linalg_std_op};
 
 pub(super) fn solve_matrix_cotangent(
-    emitter: &mut impl OpEmitter<StdTensorOp>,
-    rhs_cotangent: LocalValId,
-    solution: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    rhs_cotangent: LocalValueId,
+    solution: ValueRef<StdTensorOp>,
     left_side: bool,
     transpose_a: bool,
     rank: usize,
     dtype: DType,
-) -> LocalValId {
-    let negative_rhs_cotangent = linear_neg(emitter, rhs_cotangent);
-    let solution_h = adjoint_matrix_fixed(emitter, solution, rank, dtype);
+) -> LocalValueId {
+    let negative_rhs_cotangent = linear_neg(builder, rhs_cotangent);
+    let solution_h = adjoint_matrix_fixed(builder, solution, rank, dtype);
     let op_matrix_cotangent = if left_side {
         matmul_linear(
-            emitter,
-            ValRef::Local(negative_rhs_cotangent),
-            ValRef::Local(solution_h),
+            builder,
+            ValueRef::Local(negative_rhs_cotangent),
+            ValueRef::Local(solution_h),
             vec![true, false],
             rank,
         )
     } else {
         matmul_linear(
-            emitter,
-            ValRef::Local(solution_h),
-            ValRef::Local(negative_rhs_cotangent),
+            builder,
+            ValueRef::Local(solution_h),
+            ValueRef::Local(negative_rhs_cotangent),
             vec![false, true],
             rank,
         )
     };
     if transpose_a {
-        transpose_matrix_linear(emitter, op_matrix_cotangent, rank)
+        transpose_matrix_linear(builder, op_matrix_cotangent, rank)
     } else {
         op_matrix_cotangent
     }
 }
 
 pub(super) fn solve_in_graph(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    a: ValRef<StdTensorOp>,
-    b: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    a: ValueRef<StdTensorOp>,
+    b: ValueRef<StdTensorOp>,
     rank: usize,
-) -> LocalValId {
-    let lu_outputs = builder.add_op(linalg_std_op(LinalgOp::Lu), vec![a], OpMode::Primal);
+) -> LocalValueId {
+    let lu_outputs =
+        builder.add_operation(linalg_std_op(LinalgOp::Lu), vec![a], OperationRole::Primary);
     let p = lu_outputs[0];
     let l = lu_outputs[1];
     let u = lu_outputs[2];
-    let pb = matmul_linear(builder, ValRef::Local(p), b, vec![false, true], rank);
-    let z = builder.add_op(
+    let pb = matmul_linear(builder, ValueRef::Local(p), b, vec![false, true], rank);
+    let z = builder.add_operation(
         linalg_std_op(LinalgOp::TriangularSolve {
             left_side: true,
             lower: true,
             transpose_a: false,
             unit_diagonal: true,
         }),
-        vec![ValRef::Local(l), ValRef::Local(pb)],
-        OpMode::Linear {
+        vec![ValueRef::Local(l), ValueRef::Local(pb)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0];
-    builder.add_op(
+    builder.add_operation(
         linalg_std_op(LinalgOp::TriangularSolve {
             left_side: true,
             lower: false,
             transpose_a: false,
             unit_diagonal: false,
         }),
-        vec![ValRef::Local(u), ValRef::Local(z)],
-        OpMode::Linear {
+        vec![ValueRef::Local(u), ValueRef::Local(z)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0]
 }
 
 pub(super) fn fixed_unary(
-    emitter: &mut impl OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     op: StdTensorOp,
-    input: ValRef<StdTensorOp>,
-) -> LocalValId {
-    emitter.add_op(op, vec![input], OpMode::Primal)[0]
+    input: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    builder.add_operation(op, vec![input], OperationRole::Primary)[0]
 }
 
 pub(super) fn fixed_binary(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     op: StdTensorOp,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
-    builder.add_op(op, vec![lhs, rhs], OpMode::Primal)[0]
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    builder.add_operation(op, vec![lhs, rhs], OperationRole::Primary)[0]
 }
 
 pub(super) fn linear_unary(
-    builder: &mut impl OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     op: StdTensorOp,
-    input: LocalValId,
-) -> LocalValId {
-    builder.add_op(
+    input: LocalValueId,
+) -> LocalValueId {
+    builder.add_operation(
         op,
-        vec![ValRef::Local(input)],
-        OpMode::Linear {
+        vec![ValueRef::Local(input)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0]
 }
 
 pub(super) fn linear_binary(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     op: StdTensorOp,
-    lhs: LocalValId,
-    rhs: LocalValId,
-) -> LocalValId {
-    builder.add_op(
+    lhs: LocalValueId,
+    rhs: LocalValueId,
+) -> LocalValueId {
+    builder.add_operation(
         op,
-        vec![ValRef::Local(lhs), ValRef::Local(rhs)],
-        OpMode::Linear {
+        vec![ValueRef::Local(lhs), ValueRef::Local(rhs)],
+        OperationRole::Linearized {
             active_mask: vec![true, true],
         },
     )[0]
 }
 
 pub(super) fn fixed_add(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
     fixed_binary(builder, StdTensorOp::Add, lhs, rhs)
 }
 
 pub(super) fn fixed_mul(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
     fixed_binary(builder, StdTensorOp::Mul, lhs, rhs)
 }
 
 pub(super) fn fixed_div(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
     fixed_binary(builder, StdTensorOp::Div, lhs, rhs)
 }
 
 pub(super) fn fixed_scale(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
     factor: f64,
-) -> LocalValId {
-    let constant = builder.add_op(StdTensorOp::constant_f64(factor), vec![], OpMode::Primal);
-    builder.add_op(
+) -> LocalValueId {
+    let constant = builder.add_operation(
+        StdTensorOp::constant_f64(factor),
+        vec![],
+        OperationRole::Primary,
+    );
+    builder.add_operation(
         StdTensorOp::Mul,
-        vec![ValRef::Local(constant[0]), input],
-        OpMode::Primal,
+        vec![ValueRef::Local(constant[0]), input],
+        OperationRole::Primary,
     )[0]
 }
 
 pub(super) fn broadcast_in_dim_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
     shape: Vec<DimExpr>,
     dims: Vec<usize>,
-) -> LocalValId {
+) -> LocalValueId {
     fixed_unary(builder, StdTensorOp::BroadcastInDim { shape, dims }, input)
 }
 
 pub(super) fn reduce_sum_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
     axes: Vec<usize>,
-) -> LocalValId {
+) -> LocalValueId {
     fixed_unary(builder, StdTensorOp::ReduceSum { axes }, input)
 }
 
 pub(super) fn pad_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
     rank: usize,
     edge_padding_low: Vec<i64>,
     edge_padding_high: Vec<i64>,
-) -> LocalValId {
+) -> LocalValueId {
     fixed_unary(
         builder,
         StdTensorOp::Pad(PadConfig {
@@ -199,125 +204,129 @@ pub(super) fn pad_fixed(
 }
 
 pub(super) fn fixed_sub(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
     let neg_rhs = fixed_unary(builder, StdTensorOp::Neg, rhs);
-    fixed_add(builder, lhs, ValRef::Local(neg_rhs))
+    fixed_add(builder, lhs, ValueRef::Local(neg_rhs))
 }
 
 pub(super) fn linear_add(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: LocalValId,
-    rhs: LocalValId,
-) -> LocalValId {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: LocalValueId,
+    rhs: LocalValueId,
+) -> LocalValueId {
     linear_binary(builder, StdTensorOp::Add, lhs, rhs)
 }
 
 pub(super) fn linear_neg(
-    builder: &mut impl OpEmitter<StdTensorOp>,
-    input: LocalValId,
-) -> LocalValId {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
+) -> LocalValueId {
     linear_unary(builder, StdTensorOp::Neg, input)
 }
 
 pub(super) fn linear_scale(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
     factor: f64,
-) -> LocalValId {
-    let constant = builder.add_op(StdTensorOp::constant_f64(factor), vec![], OpMode::Primal);
-    builder.add_op(
+) -> LocalValueId {
+    let constant = builder.add_operation(
+        StdTensorOp::constant_f64(factor),
+        vec![],
+        OperationRole::Primary,
+    );
+    builder.add_operation(
         StdTensorOp::Mul,
-        vec![ValRef::Local(constant[0]), ValRef::Local(input)],
-        OpMode::Linear {
+        vec![ValueRef::Local(constant[0]), ValueRef::Local(input)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0]
 }
 
 pub(super) fn linear_sub(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: LocalValId,
-    rhs: LocalValId,
-) -> LocalValId {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: LocalValueId,
+    rhs: LocalValueId,
+) -> LocalValueId {
     let neg_rhs = linear_neg(builder, rhs);
     linear_add(builder, lhs, neg_rhs)
 }
 
 pub(super) fn linear_div_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: LocalValId,
-    rhs: ValRef<StdTensorOp>,
-) -> LocalValId {
-    builder.add_op(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: LocalValueId,
+    rhs: ValueRef<StdTensorOp>,
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::Div,
-        vec![ValRef::Local(lhs), rhs],
-        OpMode::Linear {
+        vec![ValueRef::Local(lhs), rhs],
+        OperationRole::Linearized {
             active_mask: vec![true, false],
         },
     )[0]
 }
 
 pub(super) fn hadamard_fixed_linear(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    fixed: ValRef<StdTensorOp>,
-    active: LocalValId,
-) -> LocalValId {
-    builder.add_op(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    fixed: ValueRef<StdTensorOp>,
+    active: LocalValueId,
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::Mul,
-        vec![fixed, ValRef::Local(active)],
-        OpMode::Linear {
+        vec![fixed, ValueRef::Local(active)],
+        OperationRole::Linearized {
             active_mask: vec![false, true],
         },
     )[0]
 }
 
 pub(super) fn one_like_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    anchor: ValRef<StdTensorOp>,
-) -> LocalValId {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    anchor: ValueRef<StdTensorOp>,
+) -> LocalValueId {
     let zero = fixed_sub(builder, anchor.clone(), anchor);
-    fixed_unary(builder, StdTensorOp::Exp, ValRef::Local(zero))
+    fixed_unary(builder, StdTensorOp::Exp, ValueRef::Local(zero))
 }
 
 pub(super) fn extract_diag_linear(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: LocalValId,
-) -> LocalValId {
-    builder.add_op(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::ExtractDiag {
             axis_a: 0,
             axis_b: 1,
         },
-        vec![ValRef::Local(input)],
-        OpMode::Linear {
+        vec![ValueRef::Local(input)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0]
 }
 
 pub(super) fn embed_diag_linear(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: LocalValId,
-) -> LocalValId {
-    builder.add_op(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::EmbedDiag {
             axis_a: 0,
             axis_b: 1,
         },
-        vec![ValRef::Local(input)],
-        OpMode::Linear {
+        vec![ValueRef::Local(input)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0]
 }
 
 pub(super) fn embed_diag_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
-) -> LocalValId {
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+) -> LocalValueId {
     fixed_unary(
         builder,
         StdTensorOp::EmbedDiag {
@@ -329,12 +338,12 @@ pub(super) fn embed_diag_fixed(
 }
 
 pub(super) fn transpose_matrix_fixed(
-    emitter: &mut impl OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
     rank: usize,
-) -> LocalValId {
+) -> LocalValueId {
     fixed_unary(
-        emitter,
+        builder,
         StdTensorOp::Transpose {
             perm: matrix_transpose_perm(rank),
         },
@@ -343,55 +352,55 @@ pub(super) fn transpose_matrix_fixed(
 }
 
 pub(super) fn adjoint_matrix_fixed(
-    builder: &mut impl OpEmitter<StdTensorOp>,
-    input: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
     rank: usize,
     dtype: DType,
-) -> LocalValId {
+) -> LocalValueId {
     let input = conjugate_primal_if_dtype_complex(builder, input, dtype);
     transpose_matrix_fixed(builder, input, rank)
 }
 
 pub(super) fn adjoint_matrix_linear(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
     rank: usize,
     dtype: DType,
-) -> LocalValId {
+) -> LocalValueId {
     let conjugated = conjugate_linear_if_dtype_complex(builder, input, dtype);
-    builder.add_op(
+    builder.add_operation(
         StdTensorOp::Transpose {
             perm: matrix_transpose_perm(rank),
         },
-        vec![ValRef::Local(conjugated)],
-        OpMode::Linear {
+        vec![ValueRef::Local(conjugated)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0]
 }
 
 pub(super) fn transpose_matrix_linear(
-    emitter: &mut impl OpEmitter<StdTensorOp>,
-    input: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
     rank: usize,
-) -> LocalValId {
-    emitter.add_op(
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::Transpose {
             perm: matrix_transpose_perm(rank),
         },
-        vec![ValRef::Local(input)],
-        OpMode::Linear {
+        vec![ValueRef::Local(input)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0]
 }
 
 pub(super) fn project_triangular_operand_linear(
-    builder: &mut impl OpEmitter<StdTensorOp>,
-    input: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
     lower: bool,
     unit_diagonal: bool,
-) -> LocalValId {
+) -> LocalValueId {
     let op = if lower {
         StdTensorOp::Tril {
             k: if unit_diagonal { -1 } else { 0 },
@@ -405,15 +414,15 @@ pub(super) fn project_triangular_operand_linear(
 }
 
 pub(super) fn self_adjoint_from_lower_linear(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
     rank: usize,
     dtype: DType,
-) -> LocalValId {
-    let strict_lower = builder.add_op(
+) -> LocalValueId {
+    let strict_lower = builder.add_operation(
         StdTensorOp::Tril { k: -1 },
-        vec![ValRef::Local(input)],
-        OpMode::Linear {
+        vec![ValueRef::Local(input)],
+        OperationRole::Linearized {
             active_mask: vec![true],
         },
     )[0];
@@ -433,33 +442,33 @@ pub(super) fn self_adjoint_from_lower_linear(
 }
 
 pub(super) fn matmul_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
     rank: usize,
-) -> LocalValId {
-    builder.add_op(
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::DotGeneral {
             config: matrix_multiply_config(rank),
         },
         vec![lhs, rhs],
-        OpMode::Primal,
+        OperationRole::Primary,
     )[0]
 }
 
 pub(super) fn matmul_linear(
-    builder: &mut impl OpEmitter<StdTensorOp>,
-    lhs: ValRef<StdTensorOp>,
-    rhs: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: ValueRef<StdTensorOp>,
+    rhs: ValueRef<StdTensorOp>,
     active_mask: Vec<bool>,
     rank: usize,
-) -> LocalValId {
-    builder.add_op(
+) -> LocalValueId {
+    builder.add_operation(
         StdTensorOp::DotGeneral {
             config: matrix_multiply_config(rank),
         },
         vec![lhs, rhs],
-        OpMode::Linear { active_mask },
+        OperationRole::Linearized { active_mask },
     )[0]
 }
 
@@ -513,18 +522,18 @@ pub(super) fn vector_to_matrix_broadcast_dims(batch_ndim: usize) -> Vec<usize> {
 }
 
 pub(super) fn leading_column_selector_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     leading_cols: usize,
     total_cols: usize,
     batch_shape: &[DimExpr],
-    anchor: ValRef<StdTensorOp>,
+    anchor: ValueRef<StdTensorOp>,
     anchor_shape: &[DimExpr],
-) -> LocalValId {
+) -> LocalValueId {
     let eye = identity_matrix_fixed(builder, leading_cols, batch_shape, anchor, anchor_shape);
     let rank = 2 + batch_shape.len();
     pad_fixed(
         builder,
-        ValRef::Local(eye),
+        ValueRef::Local(eye),
         rank,
         vec![0; rank],
         pad_vec(rank, 1, (total_cols - leading_cols) as i64),
@@ -532,18 +541,18 @@ pub(super) fn leading_column_selector_fixed(
 }
 
 pub(super) fn trailing_column_selector_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     leading_cols: usize,
     trailing_cols: usize,
     batch_shape: &[DimExpr],
-    anchor: ValRef<StdTensorOp>,
+    anchor: ValueRef<StdTensorOp>,
     anchor_shape: &[DimExpr],
-) -> LocalValId {
+) -> LocalValueId {
     let eye = identity_matrix_fixed(builder, trailing_cols, batch_shape, anchor, anchor_shape);
     let rank = 2 + batch_shape.len();
     pad_fixed(
         builder,
-        ValRef::Local(eye),
+        ValueRef::Local(eye),
         rank,
         pad_vec(rank, 1, leading_cols as i64),
         vec![0; rank],
@@ -551,38 +560,38 @@ pub(super) fn trailing_column_selector_fixed(
 }
 
 pub(super) fn identity_matrix_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
     size: usize,
     batch_shape: &[DimExpr],
-    anchor: ValRef<StdTensorOp>,
+    anchor: ValueRef<StdTensorOp>,
     anchor_shape: &[DimExpr],
-) -> LocalValId {
+) -> LocalValueId {
     let one_scalar = scalar_one_fixed(builder, anchor, anchor_shape);
     let ones = broadcast_in_dim_fixed(
         builder,
-        ValRef::Local(one_scalar),
+        ValueRef::Local(one_scalar),
         vector_shape(size, batch_shape),
         vec![],
     );
-    embed_diag_fixed(builder, ValRef::Local(ones))
+    embed_diag_fixed(builder, ValueRef::Local(ones))
 }
 
 pub(super) fn scalar_one_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    anchor: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    anchor: ValueRef<StdTensorOp>,
     anchor_shape: &[DimExpr],
-) -> LocalValId {
+) -> LocalValueId {
     let zero = fixed_sub(builder, anchor.clone(), anchor);
     let zero_scalar = if anchor_shape.is_empty() {
         zero
     } else {
         reduce_sum_fixed(
             builder,
-            ValRef::Local(zero),
+            ValueRef::Local(zero),
             (0..anchor_shape.len()).collect(),
         )
     };
-    fixed_unary(builder, StdTensorOp::Exp, ValRef::Local(zero_scalar))
+    fixed_unary(builder, StdTensorOp::Exp, ValueRef::Local(zero_scalar))
 }
 
 pub(super) fn pad_vec(rank: usize, axis: usize, amount: i64) -> Vec<i64> {
@@ -599,19 +608,19 @@ pub(super) fn pad_matrix_low(rank: usize, row_amount: i64, col_amount: i64) -> V
 }
 
 pub(super) fn augment_unit_lower_to_square_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    l: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    l: ValueRef<StdTensorOp>,
     rows: usize,
     cols: usize,
     batch_shape: &[DimExpr],
     l_shape: &[DimExpr],
     rank: usize,
-) -> LocalValId {
+) -> LocalValueId {
     let strict_lower = fixed_unary(builder, StdTensorOp::Tril { k: -1 }, l.clone());
     let strict_lower_square = if cols < rows {
         pad_fixed(
             builder,
-            ValRef::Local(strict_lower),
+            ValueRef::Local(strict_lower),
             rank,
             vec![0; rank],
             pad_vec(rank, 1, (rows - cols) as i64),
@@ -622,20 +631,20 @@ pub(super) fn augment_unit_lower_to_square_fixed(
     let identity = identity_matrix_fixed(builder, rows, batch_shape, l, l_shape);
     fixed_add(
         builder,
-        ValRef::Local(strict_lower_square),
-        ValRef::Local(identity),
+        ValueRef::Local(strict_lower_square),
+        ValueRef::Local(identity),
     )
 }
 
 pub(super) fn augment_upper_to_square_fixed(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    u: ValRef<StdTensorOp>,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    u: ValueRef<StdTensorOp>,
     rows: usize,
     cols: usize,
     batch_shape: &[DimExpr],
     u_shape: &[DimExpr],
     rank: usize,
-) -> LocalValId {
+) -> LocalValueId {
     let upper = fixed_unary(builder, StdTensorOp::Triu { k: 0 }, u.clone());
     if rows == cols {
         return upper;
@@ -643,7 +652,7 @@ pub(super) fn augment_upper_to_square_fixed(
 
     let upper_square = pad_fixed(
         builder,
-        ValRef::Local(upper),
+        ValueRef::Local(upper),
         rank,
         vec![0; rank],
         pad_vec(rank, 0, (cols - rows) as i64),
@@ -651,56 +660,56 @@ pub(super) fn augment_upper_to_square_fixed(
     let trailing_eye = identity_matrix_fixed(builder, cols - rows, batch_shape, u, u_shape);
     let trailing_eye = pad_fixed(
         builder,
-        ValRef::Local(trailing_eye),
+        ValueRef::Local(trailing_eye),
         rank,
         pad_matrix_low(rank, rows as i64, rows as i64),
         vec![0; rank],
     );
     fixed_add(
         builder,
-        ValRef::Local(upper_square),
-        ValRef::Local(trailing_eye),
+        ValueRef::Local(upper_square),
+        ValueRef::Local(trailing_eye),
     )
 }
 
 pub(super) fn take_leading_cols_linear(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
     cols: usize,
     total_cols: usize,
     batch_shape: &[DimExpr],
-    anchor: ValRef<StdTensorOp>,
+    anchor: ValueRef<StdTensorOp>,
     anchor_shape: &[DimExpr],
     rank: usize,
-) -> LocalValId {
+) -> LocalValueId {
     let selector =
         leading_column_selector_fixed(builder, cols, total_cols, batch_shape, anchor, anchor_shape);
-    let selector_t = transpose_matrix_fixed(builder, ValRef::Local(selector), rank);
+    let selector_t = transpose_matrix_fixed(builder, ValueRef::Local(selector), rank);
     matmul_linear(
         builder,
-        ValRef::Local(input),
-        ValRef::Local(selector_t),
+        ValueRef::Local(input),
+        ValueRef::Local(selector_t),
         vec![true, false],
         rank,
     )
 }
 
 pub(super) fn take_leading_rows_linear(
-    builder: &mut dyn OpEmitter<StdTensorOp>,
-    input: LocalValId,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
     rows: usize,
     total_rows: usize,
     batch_shape: &[DimExpr],
-    anchor: ValRef<StdTensorOp>,
+    anchor: ValueRef<StdTensorOp>,
     anchor_shape: &[DimExpr],
     rank: usize,
-) -> LocalValId {
+) -> LocalValueId {
     let selector =
         leading_column_selector_fixed(builder, rows, total_rows, batch_shape, anchor, anchor_shape);
     matmul_linear(
         builder,
-        ValRef::Local(selector),
-        ValRef::Local(input),
+        ValueRef::Local(selector),
+        ValueRef::Local(input),
         vec![false, true],
         rank,
     )

--- a/tenferro-linalg/src/extension.rs
+++ b/tenferro-linalg/src/extension.rs
@@ -222,11 +222,11 @@ impl ExtensionOpTrait for LinalgExtensionOp {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         self.op.input_count()
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         self.op.output_count()
     }
 
@@ -235,14 +235,14 @@ impl ExtensionOpTrait for LinalgExtensionOp {
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
     ) -> Vec<(DType, Vec<SymDim>)> {
-        assert_eq!(input_dtypes.len(), self.n_inputs());
-        assert_eq!(input_shapes.len(), self.n_inputs());
+        assert_eq!(input_dtypes.len(), self.input_count());
+        assert_eq!(input_shapes.len(), self.input_count());
         match self.op {
             LinalgOp::Cholesky
             | LinalgOp::FullPivLuSolve { .. }
             | LinalgOp::Solve { .. }
             | LinalgOp::TriangularSolve { .. } => {
-                let output_shape = if self.n_inputs() == 1 {
+                let output_shape = if self.input_count() == 1 {
                     input_shapes[0].to_vec()
                 } else {
                     input_shapes[1].to_vec()
@@ -259,7 +259,7 @@ impl ExtensionOpTrait for LinalgExtensionOp {
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        let expected = self.n_inputs();
+        let expected = self.input_count();
         if inputs.len() != expected {
             return Err(Error::InvalidConfig {
                 op: "linalg_eager_execute",

--- a/tenferro-runtime/src/ad_support.rs
+++ b/tenferro-runtime/src/ad_support.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use computegraph::fragment::Fragment;
-use computegraph::types::{GlobalValKey, LocalValId};
+use computegraph::graph::Graph;
+use computegraph::types::{LocalValueId, ValueKey};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{DType, Tensor, TypedTensor};
@@ -13,7 +13,7 @@ pub use crate::checkpoint::CheckpointNode;
 use crate::metadata::MetadataScope as RuntimeMetadataScope;
 pub use crate::metadata::{
     metadata_scopes_for_scope, metadata_scopes_with_new, metadata_scopes_with_scope,
-    push_metadata_scope, register_scoped_fragment_metadata, register_scoped_live_fragment_metadata,
+    push_metadata_scope, register_scoped_graph_metadata, register_scoped_live_graph_metadata,
     register_scoped_metadata_batch, register_scoped_value_metadata, registered_meta,
     tensor_meta_from_tensor, MetadataScope,
 };
@@ -24,12 +24,12 @@ use crate::traced::{next_input_key, next_traced_id, TracedTensor};
 pub struct TracedTensorParts {
     pub rank: usize,
     pub dtype: DType,
-    pub fragment: Arc<Fragment<StdTensorOp>>,
-    pub val: LocalValId,
+    pub graph: Arc<Graph<StdTensorOp>>,
+    pub val: LocalValueId,
     pub data: Option<Arc<Tensor>>,
     pub shape_hint: Option<Vec<SymDim>>,
     pub inputs_map: Arc<HashMap<TensorInputKey, Arc<Tensor>>>,
-    pub extra_roots: Vec<Arc<Fragment<StdTensorOp>>>,
+    pub extra_roots: Vec<Arc<Graph<StdTensorOp>>>,
     pub checkpoint_chain: Option<Arc<CheckpointNode>>,
     pub metadata_scopes: Vec<Arc<RuntimeMetadataScope>>,
 }
@@ -40,7 +40,7 @@ pub fn traced_tensor_from_parts(parts: TracedTensorParts) -> TracedTensor {
         id: next_traced_id(),
         rank: parts.rank,
         dtype: parts.dtype,
-        fragment: parts.fragment,
+        graph: parts.graph,
         val: parts.val,
         data: parts.data,
         shape_hint: parts.shape_hint,
@@ -59,7 +59,7 @@ pub fn traced_inputs_map(tensor: &TracedTensor) -> Arc<HashMap<TensorInputKey, A
     Arc::clone(&tensor.inputs_map)
 }
 
-pub fn traced_extra_roots(tensor: &TracedTensor) -> Vec<Arc<Fragment<StdTensorOp>>> {
+pub fn traced_extra_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>> {
     tensor.extra_roots.clone()
 }
 
@@ -71,34 +71,34 @@ pub fn traced_metadata_scopes(tensor: &TracedTensor) -> &[Arc<RuntimeMetadataSco
     &tensor.metadata_scopes
 }
 
-pub fn traced_resolve_roots(tensor: &TracedTensor) -> Vec<Arc<Fragment<StdTensorOp>>> {
+pub fn traced_resolve_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>> {
     tensor.resolve_roots()
 }
 
 pub fn checkpoint_traced_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>) {
-    let old_fragment = tensor.fragment.clone();
-    let old_output_key = old_fragment.vals()[tensor.val].key.clone();
+    let old_graph = tensor.graph.clone();
+    let old_output_key = old_graph.values()[tensor.val].key.clone();
     let old_inputs = (*tensor.inputs_map).clone();
     let concrete_meta = tensor_meta_from_tensor(data.as_ref());
     let new_key = next_input_key();
-    let mut builder = computegraph::fragment::FragmentBuilder::new();
+    let mut builder = computegraph::graph::GraphBuilder::new();
     let leaf_val = builder.add_input(new_key.clone());
     builder.set_outputs(vec![leaf_val]);
-    let new_fragment = Arc::new(builder.build());
+    let new_graph = Arc::new(builder.build());
     let new_metadata_scope = register_scoped_value_metadata(
-        new_fragment.vals()[leaf_val].key.clone(),
+        new_graph.values()[leaf_val].key.clone(),
         concrete_meta.clone(),
     );
     let old_output_metadata_scope =
         register_scoped_value_metadata(old_output_key.clone(), concrete_meta);
     let node = CheckpointNode {
-        fragment: old_fragment,
+        graph: old_graph,
         alias_key: new_key.clone(),
         alias_target: old_output_key,
         old_inputs,
         prev: tensor.checkpoint_chain.take(),
     };
-    tensor.fragment = new_fragment;
+    tensor.graph = new_graph;
     tensor.val = leaf_val;
     tensor.extra_roots.clear();
     tensor.data = Some(Arc::clone(&data));
@@ -127,16 +127,16 @@ pub fn fresh_input_key() -> TensorInputKey {
 }
 
 pub fn leaf_input_key(tensor: &TracedTensor) -> TensorInputKey {
-    match &tensor.fragment.vals()[tensor.val].key {
-        GlobalValKey::Input(key) => key.clone(),
+    match &tensor.graph.values()[tensor.val].key {
+        ValueKey::Input(key) => key.clone(),
         other => panic!("expected traced leaf input, got {:?}", other),
     }
 }
 
-pub fn linear_input_key(fragment: &Fragment<StdTensorOp>, local_id: LocalValId) -> TensorInputKey {
-    match &fragment.vals()[local_id].key {
-        GlobalValKey::Input(key) => key.clone(),
-        other => panic!("expected linear fragment input, got {:?}", other),
+pub fn linear_input_key(graph: &Graph<StdTensorOp>, local_id: LocalValueId) -> TensorInputKey {
+    match &graph.values()[local_id].key {
+        ValueKey::Input(key) => key.clone(),
+        other => panic!("expected linear graph input, got {:?}", other),
     }
 }
 

--- a/tenferro-runtime/src/checkpoint.rs
+++ b/tenferro-runtime/src/checkpoint.rs
@@ -1,23 +1,23 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use computegraph::fragment::Fragment;
-use computegraph::types::GlobalValKey;
+use computegraph::graph::Graph;
+use computegraph::types::ValueKey;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::Tensor;
 
 #[derive(Clone)]
 pub struct CheckpointNode {
-    pub fragment: Arc<Fragment<StdTensorOp>>,
+    pub graph: Arc<Graph<StdTensorOp>>,
     pub alias_key: TensorInputKey,
-    pub alias_target: GlobalValKey<StdTensorOp>,
+    pub alias_target: ValueKey<StdTensorOp>,
     pub old_inputs: HashMap<TensorInputKey, Arc<Tensor>>,
     pub prev: Option<Arc<CheckpointNode>>,
 }
 
 impl CheckpointNode {
-    pub fn collect_aliases(&self) -> HashMap<TensorInputKey, GlobalValKey<StdTensorOp>> {
+    pub fn collect_aliases(&self) -> HashMap<TensorInputKey, ValueKey<StdTensorOp>> {
         let mut aliases = HashMap::new();
         let mut current: Option<&CheckpointNode> = Some(self);
         while let Some(node) = current {
@@ -27,14 +27,14 @@ impl CheckpointNode {
         aliases
     }
 
-    pub fn collect_fragments(&self) -> Vec<Arc<Fragment<StdTensorOp>>> {
-        let mut fragments = Vec::new();
+    pub fn collect_graphs(&self) -> Vec<Arc<Graph<StdTensorOp>>> {
+        let mut graphs = Vec::new();
         let mut current: Option<&CheckpointNode> = Some(self);
         while let Some(node) = current {
-            fragments.push(node.fragment.clone());
+            graphs.push(node.graph.clone());
             current = node.prev.as_deref();
         }
-        fragments
+        graphs
     }
 
     pub fn collect_inputs(&self) -> HashMap<TensorInputKey, Arc<Tensor>> {
@@ -54,7 +54,7 @@ impl CheckpointNode {
     /// Merge two checkpoint chains into a single linked list.
     ///
     /// The lhs chain is reconstructed on top of the rhs chain so that
-    /// `collect_aliases`, `collect_fragments`, and `collect_inputs`
+    /// `collect_aliases`, `collect_graphs`, and `collect_inputs`
     /// traverse both sides during the AD pass.
     pub(crate) fn merge_chains(
         lhs: Option<Arc<CheckpointNode>>,
@@ -73,7 +73,7 @@ impl CheckpointNode {
                 let mut prev: Option<Arc<CheckpointNode>> = Some(rhs_head);
                 for node in nodes.into_iter().rev() {
                     prev = Some(Arc::new(CheckpointNode {
-                        fragment: node.fragment.clone(),
+                        graph: node.graph.clone(),
                         alias_key: node.alias_key.clone(),
                         alias_target: node.alias_target.clone(),
                         old_inputs: node.old_inputs.clone(),

--- a/tenferro-runtime/src/compiler/dot_decomposer.rs
+++ b/tenferro-runtime/src/compiler/dot_decomposer.rs
@@ -95,7 +95,7 @@ pub fn dot_decomposer(program: &mut ExecProgram, input_shapes: &[Vec<DimExpr>]) 
                 let lhs_extents = require_slot_extents(&slot_extents, lhs_slot);
                 let rhs_extents = require_slot_extents(&slot_extents, rhs_slot);
                 if !is_dot_canonical(config, lhs_shape.len(), rhs_shape.len()) {
-                    let mut emitter = InstructionEmitter {
+                    let mut builder = InstructionBuilder {
                         n_slots: &mut n_slots,
                         instructions: &mut new_instructions,
                     };
@@ -116,7 +116,7 @@ pub fn dot_decomposer(program: &mut ExecProgram, input_shapes: &[Vec<DimExpr>]) 
                             lhs_conj,
                             rhs_conj,
                         },
-                        &mut emitter,
+                        &mut builder,
                     );
                     continue;
                 }
@@ -151,7 +151,7 @@ struct DotDecomposeInput<'a> {
     rhs_conj: bool,
 }
 
-struct InstructionEmitter<'a> {
+struct InstructionBuilder<'a> {
     n_slots: &'a mut usize,
     instructions: &'a mut Vec<ExecInstruction>,
 }
@@ -170,7 +170,7 @@ enum MergeSide {
     Rhs,
 }
 
-impl InstructionEmitter<'_> {
+impl InstructionBuilder<'_> {
     fn next_slot(&mut self) -> usize {
         let slot = *self.n_slots;
         *self.n_slots += 1;
@@ -259,7 +259,7 @@ fn product_of_input_dims(input_idx: usize, start: usize, end: usize) -> DimExpr 
 }
 
 /// Emit decomposed instructions for a single non-canonical DotGeneral.
-fn decompose_dot(input: DotDecomposeInput<'_>, emitter: &mut InstructionEmitter<'_>) {
+fn decompose_dot(input: DotDecomposeInput<'_>, builder: &mut InstructionBuilder<'_>) {
     let instr = input.instr;
     let config = input.config;
     let lhs = input.lhs;
@@ -295,7 +295,7 @@ fn decompose_dot(input: DotDecomposeInput<'_>, emitter: &mut InstructionEmitter<
         .chain(config.lhs_batch_dims.iter())
         .copied()
         .collect();
-    let lhs_after_transpose = emit_transpose_if_needed(lhs, &lhs_target_perm, instr.dtype, emitter);
+    let lhs_after_transpose = emit_transpose_if_needed(lhs, &lhs_target_perm, instr.dtype, builder);
 
     let lhs_canon = if fi_l > 1 || ci_l > 1 {
         emit_merge_reshape(
@@ -307,7 +307,7 @@ fn decompose_dot(input: DotDecomposeInput<'_>, emitter: &mut InstructionEmitter<
                 side: MergeSide::Lhs,
             },
             instr.dtype,
-            emitter,
+            builder,
         )
     } else {
         lhs_after_transpose
@@ -320,7 +320,7 @@ fn decompose_dot(input: DotDecomposeInput<'_>, emitter: &mut InstructionEmitter<
         .chain(config.rhs_batch_dims.iter())
         .copied()
         .collect();
-    let rhs_after_transpose = emit_transpose_if_needed(rhs, &rhs_target_perm, instr.dtype, emitter);
+    let rhs_after_transpose = emit_transpose_if_needed(rhs, &rhs_target_perm, instr.dtype, builder);
 
     let rhs_canon = if fi_r > 1 || ci_r > 1 {
         emit_merge_reshape(
@@ -332,7 +332,7 @@ fn decompose_dot(input: DotDecomposeInput<'_>, emitter: &mut InstructionEmitter<
                 side: MergeSide::Rhs,
             },
             instr.dtype,
-            emitter,
+            builder,
         )
     } else {
         rhs_after_transpose
@@ -350,7 +350,7 @@ fn decompose_dot(input: DotDecomposeInput<'_>, emitter: &mut InstructionEmitter<
     let needs_output_reshape = fi_l > 1 || fi_r > 1;
 
     let canonical_output_slot = if needs_output_reshape {
-        emitter.next_slot()
+        builder.next_slot()
     } else {
         instr.output_slots[0]
     };
@@ -374,7 +374,7 @@ fn decompose_dot(input: DotDecomposeInput<'_>, emitter: &mut InstructionEmitter<
             .push(lhs_canon.extents[lhs_free_count_canon + 1 + axis_offset].clone());
     }
 
-    emitter.push(ExecInstruction {
+    builder.push(ExecInstruction {
         op: if input.lhs_conj || input.rhs_conj {
             ExecOp::DotGeneralWithConj {
                 config: canonical_config,
@@ -413,7 +413,7 @@ fn decompose_dot(input: DotDecomposeInput<'_>, emitter: &mut InstructionEmitter<
         // directly, which we cloned from `instr` above.
         let metadata_shape = instr.output_shapes[0].clone();
 
-        emitter.push(ExecInstruction {
+        builder.push(ExecInstruction {
             op: ExecOp::Reshape {
                 shape: to_shape.clone(),
             },
@@ -431,7 +431,7 @@ fn emit_transpose_if_needed(
     operand: OperandMeta<'_>,
     target_perm: &[usize],
     dtype: DType,
-    emitter: &mut InstructionEmitter<'_>,
+    builder: &mut InstructionBuilder<'_>,
 ) -> EmittedOperand {
     let is_identity = target_perm.iter().enumerate().all(|(i, &p)| i == p);
     if is_identity {
@@ -449,8 +449,8 @@ fn emit_transpose_if_needed(
         .iter()
         .map(|&axis| operand.extents[axis].clone())
         .collect();
-    let out_slot = emitter.next_slot();
-    emitter.push(ExecInstruction {
+    let out_slot = builder.next_slot();
+    builder.push(ExecInstruction {
         op: ExecOp::Transpose {
             perm: target_perm.to_vec(),
         },
@@ -472,7 +472,7 @@ fn emit_merge_reshape(
     operand: &EmittedOperand,
     spec: MergeReshapeSpec,
     dtype: DType,
-    emitter: &mut InstructionEmitter<'_>,
+    builder: &mut InstructionBuilder<'_>,
 ) -> EmittedOperand {
     let to_shape = match spec.side {
         MergeSide::Lhs => lhs_merge_shape(spec),
@@ -483,8 +483,8 @@ fn emit_merge_reshape(
         MergeSide::Rhs => rhs_merge_meta(operand, spec),
     };
 
-    let out_slot = emitter.next_slot();
-    emitter.push(ExecInstruction {
+    let out_slot = builder.next_slot();
+    builder.push(ExecInstruction {
         op: ExecOp::Reshape { shape: to_shape },
         input_slots: vec![operand.slot],
         output_slots: vec![out_slot],

--- a/tenferro-runtime/src/compiler/mod.rs
+++ b/tenferro-runtime/src/compiler/mod.rs
@@ -69,7 +69,7 @@ pub fn compile_std_to_exec(
                 .collect();
 
             let (output_dtype, output_shapes, output_extents) = if let StdTensorOp::Extension(ext) =
-                &instr.op
+                &instr.operation
             {
                 let metas =
                     infer_extension_output_meta(ext.as_ref(), &input_dtypes, &input_shapes_refs);
@@ -100,14 +100,14 @@ pub fn compile_std_to_exec(
                 let extents = exact_extents_from_shapes(&shapes);
                 (dtype, shapes, extents)
             } else {
-                let dtype = infer_output_dtype(&instr.op, &input_dtypes);
-                let shapes = infer_output_shapes(&instr.op, &input_shapes_refs);
-                let extents = infer_output_extents(&instr.op, &input_shapes_refs);
+                let dtype = infer_output_dtype(&instr.operation, &input_dtypes);
+                let shapes = infer_output_shapes(&instr.operation, &input_shapes_refs);
+                let extents = infer_output_extents(&instr.operation, &input_shapes_refs);
                 assert_eq!(
                     shapes.len(),
                     instr.outputs.len(),
                     "compile_std_to_exec: {:?} inferred {} output shapes for {} output slots",
-                    instr.op,
+                    instr.operation,
                     shapes.len(),
                     instr.outputs.len()
                 );
@@ -115,7 +115,7 @@ pub fn compile_std_to_exec(
                     extents.len(),
                     instr.outputs.len(),
                     "compile_std_to_exec: {:?} inferred {} output extents for {} output slots",
-                    instr.op,
+                    instr.operation,
                     extents.len(),
                     instr.outputs.len()
                 );
@@ -136,7 +136,7 @@ pub fn compile_std_to_exec(
             }
 
             ExecInstruction {
-                op: ExecOp::from_std_tensor_op(&instr.op),
+                op: ExecOp::from_std_tensor_op(&instr.operation),
                 input_slots: instr.inputs.clone(),
                 output_slots: instr.outputs.clone(),
                 dtype: output_dtype,

--- a/tenferro-runtime/src/exec/tests.rs
+++ b/tenferro-runtime/src/exec/tests.rs
@@ -375,11 +375,11 @@ impl ExtensionOp for TestExtension {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 

--- a/tenferro-runtime/src/extension.rs
+++ b/tenferro-runtime/src/extension.rs
@@ -19,14 +19,14 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use computegraph::fragment::FragmentBuilder;
-use computegraph::types::{OpMode, ValRef};
+use computegraph::graph::GraphBuilder;
+use computegraph::types::{OperationRole, ValueRef};
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::SymDim;
 
 use crate::checkpoint::CheckpointNode;
-use crate::metadata::{push_metadata_scope, register_scoped_fragment_metadata};
+use crate::metadata::{push_metadata_scope, register_scoped_graph_metadata};
 use crate::traced::{next_traced_id, TracedTensor};
 
 pub use tenferro_ops::ext_op::ExtensionOp as ExtensionOpTrait;
@@ -47,7 +47,7 @@ pub use crate::extension_runtime::{
 /// output slot of the extension. Output shapes are inferred via
 /// [`ExtensionOp::infer_output_meta`] using the input shape hints.
 ///
-/// `inputs.len()` must equal `op.n_inputs()`, and each input's
+/// `inputs.len()` must equal `op.input_count()`, and each input's
 /// `shape_hint` must be present (i.e. the extension must be used on
 /// tensors whose rank is known at graph-build time). For symbolic-shape
 /// composition, bind the placeholder tensors via
@@ -71,8 +71,8 @@ pub use crate::extension_runtime::{
 /// #     }
 /// #     fn clone_arc(&self) -> Arc<dyn ExtensionOpTrait> { Arc::new(self.clone()) }
 /// #     fn as_any(&self) -> &dyn Any { self }
-/// #     fn n_inputs(&self) -> usize { 1 }
-/// #     fn n_outputs(&self) -> usize { 1 }
+/// #     fn input_count(&self) -> usize { 1 }
+/// #     fn output_count(&self) -> usize { 1 }
 /// #     fn infer_output_meta(
 /// #         &self,
 /// #         dtypes: &[DType],
@@ -92,10 +92,10 @@ pub use crate::extension_runtime::{
 pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Vec<TracedTensor> {
     assert_eq!(
         inputs.len(),
-        op.n_inputs(),
+        op.input_count(),
         "extension::apply: op family {:?} expects {} inputs, got {}",
         op.family_id(),
-        op.n_inputs(),
+        op.input_count(),
         inputs.len()
     );
 
@@ -122,29 +122,29 @@ pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Vec<TracedTe
     let output_metas = op.infer_output_meta(&input_dtypes, &input_shape_refs);
     assert_eq!(
         output_metas.len(),
-        op.n_outputs(),
+        op.output_count(),
         "extension::apply: op family {:?} declared {} outputs but \
          infer_output_meta returned {}",
         op.family_id(),
-        op.n_outputs(),
+        op.output_count(),
         output_metas.len()
     );
 
-    // Build the fragment that carries the Extension op.
-    let mut builder = FragmentBuilder::<StdTensorOp>::new();
+    // Build the graph that carries the Extension op.
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
     for input in inputs {
-        builder.add_parent(input.fragment.clone());
+        builder.add_parent(input.graph.clone());
     }
-    let op_inputs: Vec<ValRef<StdTensorOp>> = inputs
+    let op_inputs: Vec<ValueRef<StdTensorOp>> = inputs
         .iter()
-        .map(|t| ValRef::External(t.fragment.vals()[t.val].key.clone()))
+        .map(|t| ValueRef::External(t.graph.values()[t.val].key.clone()))
         .collect();
     let carrier = StdTensorOp::Extension(op.clone());
-    let outputs = builder.add_op(carrier, op_inputs, OpMode::Primal);
+    let outputs = builder.add_operation(carrier, op_inputs, OperationRole::Primary);
     builder.set_outputs(outputs.clone());
-    let fragment = Arc::new(builder.build());
-    let metadata_scope = Arc::new(register_scoped_fragment_metadata(
-        fragment.as_ref(),
+    let graph = Arc::new(builder.build());
+    let metadata_scope = Arc::new(register_scoped_graph_metadata(
+        graph.as_ref(),
         std::iter::empty(),
     ));
 
@@ -187,7 +187,7 @@ pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Vec<TracedTe
                 id: next_traced_id(),
                 rank: shape.len(),
                 dtype,
-                fragment: fragment.clone(),
+                graph: graph.clone(),
                 val,
                 data: None,
                 shape_hint,

--- a/tenferro-runtime/src/graph/compiler.rs
+++ b/tenferro-runtime/src/graph/compiler.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use computegraph::compile::compile;
 use computegraph::materialize::materialize_merge;
 use computegraph::resolve::resolve;
-use computegraph::types::GlobalValKey;
+use computegraph::types::ValueKey;
 use lru::LruCache;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
@@ -305,7 +305,7 @@ impl GraphCompiler {
         let mut output_keys = Vec::with_capacity(outputs.len());
         for output in outputs {
             roots.extend(output.resolve_roots());
-            output_keys.push(output.fragment.vals()[output.val].key.clone());
+            output_keys.push(output.graph.values()[output.val].key.clone());
         }
 
         let view = resolve(roots);
@@ -316,7 +316,7 @@ impl GraphCompiler {
         let mut input_dtypes = Vec::with_capacity(graph.inputs.len());
         let mut input_shapes = Vec::with_capacity(graph.inputs.len());
         for key in &graph.inputs {
-            let GlobalValKey::Input(input_key) = key else {
+            let ValueKey::Input(input_key) = key else {
                 return Err(Error::Internal(
                     "expected Input key in graph inputs".to_string(),
                 ));

--- a/tenferro-runtime/src/metadata.rs
+++ b/tenferro-runtime/src/metadata.rs
@@ -1,5 +1,5 @@
-use computegraph::fragment::Fragment;
-use computegraph::types::{GlobalValKey, LocalValId, ValRef};
+use computegraph::graph::Graph;
+use computegraph::types::{LocalValueId, ValueKey, ValueRef};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -38,37 +38,37 @@ pub fn tensor_meta_from_tensor(tensor: &Tensor) -> TensorMeta {
 }
 
 pub fn register_scoped_value_metadata(
-    key: GlobalValKey<StdTensorOp>,
+    key: ValueKey<StdTensorOp>,
     meta: TensorMeta,
 ) -> MetadataScope {
     register_scoped_global_metadata_batch([(key, meta)])
 }
 
 pub fn register_scoped_metadata_batch(
-    entries: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
+    entries: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
 ) -> MetadataScope {
     register_scoped_global_metadata_batch(entries)
 }
 
-pub fn registered_meta(key: &GlobalValKey<StdTensorOp>) -> TensorMeta {
+pub fn registered_meta(key: &ValueKey<StdTensorOp>) -> TensorMeta {
     lookup_global_metadata(key)
         .unwrap_or_else(|| panic!("metadata lookup: missing registered metadata for {:?}", key))
 }
 
-pub fn register_scoped_fragment_metadata(
-    fragment: &Fragment<StdTensorOp>,
-    seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
+pub fn register_scoped_graph_metadata(
+    graph: &Graph<StdTensorOp>,
+    seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
 ) -> MetadataScope {
-    register_scoped_global_metadata_batch(fragment_metadata_registrations(fragment, None, seeded))
+    register_scoped_global_metadata_batch(graph_metadata_registrations(graph, None, seeded))
 }
 
-pub fn register_scoped_live_fragment_metadata(
-    fragment: &Fragment<StdTensorOp>,
-    live_values: &HashSet<LocalValId>,
-    seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
+pub fn register_scoped_live_graph_metadata(
+    graph: &Graph<StdTensorOp>,
+    live_values: &HashSet<LocalValueId>,
+    seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
 ) -> MetadataScope {
-    register_scoped_global_metadata_batch(fragment_metadata_registrations(
-        fragment,
+    register_scoped_global_metadata_batch(graph_metadata_registrations(
+        graph,
         Some(live_values),
         seeded,
     ))
@@ -125,23 +125,22 @@ fn extend_metadata_scopes<'a>(
     }
 }
 
-fn fragment_metadata_registrations(
-    fragment: &Fragment<StdTensorOp>,
-    live_values: Option<&HashSet<LocalValId>>,
-    seeded: impl IntoIterator<Item = (GlobalValKey<StdTensorOp>, TensorMeta)>,
-) -> Vec<(GlobalValKey<StdTensorOp>, TensorMeta)> {
+fn graph_metadata_registrations(
+    graph: &Graph<StdTensorOp>,
+    live_values: Option<&HashSet<LocalValueId>>,
+    seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
+) -> Vec<(ValueKey<StdTensorOp>, TensorMeta)> {
     let seeded: Vec<_> = seeded.into_iter().collect();
     // Start from just the seeded inputs. External keys not in `seeded` are
     // resolved on demand via a single-key lookup against the global
     // registry — crucially, we do NOT clone the entire global map. The
     // global registry grows monotonically across a process, so a full-map
-    // snapshot per fragment construction is quadratic in the total number
+    // snapshot per graph construction is quadratic in the total number
     // of registered ops and dominated oracle_replay runtime.
-    let mut known: HashMap<GlobalValKey<StdTensorOp>, TensorMeta> =
-        seeded.iter().cloned().collect();
+    let mut known: HashMap<ValueKey<StdTensorOp>, TensorMeta> = seeded.iter().cloned().collect();
 
     let mut registrations = seeded;
-    for op_node in fragment.ops() {
+    for op_node in graph.operations() {
         if let Some(live_values) = live_values {
             if !op_node
                 .outputs
@@ -157,8 +156,8 @@ fn fragment_metadata_registrations(
             .iter()
             .map(|input| {
                 let key = match input {
-                    ValRef::Local(local_id) => &fragment.vals()[*local_id].key,
-                    ValRef::External(key) => key,
+                    ValueRef::Local(local_id) => &graph.values()[*local_id].key,
+                    ValueRef::External(key) => key,
                 };
                 known
                     .get(key)
@@ -173,9 +172,9 @@ fn fragment_metadata_registrations(
             })
             .collect();
 
-        let output_metas = infer_output_metas(&op_node.op, &input_metas);
+        let output_metas = infer_output_metas(&op_node.operation, &input_metas);
         for (&output_id, meta) in op_node.outputs.iter().zip(output_metas) {
-            let key = fragment.vals()[output_id].key.clone();
+            let key = graph.values()[output_id].key.clone();
             known.insert(key.clone(), meta.clone());
             registrations.push((key, meta));
         }

--- a/tenferro-runtime/src/segment.rs
+++ b/tenferro-runtime/src/segment.rs
@@ -411,7 +411,7 @@ fn build_elementwise_fusion_plan(
 
     Some(ElementwiseFusionPlan {
         dtype,
-        n_inputs: input_slots.len(),
+        input_count: input_slots.len(),
         outputs,
         ops,
     })

--- a/tenferro-runtime/src/shape_infer.rs
+++ b/tenferro-runtime/src/shape_infer.rs
@@ -335,7 +335,7 @@ pub fn infer_output_extents(
 /// [`infer_output_dtype`] only returns the first slot's dtype. Prefer this
 /// when populating `ExecInstruction` fields.
 ///
-/// `input_dtypes` must have length `op.n_inputs()` and be consistent with
+/// `input_dtypes` must have length `op.input_count()` and be consistent with
 /// `input_shapes`. `input_shapes` uses [`DimExpr`] expressions so shape
 /// inference can flow through composed symbolic graphs.
 pub fn infer_extension_output_meta(
@@ -406,7 +406,7 @@ fn extension_first_output_dtype(op: &dyn ExtensionOp, input_dtypes: &[DType]) ->
     // unknown to the caller. Extensions whose dtype depends on shape must
     // be handled through [`infer_extension_output_meta`], which
     // `compile_std_to_exec` prefers for the `Extension` arm.
-    let empty_rows: Vec<&[SymDim]> = (0..op.n_inputs()).map(|_| [].as_slice()).collect();
+    let empty_rows: Vec<&[SymDim]> = (0..op.input_count()).map(|_| [].as_slice()).collect();
     let metas = op.infer_output_meta(input_dtypes, &empty_rows);
     if metas.is_empty() {
         panic!(

--- a/tenferro-runtime/src/shape_packing.rs
+++ b/tenferro-runtime/src/shape_packing.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use computegraph::fragment::FragmentBuilder;
-use computegraph::types::{OpMode, ValRef};
+use computegraph::graph::GraphBuilder;
+use computegraph::types::{OperationRole, ValueRef};
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{GatherConfig, Tensor, TypedTensor};
 
 use crate::checkpoint::CheckpointNode;
 use crate::error::{Error, Result};
-use crate::metadata::{metadata_scopes_with_new, register_scoped_fragment_metadata};
+use crate::metadata::{metadata_scopes_with_new, register_scoped_graph_metadata};
 use crate::shape_infer::promote_dtypes;
 use crate::sym_dim::SymDim;
 use crate::traced::{apply_binary_preserve_input_dtypes, next_traced_id, try_concrete_shape};
@@ -226,25 +226,25 @@ fn apply_nary_concatenate(
         })
         .collect::<Vec<_>>();
 
-    let mut builder = FragmentBuilder::new();
+    let mut builder = GraphBuilder::new();
     for tensor in &tensors {
-        builder.add_parent(tensor.fragment.clone());
+        builder.add_parent(tensor.graph.clone());
     }
     let input_refs = tensors
         .iter()
-        .map(|tensor| ValRef::External(tensor.fragment.vals()[tensor.val].key.clone()))
+        .map(|tensor| ValueRef::External(tensor.graph.values()[tensor.val].key.clone()))
         .collect::<Vec<_>>();
-    let outputs = builder.add_op(
+    let outputs = builder.add_operation(
         StdTensorOp::Concatenate {
             axis,
-            n_inputs: tensors.len(),
+            input_count: tensors.len(),
         },
         input_refs,
-        OpMode::Primal,
+        OperationRole::Primary,
     );
     builder.set_outputs(outputs.clone());
-    let fragment = Arc::new(builder.build());
-    let metadata_scope = register_scoped_fragment_metadata(fragment.as_ref(), std::iter::empty());
+    let graph = Arc::new(builder.build());
+    let metadata_scope = register_scoped_graph_metadata(graph.as_ref(), std::iter::empty());
 
     let mut inputs_map = HashMap::new();
     let mut extra_roots = Vec::new();
@@ -269,7 +269,7 @@ fn apply_nary_concatenate(
         id: next_traced_id(),
         rank: out_shape.len(),
         dtype: out_dtype,
-        fragment,
+        graph,
         val: outputs[0],
         data: None,
         shape_hint: Some(out_shape.into_iter().map(SymDim::from).collect()),

--- a/tenferro-runtime/src/traced.rs
+++ b/tenferro-runtime/src/traced.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use computegraph::fragment::{Fragment, FragmentBuilder};
-use computegraph::types::{GlobalValKey, OpMode, ValRef};
-use computegraph::LocalValId;
+use computegraph::graph::{Graph, GraphBuilder};
+use computegraph::types::{OperationRole, ValueKey, ValueRef};
+use computegraph::LocalValueId;
 use num_complex::{Complex32, Complex64};
 use tenferro_ops::broadcast::{broadcast_input_plan, broadcast_shape, broadcast_shapes};
 use tenferro_ops::dim_expr::DimExpr;
@@ -17,7 +17,7 @@ use super::sym_dim::SymDim;
 use crate::checkpoint::CheckpointNode;
 use crate::metadata::{
     concrete_tensor_meta, metadata_scopes_for_scope, metadata_scopes_with_new, push_metadata_scope,
-    register_scoped_fragment_metadata, register_scoped_value_metadata, symbolic_input_meta,
+    register_scoped_graph_metadata, register_scoped_value_metadata, symbolic_input_meta,
     tensor_meta, MetadataScope,
 };
 use crate::scalar_semantics::round_real_to_i64;
@@ -42,12 +42,12 @@ pub struct TracedTensor {
     pub id: TracedTensorId,
     pub rank: usize,
     pub dtype: DType,
-    pub fragment: Arc<Fragment<StdTensorOp>>,
-    pub val: LocalValId,
+    pub graph: Arc<Graph<StdTensorOp>>,
+    pub val: LocalValueId,
     pub data: Option<Arc<Tensor>>,
     pub(crate) shape_hint: Option<Vec<SymDim>>,
     pub(crate) inputs_map: Arc<HashMap<TensorInputKey, Arc<Tensor>>>,
-    pub(crate) extra_roots: Vec<Arc<Fragment<StdTensorOp>>>,
+    pub(crate) extra_roots: Vec<Arc<Graph<StdTensorOp>>>,
     pub(crate) checkpoint_chain: Option<Arc<CheckpointNode>>,
     pub(crate) metadata_scopes: Vec<Arc<MetadataScope>>,
 }
@@ -218,12 +218,12 @@ impl TracedTensor {
         let id = next_traced_id();
         let data = Arc::new(tensor);
 
-        let mut builder = FragmentBuilder::new();
+        let mut builder = GraphBuilder::new();
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
-        let fragment = Arc::new(builder.build());
+        let graph = Arc::new(builder.build());
         let metadata_scope = register_scoped_value_metadata(
-            fragment.vals()[val].key.clone(),
+            graph.values()[val].key.clone(),
             concrete_tensor_meta(dtype, &shape),
         );
 
@@ -234,7 +234,7 @@ impl TracedTensor {
             id,
             rank,
             dtype,
-            fragment,
+            graph,
             val,
             data: Some(data),
             shape_hint: Some(shape.into_iter().map(SymDim::from).collect()),
@@ -271,12 +271,12 @@ impl TracedTensor {
         let id = next_traced_id();
         let data = Arc::new(tensor);
 
-        let mut builder = FragmentBuilder::new();
+        let mut builder = GraphBuilder::new();
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
-        let fragment = Arc::new(builder.build());
+        let graph = Arc::new(builder.build());
         let metadata_scope = register_scoped_value_metadata(
-            fragment.vals()[val].key.clone(),
+            graph.values()[val].key.clone(),
             symbolic_input_meta(dtype, id, rank),
         );
 
@@ -287,7 +287,7 @@ impl TracedTensor {
             id,
             rank,
             dtype,
-            fragment,
+            graph,
             val,
             data: Some(data),
             shape_hint: None,
@@ -320,12 +320,12 @@ impl TracedTensor {
         let key = next_input_key();
         let id = next_traced_id();
 
-        let mut builder = FragmentBuilder::new();
+        let mut builder = GraphBuilder::new();
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
-        let fragment = Arc::new(builder.build());
+        let graph = Arc::new(builder.build());
         let metadata_scope = register_scoped_value_metadata(
-            fragment.vals()[val].key.clone(),
+            graph.values()[val].key.clone(),
             concrete_tensor_meta(dtype, &shape),
         );
 
@@ -333,7 +333,7 @@ impl TracedTensor {
             id,
             rank,
             dtype,
-            fragment,
+            graph,
             val,
             data: None,
             shape_hint: Some(shape.into_iter().map(SymDim::from).collect()),
@@ -364,12 +364,12 @@ impl TracedTensor {
         let key = next_input_key();
         let id = next_traced_id();
 
-        let mut builder = FragmentBuilder::new();
+        let mut builder = GraphBuilder::new();
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
-        let fragment = Arc::new(builder.build());
+        let graph = Arc::new(builder.build());
         let metadata_scope = register_scoped_value_metadata(
-            fragment.vals()[val].key.clone(),
+            graph.values()[val].key.clone(),
             symbolic_input_meta(dtype, id, rank),
         );
 
@@ -377,7 +377,7 @@ impl TracedTensor {
             id,
             rank,
             dtype,
-            fragment,
+            graph,
             val,
             data: None,
             shape_hint: None,
@@ -482,11 +482,11 @@ impl TracedTensor {
         concrete_shape(self)
     }
 
-    /// If this `TracedTensor` is a leaf (single-node input fragment),
+    /// If this `TracedTensor` is a leaf (single-node input graph),
     /// return its input key. Computed tensors return `None`.
     pub fn input_key(&self) -> Option<TensorInputKey> {
-        match &self.fragment.vals()[self.val].key {
-            GlobalValKey::Input(key) => Some(key.clone()),
+        match &self.graph.values()[self.val].key {
+            ValueKey::Input(key) => Some(key.clone()),
             _ => None,
         }
     }
@@ -1520,20 +1520,20 @@ pub(crate) fn apply_unary_with_dtype(
     out_shape_hint: Option<Vec<SymDim>>,
     out_dtype: DType,
 ) -> TracedTensor {
-    let mut builder = FragmentBuilder::new();
-    builder.add_parent(input.fragment.clone());
-    let input_ref = ValRef::External(input.fragment.vals()[input.val].key.clone());
-    let outputs = builder.add_op(op, vec![input_ref], OpMode::Primal);
+    let mut builder = GraphBuilder::new();
+    builder.add_parent(input.graph.clone());
+    let input_ref = ValueRef::External(input.graph.values()[input.val].key.clone());
+    let outputs = builder.add_operation(op, vec![input_ref], OperationRole::Primary);
     builder.set_outputs(outputs.clone());
-    let fragment = Arc::new(builder.build());
+    let graph = Arc::new(builder.build());
     let metadata_scope =
-        register_single_output_metadata(fragment.as_ref(), outputs[0], out_dtype, &out_shape_hint);
+        register_single_output_metadata(graph.as_ref(), outputs[0], out_dtype, &out_shape_hint);
 
     TracedTensor {
         id: next_traced_id(),
         rank: out_rank,
         dtype: out_dtype,
-        fragment,
+        graph,
         val: outputs[0],
         data: None,
         shape_hint: out_shape_hint,
@@ -1562,27 +1562,23 @@ pub(crate) fn apply_unary_with_shape_refs(
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
 ) -> TracedTensor {
-    let mut builder = FragmentBuilder::new();
-    builder.add_parent(input.fragment.clone());
+    let mut builder = GraphBuilder::new();
+    builder.add_parent(input.graph.clone());
     for t in shape_refs {
-        builder.add_parent(t.fragment.clone());
+        builder.add_parent(t.graph.clone());
     }
-    let mut op_inputs: Vec<ValRef<StdTensorOp>> = Vec::with_capacity(1 + shape_refs.len());
-    op_inputs.push(ValRef::External(
-        input.fragment.vals()[input.val].key.clone(),
+    let mut op_inputs: Vec<ValueRef<StdTensorOp>> = Vec::with_capacity(1 + shape_refs.len());
+    op_inputs.push(ValueRef::External(
+        input.graph.values()[input.val].key.clone(),
     ));
     for t in shape_refs {
-        op_inputs.push(ValRef::External(t.fragment.vals()[t.val].key.clone()));
+        op_inputs.push(ValueRef::External(t.graph.values()[t.val].key.clone()));
     }
-    let outputs = builder.add_op(op, op_inputs, OpMode::Primal);
+    let outputs = builder.add_operation(op, op_inputs, OperationRole::Primary);
     builder.set_outputs(outputs.clone());
-    let fragment = Arc::new(builder.build());
-    let metadata_scope = register_single_output_metadata(
-        fragment.as_ref(),
-        outputs[0],
-        input.dtype,
-        &out_shape_hint,
-    );
+    let graph = Arc::new(builder.build());
+    let metadata_scope =
+        register_single_output_metadata(graph.as_ref(), outputs[0], input.dtype, &out_shape_hint);
 
     let mut merged = (*input.inputs_map).clone();
     for t in shape_refs {
@@ -1604,7 +1600,7 @@ pub(crate) fn apply_unary_with_shape_refs(
         id: next_traced_id(),
         rank: out_rank,
         dtype: input.dtype,
-        fragment,
+        graph,
         val: outputs[0],
         data: None,
         shape_hint: out_shape_hint,
@@ -1630,18 +1626,18 @@ pub(crate) fn apply_nullary(
     dtype: DType,
     shape_hint: Option<Vec<SymDim>>,
 ) -> TracedTensor {
-    let mut builder = FragmentBuilder::new();
-    let outputs = builder.add_op(op, vec![], OpMode::Primal);
+    let mut builder = GraphBuilder::new();
+    let outputs = builder.add_operation(op, vec![], OperationRole::Primary);
     builder.set_outputs(outputs.clone());
-    let fragment = Arc::new(builder.build());
+    let graph = Arc::new(builder.build());
     let metadata_scope =
-        register_single_output_metadata(fragment.as_ref(), outputs[0], dtype, &shape_hint);
+        register_single_output_metadata(graph.as_ref(), outputs[0], dtype, &shape_hint);
 
     TracedTensor {
         id: next_traced_id(),
         rank,
         dtype,
-        fragment,
+        graph,
         val: outputs[0],
         data: None,
         shape_hint,
@@ -1779,17 +1775,17 @@ fn apply_binary_with_output_dtype(
     out_shape_hint: Option<Vec<SymDim>>,
     out_dtype: DType,
 ) -> TracedTensor {
-    let lhs_ref = ValRef::External(lhs.fragment.vals()[lhs.val].key.clone());
-    let rhs_ref = ValRef::External(rhs.fragment.vals()[rhs.val].key.clone());
+    let lhs_ref = ValueRef::External(lhs.graph.values()[lhs.val].key.clone());
+    let rhs_ref = ValueRef::External(rhs.graph.values()[rhs.val].key.clone());
 
-    let mut builder = FragmentBuilder::new();
-    builder.add_parent(lhs.fragment.clone());
-    builder.add_parent(rhs.fragment.clone());
-    let outputs = builder.add_op(op, vec![lhs_ref, rhs_ref], OpMode::Primal);
+    let mut builder = GraphBuilder::new();
+    builder.add_parent(lhs.graph.clone());
+    builder.add_parent(rhs.graph.clone());
+    let outputs = builder.add_operation(op, vec![lhs_ref, rhs_ref], OperationRole::Primary);
     builder.set_outputs(outputs.clone());
-    let fragment = Arc::new(builder.build());
+    let graph = Arc::new(builder.build());
     let metadata_scope =
-        register_single_output_metadata(fragment.as_ref(), outputs[0], out_dtype, &out_shape_hint);
+        register_single_output_metadata(graph.as_ref(), outputs[0], out_dtype, &out_shape_hint);
 
     let mut merged = (*lhs.inputs_map).clone();
     merged.extend(rhs.inputs_map.iter().map(|(k, v)| (k.clone(), v.clone())));
@@ -1800,7 +1796,7 @@ fn apply_binary_with_output_dtype(
         id: next_traced_id(),
         rank: out_rank,
         dtype: out_dtype,
-        fragment,
+        graph,
         val: outputs[0],
         data: None,
         shape_hint: out_shape_hint,
@@ -1829,19 +1825,23 @@ fn apply_ternary_with_output_dtype(
     out_shape_hint: Option<Vec<SymDim>>,
     out_dtype: DType,
 ) -> TracedTensor {
-    let first_ref = ValRef::External(first.fragment.vals()[first.val].key.clone());
-    let second_ref = ValRef::External(second.fragment.vals()[second.val].key.clone());
-    let third_ref = ValRef::External(third.fragment.vals()[third.val].key.clone());
+    let first_ref = ValueRef::External(first.graph.values()[first.val].key.clone());
+    let second_ref = ValueRef::External(second.graph.values()[second.val].key.clone());
+    let third_ref = ValueRef::External(third.graph.values()[third.val].key.clone());
 
-    let mut builder = FragmentBuilder::new();
-    builder.add_parent(first.fragment.clone());
-    builder.add_parent(second.fragment.clone());
-    builder.add_parent(third.fragment.clone());
-    let outputs = builder.add_op(op, vec![first_ref, second_ref, third_ref], OpMode::Primal);
+    let mut builder = GraphBuilder::new();
+    builder.add_parent(first.graph.clone());
+    builder.add_parent(second.graph.clone());
+    builder.add_parent(third.graph.clone());
+    let outputs = builder.add_operation(
+        op,
+        vec![first_ref, second_ref, third_ref],
+        OperationRole::Primary,
+    );
     builder.set_outputs(outputs.clone());
-    let fragment = Arc::new(builder.build());
+    let graph = Arc::new(builder.build());
     let metadata_scope =
-        register_single_output_metadata(fragment.as_ref(), outputs[0], out_dtype, &out_shape_hint);
+        register_single_output_metadata(graph.as_ref(), outputs[0], out_dtype, &out_shape_hint);
 
     let mut merged = (*first.inputs_map).clone();
     merged.extend(
@@ -1868,7 +1868,7 @@ fn apply_ternary_with_output_dtype(
         id: next_traced_id(),
         rank: out_rank,
         dtype: out_dtype,
-        fragment,
+        graph,
         val: outputs[0],
         data: None,
         shape_hint: out_shape_hint,
@@ -1887,25 +1887,25 @@ fn apply_ternary_with_output_dtype(
 }
 
 fn register_single_output_metadata(
-    fragment: &Fragment<StdTensorOp>,
-    output: LocalValId,
+    graph: &Graph<StdTensorOp>,
+    output: LocalValueId,
     dtype: DType,
     shape_hint: &Option<Vec<SymDim>>,
 ) -> MetadataScope {
     if let Some(shape) = shape_hint {
         register_scoped_value_metadata(
-            fragment.vals()[output].key.clone(),
+            graph.values()[output].key.clone(),
             tensor_meta(dtype, shape.clone()),
         )
     } else {
-        register_scoped_fragment_metadata(fragment, std::iter::empty())
+        register_scoped_graph_metadata(graph, std::iter::empty())
     }
 }
 
 impl TracedTensor {
-    pub(crate) fn resolve_roots(&self) -> Vec<Arc<Fragment<StdTensorOp>>> {
+    pub(crate) fn resolve_roots(&self) -> Vec<Arc<Graph<StdTensorOp>>> {
         let mut roots = Vec::with_capacity(1 + self.extra_roots.len());
-        roots.push(self.fragment.clone());
+        roots.push(self.graph.clone());
         roots.extend(self.extra_roots.iter().cloned());
         roots
     }

--- a/tenferro-runtime/tests/extension_runtime.rs
+++ b/tenferro-runtime/tests/extension_runtime.rs
@@ -41,11 +41,11 @@ impl ExtensionOp for IdentityRuntimeOp {
         self
     }
 
-    fn n_inputs(&self) -> usize {
+    fn input_count(&self) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn output_count(&self) -> usize {
         1
     }
 

--- a/tenferro-tensor/src/backend.rs
+++ b/tenferro-tensor/src/backend.rs
@@ -20,7 +20,7 @@ fn read_tensor<'a>(op: &'static str, input: TensorRead<'a>) -> crate::Result<&'a
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ElementwiseFusionPlan {
     pub dtype: crate::DType,
-    pub n_inputs: usize,
+    pub input_count: usize,
     pub outputs: Vec<usize>,
     pub ops: Vec<ElementwiseFusionInst>,
 }


### PR DESCRIPTION
## Summary

- Pins `computegraph-rs` to `691def2d82fd4367b397d61209449f68e82050b7` and `tidu-rs` to `9934d8b775fcfbbad8e2daf3f9af54477da63e35`.
- Migrates tenferro source/tests/extensions from the old Fragment/Emitter/Val/Op API to Graph/Value/Operation terminology.
- Replaces the removed `OpEmitter` boundary with `PrimitiveRuleBuilder`, renames eager builder internals, and updates current docs including `docs/architecture/primitive-ad.md`.
- Fixes the `tenferro-linalg/autodiff` compile failure reported in #964 by making linalg AD helpers accept the trait-object builder boundary used by extension rules.
- Adds work log: `docs/worklogs/2026-06-01-graph-terminology-migration.md`.

Companion PRs:

- computegraph-rs: https://github.com/tensor4all/computegraph-rs/pull/4
- tidu-rs: https://github.com/tensor4all/tidu-rs/pull/31

Fixes #964.

## Verification

- `cargo check --workspace --all-targets`
- `cargo check -p tenferro-linalg --features autodiff`
- `cargo fmt --all --check`
- `cargo fmt --manifest-path ext/tropical/Cargo.toml --all --check`
- `cargo test --workspace --release`
- `cargo test -p tenferro-linalg --features autodiff --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-doc-snippets.py --check`
- `python3 scripts/check-docs-site.py`
- `cargo clippy --workspace --all-targets --release -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `CUDARC_CUDA_VERSION=12080 cargo test --no-run --package tenferro-gpu --package tenferro-ad --package tenferro-linalg --features cuda --release`
- `git diff --check`
- old terminology scans over active source and current docs
