### PR TITLE
[codex] define maintainer governance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ Thanks for helping improve tenferro-rs. This file describes the external
 contribution path. Repository-specific implementation rules live in
 `REPOSITORY_RULES.md`.
 
+Governance, maintainer roles, merge authority, and project-direction decisions
+are defined in [GOVERNANCE.md](GOVERNANCE.md). The maintainer list is
+maintained in [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
 ## Agent-assisted workflows
 
 Agent-assisted issue and bug-fix PR preparation is supported.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,8 @@ Maintainers are the listed project stewards for tenferro-rs policy and release
 direction. GitHub write/admin access may be broader than this list and does not
 by itself confer maintainer status.
 
-- Hiroshi Shinaoka
+- Hiroshi Shinaoka (Lead Maintainer)
+- Satoshi Terasaki
 
 ## Contributors
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,53 @@
+# Governance
+
+tenferro-rs uses a maintainer-led governance model.
+
+The project aims to make decisions by discussion and rough consensus. When
+consensus is not available, the Lead Maintainer is the final arbiter of project
+direction.
+
+The current maintainers and Lead Maintainer designation are listed in
+[CONTRIBUTORS.md](CONTRIBUTORS.md).
+
+## Maintainers
+
+Maintainers have merge authority for tenferro-rs.
+
+Maintainers are responsible for reviewing contributions, preserving code
+quality, enforcing repository rules, keeping CI and validation expectations
+meaningful, and maintaining the parts of the project they accept changes for.
+
+Merge authority is not ownership of project direction. Maintainers are expected
+to follow the project's documented design goals, accepted issues, design
+records, repository rules, and decisions made through this governance process.
+
+Maintainers may merge bug fixes, documentation changes, cleanup, and accepted
+feature work when the change satisfies the repository's review and validation
+expectations.
+
+## Lead Maintainer
+
+The Lead Maintainer has final authority over project direction.
+
+This includes final decisions on architecture, public API policy, roadmap
+priorities, release strategy, breaking changes, maintainer appointments and
+removals, and unresolved technical disagreements.
+
+The Lead Maintainer should seek consensus first, but may make a final decision
+when consensus cannot be reached or when timely action is required.
+
+The Lead Maintainer is the final arbiter of direction, not the sole reviewer,
+sole contributor, or sole maintainer.
+
+## Contributors
+
+Contributors may participate through issues, pull requests, design discussions,
+documentation, examples, benchmarks, and external prototype code.
+
+Contributor recognition does not imply maintainer status, merge authority,
+copyright transfer, or ownership of project direction.
+
+## Changes To Governance
+
+Changes to this governance document require maintainer review and approval from
+the Lead Maintainer.

--- a/README.md
+++ b/README.md
@@ -114,3 +114,7 @@ reviewed first.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the external contribution policy and
 the supported AI-assisted issue-intake and bug-fix PR workflows across Codex
 CLI, Claude Code, and OpenCode.
+
+See [GOVERNANCE.md](GOVERNANCE.md) for maintainer roles, merge authority, and
+the project-direction decision model. Maintainers are listed in
+[CONTRIBUTORS.md](CONTRIBUTORS.md).


### PR DESCRIPTION
## Summary

- Add `GOVERNANCE.md` defining the maintainer-led governance model.
- Define maintainer merge authority and the Lead Maintainer's final authority over project direction.
- Keep the actual maintainer list in `CONTRIBUTORS.md`, marking Hiroshi Shinaoka as Lead Maintainer and adding Satoshi Terasaki as a maintainer.
- Link governance and maintainer-list docs from `README.md` and `CONTRIBUTING.md`.

## Why

The repository already referred to maintainer review, merge authority, and roadmap decisions, but those responsibilities were not defined in one place. This makes the role boundary explicit without putting individual names in the governance policy itself.

## Validation

- `git diff --check HEAD^ HEAD`
- Verified the branch compares cleanly against `main` as one commit ahead with the intended four files changed.

Rust tests were not run because this is a docs-only governance change.