### PR TITLE
[codex] fix linalg prepared solve execution

### DIFF
--- a/docs/spec/backend-contract.md
+++ b/docs/spec/backend-contract.md
@@ -66,6 +66,7 @@ pub struct ExecInstruction {
     pub output_slots: Vec<usize>,
     pub dtype: DType,
     pub output_shapes: Vec<Vec<DimExpr>>,
+    pub output_extents: Vec<Vec<ShapeExtent<DimExpr>>>,
     pub last_use: Vec<bool>,
 }
 ```
@@ -73,10 +74,14 @@ pub struct ExecInstruction {
 ### Core guarantees
 
 - Each instruction is SSA over slots: outputs are written once.
-- `dtype` is the inferred output dtype for that instruction.
+- `dtype` is a representative instruction dtype used by legacy single-output
+  paths. For multi-output extensions, per-output slot metadata is the
+  authoritative dtype source.
 - `output_shapes` contains one symbolic shape per output slot.
+- `output_extents` contains one extent vector per output slot.
 - `last_use` is populated after lowering and is used for buffer reclamation.
-- Multi-output linalg instructions write directly to multiple output slots.
+- Multi-output extension instructions write directly to multiple output slots
+  and may use mixed output dtypes.
 
 ### ExecOp vocabulary
 
@@ -114,10 +119,12 @@ variants.
 
 For each computegraph instruction it:
 
-1. infers the output dtype with `infer_output_dtype()`
-2. infers output shapes with `infer_output_shapes()`
+1. infers output dtype, shape, and extent metadata; extension instructions use
+   `infer_extension_output_meta()` for one `(dtype, shape)` pair per output
+   slot
+2. resolves output extents
 3. lowers `StdTensorOp` to `ExecOp`
-4. records output slot dtype/shape metadata
+4. records output slot dtype/shape/extent metadata
 5. runs the compiler passes on the resulting `ExecProgram`
 6. populates `last_use`
 

--- a/docs/worklogs/2026-06-02-linalg-prepared-solve.md
+++ b/docs/worklogs/2026-06-02-linalg-prepared-solve.md
@@ -1,0 +1,103 @@
+# Linalg prepared solve work log
+
+Date: 2026-06-02
+
+## Session summary
+
+This change reshapes linalg solve-related execution so eager, traced, and AD
+paths can reuse one LU factorization instead of repeatedly materializing public
+`P/L/U` outputs:
+
+- traced and eager `solve` now emit internal `LuFactor` plus
+  `LuSolvePrepared`,
+- traced `slogdet` consumes packed LU and parity instead of public `lu()`
+  outputs,
+- matrix norm `ord=2/-2` uses an internal singular-values-only op,
+- CUDA solve consumes packed LU and I32 pivots directly, applying pivots on the
+  device and using cuBLAS triangular solves,
+- linalg AD emits prepared solve linearization and transpose rules,
+- the runtime compiler now records extension output dtype/shape metadata per
+  output slot, which supports mixed-output extensions such as packed LU plus
+  I32 pivots.
+
+The user-visible linalg wrappers remain unchanged. Internal prepared operations
+are intentionally not exported as public wrapper APIs or hidden extension
+payload constructors.
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| `REPOSITORY_RULES.md` | Confirm public-surface, extension dispatch, AD, GPU, and work-log rules. | Kept prepared helpers internal and avoided hidden fallback paths. |
+| Shared tensor4all rules | Confirm cross-project public API, layering, performance, and numerical rules. | Fixed the compiler/runtime abstraction instead of adding a local workaround. |
+| `docs/design/gpu-backend-design.md` | Check CUDA ownership, launch, placement, and unsupported-op contracts. | Kept all pivot application and packed solve work on device. |
+| `docs/design/tensor-prims.md` | Check current backend/linalg surface ownership. | Left public linalg wrappers unchanged and used the linalg extension backend surface. |
+| `docs/spec/backend-contract.md` | Check compiled execution metadata contract. | Updated stale single-output dtype wording for mixed-dtype extension outputs. |
+| `../jax/jax/_src/lax/linalg.py` | Compare solve, LU solve, SVD, QR, and triangular solve structure. | Mirrored JAX's split between factorization and prepared solve for solve sensitivities; added singular-values-only SVD for norm. |
+
+## Reference code
+
+JAX implements `solve` by computing `lu(stop_gradient(a))` once and passing
+that factorization into `custom_linear_solve`, with both `solve` and
+`transpose_solve` delegating to `lu_solve`. JAX's `lu_solve` applies the
+permutation and then uses triangular solves over packed LU.
+
+JAX SVD has a `compute_uv=False` mode for singular values only. tenferro did
+not have a public `svd_values` wrapper in this change; it added only an
+internal extension op so norm does not allocate U/VT when it only needs
+singular values.
+
+QR, Cholesky, Eigh, and triangular solve did not show the same "public
+factorization materializes extra outputs before solve" problem. Their current
+tenferro paths still have ordinary performance work to do, but this batch did
+not find the same factor-reuse design flaw there.
+
+## Decisions made
+
+- **Use internal prepared ops rather than new public APIs.** `LuFactor`,
+  `LuSolvePrepared`, and `SvdVals` are extension payloads used by wrappers and
+  AD rules. They are not exposed as user-facing linalg functions, and their
+  payload construction is crate-local rather than a `#[doc(hidden)]` public
+  support surface.
+- **Store extension metadata per output slot.** `LuFactor` returns
+  `packed_lu`, I32 `pivots`, and `parity`; the compiler must not assume a
+  single dtype for every output of one instruction.
+- **Use bool flags at the backend trait boundary.** The public backend trait
+  needs a hidden prepared-solve hook for runtime dispatch, but it does not need
+  to expose a public `LuSolveMode` type.
+- **Keep CUDA solve on the backend.** CUDA prepared solve applies pivots and
+  runs triangular solves on device. It returns explicit errors for unsupported
+  variants instead of falling back to CPU or rebuilding a backend.
+- **Do not optimize CPU prepared solve in this batch.** CPU default prepared
+  solve preserves correctness by delegating to `solve`; CUDA is the path where
+  the observed regression was severe.
+
+## Rejected or deferred alternatives
+
+- **No public `lu_factor` / `lu_solve` wrappers in this PR.** They may be useful
+  later, but this batch only needs internal factor reuse.
+- **No squash of prepared ops into public `solve`.** AD needs to reference the
+  factorized boundary explicitly, matching the traced linearization model.
+- **No full CPU packed-LU solve optimization yet.** It is useful follow-up work
+  but not required to remove the CUDA eager regression.
+- **No FFT CUDA implementation in this PR.** FFT GPU support is tracked as
+  follow-up work.
+
+## Verification performed
+
+- `cargo fmt --all --check`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `cargo test -p tenferro-runtime`
+- `cargo test -p tenferro-linalg`
+- `cargo test -p tenferro-linalg --features autodiff`
+- `cargo test -p tenferro-linalg --features cuda`
+- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-linalg --features cuda -- --ignored`
+
+## Remaining risks
+
+- CPU prepared LU factor reuse remains a performance follow-up.
+- FFT CUDA execution remains unsupported and is tracked separately.

--- a/tenferro-linalg/src/ad.rs
+++ b/tenferro-linalg/src/ad.rs
@@ -32,7 +32,7 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
-use crate::ad_support::{LinalgExtensionOp, LinalgOp};
+use crate::extension::{LinalgExtensionOp, LinalgOp};
 use crate::LINALG_EXTENSION_FAMILY_ID;
 
 mod rules;
@@ -93,11 +93,21 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
         let op = downcast_ad_op(op, ADRuleKind::Jvp)?;
         let tangents = match op.op() {
             LinalgOp::Lu => rules::linearize_lu(builder, primal_in, primal_out, tangent_in, ctx),
+            LinalgOp::LuFactor => vec![None; op.output_count()],
+            LinalgOp::LuSolvePrepared {
+                transpose_a,
+                conjugate_a,
+            } => rules::linearize_lu_solve_prepared(
+                builder,
+                primal_in,
+                primal_out,
+                tangent_in,
+                transpose_a,
+                conjugate_a,
+                ctx,
+            ),
             LinalgOp::FullPivLu => {
                 rules::linearize_full_piv_lu(builder, primal_in, primal_out, tangent_in, ctx)
-            }
-            LinalgOp::Solve { transpose_a } => {
-                rules::linearize_solve(builder, primal_in, primal_out, tangent_in, transpose_a, ctx)
             }
             LinalgOp::FullPivLuSolve { transpose_a } => rules::linearize_full_piv_lu_solve(
                 builder,
@@ -128,6 +138,9 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
             }
             LinalgOp::Svd { eps } => {
                 rules::linearize_svd(builder, primal_in, primal_out, tangent_in, eps, ctx)
+            }
+            LinalgOp::SvdVals { eps } => {
+                rules::linearize_svd_values(builder, primal_in, tangent_in, eps, ctx)
             }
             LinalgOp::Qr => rules::linearize_qr(builder, primal_in, primal_out, tangent_in, ctx),
             LinalgOp::Eigh { eps } => {
@@ -168,9 +181,18 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
                 unit_diagonal,
                 ctx,
             ),
-            LinalgOp::Solve { transpose_a } => {
-                rules::transpose_solve(&mut builder, cotangent_out, inputs, mode, transpose_a, ctx)
-            }
+            LinalgOp::LuSolvePrepared {
+                transpose_a,
+                conjugate_a,
+            } => rules::transpose_lu_solve_prepared(
+                &mut builder,
+                cotangent_out,
+                inputs,
+                mode,
+                transpose_a,
+                conjugate_a,
+                ctx,
+            ),
             LinalgOp::FullPivLuSolve { transpose_a } => rules::transpose_full_piv_lu_solve(
                 &mut builder,
                 cotangent_out,
@@ -181,8 +203,10 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
             ),
             LinalgOp::Cholesky
             | LinalgOp::Lu
+            | LinalgOp::LuFactor
             | LinalgOp::FullPivLu
             | LinalgOp::Svd { .. }
+            | LinalgOp::SvdVals { .. }
             | LinalgOp::Qr
             | LinalgOp::Eigh { .. }
             | LinalgOp::Eig { .. } => vec![None; op.input_count()],

--- a/tenferro-linalg/src/ad/rules/mod.rs
+++ b/tenferro-linalg/src/ad/rules/mod.rs
@@ -3,7 +3,7 @@ use tenferro_ops::ad::PrimitiveRuleBuilder;
 
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 
-use crate::ad_support::{LinalgExtensionOp, LinalgOp};
+use crate::extension::{LinalgExtensionOp, LinalgOp};
 use tenferro_ops::ad::context::{resolve_and_guard, ShapeGuardContext};
 pub(crate) use tenferro_ops::ad::support::{
     conjugate_linear_if_dtype_complex, conjugate_primal_if_dtype_complex,
@@ -16,8 +16,8 @@ mod solve;
 mod support;
 
 pub(crate) use solve::{
-    linearize_full_piv_lu_solve, linearize_solve, linearize_triangular_solve,
-    transpose_full_piv_lu_solve, transpose_solve, transpose_triangular_solve,
+    linearize_full_piv_lu_solve, linearize_lu_solve_prepared, linearize_triangular_solve,
+    transpose_full_piv_lu_solve, transpose_lu_solve_prepared, transpose_triangular_solve,
 };
 use support::*;
 
@@ -463,6 +463,47 @@ pub(crate) fn linearize_svd(
     let dvt = adjoint_matrix_linear(builder, dv, matrix_rank, dtype);
 
     vec![Some(du), Some(ds), Some(dvt)]
+}
+
+pub(crate) fn linearize_svd_values(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+    eps: f64,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValueId>> {
+    let Some(da) = tangent_in[0] else {
+        return vec![None];
+    };
+
+    let input_shape = primal_input_shape(ctx, primal_in);
+    let input_shape = input_shape.as_slice();
+    let matrix_rank = input_shape.len();
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let svd_outputs = builder.add_operation(
+        linalg_std_op(LinalgOp::Svd { eps }),
+        vec![ValueRef::External(primal_in[0].clone())],
+        OperationRole::Primary,
+    );
+    let u = ValueRef::Local(svd_outputs[0]);
+    let vt = ValueRef::Local(svd_outputs[2]);
+    let uh = adjoint_matrix_fixed(builder, u, matrix_rank, dtype);
+    let v = adjoint_matrix_fixed(builder, vt, matrix_rank, dtype);
+    let tmp = matmul_linear(
+        builder,
+        ValueRef::Local(uh),
+        ValueRef::Local(da),
+        vec![false, true],
+        matrix_rank,
+    );
+    let ds_mat = matmul_linear(
+        builder,
+        ValueRef::Local(tmp),
+        ValueRef::Local(v),
+        vec![true, false],
+        matrix_rank,
+    );
+    vec![Some(extract_diag_linear(builder, ds_mat))]
 }
 
 pub(crate) fn linearize_eigh(

--- a/tenferro-linalg/src/ad/rules/solve.rs
+++ b/tenferro-linalg/src/ad/rules/solve.rs
@@ -3,10 +3,10 @@ use tenferro_ops::ad::context::ShapeGuardContext;
 use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 
-use crate::ad_support::LinalgOp;
+use crate::extension::LinalgOp;
 
 use super::support::*;
-use super::{conjugate_primal_if_dtype_complex, linalg_std_op};
+use super::{conjugate_linear_if_dtype_complex, conjugate_primal_if_dtype_complex, linalg_std_op};
 
 pub(crate) fn linearize_triangular_solve(
     builder: &mut dyn PrimitiveRuleBuilder,
@@ -77,20 +77,17 @@ pub(crate) fn linearize_triangular_solve(
 
 #[derive(Clone, Copy)]
 enum LinearSolveOp {
-    Solve,
     FullPivLuSolve,
 }
 
 fn linear_solve_op(kind: LinearSolveOp, transpose_a: bool) -> StdTensorOp {
     match kind {
-        LinearSolveOp::Solve => linalg_std_op(LinalgOp::Solve { transpose_a }),
         LinearSolveOp::FullPivLuSolve => linalg_std_op(LinalgOp::FullPivLuSolve { transpose_a }),
     }
 }
 
 fn linear_solve_op_name(kind: LinearSolveOp) -> &'static str {
     match kind {
-        LinearSolveOp::Solve => "linearize_solve",
         LinearSolveOp::FullPivLuSolve => "linearize_full_piv_lu_solve",
     }
 }
@@ -155,23 +152,70 @@ fn linearize_linear_solve(
     vec![Some(out[0])]
 }
 
-pub(crate) fn linearize_solve(
+pub(crate) fn linearize_lu_solve_prepared(
     builder: &mut dyn PrimitiveRuleBuilder,
     primal_in: &[ValueKey<StdTensorOp>],
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
     transpose_a: bool,
+    conjugate_a: bool,
     ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
-    linearize_linear_solve(
-        builder,
-        primal_in,
-        primal_out,
-        tangent_in,
-        transpose_a,
-        ctx,
-        LinearSolveOp::Solve,
-    )
+    let lhs_rank = ctx
+        .shape_of(&ValueRef::External(primal_in[0].clone()))
+        .len();
+    let rhs_rank = ctx
+        .shape_of(&ValueRef::External(primal_in[3].clone()))
+        .len();
+    assert!(
+        lhs_rank >= 2 && rhs_rank >= 2,
+        "linearize_lu_solve_prepared: expected matrix operands"
+    );
+    assert_eq!(
+        lhs_rank, rhs_rank,
+        "linearize_lu_solve_prepared: rank mismatch between lhs and rhs"
+    );
+    let rank = lhs_rank;
+    let mut rhs_tangent = tangent_in[3];
+
+    if let Some(da) = tangent_in[0] {
+        let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+        let d_op_a = match (transpose_a, conjugate_a) {
+            (false, false) => da,
+            (true, false) => transpose_matrix_linear(builder, da, rank),
+            (true, true) => adjoint_matrix_linear(builder, da, rank, dtype),
+            (false, true) => conjugate_linear_if_dtype_complex(builder, da, dtype),
+        };
+        let x = ValueRef::External(primal_out[0].clone());
+        let correction =
+            matmul_linear(builder, ValueRef::Local(d_op_a), x, vec![true, false], rank);
+        let neg_correction = linear_neg(builder, correction);
+        rhs_tangent = Some(match rhs_tangent {
+            Some(db) => linear_add(builder, db, neg_correction),
+            None => neg_correction,
+        });
+    }
+
+    let Some(rhs_tangent) = rhs_tangent else {
+        return vec![None];
+    };
+
+    let out = builder.add_operation(
+        linalg_std_op(LinalgOp::LuSolvePrepared {
+            transpose_a,
+            conjugate_a,
+        }),
+        vec![
+            ValueRef::External(primal_in[0].clone()),
+            ValueRef::External(primal_in[1].clone()),
+            ValueRef::External(primal_in[2].clone()),
+            ValueRef::Local(rhs_tangent),
+        ],
+        OperationRole::Linearized {
+            active_mask: vec![false, false, false, true],
+        },
+    );
+    vec![Some(out[0])]
 }
 
 pub(crate) fn linearize_full_piv_lu_solve(
@@ -352,23 +396,44 @@ fn transpose_linear_solve(
     result
 }
 
-pub(crate) fn transpose_solve(
+pub(crate) fn transpose_lu_solve_prepared(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
     transpose_a: bool,
-    ctx: &mut ShapeGuardContext,
+    conjugate_a: bool,
+    _ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
-    transpose_linear_solve(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        transpose_a,
-        ctx,
-        LinearSolveOp::Solve,
-    )
+    let Some(ct) = cotangent_out[0] else {
+        return vec![None, None, None, None];
+    };
+    let OperationRole::Linearized { active_mask } = mode else {
+        return vec![None, None, None, None];
+    };
+
+    let mut result = vec![None, None, None, None];
+    if active_mask[3] {
+        let (adjoint_transpose_a, adjoint_conjugate_a) =
+            adjoint_lu_solve_flags(transpose_a, conjugate_a);
+        let out = builder.add_operation(
+            linalg_std_op(LinalgOp::LuSolvePrepared {
+                transpose_a: adjoint_transpose_a,
+                conjugate_a: adjoint_conjugate_a,
+            }),
+            vec![
+                inputs[0].clone(),
+                inputs[1].clone(),
+                inputs[2].clone(),
+                ValueRef::Local(ct),
+            ],
+            OperationRole::Linearized {
+                active_mask: vec![false, false, false, true],
+            },
+        );
+        result[3] = Some(out[0]);
+    }
+    result
 }
 
 pub(crate) fn transpose_full_piv_lu_solve(
@@ -388,4 +453,12 @@ pub(crate) fn transpose_full_piv_lu_solve(
         ctx,
         LinearSolveOp::FullPivLuSolve,
     )
+}
+
+fn adjoint_lu_solve_flags(transpose_a: bool, conjugate_a: bool) -> (bool, bool) {
+    if !transpose_a && !conjugate_a {
+        (true, true)
+    } else {
+        (false, false)
+    }
 }

--- a/tenferro-linalg/src/ad/rules/support.rs
+++ b/tenferro-linalg/src/ad/rules/support.rs
@@ -4,7 +4,7 @@ use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{DType, DotGeneralConfig, PadConfig};
 
-use crate::ad_support::LinalgOp;
+use crate::extension::LinalgOp;
 
 use super::{conjugate_linear_if_dtype_complex, conjugate_primal_if_dtype_complex, linalg_std_op};
 
@@ -47,36 +47,26 @@ pub(super) fn solve_in_graph(
     builder: &mut dyn PrimitiveRuleBuilder,
     a: ValueRef<StdTensorOp>,
     b: ValueRef<StdTensorOp>,
-    rank: usize,
+    _rank: usize,
 ) -> LocalValueId {
-    let lu_outputs =
-        builder.add_operation(linalg_std_op(LinalgOp::Lu), vec![a], OperationRole::Primary);
-    let p = lu_outputs[0];
-    let l = lu_outputs[1];
-    let u = lu_outputs[2];
-    let pb = matmul_linear(builder, ValueRef::Local(p), b, vec![false, true], rank);
-    let z = builder.add_operation(
-        linalg_std_op(LinalgOp::TriangularSolve {
-            left_side: true,
-            lower: true,
-            transpose_a: false,
-            unit_diagonal: true,
-        }),
-        vec![ValueRef::Local(l), ValueRef::Local(pb)],
-        OperationRole::Linearized {
-            active_mask: vec![false, true],
-        },
-    )[0];
+    let lu_outputs = builder.add_operation(
+        linalg_std_op(LinalgOp::LuFactor),
+        vec![a.clone()],
+        OperationRole::Primary,
+    );
     builder.add_operation(
-        linalg_std_op(LinalgOp::TriangularSolve {
-            left_side: true,
-            lower: false,
+        linalg_std_op(LinalgOp::LuSolvePrepared {
             transpose_a: false,
-            unit_diagonal: false,
+            conjugate_a: false,
         }),
-        vec![ValueRef::Local(u), ValueRef::Local(z)],
+        vec![
+            a,
+            ValueRef::Local(lu_outputs[0]),
+            ValueRef::Local(lu_outputs[1]),
+            b,
+        ],
         OperationRole::Linearized {
-            active_mask: vec![false, true],
+            active_mask: vec![false, false, false, true],
         },
     )[0]
 }

--- a/tenferro-linalg/src/backend.rs
+++ b/tenferro-linalg/src/backend.rs
@@ -25,6 +25,16 @@ pub trait LinalgBackend: TensorBackend {
         unit_diagonal: bool,
     ) -> tenferro_tensor::Result<Tensor>;
     fn lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+    #[doc(hidden)]
+    fn lu_factor(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Err(tenferro_tensor::Error::backend_failure(
+            "lu_factor",
+            format!(
+                "backend {} does not implement internal packed LU factorization",
+                std::any::type_name::<Self>()
+            ),
+        ))
+    }
     fn full_piv_lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
     fn full_piv_lu_solve(
         &mut self,
@@ -33,6 +43,17 @@ pub trait LinalgBackend: TensorBackend {
         transpose_a: bool,
     ) -> tenferro_tensor::Result<Tensor>;
     fn svd(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+    #[doc(hidden)]
+    fn svd_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+        let mut outputs = self.svd(input)?.into_iter();
+        let _u = outputs.next();
+        outputs.next().ok_or_else(|| {
+            tenferro_tensor::Error::backend_failure(
+                "svd_values",
+                "backend svd returned no singular-value output",
+            )
+        })
+    }
 
     /// Compute a singular value decomposition from a borrowed tensor view.
     ///
@@ -65,4 +86,42 @@ pub trait LinalgBackend: TensorBackend {
     fn eigh(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
     fn eig(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
     fn solve(&mut self, a: &Tensor, b: &Tensor) -> tenferro_tensor::Result<Tensor>;
+    #[doc(hidden)]
+    fn lu_solve_prepared(
+        &mut self,
+        a: &Tensor,
+        _packed_lu: &Tensor,
+        _pivots: &Tensor,
+        b: &Tensor,
+        transpose_a: bool,
+        conjugate_a: bool,
+    ) -> tenferro_tensor::Result<Tensor> {
+        let a_conj;
+        let a_op = if conjugate_a {
+            a_conj = self.conj(a)?;
+            &a_conj
+        } else {
+            a
+        };
+        if transpose_a {
+            let perm = matrix_transpose_perm("lu_solve_prepared", a_op)?;
+            let a_t = self.transpose(a_op, &perm)?;
+            self.solve(&a_t, b)
+        } else {
+            self.solve(a_op, b)
+        }
+    }
+}
+
+fn matrix_transpose_perm(op: &'static str, input: &Tensor) -> tenferro_tensor::Result<Vec<usize>> {
+    let rank = input.shape().len();
+    if rank < 2 {
+        return Err(tenferro_tensor::Error::InvalidConfig {
+            op,
+            message: "matrix operand rank must be at least 2".into(),
+        });
+    }
+    let mut perm: Vec<usize> = (0..rank).collect();
+    perm.swap(0, 1);
+    Ok(perm)
 }

--- a/tenferro-linalg/src/cpu/backend.rs
+++ b/tenferro-linalg/src/cpu/backend.rs
@@ -226,6 +226,46 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
+    fn lu_factor(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
+        ensure_host_tensor("lu_factor", input)?;
+        let outputs = self.lu(input)?;
+        let [_p, l, u, parity] = outputs.as_slice() else {
+            return Err(Error::backend_failure(
+                "lu_factor",
+                "public LU returned an unexpected number of outputs",
+            ));
+        };
+        let (packed_lu, parity) = match (input, l, u, parity) {
+            (Tensor::F32(input), Tensor::F32(l), Tensor::F32(u), Tensor::F32(parity)) => (
+                Tensor::F32(pack_lu_from_public_outputs(input, l, u)?),
+                Tensor::F32(parity.clone()),
+            ),
+            (Tensor::F64(input), Tensor::F64(l), Tensor::F64(u), Tensor::F64(parity)) => (
+                Tensor::F64(pack_lu_from_public_outputs(input, l, u)?),
+                Tensor::F64(parity.clone()),
+            ),
+            (Tensor::C32(input), Tensor::C32(l), Tensor::C32(u), Tensor::C32(parity)) => (
+                Tensor::C32(pack_lu_from_public_outputs(input, l, u)?),
+                Tensor::C32(parity.clone()),
+            ),
+            (Tensor::C64(input), Tensor::C64(l), Tensor::C64(u), Tensor::C64(parity)) => (
+                Tensor::C64(pack_lu_from_public_outputs(input, l, u)?),
+                Tensor::C64(parity.clone()),
+            ),
+            (Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_), _, _, _) => {
+                return Err(unsupported_dtype("lu_factor", input.dtype()));
+            }
+            _ => {
+                return Err(Error::backend_failure(
+                    "lu_factor",
+                    "public LU returned outputs with unexpected dtypes",
+                ));
+            }
+        };
+        let pivots = Tensor::I32(identity_pivots(input.shape()));
+        Ok(vec![packed_lu, pivots, parity])
+    }
+
     fn full_piv_lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("full_piv_lu", input)?;
         match self.kind() {
@@ -684,6 +724,10 @@ fn has_zero_dim(shape: &[usize]) -> bool {
     shape.contains(&0)
 }
 
+fn batch_count(batch_shape: &[usize]) -> usize {
+    batch_shape.iter().product::<usize>().max(1)
+}
+
 fn batched_vector_rhs_shape(a: &Tensor, b: &Tensor) -> Option<Vec<usize>> {
     if b.shape().len() == 1 {
         return Some(vec![b.shape()[0], 1]);
@@ -715,6 +759,63 @@ fn zeros_like_tensor(input: &Tensor) -> Tensor {
         Tensor::C32(t) => Tensor::C32(TypedTensor::zeros(t.shape().to_vec())),
         Tensor::C64(t) => Tensor::C64(TypedTensor::zeros(t.shape().to_vec())),
     }
+}
+
+fn pack_lu_from_public_outputs<T: Clone + Default>(
+    input: &TypedTensor<T>,
+    l: &TypedTensor<T>,
+    u: &TypedTensor<T>,
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let shape = input.shape();
+    if shape.len() < 2 {
+        return Err(Error::RankMismatch {
+            op: "lu_factor",
+            expected: 2,
+            actual: shape.len(),
+        });
+    }
+    let m = shape[0];
+    let n = shape[1];
+    let k = m.min(n);
+    let batch_total = batch_count(&shape[2..]);
+    let matrix_len = m * n;
+    let l_stride = m * k;
+    let u_stride = k * n;
+    let mut data = vec![T::default(); matrix_len * batch_total];
+    for batch in 0..batch_total {
+        let packed_offset = batch * matrix_len;
+        let l_offset = batch * l_stride;
+        let u_offset = batch * u_stride;
+        for col in 0..n {
+            for row in 0..m {
+                let dst = packed_offset + row + col * m;
+                data[dst] = if row > col && col < k {
+                    l.host_data()[l_offset + row + col * m].clone()
+                } else if row <= col && row < k {
+                    u.host_data()[u_offset + row + col * k].clone()
+                } else {
+                    T::default()
+                };
+            }
+        }
+    }
+    Ok(TypedTensor::from_vec_col_major(shape.to_vec(), data))
+}
+
+fn identity_pivots(shape: &[usize]) -> TypedTensor<i32> {
+    let m = shape[0];
+    let n = shape[1];
+    let k = m.min(n);
+    let batch_total = batch_count(&shape[2..]);
+    let mut pivot_shape = vec![k];
+    pivot_shape.extend_from_slice(&shape[2..]);
+    let mut data = vec![0_i32; k * batch_total];
+    for batch in 0..batch_total {
+        for step in 0..k {
+            data[batch * k + step] = (step + 1) as i32;
+        }
+    }
+    TypedTensor::from_vec_col_major(pivot_shape, data)
 }
 
 // Used only by feature-disabled provider branches, so default feature builds

--- a/tenferro-linalg/src/eager_backend.rs
+++ b/tenferro-linalg/src/eager_backend.rs
@@ -36,6 +36,10 @@ impl LinalgBackend for EagerBackend {
         dispatch_linalg!(self, lu(input))
     }
 
+    fn lu_factor(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
+        dispatch_linalg!(self, lu_factor(input))
+    }
+
     fn full_piv_lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         dispatch_linalg!(self, full_piv_lu(input))
     }
@@ -51,6 +55,10 @@ impl LinalgBackend for EagerBackend {
 
     fn svd(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         dispatch_linalg!(self, svd(input))
+    }
+
+    fn svd_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+        dispatch_linalg!(self, svd_values(input))
     }
 
     fn svd_view(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -71,5 +79,20 @@ impl LinalgBackend for EagerBackend {
 
     fn solve(&mut self, a: &Tensor, b: &Tensor) -> tenferro_tensor::Result<Tensor> {
         dispatch_linalg!(self, solve(a, b))
+    }
+
+    fn lu_solve_prepared(
+        &mut self,
+        a: &Tensor,
+        packed_lu: &Tensor,
+        pivots: &Tensor,
+        b: &Tensor,
+        transpose_a: bool,
+        conjugate_a: bool,
+    ) -> tenferro_tensor::Result<Tensor> {
+        dispatch_linalg!(
+            self,
+            lu_solve_prepared(a, packed_lu, pivots, b, transpose_a, conjugate_a)
+        )
     }
 }

--- a/tenferro-linalg/src/eager_tensor.rs
+++ b/tenferro-linalg/src/eager_tensor.rs
@@ -4,7 +4,7 @@ use tenferro_ad::error::{Error, Result};
 use tenferro_ad::extension::apply_eager;
 use tenferro_ad::EagerTensor;
 
-use crate::ad_support::{LinalgExtensionOp, LinalgOp};
+use crate::extension::{LinalgExtensionOp, LinalgOp};
 use crate::register_runtime;
 
 fn apply_linalg_eager(op: LinalgOp, inputs: &[&EagerTensor]) -> Result<Vec<EagerTensor>> {
@@ -194,8 +194,28 @@ pub fn full_piv_lu_solve(a: &EagerTensor, b: &EagerTensor) -> Result<EagerTensor
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
 pub fn solve(a: &EagerTensor, b: &EagerTensor) -> Result<EagerTensor> {
+    let mut factor_outputs = apply_linalg_eager(LinalgOp::LuFactor, &[a])?.into_iter();
+    let (packed_lu, pivots) = match (
+        factor_outputs.next(),
+        factor_outputs.next(),
+        factor_outputs.next(),
+        factor_outputs.next(),
+    ) {
+        (Some(packed_lu), Some(pivots), Some(_parity), None) => (packed_lu, pivots),
+        _ => {
+            return Err(Error::Internal(
+                "lu_factor eager op returned an unexpected number of outputs".to_string(),
+            ));
+        }
+    };
     one_output(
-        apply_linalg_eager(LinalgOp::Solve { transpose_a: false }, &[a, b])?,
+        apply_linalg_eager(
+            LinalgOp::LuSolvePrepared {
+                transpose_a: false,
+                conjugate_a: false,
+            },
+            &[a, &packed_lu, &pivots, b],
+        )?,
         "solve",
     )
 }

--- a/tenferro-linalg/src/extension.rs
+++ b/tenferro-linalg/src/extension.rs
@@ -9,18 +9,29 @@ use tenferro_tensor::{DType, DeviceKind, Error, GpuBackendKind, MemoryKind, Plac
 
 use crate::backend::LinalgBackend;
 
+#[cfg(all(test, not(feature = "cuda")))]
+mod tests;
+
 pub const LINALG_EXTENSION_FAMILY_ID: &str = "tenferro-linalg.linalg.v1";
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[doc(hidden)]
-pub enum LinalgOp {
+pub(crate) enum LinalgOp {
     Cholesky,
     Lu,
+    LuFactor,
+    LuSolvePrepared {
+        transpose_a: bool,
+        conjugate_a: bool,
+    },
     FullPivLu,
     FullPivLuSolve {
         transpose_a: bool,
     },
     Svd {
+        eps: f64,
+    },
+    SvdVals {
         eps: f64,
     },
     Qr,
@@ -29,9 +40,6 @@ pub enum LinalgOp {
     },
     Eig {
         input_dtype: DType,
-    },
-    Solve {
-        transpose_a: bool,
     },
     TriangularSolve {
         left_side: bool,
@@ -42,14 +50,16 @@ pub enum LinalgOp {
 }
 
 impl LinalgOp {
-    pub fn output_count(self) -> usize {
+    fn output_count(self) -> usize {
         match self {
             Self::Cholesky
             | Self::FullPivLuSolve { .. }
-            | Self::Solve { .. }
+            | Self::LuSolvePrepared { .. }
+            | Self::SvdVals { .. }
             | Self::TriangularSolve { .. } => 1,
             Self::Svd { .. } => 3,
             Self::Qr | Self::Eigh { .. } | Self::Eig { .. } => 2,
+            Self::LuFactor => 3,
             Self::Lu => 4,
             Self::FullPivLu => 5,
         }
@@ -57,7 +67,8 @@ impl LinalgOp {
 
     fn input_count(self) -> usize {
         match self {
-            Self::FullPivLuSolve { .. } | Self::Solve { .. } | Self::TriangularSolve { .. } => 2,
+            Self::FullPivLuSolve { .. } | Self::TriangularSolve { .. } => 2,
+            Self::LuSolvePrepared { .. } => 4,
             _ => 1,
         }
     }
@@ -72,24 +83,26 @@ impl LinalgOp {
             Self::Qr => 5,
             Self::Eigh { .. } => 6,
             Self::Eig { .. } => 7,
-            Self::Solve { .. } => 8,
             Self::TriangularSolve { .. } => 9,
+            Self::LuFactor => 10,
+            Self::LuSolvePrepared { .. } => 11,
+            Self::SvdVals { .. } => 12,
         }
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
 #[doc(hidden)]
-pub struct LinalgExtensionOp {
+pub(crate) struct LinalgExtensionOp {
     op: LinalgOp,
 }
 
 impl LinalgExtensionOp {
-    pub fn new(op: LinalgOp) -> Self {
+    pub(crate) fn new(op: LinalgOp) -> Self {
         Self { op }
     }
 
-    pub fn op(&self) -> LinalgOp {
+    pub(crate) fn op(&self) -> LinalgOp {
         self.op
     }
 }
@@ -187,10 +200,19 @@ impl ExtensionOpTrait for LinalgExtensionOp {
     fn payload_hash(&self, hasher: &mut dyn Hasher) {
         hasher.write_u8(self.op.tag());
         match self.op {
-            LinalgOp::Svd { eps } | LinalgOp::Eigh { eps } => hasher.write_u64(eps.to_bits()),
+            LinalgOp::Svd { eps } | LinalgOp::SvdVals { eps } | LinalgOp::Eigh { eps } => {
+                hasher.write_u64(eps.to_bits())
+            }
             LinalgOp::Eig { input_dtype } => hash_dtype(hasher, input_dtype),
-            LinalgOp::Solve { transpose_a } | LinalgOp::FullPivLuSolve { transpose_a } => {
+            LinalgOp::FullPivLuSolve { transpose_a } => {
                 hasher.write_u8(u8::from(transpose_a));
+            }
+            LinalgOp::LuSolvePrepared {
+                transpose_a,
+                conjugate_a,
+            } => {
+                hasher.write_u8(u8::from(transpose_a));
+                hasher.write_u8(u8::from(conjugate_a));
             }
             LinalgOp::TriangularSolve {
                 left_side,
@@ -203,7 +225,11 @@ impl ExtensionOpTrait for LinalgExtensionOp {
                 hasher.write_u8(u8::from(transpose_a));
                 hasher.write_u8(u8::from(unit_diagonal));
             }
-            LinalgOp::Cholesky | LinalgOp::Lu | LinalgOp::FullPivLu | LinalgOp::Qr => {}
+            LinalgOp::Cholesky
+            | LinalgOp::Lu
+            | LinalgOp::LuFactor
+            | LinalgOp::FullPivLu
+            | LinalgOp::Qr => {}
         }
     }
 
@@ -240,7 +266,6 @@ impl ExtensionOpTrait for LinalgExtensionOp {
         match self.op {
             LinalgOp::Cholesky
             | LinalgOp::FullPivLuSolve { .. }
-            | LinalgOp::Solve { .. }
             | LinalgOp::TriangularSolve { .. } => {
                 let output_shape = if self.input_count() == 1 {
                     input_shapes[0].to_vec()
@@ -249,9 +274,19 @@ impl ExtensionOpTrait for LinalgExtensionOp {
                 };
                 vec![(promote_dtypes(input_dtypes), output_shape)]
             }
+            LinalgOp::LuSolvePrepared { .. } => {
+                vec![(
+                    promote_dtypes(&[input_dtypes[0], input_dtypes[3]]),
+                    input_shapes[3].to_vec(),
+                )]
+            }
             LinalgOp::Lu => lu_meta(input_dtypes[0], input_shapes[0]),
+            LinalgOp::LuFactor => lu_factor_meta(input_dtypes[0], input_shapes[0]),
             LinalgOp::FullPivLu => full_piv_lu_meta(input_dtypes[0], input_shapes[0]),
             LinalgOp::Svd { .. } => svd_meta(input_dtypes[0], input_shapes[0]),
+            LinalgOp::SvdVals { .. } => {
+                vec![svd_values_meta(input_dtypes[0], input_shapes[0])]
+            }
             LinalgOp::Qr => qr_meta(input_dtypes[0], input_shapes[0]),
             LinalgOp::Eigh { .. } => eigh_meta(input_dtypes[0], input_shapes[0]),
             LinalgOp::Eig { input_dtype } => eig_meta(input_dtype, input_shapes[0]),
@@ -308,6 +343,18 @@ fn execute_linalg<B: LinalgBackend>(
     match op {
         LinalgOp::Cholesky => Ok(vec![backend.cholesky(inputs[0])?]),
         LinalgOp::Lu => backend.lu(inputs[0]),
+        LinalgOp::LuFactor => backend.lu_factor(inputs[0]),
+        LinalgOp::LuSolvePrepared {
+            transpose_a,
+            conjugate_a,
+        } => Ok(vec![backend.lu_solve_prepared(
+            inputs[0],
+            inputs[1],
+            inputs[2],
+            inputs[3],
+            transpose_a,
+            conjugate_a,
+        )?]),
         LinalgOp::FullPivLu => backend.full_piv_lu(inputs[0]),
         LinalgOp::FullPivLuSolve { transpose_a } => Ok(vec![backend.full_piv_lu_solve(
             inputs[0],
@@ -315,20 +362,10 @@ fn execute_linalg<B: LinalgBackend>(
             transpose_a,
         )?]),
         LinalgOp::Svd { .. } => backend.svd(inputs[0]),
+        LinalgOp::SvdVals { .. } => Ok(vec![backend.svd_values(inputs[0])?]),
         LinalgOp::Qr => backend.qr(inputs[0]),
         LinalgOp::Eigh { .. } => backend.eigh(inputs[0]),
         LinalgOp::Eig { .. } => backend.eig(inputs[0]),
-        LinalgOp::Solve { transpose_a } => {
-            let a_transposed;
-            let a = if transpose_a {
-                let perm = matrix_transpose_perm(inputs[0])?;
-                a_transposed = backend.transpose(inputs[0], &perm)?;
-                &a_transposed
-            } else {
-                inputs[0]
-            };
-            Ok(vec![backend.solve(a, inputs[1])?])
-        }
         LinalgOp::TriangularSolve {
             left_side,
             lower,
@@ -345,19 +382,6 @@ fn execute_linalg<B: LinalgBackend>(
     }
 }
 
-fn matrix_transpose_perm(input: &Tensor) -> tenferro_tensor::Result<Vec<usize>> {
-    let rank = input.shape().len();
-    if rank < 2 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "solve",
-            message: "matrix operand rank must be at least 2".into(),
-        });
-    }
-    let mut perm: Vec<usize> = (0..rank).collect();
-    perm.swap(0, 1);
-    Ok(perm)
-}
-
 fn lu_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
     let m = shape[0].clone();
     let n = shape[1].clone();
@@ -367,6 +391,18 @@ fn lu_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
         (dtype, matrix_shape(m.clone(), m, batch)),
         (dtype, matrix_shape(shape[0].clone(), k.clone(), batch)),
         (dtype, matrix_shape(k, n, batch)),
+        (dtype, batch.to_vec()),
+    ]
+}
+
+fn lu_factor_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
+    let m = shape[0].clone();
+    let n = shape[1].clone();
+    let k = m.min(n);
+    let batch = &shape[2..];
+    vec![
+        (dtype, shape.to_vec()),
+        (DType::I32, vector_shape(k, batch)),
         (dtype, batch.to_vec()),
     ]
 }
@@ -390,9 +426,17 @@ fn svd_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
     let batch = &shape[2..];
     vec![
         (dtype, matrix_shape(m, k.clone(), batch)),
-        (dtype, vector_shape(k.clone(), batch)),
+        (singular_values_dtype(dtype), vector_shape(k.clone(), batch)),
         (dtype, matrix_shape(k, n, batch)),
     ]
+}
+
+fn svd_values_meta(dtype: DType, shape: &[SymDim]) -> (DType, Vec<SymDim>) {
+    let m = shape[0].clone();
+    let n = shape[1].clone();
+    let k = m.min(n);
+    let batch = &shape[2..];
+    (singular_values_dtype(dtype), vector_shape(k, batch))
 }
 
 fn qr_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
@@ -442,6 +486,14 @@ fn eig_output_dtype(dtype: DType) -> DType {
         DType::F64 | DType::C64 => DType::C64,
         DType::F32 | DType::C32 => DType::C32,
         DType::I32 | DType::I64 | DType::Bool => DType::C64,
+    }
+}
+
+fn singular_values_dtype(dtype: DType) -> DType {
+    match dtype {
+        DType::C64 => DType::F64,
+        DType::C32 => DType::F32,
+        other => other,
     }
 }
 

--- a/tenferro-linalg/src/extension/tests.rs
+++ b/tenferro-linalg/src/extension/tests.rs
@@ -1,13 +1,12 @@
-#![cfg(not(feature = "cuda"))]
-
 use std::sync::Arc;
 
-use tenferro_linalg::ad_support::{LinalgExtensionOp, LinalgOp};
 use tenferro_runtime::extension::ExtensionOpTrait;
 use tenferro_tensor::{
     Buffer, BufferHandle, ComputeDevice, DeviceKind, Error, GpuBackendKind, MemoryKind, Placement,
     Tensor, TypedTensor,
 };
+
+use super::{LinalgExtensionOp, LinalgOp};
 
 #[test]
 fn eager_linalg_rejects_cuda_tensor_when_cuda_feature_is_disabled() {

--- a/tenferro-linalg/src/gpu/ffi/cusolver.rs
+++ b/tenferro-linalg/src/gpu/ffi/cusolver.rs
@@ -67,6 +67,7 @@ pub enum CublasSideMode {
 pub enum CublasOperation {
     N = 0,
     T = 1,
+    C = 2,
 }
 
 #[repr(i32)]

--- a/tenferro-linalg/src/gpu/kernels.rs
+++ b/tenferro-linalg/src/gpu/kernels.rs
@@ -53,7 +53,7 @@ pub fn lu_extract_outputs<E: CubePrimitive + core::ops::Neg<Output = E>>(
     u_out: &mut Tensor<E>,
     parity_out: &mut Tensor<E>,
     work: &Tensor<E>,
-    pivots: &Array<u32>,
+    pivots: &Array<i32>,
     #[comptime] k: usize,
     #[comptime] rank: usize,
 ) {
@@ -62,18 +62,18 @@ pub fn lu_extract_outputs<E: CubePrimitive + core::ops::Neg<Output = E>>(
         let row = p_out.coordinate(pos, 0usize);
         let col = p_out.coordinate(pos, 1usize);
         let batch = batch_linear_index(p_out, pos, 2usize, rank);
-        let mut final_row = col as u32;
+        let mut final_row = col as i32;
         #[unroll]
         for step in 0usize..k {
-            let step_u32 = step as u32;
-            let pivot = pivots[step + batch * k] - 1u32;
-            if final_row == step_u32 {
+            let step_i32 = step as i32;
+            let pivot = pivots[step + batch * k] - 1i32;
+            if final_row == step_i32 {
                 final_row = pivot;
             } else if final_row == pivot {
-                final_row = step_u32;
+                final_row = step_i32;
             }
         }
-        p_out[pos] = if final_row == row as u32 {
+        p_out[pos] = if final_row == row as i32 {
             one_value::<E>()
         } else {
             zero_value::<E>()
@@ -109,12 +109,84 @@ pub fn lu_extract_outputs<E: CubePrimitive + core::ops::Neg<Output = E>>(
         let mut sign = one_value::<E>();
         #[unroll]
         for step in 0usize..k {
-            let step_u32 = step as u32;
-            let pivot = pivots[step + batch * k] - 1u32;
-            if pivot != step_u32 {
+            let step_i32 = step as i32;
+            let pivot = pivots[step + batch * k] - 1i32;
+            if pivot != step_i32 {
                 sign = -sign;
             }
         }
         parity_out[pos] = sign;
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn lu_parity<E: CubePrimitive + core::ops::Neg<Output = E>>(
+    parity_out: &mut Tensor<E>,
+    pivots: &Array<i32>,
+    #[comptime] k: usize,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < parity_out.len() {
+        let mut sign = one_value::<E>();
+        #[unroll]
+        for step in 0usize..k {
+            let step_i32 = step as i32;
+            let pivot = pivots[step + pos * k] - 1i32;
+            if pivot != step_i32 {
+                sign = -sign;
+            }
+        }
+        parity_out[pos] = sign;
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn lu_apply_pivots<E: CubePrimitive>(
+    out: &mut Tensor<E>,
+    input: &Tensor<E>,
+    pivots: &Array<i32>,
+    #[comptime] k: usize,
+    #[comptime] rank: usize,
+    #[comptime] inverse: bool,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < out.len() {
+        let row = out.coordinate(pos, 0usize);
+        let col = out.coordinate(pos, 1usize);
+        let batch = batch_linear_index(out, pos, 2usize, rank);
+        let mut source_row = row as i32;
+        if inverse {
+            #[unroll]
+            for step in 0usize..k {
+                let step_i32 = step as i32;
+                let pivot = pivots[step + batch * k] - 1i32;
+                if source_row == step_i32 {
+                    source_row = pivot;
+                } else if source_row == pivot {
+                    source_row = step_i32;
+                }
+            }
+        } else {
+            #[unroll]
+            for offset in 0usize..k {
+                let step = k - 1usize - offset;
+                let step_i32 = step as i32;
+                let pivot = pivots[step + batch * k] - 1i32;
+                if source_row == step_i32 {
+                    source_row = pivot;
+                } else if source_row == pivot {
+                    source_row = step_i32;
+                }
+            }
+        }
+
+        let mut input_offset =
+            (source_row as usize) * input.stride(0usize) + col * input.stride(1usize);
+        #[unroll]
+        for axis in 2usize..rank {
+            let coord = out.coordinate(pos, axis);
+            input_offset += coord * input.stride(axis);
+        }
+        out[pos] = input[input_offset];
     }
 }

--- a/tenferro-linalg/src/gpu/linalg.rs
+++ b/tenferro-linalg/src/gpu/linalg.rs
@@ -23,10 +23,9 @@ use tenferro_gpu::cubecl::{
     download_tensor, CubeclBackend, CubeclRuntime, CudaExtensionCacheGuard,
 };
 use tenferro_gpu::CubeclBuffer;
-use tenferro_tensor::config::{DotGeneralConfig, SliceConfig};
+use tenferro_tensor::config::SliceConfig;
 use tenferro_tensor::{
-    Buffer, DType, Error, Tensor, TensorDot, TensorElementwise, TensorReduction, TensorStructural,
-    TypedTensor,
+    Buffer, DType, Error, Tensor, TensorElementwise, TensorReduction, TensorStructural, TypedTensor,
 };
 
 type Result<T> = tenferro_tensor::Result<T>;
@@ -218,6 +217,42 @@ pub(super) fn lu(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Tens
     }
 }
 
+pub(super) fn lu_factor(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Tensor>> {
+    match input {
+        Tensor::F32(t) => lu_factor_typed(backend, t).map(|(packed_lu, pivots, parity)| {
+            vec![
+                Tensor::F32(packed_lu),
+                Tensor::I32(pivots),
+                Tensor::F32(parity),
+            ]
+        }),
+        Tensor::F64(t) => lu_factor_typed(backend, t).map(|(packed_lu, pivots, parity)| {
+            vec![
+                Tensor::F64(packed_lu),
+                Tensor::I32(pivots),
+                Tensor::F64(parity),
+            ]
+        }),
+        Tensor::C32(t) => lu_factor_typed(backend, t).map(|(packed_lu, pivots, parity)| {
+            vec![
+                Tensor::C32(packed_lu),
+                Tensor::I32(pivots),
+                Tensor::C32(parity),
+            ]
+        }),
+        Tensor::C64(t) => lu_factor_typed(backend, t).map(|(packed_lu, pivots, parity)| {
+            vec![
+                Tensor::C64(packed_lu),
+                Tensor::I32(pivots),
+                Tensor::C64(parity),
+            ]
+        }),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_linalg_dtype("lu_factor", input))
+        }
+    }
+}
+
 pub(super) fn full_piv_lu(_backend: &mut CubeclBackend, _input: &Tensor) -> Result<Vec<Tensor>> {
     Err(Error::backend_failure(
         "full_piv_lu",
@@ -249,6 +284,18 @@ pub(super) fn svd(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Ten
             .map(|(u, s, vt)| vec![Tensor::C64(u), Tensor::F64(s), Tensor::C64(vt)]),
         Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
             Err(unsupported_linalg_dtype("svd", input))
+        }
+    }
+}
+
+pub(super) fn svd_values(backend: &mut CubeclBackend, input: &Tensor) -> Result<Tensor> {
+    match input {
+        Tensor::F32(t) => svd_values_typed(backend, t).map(Tensor::F32),
+        Tensor::F64(t) => svd_values_typed(backend, t).map(Tensor::F64),
+        Tensor::C32(t) => svd_values_typed(backend, t).map(Tensor::F32),
+        Tensor::C64(t) => svd_values_typed(backend, t).map(Tensor::F64),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_linalg_dtype("svd_values", input))
         }
     }
 }
@@ -307,19 +354,87 @@ pub(super) fn solve(backend: &mut CubeclBackend, a: &Tensor, b: &Tensor) -> Resu
         (b.clone(), None)
     };
 
-    let outputs = lu(backend, a)?;
-    let p = &outputs[0];
-    let l = &outputs[1];
-    let u = &outputs[2];
-    validate_nonsingular_gpu(backend, u)?;
-
-    let pb = matmul_preserve_trailing_batch(backend, p, &rhs)?;
-    let z = triangular_solve(backend, l, &pb, true, true, false, true)?;
-    let x = triangular_solve(backend, u, &z, true, false, false, false)?;
+    let factors = lu_factor(backend, a)?;
+    let [packed_lu, pivots, _parity] = factors.as_slice() else {
+        return Err(Error::backend_failure(
+            OP,
+            "lu_factor returned an unexpected number of outputs",
+        ));
+    };
+    let x = lu_solve_prepared(backend, a, packed_lu, pivots, &rhs, false, false)?;
     if let Some(shape) = restore_shape {
         backend.reshape(&x, &shape)
     } else {
         Ok(x)
+    }
+}
+
+pub(super) fn lu_solve_prepared(
+    backend: &mut CubeclBackend,
+    a: &Tensor,
+    packed_lu: &Tensor,
+    pivots: &Tensor,
+    b: &Tensor,
+    transpose_a: bool,
+    conjugate_a: bool,
+) -> Result<Tensor> {
+    const OP: &str = "lu_solve_prepared";
+
+    backend.runtime().set_current_cuda_context(OP)?;
+    ensure_supported_linalg_pair(OP, a, b)?;
+    ensure_supported_linalg_pair(OP, a, packed_lu)?;
+    ensure_cubecl_resident_tensor(OP, a)?;
+    ensure_cubecl_resident_tensor(OP, packed_lu)?;
+    ensure_cubecl_resident_tensor(OP, pivots)?;
+    ensure_cubecl_resident_tensor(OP, b)?;
+    if !matches!(pivots, Tensor::I32(_)) {
+        return Err(Error::DTypeMismatch {
+            op: OP,
+            lhs: DType::I32,
+            rhs: pivots.dtype(),
+        });
+    }
+    if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
+        return zero_like_linalg_device_tensor(backend.runtime(), b, OP);
+    }
+
+    let (rhs, restore_shape) = if let Some(matrix_rhs_shape) = batched_vector_rhs_shape(a, b) {
+        (
+            backend.reshape(b, &matrix_rhs_shape)?,
+            Some(b.shape().to_vec()),
+        )
+    } else {
+        (b.clone(), None)
+    };
+
+    validate_nonsingular_gpu(backend, packed_lu)?;
+    let result = match (packed_lu, pivots, &rhs) {
+        (Tensor::F32(lu), Tensor::I32(pivots), Tensor::F32(rhs)) => {
+            lu_solve_prepared_typed(backend, lu, pivots, rhs, transpose_a, conjugate_a)
+                .map(Tensor::F32)
+        }
+        (Tensor::F64(lu), Tensor::I32(pivots), Tensor::F64(rhs)) => {
+            lu_solve_prepared_typed(backend, lu, pivots, rhs, transpose_a, conjugate_a)
+                .map(Tensor::F64)
+        }
+        (Tensor::C32(lu), Tensor::I32(pivots), Tensor::C32(rhs)) => {
+            lu_solve_prepared_typed(backend, lu, pivots, rhs, transpose_a, conjugate_a)
+                .map(Tensor::C32)
+        }
+        (Tensor::C64(lu), Tensor::I32(pivots), Tensor::C64(rhs)) => {
+            lu_solve_prepared_typed(backend, lu, pivots, rhs, transpose_a, conjugate_a)
+                .map(Tensor::C64)
+        }
+        _ => Err(Error::backend_failure(
+            OP,
+            "packed LU, pivots, and rhs dtypes are inconsistent",
+        )),
+    }?;
+
+    if let Some(shape) = restore_shape {
+        backend.reshape(&result, &shape)
+    } else {
+        Ok(result)
     }
 }
 
@@ -406,24 +521,52 @@ fn triangular_solve_typed<T>(
 where
     T: LinalgScalar,
 {
-    const OP: &str = "triangular_solve";
+    let trans = if transpose_a {
+        CublasOperation::T
+    } else {
+        CublasOperation::N
+    };
+    triangular_solve_typed_with_op(
+        backend,
+        a,
+        b,
+        left_side,
+        lower,
+        trans,
+        unit_diagonal,
+        "triangular_solve",
+    )
+}
 
-    backend.runtime().set_current_cuda_context(OP)?;
-    ensure_cubecl_resident_typed(OP, a)?;
-    ensure_cubecl_resident_typed(OP, b)?;
-    let n = square_matrix_dim(OP, a.shape())?;
-    validate_triangular_rhs(OP, a.shape(), b.shape(), left_side)?;
+fn triangular_solve_typed_with_op<T>(
+    backend: &CubeclBackend,
+    a: &TypedTensor<T>,
+    b: &TypedTensor<T>,
+    left_side: bool,
+    lower: bool,
+    trans: CublasOperation,
+    unit_diagonal: bool,
+    op: &'static str,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar,
+{
+    backend.runtime().set_current_cuda_context(op)?;
+    ensure_cubecl_resident_typed(op, a)?;
+    ensure_cubecl_resident_typed(op, b)?;
+    let n = square_matrix_dim(op, a.shape())?;
+    validate_triangular_rhs(op, a.shape(), b.shape(), left_side)?;
     if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
         return Ok(alloc_output(backend.runtime(), b.shape()));
     }
 
-    let out = clone_device_tensor(backend.runtime(), b, OP)?;
+    let out = clone_device_tensor(backend.runtime(), b, op)?;
     let handles = linalg_handles(backend)?;
-    let stream = raw_stream(backend.runtime(), OP)?;
-    handles.cublas().set_stream(stream, OP)?;
+    let stream = raw_stream(backend.runtime(), op)?;
+    handles.cublas().set_stream(stream, op)?;
 
-    let a_ptr = typed_device_ptr(backend.runtime(), a, OP)?;
-    let out_ptr = typed_device_ptr(backend.runtime(), &out, OP)?;
+    let a_ptr = typed_device_ptr(backend.runtime(), a, op)?;
+    let out_ptr = typed_device_ptr(backend.runtime(), &out, op)?;
     let side = if left_side {
         CublasSideMode::Left
     } else {
@@ -434,11 +577,6 @@ where
     } else {
         CublasFillMode::Upper
     };
-    let trans = if transpose_a {
-        CublasOperation::T
-    } else {
-        CublasOperation::N
-    };
     let diag = if unit_diagonal {
         CublasDiagType::Unit
     } else {
@@ -448,10 +586,10 @@ where
     let cols = b.shape()[1];
     let a_stride = n * n;
     let out_stride = rows * cols;
-    let lda = as_i32(n, OP, "lda")?;
-    let ldb = as_i32(rows, OP, "ldb")?;
-    let m = as_i32(rows, OP, "m")?;
-    let n_rhs = as_i32(cols, OP, "n")?;
+    let lda = as_i32(n, op, "lda")?;
+    let ldb = as_i32(rows, op, "ldb")?;
+    let m = as_i32(rows, op, "m")?;
+    let n_rhs = as_i32(cols, op, "n")?;
     let alpha = T::one();
 
     for batch in 0..batch_count(&b.shape()[2..]) {
@@ -471,7 +609,7 @@ where
                 lda,
                 batch_b,
                 ldb,
-                OP,
+                op,
             )?;
         }
     }
@@ -493,12 +631,34 @@ where
 {
     const OP: &str = "lu";
 
+    let (packed_lu, pivots, parity) = lu_factor_typed(backend, input)?;
+    let (m, n) = matrix_dims(OP, input.shape())?;
+    let (p, l, u, _extracted_parity) = build_lu_outputs_device(
+        backend.runtime(),
+        &packed_lu,
+        &pivots,
+        m,
+        n,
+        &input.shape()[2..],
+    )?;
+    Ok((p, l, u, parity))
+}
+
+fn lu_factor_typed<T>(
+    backend: &CubeclBackend,
+    input: &TypedTensor<T>,
+) -> Result<(TypedTensor<T>, TypedTensor<i32>, TypedTensor<T>)>
+where
+    T: LinalgScalar,
+{
+    const OP: &str = "lu_factor";
+
     backend.runtime().set_current_cuda_context(OP)?;
     ensure_cubecl_resident_typed(OP, input)?;
     let (m, n) = matrix_dims(OP, input.shape())?;
     let k = m.min(n);
     if has_zero_dim(input.shape()) {
-        return zero_sized_lu_outputs(backend.runtime(), input.shape());
+        return zero_sized_lu_factor_outputs(backend.runtime(), input.shape());
     }
 
     let work = clone_device_tensor(backend.runtime(), input, OP)?;
@@ -517,7 +677,7 @@ where
     let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
     let mut pivot_shape = vec![k];
     pivot_shape.extend_from_slice(&input.shape()[2..]);
-    let pivots = alloc_output::<u32>(backend.runtime(), &pivot_shape);
+    let pivots = alloc_output::<i32>(backend.runtime(), &pivot_shape);
     let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
     let pivots_ptr = typed_device_ptr(backend.runtime(), &pivots, OP)?;
     let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
@@ -525,7 +685,7 @@ where
 
     for batch in 0..batch_total {
         let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * matrix_stride) };
-        let batch_pivots = unsafe { batch_ptr::<u32>(pivots_ptr, batch * k) };
+        let batch_pivots = unsafe { batch_ptr::<i32>(pivots_ptr, batch * k) };
         let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch) };
         unsafe {
             handles.cusolver().getrf(
@@ -555,7 +715,75 @@ where
         }
     }
 
-    build_lu_outputs_device(backend.runtime(), &work, &pivots, m, n, &input.shape()[2..])
+    let parity = build_lu_parity_device(backend.runtime(), &pivots, k, &input.shape()[2..])?;
+    Ok((work, pivots, parity))
+}
+
+fn lu_solve_prepared_typed<T>(
+    backend: &CubeclBackend,
+    packed_lu: &TypedTensor<T>,
+    pivots: &TypedTensor<i32>,
+    b: &TypedTensor<T>,
+    transpose_a: bool,
+    conjugate_a: bool,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar,
+{
+    const OP: &str = "lu_solve_prepared";
+
+    backend.runtime().set_current_cuda_context(OP)?;
+    ensure_cubecl_resident_typed(OP, packed_lu)?;
+    ensure_cubecl_resident_typed(OP, pivots)?;
+    ensure_cubecl_resident_typed(OP, b)?;
+    validate_lu_solve_prepared_shapes(packed_lu.shape(), pivots.shape(), b.shape())?;
+    if has_zero_dim(packed_lu.shape()) || has_zero_dim(b.shape()) {
+        return Ok(alloc_output(backend.runtime(), b.shape()));
+    }
+
+    match (transpose_a, conjugate_a) {
+        (false, false) => {
+            let pb = apply_lu_pivots_typed(backend.runtime(), b, pivots, false)?;
+            let z = triangular_solve_typed_with_op(
+                backend,
+                packed_lu,
+                &pb,
+                true,
+                true,
+                CublasOperation::N,
+                true,
+                OP,
+            )?;
+            triangular_solve_typed_with_op(
+                backend,
+                packed_lu,
+                &z,
+                true,
+                false,
+                CublasOperation::N,
+                false,
+                OP,
+            )
+        }
+        (true, conjugate_a) => {
+            let trans = if conjugate_a {
+                CublasOperation::C
+            } else {
+                CublasOperation::T
+            };
+            let z = triangular_solve_typed_with_op(
+                backend, packed_lu, b, true, false, trans, false, OP,
+            )?;
+            let y = triangular_solve_typed_with_op(
+                backend, packed_lu, &z, true, true, trans, true, OP,
+            )?;
+            apply_lu_pivots_typed(backend.runtime(), &y, pivots, true)
+        }
+        (false, true) => Err(Error::backend_failure(
+            OP,
+            "conjugate-only prepared LU solve is unsupported on CUDA; use transpose+conjugate or solve the conjugated matrix explicitly",
+        )),
+    }
 }
 
 fn svd_typed<T>(
@@ -652,6 +880,84 @@ where
     }
 
     Ok((u, s, vt))
+}
+
+fn svd_values_typed<T>(
+    backend: &CubeclBackend,
+    input: &TypedTensor<T>,
+) -> Result<TypedTensor<T::Real>>
+where
+    T: LinalgScalar,
+{
+    const OP: &str = "svd_values";
+
+    backend.runtime().set_current_cuda_context(OP)?;
+    ensure_cubecl_resident_typed(OP, input)?;
+    let (m, n) = matrix_dims(OP, input.shape())?;
+    let k = m.min(n);
+    let batch_shape = &input.shape()[2..];
+    let mut s_shape = vec![k];
+    s_shape.extend_from_slice(batch_shape);
+    if has_zero_dim(input.shape()) {
+        return Ok(alloc_output(backend.runtime(), &s_shape));
+    }
+
+    let work = clone_device_tensor(backend.runtime(), input, OP)?;
+    let s = alloc_output::<T::Real>(backend.runtime(), &s_shape);
+    let handles = linalg_handles(backend)?;
+    let stream = raw_stream(backend.runtime(), OP)?;
+    handles.cusolver().set_stream(stream, OP)?;
+
+    let a_ptr = typed_device_ptr(backend.runtime(), &work, OP)?;
+    let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
+    let m_i32 = as_i32(m, OP, "m")?;
+    let n_i32 = as_i32(n, OP, "n")?;
+    let lda = as_i32(m, OP, "lda")?;
+    let lwork = handles
+        .cusolver()
+        .gesvd_buffer_size(T::DATA_TYPE, m_i32, n_i32, OP)?;
+    let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
+    let rwork = if T::NEEDS_RWORK {
+        alloc_workspace_elems::<T::Real>(backend.runtime(), as_i32(5 * k, OP, "rwork")?, OP)?
+    } else {
+        Workspace::none()
+    };
+    let info = alloc_workspace_bytes(backend.runtime(), std::mem::size_of::<i32>(), OP)?;
+    let batch_total = batch_count(batch_shape);
+    let a_stride = m * n;
+    let s_stride = k;
+    let job = b'N' as c_char;
+
+    for batch in 0..batch_total {
+        let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
+        let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, batch * s_stride) };
+        unsafe {
+            handles.cusolver().gesvd(
+                T::DATA_TYPE,
+                job,
+                job,
+                m_i32,
+                n_i32,
+                batch_a,
+                lda,
+                batch_s,
+                std::ptr::null_mut(),
+                1,
+                std::ptr::null_mut(),
+                1,
+                workspace.ptr,
+                lwork,
+                rwork.ptr,
+                info.ptr.cast::<i32>(),
+                OP,
+            )?;
+        }
+        let mut host_info = [0_i32; 1];
+        copy_device_to_host(backend.runtime(), &mut host_info, info.ptr.cast_const(), OP)?;
+        check_solver_info(OP, "cusolverDn*gesvd", host_info[0])?;
+    }
+
+    Ok(s)
 }
 
 fn qr_typed<T>(
@@ -842,7 +1148,7 @@ where
 fn build_lu_outputs_device<T>(
     rt: &CubeclRuntime,
     lu: &TypedTensor<T>,
-    pivots: &TypedTensor<u32>,
+    pivots: &TypedTensor<i32>,
     m: usize,
     n: usize,
     batch_shape: &[usize],
@@ -902,15 +1208,82 @@ where
     Ok((p, l, u, parity))
 }
 
-fn zero_sized_lu_outputs<T>(
+fn build_lu_parity_device<T>(
+    rt: &CubeclRuntime,
+    pivots: &TypedTensor<i32>,
+    k: usize,
+    batch_shape: &[usize],
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar,
+{
+    let parity = alloc_output::<T>(rt, batch_shape);
+    let client = rt.client();
+    let parity_arg = typed_tensor_binding(&parity, "lu_factor")?;
+    let pivots_arg = typed_tensor_array_arg(pivots, "lu_factor")?;
+    unsafe {
+        cubecl_linalg::lu_parity::launch_unchecked::<T, CudaRuntime>(
+            client,
+            cube_count_for_len(parity.n_elements()),
+            cube_dim_1d(),
+            parity_arg.into_tensor_arg(),
+            pivots_arg,
+            k,
+        );
+    }
+    client.flush().map_err(|err| {
+        Error::backend_failure(
+            "lu_factor",
+            format!("LU parity extraction launch failed: {err:?}"),
+        )
+    })?;
+    Ok(parity)
+}
+
+fn apply_lu_pivots_typed<T>(
+    rt: &CubeclRuntime,
+    input: &TypedTensor<T>,
+    pivots: &TypedTensor<i32>,
+    inverse: bool,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar,
+{
+    let out = alloc_output::<T>(rt, input.shape());
+    if out.n_elements() == 0 {
+        return Ok(out);
+    }
+    let k = pivots.shape()[0];
+    let client = rt.client();
+    let out_arg = typed_tensor_binding(&out, "lu_solve_prepared")?;
+    let input_arg = typed_tensor_binding(input, "lu_solve_prepared")?;
+    let pivots_arg = typed_tensor_array_arg(pivots, "lu_solve_prepared")?;
+    unsafe {
+        cubecl_linalg::lu_apply_pivots::launch_unchecked::<T, CudaRuntime>(
+            client,
+            cube_count_for_len(out.n_elements()),
+            cube_dim_1d(),
+            out_arg.into_tensor_arg(),
+            input_arg.into_tensor_arg(),
+            pivots_arg,
+            k,
+            input.shape().len(),
+            inverse,
+        );
+    }
+    client.flush().map_err(|err| {
+        Error::backend_failure(
+            "lu_solve_prepared",
+            format!("LU pivot application launch failed: {err:?}"),
+        )
+    })?;
+    Ok(out)
+}
+
+fn zero_sized_lu_factor_outputs<T>(
     rt: &CubeclRuntime,
     shape: &[usize],
-) -> Result<(
-    TypedTensor<T>,
-    TypedTensor<T>,
-    TypedTensor<T>,
-    TypedTensor<T>,
-)>
+) -> Result<(TypedTensor<T>, TypedTensor<i32>, TypedTensor<T>)>
 where
     T: LinalgScalar,
 {
@@ -918,12 +1291,8 @@ where
     let n = shape[1];
     let k = m.min(n);
     let batch_shape = &shape[2..];
-    let mut p_shape = vec![m, m];
-    p_shape.extend_from_slice(batch_shape);
-    let mut l_shape = vec![m, k];
-    l_shape.extend_from_slice(batch_shape);
-    let mut u_shape = vec![k, n];
-    u_shape.extend_from_slice(batch_shape);
+    let mut pivot_shape = vec![k];
+    pivot_shape.extend_from_slice(batch_shape);
     let parity_shape = batch_shape.to_vec();
     let parity_len = batch_count(batch_shape);
     let parity = upload_host_tensor(
@@ -931,9 +1300,8 @@ where
         TypedTensor::from_vec_col_major(parity_shape, vec![T::one(); parity_len.max(1)]),
     )?;
     Ok((
-        alloc_output(rt, &p_shape),
-        alloc_output(rt, &l_shape),
-        alloc_output(rt, &u_shape),
+        alloc_output(rt, shape),
+        alloc_output(rt, &pivot_shape),
         parity,
     ))
 }
@@ -1156,6 +1524,38 @@ fn validate_triangular_rhs(
     Ok(())
 }
 
+fn validate_lu_solve_prepared_shapes(
+    lu_shape: &[usize],
+    pivots_shape: &[usize],
+    b_shape: &[usize],
+) -> Result<()> {
+    let n = square_matrix_dim("lu_solve_prepared", lu_shape)?;
+    let (b_rows, _) = matrix_dims("lu_solve_prepared", b_shape)?;
+    if b_rows != n {
+        return Err(Error::InvalidConfig {
+            op: "lu_solve_prepared",
+            message: format!("rhs row count mismatch: expected {n}, got {b_rows}"),
+        });
+    }
+    if lu_shape[2..] != b_shape[2..] {
+        return Err(Error::ShapeMismatch {
+            op: "lu_solve_prepared",
+            lhs: lu_shape.to_vec(),
+            rhs: b_shape.to_vec(),
+        });
+    }
+    let mut expected_pivots = vec![n];
+    expected_pivots.extend_from_slice(&lu_shape[2..]);
+    if pivots_shape != expected_pivots {
+        return Err(Error::ShapeMismatch {
+            op: "lu_solve_prepared",
+            lhs: expected_pivots,
+            rhs: pivots_shape.to_vec(),
+        });
+    }
+    Ok(())
+}
+
 fn check_solver_info(op: &'static str, call: &'static str, info: i32) -> Result<()> {
     if info == 0 {
         return Ok(());
@@ -1240,25 +1640,6 @@ fn batched_vector_rhs_shape(a: &Tensor, b: &Tensor) -> Option<Vec<usize>> {
     let mut rhs_shape = vec![b.shape()[0], 1];
     rhs_shape.extend_from_slice(&b.shape()[1..]);
     Some(rhs_shape)
-}
-
-fn matmul_preserve_trailing_batch(
-    backend: &mut CubeclBackend,
-    lhs: &Tensor,
-    rhs: &Tensor,
-) -> Result<Tensor> {
-    let rank = lhs.shape().len();
-    let batch_dims: Vec<usize> = (2..rank).collect();
-    backend.dot_general(
-        lhs,
-        rhs,
-        &DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: batch_dims.clone(),
-            rhs_batch_dims: batch_dims,
-        },
-    )
 }
 
 /// Validate that U's diagonal has no singular/zero entries — GPU-accelerated.

--- a/tenferro-linalg/src/gpu/mod.rs
+++ b/tenferro-linalg/src/gpu/mod.rs
@@ -28,6 +28,10 @@ impl LinalgBackend for CubeclBackend {
         linalg::lu(self, input)
     }
 
+    fn lu_factor(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
+        linalg::lu_factor(self, input)
+    }
+
     fn full_piv_lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         linalg::full_piv_lu(self, input)
     }
@@ -43,6 +47,10 @@ impl LinalgBackend for CubeclBackend {
 
     fn svd(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         linalg::svd(self, input)
+    }
+
+    fn svd_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+        linalg::svd_values(self, input)
     }
 
     fn svd_view(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -87,6 +95,18 @@ impl LinalgBackend for CubeclBackend {
 
     fn solve(&mut self, a: &Tensor, b: &Tensor) -> tenferro_tensor::Result<Tensor> {
         linalg::solve(self, a, b)
+    }
+
+    fn lu_solve_prepared(
+        &mut self,
+        a: &Tensor,
+        packed_lu: &Tensor,
+        pivots: &Tensor,
+        b: &Tensor,
+        transpose_a: bool,
+        conjugate_a: bool,
+    ) -> tenferro_tensor::Result<Tensor> {
+        linalg::lu_solve_prepared(self, a, packed_lu, pivots, b, transpose_a, conjugate_a)
     }
 }
 

--- a/tenferro-linalg/src/lib.rs
+++ b/tenferro-linalg/src/lib.rs
@@ -39,11 +39,6 @@ mod gpu;
 mod traced;
 pub mod traced_tensor;
 
-#[doc(hidden)]
-pub mod ad_support {
-    pub use crate::extension::{LinalgExtensionOp, LinalgOp};
-}
-
 #[cfg(feature = "autodiff")]
 pub use ad::{ad_rules, register_extension_rule};
 pub use backend::LinalgBackend;

--- a/tenferro-linalg/src/traced.rs
+++ b/tenferro-linalg/src/traced.rs
@@ -219,12 +219,24 @@ pub fn eig(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// assert_eq!(x.rank, 2);
 /// ```
 pub fn solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
+    let mut factor_outputs =
+        apply(Arc::new(LinalgExtensionOp::new(LinalgOp::LuFactor)), &[a]).into_iter();
+    let (packed_lu, pivots) = match (
+        factor_outputs.next(),
+        factor_outputs.next(),
+        factor_outputs.next(),
+        factor_outputs.next(),
+    ) {
+        (Some(packed_lu), Some(pivots), Some(_parity), None) => (packed_lu, pivots),
+        _ => return Err(unexpected_output_count("lu_factor", 3)),
+    };
     one_output(
         apply(
-            Arc::new(LinalgExtensionOp::new(LinalgOp::Solve {
+            Arc::new(LinalgExtensionOp::new(LinalgOp::LuSolvePrepared {
                 transpose_a: false,
+                conjugate_a: false,
             })),
-            &[a, b],
+            &[a, &packed_lu, &pivots, b],
         ),
         "solve",
     )
@@ -304,8 +316,18 @@ pub fn triangular_solve(
 /// assert_eq!(logabsdet.rank, 0);
 /// ```
 pub fn slogdet(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
-    let (_, _, u, parity) = lu(a)?;
-    let diag_u = u.extract_diag(0, 1);
+    let mut factor_outputs =
+        apply(Arc::new(LinalgExtensionOp::new(LinalgOp::LuFactor)), &[a]).into_iter();
+    let (packed_lu, parity) = match (
+        factor_outputs.next(),
+        factor_outputs.next(),
+        factor_outputs.next(),
+        factor_outputs.next(),
+    ) {
+        (Some(packed_lu), Some(_pivots), Some(parity), None) => (packed_lu, parity),
+        _ => return Err(unexpected_output_count("lu_factor", 3)),
+    };
+    let diag_u = packed_lu.extract_diag(0, 1);
     let sign_u = diag_u.sign().reduce_prod(&[0]);
     let sign = &parity * &sign_u;
     let logabsdet = diag_u.abs().log().reduce_sum(&[0]);
@@ -669,16 +691,26 @@ fn matrix_norm(a: &TracedTensor, axes: &[usize], ord: Option<f64>) -> Result<Tra
         Some(1.0) => matrix_col_sum_norm(&abs, true),
         Some(-1.0) => matrix_col_sum_norm(&abs, false),
         Some(2.0) => {
-            let singular_values = svd(&matrix)?.1.abs();
+            let singular_values = svd_values(&matrix)?.abs();
             singular_values.reduce_max(&[0])
         }
         Some(-2.0) => {
-            let singular_values = svd(&matrix)?.1.abs();
+            let singular_values = svd_values(&matrix)?.abs();
             singular_values.reduce_min(&[0])
         }
         Some(0.0) => count_nonzero(&abs, &[0, 1]),
         Some(p) => p_norm(&abs, &[0, 1], p),
     })
+}
+
+fn svd_values(a: &TracedTensor) -> Result<TracedTensor> {
+    one_output(
+        apply(
+            Arc::new(LinalgExtensionOp::new(LinalgOp::SvdVals { eps: 1e-12 })),
+            &[a],
+        ),
+        "svd_values",
+    )
 }
 
 fn count_nonzero(abs: &TracedTensor, axes: &[usize]) -> TracedTensor {

--- a/tenferro-linalg/tests/backend_errors.rs
+++ b/tenferro-linalg/tests/backend_errors.rs
@@ -1,6 +1,7 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
+use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::LinalgBackend;
 use tenferro_tensor::{
@@ -13,6 +14,28 @@ use tenferro_tensor::{
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+}
+
+fn c64_tensor(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
+    Tensor::C64(TypedTensor::from_vec_col_major(shape, data))
+}
+
+fn i32_tensor(shape: Vec<usize>, data: Vec<i32>) -> Tensor {
+    Tensor::I32(TypedTensor::from_vec_col_major(shape, data))
+}
+
+fn f64_values(tensor: &Tensor) -> Vec<f64> {
+    match tensor {
+        Tensor::F64(tensor) => tensor.host_data().to_vec(),
+        other => panic!("expected F64 tensor, got {:?}", other.dtype()),
+    }
+}
+
+fn c64_values(tensor: &Tensor) -> Vec<Complex64> {
+    match tensor {
+        Tensor::C64(tensor) => tensor.host_data().to_vec(),
+        other => panic!("expected C64 tensor, got {:?}", other.dtype()),
+    }
 }
 
 fn opaque_backend_placement() -> Placement {
@@ -176,6 +199,15 @@ fn default_svd_view_returns_explicit_backend_boundary_error() {
     let input = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0]);
     let mut backend = DefaultOnlyLinalgBackend;
 
+    let err = backend.lu_factor(&Tensor::F64(input.clone())).unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "lu_factor",
+            ref message,
+        } if message.contains("does not implement")
+    ));
+
     let err = backend
         .svd_view(TensorView::F64(input.as_view()))
         .unwrap_err();
@@ -186,6 +218,66 @@ fn default_svd_view_returns_explicit_backend_boundary_error() {
             op: "svd",
             ref message,
         } if message.contains("borrowed tensor views")
+    ));
+}
+
+#[test]
+fn default_lu_solve_prepared_delegates_to_solve_modes() {
+    let mut backend = CpuBackend::new();
+    let pivots = i32_tensor(vec![2], vec![0, 1]);
+
+    let a = f64_tensor(vec![2, 2], vec![2.0, 0.0, 0.0, 3.0]);
+    let b = f64_tensor(vec![2, 1], vec![4.0, 9.0]);
+    let x = backend
+        .lu_solve_prepared(&a, &a, &pivots, &b, false, false)
+        .unwrap();
+    assert_eq!(f64_values(&x), vec![2.0, 3.0]);
+
+    let a = f64_tensor(vec![2, 2], vec![1.0, 0.0, 2.0, 3.0]);
+    let b = f64_tensor(vec![2, 1], vec![5.0, 31.0]);
+    let x = backend
+        .lu_solve_prepared(&a, &a, &pivots, &b, true, false)
+        .unwrap();
+    assert_eq!(f64_values(&x), vec![5.0, 7.0]);
+
+    let a = c64_tensor(
+        vec![2, 2],
+        vec![
+            Complex64::new(1.0, 1.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(2.0, -1.0),
+        ],
+    );
+    let b = c64_tensor(
+        vec![2, 1],
+        vec![Complex64::new(2.0, -2.0), Complex64::new(6.0, 3.0)],
+    );
+    let x = backend
+        .lu_solve_prepared(&a, &a, &pivots, &b, true, true)
+        .unwrap();
+    let values = c64_values(&x);
+    assert!((values[0] - Complex64::new(2.0, 0.0)).norm() < 1.0e-12);
+    assert!((values[1] - Complex64::new(3.0, 0.0)).norm() < 1.0e-12);
+}
+
+#[test]
+fn default_lu_solve_prepared_rejects_rank_less_than_two_transpose() {
+    let mut backend = CpuBackend::new();
+    let a = f64_tensor(vec![2], vec![1.0, 2.0]);
+    let b = f64_tensor(vec![2], vec![1.0, 2.0]);
+    let pivots = i32_tensor(vec![2], vec![0, 1]);
+
+    let err = backend
+        .lu_solve_prepared(&a, &a, &pivots, &b, true, false)
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::InvalidConfig {
+            op: "lu_solve_prepared",
+            ..
+        }
     ));
 }
 

--- a/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -120,6 +120,40 @@ fn gpu_lu_outputs_are_not_rebuilt_by_host_roundtrip() {
 }
 
 #[test]
+fn gpu_solve_uses_packed_lu_without_public_lu_materialization() {
+    let source = linalg_source();
+    let solve_source = source_section(&source, "pub(super) fn solve", "fn cholesky_typed");
+    let banned = [
+        "let outputs = lu(backend, a)?;",
+        "let p = &outputs[0];",
+        "let l = &outputs[1];",
+        "let u = &outputs[2];",
+        "matmul_preserve_trailing_batch(backend, p, &rhs)?",
+    ];
+
+    let mut violations = Vec::new();
+    for needle in banned {
+        if solve_source.contains(needle) {
+            violations.push(format!("gpu/linalg.rs solve contains {needle}"));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "GPU solve must consume packed LU factors directly instead of materializing public P/L/U outputs:\n{}",
+        violations.join("\n")
+    );
+    assert!(
+        solve_source.contains("lu_factor("),
+        "GPU solve should factor into packed LU with pivots"
+    );
+    assert!(
+        solve_source.contains("lu_solve_prepared("),
+        "GPU solve should use the prepared LU solve path"
+    );
+}
+
+#[test]
 fn cubecl_linalg_overrides_svd_view_with_backend_canonicalization() {
     let source = gpu_mod_source();
     let svd_view_source = source_section(&source, "fn svd_view", "fn qr");
@@ -171,15 +205,15 @@ fn gpu_linalg_zero_dim_fast_paths_validate_residency_before_allocating_outputs()
         assert_before(section, residency_check, "if has_zero_dim");
     }
 
-    let triangular = source_section(&source, "fn triangular_solve_typed", "fn lu_typed");
+    let triangular = source_section(&source, "fn triangular_solve_typed_with_op", "fn lu_typed");
     assert_before(
         triangular,
-        "ensure_cubecl_resident_typed(OP, a)?;",
+        "ensure_cubecl_resident_typed(op, a)?;",
         "if has_zero_dim",
     );
     assert_before(
         triangular,
-        "ensure_cubecl_resident_typed(OP, b)?;",
+        "ensure_cubecl_resident_typed(op, b)?;",
         "if has_zero_dim",
     );
 

--- a/tenferro-linalg/tests/linalg_internal_path_contract.rs
+++ b/tenferro-linalg/tests/linalg_internal_path_contract.rs
@@ -1,0 +1,99 @@
+use std::{fs, path::Path};
+
+fn crate_source(path: &str) -> String {
+    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join(path))
+        .unwrap_or_else(|err| panic!("crate source {path} should be readable: {err}"))
+}
+
+fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+    let start_idx = source
+        .find(start)
+        .unwrap_or_else(|| panic!("source should contain section start {start:?}"));
+    let remaining = &source[start_idx..];
+    let end_idx = remaining
+        .find(end)
+        .map(|offset| start_idx + offset)
+        .unwrap_or(source.len());
+    &source[start_idx..end_idx]
+}
+
+#[test]
+fn traced_solve_builds_factor_then_prepared_solve() {
+    let source = crate_source("src/traced.rs");
+    let solve_source = source_section(
+        &source,
+        "pub fn solve",
+        "/// Build a traced full-pivot LU solve op",
+    );
+
+    assert!(
+        solve_source.contains("LinalgOp::LuFactor"),
+        "traced solve should emit an internal packed LU factor op"
+    );
+    assert!(
+        solve_source.contains("LinalgOp::LuSolvePrepared"),
+        "traced solve should emit an internal prepared LU solve op"
+    );
+    assert!(
+        !solve_source.contains("LinalgOp::Solve"),
+        "traced solve should not emit the legacy monolithic solve op"
+    );
+}
+
+#[test]
+fn traced_slogdet_consumes_packed_lu_instead_of_public_lu_outputs() {
+    let source = crate_source("src/traced.rs");
+    let slogdet_source = source_section(
+        &source,
+        "pub fn slogdet",
+        "/// Build a traced determinant op",
+    );
+
+    assert!(
+        slogdet_source.contains("LinalgOp::LuFactor"),
+        "slogdet should use packed LU factors"
+    );
+    assert!(
+        !slogdet_source.contains("lu(a)?"),
+        "slogdet should not call public lu(), which materializes P/L/U outputs"
+    );
+}
+
+#[test]
+fn matrix_norm_uses_singular_values_only_path() {
+    let source = crate_source("src/traced.rs");
+    let matrix_norm_source = source_section(&source, "fn matrix_norm", "fn count_nonzero");
+
+    assert!(
+        matrix_norm_source.contains("svd_values("),
+        "matrix norm ord=2/-2 should use a singular-values-only internal op"
+    );
+    assert!(
+        !matrix_norm_source.contains("svd(&matrix)?.1"),
+        "matrix norm should not materialize U/V when only singular values are needed"
+    );
+}
+
+#[test]
+fn linalg_ad_has_prepared_solve_rules() {
+    let source = crate_source("src/ad/rules/solve.rs");
+
+    assert!(
+        source.contains("linearize_lu_solve_prepared"),
+        "linalg AD should define a linearize rule for prepared LU solve"
+    );
+    assert!(
+        source.contains("transpose_lu_solve_prepared"),
+        "linalg AD should define a transpose rule for prepared LU solve"
+    );
+}
+
+#[test]
+fn backend_surface_does_not_expose_internal_lu_solve_mode_type() {
+    let source = crate_source("src/backend.rs");
+
+    assert!(
+        !source.contains("LuSolveMode"),
+        "internal prepared-solve mode state should not be exposed as a backend public type"
+    );
+}

--- a/tenferro-runtime/src/compiler/mod.rs
+++ b/tenferro-runtime/src/compiler/mod.rs
@@ -68,69 +68,64 @@ pub fn compile_std_to_exec(
                 })
                 .collect();
 
-            let (output_dtype, output_shapes, output_extents) = if let StdTensorOp::Extension(ext) =
-                &instr.operation
-            {
-                let metas =
-                    infer_extension_output_meta(ext.as_ref(), &input_dtypes, &input_shapes_refs);
-                assert_eq!(
-                    metas.len(),
-                    instr.outputs.len(),
-                    "compile_std_to_exec: extension family_id={:?} \
+            let (output_dtypes, output_shapes, output_extents) =
+                if let StdTensorOp::Extension(ext) = &instr.operation {
+                    let metas = infer_extension_output_meta(
+                        ext.as_ref(),
+                        &input_dtypes,
+                        &input_shapes_refs,
+                    );
+                    assert_eq!(
+                        metas.len(),
+                        instr.outputs.len(),
+                        "compile_std_to_exec: extension family_id={:?} \
                          inferred {} output metas for {} output slots",
-                    ext.family_id(),
-                    metas.len(),
-                    instr.outputs.len()
-                );
-                // Current compiler supports a single dtype per instruction;
-                // per spec Section 7, extensions must keep a uniform dtype
-                // across all outputs. Surface a clean panic if violated.
-                let dtypes_consistent = metas.iter().all(|(dtype, _)| *dtype == metas[0].0);
-                assert!(
-                    dtypes_consistent,
-                    "compile_std_to_exec: extension family_id={:?} returned \
-                         multiple output dtypes {:?}; multi-dtype extensions are \
-                         not yet supported in the compiled path",
-                    ext.family_id(),
-                    metas.iter().map(|(dtype, _)| *dtype).collect::<Vec<_>>()
-                );
-                let dtype = metas[0].0;
-                let shapes: Vec<Vec<DimExpr>> =
-                    metas.into_iter().map(|(_dtype, shape)| shape).collect();
-                let extents = exact_extents_from_shapes(&shapes);
-                (dtype, shapes, extents)
-            } else {
-                let dtype = infer_output_dtype(&instr.operation, &input_dtypes);
-                let shapes = infer_output_shapes(&instr.operation, &input_shapes_refs);
-                let extents = infer_output_extents(&instr.operation, &input_shapes_refs);
-                assert_eq!(
-                    shapes.len(),
-                    instr.outputs.len(),
-                    "compile_std_to_exec: {:?} inferred {} output shapes for {} output slots",
-                    instr.operation,
-                    shapes.len(),
-                    instr.outputs.len()
-                );
-                assert_eq!(
-                    extents.len(),
-                    instr.outputs.len(),
-                    "compile_std_to_exec: {:?} inferred {} output extents for {} output slots",
-                    instr.operation,
-                    extents.len(),
-                    instr.outputs.len()
-                );
-                let resolved_extents =
-                    resolve_output_extents(extents, &input_shapes_refs, &input_extents_refs);
-                (dtype, shapes, resolved_extents)
-            };
+                        ext.family_id(),
+                        metas.len(),
+                        instr.outputs.len()
+                    );
+                    let dtypes: Vec<DType> = metas.iter().map(|(dtype, _)| *dtype).collect();
+                    let shapes: Vec<Vec<DimExpr>> =
+                        metas.into_iter().map(|(_dtype, shape)| shape).collect();
+                    let extents = exact_extents_from_shapes(&shapes);
+                    (dtypes, shapes, extents)
+                } else {
+                    let dtype = infer_output_dtype(&instr.operation, &input_dtypes);
+                    let shapes = infer_output_shapes(&instr.operation, &input_shapes_refs);
+                    let extents = infer_output_extents(&instr.operation, &input_shapes_refs);
+                    assert_eq!(
+                        shapes.len(),
+                        instr.outputs.len(),
+                        "compile_std_to_exec: {:?} inferred {} output shapes for {} output slots",
+                        instr.operation,
+                        shapes.len(),
+                        instr.outputs.len()
+                    );
+                    assert_eq!(
+                        extents.len(),
+                        instr.outputs.len(),
+                        "compile_std_to_exec: {:?} inferred {} output extents for {} output slots",
+                        instr.operation,
+                        extents.len(),
+                        instr.outputs.len()
+                    );
+                    let resolved_extents =
+                        resolve_output_extents(extents, &input_shapes_refs, &input_extents_refs);
+                    (vec![dtype; instr.outputs.len()], shapes, resolved_extents)
+                };
 
-            for ((slot, shape), extents) in instr
+            let instruction_dtype = output_dtypes
+                .first()
+                .copied()
+                .unwrap_or_else(|| panic!("compile_std_to_exec: instruction has no outputs"));
+            for (((slot, dtype), shape), extents) in instr
                 .outputs
                 .iter()
+                .zip(output_dtypes.iter())
                 .zip(output_shapes.iter())
                 .zip(output_extents.iter())
             {
-                slot_dtypes[*slot] = Some(output_dtype);
+                slot_dtypes[*slot] = Some(*dtype);
                 slot_shapes[*slot] = Some(shape.clone());
                 slot_extents[*slot] = Some(extents.clone());
             }
@@ -139,7 +134,7 @@ pub fn compile_std_to_exec(
                 op: ExecOp::from_std_tensor_op(&instr.operation),
                 input_slots: instr.inputs.clone(),
                 output_slots: instr.outputs.clone(),
-                dtype: output_dtype,
+                dtype: instruction_dtype,
                 output_shapes,
                 output_extents,
                 last_use: Vec::new(),
@@ -439,20 +434,63 @@ fn collect_slot_meta(
         });
     }
     for instr in &program.instructions {
-        for ((&slot, shape), extents) in instr
+        let output_dtypes = instruction_output_dtypes(instr, &slot_meta);
+        for (((&slot, dtype), shape), extents) in instr
             .output_slots
             .iter()
+            .zip(output_dtypes.iter())
             .zip(instr.output_shapes.iter())
             .zip(instr.output_extents.iter())
         {
             slot_meta[slot] = Some(SlotMeta {
-                dtype: instr.dtype,
+                dtype: *dtype,
                 shape: shape.clone(),
                 extents: extents.clone(),
             });
         }
     }
     slot_meta
+}
+
+fn instruction_output_dtypes(
+    instr: &ExecInstruction,
+    slot_meta: &[Option<SlotMeta>],
+) -> Vec<DType> {
+    let ExecOp::Extension(ext) = &instr.op else {
+        return vec![instr.dtype; instr.output_slots.len()];
+    };
+    let input_dtypes: Vec<DType> = instr
+        .input_slots
+        .iter()
+        .map(|&slot| {
+            slot_meta[slot]
+                .as_ref()
+                .unwrap_or_else(|| panic!("collect_slot_meta: missing dtype for slot {slot}"))
+                .dtype
+        })
+        .collect();
+    let input_shapes: Vec<Vec<DimExpr>> = instr
+        .input_slots
+        .iter()
+        .map(|&slot| {
+            slot_meta[slot]
+                .as_ref()
+                .unwrap_or_else(|| panic!("collect_slot_meta: missing shape for slot {slot}"))
+                .shape
+                .clone()
+        })
+        .collect();
+    let input_shape_refs: Vec<&[DimExpr]> = input_shapes.iter().map(Vec::as_slice).collect();
+    let metas = infer_extension_output_meta(ext.as_ref(), &input_dtypes, &input_shape_refs);
+    assert_eq!(
+        metas.len(),
+        instr.output_slots.len(),
+        "collect_slot_meta: extension family_id={:?} inferred {} output metas for {} output slots",
+        ext.family_id(),
+        metas.len(),
+        instr.output_slots.len()
+    );
+    metas.into_iter().map(|(dtype, _shape)| dtype).collect()
 }
 
 struct ConjSinkingState<'a> {


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

N/A

## Summary

- Rework traced and eager `solve` to emit internal `LuFactor` + `LuSolvePrepared` ops so CUDA solve can reuse packed LU/pivots instead of rebuilding public `P/L/U` outputs.
- Add prepared-solve linalg AD rules and an internal singular-values-only path for matrix norm `ord=2/-2`.
- Teach runtime compilation to preserve extension output metadata per output slot, including mixed dtypes such as packed LU plus I32 pivots.
- Keep prepared linalg payload construction crate-local; no new public wrapper API or hidden public `ad_support` construction surface is added.
- Update CUDA linalg execution to keep pivot application and triangular solves on device, with tests covering source contracts and real GPU execution.

Follow-up: FFT CUDA execution remains separate and is already tracked in #967.

## Work log

`docs/worklogs/2026-06-02-linalg-prepared-solve.md`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [ ] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo test -p tenferro-linalg`
- `cargo test -p tenferro-linalg --features autodiff`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-linalg --features cuda`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-linalg --features cuda -- --ignored`