### PR TITLE
Optimize linalg prepared and values-only paths

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -118,6 +118,13 @@ rules from `tensor4all-agent-rules`.
   runtime before dispatch, following the crate's established pattern, or expose
   the missing-runtime error. Add regression tests for missing-runtime behavior
   when changing extension dispatch.
+- Hidden backend hooks for internal optimized operations, such as prepared
+  solves, values-only decompositions, cache-aware kernels, or device-specific
+  fast paths, must not silently fall back to a slower public operation, full
+  decomposition, freshly constructed backend, CPU transfer, or reference
+  implementation. The trait default should return an explicit unsupported or
+  backend error, and each backend that supports the path must override the hook
+  directly. Add source-contract or behavior tests when introducing such hooks.
 - Optional capabilities are feature boundaries, not new operation-family
   crates. Put operation-specific AD support behind an `autodiff` feature in the
   owning operation crate instead of adding `*-ad` companion crates.

--- a/docs/worklogs/2026-06-02-linalg-values-batch-optimizations.md
+++ b/docs/worklogs/2026-06-02-linalg-values-batch-optimizations.md
@@ -1,0 +1,59 @@
+# Linalg Values-Only And Batch Optimizations
+
+## Session Summary
+
+Implemented the remaining linalg optimization cleanup after the prepared-solve
+work merged to `origin/main`. The changes remove silent full-decomposition
+fallbacks for hidden values/prepared hooks, add values-only Hermitian
+eigenvalue execution, reuse CPU packed LU factors, avoid dense diagonal
+materialization in traced `pinv`, and reduce CUDA per-batch synchronization.
+
+## Context Read
+
+- `REPOSITORY_RULES.md`
+- Shared tensor4all common, Rust, numerical, performance, docs, and benchmark
+  rules
+- `docs/design/gpu-backend-design.md`
+- Existing linalg worklog: `docs/worklogs/2026-06-02-linalg-prepared-solve.md`
+- JAX linalg reference under `../jax/jax/_src/lax/linalg.py`
+
+## Decisions Made
+
+- Added hidden backend hooks for values-only paths instead of widening public
+  API. Backends that do not implement these hooks now return explicit backend
+  errors instead of silently using full decompositions.
+- `eigvalsh` now emits an internal `EighVals` op. Its JVP computes the needed
+  eigenvectors inside the rule and returns only the eigenvalue tangent.
+- CPU `lu_factor` now factors directly through the provider and returns packed
+  LU, pivots, and parity. CPU `lu_solve_prepared` consumes those factors through
+  pivot application and triangular solves.
+- CPU and CUDA values-only SVD/eigh paths return real singular/eigenvalue
+  tensors for complex inputs.
+- CUDA `cholesky`, `svd`, `svd_values`, `qr`, and `eigh` now write solver info
+  into a batched device tensor and download/check it once after the loop.
+- CUDA triangular solve uses cuBLAS `trsmBatched` for batched inputs and keeps
+  the scalar `trsm` path for a single batch.
+- Traced `pinv` scales SVD vectors by broadcasting reciprocal singular values,
+  avoiding dense diagonal matrix materialization.
+
+## Rejected Or Deferred Alternatives
+
+- Public `LuFactor`, `LuSolve`, or `EighVals` APIs were not added. The current
+  request can be handled by internal extension ops and hidden backend hooks.
+- Full non-symmetric CUDA `eig` remains unsupported because cuSOLVER does not
+  provide the required operation.
+- FFT GPU work remains deferred for issue tracking.
+
+## Verification Performed
+
+- `cargo test -p tenferro-linalg`
+- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.5 LD_LIBRARY_PATH=/usr/local/cuda-12.5/targets/x86_64-linux/lib:/usr/local/cuda-12.5/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-linalg --features cuda`
+- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.5 LD_LIBRARY_PATH=/usr/local/cuda-12.5/targets/x86_64-linux/lib:/usr/local/cuda-12.5/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-linalg --features cuda --test gpu_linalg -- --ignored`
+
+## Remaining Risks
+
+- cuBLAS batched TRSM uses pointer-array batched APIs. It is covered by a GPU
+  test on the local A100, but larger batch-size benchmarking is still needed.
+- Public `eigh` metadata for complex inputs was not changed in this session to
+  avoid broad compatibility churn. The new `EighVals` path uses real output
+  metadata.

--- a/tenferro-linalg/src/ad.rs
+++ b/tenferro-linalg/src/ad.rs
@@ -146,6 +146,9 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
             LinalgOp::Eigh { eps } => {
                 rules::linearize_eigh(builder, primal_in, primal_out, tangent_in, eps, ctx)
             }
+            LinalgOp::EighVals { eps } => {
+                rules::linearize_eigh_values(builder, primal_in, tangent_in, eps, ctx)
+            }
             LinalgOp::Eig { input_dtype } => {
                 rules::linearize_eig(builder, primal_in, primal_out, tangent_in, input_dtype, ctx)
             }
@@ -209,6 +212,7 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
             | LinalgOp::SvdVals { .. }
             | LinalgOp::Qr
             | LinalgOp::Eigh { .. }
+            | LinalgOp::EighVals { .. }
             | LinalgOp::Eig { .. } => vec![None; op.input_count()],
         };
         Ok(cotangents)

--- a/tenferro-linalg/src/ad/rules/mod.rs
+++ b/tenferro-linalg/src/ad/rules/mod.rs
@@ -574,6 +574,47 @@ pub(crate) fn linearize_eigh(
     vec![Some(dw), Some(dv)]
 }
 
+pub(crate) fn linearize_eigh_values(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+    eps: f64,
+    ctx: &mut ShapeGuardContext,
+) -> Vec<Option<LocalValueId>> {
+    let Some(da) = tangent_in[0] else {
+        return vec![None];
+    };
+
+    let input_shape = primal_input_shape(ctx, primal_in);
+    let input_shape = input_shape.as_slice();
+    let matrix_rank = input_shape.len();
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let eigh_outputs = builder.add_operation(
+        linalg_std_op(LinalgOp::Eigh { eps }),
+        vec![ValueRef::External(primal_in[0].clone())],
+        OperationRole::Primary,
+    );
+    let v = ValueRef::Local(eigh_outputs[1]);
+    let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
+    let vh = adjoint_matrix_fixed(builder, v.clone(), matrix_rank, dtype);
+    let tmp = matmul_linear(
+        builder,
+        ValueRef::Local(vh),
+        ValueRef::Local(da_self_adjoint),
+        vec![false, true],
+        matrix_rank,
+    );
+    let projected = matmul_linear(
+        builder,
+        ValueRef::Local(tmp),
+        v,
+        vec![true, false],
+        matrix_rank,
+    );
+
+    vec![Some(extract_diag_linear(builder, projected))]
+}
+
 pub(crate) fn linearize_cholesky(
     builder: &mut dyn PrimitiveRuleBuilder,
     primal_in: &[ValueKey<StdTensorOp>],

--- a/tenferro-linalg/src/backend.rs
+++ b/tenferro-linalg/src/backend.rs
@@ -44,15 +44,14 @@ pub trait LinalgBackend: TensorBackend {
     ) -> tenferro_tensor::Result<Tensor>;
     fn svd(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
     #[doc(hidden)]
-    fn svd_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
-        let mut outputs = self.svd(input)?.into_iter();
-        let _u = outputs.next();
-        outputs.next().ok_or_else(|| {
-            tenferro_tensor::Error::backend_failure(
-                "svd_values",
-                "backend svd returned no singular-value output",
-            )
-        })
+    fn svd_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+        Err(tenferro_tensor::Error::backend_failure(
+            "svd_values",
+            format!(
+                "backend {} does not implement internal singular-values-only decomposition",
+                std::any::type_name::<Self>()
+            ),
+        ))
     }
 
     /// Compute a singular value decomposition from a borrowed tensor view.
@@ -84,44 +83,34 @@ pub trait LinalgBackend: TensorBackend {
 
     fn qr(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
     fn eigh(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+    #[doc(hidden)]
+    fn eigh_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+        Err(tenferro_tensor::Error::backend_failure(
+            "eigh_values",
+            format!(
+                "backend {} does not implement internal Hermitian eigenvalues-only decomposition",
+                std::any::type_name::<Self>()
+            ),
+        ))
+    }
     fn eig(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
     fn solve(&mut self, a: &Tensor, b: &Tensor) -> tenferro_tensor::Result<Tensor>;
     #[doc(hidden)]
     fn lu_solve_prepared(
         &mut self,
-        a: &Tensor,
+        _a: &Tensor,
         _packed_lu: &Tensor,
         _pivots: &Tensor,
-        b: &Tensor,
-        transpose_a: bool,
-        conjugate_a: bool,
+        _b: &Tensor,
+        _transpose_a: bool,
+        _conjugate_a: bool,
     ) -> tenferro_tensor::Result<Tensor> {
-        let a_conj;
-        let a_op = if conjugate_a {
-            a_conj = self.conj(a)?;
-            &a_conj
-        } else {
-            a
-        };
-        if transpose_a {
-            let perm = matrix_transpose_perm("lu_solve_prepared", a_op)?;
-            let a_t = self.transpose(a_op, &perm)?;
-            self.solve(&a_t, b)
-        } else {
-            self.solve(a_op, b)
-        }
+        Err(tenferro_tensor::Error::backend_failure(
+            "lu_solve_prepared",
+            format!(
+                "backend {} does not implement internal prepared LU solve",
+                std::any::type_name::<Self>()
+            ),
+        ))
     }
-}
-
-fn matrix_transpose_perm(op: &'static str, input: &Tensor) -> tenferro_tensor::Result<Vec<usize>> {
-    let rank = input.shape().len();
-    if rank < 2 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op,
-            message: "matrix operand rank must be at least 2".into(),
-        });
-    }
-    let mut perm: Vec<usize> = (0..rank).collect();
-    perm.swap(0, 1);
-    Ok(perm)
 }

--- a/tenferro-linalg/src/cpu/backend.rs
+++ b/tenferro-linalg/src/cpu/backend.rs
@@ -4,7 +4,8 @@ use super::linalg;
 
 use tenferro_cpu::{CpuBackend, CpuBackendKind};
 use tenferro_tensor::{
-    DType, Error, Tensor, TensorStructural, TensorView, TensorViewCanonicalization, TypedTensor,
+    validate::validate_nonsingular_u, DType, Error, Tensor, TensorElementwise, TensorStructural,
+    TensorView, TensorViewCanonicalization, TypedTensor,
 };
 
 impl LinalgBackend for CpuBackend {
@@ -228,42 +229,73 @@ impl LinalgBackend for CpuBackend {
 
     fn lu_factor(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("lu_factor", input)?;
-        let outputs = self.lu(input)?;
-        let [_p, l, u, parity] = outputs.as_slice() else {
-            return Err(Error::backend_failure(
-                "lu_factor",
-                "public LU returned an unexpected number of outputs",
-            ));
-        };
-        let (packed_lu, parity) = match (input, l, u, parity) {
-            (Tensor::F32(input), Tensor::F32(l), Tensor::F32(u), Tensor::F32(parity)) => (
-                Tensor::F32(pack_lu_from_public_outputs(input, l, u)?),
-                Tensor::F32(parity.clone()),
-            ),
-            (Tensor::F64(input), Tensor::F64(l), Tensor::F64(u), Tensor::F64(parity)) => (
-                Tensor::F64(pack_lu_from_public_outputs(input, l, u)?),
-                Tensor::F64(parity.clone()),
-            ),
-            (Tensor::C32(input), Tensor::C32(l), Tensor::C32(u), Tensor::C32(parity)) => (
-                Tensor::C32(pack_lu_from_public_outputs(input, l, u)?),
-                Tensor::C32(parity.clone()),
-            ),
-            (Tensor::C64(input), Tensor::C64(l), Tensor::C64(u), Tensor::C64(parity)) => (
-                Tensor::C64(pack_lu_from_public_outputs(input, l, u)?),
-                Tensor::C64(parity.clone()),
-            ),
-            (Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_), _, _, _) => {
-                return Err(unsupported_dtype("lu_factor", input.dtype()));
+        match self.kind() {
+            CpuBackendKind::Faer => {
+                #[cfg(feature = "cpu-faer")]
+                {
+                    let ctx = self.linalg_context();
+                    self.with_linalg_pool(|buffers| match input {
+                        Tensor::F32(t) => linalg::faer::lu_factor(ctx.as_ref(), buffers, t).map(
+                            |(lu, pivots, parity)| {
+                                vec![Tensor::F32(lu), Tensor::I32(pivots), Tensor::F32(parity)]
+                            },
+                        ),
+                        Tensor::F64(t) => linalg::faer::lu_factor(ctx.as_ref(), buffers, t).map(
+                            |(lu, pivots, parity)| {
+                                vec![Tensor::F64(lu), Tensor::I32(pivots), Tensor::F64(parity)]
+                            },
+                        ),
+                        Tensor::C32(t) => linalg::faer::lu_factor(ctx.as_ref(), buffers, t).map(
+                            |(lu, pivots, parity)| {
+                                vec![Tensor::C32(lu), Tensor::I32(pivots), Tensor::C32(parity)]
+                            },
+                        ),
+                        Tensor::C64(t) => linalg::faer::lu_factor(ctx.as_ref(), buffers, t).map(
+                            |(lu, pivots, parity)| {
+                                vec![Tensor::C64(lu), Tensor::I32(pivots), Tensor::C64(parity)]
+                            },
+                        ),
+                        _ => Err(unsupported_dtype("lu_factor", input.dtype())),
+                    })
+                }
+                #[cfg(not(feature = "cpu-faer"))]
+                {
+                    Err(unsupported_provider("lu_factor", self.kind()))
+                }
             }
-            _ => {
-                return Err(Error::backend_failure(
-                    "lu_factor",
-                    "public LU returned outputs with unexpected dtypes",
-                ));
+            CpuBackendKind::Blas => {
+                #[cfg(feature = "cpu-blas")]
+                {
+                    self.with_linalg_pool(|buffers| match input {
+                        Tensor::F32(t) => {
+                            linalg::blas::lu_factor(buffers, t).map(|(lu, pivots, parity)| {
+                                vec![Tensor::F32(lu), Tensor::I32(pivots), Tensor::F32(parity)]
+                            })
+                        }
+                        Tensor::F64(t) => {
+                            linalg::blas::lu_factor(buffers, t).map(|(lu, pivots, parity)| {
+                                vec![Tensor::F64(lu), Tensor::I32(pivots), Tensor::F64(parity)]
+                            })
+                        }
+                        Tensor::C32(t) => {
+                            linalg::blas::lu_factor(buffers, t).map(|(lu, pivots, parity)| {
+                                vec![Tensor::C32(lu), Tensor::I32(pivots), Tensor::C32(parity)]
+                            })
+                        }
+                        Tensor::C64(t) => {
+                            linalg::blas::lu_factor(buffers, t).map(|(lu, pivots, parity)| {
+                                vec![Tensor::C64(lu), Tensor::I32(pivots), Tensor::C64(parity)]
+                            })
+                        }
+                        _ => Err(unsupported_dtype("lu_factor", input.dtype())),
+                    })
+                }
+                #[cfg(not(feature = "cpu-blas"))]
+                {
+                    Err(unsupported_provider("lu_factor", self.kind()))
+                }
             }
-        };
-        let pivots = Tensor::I32(identity_pivots(input.shape()));
-        Ok(vec![packed_lu, pivots, parity])
+        }
     }
 
     fn full_piv_lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -464,6 +496,53 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
+    fn svd_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+        ensure_host_tensor("svd_values", input)?;
+        match self.kind() {
+            CpuBackendKind::Faer => {
+                #[cfg(feature = "cpu-faer")]
+                {
+                    let ctx = self.linalg_context();
+                    self.with_linalg_pool(|buffers| match input {
+                        Tensor::F32(t) => {
+                            linalg::faer::svd_values(ctx.as_ref(), buffers, t).map(Tensor::F32)
+                        }
+                        Tensor::F64(t) => {
+                            linalg::faer::svd_values(ctx.as_ref(), buffers, t).map(Tensor::F64)
+                        }
+                        Tensor::C32(t) => {
+                            linalg::faer::svd_values(ctx.as_ref(), buffers, t).map(Tensor::F32)
+                        }
+                        Tensor::C64(t) => {
+                            linalg::faer::svd_values(ctx.as_ref(), buffers, t).map(Tensor::F64)
+                        }
+                        _ => Err(unsupported_dtype("svd_values", input.dtype())),
+                    })
+                }
+                #[cfg(not(feature = "cpu-faer"))]
+                {
+                    Err(unsupported_provider("svd_values", self.kind()))
+                }
+            }
+            CpuBackendKind::Blas => {
+                #[cfg(feature = "cpu-blas")]
+                {
+                    self.with_linalg_pool(|buffers| match input {
+                        Tensor::F32(t) => linalg::blas::svd_values(buffers, t).map(Tensor::F32),
+                        Tensor::F64(t) => linalg::blas::svd_values(buffers, t).map(Tensor::F64),
+                        Tensor::C32(t) => linalg::blas::svd_values(buffers, t).map(Tensor::F32),
+                        Tensor::C64(t) => linalg::blas::svd_values(buffers, t).map(Tensor::F64),
+                        _ => Err(unsupported_dtype("svd_values", input.dtype())),
+                    })
+                }
+                #[cfg(not(feature = "cpu-blas"))]
+                {
+                    Err(unsupported_provider("svd_values", self.kind()))
+                }
+            }
+        }
+    }
+
     fn svd_view(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         match input {
             TensorView::F32(view) => {
@@ -586,6 +665,53 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
+    fn eigh_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+        ensure_host_tensor("eigh_values", input)?;
+        match self.kind() {
+            CpuBackendKind::Faer => {
+                #[cfg(feature = "cpu-faer")]
+                {
+                    let ctx = self.linalg_context();
+                    self.with_linalg_pool(|buffers| match input {
+                        Tensor::F32(t) => {
+                            linalg::faer::eigh_values(ctx.as_ref(), buffers, t).map(Tensor::F32)
+                        }
+                        Tensor::F64(t) => {
+                            linalg::faer::eigh_values(ctx.as_ref(), buffers, t).map(Tensor::F64)
+                        }
+                        Tensor::C32(t) => {
+                            linalg::faer::eigh_values(ctx.as_ref(), buffers, t).map(Tensor::F32)
+                        }
+                        Tensor::C64(t) => {
+                            linalg::faer::eigh_values(ctx.as_ref(), buffers, t).map(Tensor::F64)
+                        }
+                        _ => Err(unsupported_dtype("eigh_values", input.dtype())),
+                    })
+                }
+                #[cfg(not(feature = "cpu-faer"))]
+                {
+                    Err(unsupported_provider("eigh_values", self.kind()))
+                }
+            }
+            CpuBackendKind::Blas => {
+                #[cfg(feature = "cpu-blas")]
+                {
+                    self.with_linalg_pool(|buffers| match input {
+                        Tensor::F32(t) => linalg::blas::eigh_values(buffers, t).map(Tensor::F32),
+                        Tensor::F64(t) => linalg::blas::eigh_values(buffers, t).map(Tensor::F64),
+                        Tensor::C32(t) => linalg::blas::eigh_values(buffers, t).map(Tensor::F32),
+                        Tensor::C64(t) => linalg::blas::eigh_values(buffers, t).map(Tensor::F64),
+                        _ => Err(unsupported_dtype("eigh_values", input.dtype())),
+                    })
+                }
+                #[cfg(not(feature = "cpu-blas"))]
+                {
+                    Err(unsupported_provider("eigh_values", self.kind()))
+                }
+            }
+        }
+    }
+
     fn eig(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("eig", input)?;
         if !matches!(
@@ -616,6 +742,67 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("eig", self.kind()))
                 }
             }
+        }
+    }
+
+    fn lu_solve_prepared(
+        &mut self,
+        a: &Tensor,
+        packed_lu: &Tensor,
+        pivots: &Tensor,
+        b: &Tensor,
+        transpose_a: bool,
+        conjugate_a: bool,
+    ) -> tenferro_tensor::Result<Tensor> {
+        const OP: &str = "lu_solve_prepared";
+
+        ensure_host_tensor(OP, a)?;
+        ensure_host_tensor(OP, packed_lu)?;
+        ensure_host_tensor(OP, pivots)?;
+        ensure_host_tensor(OP, b)?;
+        ensure_supported_linalg_pair(OP, a, b)?;
+        ensure_supported_linalg_pair(OP, a, packed_lu)?;
+        if !matches!(pivots, Tensor::I32(_)) {
+            return Err(Error::DTypeMismatch {
+                op: OP,
+                lhs: DType::I32,
+                rhs: pivots.dtype(),
+            });
+        }
+        if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
+            return Ok(zeros_like_tensor(b));
+        }
+
+        let (rhs, restore_shape) = if let Some(matrix_rhs_shape) = batched_vector_rhs_shape(a, b) {
+            (
+                self.reshape(b, &matrix_rhs_shape)?,
+                Some(b.shape().to_vec()),
+            )
+        } else {
+            (b.clone(), None)
+        };
+
+        validate_lu_solve_prepared_shapes(packed_lu.shape(), pivots.shape(), rhs.shape())?;
+        validate_nonsingular_u(packed_lu)?;
+        let lu_op = if conjugate_a {
+            self.conj(packed_lu)?
+        } else {
+            packed_lu.clone()
+        };
+        let result = if transpose_a {
+            let z = self.triangular_solve(&lu_op, &rhs, true, false, true, false)?;
+            let y = self.triangular_solve(&lu_op, &z, true, true, true, true)?;
+            apply_lu_pivots_cpu(&y, pivots, true)?
+        } else {
+            let pb = apply_lu_pivots_cpu(&rhs, pivots, false)?;
+            let y = self.triangular_solve(&lu_op, &pb, true, true, false, true)?;
+            self.triangular_solve(&lu_op, &y, true, false, false, false)?
+        };
+
+        if let Some(shape) = restore_shape {
+            self.reshape(&result, &shape)
+        } else {
+            Ok(result)
         }
     }
 
@@ -720,6 +907,26 @@ fn ensure_host_typed_tensor<T: 'static>(
     Ok(())
 }
 
+fn ensure_supported_linalg_pair(
+    op: &'static str,
+    lhs: &Tensor,
+    rhs: &Tensor,
+) -> tenferro_tensor::Result<()> {
+    if lhs.dtype() != rhs.dtype() {
+        return Err(Error::DTypeMismatch {
+            op,
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        });
+    }
+    match lhs {
+        Tensor::F32(_) | Tensor::F64(_) | Tensor::C32(_) | Tensor::C64(_) => Ok(()),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_dtype(op, lhs.dtype()))
+        }
+    }
+}
+
 fn has_zero_dim(shape: &[usize]) -> bool {
     shape.contains(&0)
 }
@@ -761,61 +968,152 @@ fn zeros_like_tensor(input: &Tensor) -> Tensor {
     }
 }
 
-fn pack_lu_from_public_outputs<T: Clone + Default>(
+fn apply_lu_pivots_cpu(
+    input: &Tensor,
+    pivots: &Tensor,
+    inverse: bool,
+) -> tenferro_tensor::Result<Tensor> {
+    let Tensor::I32(pivots) = pivots else {
+        return Err(Error::DTypeMismatch {
+            op: "lu_solve_prepared",
+            lhs: DType::I32,
+            rhs: pivots.dtype(),
+        });
+    };
+    match input {
+        Tensor::F32(t) => apply_lu_pivots_typed(t, pivots, inverse).map(Tensor::F32),
+        Tensor::F64(t) => apply_lu_pivots_typed(t, pivots, inverse).map(Tensor::F64),
+        Tensor::C32(t) => apply_lu_pivots_typed(t, pivots, inverse).map(Tensor::C32),
+        Tensor::C64(t) => apply_lu_pivots_typed(t, pivots, inverse).map(Tensor::C64),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_dtype("lu_solve_prepared", input.dtype()))
+        }
+    }
+}
+
+fn apply_lu_pivots_typed<T: Clone>(
     input: &TypedTensor<T>,
-    l: &TypedTensor<T>,
-    u: &TypedTensor<T>,
+    pivots: &TypedTensor<i32>,
+    inverse: bool,
 ) -> tenferro_tensor::Result<TypedTensor<T>> {
     let shape = input.shape();
     if shape.len() < 2 {
         return Err(Error::RankMismatch {
-            op: "lu_factor",
+            op: "lu_solve_prepared",
             expected: 2,
             actual: shape.len(),
         });
     }
-    let m = shape[0];
-    let n = shape[1];
-    let k = m.min(n);
+    let rows = shape[0];
+    let cols = shape[1];
+    let k = pivots.shape()[0];
+    if k > rows || pivots.shape()[1..] != shape[2..] {
+        return Err(Error::ShapeMismatch {
+            op: "lu_solve_prepared",
+            lhs: pivots.shape().to_vec(),
+            rhs: shape.to_vec(),
+        });
+    }
     let batch_total = batch_count(&shape[2..]);
-    let matrix_len = m * n;
-    let l_stride = m * k;
-    let u_stride = k * n;
-    let mut data = vec![T::default(); matrix_len * batch_total];
+    let matrix_stride = rows * cols;
+    let pivot_stride = k;
+    let mut data = Vec::with_capacity(input.host_data().len());
+
     for batch in 0..batch_total {
-        let packed_offset = batch * matrix_len;
-        let l_offset = batch * l_stride;
-        let u_offset = batch * u_stride;
-        for col in 0..n {
-            for row in 0..m {
-                let dst = packed_offset + row + col * m;
-                data[dst] = if row > col && col < k {
-                    l.host_data()[l_offset + row + col * m].clone()
-                } else if row <= col && row < k {
-                    u.host_data()[u_offset + row + col * k].clone()
-                } else {
-                    T::default()
-                };
+        let mut perm: Vec<usize> = (0..rows).collect();
+        let pivot_offset = batch * pivot_stride;
+        for step in 0..k {
+            let pivot_one_based = pivots.host_data()[pivot_offset + step];
+            if pivot_one_based <= 0 {
+                return Err(Error::backend_failure(
+                    "lu_solve_prepared",
+                    "LU pivot index must be 1-based and positive",
+                ));
+            }
+            let pivot = usize::try_from(pivot_one_based - 1).map_err(|_| {
+                Error::backend_failure("lu_solve_prepared", "LU pivot index is invalid")
+            })?;
+            if pivot >= rows {
+                return Err(Error::backend_failure(
+                    "lu_solve_prepared",
+                    "LU pivot index is out of bounds",
+                ));
+            }
+            perm.swap(step, pivot);
+        }
+        let row_map = if inverse {
+            let mut inv = vec![0usize; rows];
+            for (row, &source) in perm.iter().enumerate() {
+                inv[source] = row;
+            }
+            inv
+        } else {
+            perm
+        };
+        let batch_offset = batch * matrix_stride;
+        for col in 0..cols {
+            for &source_row in &row_map {
+                data.push(input.host_data()[batch_offset + source_row + col * rows].clone());
             }
         }
     }
+
     Ok(TypedTensor::from_vec_col_major(shape.to_vec(), data))
 }
 
-fn identity_pivots(shape: &[usize]) -> TypedTensor<i32> {
-    let m = shape[0];
-    let n = shape[1];
-    let k = m.min(n);
-    let batch_total = batch_count(&shape[2..]);
-    let mut pivot_shape = vec![k];
-    pivot_shape.extend_from_slice(&shape[2..]);
-    let mut data = vec![0_i32; k * batch_total];
-    for batch in 0..batch_total {
-        for step in 0..k {
-            data[batch * k + step] = (step + 1) as i32;
-        }
+fn validate_lu_solve_prepared_shapes(
+    lu_shape: &[usize],
+    pivots_shape: &[usize],
+    b_shape: &[usize],
+) -> tenferro_tensor::Result<()> {
+    let n = square_matrix_dim("lu_solve_prepared", lu_shape)?;
+    let (b_rows, _) = matrix_dims("lu_solve_prepared", b_shape)?;
+    if b_rows != n {
+        return Err(Error::InvalidConfig {
+            op: "lu_solve_prepared",
+            message: format!("rhs row count mismatch: expected {n}, got {b_rows}"),
+        });
     }
-    TypedTensor::from_vec_col_major(pivot_shape, data)
+    if lu_shape[2..] != b_shape[2..] {
+        return Err(Error::ShapeMismatch {
+            op: "lu_solve_prepared",
+            lhs: lu_shape.to_vec(),
+            rhs: b_shape.to_vec(),
+        });
+    }
+    let mut expected_pivots = vec![n];
+    expected_pivots.extend_from_slice(&lu_shape[2..]);
+    if pivots_shape != expected_pivots {
+        return Err(Error::ShapeMismatch {
+            op: "lu_solve_prepared",
+            lhs: expected_pivots,
+            rhs: pivots_shape.to_vec(),
+        });
+    }
+    Ok(())
+}
+
+fn matrix_dims(op: &'static str, shape: &[usize]) -> tenferro_tensor::Result<(usize, usize)> {
+    if shape.len() < 2 {
+        return Err(Error::RankMismatch {
+            op,
+            expected: 2,
+            actual: shape.len(),
+        });
+    }
+    Ok((shape[0], shape[1]))
+}
+
+fn square_matrix_dim(op: &'static str, shape: &[usize]) -> tenferro_tensor::Result<usize> {
+    let (rows, cols) = matrix_dims(op, shape)?;
+    if rows != cols {
+        return Err(Error::ShapeMismatch {
+            op,
+            lhs: vec![rows],
+            rhs: vec![cols],
+        });
+    }
+    Ok(rows)
 }
 
 // Used only by feature-disabled provider branches, so default feature builds

--- a/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -363,8 +363,7 @@ fn swap_sequence_from_permutation(
 ) -> tenferro_tensor::Result<Vec<i32>> {
     let mut current: Vec<usize> = (0..perm.len()).collect();
     let mut pivots = Vec::with_capacity(k);
-    for step in 0..k {
-        let wanted = perm[step];
+    for (step, &wanted) in perm.iter().take(k).enumerate() {
         let pivot = current
             .iter()
             .position(|&row| row == wanted)

--- a/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -11,6 +11,8 @@ use tenferro_cpu::CpuContext;
 use tenferro_tensor::{Tensor, TypedTensor};
 
 pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
+    type Real: Copy + Clone + PoolScalar;
+
     fn parity_one() -> Self;
     fn cholesky_2d(
         ctx: &CpuContext,
@@ -22,6 +24,11 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
+    fn lu_factor_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<(TypedTensor<Self>, TypedTensor<i32>, TypedTensor<Self>)>;
     fn full_piv_lu_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -58,6 +65,11 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
+    fn svd_values_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>>;
     fn qr_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -68,6 +80,11 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
+    fn eigh_values_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>>;
 }
 
 fn matrix_dims<T>(
@@ -206,6 +223,10 @@ fn checked_product(
         .ok_or_else(|| invalid_config(op, format!("{role} element count overflows usize")))
 }
 
+fn batch_count(batch_shape: &[usize]) -> usize {
+    batch_shape.iter().product::<usize>().max(1)
+}
+
 fn checked_repeated_len(
     op: &'static str,
     role: &'static str,
@@ -333,6 +354,27 @@ fn permutation_matrix<T: Copy + Default>(perm: &[usize], one: T) -> Vec<T> {
         data[row + source * n] = one;
     }
     data
+}
+
+fn swap_sequence_from_permutation(
+    perm: &[usize],
+    k: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<Vec<i32>> {
+    let mut current: Vec<usize> = (0..perm.len()).collect();
+    let mut pivots = Vec::with_capacity(k);
+    for step in 0..k {
+        let wanted = perm[step];
+        let pivot = current
+            .iter()
+            .position(|&row| row == wanted)
+            .ok_or_else(|| invalid_config(op, "invalid row permutation"))?;
+        current.swap(step, pivot);
+        let pivot_one_based = i32::try_from(pivot + 1)
+            .map_err(|_| invalid_config(op, "pivot index exceeds i32 range"))?;
+        pivots.push(pivot_one_based);
+    }
+    Ok(pivots)
 }
 
 impl_complex_vec_helpers!(
@@ -789,6 +831,8 @@ where
 macro_rules! impl_faer_linalg_for_real {
     ($scalar:ty) => {
         impl FaerLinalg for $scalar {
+    type Real = $scalar;
+
     fn parity_one() -> Self {
         1.0
     }
@@ -876,6 +920,49 @@ macro_rules! impl_faer_linalg_for_real {
             tensor_from_vec_with_template(vec![k, n], u_data, input),
             tensor_from_vec_with_template(vec![], vec![parity], input),
         ])
+    }
+
+    fn lu_factor_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<(TypedTensor<Self>, TypedTensor<i32>, TypedTensor<Self>)> {
+        let (m, n) = matrix_dims(input, "lu_factor")?;
+        let k = m.min(n);
+        let mut lu = Mat::zeros(m, n);
+        lu.copy_from(MatRef::from_column_major_slice(input.host_data(), m, n));
+        let mut perm = vec![0usize; m];
+        let mut perm_inv = vec![0usize; m];
+        let mut mem = MemBuffer::new(
+            faer::linalg::lu::partial_pivoting::factor::lu_in_place_scratch::<usize, Self>(
+                m,
+                n,
+                ctx.faer_par(),
+                Default::default(),
+            ),
+        );
+        let stack = MemStack::new(&mut mem);
+        let info = faer::linalg::lu::partial_pivoting::factor::lu_in_place(
+            lu.as_mut(),
+            &mut perm,
+            &mut perm_inv,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .0;
+        let parity = if info.transposition_count % 2 == 0 {
+            1.0
+        } else {
+            -1.0
+        };
+        let pivots = swap_sequence_from_permutation(&perm, k, "lu_factor")?;
+
+        Ok((
+            tensor_from_vec_with_template(vec![m, n], col_major_vec_from_mat(buffers, lu.as_ref()), input),
+            tensor_from_vec_with_template(vec![k], pivots, input),
+            tensor_from_vec_with_template(vec![], vec![parity], input),
+        ))
     }
 
     fn full_piv_lu_2d(
@@ -1303,6 +1390,38 @@ macro_rules! impl_faer_linalg_for_real {
         Ok(vec![u, s, vt])
     }
 
+    fn svd_values_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+        let (m, n) = matrix_dims(input, "svd_values")?;
+        let k = m.min(n);
+        let mat = MatRef::from_column_major_slice(input.host_data(), m, n);
+        let mut s = Diag::zeros(k);
+        let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<Self>(
+            m,
+            n,
+            faer::linalg::svd::ComputeSvdVectors::No,
+            faer::linalg::svd::ComputeSvdVectors::No,
+            ctx.faer_par(),
+            Default::default(),
+        ));
+        let stack = MemStack::new(&mut mem);
+        faer::linalg::svd::svd(
+            mat,
+            s.as_mut(),
+            None,
+            None,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .map_err(|_| decomposition_failed("svd_values"))?;
+
+        Ok(tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), input))
+    }
+
     fn qr_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -1400,6 +1519,34 @@ macro_rules! impl_faer_linalg_for_real {
 
         Ok(vec![values, vectors])
     }
+
+    fn eigh_values_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+        let n = square_matrix_dim(input, "eigh_values")?;
+        let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
+        let mut values = Diag::zeros(n);
+        let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<Self>(
+            n,
+            faer::linalg::evd::ComputeEigenvectors::No,
+            ctx.faer_par(),
+            Default::default(),
+        ));
+        let stack = MemStack::new(&mut mem);
+        faer::linalg::evd::self_adjoint_evd(
+            mat,
+            values.as_mut(),
+            None,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .map_err(|_| decomposition_failed("eigh_values"))?;
+
+        Ok(tensor_from_vec_with_template(vec![n], vec_from_diag(buffers, values.as_ref()), input))
+    }
         }
     };
 }
@@ -1410,6 +1557,7 @@ impl_faer_linalg_for_real!(f64);
 macro_rules! impl_faer_linalg_for_complex {
     (
         $complex:ty,
+        $real:ty,
         $faer_complex:ty,
         $to_faer_slice:ident,
         $to_faer_slice_mut:ident,
@@ -1419,6 +1567,8 @@ macro_rules! impl_faer_linalg_for_complex {
         $matrix_from_predicate:ident
     ) => {
         impl FaerLinalg for $complex {
+    type Real = $real;
+
     fn parity_one() -> Self {
         <$complex>::new(1.0, 0.0)
     }
@@ -1513,6 +1663,53 @@ macro_rules! impl_faer_linalg_for_complex {
             tensor_from_vec_with_template(vec![k, n], u_data, input),
             tensor_from_vec_with_template(vec![], vec![parity], input),
         ])
+    }
+
+    fn lu_factor_2d(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<(TypedTensor<Self>, TypedTensor<i32>, TypedTensor<Self>)> {
+        let (m, n) = matrix_dims(input, "lu_factor")?;
+        let k = m.min(n);
+        let mut lu = Mat::zeros(m, n);
+        lu.copy_from(MatRef::from_column_major_slice(
+            $to_faer_slice(input.host_data()),
+            m,
+            n,
+        ));
+        let mut perm = vec![0usize; m];
+        let mut perm_inv = vec![0usize; m];
+        let mut mem = MemBuffer::new(
+            faer::linalg::lu::partial_pivoting::factor::lu_in_place_scratch::<usize, $faer_complex>(
+                m,
+                n,
+                ctx.faer_par(),
+                Default::default(),
+            ),
+        );
+        let stack = MemStack::new(&mut mem);
+        let info = faer::linalg::lu::partial_pivoting::factor::lu_in_place(
+            lu.as_mut(),
+            &mut perm,
+            &mut perm_inv,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .0;
+        let parity = if info.transposition_count % 2 == 0 {
+            <$complex>::new(1.0, 0.0)
+        } else {
+            <$complex>::new(-1.0, 0.0)
+        };
+        let pivots = swap_sequence_from_permutation(&perm, k, "lu_factor")?;
+
+        Ok((
+            tensor_from_vec_with_template(vec![m, n], $vec_from_mat(_buffers, lu.as_ref()), input),
+            tensor_from_vec_with_template(vec![k], pivots, input),
+            tensor_from_vec_with_template(vec![], vec![parity], input),
+        ))
     }
 
     fn full_piv_lu_2d(
@@ -1971,6 +2168,43 @@ macro_rules! impl_faer_linalg_for_complex {
         Ok(vec![u, s, vt])
     }
 
+    fn svd_values_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+        let (m, n) = matrix_dims(input, "svd_values")?;
+        let k = m.min(n);
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), m, n);
+        let mut s = Diag::zeros(k);
+        let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<$faer_complex>(
+            m,
+            n,
+            faer::linalg::svd::ComputeSvdVectors::No,
+            faer::linalg::svd::ComputeSvdVectors::No,
+            ctx.faer_par(),
+            Default::default(),
+        ));
+        let stack = MemStack::new(&mut mem);
+        faer::linalg::svd::svd(
+            mat,
+            s.as_mut(),
+            None,
+            None,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .map_err(|_| decomposition_failed("svd_values"))?;
+
+        let col = s.as_ref().column_vector();
+        let mut data = buffers.acquire_with_capacity::<$real>(col.nrows());
+        for i in 0..col.nrows() {
+            data.push(col[i].re);
+        }
+        Ok(tensor_from_vec_with_template(vec![k], data, input))
+    }
+
     fn qr_2d(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
@@ -2071,12 +2305,46 @@ macro_rules! impl_faer_linalg_for_complex {
 
         Ok(vec![values, vectors])
     }
+
+    fn eigh_values_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+        let n = square_matrix_dim(input, "eigh_values")?;
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), n, n);
+        let mut values = Diag::zeros(n);
+        let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<$faer_complex>(
+            n,
+            faer::linalg::evd::ComputeEigenvectors::No,
+            ctx.faer_par(),
+            Default::default(),
+        ));
+        let stack = MemStack::new(&mut mem);
+        faer::linalg::evd::self_adjoint_evd(
+            mat,
+            values.as_mut(),
+            None,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .map_err(|_| decomposition_failed("eigh_values"))?;
+
+        let col = values.as_ref().column_vector();
+        let mut data = buffers.acquire_with_capacity::<$real>(col.nrows());
+        for i in 0..col.nrows() {
+            data.push(col[i].re);
+        }
+        Ok(tensor_from_vec_with_template(vec![n], data, input))
+    }
         }
     };
 }
 
 impl_faer_linalg_for_complex!(
     Complex32,
+    f32,
     faer::c32,
     complex32_to_faer_slice,
     complex32_to_faer_slice_mut,
@@ -2087,6 +2355,7 @@ impl_faer_linalg_for_complex!(
 );
 impl_faer_linalg_for_complex!(
     Complex64,
+    f64,
     faer::c64,
     complex64_to_faer_slice,
     complex64_to_faer_slice_mut,
@@ -2149,6 +2418,63 @@ pub(crate) fn lu<T: FaerLinalg>(
     batched_multi_result("lu", buffers, input, 2, |buffers, batch| {
         T::lu_2d(ctx, buffers, batch)
     })
+}
+
+pub(crate) fn lu_factor<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<i32>, TypedTensor<T>)> {
+    if has_zero_dim(input.shape()) {
+        let (m, n, batch_shape) = matrix_core_and_batch(input, "lu_factor")?;
+        let k = m.min(n);
+        let parity_len = batch_count(batch_shape);
+        return Ok((
+            tensor_from_vec_with_template(input.shape().to_vec(), Vec::new(), input),
+            tensor_from_vec_with_template(
+                vector_with_batch_shape(k, batch_shape),
+                Vec::new(),
+                input,
+            ),
+            tensor_from_vec_with_template(
+                batch_shape.to_vec(),
+                vec![T::parity_one(); parity_len],
+                input,
+            ),
+        ));
+    }
+
+    let (m, n, batch_shape) = matrix_core_and_batch(input, "lu_factor")?;
+    if batch_shape.is_empty() {
+        return T::lu_factor_2d(ctx, buffers, input);
+    }
+
+    let k = m.min(n);
+    let matrix_len = m * n;
+    let batch_total = batch_count(batch_shape);
+    let mut lu_data = buffers.acquire_with_capacity::<T>(matrix_len * batch_total);
+    let mut pivot_data = Vec::with_capacity(k * batch_total);
+    let mut parity_data = buffers.acquire_with_capacity::<T>(batch_total);
+
+    for batch in 0..batch_total {
+        let start = batch * matrix_len;
+        let end = start + matrix_len;
+        let batch_input = tensor_from_vec_with_template(
+            vec![m, n],
+            input.host_data()[start..end].to_vec(),
+            input,
+        );
+        let (packed, pivots, parity) = T::lu_factor_2d(ctx, buffers, &batch_input)?;
+        lu_data.extend_from_slice(packed.host_data());
+        pivot_data.extend_from_slice(pivots.host_data());
+        parity_data.extend_from_slice(parity.host_data());
+    }
+
+    Ok((
+        tensor_from_vec_with_template(input.shape().to_vec(), lu_data, input),
+        tensor_from_vec_with_template(vector_with_batch_shape(k, batch_shape), pivot_data, input),
+        tensor_from_vec_with_template(batch_shape.to_vec(), parity_data, input),
+    ))
 }
 
 pub(crate) fn full_piv_lu<T: FaerLinalg>(
@@ -2343,6 +2669,27 @@ pub(crate) fn svd<T: FaerLinalg>(
     })
 }
 
+pub(crate) fn svd_values<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<TypedTensor<T::Real>> {
+    if has_zero_dim(input.shape()) {
+        let (m, n, batch_shape) = matrix_core_and_batch(input, "svd_values")?;
+        let k = m.min(n);
+        return Ok(tensor_from_vec_with_template(
+            vector_with_batch_shape(k, batch_shape),
+            Vec::new(),
+            input,
+        ));
+    }
+    let mut outputs =
+        batched_multi_convert_result("svd_values", buffers, input, 2, |buffers, batch| {
+            T::svd_values_2d(ctx, buffers, batch).map(|values| vec![values])
+        })?;
+    Ok(outputs.remove(0))
+}
+
 pub(crate) fn qr<T: FaerLinalg>(
     ctx: &CpuContext,
     buffers: &mut BufferPool,
@@ -2392,6 +2739,26 @@ pub(crate) fn eigh<T: FaerLinalg>(
     batched_multi_result("eigh", buffers, input, 2, |buffers, batch| {
         T::eigh_2d(ctx, buffers, batch)
     })
+}
+
+pub(crate) fn eigh_values<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<TypedTensor<T::Real>> {
+    if has_zero_dim(input.shape()) {
+        let (n, batch_shape) = square_core_and_batch(input, "eigh_values")?;
+        return Ok(tensor_from_vec_with_template(
+            vector_with_batch_shape(n, batch_shape),
+            Vec::new(),
+            input,
+        ));
+    }
+    let mut outputs =
+        batched_multi_convert_result("eigh_values", buffers, input, 2, |buffers, batch| {
+            T::eigh_values_2d(ctx, buffers, batch).map(|values| vec![values])
+        })?;
+    Ok(outputs.remove(0))
 }
 
 macro_rules! impl_eig_real_2d {

--- a/tenferro-linalg/src/cpu/linalg/lapack_linalg.rs
+++ b/tenferro-linalg/src/cpu/linalg/lapack_linalg.rs
@@ -11,10 +11,10 @@ mod triangular_solve;
 
 pub(crate) use cholesky::cholesky;
 pub(crate) use eig::eig;
-pub(crate) use eigh::eigh;
+pub(crate) use eigh::{eigh, eigh_values};
 pub(crate) use full_piv_lu::{full_piv_lu, full_piv_lu_solve};
-pub(crate) use lu::lu;
+pub(crate) use lu::{lu, lu_factor};
 pub(crate) use qr::qr;
 pub(crate) use solve::solve;
-pub(crate) use svd::svd;
+pub(crate) use svd::{svd, svd_values};
 pub(crate) use triangular_solve::triangular_solve;

--- a/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs
+++ b/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs
@@ -10,15 +10,23 @@ use super::helpers::{
 };
 
 pub(crate) trait LapackEigh: Clone + Copy + Default {
+    type Real: Clone + Copy + Default;
+
     fn eigh_2d(
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
+    fn eigh_values_2d(
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>>;
 }
 
 macro_rules! impl_real_eigh {
     ($scalar:ty, $syev:path, $routine:literal) => {
         impl LapackEigh for $scalar {
+            type Real = $scalar;
+
             fn eigh_2d(
                 _buffers: &mut BufferPool,
                 input: &TypedTensor<Self>,
@@ -65,6 +73,50 @@ macro_rules! impl_real_eigh {
                     tensor_from_vec_with_template(vec![n, n], vectors, input),
                 ])
             }
+
+            fn eigh_values_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+                let n = square_matrix_dim(input, "eigh_values")?;
+                let n_i32 = dim_i32(n, "eigh_values")?;
+                let mut work_matrix = input.host_data().to_vec();
+                let mut values = vec![0.0 as $scalar; n];
+                let mut query = vec![0.0 as $scalar; 1];
+                let mut info = 0;
+                unsafe {
+                    $syev(
+                        b'N',
+                        b'L',
+                        n_i32,
+                        &mut work_matrix,
+                        n_i32,
+                        &mut values,
+                        &mut query,
+                        -1,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("eigh_values", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0] as f64, "eigh_values", $routine)?;
+                let mut work = vec![0.0 as $scalar; lwork as usize];
+                unsafe {
+                    $syev(
+                        b'N',
+                        b'L',
+                        n_i32,
+                        &mut work_matrix,
+                        n_i32,
+                        &mut values,
+                        &mut work,
+                        lwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("eigh_values", $routine, info)?;
+
+                Ok(tensor_from_vec_with_template(vec![n], values, input))
+            }
         }
     };
 }
@@ -72,6 +124,8 @@ macro_rules! impl_real_eigh {
 macro_rules! impl_complex_eigh {
     ($complex:ty, $real:ty, $heev:path, $routine:literal) => {
         impl LapackEigh for $complex {
+            type Real = $real;
+
             fn eigh_2d(
                 _buffers: &mut BufferPool,
                 input: &TypedTensor<Self>,
@@ -128,6 +182,53 @@ macro_rules! impl_complex_eigh {
                     tensor_from_vec_with_template(vec![n, n], vectors, input),
                 ])
             }
+
+            fn eigh_values_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+                let n = square_matrix_dim(input, "eigh_values")?;
+                let n_i32 = dim_i32(n, "eigh_values")?;
+                let mut work_matrix = input.host_data().to_vec();
+                let mut values = vec![0.0 as $real; n];
+                let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                let mut rwork = vec![0.0 as $real; (3 * n).saturating_sub(2).max(1)];
+                let mut info = 0;
+                unsafe {
+                    $heev(
+                        b'N',
+                        b'L',
+                        n_i32,
+                        &mut work_matrix,
+                        n_i32,
+                        &mut values,
+                        &mut query,
+                        -1,
+                        &mut rwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("eigh_values", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0].re as f64, "eigh_values", $routine)?;
+                let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                unsafe {
+                    $heev(
+                        b'N',
+                        b'L',
+                        n_i32,
+                        &mut work_matrix,
+                        n_i32,
+                        &mut values,
+                        &mut work,
+                        lwork,
+                        &mut rwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("eigh_values", $routine, info)?;
+
+                Ok(tensor_from_vec_with_template(vec![n], values, input))
+            }
         }
     };
 }
@@ -164,4 +265,53 @@ pub(crate) fn eigh<T: LapackEigh>(
         ]);
     }
     batched_multi("eigh", buffers, input, eigh_2d)
+}
+
+fn eigh_values_2d<T: LapackEigh>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<TypedTensor<T::Real>> {
+    T::eigh_values_2d(buffers, input)
+}
+
+pub(crate) fn eigh_values<T: LapackEigh>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<TypedTensor<T::Real>> {
+    if has_zero_dim(input.shape()) {
+        let (n, batch_shape) = square_core_and_batch_result(input, "eigh_values")?;
+        return Ok(tensor_from_vec_with_template(
+            vector_with_batch_shape(n, batch_shape),
+            Vec::new(),
+            input,
+        ));
+    }
+
+    let (core_shape, batch_shape) =
+        super::helpers::split_core_and_batch_result(input, 2, "eigh_values")?;
+    if batch_shape.is_empty() {
+        return eigh_values_2d(buffers, input);
+    }
+
+    let n = core_shape[0];
+    let slice_size = n * n;
+    let batch_total: usize = batch_shape.iter().product();
+    let mut data = Vec::with_capacity(n * batch_total);
+    for batch in 0..batch_total {
+        let start = batch * slice_size;
+        let end = start + slice_size;
+        let batch_input = tensor_from_vec_with_template(
+            core_shape.to_vec(),
+            input.host_data()[start..end].to_vec(),
+            input,
+        );
+        let values = eigh_values_2d(buffers, &batch_input)?;
+        data.extend_from_slice(values.host_data());
+    }
+
+    Ok(tensor_from_vec_with_template(
+        vector_with_batch_shape(n, batch_shape),
+        data,
+        input,
+    ))
 }

--- a/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
+++ b/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
@@ -6,7 +6,7 @@ use tenferro_tensor::TypedTensor;
 use super::helpers::{
     batch_element_count, batched_multi, check_lapack_info, dim_i32, has_zero_dim,
     leading_upper_triangle_from_lapack, matrix_core_and_batch_result, matrix_dims,
-    matrix_with_batch_shape, tensor_from_vec_with_template,
+    matrix_with_batch_shape, tensor_from_vec_with_template, vector_with_batch_shape,
 };
 
 pub(crate) trait LapackLu: Clone + Copy + Default {
@@ -144,6 +144,37 @@ fn lu_2d<T: LapackLu>(
     ])
 }
 
+fn lu_factor_2d<T: LapackLu>(
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<i32>, TypedTensor<T>)> {
+    let (m, n) = matrix_dims(input, "lu_factor")?;
+    let k = m.min(n);
+    let m_i32 = dim_i32(m, "lu_factor")?;
+    let n_i32 = dim_i32(n, "lu_factor")?;
+    let mut lu = input.host_data().to_vec();
+    let mut ipiv = vec![0_i32; k];
+    let mut info = 0;
+    T::getrf(m_i32, n_i32, &mut lu, m_i32, &mut ipiv, &mut info);
+    check_lapack_info("lu_factor", "getrf", info.min(0))?;
+
+    let swap_count = ipiv
+        .iter()
+        .enumerate()
+        .filter(|(idx, pivot_one_based)| **pivot_one_based != (*idx as i32 + 1))
+        .count();
+    let parity = if swap_count % 2 == 0 {
+        T::one()
+    } else {
+        T::negative_one()
+    };
+
+    Ok((
+        tensor_from_vec_with_template(vec![m, n], lu, input),
+        tensor_from_vec_with_template(vec![k], ipiv, input),
+        tensor_from_vec_with_template(vec![], vec![parity], input),
+    ))
+}
+
 pub(crate) fn lu<T: LapackLu>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
@@ -176,4 +207,56 @@ pub(crate) fn lu<T: LapackLu>(
         ]);
     }
     batched_multi("lu", buffers, input, lu_2d)
+}
+
+pub(crate) fn lu_factor<T: LapackLu>(
+    _buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<i32>, TypedTensor<T>)> {
+    if has_zero_dim(input.shape()) {
+        let (m, n, batch_shape) = matrix_core_and_batch_result(input, "lu_factor")?;
+        let k = m.min(n);
+        let parity_elements = batch_element_count("lu_factor", batch_shape)?;
+        return Ok((
+            tensor_from_vec_with_template(input.shape().to_vec(), Vec::new(), input),
+            tensor_from_vec_with_template(
+                vector_with_batch_shape(k, batch_shape),
+                Vec::new(),
+                input,
+            ),
+            tensor_from_vec_with_template(
+                batch_shape.to_vec(),
+                vec![T::one(); parity_elements],
+                input,
+            ),
+        ));
+    }
+
+    let (m, n, batch_shape) = matrix_core_and_batch_result(input, "lu_factor")?;
+    let matrix_len = m * n;
+    let k = m.min(n);
+    let batch_total = batch_element_count("lu_factor", batch_shape)?;
+    let mut lu_data = Vec::with_capacity(matrix_len * batch_total);
+    let mut pivot_data = Vec::with_capacity(k * batch_total);
+    let mut parity_data = Vec::with_capacity(batch_total);
+
+    for batch in 0..batch_total {
+        let start = batch * matrix_len;
+        let end = start + matrix_len;
+        let batch_input = tensor_from_vec_with_template(
+            vec![m, n],
+            input.host_data()[start..end].to_vec(),
+            input,
+        );
+        let (packed, pivots, parity) = lu_factor_2d(&batch_input)?;
+        lu_data.extend_from_slice(packed.host_data());
+        pivot_data.extend_from_slice(pivots.host_data());
+        parity_data.extend_from_slice(parity.host_data());
+    }
+
+    Ok((
+        tensor_from_vec_with_template(input.shape().to_vec(), lu_data, input),
+        tensor_from_vec_with_template(vector_with_batch_shape(k, batch_shape), pivot_data, input),
+        tensor_from_vec_with_template(batch_shape.to_vec(), parity_data, input),
+    ))
 }

--- a/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
+++ b/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
@@ -9,15 +9,23 @@ use super::helpers::{
 };
 
 pub(crate) trait LapackSvd: Clone + Copy + Default {
+    type Real: Clone + Copy + Default;
+
     fn svd_2d(
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
+    fn svd_values_2d(
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>>;
 }
 
 macro_rules! impl_real_svd {
     ($scalar:ty, $gesvd:path, $routine:literal) => {
         impl LapackSvd for $scalar {
+            type Real = $scalar;
+
             fn svd_2d(
                 _buffers: &mut BufferPool,
                 input: &TypedTensor<Self>,
@@ -57,6 +65,63 @@ macro_rules! impl_real_svd {
                     tensor_from_vec_with_template(vec![k, n], vt, input),
                 ])
             }
+
+            fn svd_values_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+                let (m, n) = matrix_dims(input, "svd_values")?;
+                let k = m.min(n);
+                let m_i32 = dim_i32(m, "svd_values")?;
+                let n_i32 = dim_i32(n, "svd_values")?;
+
+                let mut a = input.host_data().to_vec();
+                let mut s = vec![0.0 as $scalar; k];
+                let mut query = vec![0.0 as $scalar; 1];
+                let mut info = 0;
+                unsafe {
+                    $gesvd(
+                        b'N',
+                        b'N',
+                        m_i32,
+                        n_i32,
+                        &mut a,
+                        m_i32,
+                        &mut s,
+                        &mut [],
+                        1,
+                        &mut [],
+                        1,
+                        &mut query,
+                        -1,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("svd_values", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0] as f64, "svd_values", $routine)?;
+                let mut work = vec![0.0 as $scalar; lwork as usize];
+                unsafe {
+                    $gesvd(
+                        b'N',
+                        b'N',
+                        m_i32,
+                        n_i32,
+                        &mut a,
+                        m_i32,
+                        &mut s,
+                        &mut [],
+                        1,
+                        &mut [],
+                        1,
+                        &mut work,
+                        lwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("svd_values", $routine, info)?;
+
+                Ok(tensor_from_vec_with_template(vec![k], s, input))
+            }
         }
     };
 }
@@ -64,6 +129,8 @@ macro_rules! impl_real_svd {
 macro_rules! impl_complex_svd {
     ($complex:ty, $real:ty, $gesvd:path, $routine:literal) => {
         impl LapackSvd for $complex {
+            type Real = $real;
+
             fn svd_2d(
                 _buffers: &mut BufferPool,
                 input: &TypedTensor<Self>,
@@ -110,6 +177,66 @@ macro_rules! impl_complex_svd {
                     tensor_from_vec_with_template(vec![k, n], vt, input),
                 ])
             }
+
+            fn svd_values_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+                let (m, n) = matrix_dims(input, "svd_values")?;
+                let k = m.min(n);
+                let m_i32 = dim_i32(m, "svd_values")?;
+                let n_i32 = dim_i32(n, "svd_values")?;
+
+                let mut a = input.host_data().to_vec();
+                let mut s = vec![0.0 as $real; k];
+                let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
+                let mut info = 0;
+                unsafe {
+                    $gesvd(
+                        b'N',
+                        b'N',
+                        m_i32,
+                        n_i32,
+                        &mut a,
+                        m_i32,
+                        &mut s,
+                        &mut [],
+                        1,
+                        &mut [],
+                        1,
+                        &mut query,
+                        -1,
+                        &mut rwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("svd_values", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0].re as f64, "svd_values", $routine)?;
+                let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                unsafe {
+                    $gesvd(
+                        b'N',
+                        b'N',
+                        m_i32,
+                        n_i32,
+                        &mut a,
+                        m_i32,
+                        &mut s,
+                        &mut [],
+                        1,
+                        &mut [],
+                        1,
+                        &mut work,
+                        lwork,
+                        &mut rwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("svd_values", $routine, info)?;
+
+                Ok(tensor_from_vec_with_template(vec![k], s, input))
+            }
         }
     };
 }
@@ -154,4 +281,52 @@ pub(crate) fn svd<T: LapackSvd>(
         ]);
     }
     batched_multi("svd", buffers, input, svd_2d)
+}
+
+fn svd_values_2d<T: LapackSvd>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<TypedTensor<T::Real>> {
+    T::svd_values_2d(buffers, input)
+}
+
+pub(crate) fn svd_values<T: LapackSvd>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<TypedTensor<T::Real>> {
+    if has_zero_dim(input.shape()) {
+        let (matrix_shape, batch_shape) = split_core_and_batch_result(input, 2, "svd_values")?;
+        let k = matrix_shape[0].min(matrix_shape[1]);
+        return Ok(tensor_from_vec_with_template(
+            vector_with_batch_shape(k, batch_shape),
+            Vec::new(),
+            input,
+        ));
+    }
+
+    let (core_shape, batch_shape) = split_core_and_batch_result(input, 2, "svd_values")?;
+    if batch_shape.is_empty() {
+        return svd_values_2d(buffers, input);
+    }
+
+    let slice_size: usize = core_shape.iter().product();
+    let batch_total: usize = batch_shape.iter().product();
+    let k = core_shape[0].min(core_shape[1]);
+    let mut data = Vec::with_capacity(k * batch_total);
+    for batch in 0..batch_total {
+        let start = batch * slice_size;
+        let end = start + slice_size;
+        let batch_input = tensor_from_vec_with_template(
+            core_shape.to_vec(),
+            input.host_data()[start..end].to_vec(),
+            input,
+        );
+        let values = svd_values_2d(buffers, &batch_input)?;
+        data.extend_from_slice(values.host_data());
+    }
+    Ok(tensor_from_vec_with_template(
+        vector_with_batch_shape(k, batch_shape),
+        data,
+        input,
+    ))
 }

--- a/tenferro-linalg/src/eager_backend.rs
+++ b/tenferro-linalg/src/eager_backend.rs
@@ -73,6 +73,10 @@ impl LinalgBackend for EagerBackend {
         dispatch_linalg!(self, eigh(input))
     }
 
+    fn eigh_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+        dispatch_linalg!(self, eigh_values(input))
+    }
+
     fn eig(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         dispatch_linalg!(self, eig(input))
     }

--- a/tenferro-linalg/src/extension.rs
+++ b/tenferro-linalg/src/extension.rs
@@ -38,6 +38,9 @@ pub(crate) enum LinalgOp {
     Eigh {
         eps: f64,
     },
+    EighVals {
+        eps: f64,
+    },
     Eig {
         input_dtype: DType,
     },
@@ -53,6 +56,7 @@ impl LinalgOp {
     fn output_count(self) -> usize {
         match self {
             Self::Cholesky
+            | Self::EighVals { .. }
             | Self::FullPivLuSolve { .. }
             | Self::LuSolvePrepared { .. }
             | Self::SvdVals { .. }
@@ -87,6 +91,7 @@ impl LinalgOp {
             Self::LuFactor => 10,
             Self::LuSolvePrepared { .. } => 11,
             Self::SvdVals { .. } => 12,
+            Self::EighVals { .. } => 13,
         }
     }
 }
@@ -200,9 +205,10 @@ impl ExtensionOpTrait for LinalgExtensionOp {
     fn payload_hash(&self, hasher: &mut dyn Hasher) {
         hasher.write_u8(self.op.tag());
         match self.op {
-            LinalgOp::Svd { eps } | LinalgOp::SvdVals { eps } | LinalgOp::Eigh { eps } => {
-                hasher.write_u64(eps.to_bits())
-            }
+            LinalgOp::Svd { eps }
+            | LinalgOp::SvdVals { eps }
+            | LinalgOp::Eigh { eps }
+            | LinalgOp::EighVals { eps } => hasher.write_u64(eps.to_bits()),
             LinalgOp::Eig { input_dtype } => hash_dtype(hasher, input_dtype),
             LinalgOp::FullPivLuSolve { transpose_a } => {
                 hasher.write_u8(u8::from(transpose_a));
@@ -289,6 +295,7 @@ impl ExtensionOpTrait for LinalgExtensionOp {
             }
             LinalgOp::Qr => qr_meta(input_dtypes[0], input_shapes[0]),
             LinalgOp::Eigh { .. } => eigh_meta(input_dtypes[0], input_shapes[0]),
+            LinalgOp::EighVals { .. } => vec![eigh_values_meta(input_dtypes[0], input_shapes[0])],
             LinalgOp::Eig { input_dtype } => eig_meta(input_dtype, input_shapes[0]),
         }
     }
@@ -365,6 +372,7 @@ fn execute_linalg<B: LinalgBackend>(
         LinalgOp::SvdVals { .. } => Ok(vec![backend.svd_values(inputs[0])?]),
         LinalgOp::Qr => backend.qr(inputs[0]),
         LinalgOp::Eigh { .. } => backend.eigh(inputs[0]),
+        LinalgOp::EighVals { .. } => Ok(vec![backend.eigh_values(inputs[0])?]),
         LinalgOp::Eig { .. } => backend.eig(inputs[0]),
         LinalgOp::TriangularSolve {
             left_side,
@@ -457,6 +465,12 @@ fn eigh_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
         (dtype, vector_shape(n.clone(), batch)),
         (dtype, matrix_shape(n.clone(), n, batch)),
     ]
+}
+
+fn eigh_values_meta(dtype: DType, shape: &[SymDim]) -> (DType, Vec<SymDim>) {
+    let n = shape[0].clone();
+    let batch = &shape[2..];
+    (singular_values_dtype(dtype), vector_shape(n, batch))
 }
 
 fn eig_meta(input_dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {

--- a/tenferro-linalg/src/gpu/ffi/cusolver.rs
+++ b/tenferro-linalg/src/gpu/ffi/cusolver.rs
@@ -73,6 +73,7 @@ pub enum CublasOperation {
 #[repr(i32)]
 #[derive(Clone, Copy)]
 pub enum CusolverEigMode {
+    NoVector = 0,
     Vector = 1,
 }
 
@@ -591,6 +592,66 @@ type TrsmC64Fn = unsafe extern "C" fn(
     *mut Complex64,
     i32,
 ) -> CublasStatus;
+type TrsmBatchedF32Fn = unsafe extern "C" fn(
+    CublasHandleRaw,
+    CublasSideMode,
+    CublasFillMode,
+    CublasOperation,
+    CublasDiagType,
+    i32,
+    i32,
+    *const f32,
+    *const *const f32,
+    i32,
+    *mut *mut f32,
+    i32,
+    i32,
+) -> CublasStatus;
+type TrsmBatchedF64Fn = unsafe extern "C" fn(
+    CublasHandleRaw,
+    CublasSideMode,
+    CublasFillMode,
+    CublasOperation,
+    CublasDiagType,
+    i32,
+    i32,
+    *const f64,
+    *const *const f64,
+    i32,
+    *mut *mut f64,
+    i32,
+    i32,
+) -> CublasStatus;
+type TrsmBatchedC32Fn = unsafe extern "C" fn(
+    CublasHandleRaw,
+    CublasSideMode,
+    CublasFillMode,
+    CublasOperation,
+    CublasDiagType,
+    i32,
+    i32,
+    *const Complex32,
+    *const *const Complex32,
+    i32,
+    *mut *mut Complex32,
+    i32,
+    i32,
+) -> CublasStatus;
+type TrsmBatchedC64Fn = unsafe extern "C" fn(
+    CublasHandleRaw,
+    CublasSideMode,
+    CublasFillMode,
+    CublasOperation,
+    CublasDiagType,
+    i32,
+    i32,
+    *const Complex64,
+    *const *const Complex64,
+    i32,
+    *mut *mut Complex64,
+    i32,
+    i32,
+) -> CublasStatus;
 
 struct CusolverVtable {
     create: CusolverCreateFn,
@@ -712,6 +773,10 @@ struct CublasVtable {
     dtrsm: TrsmF64Fn,
     ctrsm: TrsmC32Fn,
     ztrsm: TrsmC64Fn,
+    strsm_batched: TrsmBatchedF32Fn,
+    dtrsm_batched: TrsmBatchedF64Fn,
+    ctrsm_batched: TrsmBatchedC32Fn,
+    ztrsm_batched: TrsmBatchedC64Fn,
 }
 
 impl CublasVtable {
@@ -724,6 +789,10 @@ impl CublasVtable {
             dtrsm: load_symbol(lib, b"cublasDtrsm_v2\0", "cuBLAS")?,
             ctrsm: load_symbol(lib, b"cublasCtrsm_v2\0", "cuBLAS")?,
             ztrsm: load_symbol(lib, b"cublasZtrsm_v2\0", "cuBLAS")?,
+            strsm_batched: load_symbol(lib, b"cublasStrsmBatched\0", "cuBLAS")?,
+            dtrsm_batched: load_symbol(lib, b"cublasDtrsmBatched\0", "cuBLAS")?,
+            ctrsm_batched: load_symbol(lib, b"cublasCtrsmBatched\0", "cuBLAS")?,
+            ztrsm_batched: load_symbol(lib, b"cublasZtrsmBatched\0", "cuBLAS")?,
         })
     }
 }
@@ -1706,6 +1775,88 @@ impl CublasHandle {
             ),
         };
         self.lib.check_status(status, op, "cublas*trsm_v2")
+    }
+
+    pub unsafe fn trsm_batched(
+        &self,
+        dtype: CudaDataType,
+        side: CublasSideMode,
+        uplo: CublasFillMode,
+        trans: CublasOperation,
+        diag: CublasDiagType,
+        m: i32,
+        n: i32,
+        alpha: *const c_void,
+        a_array: *const c_void,
+        lda: i32,
+        b_array: *mut c_void,
+        ldb: i32,
+        batch_count: i32,
+        op: &'static str,
+    ) -> Result<()> {
+        let status = match dtype {
+            CudaDataType::F32 => (self.lib.vtable.strsm_batched)(
+                self.raw,
+                side,
+                uplo,
+                trans,
+                diag,
+                m,
+                n,
+                alpha.cast(),
+                a_array.cast(),
+                lda,
+                b_array.cast(),
+                ldb,
+                batch_count,
+            ),
+            CudaDataType::F64 => (self.lib.vtable.dtrsm_batched)(
+                self.raw,
+                side,
+                uplo,
+                trans,
+                diag,
+                m,
+                n,
+                alpha.cast(),
+                a_array.cast(),
+                lda,
+                b_array.cast(),
+                ldb,
+                batch_count,
+            ),
+            CudaDataType::Complex32 => (self.lib.vtable.ctrsm_batched)(
+                self.raw,
+                side,
+                uplo,
+                trans,
+                diag,
+                m,
+                n,
+                alpha.cast(),
+                a_array.cast(),
+                lda,
+                b_array.cast(),
+                ldb,
+                batch_count,
+            ),
+            CudaDataType::Complex64 => (self.lib.vtable.ztrsm_batched)(
+                self.raw,
+                side,
+                uplo,
+                trans,
+                diag,
+                m,
+                n,
+                alpha.cast(),
+                a_array.cast(),
+                lda,
+                b_array.cast(),
+                ldb,
+                batch_count,
+            ),
+        };
+        self.lib.check_status(status, op, "cublas*trsmBatched")
     }
 }
 

--- a/tenferro-linalg/src/gpu/linalg.rs
+++ b/tenferro-linalg/src/gpu/linalg.rs
@@ -324,6 +324,18 @@ pub(super) fn eigh(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Te
     }
 }
 
+pub(super) fn eigh_values(backend: &mut CubeclBackend, input: &Tensor) -> Result<Tensor> {
+    match input {
+        Tensor::F32(t) => eigh_values_typed(backend, t).map(Tensor::F32),
+        Tensor::F64(t) => eigh_values_typed(backend, t).map(Tensor::F64),
+        Tensor::C32(t) => eigh_values_typed(backend, t).map(Tensor::F32),
+        Tensor::C64(t) => eigh_values_typed(backend, t).map(Tensor::F64),
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_linalg_dtype("eigh_values", input))
+        }
+    }
+}
+
 pub(super) fn eig(_backend: &mut CubeclBackend, _input: &Tensor) -> Result<Vec<Tensor>> {
     Err(Error::backend_failure(
         "eig",
@@ -469,42 +481,28 @@ where
         OP,
     )?;
     let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
-    let info = alloc_workspace_bytes(backend.runtime(), std::mem::size_of::<i32>(), OP)?;
+    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let matrix_stride = n * n;
 
     for batch in 0..batch_total {
-        let batch_ptr = unsafe { batch_ptr::<T>(first_ptr, batch * matrix_stride) };
+        let batch_a = unsafe { batch_ptr::<T>(first_ptr, batch * matrix_stride) };
+        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
         unsafe {
             handles.cusolver().potrf(
                 T::DATA_TYPE,
                 CublasFillMode::Lower,
                 n_i32,
-                batch_ptr,
+                batch_a,
                 lda,
                 workspace.ptr,
                 lwork,
-                info.ptr.cast::<i32>(),
+                batch_info,
                 OP,
             )?;
         }
-        let mut host_info = [0_i32; 1];
-        copy_device_to_host(backend.runtime(), &mut host_info, info.ptr.cast_const(), OP)?;
-        match host_info[0] {
-            0 => {}
-            x if x < 0 => {
-                return Err(Error::backend_failure(
-                    OP,
-                    format!("cusolverDn*potrf reported invalid parameter {}", -x),
-                ));
-            }
-            x => {
-                return Err(Error::backend_failure(
-                    OP,
-                    format!("matrix is not positive definite (minor {x})"),
-                ));
-            }
-        }
     }
+    check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*potrf")?;
 
     backend.tril_typed(&work, 0)
 }
@@ -592,9 +590,39 @@ where
     let n_rhs = as_i32(cols, op, "n")?;
     let alpha = T::one();
 
-    for batch in 0..batch_count(&b.shape()[2..]) {
-        let batch_a = unsafe { batch_const_ptr::<T>(a_ptr.cast_const(), batch * a_stride) };
-        let batch_b = unsafe { batch_ptr::<T>(out_ptr, batch * out_stride) };
+    let batch_total = batch_count(&b.shape()[2..]);
+    if batch_total > 1 {
+        let mut a_pointers = Vec::with_capacity(batch_total);
+        let mut b_pointers = Vec::with_capacity(batch_total);
+        for batch in 0..batch_total {
+            let batch_a = unsafe { batch_const_ptr::<T>(a_ptr.cast_const(), batch * a_stride) };
+            let batch_b = unsafe { batch_ptr::<T>(out_ptr, batch * out_stride) };
+            a_pointers.push(batch_a as usize);
+            b_pointers.push(batch_b as usize);
+        }
+        let a_array = upload_pointer_array(backend.runtime(), &a_pointers, op)?;
+        let b_array = upload_pointer_array(backend.runtime(), &b_pointers, op)?;
+        unsafe {
+            handles.cublas().trsm_batched(
+                T::DATA_TYPE,
+                side,
+                uplo,
+                trans,
+                diag,
+                m,
+                n_rhs,
+                (&alpha as *const T).cast(),
+                a_array.ptr.cast_const(),
+                lda,
+                b_array.ptr,
+                ldb,
+                as_i32(batch_total, op, "batch_count")?,
+                op,
+            )?;
+        }
+    } else {
+        let batch_a = unsafe { batch_const_ptr::<T>(a_ptr.cast_const(), 0) };
+        let batch_b = unsafe { batch_ptr::<T>(out_ptr, 0) };
         unsafe {
             handles.cublas().trsm(
                 T::DATA_TYPE,
@@ -686,7 +714,7 @@ where
     for batch in 0..batch_total {
         let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * matrix_stride) };
         let batch_pivots = unsafe { batch_ptr::<i32>(pivots_ptr, batch * k) };
-        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch) };
+        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
         unsafe {
             handles.cusolver().getrf(
                 T::DATA_TYPE,
@@ -840,8 +868,9 @@ where
     } else {
         Workspace::none()
     };
-    let info = alloc_workspace_bytes(backend.runtime(), std::mem::size_of::<i32>(), OP)?;
     let batch_total = batch_count(batch_shape);
+    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let a_stride = m * n;
     let u_stride = m * k;
     let s_stride = k;
@@ -853,6 +882,7 @@ where
         let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, batch * s_stride) };
         let batch_u = unsafe { batch_ptr::<T>(u_ptr, batch * u_stride) };
         let batch_vt = unsafe { batch_ptr::<T>(vt_ptr, batch * vt_stride) };
+        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
         unsafe {
             handles.cusolver().gesvd(
                 T::DATA_TYPE,
@@ -870,14 +900,12 @@ where
                 workspace.ptr,
                 lwork,
                 rwork.ptr,
-                info.ptr.cast::<i32>(),
+                batch_info,
                 OP,
             )?;
         }
-        let mut host_info = [0_i32; 1];
-        copy_device_to_host(backend.runtime(), &mut host_info, info.ptr.cast_const(), OP)?;
-        check_solver_info(OP, "cusolverDn*gesvd", host_info[0])?;
     }
+    check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*gesvd")?;
 
     Ok((u, s, vt))
 }
@@ -922,8 +950,9 @@ where
     } else {
         Workspace::none()
     };
-    let info = alloc_workspace_bytes(backend.runtime(), std::mem::size_of::<i32>(), OP)?;
     let batch_total = batch_count(batch_shape);
+    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let a_stride = m * n;
     let s_stride = k;
     let job = b'N' as c_char;
@@ -931,6 +960,7 @@ where
     for batch in 0..batch_total {
         let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
         let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, batch * s_stride) };
+        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
         unsafe {
             handles.cusolver().gesvd(
                 T::DATA_TYPE,
@@ -948,14 +978,12 @@ where
                 workspace.ptr,
                 lwork,
                 rwork.ptr,
-                info.ptr.cast::<i32>(),
+                batch_info,
                 OP,
             )?;
         }
-        let mut host_info = [0_i32; 1];
-        copy_device_to_host(backend.runtime(), &mut host_info, info.ptr.cast_const(), OP)?;
-        check_solver_info(OP, "cusolverDn*gesvd", host_info[0])?;
     }
+    check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*gesvd")?;
 
     Ok(s)
 }
@@ -1003,7 +1031,6 @@ where
             .geqrf_buffer_size(T::DATA_TYPE, m_i32, n_i32, work_ptr, lda, OP)?;
     let geqrf_workspace = alloc_workspace_elems::<T>(backend.runtime(), geqrf_lwork, OP)?;
     let tau = alloc_workspace_bytes(backend.runtime(), k * std::mem::size_of::<T>(), OP)?;
-    let info = alloc_workspace_bytes(backend.runtime(), std::mem::size_of::<i32>(), OP)?;
     let orgqr_lwork = handles.cusolver().orgqr_buffer_size(
         T::DATA_TYPE,
         m_i32,
@@ -1016,12 +1043,18 @@ where
     )?;
     let orgqr_workspace = alloc_workspace_elems::<T>(backend.runtime(), orgqr_lwork, OP)?;
     let batch_total = batch_count(batch_shape);
+    let geqrf_info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let orgqr_info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let geqrf_info_ptr = typed_device_ptr(backend.runtime(), &geqrf_info, OP)?;
+    let orgqr_info_ptr = typed_device_ptr(backend.runtime(), &orgqr_info, OP)?;
     let work_stride = m * n;
     let q_stride = m * k;
 
     for batch in 0..batch_total {
         let batch_work = unsafe { batch_ptr::<T>(work_ptr, batch * work_stride) };
         let batch_q = unsafe { batch_ptr::<T>(q_ptr, batch * q_stride) };
+        let batch_geqrf_info = unsafe { batch_ptr::<i32>(geqrf_info_ptr, batch).cast::<i32>() };
+        let batch_orgqr_info = unsafe { batch_ptr::<i32>(orgqr_info_ptr, batch).cast::<i32>() };
         unsafe {
             handles.cusolver().geqrf(
                 T::DATA_TYPE,
@@ -1032,13 +1065,10 @@ where
                 tau.ptr,
                 geqrf_workspace.ptr,
                 geqrf_lwork,
-                info.ptr.cast::<i32>(),
+                batch_geqrf_info,
                 OP,
             )?;
         }
-        let mut host_info = [0_i32; 1];
-        copy_device_to_host(backend.runtime(), &mut host_info, info.ptr.cast_const(), OP)?;
-        check_solver_info(OP, "cusolverDn*geqrf", host_info[0])?;
 
         copy_device_to_device(
             backend.runtime(),
@@ -1058,13 +1088,13 @@ where
                 tau.ptr.cast_const(),
                 orgqr_workspace.ptr,
                 orgqr_lwork,
-                info.ptr.cast::<i32>(),
+                batch_orgqr_info,
                 OP,
             )?;
         }
-        copy_device_to_host(backend.runtime(), &mut host_info, info.ptr.cast_const(), OP)?;
-        check_solver_info(OP, "cusolverDn*orgqr", host_info[0])?;
     }
+    check_solver_info_tensor(backend.runtime(), &geqrf_info, OP, "cusolverDn*geqrf")?;
+    check_solver_info_tensor(backend.runtime(), &orgqr_info, OP, "cusolverDn*orgqr")?;
 
     let r_input = backend.slice_typed(&work, &matrix_slice_config(input.shape(), k, n))?;
     let r = backend.triu_typed(&r_input, 0)?;
@@ -1114,14 +1144,16 @@ where
         OP,
     )?;
     let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
-    let info = alloc_workspace_bytes(backend.runtime(), std::mem::size_of::<i32>(), OP)?;
     let batch_total = batch_count(batch_shape);
+    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let matrix_stride = n * n;
     let values_stride = n;
 
     for batch in 0..batch_total {
         let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * matrix_stride) };
         let batch_w = unsafe { batch_ptr::<T::Real>(values_ptr, batch * values_stride) };
+        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
         unsafe {
             handles.cusolver().syevd(
                 T::DATA_TYPE,
@@ -1133,16 +1165,85 @@ where
                 batch_w,
                 workspace.ptr,
                 lwork,
-                info.ptr.cast::<i32>(),
+                batch_info,
                 OP,
             )?;
         }
-        let mut host_info = [0_i32; 1];
-        copy_device_to_host(backend.runtime(), &mut host_info, info.ptr.cast_const(), OP)?;
-        check_solver_info(OP, "cusolverDn*syevd", host_info[0])?;
     }
+    check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*syevd")?;
 
     Ok((values, work))
+}
+
+fn eigh_values_typed<T>(
+    backend: &CubeclBackend,
+    input: &TypedTensor<T>,
+) -> Result<TypedTensor<T::Real>>
+where
+    T: LinalgScalar,
+{
+    const OP: &str = "eigh_values";
+
+    backend.runtime().set_current_cuda_context(OP)?;
+    ensure_cubecl_resident_typed(OP, input)?;
+    let n = square_matrix_dim(OP, input.shape())?;
+    let batch_shape = &input.shape()[2..];
+    let mut values_shape = vec![n];
+    values_shape.extend_from_slice(batch_shape);
+    if has_zero_dim(input.shape()) {
+        return Ok(alloc_output(backend.runtime(), &values_shape));
+    }
+
+    let work = clone_device_tensor(backend.runtime(), input, OP)?;
+    let values = alloc_output::<T::Real>(backend.runtime(), &values_shape);
+    let handles = linalg_handles(backend)?;
+    let stream = raw_stream(backend.runtime(), OP)?;
+    handles.cusolver().set_stream(stream, OP)?;
+
+    let a_ptr = typed_device_ptr(backend.runtime(), &work, OP)?;
+    let values_ptr = typed_device_ptr(backend.runtime(), &values, OP)?;
+    let n_i32 = as_i32(n, OP, "n")?;
+    let lda = as_i32(n, OP, "lda")?;
+    let lwork = handles.cusolver().syevd_buffer_size(
+        T::DATA_TYPE,
+        CusolverEigMode::NoVector,
+        CublasFillMode::Lower,
+        n_i32,
+        a_ptr.cast_const(),
+        lda,
+        values_ptr.cast_const(),
+        OP,
+    )?;
+    let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
+    let batch_total = batch_count(batch_shape);
+    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
+    let matrix_stride = n * n;
+    let values_stride = n;
+
+    for batch in 0..batch_total {
+        let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * matrix_stride) };
+        let batch_w = unsafe { batch_ptr::<T::Real>(values_ptr, batch * values_stride) };
+        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+        unsafe {
+            handles.cusolver().syevd(
+                T::DATA_TYPE,
+                CusolverEigMode::NoVector,
+                CublasFillMode::Lower,
+                n_i32,
+                batch_a,
+                lda,
+                batch_w,
+                workspace.ptr,
+                lwork,
+                batch_info,
+                OP,
+            )?;
+        }
+    }
+    check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*syevd")?;
+
+    Ok(values)
 }
 
 fn build_lu_outputs_device<T>(
@@ -1411,6 +1512,26 @@ where
     ))
 }
 
+fn upload_pointer_array(
+    rt: &CubeclRuntime,
+    pointers: &[usize],
+    op: &'static str,
+) -> Result<Workspace> {
+    let nbytes = std::mem::size_of_val(pointers);
+    let bytes = unsafe { std::slice::from_raw_parts(pointers.as_ptr().cast::<u8>(), nbytes) };
+    let handle = rt.client().create_from_slice(bytes);
+    let resource = rt.client().get_resource(handle.clone()).map_err(|err| {
+        Error::backend_failure(
+            op,
+            format!("failed to obtain pointer-array resource: {err:?}"),
+        )
+    })?;
+    Ok(Workspace {
+        _handle: Some(handle),
+        ptr: resource.resource().ptr as usize as *mut c_void,
+    })
+}
+
 fn download_device_tensor<T>(
     rt: &CubeclRuntime,
     tensor: &TypedTensor<T>,
@@ -1444,21 +1565,6 @@ fn copy_device_to_device(
     let stream = raw_stream(rt, op)? as cudaStream_t;
     unsafe { cuda_result::memcpy_dtod_async(dst, src, nbytes, stream) }
         .map_err(|err| Error::backend_failure(op, format!("cudaMemcpyAsync DtoD failed: {err:?}")))
-}
-
-fn copy_device_to_host<T: Copy>(
-    rt: &CubeclRuntime,
-    dst: &mut [T],
-    src: *const c_void,
-    op: &'static str,
-) -> Result<()> {
-    let stream = raw_stream(rt, op)? as cudaStream_t;
-    unsafe { cuda_result::memcpy_dtoh_async(dst, src, stream) }.map_err(|err| {
-        Error::backend_failure(op, format!("cudaMemcpyAsync DtoH failed: {err:?}"))
-    })?;
-    unsafe { cuda_result::stream::synchronize(stream) }.map_err(|err| {
-        Error::backend_failure(op, format!("CUDA stream synchronize failed: {err:?}"))
-    })
 }
 
 fn matrix_slice_config(shape: &[usize], row_limit: usize, col_limit: usize) -> SliceConfig {
@@ -1570,6 +1676,19 @@ fn check_solver_info(op: &'static str, call: &'static str, info: i32) -> Result<
         op,
         format!("{call} failed with info={info}"),
     ))
+}
+
+fn check_solver_info_tensor(
+    rt: &CubeclRuntime,
+    info: &TypedTensor<i32>,
+    op: &'static str,
+    call: &'static str,
+) -> Result<()> {
+    let host_info = download_device_tensor(rt, info, op)?;
+    for &value in host_info.host_data() {
+        check_solver_info(op, call, value)?;
+    }
+    Ok(())
 }
 
 fn has_zero_dim(shape: &[usize]) -> bool {

--- a/tenferro-linalg/src/gpu/mod.rs
+++ b/tenferro-linalg/src/gpu/mod.rs
@@ -89,6 +89,10 @@ impl LinalgBackend for CubeclBackend {
         linalg::eigh(self, input)
     }
 
+    fn eigh_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+        linalg::eigh_values(self, input)
+    }
+
     fn eig(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         linalg::eig(self, input)
     }

--- a/tenferro-linalg/src/traced.rs
+++ b/tenferro-linalg/src/traced.rs
@@ -382,7 +382,7 @@ pub fn inv(a: &TracedTensor) -> Result<TracedTensor> {
 /// assert_eq!(values.rank, 1);
 /// ```
 pub fn eigvalsh(a: &TracedTensor) -> Result<TracedTensor> {
-    Ok(eigh(a)?.0)
+    eigh_values(a)
 }
 
 /// Build a traced general eigenvalue-only op.
@@ -451,8 +451,7 @@ pub fn pinv_with_rtol(a: &TracedTensor, rtol: f64) -> Result<TracedTensor> {
 
     let v = vt.conj().transpose(&matrix_transpose_perm(vt.rank));
     let uh = u.conj().transpose(&matrix_transpose_perm(u.rank));
-    let s_inv_diag = s_inv.embed_diag(0, 1);
-    let vs = matmul_preserve_trailing_batch(&v, &s_inv_diag);
+    let vs = scale_matrix_columns(&v, &s_inv);
     Ok(matmul_preserve_trailing_batch(&vs, &uh))
 }
 
@@ -711,6 +710,27 @@ fn svd_values(a: &TracedTensor) -> Result<TracedTensor> {
         ),
         "svd_values",
     )
+}
+
+fn eigh_values(a: &TracedTensor) -> Result<TracedTensor> {
+    one_output(
+        apply(
+            Arc::new(LinalgExtensionOp::new(LinalgOp::EighVals { eps: 1e-12 })),
+            &[a],
+        ),
+        "eigh_values",
+    )
+}
+
+fn scale_matrix_columns(matrix: &TracedTensor, scale: &TracedTensor) -> TracedTensor {
+    let matrix_shape = matrix.concrete_shape();
+    let mut scale_shape = vec![1, scale.concrete_shape()[0]];
+    scale_shape.extend_from_slice(&matrix_shape[2..]);
+    let dims: Vec<usize> = (0..matrix_shape.len()).collect();
+    let scale = scale
+        .reshape(&scale_shape)
+        .broadcast_in_dim(&matrix_shape, &dims);
+    matrix * &scale
 }
 
 fn count_nonzero(abs: &TracedTensor, axes: &[usize]) -> TracedTensor {

--- a/tenferro-linalg/tests/backend_errors.rs
+++ b/tenferro-linalg/tests/backend_errors.rs
@@ -1,7 +1,7 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::LinalgBackend;
 use tenferro_tensor::{
@@ -16,8 +16,16 @@ fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
 }
 
+fn f32_tensor(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
+    Tensor::F32(TypedTensor::from_vec_col_major(shape, data))
+}
+
 fn c64_tensor(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
     Tensor::C64(TypedTensor::from_vec_col_major(shape, data))
+}
+
+fn c32_tensor(shape: Vec<usize>, data: Vec<Complex32>) -> Tensor {
+    Tensor::C32(TypedTensor::from_vec_col_major(shape, data))
 }
 
 fn i32_tensor(shape: Vec<usize>, data: Vec<i32>) -> Tensor {
@@ -208,6 +216,15 @@ fn default_svd_view_returns_explicit_backend_boundary_error() {
         } if message.contains("does not implement")
     ));
 
+    let err = backend.svd_values(&Tensor::F64(input.clone())).unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "svd_values",
+            ref message,
+        } if message.contains("does not implement")
+    ));
+
     let err = backend
         .svd_view(TensorView::F64(input.as_view()))
         .unwrap_err();
@@ -219,26 +236,59 @@ fn default_svd_view_returns_explicit_backend_boundary_error() {
             ref message,
         } if message.contains("borrowed tensor views")
     ));
+
+    let err = backend
+        .eigh_values(&Tensor::F64(input.clone()))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "eigh_values",
+            ref message,
+        } if message.contains("does not implement")
+    ));
+
+    let pivots = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1, 2]));
+    let err = backend
+        .lu_solve_prepared(
+            &Tensor::F64(input.clone()),
+            &Tensor::F64(input.clone()),
+            &pivots,
+            &Tensor::F64(input),
+            false,
+            false,
+        )
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "lu_solve_prepared",
+            ref message,
+        } if message.contains("does not implement")
+    ));
 }
 
 #[test]
-fn default_lu_solve_prepared_delegates_to_solve_modes() {
+fn cpu_lu_solve_prepared_consumes_packed_factor_outputs() {
     let mut backend = CpuBackend::new();
-    let pivots = i32_tensor(vec![2], vec![0, 1]);
 
     let a = f64_tensor(vec![2, 2], vec![2.0, 0.0, 0.0, 3.0]);
     let b = f64_tensor(vec![2, 1], vec![4.0, 9.0]);
+    let factors = backend.lu_factor(&a).unwrap();
     let x = backend
-        .lu_solve_prepared(&a, &a, &pivots, &b, false, false)
+        .lu_solve_prepared(&a, &factors[0], &factors[1], &b, false, false)
         .unwrap();
     assert_eq!(f64_values(&x), vec![2.0, 3.0]);
 
     let a = f64_tensor(vec![2, 2], vec![1.0, 0.0, 2.0, 3.0]);
     let b = f64_tensor(vec![2, 1], vec![5.0, 31.0]);
+    let factors = backend.lu_factor(&a).unwrap();
     let x = backend
-        .lu_solve_prepared(&a, &a, &pivots, &b, true, false)
+        .lu_solve_prepared(&a, &factors[0], &factors[1], &b, true, false)
         .unwrap();
-    assert_eq!(f64_values(&x), vec![5.0, 7.0]);
+    let values = f64_values(&x);
+    assert!((values[0] - 5.0).abs() < 1.0e-12);
+    assert!((values[1] - 7.0).abs() < 1.0e-12);
 
     let a = c64_tensor(
         vec![2, 2],
@@ -253,8 +303,9 @@ fn default_lu_solve_prepared_delegates_to_solve_modes() {
         vec![2, 1],
         vec![Complex64::new(2.0, -2.0), Complex64::new(6.0, 3.0)],
     );
+    let factors = backend.lu_factor(&a).unwrap();
     let x = backend
-        .lu_solve_prepared(&a, &a, &pivots, &b, true, true)
+        .lu_solve_prepared(&a, &factors[0], &factors[1], &b, true, true)
         .unwrap();
     let values = c64_values(&x);
     assert!((values[0] - Complex64::new(2.0, 0.0)).norm() < 1.0e-12);
@@ -262,11 +313,180 @@ fn default_lu_solve_prepared_delegates_to_solve_modes() {
 }
 
 #[test]
-fn default_lu_solve_prepared_rejects_rank_less_than_two_transpose() {
+fn cpu_lu_factor_covers_pivoted_real_and_complex_dtypes() {
+    let mut backend = CpuBackend::new();
+
+    let a = f32_tensor(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]);
+    let factors = backend.lu_factor(&a).unwrap();
+    assert!(matches!(&factors[0], Tensor::F32(t) if t.shape() == [2, 2]));
+    assert!(matches!(&factors[1], Tensor::I32(t) if t.host_data() == [2, 2]));
+    assert!(matches!(&factors[2], Tensor::F32(t) if t.host_data() == [-1.0]));
+
+    let a = c32_tensor(
+        vec![2, 2],
+        vec![
+            Complex32::new(2.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(3.0, 1.0),
+        ],
+    );
+    let factors = backend.lu_factor(&a).unwrap();
+    assert!(matches!(&factors[0], Tensor::C32(t) if t.shape() == [2, 2]));
+    assert!(matches!(&factors[1], Tensor::I32(t) if t.host_data() == [1, 2]));
+    assert!(matches!(&factors[2], Tensor::C32(t) if t.host_data() == [Complex32::new(1.0, 0.0)]));
+}
+
+#[test]
+fn cpu_values_only_decompositions_cover_real_complex_and_batched_inputs() {
+    let mut backend = CpuBackend::new();
+
+    let s = backend
+        .svd_values(&f32_tensor(vec![2, 2], vec![3.0, 0.0, 0.0, 4.0]))
+        .unwrap();
+    assert!(matches!(s, Tensor::F32(ref t) if t.shape() == [2]));
+
+    let s = backend
+        .svd_values(&f64_tensor(
+            vec![2, 2, 2],
+            vec![3.0, 0.0, 0.0, 4.0, 5.0, 0.0, 0.0, 6.0],
+        ))
+        .unwrap();
+    assert!(matches!(s, Tensor::F64(ref t) if t.shape() == [2, 2]));
+
+    let s = backend
+        .svd_values(&c32_tensor(
+            vec![2, 2],
+            vec![
+                Complex32::new(3.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(4.0, 0.0),
+            ],
+        ))
+        .unwrap();
+    assert!(matches!(s, Tensor::F32(ref t) if t.shape() == [2]));
+
+    let s = backend
+        .svd_values(&c64_tensor(
+            vec![2, 2],
+            vec![
+                Complex64::new(3.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(4.0, 0.0),
+            ],
+        ))
+        .unwrap();
+    assert!(matches!(s, Tensor::F64(ref t) if t.shape() == [2]));
+
+    let values = backend
+        .eigh_values(&f32_tensor(vec![2, 2], vec![3.0, 0.0, 0.0, 4.0]))
+        .unwrap();
+    assert!(matches!(values, Tensor::F32(ref t) if t.shape() == [2]));
+
+    let values = backend
+        .eigh_values(&f64_tensor(
+            vec![2, 2, 2],
+            vec![3.0, 0.0, 0.0, 4.0, 5.0, 0.0, 0.0, 6.0],
+        ))
+        .unwrap();
+    assert!(matches!(values, Tensor::F64(ref t) if t.shape() == [2, 2]));
+
+    let values = backend
+        .eigh_values(&c32_tensor(
+            vec![2, 2],
+            vec![
+                Complex32::new(3.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(4.0, 0.0),
+            ],
+        ))
+        .unwrap();
+    assert!(matches!(values, Tensor::F32(ref t) if t.shape() == [2]));
+
+    let values = backend
+        .eigh_values(&c64_tensor(
+            vec![2, 2],
+            vec![
+                Complex64::new(3.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(4.0, 0.0),
+            ],
+        ))
+        .unwrap();
+    assert!(matches!(values, Tensor::F64(ref t) if t.shape() == [2]));
+}
+
+#[test]
+fn cpu_lu_solve_prepared_restores_vector_rhs_and_validates_inputs() {
+    let mut backend = CpuBackend::new();
+    let a = f64_tensor(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0]);
+    let factors = backend.lu_factor(&a).unwrap();
+    let b = f64_tensor(vec![2], vec![6.0, 20.0]);
+
+    let x = backend
+        .lu_solve_prepared(&a, &factors[0], &factors[1], &b, false, false)
+        .unwrap();
+    assert_eq!(x.shape(), &[2]);
+    assert_eq!(f64_values(&x), vec![3.0, 5.0]);
+
+    let empty_a = f64_tensor(vec![0, 0], Vec::new());
+    let empty_b = f64_tensor(vec![0, 1], Vec::new());
+    let empty_pivots = i32_tensor(vec![0], Vec::new());
+    let x = backend
+        .lu_solve_prepared(&empty_a, &empty_a, &empty_pivots, &empty_b, false, false)
+        .unwrap();
+    assert_eq!(x.shape(), &[0, 1]);
+
+    let bad_pivots = f64_tensor(vec![2], vec![1.0, 2.0]);
+    let err = backend
+        .lu_solve_prepared(&a, &factors[0], &bad_pivots, &b, false, false)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::DTypeMismatch {
+            op: "lu_solve_prepared",
+            ..
+        }
+    ));
+
+    let bad_b = c64_tensor(
+        vec![2, 1],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+    );
+    let err = backend
+        .lu_solve_prepared(&a, &factors[0], &factors[1], &bad_b, false, false)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::DTypeMismatch {
+            op: "lu_solve_prepared",
+            ..
+        }
+    ));
+
+    let bad_pivots = i32_tensor(vec![2], vec![0, 2]);
+    let err = backend
+        .lu_solve_prepared(&a, &a, &bad_pivots, &b, false, false)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "lu_solve_prepared",
+            ref message,
+        } if message.contains("1-based")
+    ));
+}
+
+#[test]
+fn cpu_lu_solve_prepared_rejects_rank_less_than_two() {
     let mut backend = CpuBackend::new();
     let a = f64_tensor(vec![2], vec![1.0, 2.0]);
     let b = f64_tensor(vec![2], vec![1.0, 2.0]);
-    let pivots = i32_tensor(vec![2], vec![0, 1]);
+    let pivots = i32_tensor(vec![2], vec![1, 2]);
 
     let err = backend
         .lu_solve_prepared(&a, &a, &pivots, &b, true, false)
@@ -274,7 +494,7 @@ fn default_lu_solve_prepared_rejects_rank_less_than_two_transpose() {
 
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::RankMismatch {
             op: "lu_solve_prepared",
             ..
         }

--- a/tenferro-linalg/tests/gpu_linalg.rs
+++ b/tenferro-linalg/tests/gpu_linalg.rs
@@ -310,6 +310,30 @@ fn test_cubecl_triangular_solve_c32_reconstructs_rhs() {
 
 #[test]
 #[ignore]
+fn test_cubecl_triangular_solve_batched_f64_matches_cpu() {
+    let a = tensor_f64(vec![2, 2, 2], vec![2.0, 0.0, 1.0, 3.0, 4.0, 0.0, -1.0, 2.0]);
+    let b = tensor_f64(vec![2, 1, 2], vec![5.0, 9.0, 2.0, 3.0]);
+    let mut cpu = cpu_backend();
+    let expected = cpu
+        .triangular_solve(&a, &b, true, false, false, false)
+        .unwrap();
+    let mut gpu = gpu_backend();
+    let actual = gpu
+        .triangular_solve(
+            &upload(&gpu, &a),
+            &upload(&gpu, &b),
+            true,
+            false,
+            false,
+            false,
+        )
+        .unwrap();
+    let actual = download(&gpu, &actual);
+    assert_tensor_close(&actual, &expected, 1e-9);
+}
+
+#[test]
+#[ignore]
 fn test_cubecl_lu_f32_reconstructs_pa_equals_lu() {
     let input = tensor_f32(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]);
     let mut gpu = gpu_backend();
@@ -471,6 +495,27 @@ fn test_cubecl_eigh_c64_reconstructs_input() {
         2,
     );
     assert_slice_close_c64(&recon, input.as_slice::<Complex64>().unwrap(), 1e-9);
+}
+
+#[test]
+#[ignore]
+fn test_cubecl_eigh_values_c64_matches_cpu() {
+    let l = vec![
+        Complex64::new(2.0, 0.0),
+        Complex64::new(1.0, -1.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(1.5, 0.0),
+    ];
+    let input = tensor_c64(
+        vec![2, 2],
+        matmul_c64(&l, &conj_transpose_c64(&l, 2, 2), 2, 2, 2),
+    );
+    let mut cpu = cpu_backend();
+    let expected = cpu.eigh_values(&input).unwrap();
+    let mut gpu = gpu_backend();
+    let actual = gpu.eigh_values(&upload(&gpu, &input)).unwrap();
+    let actual = download(&gpu, &actual);
+    assert_tensor_close(&actual, &expected, 1e-9);
 }
 
 #[test]

--- a/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -171,6 +171,109 @@ fn cubecl_linalg_overrides_svd_view_with_backend_canonicalization() {
 }
 
 #[test]
+fn gpu_solver_info_checks_are_batched_outside_kernel_loops() {
+    let source = linalg_source();
+
+    for (start, end, info_name, call_name) in [
+        (
+            "fn cholesky_typed",
+            "fn triangular_solve_typed",
+            "info = alloc_output::<i32>(backend.runtime(), &[batch_total])",
+            "check_solver_info_tensor(backend.runtime(), &info, OP, \"cusolverDn*potrf\")",
+        ),
+        (
+            "fn svd_typed",
+            "fn svd_values_typed",
+            "info = alloc_output::<i32>(backend.runtime(), &[batch_total])",
+            "check_solver_info_tensor(backend.runtime(), &info, OP, \"cusolverDn*gesvd\")",
+        ),
+        (
+            "fn svd_values_typed",
+            "fn qr_typed",
+            "info = alloc_output::<i32>(backend.runtime(), &[batch_total])",
+            "check_solver_info_tensor(backend.runtime(), &info, OP, \"cusolverDn*gesvd\")",
+        ),
+        (
+            "fn eigh_typed",
+            "fn build_lu_outputs_device",
+            "info = alloc_output::<i32>(backend.runtime(), &[batch_total])",
+            "check_solver_info_tensor(backend.runtime(), &info, OP, \"cusolverDn*syevd\")",
+        ),
+    ] {
+        let section = source_section(&source, start, end);
+        assert!(
+            section.contains(info_name),
+            "{start} should allocate one solver-info tensor for the whole batch"
+        );
+        assert!(
+            section.contains(call_name),
+            "{start} should check solver info once after the batch loop"
+        );
+        assert!(
+            !section.contains("copy_device_to_host"),
+            "{start} should not synchronize inside the per-batch loop"
+        );
+    }
+
+    let qr = source_section(&source, "fn qr_typed", "fn eigh_typed");
+    for needle in [
+        "geqrf_info = alloc_output::<i32>(backend.runtime(), &[batch_total])",
+        "orgqr_info = alloc_output::<i32>(backend.runtime(), &[batch_total])",
+        "check_solver_info_tensor(backend.runtime(), &geqrf_info, OP, \"cusolverDn*geqrf\")",
+        "check_solver_info_tensor(backend.runtime(), &orgqr_info, OP, \"cusolverDn*orgqr\")",
+    ] {
+        assert!(
+            qr.contains(needle),
+            "QR should use batched info handling: missing {needle}"
+        );
+    }
+    assert!(
+        !qr.contains("copy_device_to_host"),
+        "QR should not synchronize inside the per-batch loop"
+    );
+}
+
+#[test]
+fn gpu_eigh_values_uses_cusolver_no_vector_mode() {
+    let source = linalg_source();
+    let gpu_mod = gpu_mod_source();
+    let ffi = read_workspace_source("tenferro-linalg/src/gpu/ffi/cusolver.rs");
+
+    assert!(
+        source.contains("pub(super) fn eigh_values"),
+        "GPU linalg should expose an internal eigh_values hook"
+    );
+    assert!(
+        source.contains("CusolverEigMode::NoVector"),
+        "GPU eigvalsh should use cuSOLVER values-only mode"
+    );
+    assert!(
+        gpu_mod.contains("fn eigh_values"),
+        "CubeCL linalg backend should override eigh_values"
+    );
+    assert!(
+        ffi.contains("NoVector = 0"),
+        "cuSOLVER eig mode enum should expose values-only mode"
+    );
+}
+
+#[test]
+fn gpu_triangular_solve_uses_batched_cublas_when_batching_is_present() {
+    let source = linalg_source();
+    let ffi = read_workspace_source("tenferro-linalg/src/gpu/ffi/cusolver.rs");
+    let triangular = source_section(&source, "fn triangular_solve_typed_with_op", "fn lu_typed");
+
+    assert!(
+        ffi.contains("trsm_batched"),
+        "cuBLAS FFI should expose a batched triangular solve entry point"
+    );
+    assert!(
+        triangular.contains("trsm_batched"),
+        "GPU triangular_solve should use the batched entry point for batched inputs"
+    );
+}
+
+#[test]
 fn gpu_linalg_zero_dim_fast_paths_validate_residency_before_allocating_outputs() {
     let source = linalg_source();
 

--- a/tenferro-linalg/tests/linalg_internal_path_contract.rs
+++ b/tenferro-linalg/tests/linalg_internal_path_contract.rs
@@ -75,6 +75,91 @@ fn matrix_norm_uses_singular_values_only_path() {
 }
 
 #[test]
+fn traced_eigvalsh_uses_hermitian_values_only_path() {
+    let source = crate_source("src/traced.rs");
+    let eigvalsh_source = source_section(
+        &source,
+        "pub fn eigvalsh",
+        "/// Build a traced general eigenvalue-only op",
+    );
+
+    assert!(
+        eigvalsh_source.contains("eigh_values("),
+        "eigvalsh should emit a Hermitian eigenvalues-only internal op"
+    );
+    assert!(
+        !eigvalsh_source.contains("eigh(a)?.0"),
+        "eigvalsh should not materialize eigenvectors and then discard them"
+    );
+
+    let extension_source = crate_source("src/extension.rs");
+    assert!(
+        extension_source.contains("LinalgOp::EighVals"),
+        "linalg extension should define an internal EighVals op"
+    );
+    assert!(
+        extension_source.contains("backend.eigh_values"),
+        "EighVals execution should dispatch to a backend values-only hook"
+    );
+}
+
+#[test]
+fn traced_pinv_scales_svd_vectors_without_dense_diagonal_materialization() {
+    let source = crate_source("src/traced.rs");
+    let pinv_source = source_section(
+        &source,
+        "pub fn pinv_with_rtol",
+        "/// Build a traced vector, matrix, or tensor norm op",
+    );
+
+    assert!(
+        pinv_source.contains("scale_matrix_columns"),
+        "pinv should broadcast singular-value reciprocals across V columns"
+    );
+    assert!(
+        !pinv_source.contains("s_inv.embed_diag"),
+        "pinv should not materialize a dense diagonal matrix for singular values"
+    );
+}
+
+#[test]
+fn cpu_backend_overrides_prepared_lu_and_values_only_paths() {
+    let source = crate_source("src/cpu/backend.rs");
+    let lu_factor_source = source_section(&source, "fn lu_factor", "fn full_piv_lu");
+
+    assert!(
+        !lu_factor_source.contains("self.lu(input)?"),
+        "CPU lu_factor should factor directly instead of rebuilding from public LU outputs"
+    );
+    assert!(
+        !lu_factor_source.contains("identity_pivots"),
+        "CPU lu_factor should return real pivot metadata, not identity pivots"
+    );
+    for needle in ["fn lu_solve_prepared", "fn svd_values", "fn eigh_values"] {
+        assert!(
+            source.contains(needle),
+            "CPU backend should override {needle}"
+        );
+    }
+}
+
+#[test]
+fn backend_surface_has_hidden_hermitian_values_only_hook() {
+    let source = crate_source("src/backend.rs");
+
+    assert!(
+        source.contains("fn eigh_values"),
+        "backend surface should include a hidden eigh_values hook"
+    );
+    assert!(
+        source.contains(
+            "backend {} does not implement internal Hermitian eigenvalues-only decomposition"
+        ),
+        "default eigh_values should fail explicitly instead of silently using full eigh"
+    );
+}
+
+#[test]
 fn linalg_ad_has_prepared_solve_rules() {
     let source = crate_source("src/ad/rules/solve.rs");
 


### PR DESCRIPTION
## Summary

- add direct linalg internal hooks for packed LU factors, prepared LU solve, and values-only SVD/Eigh paths
- route traced `eigvalsh` and `pinv` away from unnecessary full decompositions/dense diagonal materialization
- add CPU Faer/LAPACK values-only implementations and CUDA batched solver-info/TRSM coverage
- document the no-silent-fallback rule for internal optimized backend hooks

## Why

The previous design could silently fall back from optimized internal paths to slower public/full-operation paths. That hides performance regressions and makes GPU linalg behavior harder to audit. This PR makes unsupported internal hooks explicit errors and implements the intended direct paths for supported backends.

Work log: `docs/worklogs/2026-06-02-linalg-values-batch-optimizations.md`

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.5 LD_LIBRARY_PATH=/usr/local/cuda-12.5/targets/x86_64-linux/lib:/usr/local/cuda-12.5/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-linalg --features cuda --test gpu_linalg -- --ignored`
