### PR TITLE
Make CUDA SVD driver selection JAX-compatible

### DIFF
--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -243,6 +243,13 @@ CUDA library calls:
 | Contraction | cuTENSOR-backed paths for supported real and complex floating dtypes |
 | Linalg | cuSOLVER/cuBLAS-backed SVD, QR, Cholesky, LU, Eigh, LU solve, and triangular solve for supported real and complex floating dtypes |
 
+CUDA SVD follows JAX-compatible default driver selection as an internal backend
+policy: use cuSOLVER Jacobi `gesvdj` when both matrix dimensions are at most
+1024, otherwise use QR-based `gesvd`. `gesvdj` returns V, so the backend
+materializes the public `vt` output by copying V to V^H on the device. The
+singular-values-only path still passes scratch U/V buffers to `gesvdj` because
+cuSOLVER rejects null U/V pointers on that path.
+
 The published [`Devices and GPU`](../guides/devices-and-gpu.md) guide contains
 the current CUDA operation and dtype matrix. Keep that matrix synchronized with
 the `CubeclBackend` `TensorBackend` implementation when adding or removing CUDA

--- a/docs/worklogs/2026-06-02-jax-compatible-svd-driver.md
+++ b/docs/worklogs/2026-06-02-jax-compatible-svd-driver.md
@@ -1,0 +1,76 @@
+# JAX-Compatible CUDA SVD Driver Selection
+
+Date: 2026-06-02
+
+## Session summary
+
+Changed the CUDA SVD path to use JAX-compatible default driver selection:
+`gesvdj` for concrete matrices with both dimensions at most 1024, and the
+existing `gesvd` path for larger matrices. This targets the benchmark gap where
+tenferro used QR-based `gesvd` for 256x256 CUDA SVD while JAX and PyTorch use
+Jacobi `gesvdj` by default.
+
+## Context read
+
+- `REPOSITORY_RULES.md`
+- Shared tensor4all common, Rust performance, and numerical rules
+- Existing CUDA linalg implementation and source-contract tests
+- JAX SVD lowering in `../jax/jax/_src/lax/linalg.py`
+- JAX cuSOLVER FFI implementation in `../jax/jaxlib/gpu/solver_kernels_ffi.cc`
+- Local cuSOLVER header `/usr/include/cusolverDn.h`
+
+## Reference code
+
+JAX resolves CUDA SVD defaults to Jacobi for `m, n <= 1024`, otherwise
+`gesvd`. Its `gesvdj` lowering returns V, then transposes and conjugates it to
+produce V^H. JAX also allocates U and V buffers for Jacobi even when
+`compute_uv=false`; cuSOLVER rejects null U/V pointers in that path on this
+host.
+
+PyTorch documentation and local benchmark A/B showed the same practical default
+for the 256x256 benchmark: `driver=None` matches `gesvdj`, while explicit
+`gesvd` matches tenferro's previous slower path.
+
+## Decisions made
+
+- Added cuSOLVER `gesvdj` FFI and `gesvdjInfo` lifetime management inside the
+  existing linalg CUDA FFI module.
+- Kept the public SVD API unchanged. The driver choice is an internal backend
+  policy, not a user-visible driver argument.
+- Added an internal `select_svd_driver(m, n)` helper with JAX's 1024 threshold.
+- For full SVD, `gesvdj` writes U and V; tenferro then copies V to V^H with a
+  small CUDA kernel so the existing `vt` contract remains unchanged.
+- For values-only SVD, `gesvdj` still allocates scratch U/V buffers and passes
+  them to cuSOLVER, matching JAX's cuSOLVER contract handling.
+
+## Rejected or deferred alternatives
+
+- Did not add a public driver-selection API. That would widen the public
+  surface for a backend policy change.
+- Did not use `gesvda` as the default. PyTorch exposes it, but neither JAX nor
+  PyTorch uses it as the normal exact SVD default.
+- Did not route V-to-VT through runtime typed transpose helpers because CubeCL
+  rejects borrowed tensor views at that execution boundary.
+- Did not add `gesvdjBatched`; the current PR only changes the default driver
+  selection needed for the observed benchmark mismatch.
+
+## Verification performed
+
+- `cargo fmt --all --check`
+- `cargo check -p tenferro-linalg --features cuda`
+- `cargo test -p tenferro-linalg gpu_svd_uses_jax_compatible_default_driver_selection`
+- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/lib64:/usr/local/cuda/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-linalg --features cuda test_cubecl_svd -- --ignored --nocapture`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+
+## Remaining risks
+
+- The implementation does not yet benchmark the new path inside this PR. The
+  prior benchmark comparison indicates `gesvdj` is the required driver for the
+  256x256 gap, but fresh benchmark result updates can happen in the benchmark
+  repository.
+- Small batched SVD could be further optimized with `gesvdjBatched`, but that is
+  separate from the JAX-compatible default driver policy.

--- a/tenferro-linalg/src/gpu/ffi/cusolver.rs
+++ b/tenferro-linalg/src/gpu/ffi/cusolver.rs
@@ -25,6 +25,7 @@ const CUBLAS_DEFAULT_PATHS: &[&str] = &[
 pub type CusolverDnHandleRaw = *mut c_void;
 pub type CublasHandleRaw = *mut c_void;
 pub type CudaStream = *mut c_void;
+type GesvdjInfoRaw = *mut c_void;
 
 type CusolverStatus = i32;
 type CublasStatus = i32;
@@ -444,6 +445,145 @@ type GesvdC64Fn = unsafe extern "C" fn(
     *mut i32,
 ) -> CusolverStatus;
 
+type CreateGesvdjInfoFn = unsafe extern "C" fn(*mut GesvdjInfoRaw) -> CusolverStatus;
+type DestroyGesvdjInfoFn = unsafe extern "C" fn(GesvdjInfoRaw) -> CusolverStatus;
+type GesvdjBufferSizeF32Fn = unsafe extern "C" fn(
+    CusolverDnHandleRaw,
+    CusolverEigMode,
+    i32,
+    i32,
+    i32,
+    *const f32,
+    i32,
+    *const f32,
+    *const f32,
+    i32,
+    *const f32,
+    i32,
+    *mut i32,
+    GesvdjInfoRaw,
+) -> CusolverStatus;
+type GesvdjBufferSizeF64Fn = unsafe extern "C" fn(
+    CusolverDnHandleRaw,
+    CusolverEigMode,
+    i32,
+    i32,
+    i32,
+    *const f64,
+    i32,
+    *const f64,
+    *const f64,
+    i32,
+    *const f64,
+    i32,
+    *mut i32,
+    GesvdjInfoRaw,
+) -> CusolverStatus;
+type GesvdjBufferSizeC32Fn = unsafe extern "C" fn(
+    CusolverDnHandleRaw,
+    CusolverEigMode,
+    i32,
+    i32,
+    i32,
+    *const Complex32,
+    i32,
+    *const f32,
+    *const Complex32,
+    i32,
+    *const Complex32,
+    i32,
+    *mut i32,
+    GesvdjInfoRaw,
+) -> CusolverStatus;
+type GesvdjBufferSizeC64Fn = unsafe extern "C" fn(
+    CusolverDnHandleRaw,
+    CusolverEigMode,
+    i32,
+    i32,
+    i32,
+    *const Complex64,
+    i32,
+    *const f64,
+    *const Complex64,
+    i32,
+    *const Complex64,
+    i32,
+    *mut i32,
+    GesvdjInfoRaw,
+) -> CusolverStatus;
+type GesvdjF32Fn = unsafe extern "C" fn(
+    CusolverDnHandleRaw,
+    CusolverEigMode,
+    i32,
+    i32,
+    i32,
+    *mut f32,
+    i32,
+    *mut f32,
+    *mut f32,
+    i32,
+    *mut f32,
+    i32,
+    *mut f32,
+    i32,
+    *mut i32,
+    GesvdjInfoRaw,
+) -> CusolverStatus;
+type GesvdjF64Fn = unsafe extern "C" fn(
+    CusolverDnHandleRaw,
+    CusolverEigMode,
+    i32,
+    i32,
+    i32,
+    *mut f64,
+    i32,
+    *mut f64,
+    *mut f64,
+    i32,
+    *mut f64,
+    i32,
+    *mut f64,
+    i32,
+    *mut i32,
+    GesvdjInfoRaw,
+) -> CusolverStatus;
+type GesvdjC32Fn = unsafe extern "C" fn(
+    CusolverDnHandleRaw,
+    CusolverEigMode,
+    i32,
+    i32,
+    i32,
+    *mut Complex32,
+    i32,
+    *mut f32,
+    *mut Complex32,
+    i32,
+    *mut Complex32,
+    i32,
+    *mut Complex32,
+    i32,
+    *mut i32,
+    GesvdjInfoRaw,
+) -> CusolverStatus;
+type GesvdjC64Fn = unsafe extern "C" fn(
+    CusolverDnHandleRaw,
+    CusolverEigMode,
+    i32,
+    i32,
+    i32,
+    *mut Complex64,
+    i32,
+    *mut f64,
+    *mut Complex64,
+    i32,
+    *mut Complex64,
+    i32,
+    *mut Complex64,
+    i32,
+    *mut i32,
+    GesvdjInfoRaw,
+) -> CusolverStatus;
+
 type SyevdBufferSizeF32Fn = unsafe extern "C" fn(
     CusolverDnHandleRaw,
     CusolverEigMode,
@@ -697,6 +837,16 @@ struct CusolverVtable {
     dgesvd: GesvdF64Fn,
     cgesvd: GesvdC32Fn,
     zgesvd: GesvdC64Fn,
+    create_gesvdj_info: CreateGesvdjInfoFn,
+    destroy_gesvdj_info: DestroyGesvdjInfoFn,
+    sgesvdj_buffer_size: GesvdjBufferSizeF32Fn,
+    dgesvdj_buffer_size: GesvdjBufferSizeF64Fn,
+    cgesvdj_buffer_size: GesvdjBufferSizeC32Fn,
+    zgesvdj_buffer_size: GesvdjBufferSizeC64Fn,
+    sgesvdj: GesvdjF32Fn,
+    dgesvdj: GesvdjF64Fn,
+    cgesvdj: GesvdjC32Fn,
+    zgesvdj: GesvdjC64Fn,
     ssyevd_buffer_size: SyevdBufferSizeF32Fn,
     dsyevd_buffer_size: SyevdBufferSizeF64Fn,
     cheevd_buffer_size: SyevdBufferSizeC32Fn,
@@ -753,6 +903,16 @@ impl CusolverVtable {
             dgesvd: load_symbol(lib, b"cusolverDnDgesvd\0", "cuSOLVER")?,
             cgesvd: load_symbol(lib, b"cusolverDnCgesvd\0", "cuSOLVER")?,
             zgesvd: load_symbol(lib, b"cusolverDnZgesvd\0", "cuSOLVER")?,
+            create_gesvdj_info: load_symbol(lib, b"cusolverDnCreateGesvdjInfo\0", "cuSOLVER")?,
+            destroy_gesvdj_info: load_symbol(lib, b"cusolverDnDestroyGesvdjInfo\0", "cuSOLVER")?,
+            sgesvdj_buffer_size: load_symbol(lib, b"cusolverDnSgesvdj_bufferSize\0", "cuSOLVER")?,
+            dgesvdj_buffer_size: load_symbol(lib, b"cusolverDnDgesvdj_bufferSize\0", "cuSOLVER")?,
+            cgesvdj_buffer_size: load_symbol(lib, b"cusolverDnCgesvdj_bufferSize\0", "cuSOLVER")?,
+            zgesvdj_buffer_size: load_symbol(lib, b"cusolverDnZgesvdj_bufferSize\0", "cuSOLVER")?,
+            sgesvdj: load_symbol(lib, b"cusolverDnSgesvdj\0", "cuSOLVER")?,
+            dgesvdj: load_symbol(lib, b"cusolverDnDgesvdj\0", "cuSOLVER")?,
+            cgesvdj: load_symbol(lib, b"cusolverDnCgesvdj\0", "cuSOLVER")?,
+            zgesvdj: load_symbol(lib, b"cusolverDnZgesvdj\0", "cuSOLVER")?,
             ssyevd_buffer_size: load_symbol(lib, b"cusolverDnSsyevd_bufferSize\0", "cuSOLVER")?,
             dsyevd_buffer_size: load_symbol(lib, b"cusolverDnDsyevd_bufferSize\0", "cuSOLVER")?,
             cheevd_buffer_size: load_symbol(lib, b"cusolverDnCheevd_bufferSize\0", "cuSOLVER")?,
@@ -987,6 +1147,25 @@ pub struct CusolverDnHandle {
 
 unsafe impl Send for CusolverDnHandle {}
 
+pub struct GesvdjInfo<'a> {
+    handle: &'a CusolverDnHandle,
+    raw: GesvdjInfoRaw,
+}
+
+impl<'a> GesvdjInfo<'a> {
+    fn raw(&self) -> GesvdjInfoRaw {
+        self.raw
+    }
+}
+
+impl Drop for GesvdjInfo<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            (self.handle.lib.vtable.destroy_gesvdj_info)(self.raw);
+        }
+    }
+}
+
 impl CusolverDnHandle {
     pub fn load() -> Result<Self> {
         let lib = CusolverLibrary::load()?;
@@ -999,6 +1178,14 @@ impl CusolverDnHandle {
     pub fn set_stream(&self, stream: CudaStream, op: &'static str) -> Result<()> {
         let status = unsafe { (self.lib.vtable.set_stream)(self.raw, stream) };
         self.lib.check_status(status, op, "cusolverDnSetStream")
+    }
+
+    pub fn create_gesvdj_info(&self, op: &'static str) -> Result<GesvdjInfo<'_>> {
+        let mut raw = std::ptr::null_mut();
+        let status = unsafe { (self.lib.vtable.create_gesvdj_info)(&mut raw) };
+        self.lib
+            .check_status(status, op, "cusolverDnCreateGesvdjInfo")?;
+        Ok(GesvdjInfo { handle: self, raw })
     }
 
     pub fn potrf_buffer_size(
@@ -1447,6 +1634,97 @@ impl CusolverDnHandle {
         Ok(lwork)
     }
 
+    pub fn gesvdj_buffer_size(
+        &self,
+        dtype: CudaDataType,
+        jobz: CusolverEigMode,
+        econ: i32,
+        m: i32,
+        n: i32,
+        a: *const c_void,
+        lda: i32,
+        s: *const c_void,
+        u: *const c_void,
+        ldu: i32,
+        v: *const c_void,
+        ldv: i32,
+        params: &GesvdjInfo<'_>,
+        op: &'static str,
+    ) -> Result<i32> {
+        let mut lwork = 0;
+        let status = unsafe {
+            match dtype {
+                CudaDataType::F32 => (self.lib.vtable.sgesvdj_buffer_size)(
+                    self.raw,
+                    jobz,
+                    econ,
+                    m,
+                    n,
+                    a.cast(),
+                    lda,
+                    s.cast(),
+                    u.cast(),
+                    ldu,
+                    v.cast(),
+                    ldv,
+                    &mut lwork,
+                    params.raw(),
+                ),
+                CudaDataType::F64 => (self.lib.vtable.dgesvdj_buffer_size)(
+                    self.raw,
+                    jobz,
+                    econ,
+                    m,
+                    n,
+                    a.cast(),
+                    lda,
+                    s.cast(),
+                    u.cast(),
+                    ldu,
+                    v.cast(),
+                    ldv,
+                    &mut lwork,
+                    params.raw(),
+                ),
+                CudaDataType::Complex32 => (self.lib.vtable.cgesvdj_buffer_size)(
+                    self.raw,
+                    jobz,
+                    econ,
+                    m,
+                    n,
+                    a.cast(),
+                    lda,
+                    s.cast(),
+                    u.cast(),
+                    ldu,
+                    v.cast(),
+                    ldv,
+                    &mut lwork,
+                    params.raw(),
+                ),
+                CudaDataType::Complex64 => (self.lib.vtable.zgesvdj_buffer_size)(
+                    self.raw,
+                    jobz,
+                    econ,
+                    m,
+                    n,
+                    a.cast(),
+                    lda,
+                    s.cast(),
+                    u.cast(),
+                    ldu,
+                    v.cast(),
+                    ldv,
+                    &mut lwork,
+                    params.raw(),
+                ),
+            }
+        };
+        self.lib
+            .check_status(status, op, "cusolverDn*gesvdj_bufferSize")?;
+        Ok(lwork)
+    }
+
     pub unsafe fn gesvd(
         &self,
         dtype: CudaDataType,
@@ -1542,6 +1820,103 @@ impl CusolverDnHandle {
             ),
         };
         self.lib.check_status(status, op, "cusolverDn*gesvd")
+    }
+
+    pub unsafe fn gesvdj(
+        &self,
+        dtype: CudaDataType,
+        jobz: CusolverEigMode,
+        econ: i32,
+        m: i32,
+        n: i32,
+        a: *mut c_void,
+        lda: i32,
+        s: *mut c_void,
+        u: *mut c_void,
+        ldu: i32,
+        v: *mut c_void,
+        ldv: i32,
+        workspace: *mut c_void,
+        lwork: i32,
+        info: *mut i32,
+        params: &GesvdjInfo<'_>,
+        op: &'static str,
+    ) -> Result<()> {
+        let status = match dtype {
+            CudaDataType::F32 => (self.lib.vtable.sgesvdj)(
+                self.raw,
+                jobz,
+                econ,
+                m,
+                n,
+                a.cast(),
+                lda,
+                s.cast(),
+                u.cast(),
+                ldu,
+                v.cast(),
+                ldv,
+                workspace.cast(),
+                lwork,
+                info,
+                params.raw(),
+            ),
+            CudaDataType::F64 => (self.lib.vtable.dgesvdj)(
+                self.raw,
+                jobz,
+                econ,
+                m,
+                n,
+                a.cast(),
+                lda,
+                s.cast(),
+                u.cast(),
+                ldu,
+                v.cast(),
+                ldv,
+                workspace.cast(),
+                lwork,
+                info,
+                params.raw(),
+            ),
+            CudaDataType::Complex32 => (self.lib.vtable.cgesvdj)(
+                self.raw,
+                jobz,
+                econ,
+                m,
+                n,
+                a.cast(),
+                lda,
+                s.cast(),
+                u.cast(),
+                ldu,
+                v.cast(),
+                ldv,
+                workspace.cast(),
+                lwork,
+                info,
+                params.raw(),
+            ),
+            CudaDataType::Complex64 => (self.lib.vtable.zgesvdj)(
+                self.raw,
+                jobz,
+                econ,
+                m,
+                n,
+                a.cast(),
+                lda,
+                s.cast(),
+                u.cast(),
+                ldu,
+                v.cast(),
+                ldv,
+                workspace.cast(),
+                lwork,
+                info,
+                params.raw(),
+            ),
+        };
+        self.lib.check_status(status, op, "cusolverDn*gesvdj")
     }
 
     pub fn syevd_buffer_size(

--- a/tenferro-linalg/src/gpu/kernels.rs
+++ b/tenferro-linalg/src/gpu/kernels.rs
@@ -46,6 +46,48 @@ fn matching_work_offset<Work: CubePrimitive, Out: CubePrimitive>(
     offset
 }
 
+#[cube]
+fn svd_v_to_vt_offset<E: CubePrimitive>(
+    out: &Tensor<E>,
+    v: &Tensor<E>,
+    flat: usize,
+    #[comptime] rank: usize,
+) -> usize {
+    let row = out.coordinate(flat, 0usize);
+    let col = out.coordinate(flat, 1usize);
+    let mut offset = col * v.stride(0usize) + row * v.stride(1usize);
+    #[unroll]
+    for axis in 2usize..rank {
+        let coord = out.coordinate(flat, axis);
+        offset += coord * v.stride(axis);
+    }
+    offset
+}
+
+#[cube(launch_unchecked)]
+pub fn svd_v_to_vt_real<E: CubePrimitive>(
+    out: &mut Tensor<E>,
+    v: &Tensor<E>,
+    #[comptime] rank: usize,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < out.len() {
+        out[pos] = v[svd_v_to_vt_offset(out, v, pos, rank)];
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn svd_v_to_vt_complex<C: ComplexCore>(
+    out: &mut Tensor<C>,
+    v: &Tensor<C>,
+    #[comptime] rank: usize,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < out.len() {
+        out[pos] = v[svd_v_to_vt_offset(out, v, pos, rank)].conj();
+    }
+}
+
 #[cube(launch_unchecked)]
 pub fn lu_extract_outputs<E: CubePrimitive + core::ops::Neg<Output = E>>(
     p_out: &mut Tensor<E>,

--- a/tenferro-linalg/src/gpu/linalg.rs
+++ b/tenferro-linalg/src/gpu/linalg.rs
@@ -2,7 +2,7 @@ use std::ffi::c_void;
 use std::ops::Neg;
 use std::os::raw::c_char;
 
-use cubecl::prelude::{CubeElement, CubePrimitive};
+use cubecl::prelude::{ComplexCore, CubeElement, CubePrimitive};
 use cubecl_cuda::CudaRuntime;
 use cudarc::runtime::{result as cuda_result, sys::cudaStream_t};
 use num_complex::{Complex32, Complex64};
@@ -37,6 +37,13 @@ trait LinalgScalar:
 
     const DATA_TYPE: CudaDataType;
     const NEEDS_RWORK: bool;
+
+    fn copy_svd_v_to_vt(
+        rt: &CubeclRuntime,
+        v: &TypedTensor<Self>,
+        vt_shape: &[usize],
+        op: &'static str,
+    ) -> Result<TypedTensor<Self>>;
 }
 
 impl LinalgScalar for f32 {
@@ -44,6 +51,15 @@ impl LinalgScalar for f32 {
 
     const DATA_TYPE: CudaDataType = CudaDataType::F32;
     const NEEDS_RWORK: bool = false;
+
+    fn copy_svd_v_to_vt(
+        rt: &CubeclRuntime,
+        v: &TypedTensor<Self>,
+        vt_shape: &[usize],
+        op: &'static str,
+    ) -> Result<TypedTensor<Self>> {
+        copy_svd_v_to_vt_real(rt, v, vt_shape, op)
+    }
 }
 
 impl LinalgScalar for f64 {
@@ -51,6 +67,15 @@ impl LinalgScalar for f64 {
 
     const DATA_TYPE: CudaDataType = CudaDataType::F64;
     const NEEDS_RWORK: bool = false;
+
+    fn copy_svd_v_to_vt(
+        rt: &CubeclRuntime,
+        v: &TypedTensor<Self>,
+        vt_shape: &[usize],
+        op: &'static str,
+    ) -> Result<TypedTensor<Self>> {
+        copy_svd_v_to_vt_real(rt, v, vt_shape, op)
+    }
 }
 
 impl LinalgScalar for Complex32 {
@@ -58,6 +83,15 @@ impl LinalgScalar for Complex32 {
 
     const DATA_TYPE: CudaDataType = CudaDataType::Complex32;
     const NEEDS_RWORK: bool = true;
+
+    fn copy_svd_v_to_vt(
+        rt: &CubeclRuntime,
+        v: &TypedTensor<Self>,
+        vt_shape: &[usize],
+        op: &'static str,
+    ) -> Result<TypedTensor<Self>> {
+        copy_svd_v_to_vt_complex(rt, v, vt_shape, op)
+    }
 }
 
 impl LinalgScalar for Complex64 {
@@ -65,6 +99,31 @@ impl LinalgScalar for Complex64 {
 
     const DATA_TYPE: CudaDataType = CudaDataType::Complex64;
     const NEEDS_RWORK: bool = true;
+
+    fn copy_svd_v_to_vt(
+        rt: &CubeclRuntime,
+        v: &TypedTensor<Self>,
+        vt_shape: &[usize],
+        op: &'static str,
+    ) -> Result<TypedTensor<Self>> {
+        copy_svd_v_to_vt_complex(rt, v, vt_shape, op)
+    }
+}
+
+const JAX_COMPATIBLE_GESVDJ_MAX_DIM: usize = 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SvdDriver {
+    Gesvdj,
+    Gesvd,
+}
+
+fn select_svd_driver(m: usize, n: usize) -> SvdDriver {
+    if m <= JAX_COMPATIBLE_GESVDJ_MAX_DIM && n <= JAX_COMPATIBLE_GESVDJ_MAX_DIM {
+        SvdDriver::Gesvdj
+    } else {
+        SvdDriver::Gesvd
+    }
 }
 
 fn unsupported_linalg_dtype(op: &'static str, input: &Tensor) -> Error {
@@ -814,10 +873,102 @@ where
     }
 }
 
+fn copy_svd_v_to_vt_real<T>(
+    rt: &CubeclRuntime,
+    v: &TypedTensor<T>,
+    vt_shape: &[usize],
+    op: &'static str,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar,
+{
+    let vt = alloc_output::<T>(rt, vt_shape);
+    launch_svd_v_to_vt_real(rt, v, &vt, op)?;
+    Ok(vt)
+}
+
+fn copy_svd_v_to_vt_complex<T>(
+    rt: &CubeclRuntime,
+    v: &TypedTensor<T>,
+    vt_shape: &[usize],
+    op: &'static str,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar + ComplexCore,
+{
+    let vt = alloc_output::<T>(rt, vt_shape);
+    launch_svd_v_to_vt_complex(rt, v, &vt, op)?;
+    Ok(vt)
+}
+
+fn launch_svd_v_to_vt_real<T>(
+    rt: &CubeclRuntime,
+    v: &TypedTensor<T>,
+    vt: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<()>
+where
+    T: LinalgScalar,
+{
+    if vt.n_elements() == 0 {
+        return Ok(());
+    }
+    let client = rt.client();
+    let vt_arg = typed_tensor_binding(vt, op)?;
+    let v_arg = typed_tensor_binding(v, op)?;
+    unsafe {
+        cubecl_linalg::svd_v_to_vt_real::launch_unchecked::<T, CudaRuntime>(
+            client,
+            cube_count_for_len(vt.n_elements()),
+            cube_dim_1d(),
+            vt_arg.into_tensor_arg(),
+            v_arg.into_tensor_arg(),
+            vt.shape().len(),
+        );
+    }
+    client.flush().map_err(|err| {
+        Error::backend_failure(op, format!("SVD V-to-VT copy launch failed: {err:?}"))
+    })
+}
+
+fn launch_svd_v_to_vt_complex<T>(
+    rt: &CubeclRuntime,
+    v: &TypedTensor<T>,
+    vt: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<()>
+where
+    T: LinalgScalar + ComplexCore,
+{
+    if vt.n_elements() == 0 {
+        return Ok(());
+    }
+    let client = rt.client();
+    let vt_arg = typed_tensor_binding(vt, op)?;
+    let v_arg = typed_tensor_binding(v, op)?;
+    unsafe {
+        cubecl_linalg::svd_v_to_vt_complex::launch_unchecked::<T, CudaRuntime>(
+            client,
+            cube_count_for_len(vt.n_elements()),
+            cube_dim_1d(),
+            vt_arg.into_tensor_arg(),
+            v_arg.into_tensor_arg(),
+            vt.shape().len(),
+        );
+    }
+    client.flush().map_err(|err| {
+        Error::backend_failure(op, format!("SVD V-to-VT copy launch failed: {err:?}"))
+    })
+}
+
 fn svd_typed<T>(
     backend: &CubeclBackend,
     input: &TypedTensor<T>,
-) -> Result<(TypedTensor<T>, TypedTensor<T::Real>, TypedTensor<T>)>
+) -> Result<(
+    TypedTensor<T>,
+    TypedTensor<<T as LinalgScalar>::Real>,
+    TypedTensor<T>,
+)>
 where
     T: LinalgScalar,
 {
@@ -844,70 +995,149 @@ where
 
     let work = clone_device_tensor(backend.runtime(), input, OP)?;
     let u = alloc_output::<T>(backend.runtime(), &u_shape);
-    let s = alloc_output::<T::Real>(backend.runtime(), &s_shape);
-    let vt = alloc_output::<T>(backend.runtime(), &vt_shape);
-    let handles = linalg_handles(backend)?;
-    let stream = raw_stream(backend.runtime(), OP)?;
-    handles.cusolver().set_stream(stream, OP)?;
-
-    let a_ptr = typed_device_ptr(backend.runtime(), &work, OP)?;
-    let u_ptr = typed_device_ptr(backend.runtime(), &u, OP)?;
-    let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
-    let vt_ptr = typed_device_ptr(backend.runtime(), &vt, OP)?;
+    let s = alloc_output::<<T as LinalgScalar>::Real>(backend.runtime(), &s_shape);
     let m_i32 = as_i32(m, OP, "m")?;
     let n_i32 = as_i32(n, OP, "n")?;
     let lda = as_i32(m, OP, "lda")?;
     let ldu = as_i32(m, OP, "ldu")?;
-    let ldvt = as_i32(k.max(1), OP, "ldvt")?;
-    let lwork = handles
-        .cusolver()
-        .gesvd_buffer_size(T::DATA_TYPE, m_i32, n_i32, OP)?;
-    let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
-    let rwork = if T::NEEDS_RWORK {
-        alloc_workspace_elems::<T::Real>(backend.runtime(), as_i32(5 * k, OP, "rwork")?, OP)?
-    } else {
-        Workspace::none()
-    };
     let batch_total = batch_count(batch_shape);
-    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
-    let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let a_stride = m * n;
     let u_stride = m * k;
     let s_stride = k;
-    let vt_stride = k * n;
-    let job = b'S' as c_char;
 
-    for batch in 0..batch_total {
-        let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
-        let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, batch * s_stride) };
-        let batch_u = unsafe { batch_ptr::<T>(u_ptr, batch * u_stride) };
-        let batch_vt = unsafe { batch_ptr::<T>(vt_ptr, batch * vt_stride) };
-        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
-        unsafe {
-            handles.cusolver().gesvd(
-                T::DATA_TYPE,
-                job,
-                job,
-                m_i32,
-                n_i32,
-                batch_a,
-                lda,
-                batch_s,
-                batch_u,
-                ldu,
-                batch_vt,
-                ldvt,
-                workspace.ptr,
-                lwork,
-                rwork.ptr,
-                batch_info,
-                OP,
-            )?;
+    match select_svd_driver(m, n) {
+        SvdDriver::Gesvdj => {
+            let mut v_shape = vec![n, k];
+            v_shape.extend_from_slice(batch_shape);
+            let v = alloc_output::<T>(backend.runtime(), &v_shape);
+            {
+                let handles = linalg_handles(backend)?;
+                let stream = raw_stream(backend.runtime(), OP)?;
+                handles.cusolver().set_stream(stream, OP)?;
+
+                let a_ptr = typed_device_ptr(backend.runtime(), &work, OP)?;
+                let u_ptr = typed_device_ptr(backend.runtime(), &u, OP)?;
+                let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
+                let v_ptr = typed_device_ptr(backend.runtime(), &v, OP)?;
+                let ldv = as_i32(n, OP, "ldv")?;
+                let params = handles.cusolver().create_gesvdj_info(OP)?;
+                let lwork = handles.cusolver().gesvdj_buffer_size(
+                    T::DATA_TYPE,
+                    CusolverEigMode::Vector,
+                    1,
+                    m_i32,
+                    n_i32,
+                    a_ptr.cast_const(),
+                    lda,
+                    s_ptr.cast_const(),
+                    u_ptr.cast_const(),
+                    ldu,
+                    v_ptr.cast_const(),
+                    ldv,
+                    &params,
+                    OP,
+                )?;
+                let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
+                let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+                let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
+                let v_stride = n * k;
+
+                for batch in 0..batch_total {
+                    let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
+                    let batch_s =
+                        unsafe { batch_ptr::<<T as LinalgScalar>::Real>(s_ptr, batch * s_stride) };
+                    let batch_u = unsafe { batch_ptr::<T>(u_ptr, batch * u_stride) };
+                    let batch_v = unsafe { batch_ptr::<T>(v_ptr, batch * v_stride) };
+                    let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+                    unsafe {
+                        handles.cusolver().gesvdj(
+                            T::DATA_TYPE,
+                            CusolverEigMode::Vector,
+                            1,
+                            m_i32,
+                            n_i32,
+                            batch_a,
+                            lda,
+                            batch_s,
+                            batch_u,
+                            ldu,
+                            batch_v,
+                            ldv,
+                            workspace.ptr,
+                            lwork,
+                            batch_info,
+                            &params,
+                            OP,
+                        )?;
+                    }
+                }
+                check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*gesvdj")?;
+            }
+            let vt = T::copy_svd_v_to_vt(backend.runtime(), &v, &vt_shape, OP)?;
+            Ok((u, s, vt))
+        }
+        SvdDriver::Gesvd => {
+            let vt = alloc_output::<T>(backend.runtime(), &vt_shape);
+            let handles = linalg_handles(backend)?;
+            let stream = raw_stream(backend.runtime(), OP)?;
+            handles.cusolver().set_stream(stream, OP)?;
+
+            let a_ptr = typed_device_ptr(backend.runtime(), &work, OP)?;
+            let u_ptr = typed_device_ptr(backend.runtime(), &u, OP)?;
+            let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
+            let vt_ptr = typed_device_ptr(backend.runtime(), &vt, OP)?;
+            let ldvt = as_i32(k, OP, "ldvt")?;
+            let lwork = handles
+                .cusolver()
+                .gesvd_buffer_size(T::DATA_TYPE, m_i32, n_i32, OP)?;
+            let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
+            let rwork = if T::NEEDS_RWORK {
+                alloc_workspace_elems::<<T as LinalgScalar>::Real>(
+                    backend.runtime(),
+                    as_i32(5 * k, OP, "rwork")?,
+                    OP,
+                )?
+            } else {
+                Workspace::none()
+            };
+            let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+            let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
+            let vt_stride = k * n;
+            let job = b'S' as c_char;
+
+            for batch in 0..batch_total {
+                let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
+                let batch_s =
+                    unsafe { batch_ptr::<<T as LinalgScalar>::Real>(s_ptr, batch * s_stride) };
+                let batch_u = unsafe { batch_ptr::<T>(u_ptr, batch * u_stride) };
+                let batch_vt = unsafe { batch_ptr::<T>(vt_ptr, batch * vt_stride) };
+                let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+                unsafe {
+                    handles.cusolver().gesvd(
+                        T::DATA_TYPE,
+                        job,
+                        job,
+                        m_i32,
+                        n_i32,
+                        batch_a,
+                        lda,
+                        batch_s,
+                        batch_u,
+                        ldu,
+                        batch_vt,
+                        ldvt,
+                        workspace.ptr,
+                        lwork,
+                        rwork.ptr,
+                        batch_info,
+                        OP,
+                    )?;
+                }
+            }
+            check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*gesvd")?;
+            Ok((u, s, vt))
         }
     }
-    check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*gesvd")?;
-
-    Ok((u, s, vt))
 }
 
 fn svd_values_typed<T>(
@@ -932,60 +1162,137 @@ where
 
     let work = clone_device_tensor(backend.runtime(), input, OP)?;
     let s = alloc_output::<T::Real>(backend.runtime(), &s_shape);
-    let handles = linalg_handles(backend)?;
-    let stream = raw_stream(backend.runtime(), OP)?;
-    handles.cusolver().set_stream(stream, OP)?;
-
-    let a_ptr = typed_device_ptr(backend.runtime(), &work, OP)?;
-    let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
     let m_i32 = as_i32(m, OP, "m")?;
     let n_i32 = as_i32(n, OP, "n")?;
     let lda = as_i32(m, OP, "lda")?;
-    let lwork = handles
-        .cusolver()
-        .gesvd_buffer_size(T::DATA_TYPE, m_i32, n_i32, OP)?;
-    let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
-    let rwork = if T::NEEDS_RWORK {
-        alloc_workspace_elems::<T::Real>(backend.runtime(), as_i32(5 * k, OP, "rwork")?, OP)?
-    } else {
-        Workspace::none()
-    };
     let batch_total = batch_count(batch_shape);
-    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
-    let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let a_stride = m * n;
     let s_stride = k;
-    let job = b'N' as c_char;
 
-    for batch in 0..batch_total {
-        let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
-        let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, batch * s_stride) };
-        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
-        unsafe {
-            handles.cusolver().gesvd(
+    match select_svd_driver(m, n) {
+        SvdDriver::Gesvdj => {
+            let mut u_shape = vec![m, k];
+            u_shape.extend_from_slice(batch_shape);
+            let mut v_shape = vec![n, k];
+            v_shape.extend_from_slice(batch_shape);
+            let u = alloc_output::<T>(backend.runtime(), &u_shape);
+            let v = alloc_output::<T>(backend.runtime(), &v_shape);
+            let handles = linalg_handles(backend)?;
+            let stream = raw_stream(backend.runtime(), OP)?;
+            handles.cusolver().set_stream(stream, OP)?;
+
+            let a_ptr = typed_device_ptr(backend.runtime(), &work, OP)?;
+            let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
+            let u_ptr = typed_device_ptr(backend.runtime(), &u, OP)?;
+            let v_ptr = typed_device_ptr(backend.runtime(), &v, OP)?;
+            let params = handles.cusolver().create_gesvdj_info(OP)?;
+            let lwork = handles.cusolver().gesvdj_buffer_size(
                 T::DATA_TYPE,
-                job,
-                job,
+                CusolverEigMode::NoVector,
+                1,
                 m_i32,
                 n_i32,
-                batch_a,
+                a_ptr.cast_const(),
                 lda,
-                batch_s,
-                std::ptr::null_mut(),
-                1,
-                std::ptr::null_mut(),
-                1,
-                workspace.ptr,
-                lwork,
-                rwork.ptr,
-                batch_info,
+                s_ptr.cast_const(),
+                u_ptr.cast_const(),
+                lda,
+                v_ptr.cast_const(),
+                n_i32,
+                &params,
                 OP,
             )?;
+            let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
+            let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+            let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
+            let u_stride = m * k;
+            let v_stride = n * k;
+
+            for batch in 0..batch_total {
+                let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
+                let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, batch * s_stride) };
+                let batch_u = unsafe { batch_ptr::<T>(u_ptr, batch * u_stride) };
+                let batch_v = unsafe { batch_ptr::<T>(v_ptr, batch * v_stride) };
+                let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+                unsafe {
+                    handles.cusolver().gesvdj(
+                        T::DATA_TYPE,
+                        CusolverEigMode::NoVector,
+                        1,
+                        m_i32,
+                        n_i32,
+                        batch_a,
+                        lda,
+                        batch_s,
+                        batch_u,
+                        lda,
+                        batch_v,
+                        n_i32,
+                        workspace.ptr,
+                        lwork,
+                        batch_info,
+                        &params,
+                        OP,
+                    )?;
+                }
+            }
+            check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*gesvdj")?;
+            Ok(s)
+        }
+        SvdDriver::Gesvd => {
+            let handles = linalg_handles(backend)?;
+            let stream = raw_stream(backend.runtime(), OP)?;
+            handles.cusolver().set_stream(stream, OP)?;
+
+            let a_ptr = typed_device_ptr(backend.runtime(), &work, OP)?;
+            let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
+            let lwork = handles
+                .cusolver()
+                .gesvd_buffer_size(T::DATA_TYPE, m_i32, n_i32, OP)?;
+            let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
+            let rwork = if T::NEEDS_RWORK {
+                alloc_workspace_elems::<T::Real>(
+                    backend.runtime(),
+                    as_i32(5 * k, OP, "rwork")?,
+                    OP,
+                )?
+            } else {
+                Workspace::none()
+            };
+            let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+            let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
+            let job = b'N' as c_char;
+
+            for batch in 0..batch_total {
+                let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
+                let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, batch * s_stride) };
+                let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+                unsafe {
+                    handles.cusolver().gesvd(
+                        T::DATA_TYPE,
+                        job,
+                        job,
+                        m_i32,
+                        n_i32,
+                        batch_a,
+                        lda,
+                        batch_s,
+                        std::ptr::null_mut(),
+                        1,
+                        std::ptr::null_mut(),
+                        1,
+                        workspace.ptr,
+                        lwork,
+                        rwork.ptr,
+                        batch_info,
+                        OP,
+                    )?;
+                }
+            }
+            check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*gesvd")?;
+            Ok(s)
         }
     }
-    check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*gesvd")?;
-
-    Ok(s)
 }
 
 fn qr_typed<T>(

--- a/tenferro-linalg/tests/gpu_linalg.rs
+++ b/tenferro-linalg/tests/gpu_linalg.rs
@@ -442,6 +442,18 @@ fn test_cubecl_svd_c32_reconstructs_input() {
 
 #[test]
 #[ignore]
+fn test_cubecl_svd_values_f64_matches_cpu() {
+    let input = tensor_f64(vec![3, 2], vec![1.0, 2.0, -0.5, 0.25, 3.0, -1.0]);
+    let mut cpu = cpu_backend();
+    let expected = cpu.svd_values(&input).unwrap();
+    let mut gpu = gpu_backend();
+    let actual = gpu.svd_values(&upload(&gpu, &input)).unwrap();
+    let actual = download(&gpu, &actual);
+    assert_tensor_close(&actual, &expected, 1e-9);
+}
+
+#[test]
+#[ignore]
 fn test_cubecl_qr_f32_reconstructs_input() {
     let input = tensor_f32(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 0.5, -1.0]);
     let mut gpu = gpu_backend();

--- a/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -234,6 +234,104 @@ fn gpu_solver_info_checks_are_batched_outside_kernel_loops() {
 }
 
 #[test]
+fn gpu_svd_uses_jax_compatible_default_driver_selection() {
+    let source = linalg_source();
+    let svd = source_section(&source, "fn svd_typed", "fn svd_values_typed");
+    let svd_values = source_section(&source, "fn svd_values_typed", "fn qr_typed");
+    let ffi = read_workspace_source("tenferro-linalg/src/gpu/ffi/cusolver.rs");
+    let kernels = read_workspace_source("tenferro-linalg/src/gpu/kernels.rs");
+
+    for needle in [
+        "const JAX_COMPATIBLE_GESVDJ_MAX_DIM: usize = 1024",
+        "enum SvdDriver",
+        "fn select_svd_driver",
+        "m <= JAX_COMPATIBLE_GESVDJ_MAX_DIM && n <= JAX_COMPATIBLE_GESVDJ_MAX_DIM",
+    ] {
+        assert!(
+            source.contains(needle),
+            "GPU SVD should encode JAX-compatible default driver selection: missing {needle}"
+        );
+    }
+
+    for section in [svd, svd_values] {
+        for needle in [
+            "match select_svd_driver(m, n)",
+            "SvdDriver::Gesvdj",
+            "SvdDriver::Gesvd",
+            "handles.cusolver().gesvdj(",
+            "handles.cusolver().gesvd(",
+            "check_solver_info_tensor(backend.runtime(), &info, OP, \"cusolverDn*gesvdj\")",
+            "check_solver_info_tensor(backend.runtime(), &info, OP, \"cusolverDn*gesvd\")",
+        ] {
+            assert!(
+                section.contains(needle),
+                "GPU SVD driver path should contain {needle}"
+            );
+        }
+    }
+
+    for needle in [
+        "let u = alloc_output::<T>(backend.runtime(), &u_shape);",
+        "let v = alloc_output::<T>(backend.runtime(), &v_shape);",
+        "CusolverEigMode::NoVector",
+        "batch_u",
+        "batch_v",
+    ] {
+        assert!(
+            svd_values.contains(needle),
+            "values-only gesvdj should pass scratch U/V buffers like JAX: missing {needle}"
+        );
+    }
+
+    for needle in [
+        "T::copy_svd_v_to_vt(backend.runtime(), &v, &vt_shape, OP)",
+        "copy_svd_v_to_vt_real",
+        "copy_svd_v_to_vt_complex",
+    ] {
+        assert!(
+            source.contains(needle),
+            "GPU SVD should materialize gesvdj V^H on CUDA without a host roundtrip: missing {needle}"
+        );
+    }
+    assert!(
+        !source.contains("runtime_typed_tensor::transpose"),
+        "GPU SVD should not route gesvdj V-to-VT conversion through borrowed-view typed helpers"
+    );
+
+    for needle in [
+        "pub fn svd_v_to_vt_real",
+        "pub fn svd_v_to_vt_complex",
+        ".conj()",
+    ] {
+        assert!(
+            kernels.contains(needle),
+            "GPU SVD kernels should expose real and complex V-to-VT copies: missing {needle}"
+        );
+    }
+
+    for needle in [
+        "pub struct GesvdjInfo",
+        "cusolverDnCreateGesvdjInfo",
+        "cusolverDnDestroyGesvdjInfo",
+        "cusolverDnSgesvdj_bufferSize",
+        "cusolverDnDgesvdj_bufferSize",
+        "cusolverDnCgesvdj_bufferSize",
+        "cusolverDnZgesvdj_bufferSize",
+        "cusolverDnSgesvdj",
+        "cusolverDnDgesvdj",
+        "cusolverDnCgesvdj",
+        "cusolverDnZgesvdj",
+        "pub fn gesvdj_buffer_size",
+        "pub unsafe fn gesvdj",
+    ] {
+        assert!(
+            ffi.contains(needle),
+            "cuSOLVER FFI should expose gesvdj support: missing {needle}"
+        );
+    }
+}
+
+#[test]
 fn gpu_eigh_values_uses_cusolver_no_vector_mode() {
     let source = linalg_source();
     let gpu_mod = gpu_mod_source();


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

N/A

## Summary

CUDA SVD previously always used QR-based cuSOLVER `gesvd`. JAX defaults to Jacobi `gesvdj` when both matrix dimensions are at most 1024, which is the path used by the small dense CUDA SVD benchmark.

This PR makes the CUDA SVD backend driver selection JAX-compatible without changing the public API:

- add cuSOLVER `gesvdj` FFI and `gesvdjInfo` lifetime handling
- select `gesvdj` for `m, n <= 1024`, and keep the existing `gesvd` path for larger matrices
- copy `gesvdj`'s V output to the existing public `vt` contract on device, using V^H for complex tensors
- pass scratch U/V buffers for values-only `gesvdj`, matching cuSOLVER's non-null pointer requirement observed on this host
- document the CUDA SVD driver policy in the GPU backend design doc

The bug-fix scope gate was applied: this is a backend policy fix for an existing intended CUDA SVD path, with no new public API, dependency, feature flag, operation family, or AD semantics change.

## Work log

- [docs/worklogs/2026-06-02-jax-compatible-svd-driver.md](docs/worklogs/2026-06-02-jax-compatible-svd-driver.md)

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p tenferro-linalg --features cuda`
- `cargo test -p tenferro-linalg gpu_svd_uses_jax_compatible_default_driver_selection`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/lib64:/usr/local/cuda/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-linalg --features cuda test_cubecl_svd -- --ignored --nocapture`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [ ] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
