### PR TITLE
Add traced lazy value output APIs

### DIFF
--- a/crates/tenferro-einsum/tests/traced_extension.rs
+++ b/crates/tenferro-einsum/tests/traced_extension.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "autodiff")]
 use tenferro_ad::TracedTensorAdExt;
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TensorValue, TracedTensor};
 
 #[test]
 fn concrete_traced_einsum_executes_without_extension_runtime() {
@@ -63,6 +63,32 @@ fn traced_binary_tree_col_major_matmul_uses_direct_dot_general_without_extension
     assert_eq!(out.shape(), &[4, 3]);
     assert_eq!(out.as_slice::<f64>().unwrap(), &[2.0_f64; 12]);
     assert_eq!(executor.cache_stats().extensions.entries, 0);
+}
+
+#[test]
+fn traced_einsum_final_permutation_can_return_lazy_value() {
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let mut compiler = GraphCompiler::new();
+
+    let out = tenferro_einsum::einsum(&mut compiler, &[&a], "ij->ji").unwrap();
+    let program = compiler.compile(&out).unwrap();
+
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    let values = executor.run_many_values(&program).unwrap();
+
+    assert_eq!(values.len(), 1);
+    assert_eq!(values[0].shape(), &[3, 2]);
+    match &values[0] {
+        TensorValue::View(view) => {
+            assert_eq!(view.shape(), &[3, 2]);
+            assert_eq!(view.strides(), &[2, 1]);
+        }
+        TensorValue::Tensor(_) => panic!("final einsum permutation should stay as a lazy view"),
+    }
+    assert_eq!(
+        values[0].to_tensor().as_slice::<f64>().unwrap(),
+        &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
+    );
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/exec.rs
+++ b/crates/tenferro-runtime/src/exec.rs
@@ -8,7 +8,8 @@ use tenferro_ops::{dim_expr::DimExpr, ShapeExtent};
 use tenferro_tensor::Error as TensorError;
 use tenferro_tensor::{
     BackendSession, CompareDir, DType, DotGeneralConfig, ElementwiseFusionOp, GatherConfig,
-    PadConfig, ScatterConfig, SliceConfig, Tensor, TensorBackend, TensorRead, TypedTensor,
+    PadConfig, ScatterConfig, SliceConfig, Tensor, TensorBackend, TensorRead, TensorValue,
+    TypedTensor,
 };
 
 use crate::extension_runtime::ExtensionExecutor;
@@ -47,6 +48,7 @@ pub(crate) enum DispatchMode {
 
 pub(crate) enum ExecSlot<'a> {
     Owned(Tensor),
+    Value(TensorValue),
     Read(TensorRead<'a>),
 }
 
@@ -54,6 +56,7 @@ impl<'a> ExecSlot<'a> {
     pub(crate) fn dtype(&self) -> DType {
         match self {
             Self::Owned(tensor) => tensor.dtype(),
+            Self::Value(value) => value.dtype(),
             Self::Read(read) => read.dtype(),
         }
     }
@@ -64,6 +67,7 @@ impl<'a> ExecSlot<'a> {
     {
         match self {
             Self::Owned(tensor) => TensorRead::from_tensor(tensor),
+            Self::Value(value) => value.tensor_read(),
             Self::Read(read) => read.clone(),
         }
     }
@@ -74,6 +78,10 @@ impl<'a> ExecSlot<'a> {
     {
         match self {
             Self::Owned(tensor) => Ok(tensor),
+            Self::Value(TensorValue::Tensor(tensor)) => Ok(tensor.as_ref()),
+            Self::Value(TensorValue::View(_)) => Err(Error::Internal(format!(
+                "{op}: owned TensorValue view reached an owned-only execution boundary"
+            ))),
             Self::Read(read) => read.as_tensor().ok_or_else(|| {
                 Error::Internal(format!(
                     "{op}: borrowed TensorView reached an owned-only execution boundary"
@@ -85,6 +93,7 @@ impl<'a> ExecSlot<'a> {
     pub(crate) fn shape(&self) -> &[usize] {
         match self {
             Self::Owned(tensor) => tensor.shape(),
+            Self::Value(value) => value.shape(),
             Self::Read(read) => read.shape(),
         }
     }
@@ -92,7 +101,16 @@ impl<'a> ExecSlot<'a> {
     pub(crate) fn into_tensor(self) -> Tensor {
         match self {
             Self::Owned(tensor) => tensor,
+            Self::Value(value) => value.to_tensor(),
             Self::Read(read) => read.to_tensor(),
+        }
+    }
+
+    pub(crate) fn into_value(self) -> TensorValue {
+        match self {
+            Self::Owned(tensor) => TensorValue::from_tensor(tensor),
+            Self::Value(value) => value,
+            Self::Read(read) => TensorValue::from_tensor(read.to_tensor()),
         }
     }
 }
@@ -153,6 +171,118 @@ pub(crate) fn collect_outputs_from<'input>(
                 .ok_or(TensorError::MissingValue { slot }.into())
         })
         .collect()
+}
+
+pub(crate) fn collect_output_values_from<'input>(
+    program: &ExecProgram,
+    slots: &mut [Option<ExecSlot<'input>>],
+) -> Result<Vec<TensorValue>> {
+    program
+        .output_slots
+        .iter()
+        .map(|&slot| {
+            slots[slot]
+                .take()
+                .map(ExecSlot::into_value)
+                .ok_or(TensorError::MissingValue { slot }.into())
+        })
+        .collect()
+}
+
+pub(crate) fn terminal_output_slots(program: &ExecProgram) -> Vec<bool> {
+    let mut consumed = vec![false; program.n_slots];
+    for inst in &program.instructions {
+        for &slot in &inst.input_slots {
+            if let Some(consumed) = consumed.get_mut(slot) {
+                *consumed = true;
+            }
+        }
+    }
+
+    let mut terminal = vec![false; program.n_slots];
+    for &slot in &program.output_slots {
+        if !consumed.get(slot).copied().unwrap_or(true) {
+            terminal[slot] = true;
+        }
+    }
+    terminal
+}
+
+pub(crate) fn try_execute_terminal_value_instruction<'input>(
+    slots: &mut [Option<ExecSlot<'input>>],
+    inst: &ExecInstruction,
+    terminal_slots: &[bool],
+) -> Result<bool> {
+    if inst.output_slots.len() != 1
+        || !terminal_slots
+            .get(inst.output_slots[0])
+            .copied()
+            .unwrap_or(false)
+    {
+        return Ok(false);
+    }
+
+    let output = match &inst.op {
+        ExecOp::Transpose { perm } => {
+            let input_slot = inst.input_slots[0];
+            let consume_input = inst.last_use.first().copied().unwrap_or(false);
+            let input = tensor_value_for_lazy_view(slots, input_slot, consume_input)?;
+            input.transpose_view(perm).map_err(Error::TensorRuntime)?
+        }
+        ExecOp::Reshape { shape } => {
+            let input_slot = inst.input_slots[0];
+            let consume_input = inst.last_use.first().copied().unwrap_or(false);
+            let shape = resolve_tensor_shape_exprs(slots, &inst.input_slots, shape)?;
+            let input = tensor_value_for_lazy_view(slots, input_slot, consume_input)?;
+            match input.reshape_view(&shape) {
+                Ok(value) => value,
+                Err(_) => {
+                    if consume_input {
+                        slots[input_slot] = Some(ExecSlot::Value(input));
+                    }
+                    return Ok(false);
+                }
+            }
+        }
+        ExecOp::BroadcastInDim { shape, dims } => {
+            let input_slot = inst.input_slots[0];
+            let consume_input = inst.last_use.first().copied().unwrap_or(false);
+            let shape = resolve_tensor_shape_exprs(slots, &inst.input_slots, shape)?;
+            let input = tensor_value_for_lazy_view(slots, input_slot, consume_input)?;
+            input
+                .broadcast_in_dim_view(&shape, dims)
+                .map_err(Error::TensorRuntime)?
+        }
+        ExecOp::Slice(config) => {
+            let input_slot = inst.input_slots[0];
+            let consume_input = inst.last_use.first().copied().unwrap_or(false);
+            let input = tensor_value_for_lazy_view(slots, input_slot, consume_input)?;
+            input.slice_view(config).map_err(Error::TensorRuntime)?
+        }
+        _ => return Ok(false),
+    };
+    slots[inst.output_slots[0]] = Some(ExecSlot::Value(output));
+    Ok(true)
+}
+
+fn tensor_value_for_lazy_view<'input>(
+    slots: &mut [Option<ExecSlot<'input>>],
+    slot: usize,
+    consume: bool,
+) -> Result<TensorValue> {
+    if consume {
+        return slots[slot]
+            .take()
+            .map(ExecSlot::into_value)
+            .ok_or(TensorError::MissingValue { slot }.into());
+    }
+
+    match slots[slot].as_ref() {
+        Some(ExecSlot::Owned(tensor)) => Ok(TensorValue::from_tensor(tensor.clone())),
+        Some(ExecSlot::Value(value)) => Ok(value.clone()),
+        Some(ExecSlot::Read(read)) => Ok(TensorValue::from_tensor(read.to_tensor())),
+        None => Err(TensorError::MissingValue { slot }.into()),
+    }
 }
 
 pub(crate) fn is_host_instruction(inst: &ExecInstruction) -> bool {
@@ -276,6 +406,50 @@ pub(crate) fn eval_exec_ir_unsegmented_slots_with_cache_and_workspace<
         }
 
         collect_outputs_from(program, slots)
+    })();
+    slots.clear();
+    result
+}
+
+pub(crate) fn eval_exec_ir_unsegmented_slot_values_with_cache_and_workspace<
+    'input,
+    B: TensorBackend + 'static,
+>(
+    backend: &mut B,
+    program: &ExecProgram,
+    inputs: Vec<ExecSlot<'input>>,
+    slots: &mut Vec<Option<ExecSlot<'input>>>,
+    backend_cache: &mut B::RuntimeCache,
+    mut extension_executor: Option<&mut ExtensionExecutor<B>>,
+) -> Result<Vec<TensorValue>> {
+    let result = (|| {
+        initialize_exec_slots_in(program, inputs, slots);
+        let terminal_slots = terminal_output_slots(program);
+
+        for (inst_idx, inst) in program.instructions.iter().enumerate() {
+            if try_execute_terminal_value_instruction(slots, inst, &terminal_slots)? {
+                // Already handled as a metadata-only TensorValue.
+            } else if is_host_instruction(inst) {
+                execute_host_instruction(backend, slots, inst)?;
+            } else if is_ffi_instruction(inst) {
+                execute_ffi_instruction_cached(
+                    backend,
+                    backend_cache,
+                    slots,
+                    inst,
+                    DispatchMode::Unsegmented,
+                    Some(inst_idx),
+                    extension_executor.as_deref_mut(),
+                )?;
+            } else {
+                let result =
+                    backend.with_backend_session(|exec| execute_backend_op(exec, slots, inst))?;
+                slots[inst.output_slots[0]] = Some(ExecSlot::Owned(result));
+            }
+            reclaim_last_use_inputs_backend(slots, inst, backend);
+        }
+
+        collect_output_values_from(program, slots)
     })();
     slots.clear();
     result
@@ -570,8 +744,8 @@ pub(crate) fn reclaim_last_use_inputs_exec(
 ) {
     for (i, &is_last) in inst.last_use.iter().enumerate() {
         if is_last {
-            if let Some(ExecSlot::Owned(tensor)) = slots[inst.input_slots[i]].take() {
-                exec.reclaim_buffer(tensor);
+            if let Some(slot) = slots[inst.input_slots[i]].take() {
+                reclaim_exec_slot_with_session(slot, exec);
             }
         }
     }
@@ -584,10 +758,34 @@ pub(crate) fn reclaim_last_use_inputs_backend<B: TensorBackend>(
 ) {
     for (i, &is_last) in inst.last_use.iter().enumerate() {
         if is_last {
-            if let Some(ExecSlot::Owned(tensor)) = slots[inst.input_slots[i]].take() {
+            if let Some(slot) = slots[inst.input_slots[i]].take() {
+                reclaim_exec_slot_with_backend(slot, backend);
+            }
+        }
+    }
+}
+
+fn reclaim_exec_slot_with_session(slot: ExecSlot<'_>, exec: &mut dyn BackendSession) {
+    match slot {
+        ExecSlot::Owned(tensor) => exec.reclaim_buffer(tensor),
+        ExecSlot::Value(TensorValue::Tensor(tensor)) => {
+            if let Ok(tensor) = Arc::try_unwrap(tensor) {
+                exec.reclaim_buffer(tensor);
+            }
+        }
+        ExecSlot::Value(TensorValue::View(_)) | ExecSlot::Read(_) => {}
+    }
+}
+
+fn reclaim_exec_slot_with_backend<B: TensorBackend>(slot: ExecSlot<'_>, backend: &mut B) {
+    match slot {
+        ExecSlot::Owned(tensor) => backend.reclaim_buffer(tensor),
+        ExecSlot::Value(TensorValue::Tensor(tensor)) => {
+            if let Ok(tensor) = Arc::try_unwrap(tensor) {
                 backend.reclaim_buffer(tensor);
             }
         }
+        ExecSlot::Value(TensorValue::View(_)) | ExecSlot::Read(_) => {}
     }
 }
 

--- a/crates/tenferro-runtime/src/graph/executor.rs
+++ b/crates/tenferro-runtime/src/graph/executor.rs
@@ -1,7 +1,10 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use tenferro_ops::input_key::TensorInputKey;
-use tenferro_tensor::{DType, RuntimeCacheControl, Tensor, TensorBackend, TensorRead, TypedTensor};
+use tenferro_tensor::{
+    DType, RuntimeCacheControl, Tensor, TensorBackend, TensorRead, TensorValue, TypedTensor,
+};
 
 use super::cache::GraphExecutorCacheStats;
 use super::program::{GraphProgram, GraphProgramInput};
@@ -85,6 +88,20 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
         }
     }
 
+    /// Return compact value outputs to the backend pool when ownership is unique.
+    ///
+    /// Lazy owned views are intentionally ignored because their base storage may
+    /// be aliased by view metadata.
+    pub fn reclaim_value_outputs(&mut self, outputs: Vec<TensorValue>) {
+        for value in outputs {
+            if let TensorValue::Tensor(tensor) = value {
+                if let Ok(tensor) = Arc::try_unwrap(tensor) {
+                    self.backend.reclaim_buffer(tensor);
+                }
+            }
+        }
+    }
+
     /// Borrow the extension runtime executor owned by this graph executor.
     ///
     /// # Examples
@@ -145,6 +162,12 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
         expect_single_output(&mut outputs)
     }
 
+    /// Run a one-output program and preserve lazy owned output views.
+    pub fn run_value(&mut self, program: &GraphProgram) -> Result<TensorValue> {
+        let mut outputs = self.run_many_values(program)?;
+        expect_single_value(&mut outputs)
+    }
+
     /// Run a program using the program's default input tensors.
     ///
     /// # Examples
@@ -163,6 +186,11 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// ```
     pub fn run_many(&mut self, program: &GraphProgram) -> Result<Vec<Tensor>> {
         self.run_many_with_inputs(program, &[])
+    }
+
+    /// Run a program and preserve lazy owned output views.
+    pub fn run_many_values(&mut self, program: &GraphProgram) -> Result<Vec<TensorValue>> {
+        self.run_many_values_with_inputs(program, &[])
     }
 
     /// Run a one-output program with explicit runtime placeholder bindings.
@@ -196,6 +224,16 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
         expect_single_output(&mut outputs)
     }
 
+    /// Run a one-output program with explicit bindings and preserve lazy output views.
+    pub fn run_value_with_inputs(
+        &mut self,
+        program: &GraphProgram,
+        bindings: &[(&TracedTensor, &Tensor)],
+    ) -> Result<TensorValue> {
+        let mut outputs = self.run_many_values_with_inputs(program, bindings)?;
+        expect_single_value(&mut outputs)
+    }
+
     /// Run a one-output program with explicit borrowed runtime placeholder bindings.
     ///
     /// Unlike [`run_with_inputs`](Self::run_with_inputs), caller-owned input
@@ -208,6 +246,16 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     ) -> Result<Tensor> {
         let mut outputs = self.run_many_with_input_reads(program, bindings)?;
         expect_single_output(&mut outputs)
+    }
+
+    /// Run a one-output program with borrowed bindings and preserve lazy output views.
+    pub fn run_value_with_input_reads<'a>(
+        &mut self,
+        program: &'a GraphProgram,
+        bindings: &[(&TracedTensor, TensorRead<'a>)],
+    ) -> Result<TensorValue> {
+        let mut outputs = self.run_many_values_with_input_reads(program, bindings)?;
+        expect_single_value(&mut outputs)
     }
 
     /// Run a program with explicit runtime placeholder bindings.
@@ -239,6 +287,16 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
         self.eval_exec_ir(&program.exec, input_tensors)
     }
 
+    /// Run a program with explicit bindings and preserve lazy output views.
+    pub fn run_many_values_with_inputs(
+        &mut self,
+        program: &GraphProgram,
+        bindings: &[(&TracedTensor, &Tensor)],
+    ) -> Result<Vec<TensorValue>> {
+        let input_tensors = resolve_inputs(program, bindings)?;
+        self.eval_exec_ir_values(&program.exec, input_tensors)
+    }
+
     /// Run a program with explicit borrowed runtime placeholder bindings.
     ///
     /// Bindings override program defaults and are validated against the input
@@ -251,6 +309,16 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     ) -> Result<Vec<Tensor>> {
         let inputs = resolve_input_reads(program, bindings)?;
         self.eval_exec_ir_slots(&program.exec, inputs)
+    }
+
+    /// Run a program with borrowed bindings and preserve lazy output views.
+    pub fn run_many_values_with_input_reads<'a>(
+        &mut self,
+        program: &'a GraphProgram,
+        bindings: &[(&TracedTensor, TensorRead<'a>)],
+    ) -> Result<Vec<TensorValue>> {
+        let inputs = resolve_input_reads(program, bindings)?;
+        self.eval_exec_ir_slot_values(&program.exec, inputs)
     }
 
     /// Evaluate an execution program through this executor's backend state.
@@ -287,6 +355,24 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
         )
     }
 
+    /// Evaluate an execution program and preserve lazy owned output views.
+    pub fn eval_exec_ir_values(
+        &mut self,
+        program: &ExecProgram,
+        inputs: Vec<Tensor>,
+    ) -> Result<Vec<TensorValue>> {
+        validate_exec_input_count(program, inputs.len())?;
+        let inputs = inputs.into_iter().map(ExecSlot::Owned).collect();
+        crate::segment::eval_exec_segmented_slot_values_with_cache_and_workspace(
+            &mut self.backend,
+            program,
+            inputs,
+            &mut self.slot_workspace,
+            &mut self.backend_cache,
+            Some(&mut self.extension_executor),
+        )
+    }
+
     /// Evaluate an execution program without consuming caller-owned inputs.
     ///
     /// # Examples
@@ -314,6 +400,19 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
         self.eval_exec_ir_slots(program, inputs)
     }
 
+    /// Evaluate an execution program without consuming inputs and preserve lazy outputs.
+    pub fn eval_exec_ir_non_consuming_values(
+        &mut self,
+        program: &ExecProgram,
+        inputs: &[Tensor],
+    ) -> Result<Vec<TensorValue>> {
+        let inputs = inputs
+            .iter()
+            .map(|tensor| ExecSlot::Read(TensorRead::from_tensor(tensor)))
+            .collect();
+        self.eval_exec_ir_slot_values(program, inputs)
+    }
+
     fn eval_exec_ir_slots<'a>(
         &mut self,
         program: &ExecProgram,
@@ -322,6 +421,23 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
         validate_exec_input_count(program, inputs.len())?;
         let mut slot_workspace = Vec::new();
         crate::segment::eval_exec_segmented_slots_with_cache_and_workspace(
+            &mut self.backend,
+            program,
+            inputs,
+            &mut slot_workspace,
+            &mut self.backend_cache,
+            Some(&mut self.extension_executor),
+        )
+    }
+
+    fn eval_exec_ir_slot_values<'a>(
+        &mut self,
+        program: &ExecProgram,
+        inputs: Vec<ExecSlot<'a>>,
+    ) -> Result<Vec<TensorValue>> {
+        validate_exec_input_count(program, inputs.len())?;
+        let mut slot_workspace = Vec::new();
+        crate::segment::eval_exec_segmented_slot_values_with_cache_and_workspace(
             &mut self.backend,
             program,
             inputs,
@@ -420,6 +536,18 @@ fn validate_exec_input_count(program: &ExecProgram, actual: usize) -> Result<()>
 }
 
 fn expect_single_output(outputs: &mut Vec<Tensor>) -> Result<Tensor> {
+    if outputs.len() != 1 {
+        return Err(Error::Internal(format!(
+            "expected 1 output, got {}",
+            outputs.len()
+        )));
+    }
+    outputs
+        .pop()
+        .ok_or_else(|| Error::Internal("missing graph output".to_string()))
+}
+
+fn expect_single_value(outputs: &mut Vec<TensorValue>) -> Result<TensorValue> {
     if outputs.len() != 1 {
         return Err(Error::Internal(format!(
             "expected 1 output, got {}",

--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -56,7 +56,7 @@ pub use graph::{
 pub use sym_dim::SymDim;
 pub use tenferro_tensor::{
     CacheStats, CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
-    SliceConfig, Tensor, TensorBackend, TensorRead, TensorScalar, TensorView, TypedTensor,
-    TypedTensorView,
+    SliceConfig, Tensor, TensorBackend, TensorRead, TensorScalar, TensorValue, TensorView,
+    TypedTensor, TypedTensorView,
 };
 pub use traced::TracedTensor;

--- a/crates/tenferro-runtime/src/segment.rs
+++ b/crates/tenferro-runtime/src/segment.rs
@@ -4,16 +4,20 @@ use std::collections::{HashMap, HashSet};
 
 use crate::error::Result;
 use crate::exec::{
-    can_run_in_single_exec_session, collect_outputs_from,
+    can_run_in_single_exec_session, collect_output_values_from, collect_outputs_from,
     eval_exec_ir_single_session_slots_with_workspace,
+    eval_exec_ir_unsegmented_slot_values_with_cache_and_workspace,
     eval_exec_ir_unsegmented_slots_with_cache_and_workspace, execute_backend_op,
     execute_ffi_instruction_cached, execute_host_instruction, get_read, initialize_exec_slots_in,
     is_ffi_instruction, is_host_instruction, reclaim_last_use_inputs_backend,
-    reclaim_last_use_inputs_exec, resolve_tensor_shape_exprs, DispatchMode, ExecInstruction,
-    ExecOp, ExecProgram, ExecSlot,
+    reclaim_last_use_inputs_exec, resolve_tensor_shape_exprs, terminal_output_slots,
+    try_execute_terminal_value_instruction, DispatchMode, ExecInstruction, ExecOp, ExecProgram,
+    ExecSlot,
 };
 use crate::extension_runtime::ExtensionExecutor;
-use tenferro_tensor::{ElementwiseFusionInst, ElementwiseFusionPlan, Tensor, TensorBackend};
+use tenferro_tensor::{
+    ElementwiseFusionInst, ElementwiseFusionPlan, Tensor, TensorBackend, TensorValue,
+};
 
 /// A compiled execution segment.
 ///
@@ -323,6 +327,125 @@ pub(crate) fn eval_exec_segmented_slots_with_cache_and_workspace<
         }
 
         collect_outputs_from(program, slots)
+    })();
+    slots.clear();
+    result
+}
+
+pub(crate) fn eval_exec_segmented_slot_values_with_cache_and_workspace<
+    'input,
+    B: TensorBackend + 'static,
+>(
+    backend: &mut B,
+    program: &ExecProgram,
+    inputs: Vec<ExecSlot<'input>>,
+    slots: &mut Vec<Option<ExecSlot<'input>>>,
+    backend_cache: &mut B::RuntimeCache,
+    mut extension_executor: Option<&mut ExtensionExecutor<B>>,
+) -> Result<Vec<TensorValue>> {
+    let has_fused_segment = has_multi_instruction_fused_segment(program);
+    if !has_fused_segment {
+        return eval_exec_ir_unsegmented_slot_values_with_cache_and_workspace(
+            backend,
+            program,
+            inputs,
+            slots,
+            backend_cache,
+            extension_executor,
+        );
+    }
+
+    let result = (|| {
+        initialize_exec_slots_in(program, inputs, slots);
+        let terminal_slots = terminal_output_slots(program);
+
+        let segments = segment_exec_program(program);
+        let mut inst_idx = 0usize;
+        for segment in &segments {
+            match segment {
+                Segment::Fused {
+                    instructions,
+                    input_slots,
+                    output_slots,
+                    last_use,
+                } => {
+                    backend.with_backend_session(|exec| -> Result<()> {
+                        if let Some(plan) =
+                            build_elementwise_fusion_plan(instructions, input_slots, output_slots)
+                        {
+                            let inputs = collect_segment_inputs(slots, input_slots)?;
+                            if let Some(outputs) =
+                                exec.execute_elementwise_fusion(&inputs, &plan)?
+                            {
+                                if outputs.len() != output_slots.len() {
+                                    return Err(crate::error::Error::Internal(format!(
+                                        "fused elementwise kernel produced {} outputs for {} slots",
+                                        outputs.len(),
+                                        output_slots.len()
+                                    )));
+                                }
+                                for (slot, tensor) in output_slots.iter().copied().zip(outputs) {
+                                    slots[slot] = Some(ExecSlot::Owned(tensor));
+                                }
+                                reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+                                return Ok(());
+                            }
+                        }
+                        if let Some(output) = try_execute_broadcast_multiply_segment(
+                            exec,
+                            slots,
+                            instructions,
+                            output_slots,
+                        )? {
+                            slots[output_slots[0]] = Some(ExecSlot::Owned(output));
+                            reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+                            return Ok(());
+                        }
+
+                        for inst in instructions {
+                            if try_execute_terminal_value_instruction(slots, inst, &terminal_slots)?
+                            {
+                                // Already handled as a metadata-only TensorValue.
+                            } else {
+                                let result = execute_backend_op(exec, slots, inst)?;
+                                slots[inst.output_slots[0]] = Some(ExecSlot::Owned(result));
+                            }
+                            reclaim_last_use_inputs_exec(slots, inst, exec);
+                        }
+                        Ok(())
+                    })?;
+                    inst_idx += instructions.len();
+                }
+                Segment::Ffi(inst) => {
+                    if try_execute_terminal_value_instruction(slots, inst, &terminal_slots)? {
+                        // Already handled as a metadata-only TensorValue.
+                    } else {
+                        execute_ffi_instruction_cached(
+                            backend,
+                            backend_cache,
+                            slots,
+                            inst,
+                            DispatchMode::Segmented,
+                            Some(inst_idx),
+                            extension_executor.as_deref_mut(),
+                        )?;
+                    }
+                    reclaim_last_use_inputs_backend(slots, inst, backend);
+                    inst_idx += 1;
+                }
+                Segment::Host(inst) => {
+                    if try_execute_terminal_value_instruction(slots, inst, &terminal_slots)? {
+                        // Already handled as a metadata-only TensorValue.
+                    } else {
+                        execute_host_instruction(backend, slots, inst)?;
+                    }
+                    reclaim_last_use_inputs_backend(slots, inst, backend);
+                    inst_idx += 1;
+                }
+            }
+        }
+
+        collect_output_values_from(program, slots)
     })();
     slots.clear();
     result

--- a/crates/tenferro-runtime/tests/runtime_public_api.rs
+++ b/crates/tenferro-runtime/tests/runtime_public_api.rs
@@ -1,7 +1,7 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{
     tensor, DType, DotGeneralConfig, Error, GraphCompiler, GraphExecutor, Tensor, TensorRead,
-    TracedTensor,
+    TensorValue, TracedTensor,
 };
 
 #[test]
@@ -97,6 +97,44 @@ fn graph_executor_runs_dot_general_with_borrowed_inputs() {
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].shape(), &[2, 2]);
     assert_eq!(out[0].as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn graph_executor_can_return_final_transpose_as_lazy_value() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let y = (&x + &x).transpose(&[1, 0]);
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(&y, &[(&x, DType::F64, &[2, 3])])
+        .unwrap();
+    let input = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+
+    let compact = executor
+        .run_many_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&input))])
+        .unwrap();
+    assert_eq!(
+        compact[0].as_slice::<f64>().unwrap(),
+        &[2.0, 6.0, 10.0, 4.0, 8.0, 12.0]
+    );
+
+    let values = executor
+        .run_many_values_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&input))])
+        .unwrap();
+
+    assert_eq!(values.len(), 1);
+    assert_eq!(values[0].shape(), &[3, 2]);
+    match &values[0] {
+        TensorValue::View(view) => {
+            assert_eq!(view.shape(), &[3, 2]);
+            assert_eq!(view.strides(), &[2, 1]);
+        }
+        TensorValue::Tensor(_) => panic!("final transpose should stay as a lazy owned view"),
+    }
+    assert_eq!(
+        values[0].to_tensor().as_slice::<f64>().unwrap(),
+        &[2.0, 6.0, 10.0, 4.0, 8.0, 12.0]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add TensorValue-returning GraphExecutor APIs for traced programs
- preserve terminal transpose/reshape/broadcast/slice as lazy owned output views when callers opt in
- keep existing compact Tensor APIs unchanged

## Validation
- cargo fmt --all -- --check
- cargo test -p tenferro-runtime
- cargo test -p tenferro-einsum --lib
- cargo test -p tenferro-einsum --test traced_extension
- cargo test -p tenferro-ad --test graph_executor
- cargo test -p tenferro-ad --test segment_tests
- git diff --check