### PR TITLE
[codex] Document extension payload identity contract

### DIFF
--- a/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
@@ -1,11 +1,13 @@
 //! Coverage tests for `ext_op` registry + validation.
 
 use std::any::Any;
-use std::hash::Hasher;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use computegraph::graph::GraphBuilder;
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
+use computegraph::GraphOperation;
 use tidu::{ADRuleKind, ADRuleResult};
 
 use crate::ad::context::ShapeGuardContext;
@@ -31,6 +33,19 @@ struct NoInlineRuleOp;
 #[derive(Clone, Debug)]
 struct FamilyOnlyOp {
     family: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum WindowMode {
+    Valid,
+    Same,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct PayloadOp {
+    axis: usize,
+    mode: WindowMode,
+    tensor_inputs: usize,
 }
 
 #[derive(ExtensionFamilyId)]
@@ -122,6 +137,56 @@ impl ExtensionOp for FamilyOnlyOp {
     }
 }
 
+impl ExtensionOp for PayloadOp {
+    fn family_id(&self) -> &'static str {
+        "covtest.payload.v1"
+    }
+
+    fn payload_hash(&self, hasher: &mut dyn Hasher) {
+        hasher.write_usize(self.axis);
+        match self.mode {
+            WindowMode::Valid => hasher.write_u8(0),
+            WindowMode::Same => hasher.write_u8(1),
+        }
+        hasher.write_usize(self.tensor_inputs);
+    }
+
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<PayloadOp>()
+            .is_some_and(|op| op == self)
+    }
+
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+        Arc::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn input_count(&self) -> usize {
+        self.tensor_inputs
+    }
+
+    fn output_count(&self) -> usize {
+        1
+    }
+
+    fn infer_output_meta(
+        &self,
+        input_dtypes: &[DType],
+        input_shapes: &[&[SymDim]],
+    ) -> Vec<(DType, Vec<SymDim>)> {
+        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    }
+
+    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Ok(vec![inputs[0].clone()])
+    }
+}
+
 impl ExtensionAdRule for CoverageRule {
     fn family_id(&self) -> &'static str {
         self.family
@@ -152,9 +217,72 @@ impl ExtensionAdRule for CoverageRule {
     }
 }
 
+fn payload_op(axis: usize, mode: WindowMode, tensor_inputs: usize) -> StdTensorOp {
+    StdTensorOp::Extension(Arc::new(PayloadOp {
+        axis,
+        mode,
+        tensor_inputs,
+    }))
+}
+
+fn hash_std_tensor_op(op: &StdTensorOp) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    op.hash(&mut hasher);
+    hasher.finish()
+}
+
 #[test]
 fn extension_family_id_macro_generates_stable_const() {
     assert_eq!(MacroRuleFamily::FAMILY_ID, "covtest.macro_rule.v1");
+}
+
+#[test]
+fn extension_payload_equal_when_semantic_fields_match() {
+    let lhs = payload_op(1, WindowMode::Valid, 1);
+    let rhs = payload_op(1, WindowMode::Valid, 1);
+
+    assert_eq!(lhs, rhs);
+}
+
+#[test]
+fn extension_payload_not_equal_when_axis_differs() {
+    let lhs = payload_op(1, WindowMode::Valid, 1);
+    let rhs = payload_op(2, WindowMode::Valid, 1);
+
+    assert_ne!(lhs, rhs);
+}
+
+#[test]
+fn extension_payload_not_equal_when_mode_differs() {
+    let lhs = payload_op(1, WindowMode::Valid, 1);
+    let rhs = payload_op(1, WindowMode::Same, 1);
+
+    assert_ne!(lhs, rhs);
+}
+
+#[test]
+fn extension_payload_hash_matches_for_equal_payloads() {
+    let lhs = payload_op(1, WindowMode::Valid, 1);
+    let rhs = payload_op(1, WindowMode::Valid, 1);
+
+    assert_eq!(hash_std_tensor_op(&lhs), hash_std_tensor_op(&rhs));
+}
+
+#[test]
+fn extension_payload_hash_changes_for_distinct_payloads() {
+    let lhs = payload_op(1, WindowMode::Valid, 1);
+    let rhs = payload_op(2, WindowMode::Valid, 1);
+
+    assert_ne!(hash_std_tensor_op(&lhs), hash_std_tensor_op(&rhs));
+}
+
+#[test]
+fn extension_payload_does_not_affect_tensor_input_arity() {
+    let lhs = payload_op(1, WindowMode::Valid, 2);
+    let rhs = payload_op(2, WindowMode::Same, 2);
+
+    assert_eq!(lhs.input_count(), 2);
+    assert_eq!(rhs.input_count(), 2);
 }
 
 #[test]

--- a/docs/spec/extension-op.md
+++ b/docs/spec/extension-op.md
@@ -402,6 +402,77 @@ choose one convention and document it in the trait definition comment; the
 default choice is to add `Any` via a method-based helper to keep
 `ExtensionOp` object-safe.
 
+### Non-Tensor arguments and payload identity
+
+Tensor arguments are graph inputs. They may be AD-active and participate in
+graph construction through `ValueKey` dependencies.
+
+Non-Tensor arguments are not graph inputs. Extension implementations MUST
+capture them in the concrete `ExtensionOp` payload. Examples include axes,
+modes, tolerances, normalization choices, and small configuration structs.
+
+Any payload field that affects output values, output metadata, backend
+behavior, or AD behavior is semantic payload. Semantic payload MUST participate
+in both `payload_hash` and `payload_eq`. Equal payloads MUST be interchangeable
+for graph interning, graph equality, AD rule lookup, and compile/runtime cache
+identity.
+
+Runtime cache handles, vendor plans, warm cache state, allocation addresses,
+random UUIDs, closures, process-local counters, and mutable registries MUST NOT
+participate in semantic payload identity. If a large external resource is
+needed, the payload MAY contain a stable semantic key or content hash, but not
+a process-local handle as identity.
+
+`AttrValue` or another generic attribute container is not required by the
+current Rust-native extension API. Extension authors SHOULD prefer concrete
+Rust payload types whose equality and hashing match the operation semantics.
+
+Example:
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum WindowMode {
+    Valid,
+    Same,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct WindowedReduceOp {
+    axis: usize,
+    mode: WindowMode,
+}
+
+impl ExtensionOp for WindowedReduceOp {
+    fn family_id(&self) -> &'static str {
+        "example.windowed_reduce.v1"
+    }
+
+    fn payload_hash(&self, hasher: &mut dyn std::hash::Hasher) {
+        hasher.write_usize(self.axis);
+        match self.mode {
+            WindowMode::Valid => hasher.write_u8(0),
+            WindowMode::Same => hasher.write_u8(1),
+        }
+    }
+
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<WindowedReduceOp>()
+            .is_some_and(|op| op == self)
+    }
+
+    fn input_count(&self) -> usize {
+        1
+    }
+
+    // Other required methods omitted.
+}
+```
+
+Here `axis` and `mode` are deterministic payload fields, not differentiable
+tensor inputs. `input_count()` returns only the number of tensor inputs.
+
 ---
 
 ## 6. Arity and I/O shape


### PR DESCRIPTION
## Summary
- document non-Tensor extension arguments as deterministic semantic payload
- add a concrete payload example to `docs/spec/extension-op.md`
- add carrier equality/hash/arity tests for payload fields in `ext_op_tests`

## Notes
- No `ExtensionOp` trait signature changes.
- No generic `AttrValue` abstraction.

Closes #930.

## Verification
- `cargo test -p tenferro-internal-ops ext_op_tests`
- `cargo test -p tenferro-internal-ops`
- `cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`