### PR TITLE
Use strided-rs CPU einsum kernels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,11 @@ proc-macro2 = "1"
 quote = "1"
 syn = "2"
 tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "9934d8b775fcfbbad8e2daf3f9af54477da63e35" }
-strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "f3e5a7b63d53ec634c3a4ee9febb50f7d176ee54" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "f3e5a7b63d53ec634c3a4ee9febb50f7d176ee54" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "f3e5a7b63d53ec634c3a4ee9febb50f7d176ee54", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs", rev = "f3e5a7b63d53ec634c3a4ee9febb50f7d176ee54" }
+strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "65856754716622004d70f1ee3d8a3b115e9e4fb0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "65856754716622004d70f1ee3d8a3b115e9e4fb0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "65856754716622004d70f1ee3d8a3b115e9e4fb0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs", rev = "65856754716622004d70f1ee3d8a3b115e9e4fb0" }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs", rev = "65856754716622004d70f1ee3d8a3b115e9e4fb0", default-features = false }
 libloading = "0.8"
 faer = "0.24"
 cblas-sys = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ proc-macro2 = "1"
 quote = "1"
 syn = "2"
 tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "9934d8b775fcfbbad8e2daf3f9af54477da63e35" }
-strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "65856754716622004d70f1ee3d8a3b115e9e4fb0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "65856754716622004d70f1ee3d8a3b115e9e4fb0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "65856754716622004d70f1ee3d8a3b115e9e4fb0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs", rev = "65856754716622004d70f1ee3d8a3b115e9e4fb0" }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs", rev = "65856754716622004d70f1ee3d8a3b115e9e4fb0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "ae364b95c7e27c3cb3fcd5fe08574c31f9ee9150" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "ae364b95c7e27c3cb3fcd5fe08574c31f9ee9150" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "ae364b95c7e27c3cb3fcd5fe08574c31f9ee9150", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs", rev = "ae364b95c7e27c3cb3fcd5fe08574c31f9ee9150" }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs", rev = "ae364b95c7e27c3cb3fcd5fe08574c31f9ee9150", default-features = false }
 libloading = "0.8"
 faer = "0.24"
 cblas-sys = "0.1"

--- a/crates/tenferro-ad/tests/segment_tests.rs
+++ b/crates/tenferro-ad/tests/segment_tests.rs
@@ -3,7 +3,7 @@ use tenferro_cpu::CpuBackend;
 use tenferro_runtime::exec::{ExecInstruction, ExecOp, ExecProgram};
 use tenferro_runtime::segment::{segment_exec_program, Segment};
 use tenferro_runtime::{DType, ExtensionCacheStore, ExtensionExecutionContext, GraphExecutor};
-use tenferro_tensor::{DotGeneralConfig, Tensor, TypedTensor};
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorValue, TypedTensor};
 
 #[cfg(feature = "cuda")]
 use tenferro_gpu::cubecl::{download_tensor, upload_tensor, CubeclBackend};
@@ -16,6 +16,22 @@ fn scalar_extents(
     output_count: usize,
 ) -> Vec<Vec<tenferro_ops::ShapeExtent<tenferro_ops::dim_expr::DimExpr>>> {
     vec![Vec::new(); output_count]
+}
+
+fn const_shape(shape: &[usize]) -> Vec<tenferro_ops::dim_expr::DimExpr> {
+    shape
+        .iter()
+        .map(|&dim| tenferro_ops::dim_expr::DimExpr::Const(dim))
+        .collect()
+}
+
+fn exact_extents(
+    shape: &[usize],
+) -> Vec<tenferro_ops::ShapeExtent<tenferro_ops::dim_expr::DimExpr>> {
+    const_shape(shape)
+        .into_iter()
+        .map(tenferro_ops::ShapeExtent::exact)
+        .collect()
 }
 
 fn matmul_config() -> DotGeneralConfig {
@@ -247,6 +263,97 @@ fn segmented_dispatch_matches_unsegmented_dispatch_on_cpu() {
 
     assert_tensor_vec_eq(&unsegmented, &segmented);
     assert_tensor_vec_eq(&segmented, &segmented_non_consuming);
+}
+
+fn terminal_noncompact_broadcast_multiply_program() -> ExecProgram {
+    let output_shape = vec![2, 2, 4, 3];
+    let output_exprs = const_shape(&output_shape);
+    let output_extents = exact_extents(&output_shape);
+
+    ExecProgram {
+        instructions: vec![
+            ExecInstruction {
+                op: ExecOp::BroadcastInDim {
+                    shape: output_exprs.clone(),
+                    dims: vec![1, 0, 3],
+                },
+                input_slots: vec![0],
+                output_slots: vec![2],
+                dtype: DType::F64,
+                output_shapes: vec![output_exprs.clone()].into(),
+                output_extents: vec![output_extents.clone()].into(),
+                last_use: vec![false],
+            },
+            ExecInstruction {
+                op: ExecOp::BroadcastInDim {
+                    shape: output_exprs.clone(),
+                    dims: vec![2, 3],
+                },
+                input_slots: vec![1],
+                output_slots: vec![3],
+                dtype: DType::F64,
+                output_shapes: vec![output_exprs.clone()].into(),
+                output_extents: vec![output_extents.clone()].into(),
+                last_use: vec![false],
+            },
+            ExecInstruction {
+                op: ExecOp::Multiply,
+                input_slots: vec![2, 3],
+                output_slots: vec![4],
+                dtype: DType::F64,
+                output_shapes: vec![output_exprs].into(),
+                output_extents: vec![output_extents].into(),
+                last_use: vec![true, true],
+            },
+        ],
+        input_slots: vec![0, 1],
+        output_slots: vec![4],
+        n_slots: 5,
+    }
+}
+
+fn terminal_noncompact_broadcast_multiply_inputs() -> Vec<Tensor> {
+    vec![
+        f64_tensor(vec![2, 2, 3], (0..12).map(|idx| idx as f64 + 1.0).collect()),
+        f64_tensor(vec![4, 3], (0..12).map(|idx| idx as f64 + 101.0).collect()),
+    ]
+}
+
+#[test]
+fn segmented_value_dispatch_preserves_terminal_lazy_broadcast_multiply_view() {
+    let program = terminal_noncompact_broadcast_multiply_program();
+    let inputs = terminal_noncompact_broadcast_multiply_inputs();
+
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    let mut outputs = executor
+        .eval_exec_ir_non_consuming_values(&program, &inputs)
+        .unwrap();
+    assert_eq!(outputs.len(), 1);
+    assert!(
+        matches!(outputs[0], TensorValue::View(_)),
+        "terminal broadcast-multiply segment should preserve a lazy output view"
+    );
+
+    let output = outputs.pop().unwrap().to_tensor();
+    assert_eq!(output.shape(), &[2, 2, 4, 3]);
+    let Tensor::F64(output) = output else {
+        panic!("expected f64 output")
+    };
+    let lhs = inputs[0].as_slice::<f64>().unwrap();
+    let rhs = inputs[1].as_slice::<f64>().unwrap();
+    let actual = output.host_data();
+    for t in 0..3 {
+        for o in 0..4 {
+            for k in 0..2 {
+                for j in 0..2 {
+                    let out_idx = j + 2 * k + 4 * o + 16 * t;
+                    let lhs_idx = k + 2 * j + 4 * t;
+                    let rhs_idx = o + 4 * t;
+                    assert_eq!(actual[out_idx], lhs[lhs_idx] * rhs[rhs_idx]);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(feature = "cuda")]

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -15,7 +15,7 @@ name = "tenferro_cpu"
 
 [features]
 default = ["cpu-faer"]
-cpu-faer = ["dep:faer"]
+cpu-faer = ["dep:faer", "dep:strided-einsum2", "strided-einsum2/faer"]
 cpu-blas = ["dep:cblas-sys", "dep:lapack"]
 provider-src = ["cpu-blas", "dep:blas-src", "dep:cblas-src", "dep:lapack-src"]
 provider-inject = ["cpu-blas", "dep:cblas-inject", "dep:lapack-inject"]
@@ -29,6 +29,7 @@ num-complex.workspace = true
 num-traits.workspace = true
 smallvec.workspace = true
 strided-kernel.workspace = true
+strided-einsum2 = { workspace = true, optional = true }
 thiserror.workspace = true
 faer = { workspace = true, optional = true }
 cblas-sys = { workspace = true, optional = true }

--- a/crates/tenferro-cpu/src/elementwise.rs
+++ b/crates/tenferro-cpu/src/elementwise.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 
 use num_complex::Complex;
 use num_traits::{One, Zero};
-use strided_kernel::{batched_outer_product_into_seq, map_into, zip_map2_into, zip_map3_into};
+use strided_kernel::{
+    batched_outer_product_into, broadcast_mul_into, map_into, mul_into, zip_map2_into,
+    zip_map3_into,
+};
 
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use tenferro_tensor::{
@@ -590,62 +593,6 @@ fn read_as_cpu_view(input: TensorRead<'_>) -> CpuReadView<'_> {
     }
 }
 
-fn broadcast_typed_read_view<'a, T, R>(
-    view: TypedTensorView<'a, T, R>,
-    shape: &[usize],
-    dims: &[usize],
-) -> crate::Result<TypedTensorView<'a, T>>
-where
-    T: 'static,
-    R: TensorRank,
-{
-    if view.backend_buffer().is_some() {
-        return Err(crate::cpu_backend_buffer_error("broadcast_multiply"));
-    }
-    if view.shape().len() != dims.len() {
-        return Err(crate::Error::RankMismatch {
-            op: "broadcast_multiply",
-            expected: view.shape().len(),
-            actual: dims.len(),
-        });
-    }
-
-    let mut seen = vec![false; shape.len()];
-    let mut strides = vec![0isize; shape.len()];
-    for (src_axis, &dst_axis) in dims.iter().enumerate() {
-        if dst_axis >= shape.len() {
-            return Err(crate::Error::AxisOutOfBounds {
-                op: "broadcast_multiply",
-                axis: dst_axis,
-                rank: shape.len(),
-            });
-        }
-        if seen[dst_axis] {
-            return Err(crate::Error::DuplicateAxis {
-                op: "broadcast_multiply",
-                axis: dst_axis,
-                role: "dims",
-            });
-        }
-        seen[dst_axis] = true;
-
-        let source_dim = view.shape()[src_axis];
-        let target_dim = shape[dst_axis];
-        if source_dim != target_dim && source_dim != 1 {
-            return Err(crate::Error::ShapeMismatch {
-                op: "broadcast_multiply",
-                lhs: view.shape().to_vec(),
-                rhs: shape.to_vec(),
-            });
-        }
-        if source_dim == target_dim {
-            strides[dst_axis] = view.strides()[src_axis];
-        }
-    }
-
-    TypedTensorView::from_slice(shape, &strides, view.offset(), view.as_physical_slice())
-}
-
 #[derive(Clone, Copy)]
 enum SplitOuterProductLayout {
     LhsPrefix,
@@ -887,7 +834,7 @@ where
             let rhs_outer = rhs_view
                 .permute(&rhs_perm)
                 .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
-            batched_outer_product_into_seq(
+            batched_outer_product_into(
                 &mut out.view_mut(),
                 &lhs_outer,
                 &rhs_outer,
@@ -915,7 +862,7 @@ where
             let rhs_outer = rhs_view
                 .permute(&rhs_perm)
                 .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
-            batched_outer_product_into_seq(
+            batched_outer_product_into(
                 &mut out.view_mut(),
                 &rhs_outer,
                 &lhs_outer,
@@ -1111,7 +1058,7 @@ where
 
             // SAFETY: every element in the physical base output is assigned below.
             let mut base = unsafe { typed_array_uninit_from_pool(buffers, &base_shape) };
-            batched_outer_product_into_seq(
+            batched_outer_product_into(
                 &mut base.view_mut(),
                 &lhs_outer,
                 &rhs_outer,
@@ -1162,7 +1109,7 @@ where
 
             // SAFETY: every element in the physical base output is assigned below.
             let mut base = unsafe { typed_array_uninit_from_pool(buffers, &base_shape) };
-            batched_outer_product_into_seq(
+            batched_outer_product_into(
                 &mut base.view_mut(),
                 &rhs_outer,
                 &lhs_outer,
@@ -1179,136 +1126,42 @@ where
     }
 }
 
-#[cfg(feature = "cpu-blas")]
-fn blas_dim(
-    op: &'static str,
-    name: &'static str,
-    value: usize,
-) -> crate::Result<std::os::raw::c_int> {
-    value.try_into().map_err(|_| {
-        crate::Error::backend_failure(op, format!("{name}={value} exceeds BLAS c_int range"))
-    })
-}
-
-#[cfg(feature = "cpu-blas")]
-fn try_outer_product_blas_f64(
-    buffers: &mut BufferPool,
-    lhs: &TypedTensorView<'_, f64>,
-    lhs_shape: &[usize],
-    lhs_dims: &[usize],
-    rhs: &TypedTensorView<'_, f64>,
-    rhs_shape: &[usize],
-    rhs_dims: &[usize],
-) -> crate::Result<Option<TypedTensor<f64>>> {
-    try_outer_product_blas_real(
-        buffers,
-        lhs,
-        lhs_shape,
-        lhs_dims,
-        rhs,
-        rhs_shape,
-        rhs_dims,
-        cblas_sys::cblas_dgemm,
-    )
-}
-
-#[cfg(feature = "cpu-blas")]
-fn try_outer_product_blas_f32(
-    buffers: &mut BufferPool,
-    lhs: &TypedTensorView<'_, f32>,
-    lhs_shape: &[usize],
-    lhs_dims: &[usize],
-    rhs: &TypedTensorView<'_, f32>,
-    rhs_shape: &[usize],
-    rhs_dims: &[usize],
-) -> crate::Result<Option<TypedTensor<f32>>> {
-    try_outer_product_blas_real(
-        buffers,
-        lhs,
-        lhs_shape,
-        lhs_dims,
-        rhs,
-        rhs_shape,
-        rhs_dims,
-        cblas_sys::cblas_sgemm,
-    )
-}
-
-#[cfg(feature = "cpu-blas")]
 #[allow(clippy::too_many_arguments)]
-fn try_outer_product_blas_real<T>(
+fn typed_broadcast_mul_view_with_pool<T, L, R>(
     buffers: &mut BufferPool,
-    lhs: &TypedTensorView<'_, T>,
+    lhs: &TypedTensorView<'_, T, L>,
     lhs_shape: &[usize],
     lhs_dims: &[usize],
-    rhs: &TypedTensorView<'_, T>,
+    rhs: &TypedTensorView<'_, T, R>,
     rhs_shape: &[usize],
     rhs_dims: &[usize],
-    gemm: unsafe extern "C" fn(
-        cblas_sys::CBLAS_LAYOUT,
-        cblas_sys::CBLAS_TRANSPOSE,
-        cblas_sys::CBLAS_TRANSPOSE,
-        std::os::raw::c_int,
-        std::os::raw::c_int,
-        std::os::raw::c_int,
-        T,
-        *const T,
-        std::os::raw::c_int,
-        *const T,
-        std::os::raw::c_int,
-        T,
-        *mut T,
-        std::os::raw::c_int,
-    ),
-) -> crate::Result<Option<TypedTensor<T>>>
+) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + PoolScalar + From<f32> + 'static,
+    T: Copy + Clone + Zero + Mul<Output = T> + PoolScalar + 'static,
+    L: TensorRank,
+    R: TensorRank,
 {
-    let Some(plan) = split_outer_product_plan(lhs, lhs_shape, lhs_dims, rhs, rhs_shape, rhs_dims)?
-    else {
-        return Ok(None);
-    };
-    if plan.rows == 0 || plan.cols == 0 || plan.batches != 1 {
-        return Ok(None);
+    if lhs_shape != rhs_shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "broadcast_multiply",
+            lhs: lhs_shape.to_vec(),
+            rhs: rhs_shape.to_vec(),
+        });
     }
-    let Ok(lhs_data) = lhs.as_slice() else {
-        return Ok(None);
-    };
-    let Ok(rhs_data) = rhs.as_slice() else {
-        return Ok(None);
-    };
-    let (x, y) = match plan.layout {
-        SplitOuterProductLayout::LhsPrefix => (lhs_data, rhs_data),
-        SplitOuterProductLayout::RhsPrefix => (rhs_data, lhs_data),
-    };
 
-    // SAFETY: beta=0 makes GEMM initialize every output element.
+    // SAFETY: broadcast_mul_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs_shape) };
-
-    let m = blas_dim("broadcast_multiply", "m", plan.rows)?;
-    let n = blas_dim("broadcast_multiply", "n", plan.cols)?;
-    let k = blas_dim("broadcast_multiply", "k", 1)?;
-    let lda = m;
-    let ldb = k;
-    unsafe {
-        gemm(
-            cblas_sys::CBLAS_LAYOUT::CblasColMajor,
-            cblas_sys::CBLAS_TRANSPOSE::CblasNoTrans,
-            cblas_sys::CBLAS_TRANSPOSE::CblasNoTrans,
-            m,
-            n,
-            k,
-            T::from(1.0),
-            x.as_ptr(),
-            lda,
-            y.as_ptr(),
-            ldb,
-            T::from(0.0),
-            out.data_mut().as_mut_ptr(),
-            lda,
-        );
-    }
-    Ok(Some(tensor_from_array(out)))
+    let lhs_view = typed_view_from_view("broadcast_multiply", lhs)?;
+    let rhs_view = typed_view_from_view("broadcast_multiply", rhs)?;
+    broadcast_mul_into(
+        &mut out.view_mut(),
+        &lhs_view,
+        lhs_dims,
+        &rhs_view,
+        rhs_dims,
+    )
+    .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+    Ok(tensor_from_array(out))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1331,33 +1184,15 @@ pub(crate) fn broadcast_multiply_read_with_pool(
             )? {
                 return Ok(Some(Tensor::$variant(out)));
             }
-            let lhs = broadcast_typed_read_view($lhs, lhs_shape, lhs_dims)?;
-            let rhs = broadcast_typed_read_view($rhs, rhs_shape, rhs_dims)?;
-            Ok(Some(Tensor::$variant(typed_mul_view_with_pool(
-                buffers, &lhs, &rhs,
+            Ok(Some(Tensor::$variant(typed_broadcast_mul_view_with_pool(
+                buffers, &$lhs, lhs_shape, lhs_dims, &$rhs, rhs_shape, rhs_dims,
             )?)))
         }};
     }
 
     match (lhs, rhs) {
-        (CpuReadView::F32(lhs), CpuReadView::F32(rhs)) => {
-            #[cfg(feature = "cpu-blas")]
-            if let Some(out) = try_outer_product_blas_f32(
-                buffers, &lhs, lhs_shape, lhs_dims, &rhs, rhs_shape, rhs_dims,
-            )? {
-                return Ok(Some(Tensor::F32(out)));
-            }
-            dispatch!(F32, lhs, rhs)
-        }
-        (CpuReadView::F64(lhs), CpuReadView::F64(rhs)) => {
-            #[cfg(feature = "cpu-blas")]
-            if let Some(out) = try_outer_product_blas_f64(
-                buffers, &lhs, lhs_shape, lhs_dims, &rhs, rhs_shape, rhs_dims,
-            )? {
-                return Ok(Some(Tensor::F64(out)));
-            }
-            dispatch!(F64, lhs, rhs)
-        }
+        (CpuReadView::F32(lhs), CpuReadView::F32(rhs)) => dispatch!(F32, lhs, rhs),
+        (CpuReadView::F64(lhs), CpuReadView::F64(rhs)) => dispatch!(F64, lhs, rhs),
         (CpuReadView::I32(lhs), CpuReadView::I32(rhs)) => dispatch!(I32, lhs, rhs),
         (CpuReadView::I64(lhs), CpuReadView::I64(rhs)) => dispatch!(I64, lhs, rhs),
         (CpuReadView::C32(lhs), CpuReadView::C32(rhs)) => dispatch!(C32, lhs, rhs),
@@ -1873,7 +1708,7 @@ where
 
 pub fn typed_mul<T>(lhs: &TypedTensor<T>, rhs: &TypedTensor<T>) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + Zero + Mul<Output = T> + PoolScalar,
+    T: Copy + Clone + Zero + Mul<Output = T> + PoolScalar + 'static,
 {
     with_local_pool(|buffers| typed_mul_with_pool(buffers, lhs, rhs))
 }
@@ -1884,16 +1719,15 @@ pub(crate) fn typed_mul_with_pool<T>(
     rhs: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + Zero + Mul<Output = T> + PoolScalar,
+    T: Copy + Clone + Zero + Mul<Output = T> + PoolScalar + 'static,
 {
     if lhs.shape() == rhs.shape() {
-        // SAFETY: zip_map2_into overwrites every output element.
+        // SAFETY: mul_into overwrites every output element.
         let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) };
-        zip_map2_into(
+        mul_into(
             &mut out.view_mut(),
             &typed_view("mul", lhs)?,
             &typed_view("mul", rhs)?,
-            |x, y| x * y,
         )
         .map_err(|err| crate::Error::backend_failure("mul", err))?;
         Ok(tensor_from_array(out))
@@ -1935,13 +1769,12 @@ where
     R: TensorRank,
 {
     if lhs.shape() == rhs.shape() {
-        // SAFETY: zip_map2_into overwrites every output element.
+        // SAFETY: mul_into overwrites every output element.
         let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) };
-        zip_map2_into(
+        mul_into(
             &mut out.view_mut(),
             &typed_view_from_view("mul", lhs)?,
             &typed_view_from_view("mul", rhs)?,
-            |x, y| x * y,
         )
         .map_err(|err| crate::Error::backend_failure("mul", err))?;
         Ok(tensor_from_array(out))
@@ -2411,6 +2244,50 @@ mod tests {
             out.is_none(),
             "pure shared-batch elementwise should use the ordinary zip-map path"
         );
+    }
+
+    #[test]
+    fn broadcast_multiply_fallback_handles_permuted_elementwise_without_materialization() {
+        let mut buffers = BufferPool::default();
+        let lhs_data: Vec<f64> = (0..24).map(|i| (i + 1) as f64).collect();
+        let rhs_data: Vec<f64> = (0..24).map(|i| (100 + i) as f64).collect();
+        let lhs = Tensor::F64(TypedTensor::from_vec_col_major(
+            vec![2, 3, 4],
+            lhs_data.clone(),
+        ));
+        let rhs = Tensor::F64(TypedTensor::from_vec_col_major(
+            vec![4, 2, 3],
+            rhs_data.clone(),
+        ));
+
+        let out = broadcast_multiply_read_with_pool(
+            &mut buffers,
+            TensorRead::from_tensor(&lhs),
+            &[2, 3, 4],
+            &[0, 1, 2],
+            TensorRead::from_tensor(&rhs),
+            &[2, 3, 4],
+            &[2, 0, 1],
+        )
+        .unwrap()
+        .expect("same-rank permuted elementwise multiply should use fallback broadcast mul");
+
+        let expected: Vec<f64> = (0..4)
+            .flat_map(|k| {
+                let lhs_data = &lhs_data;
+                let rhs_data = &rhs_data;
+                (0..3).flat_map(move |j| {
+                    (0..2).map(move |i| {
+                        let lhs_offset = i + 2 * j + 6 * k;
+                        let rhs_offset = k + 4 * i + 8 * j;
+                        lhs_data[lhs_offset] * rhs_data[rhs_offset]
+                    })
+                })
+            })
+            .collect();
+
+        assert_eq!(out.shape(), &[2, 3, 4]);
+        assert_eq!(out.as_slice::<f64>().unwrap(), expected.as_slice());
     }
 
     #[test]

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -20,6 +20,8 @@ use tenferro_tensor::{CacheStats, RuntimeCacheControl};
 mod blas_gemm;
 #[cfg(feature = "cpu-faer")]
 mod faer_gemm;
+#[cfg(feature = "cpu-faer")]
+mod strided_dot;
 
 #[cfg(feature = "cpu-blas")]
 use blas_gemm::BlasGemm;
@@ -709,7 +711,16 @@ pub(crate) fn dot_general_faer_cached<T>(
     config: &DotGeneralConfig,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: FaerGemm + PoolScalar + Copy + Clone + Zero + One + PartialEq + 'static,
+    T: FaerGemm
+        + PoolScalar
+        + Copy
+        + Clone
+        + Zero
+        + One
+        + PartialEq
+        + strided_einsum2::ScalarBase
+        + 'static,
+    strided_einsum2::backend::FaerBackend: strided_einsum2::Backend<T>,
 {
     dot_general_faer_with_conj_cached(
         buffers, cache, cache_slot, ctx, lhs, rhs, config, false, false,
@@ -731,8 +742,26 @@ pub(crate) fn dot_general_faer_with_conj_cached<T>(
     rhs_conj: bool,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: FaerGemm + PoolScalar + Copy + Clone + Zero + One + PartialEq + 'static,
+    T: FaerGemm
+        + PoolScalar
+        + Copy
+        + Clone
+        + Zero
+        + One
+        + PartialEq
+        + strided_einsum2::ScalarBase
+        + 'static,
+    strided_einsum2::backend::FaerBackend: strided_einsum2::Backend<T>,
 {
+    if !lhs_conj && !rhs_conj {
+        return strided_dot::dot_general_strided_with_backend::<
+            _,
+            _,
+            _,
+            strided_einsum2::backend::FaerBackend,
+        >(buffers, lhs, rhs, config);
+    }
+
     if let Some(result) = typed_faer_gemm(
         buffers,
         cache,
@@ -789,6 +818,7 @@ pub(crate) fn dot_general_faer_read_cached(
     rhs: TensorRead<'_>,
     config: &DotGeneralConfig,
 ) -> crate::Result<Option<crate::Tensor>> {
+    let _ = (cache, cache_slot, ctx);
     macro_rules! dispatch {
         ($owned:ident, $view:ident, $wrap:ident) => {
             match (&lhs, &rhs) {
@@ -796,73 +826,49 @@ pub(crate) fn dot_general_faer_read_cached(
                     TensorRead::Tensor(crate::Tensor::$owned(a)),
                     TensorRead::Tensor(crate::Tensor::$owned(b)),
                 ) => {
-                    return typed_faer_gemm(
-                        buffers,
-                        cache,
-                        cache_slot,
-                        GemmAnalysisCacheKind::Direct,
-                        ctx,
-                        a,
-                        b,
-                        config,
-                        false,
-                        false,
-                    )
-                    .map(|result| result.map(crate::Tensor::$wrap));
+                    return strided_dot::dot_general_strided_with_backend::<
+                        _,
+                        _,
+                        _,
+                        strided_einsum2::backend::FaerBackend,
+                    >(buffers, a, b, config)
+                    .map(|result| Some(crate::Tensor::$wrap(result)));
                 }
                 (
                     TensorRead::Tensor(crate::Tensor::$owned(a)),
                     TensorRead::View(TensorView::$view(b)),
                 ) => {
-                    return typed_faer_gemm(
-                        buffers,
-                        cache,
-                        cache_slot,
-                        GemmAnalysisCacheKind::Direct,
-                        ctx,
-                        a,
-                        b,
-                        config,
-                        false,
-                        false,
-                    )
-                    .map(|result| result.map(crate::Tensor::$wrap));
+                    return strided_dot::dot_general_strided_with_backend::<
+                        _,
+                        _,
+                        _,
+                        strided_einsum2::backend::FaerBackend,
+                    >(buffers, a, b, config)
+                    .map(|result| Some(crate::Tensor::$wrap(result)));
                 }
                 (
                     TensorRead::View(TensorView::$view(a)),
                     TensorRead::Tensor(crate::Tensor::$owned(b)),
                 ) => {
-                    return typed_faer_gemm(
-                        buffers,
-                        cache,
-                        cache_slot,
-                        GemmAnalysisCacheKind::Direct,
-                        ctx,
-                        a,
-                        b,
-                        config,
-                        false,
-                        false,
-                    )
-                    .map(|result| result.map(crate::Tensor::$wrap));
+                    return strided_dot::dot_general_strided_with_backend::<
+                        _,
+                        _,
+                        _,
+                        strided_einsum2::backend::FaerBackend,
+                    >(buffers, a, b, config)
+                    .map(|result| Some(crate::Tensor::$wrap(result)));
                 }
                 (
                     TensorRead::View(TensorView::$view(a)),
                     TensorRead::View(TensorView::$view(b)),
                 ) => {
-                    return typed_faer_gemm(
-                        buffers,
-                        cache,
-                        cache_slot,
-                        GemmAnalysisCacheKind::Direct,
-                        ctx,
-                        a,
-                        b,
-                        config,
-                        false,
-                        false,
-                    )
-                    .map(|result| result.map(crate::Tensor::$wrap));
+                    return strided_dot::dot_general_strided_with_backend::<
+                        _,
+                        _,
+                        _,
+                        strided_einsum2::backend::FaerBackend,
+                    >(buffers, a, b, config)
+                    .map(|result| Some(crate::Tensor::$wrap(result)));
                 }
                 _ => {}
             }

--- a/crates/tenferro-cpu/src/gemm/strided_dot.rs
+++ b/crates/tenferro-cpu/src/gemm/strided_dot.rs
@@ -1,0 +1,102 @@
+use num_traits::{One, Zero};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tenferro_tensor::{Buffer, DotGeneralConfig as TensorDotGeneralConfig, TypedTensor};
+
+use crate::buffer_pool::{BufferPool, PoolScalar};
+use crate::{default_placement, Error};
+
+use super::TypedTensorRead;
+
+#[cfg(test)]
+static DISPATCH_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(super) fn test_dispatch_count() -> usize {
+    DISPATCH_COUNT.load(Ordering::SeqCst)
+}
+
+fn map_strided_error(err: impl std::fmt::Display) -> Error {
+    Error::backend_failure("dot_general", err)
+}
+
+fn to_strided_config(config: &TensorDotGeneralConfig) -> strided_einsum2::DotGeneralConfig<'_> {
+    strided_einsum2::DotGeneralConfig {
+        lhs_contracting_dims: config.lhs_contracting_dims.as_slice(),
+        rhs_contracting_dims: config.rhs_contracting_dims.as_slice(),
+        lhs_batch_dims: config.lhs_batch_dims.as_slice(),
+        rhs_batch_dims: config.rhs_batch_dims.as_slice(),
+    }
+}
+
+fn checked_product(shape: &[usize]) -> crate::Result<usize> {
+    shape
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or_else(|| Error::backend_failure("dot_general", "output element count overflow"))
+}
+
+fn as_strided_view<'a, R, T>(read: &'a R) -> crate::Result<strided_einsum2::StridedView<'a, T>>
+where
+    R: TypedTensorRead<T>,
+    T: 'static,
+{
+    let Some(data) = read.host_data_opt() else {
+        return Err(Error::backend_failure(
+            "dot_general",
+            "CPU dot_general requires host-backed inputs",
+        ));
+    };
+    strided_einsum2::StridedView::new(data, read.shape(), read.strides().as_slice(), read.offset())
+        .map_err(map_strided_error)
+}
+
+pub(crate) fn dot_general_strided_with_backend<L, R, T, B>(
+    buffers: &mut BufferPool,
+    lhs: &L,
+    rhs: &R,
+    config: &TensorDotGeneralConfig,
+) -> crate::Result<TypedTensor<T>>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: PoolScalar + Copy + Clone + Zero + One + PartialEq + strided_einsum2::ScalarBase + 'static,
+    B: strided_einsum2::Backend<T>,
+{
+    #[cfg(test)]
+    DISPATCH_COUNT.fetch_add(1, Ordering::SeqCst);
+
+    super::validate_dot_general(lhs, rhs, config)?;
+
+    let lhs_view = as_strided_view(lhs)?;
+    let rhs_view = as_strided_view(rhs)?;
+
+    let strided_config = to_strided_config(config);
+    let out_shape = strided_config
+        .expected_output_shape(lhs.shape(), rhs.shape())
+        .map_err(map_strided_error)?;
+    let out_n = checked_product(&out_shape)?;
+
+    // SAFETY: dot_general_with_backend_into is called with beta=0 and either
+    // overwrites every output element or explicitly zero-fills k=0 outputs.
+    let mut out_data = unsafe { T::pool_acquire(buffers, out_n) };
+    let out_strides = strided_einsum2::col_major_strides(&out_shape);
+    let out_view = strided_einsum2::StridedViewMut::new(&mut out_data, &out_shape, &out_strides, 0)
+        .map_err(map_strided_error)?;
+
+    strided_einsum2::dot_general_with_backend_into::<T, B>(
+        out_view,
+        &lhs_view,
+        &rhs_view,
+        &strided_config,
+        T::one(),
+        T::zero(),
+    )
+    .map_err(map_strided_error)?;
+
+    Ok(TypedTensor::from_buffer_col_major(
+        out_shape,
+        Buffer::Host(out_data),
+        default_placement(),
+    ))
+}

--- a/crates/tenferro-cpu/src/gemm/tests.rs
+++ b/crates/tenferro-cpu/src/gemm/tests.rs
@@ -9,15 +9,18 @@ use super::blas_gemm::BlasGemm;
 use super::dot_general_blas_cached;
 #[cfg(feature = "cpu-faer")]
 use super::faer_gemm::FaerGemm;
-#[cfg(feature = "cpu-blas")]
+#[cfg(feature = "cpu-faer")]
+use super::{dot_general_faer_read_cached, strided_dot};
+#[cfg(any(feature = "cpu-blas", feature = "cpu-faer"))]
 use crate::buffer_pool::BufferPool;
 #[cfg(feature = "cpu-faer")]
 use crate::CpuContext;
 #[cfg(feature = "cpu-blas")]
 use num_complex::Complex64;
-use tenferro_tensor::DotGeneralConfig;
 use tenferro_tensor::RuntimeCacheControl;
-use tenferro_tensor::TypedTensor;
+use tenferro_tensor::{DotGeneralConfig, TypedTensor};
+#[cfg(feature = "cpu-faer")]
+use tenferro_tensor::{Tensor, TensorRead, TensorView};
 
 #[test]
 fn try_fuse_dims_reversed_strides() {
@@ -152,6 +155,45 @@ fn gemm_analysis_cache_reuses_matching_direct_plan_and_reports_stats() {
     let stats = cache.stats();
     assert_eq!(stats.entries, 1);
     assert!(stats.retained_bytes > 0);
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn faer_read_transposed_view_uses_strided_dot_without_materializing_input() {
+    let lhs_source =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let lhs_view = lhs_source.as_view().transpose_view([1, 0]).unwrap();
+    let rhs = TypedTensor::<f64>::from_vec_col_major(
+        vec![3, 2],
+        vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0],
+    );
+    let rhs = Tensor::F64(rhs);
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let mut buffers = BufferPool::new();
+    let mut cache = GemmAnalysisCache::default();
+    let ctx = CpuContext::with_threads(1);
+
+    let dispatch_count_before = strided_dot::test_dispatch_count();
+    let out = dot_general_faer_read_cached(
+        &mut buffers,
+        &mut cache,
+        Some(0),
+        &ctx,
+        TensorRead::from_view(TensorView::F64(lhs_view)),
+        TensorRead::from_tensor(&rhs),
+        &config,
+    )
+    .unwrap()
+    .expect("same-dtype f64 inputs should be handled directly");
+
+    assert!(strided_dot::test_dispatch_count() > dispatch_count_before);
+    assert_eq!(out.shape(), &[2, 2]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[50.0, 122.0, 68.0, 167.0]);
 }
 
 #[cfg(feature = "cpu-blas")]

--- a/crates/tenferro-runtime/src/segment.rs
+++ b/crates/tenferro-runtime/src/segment.rs
@@ -391,6 +391,17 @@ pub(crate) fn eval_exec_segmented_slot_values_with_cache_and_workspace<
                                 return Ok(());
                             }
                         }
+                        if let Some(output) = try_execute_terminal_broadcast_multiply_value_segment(
+                            exec,
+                            slots,
+                            instructions,
+                            output_slots,
+                            &terminal_slots,
+                        )? {
+                            slots[output_slots[0]] = Some(ExecSlot::Value(output));
+                            reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+                            return Ok(());
+                        }
                         if let Some(output) = try_execute_broadcast_multiply_segment(
                             exec,
                             slots,
@@ -504,6 +515,61 @@ fn try_execute_broadcast_multiply_segment(
     let lhs_shape = resolve_tensor_shape_exprs(slots, &lhs_bc.input_slots, lhs_shape_exprs)?;
     let rhs_shape = resolve_tensor_shape_exprs(slots, &rhs_bc.input_slots, rhs_shape_exprs)?;
     Ok(exec.execute_broadcast_multiply(
+        get_read(slots, &lhs_bc.input_slots, 0)?,
+        &lhs_shape,
+        lhs_dims,
+        get_read(slots, &rhs_bc.input_slots, 0)?,
+        &rhs_shape,
+        rhs_dims,
+    )?)
+}
+
+fn try_execute_terminal_broadcast_multiply_value_segment(
+    exec: &mut dyn tenferro_tensor::BackendSession,
+    slots: &[Option<ExecSlot<'_>>],
+    instructions: &[ExecInstruction],
+    output_slots: &[usize],
+    terminal_slots: &[bool],
+) -> Result<Option<TensorValue>> {
+    let [output_slot] = output_slots else {
+        return Ok(None);
+    };
+    if !terminal_slots.get(*output_slot).copied().unwrap_or(false) {
+        return Ok(None);
+    }
+
+    let [lhs_bc, rhs_bc, multiply] = instructions else {
+        return Ok(None);
+    };
+    let ExecOp::BroadcastInDim {
+        shape: lhs_shape_exprs,
+        dims: lhs_dims,
+    } = &lhs_bc.op
+    else {
+        return Ok(None);
+    };
+    let ExecOp::BroadcastInDim {
+        shape: rhs_shape_exprs,
+        dims: rhs_dims,
+    } = &rhs_bc.op
+    else {
+        return Ok(None);
+    };
+    if !matches!(multiply.op, ExecOp::Multiply)
+        || lhs_bc.output_slots.len() != 1
+        || rhs_bc.output_slots.len() != 1
+        || multiply.output_slots.len() != 1
+        || multiply.input_slots.len() != 2
+        || multiply.input_slots[0] != lhs_bc.output_slots[0]
+        || multiply.input_slots[1] != rhs_bc.output_slots[0]
+        || output_slots != multiply.output_slots.as_slice()
+    {
+        return Ok(None);
+    }
+
+    let lhs_shape = resolve_tensor_shape_exprs(slots, &lhs_bc.input_slots, lhs_shape_exprs)?;
+    let rhs_shape = resolve_tensor_shape_exprs(slots, &rhs_bc.input_slots, rhs_shape_exprs)?;
+    Ok(exec.execute_broadcast_multiply_value(
         get_read(slots, &lhs_bc.input_slots, 0)?,
         &lhs_shape,
         lhs_dims,

--- a/docs/worklogs/2026-06-06-strided-einsum-kernel-ownership.md
+++ b/docs/worklogs/2026-06-06-strided-einsum-kernel-ownership.md
@@ -1,0 +1,80 @@
+# Strided Einsum Kernel Ownership
+
+## Session Summary
+
+Moved CPU binary einsum support toward `strided-rs` ownership and cleaned up
+tenferro's adapter layer. The work keeps tenferro responsible for dtype
+dispatch, backend selection, buffer-pool allocation, and runtime value/view
+semantics, while `strided-kernel` and `strided-einsum2` own broadcast
+multiplication, batched outer product, and non-conjugated dot-general execution.
+
+## Context Read
+
+- `AGENTS.md`
+- `REPOSITORY_RULES.md`
+- Shared tensor4all common repository, performance, docs/tests, and Rust
+  performance rules
+- `crates/tenferro-cpu/src/elementwise.rs`
+- `crates/tenferro-cpu/src/gemm/mod.rs`
+- `crates/tenferro-cpu/src/gemm/strided_dot.rs`
+- `../strided-rs/strided-kernel/src/map_view.rs`
+- `../strided-rs/strided-kernel/src/outer_product.rs`
+- `../strided-rs/strided-einsum2/src/dot_general.rs`
+
+## Decisions Made
+
+- `strided-kernel::batched_outer_product_into` is a semantic wrapper over the
+  general `broadcast_mul_into` path. This keeps explicit outer-product calls
+  and equivalent broadcasted multiplication on one implementation path.
+- tenferro's `broadcast_multiply_read_with_pool` now uses
+  `typed_broadcast_mul_view_with_pool` for the fallback path instead of
+  materializing broadcast views before calling `mul`.
+- Removed the tenferro `cpu-blas` outer-product GEMM shortcut. BLAS remains the
+  provider for `dot_general`; elementwise and broadcast multiply go through
+  `strided-kernel` for all CPU provider selections.
+- `strided_einsum2::DotGeneralConfig` borrows axis slices. The tenferro adapter
+  passes existing `DotGeneralConfig` vectors as slices instead of cloning them
+  into a second owned config.
+- Kept current non-conjugated faer dot-general routing through
+  `strided_einsum2`; conjugated dot-general still uses the existing tenferro
+  materialization/canonicalization fallback until strided-einsum2 exposes a
+  deliberate conjugating API.
+
+## Rejected Or Deferred Alternatives
+
+- Did not add more shape-specific einsum fast paths. Current benchmark analysis
+  does not show a kernel/executor loss above the configured threshold; the
+  remaining large gap is classified as a path/intermediate issue.
+- Did not keep a BLAS outer-product special case in tenferro. It duplicated
+  elementwise ownership and made behavior depend on CPU provider features.
+- Did not add a prepared dot-general cache to `strided-einsum2` yet. The current
+  adapter overhead should be benchmarked before adding another cache layer.
+- Did not lower N-ary einsum graphs to expanded dot/reduce/transpose graphs in
+  this pass. That remains a path-planning/compiler optimization, not a kernel
+  patch.
+
+## Verification Performed
+
+- `cargo fmt --check` in `../strided-rs`
+- `cargo test -p strided-einsum2 --features parallel,blas-accelerate --no-default-features`
+- `cargo test -p strided-kernel --features parallel`
+- `cargo check -p strided-einsum2 --features parallel,blas-inject --no-default-features`
+- `cargo check -p strided-einsum2 --features parallel,blas-mkl --no-default-features`
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-cpu --features cpu-faer -- --nocapture`
+- `cargo test -p tenferro-cpu --no-default-features --features cpu-blas,src-accelerate -- --nocapture`
+- `uv run python scripts/analyze_einsum_gaps.py --report result/cpu/einsum.md --instances data/instances --threshold 1.15` in `../tenferro-benchmark`
+
+## Remaining Risks
+
+- The latest saved benchmark still has `gm_queen5_5_3.wcsp` with
+  `opt_flops` slower than PyTorch, but the analyzer classifies it as
+  `path_intermediate`. A focused `TENFERRO_ANALYZE_PATH=1` run reported a
+  rank-17 maximum intermediate, `129140163` maximum intermediate elements, and
+  `592127821` total intermediate elements for `opt_flops`; the `opt_size` path
+  caps the maximum intermediate at `43046721` elements. More kernel-level
+  optimization is not justified by the current evidence.
+- `strided_einsum2` does not yet expose a conjugating dot-general API, so
+  tenferro's conjugated CPU faer path still uses the existing fallback.
+- Full workspace release, coverage, rustdoc, and docs-site gates were not run
+  in this session.


### PR DESCRIPTION
## Summary
- route CPU broadcast multiply / outer-product-like elementwise paths through `strided-kernel`
- add `strided_einsum2` backed non-conjugated dot-general execution for the faer CPU path
- remove the tenferro-local BLAS outer-product shortcut and pin strided dependencies to `tensor4all/strided-rs@6585675`

## Why
CPU binary einsum kernels should live in `strided-rs`, while tenferro keeps backend selection, dtype dispatch, buffer pools, and runtime view/value behavior. This avoids provider-dependent ad hoc outer-product behavior in tenferro.

## Notes
- The remaining material benchmark gap is classified as a path/intermediate issue, not a kernel/executor issue.
- Local `docs/superpowers/...` planning notes were intentionally not committed.

## Verification
- `cargo fmt --all --check`
- `cargo test -p tenferro-cpu --features cpu-faer -- --nocapture`
- `cargo test -p tenferro-cpu --no-default-features --features cpu-blas,src-accelerate -- --nocapture`
- `git diff --check`
