### PR TITLE
[codex] Fix complex VJP and complex eigh dtype

### DIFF
--- a/crates/tenferro-ad/tests/ad.rs
+++ b/crates/tenferro-ad/tests/ad.rs
@@ -542,6 +542,41 @@ fn assert_close_slice_c64(actual: &[Complex64], expected: &[Complex64]) {
     }
 }
 
+fn complex_unary_vjp_key(op: &StdTensorOp) -> TensorInputKey {
+    let tag = match op {
+        StdTensorOp::Exp => 1,
+        StdTensorOp::Log => 2,
+        StdTensorOp::Sin => 3,
+        StdTensorOp::Cos => 4,
+        StdTensorOp::Tanh => 5,
+        StdTensorOp::Sqrt => 6,
+        StdTensorOp::Rsqrt => 7,
+        StdTensorOp::Expm1 => 8,
+        StdTensorOp::Log1p => 9,
+        _ => panic!("unexpected complex unary VJP op: {op:?}"),
+    };
+    tensor_input_key(91_000 + tag)
+}
+
+fn assert_complex_unary_vjp(op: StdTensorOp, derivative: impl Fn(Complex64) -> Complex64) {
+    let input_key = complex_unary_vjp_key(&op);
+    let input_data = vec![Complex64::new(0.5, 0.75), Complex64::new(-0.25, 0.4)];
+    let cotangent_data = vec![Complex64::new(0.25, -1.2), Complex64::new(-0.5, 0.75)];
+    let grad = transpose_primal_unary_op_with_inputs(
+        op,
+        input_key,
+        c64_tensor(vec![2], input_data.clone()),
+        c64_tensor(vec![2], cotangent_data.clone()),
+    );
+
+    let expected: Vec<_> = input_data
+        .iter()
+        .zip(cotangent_data.iter())
+        .map(|(&x, &ct)| ct * derivative(x).conj())
+        .collect();
+    assert_close_slice_c64(get_c64_data(&grad), &expected);
+}
+
 fn assert_jvp_matches_finite_diff(
     actual: &[f64],
     base: &[f64],
@@ -917,6 +952,82 @@ fn scale_complex_eval_and_grad_complex_sum() {
     let grad = loss.grad(&x).unwrap();
     let grad_eval = eval_tensor(grad);
     assert_close_slice_c64(get_c64_data(&grad_eval), &[factor.conj(), factor.conj()]);
+}
+
+#[test]
+fn complex_unary_vjps_conjugate_holomorphic_derivatives() {
+    assert_complex_unary_vjp(StdTensorOp::Exp, |x| x.exp());
+    assert_complex_unary_vjp(StdTensorOp::Log, |x| Complex64::new(1.0, 0.0) / x);
+    assert_complex_unary_vjp(StdTensorOp::Sin, |x| x.cos());
+    assert_complex_unary_vjp(StdTensorOp::Cos, |x| -x.sin());
+    assert_complex_unary_vjp(StdTensorOp::Tanh, |x| {
+        Complex64::new(1.0, 0.0) - x.tanh() * x.tanh()
+    });
+    assert_complex_unary_vjp(StdTensorOp::Sqrt, |x| {
+        Complex64::new(1.0, 0.0) / (Complex64::new(2.0, 0.0) * x.sqrt())
+    });
+    assert_complex_unary_vjp(StdTensorOp::Rsqrt, |x| {
+        -Complex64::new(1.0, 0.0) / (Complex64::new(2.0, 0.0) * x * x.sqrt())
+    });
+    assert_complex_unary_vjp(StdTensorOp::Expm1, |x| x.exp());
+    assert_complex_unary_vjp(StdTensorOp::Log1p, |x| {
+        Complex64::new(1.0, 0.0) / (Complex64::new(1.0, 0.0) + x)
+    });
+}
+
+#[test]
+fn complex_div_and_pow_vjps_conjugate_holomorphic_coefficients() {
+    let x_data = vec![Complex64::new(0.8, 0.35), Complex64::new(1.1, -0.2)];
+    let y_data = vec![Complex64::new(1.5, -0.25), Complex64::new(0.7, 0.45)];
+    let cotangent_data = vec![Complex64::new(-0.3, 0.9), Complex64::new(1.25, -0.5)];
+
+    let x = TracedTensor::from_tensor_concrete_shape(c64_tensor(vec![2], x_data.clone()));
+    let y = TracedTensor::from_tensor_concrete_shape(c64_tensor(vec![2], y_data.clone()));
+    let cotangent =
+        TracedTensor::from_tensor_concrete_shape(c64_tensor(vec![2], cotangent_data.clone()));
+    let quotient = x.div(&y);
+
+    let div_vjp_x = eval_tensor(quotient.vjp(&x, &cotangent));
+    let div_vjp_y = eval_tensor(quotient.vjp(&y, &cotangent));
+
+    let expected_div_x: Vec<_> = y_data
+        .iter()
+        .zip(cotangent_data.iter())
+        .map(|(&y, &ct)| ct * (Complex64::new(1.0, 0.0) / y).conj())
+        .collect();
+    let expected_div_y: Vec<_> = x_data
+        .iter()
+        .zip(y_data.iter())
+        .zip(cotangent_data.iter())
+        .map(|((&x, &y), &ct)| ct * (-(x / (y * y))).conj())
+        .collect();
+    assert_close_slice_c64(get_c64_data(&div_vjp_x), &expected_div_x);
+    assert_close_slice_c64(get_c64_data(&div_vjp_y), &expected_div_y);
+
+    let pow = x.pow(&y);
+    let pow_vjp_x = eval_tensor(pow.vjp(&x, &cotangent));
+    let pow_vjp_y = eval_tensor(pow.vjp(&y, &cotangent));
+
+    let expected_pow_x: Vec<_> = x_data
+        .iter()
+        .zip(y_data.iter())
+        .zip(cotangent_data.iter())
+        .map(|((&x, &y), &ct)| {
+            let pow_xy = x.powc(y);
+            ct * (y * pow_xy / x).conj()
+        })
+        .collect();
+    let expected_pow_y: Vec<_> = x_data
+        .iter()
+        .zip(y_data.iter())
+        .zip(cotangent_data.iter())
+        .map(|((&x, &y), &ct)| {
+            let pow_xy = x.powc(y);
+            ct * (x.ln() * pow_xy).conj()
+        })
+        .collect();
+    assert_close_slice_c64(get_c64_data(&pow_vjp_x), &expected_pow_x);
+    assert_close_slice_c64(get_c64_data(&pow_vjp_y), &expected_pow_y);
 }
 
 #[test]

--- a/crates/tenferro-internal-ops/src/ad/analytic.rs
+++ b/crates/tenferro-internal-ops/src/ad/analytic.rs
@@ -1,3 +1,5 @@
+use crate::ad::context::ShapeGuardContext;
+use crate::ad::support::{conjugate_primal_if_any_dtype_complex, dtype_of_or_real};
 use crate::ad::PrimitiveRuleBuilder;
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 
@@ -98,6 +100,27 @@ fn emit_linear_div_fixed_denominator(
             active_mask: vec![true, false],
         },
     )[0]
+}
+
+fn conjugate_for_unary_input_dtype(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+    inputs: &[ValueRef<StdTensorOp>],
+    ctx: &mut ShapeGuardContext,
+) -> ValueRef<StdTensorOp> {
+    let dtype = dtype_of_or_real(ctx, &inputs[0]);
+    conjugate_primal_if_any_dtype_complex(builder, input, &[dtype])
+}
+
+fn conjugate_for_binary_input_dtypes(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+    inputs: &[ValueRef<StdTensorOp>],
+    ctx: &mut ShapeGuardContext,
+) -> ValueRef<StdTensorOp> {
+    let lhs_dtype = dtype_of_or_real(ctx, &inputs[0]);
+    let rhs_dtype = dtype_of_or_real(ctx, &inputs[1]);
+    conjugate_primal_if_any_dtype_complex(builder, input, &[lhs_dtype, rhs_dtype])
 }
 
 fn unary_is_active(mode: &OperationRole) -> bool {
@@ -363,6 +386,7 @@ pub fn transpose_exp(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
@@ -370,11 +394,9 @@ pub fn transpose_exp(
     match cotangent_out[0] {
         Some(ct) => {
             let exp_x = emit_fixed_unary(builder, StdTensorOp::Exp, inputs[0].clone());
-            vec![Some(emit_linear_mul_fixed(
-                builder,
-                ValueRef::Local(exp_x),
-                ct,
-            ))]
+            let coeff =
+                conjugate_for_unary_input_dtype(builder, ValueRef::Local(exp_x), inputs, ctx);
+            vec![Some(emit_linear_mul_fixed(builder, coeff, ct))]
         }
         None => vec![None],
     }
@@ -385,15 +407,18 @@ pub fn transpose_log(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
     }
     match cotangent_out[0] {
         Some(ct) => {
+            let denominator =
+                conjugate_for_unary_input_dtype(builder, inputs[0].clone(), inputs, ctx);
             let out = builder.add_operation(
                 StdTensorOp::Div,
-                vec![ValueRef::Local(ct), inputs[0].clone()],
+                vec![ValueRef::Local(ct), denominator],
                 OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
@@ -409,6 +434,7 @@ pub fn transpose_sin(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
@@ -416,11 +442,9 @@ pub fn transpose_sin(
     match cotangent_out[0] {
         Some(ct) => {
             let cos_x = emit_fixed_unary(builder, StdTensorOp::Cos, inputs[0].clone());
-            vec![Some(emit_linear_mul_fixed(
-                builder,
-                ValueRef::Local(cos_x),
-                ct,
-            ))]
+            let coeff =
+                conjugate_for_unary_input_dtype(builder, ValueRef::Local(cos_x), inputs, ctx);
+            vec![Some(emit_linear_mul_fixed(builder, coeff, ct))]
         }
         None => vec![None],
     }
@@ -431,6 +455,7 @@ pub fn transpose_cos(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
@@ -439,11 +464,9 @@ pub fn transpose_cos(
         Some(ct) => {
             let sin_x = emit_fixed_unary(builder, StdTensorOp::Sin, inputs[0].clone());
             let neg_sin_x = emit_fixed_neg(builder, ValueRef::Local(sin_x));
-            vec![Some(emit_linear_mul_fixed(
-                builder,
-                ValueRef::Local(neg_sin_x),
-                ct,
-            ))]
+            let coeff =
+                conjugate_for_unary_input_dtype(builder, ValueRef::Local(neg_sin_x), inputs, ctx);
+            vec![Some(emit_linear_mul_fixed(builder, coeff, ct))]
         }
         None => vec![None],
     }
@@ -454,6 +477,7 @@ pub fn transpose_tanh(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
@@ -465,11 +489,9 @@ pub fn transpose_tanh(
             let one = emit_one_like_fixed(builder, inputs[0].clone());
             let neg_tanh_sq = emit_fixed_neg(builder, ValueRef::Local(tanh_sq));
             let coeff = emit_fixed_add(builder, ValueRef::Local(one), ValueRef::Local(neg_tanh_sq));
-            vec![Some(emit_linear_mul_fixed(
-                builder,
-                ValueRef::Local(coeff),
-                ct,
-            ))]
+            let coeff =
+                conjugate_for_unary_input_dtype(builder, ValueRef::Local(coeff), inputs, ctx);
+            vec![Some(emit_linear_mul_fixed(builder, coeff, ct))]
         }
         None => vec![None],
     }
@@ -480,6 +502,7 @@ pub fn transpose_sqrt(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
@@ -489,9 +512,11 @@ pub fn transpose_sqrt(
             let sqrt_x = emit_fixed_unary(builder, StdTensorOp::Sqrt, inputs[0].clone());
             let two_sqrt_x =
                 emit_fixed_add(builder, ValueRef::Local(sqrt_x), ValueRef::Local(sqrt_x));
+            let denominator =
+                conjugate_for_unary_input_dtype(builder, ValueRef::Local(two_sqrt_x), inputs, ctx);
             let out = builder.add_operation(
                 StdTensorOp::Div,
-                vec![ValueRef::Local(ct), ValueRef::Local(two_sqrt_x)],
+                vec![ValueRef::Local(ct), denominator],
                 OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },
@@ -507,6 +532,7 @@ pub fn transpose_rsqrt(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
@@ -521,11 +547,9 @@ pub fn transpose_rsqrt(
                 ValueRef::Local(neg_rsqrt_x),
                 ValueRef::Local(two_x),
             );
-            vec![Some(emit_linear_mul_fixed(
-                builder,
-                ValueRef::Local(coeff),
-                ct,
-            ))]
+            let coeff =
+                conjugate_for_unary_input_dtype(builder, ValueRef::Local(coeff), inputs, ctx);
+            vec![Some(emit_linear_mul_fixed(builder, coeff, ct))]
         }
         None => vec![None],
     }
@@ -536,6 +560,7 @@ pub fn transpose_pow(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
@@ -558,7 +583,8 @@ pub fn transpose_pow(
         );
         let pow_over_x = emit_fixed_div(builder, ValueRef::Local(pow_xy), inputs[0].clone());
         let coeff = emit_fixed_mul(builder, inputs[1].clone(), ValueRef::Local(pow_over_x));
-        result[0] = Some(emit_linear_mul_fixed(builder, ValueRef::Local(coeff), ct));
+        let coeff = conjugate_for_binary_input_dtypes(builder, ValueRef::Local(coeff), inputs, ctx);
+        result[0] = Some(emit_linear_mul_fixed(builder, coeff, ct));
     }
 
     if active_mask[1] {
@@ -570,7 +596,8 @@ pub fn transpose_pow(
             inputs[1].clone(),
         );
         let coeff = emit_fixed_mul(builder, ValueRef::Local(log_x), ValueRef::Local(pow_xy));
-        result[1] = Some(emit_linear_mul_fixed(builder, ValueRef::Local(coeff), ct));
+        let coeff = conjugate_for_binary_input_dtypes(builder, ValueRef::Local(coeff), inputs, ctx);
+        result[1] = Some(emit_linear_mul_fixed(builder, coeff, ct));
     }
 
     result
@@ -581,6 +608,7 @@ pub fn transpose_expm1(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
@@ -588,11 +616,9 @@ pub fn transpose_expm1(
     match cotangent_out[0] {
         Some(ct) => {
             let exp_x = emit_fixed_unary(builder, StdTensorOp::Exp, inputs[0].clone());
-            vec![Some(emit_linear_mul_fixed(
-                builder,
-                ValueRef::Local(exp_x),
-                ct,
-            ))]
+            let coeff =
+                conjugate_for_unary_input_dtype(builder, ValueRef::Local(exp_x), inputs, ctx);
+            vec![Some(emit_linear_mul_fixed(builder, coeff, ct))]
         }
         None => vec![None],
     }
@@ -603,6 +629,7 @@ pub fn transpose_log1p(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     if !unary_is_active(mode) {
         return vec![None];
@@ -611,9 +638,11 @@ pub fn transpose_log1p(
         Some(ct) => {
             let one = emit_one_like_fixed(builder, inputs[0].clone());
             let denom = emit_fixed_add(builder, inputs[0].clone(), ValueRef::Local(one));
+            let denominator =
+                conjugate_for_unary_input_dtype(builder, ValueRef::Local(denom), inputs, ctx);
             let out = builder.add_operation(
                 StdTensorOp::Div,
-                vec![ValueRef::Local(ct), ValueRef::Local(denom)],
+                vec![ValueRef::Local(ct), denominator],
                 OperationRole::Linearized {
                     active_mask: vec![true, false],
                 },

--- a/crates/tenferro-internal-ops/src/ad/elementwise.rs
+++ b/crates/tenferro-internal-ops/src/ad/elementwise.rs
@@ -1,3 +1,5 @@
+use crate::ad::context::ShapeGuardContext;
+use crate::ad::support::{conjugate_primal_if_any_dtype_complex, dtype_of_or_real};
 use crate::ad::PrimitiveRuleBuilder;
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::CompareDir;
@@ -108,6 +110,20 @@ fn emit_zero_from_active(
             active_mask: vec![true, true],
         },
     )[0]
+}
+
+fn conjugate_for_input_dtypes(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+    inputs: &[ValueRef<StdTensorOp>],
+    indices: &[usize],
+    ctx: &mut ShapeGuardContext,
+) -> ValueRef<StdTensorOp> {
+    let dtypes: Vec<_> = indices
+        .iter()
+        .map(|&index| dtype_of_or_real(ctx, &inputs[index]))
+        .collect();
+    conjugate_primal_if_any_dtype_complex(builder, input, &dtypes)
 }
 
 fn select_tangents(
@@ -354,6 +370,7 @@ pub fn transpose_div(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
@@ -368,9 +385,10 @@ pub fn transpose_div(
     let mut result = vec![None, None];
 
     if active_mask[0] {
+        let denominator = conjugate_for_input_dtypes(builder, inputs[1].clone(), inputs, &[1], ctx);
         let out = builder.add_operation(
             StdTensorOp::Div,
-            vec![ValueRef::Local(ct), inputs[1].clone()],
+            vec![ValueRef::Local(ct), denominator],
             OperationRole::Linearized {
                 active_mask: vec![true, false],
             },
@@ -382,7 +400,9 @@ pub fn transpose_div(
         let quotient = emit_fixed_div(builder, inputs[0].clone(), inputs[1].clone());
         let neg_quotient = emit_fixed_neg(builder, ValueRef::Local(quotient));
         let coeff = emit_fixed_div(builder, ValueRef::Local(neg_quotient), inputs[1].clone());
-        result[1] = Some(emit_linear_mul_fixed(builder, ValueRef::Local(coeff), ct));
+        let coeff =
+            conjugate_for_input_dtypes(builder, ValueRef::Local(coeff), inputs, &[0, 1], ctx);
+        result[1] = Some(emit_linear_mul_fixed(builder, coeff, ct));
     }
 
     result

--- a/crates/tenferro-internal-ops/src/ad/registry.rs
+++ b/crates/tenferro-internal-ops/src/ad/registry.rs
@@ -552,7 +552,22 @@ macro_rules! transpose_elementwise {
     };
 }
 
-transpose_elementwise!(transpose_div, elementwise::transpose_div);
+fn transpose_div(
+    _op: &StdTensorOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    Ok(elementwise::transpose_div(
+        builder,
+        cotangent_out,
+        inputs,
+        mode,
+        ctx,
+    ))
+}
 transpose_elementwise!(transpose_abs, elementwise::transpose_abs);
 fn transpose_sign(
     _op: &StdTensorOp,
@@ -647,9 +662,9 @@ macro_rules! analytic_transpose {
             cotangent_out: &[Option<LocalValueId>],
             inputs: &[ValueRef<StdTensorOp>],
             mode: &OperationRole,
-            _ctx: &mut ShapeGuardContext,
+            ctx: &mut ShapeGuardContext,
         ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-            Ok($callee(builder, cotangent_out, inputs, mode))
+            Ok($callee(builder, cotangent_out, inputs, mode, ctx))
         }
     };
 }

--- a/crates/tenferro-internal-ops/src/ad/support.rs
+++ b/crates/tenferro-internal-ops/src/ad/support.rs
@@ -9,6 +9,16 @@ pub fn is_real_dtype(dtype: DType) -> bool {
     matches!(dtype, DType::F32 | DType::F64)
 }
 
+fn is_complex_dtype(dtype: DType) -> bool {
+    matches!(dtype, DType::C32 | DType::C64)
+}
+
+pub(crate) fn dtype_of_or_real(ctx: &mut ShapeGuardContext, val: &ValueRef<StdTensorOp>) -> DType {
+    ctx.try_metadata_of(val)
+        .map(|metadata| metadata.dtype)
+        .unwrap_or(DType::F64)
+}
+
 pub fn conjugate_primal_if_complex(
     builder: &mut dyn PrimitiveRuleBuilder,
     input: ValueRef<StdTensorOp>,
@@ -23,12 +33,26 @@ pub fn conjugate_primal_if_dtype_complex(
     input: ValueRef<StdTensorOp>,
     dtype: DType,
 ) -> ValueRef<StdTensorOp> {
-    if is_real_dtype(dtype) {
-        input
-    } else {
+    if is_complex_dtype(dtype) {
         ValueRef::Local(
             builder.add_operation(StdTensorOp::Conj, vec![input], OperationRole::Primary)[0],
         )
+    } else {
+        input
+    }
+}
+
+pub(crate) fn conjugate_primal_if_any_dtype_complex(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+    dtypes: &[DType],
+) -> ValueRef<StdTensorOp> {
+    if dtypes.iter().copied().any(is_complex_dtype) {
+        ValueRef::Local(
+            builder.add_operation(StdTensorOp::Conj, vec![input], OperationRole::Primary)[0],
+        )
+    } else {
+        input
     }
 }
 
@@ -37,9 +61,7 @@ pub fn conjugate_linear_if_dtype_complex(
     input: LocalValueId,
     dtype: DType,
 ) -> LocalValueId {
-    if is_real_dtype(dtype) {
-        input
-    } else {
+    if is_complex_dtype(dtype) {
         builder.add_operation(
             StdTensorOp::Conj,
             vec![ValueRef::Local(input)],
@@ -47,5 +69,7 @@ pub fn conjugate_linear_if_dtype_complex(
                 active_mask: vec![true],
             },
         )[0]
+    } else {
+        input
     }
 }

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -2,6 +2,7 @@ use crate::backend::LinalgBackend;
 
 use super::linalg;
 
+use num_complex::{Complex32, Complex64};
 use tenferro_cpu::{CpuBackend, CpuBackendKind};
 use tenferro_tensor::{
     validate::validate_nonsingular_u, DType, Error, Tensor, TensorElementwise, TensorStructural,
@@ -631,9 +632,9 @@ impl LinalgBackend for CpuBackend {
                         Tensor::F64(t) => linalg::faer::eigh(ctx.as_ref(), buffers, t)
                             .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
                         Tensor::C32(t) => linalg::faer::eigh(ctx.as_ref(), buffers, t)
-                            .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
+                            .map(eigh_c32_outputs_to_public_tensors),
                         Tensor::C64(t) => linalg::faer::eigh(ctx.as_ref(), buffers, t)
-                            .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+                            .map(eigh_c64_outputs_to_public_tensors),
                         _ => Err(unsupported_dtype("eigh", input.dtype())),
                     })
                 }
@@ -650,10 +651,12 @@ impl LinalgBackend for CpuBackend {
                             .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                         Tensor::F64(t) => linalg::blas::eigh(buffers, t)
                             .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
-                        Tensor::C32(t) => linalg::blas::eigh(buffers, t)
-                            .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
-                        Tensor::C64(t) => linalg::blas::eigh(buffers, t)
-                            .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+                        Tensor::C32(t) => {
+                            linalg::blas::eigh(buffers, t).map(eigh_c32_outputs_to_public_tensors)
+                        }
+                        Tensor::C64(t) => {
+                            linalg::blas::eigh(buffers, t).map(eigh_c64_outputs_to_public_tensors)
+                        }
                         _ => Err(unsupported_dtype("eigh", input.dtype())),
                     })
                 }
@@ -966,6 +969,44 @@ fn zeros_like_tensor(input: &Tensor) -> Tensor {
         Tensor::C32(t) => Tensor::C32(TypedTensor::zeros(t.shape().to_vec())),
         Tensor::C64(t) => Tensor::C64(TypedTensor::zeros(t.shape().to_vec())),
     }
+}
+
+fn complex32_real_part_tensor(values: TypedTensor<Complex32>) -> TypedTensor<f32> {
+    let mut out = TypedTensor::from_vec_col_major(
+        values.shape().to_vec(),
+        values.host_data().iter().map(|value| value.re).collect(),
+    );
+    out.placement = values.placement.clone();
+    out
+}
+
+fn complex64_real_part_tensor(values: TypedTensor<Complex64>) -> TypedTensor<f64> {
+    let mut out = TypedTensor::from_vec_col_major(
+        values.shape().to_vec(),
+        values.host_data().iter().map(|value| value.re).collect(),
+    );
+    out.placement = values.placement.clone();
+    out
+}
+
+fn eigh_c32_outputs_to_public_tensors(outputs: Vec<TypedTensor<Complex32>>) -> Vec<Tensor> {
+    let mut outputs = outputs.into_iter();
+    let values = outputs.next().expect("eigh returns eigenvalues");
+    let vectors = outputs.next().expect("eigh returns eigenvectors");
+    vec![
+        Tensor::F32(complex32_real_part_tensor(values)),
+        Tensor::C32(vectors),
+    ]
+}
+
+fn eigh_c64_outputs_to_public_tensors(outputs: Vec<TypedTensor<Complex64>>) -> Vec<Tensor> {
+    let mut outputs = outputs.into_iter();
+    let values = outputs.next().expect("eigh returns eigenvalues");
+    let vectors = outputs.next().expect("eigh returns eigenvectors");
+    vec![
+        Tensor::F64(complex64_real_part_tensor(values)),
+        Tensor::C64(vectors),
+    ]
 }
 
 fn apply_lu_pivots_cpu(

--- a/crates/tenferro-linalg/src/cpu/tests/dtype.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/dtype.rs
@@ -72,6 +72,14 @@ fn diag_c32(values: &[Complex32]) -> Vec<Complex32> {
     out
 }
 
+fn diag_c32_from_real(values: &[f32]) -> Vec<Complex32> {
+    let mut out = vec![Complex32::new(0.0, 0.0); values.len() * values.len()];
+    for (i, value) in values.iter().enumerate() {
+        out[col_major_index(values.len(), i, i)] = Complex32::new(*value, 0.0);
+    }
+    out
+}
+
 fn f32_data(tensor: &Tensor) -> &[f32] {
     match tensor {
         Tensor::F32(inner) => inner.host_data(),
@@ -307,9 +315,17 @@ fn cpu_linalg_accepts_c32_happy_paths() {
             spd.clone(),
         )))
         .unwrap();
+    assert_eq!(eigh[0].dtype(), DType::F32);
+    assert_eq!(eigh[1].dtype(), DType::C32);
     assert_c32_slice_close(
         &matmul_c32(
-            &matmul_c32(c32_data(&eigh[1]), &diag_c32(c32_data(&eigh[0])), 2, 2, 2),
+            &matmul_c32(
+                c32_data(&eigh[1]),
+                &diag_c32_from_real(f32_data(&eigh[0])),
+                2,
+                2,
+                2,
+            ),
             &conjugate_transpose_c32(c32_data(&eigh[1]), 2, 2),
             2,
             2,

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -366,23 +366,22 @@ fn test_batched_complex_eigh() {
     let out = backend.eigh(&input).unwrap();
 
     assert_eq!(out.len(), 2);
+    assert_eq!(out[0].dtype(), DType::F64);
+    assert_eq!(out[1].dtype(), DType::C64);
     assert_eq!(out[0].shape(), &[2, 2]);
     assert_eq!(out[1].shape(), &[2, 2, 2]);
 
     for batch_idx in 0..2 {
-        let values = batch_vector_c64_from_tensor(&out[0], 2, batch_idx);
+        let values = batch_vector_f64_from_tensor(&out[0], 2, batch_idx);
         let vectors = batch_matrix_c64_from_tensor(&out[1], 2, 2, batch_idx);
         let recon = matmul_c64(
-            &matmul_c64(&vectors, &diag_c64(&values), 2, 2, 2),
+            &matmul_c64(&vectors, &diag_c64_from_real(&values), 2, 2, 2),
             &conjugate_transpose_c64(&vectors, 2, 2),
             2,
             2,
             2,
         );
         let expected = batch_matrix_c64_from_tensor(&input, 2, 2, batch_idx);
-        for value in &values {
-            assert_f64_close_tol(value.im, 0.0, 1.0e-12);
-        }
         for (actual, expected) in recon.iter().zip(expected.iter()) {
             assert_c64_close_tol(*actual, *expected, 1.0e-10);
         }

--- a/crates/tenferro-linalg/src/cpu/tests/mod.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/mod.rs
@@ -179,6 +179,14 @@ fn diag_c64(values: &[Complex64]) -> Vec<Complex64> {
     out
 }
 
+fn diag_c64_from_real(values: &[f64]) -> Vec<Complex64> {
+    let mut out = vec![Complex64::new(0.0, 0.0); values.len() * values.len()];
+    for (i, value) in values.iter().enumerate() {
+        out[col_major_index(values.len(), i, i)] = Complex64::new(*value, 0.0);
+    }
+    out
+}
+
 fn batch_matrix_f64_from_tensor(
     t: &Tensor,
     rows: usize,

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -462,7 +462,7 @@ fn eigh_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
     let n = shape[0].clone();
     let batch = &shape[2..];
     vec![
-        (dtype, vector_shape(n.clone(), batch)),
+        (singular_values_dtype(dtype), vector_shape(n.clone(), batch)),
         (dtype, matrix_shape(n.clone(), n, batch)),
     ]
 }

--- a/crates/tenferro-linalg/tests/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/traced_extension.rs
@@ -111,6 +111,9 @@ fn traced_metadata_matches_linalg_extension_shapes_and_dtypes() {
         vec![3, 3, 2],
         vec![1.0_f64; 18],
     ));
+    let complex_square = TracedTensor::from_tensor_concrete_shape(Tensor::C64(
+        TypedTensor::from_vec_col_major(vec![2, 2], vec![Complex64::new(1.0, 0.0); 4]),
+    ));
     let ints = TracedTensor::from_tensor_concrete_shape(Tensor::I64(
         TypedTensor::from_vec_col_major(vec![2, 2], vec![1, 0, 0, 2]),
     ));
@@ -131,6 +134,11 @@ fn traced_metadata_matches_linalg_extension_shapes_and_dtypes() {
     let (eigh_values, eigh_vectors) = tenferro_linalg::eigh(&square).unwrap();
     assert_eq!(eigh_values.concrete_shape(), vec![3, 2]);
     assert_eq!(eigh_vectors.concrete_shape(), vec![3, 3, 2]);
+
+    let (complex_eigh_values, complex_eigh_vectors) =
+        tenferro_linalg::eigh(&complex_square).unwrap();
+    assert_eq!(complex_eigh_values.dtype, DType::F64);
+    assert_eq!(complex_eigh_vectors.dtype, DType::C64);
 }
 
 #[test]

--- a/docs/oracle/index.md
+++ b/docs/oracle/index.md
@@ -20,6 +20,39 @@ should live in the crate that owns the behavior under test. Each test case:
 See [Oracle Coverage Status](./tensor-ad-oracles-support.md) for the current
 per-op support matrix (auto-generated).
 
+## CI policy
+
+Oracle replay has two CI tiers:
+
+1. **PR sentinel tier**: run on a standard GitHub-hosted Linux runner. This tier
+   uses a fixed sentinel set plus an affected-op subset derived from the PR
+   diff. It must stay small enough for normal pull-request turnaround and must
+   not require larger Linux or GPU runners.
+
+2. **Post-merge full tier**: run after merge to `main` on standard
+   GitHub-hosted Linux runners. This tier shards the full supported oracle
+   matrix across ordinary Linux jobs. Unsupported rows in
+   [Oracle Coverage Status](./tensor-ad-oracles-support.md) remain tracking
+   data, not required CI gates, until the owning crate implements the replay
+   adapter for that family.
+
+The PR sentinel set should be chosen by these criteria:
+
+- include at least one record for every contract the PR changes, such as dtype,
+  shape, batching, AD direction, or complex convention;
+- prefer cases that have both Torch reference payloads and finite-difference
+  checks;
+- include real and complex dtype representatives when a rule branches on
+  complex behavior;
+- include boundary cases that previously failed or that differ across CPU
+  providers;
+- keep the set deterministic and stable so a PR failure points to a contract
+  regression rather than oracle sampling variance.
+
+The current root-facade oracle harness has been removed. Until a crate-local
+replay harness is restored, CI cannot claim full oracle replay coverage; focused
+regression tests and this support matrix are the active gates.
+
 ## Links
 
 - Test source: historical root-facade oracle replay harness, now removed

--- a/docs/spec/ad-contract.md
+++ b/docs/spec/ad-contract.md
@@ -125,6 +125,35 @@ impl<Op: GraphOperation> LinearizedGraph<Op> {
    family registers an extension AD rule. Missing extension rules must report
    unsupported AD; they must not silently drop or zero gradients.
 
+## Complex AD convention
+
+tenferro follows the tidu/JAX-style complex AD convention.
+
+Forward mode treats complex primitives as real-linear maps. For a holomorphic
+elementwise map `f`, the JVP multiplies the tangent by the local derivative
+coefficient `f'(z)` without conjugating that coefficient.
+
+Reverse mode transposes real-linear maps under the real inner product
+`<a, b> = Re(conj(a) * b)`. Therefore the VJP for a holomorphic elementwise map
+uses the conjugated local derivative coefficient:
+
+```text
+primal: y = f(z)
+JVP:    dy = f'(z) * dz
+VJP:    dz_bar = y_bar * conj(f'(z))
+```
+
+The same rule applies to fixed derivative coefficients emitted by composite
+transpose rules. For example, if a binary holomorphic op emits a coefficient
+`c(x, y)` for one input in forward linearization, its transpose rule must
+multiply the output cotangent by `conj(c(x, y))` when the corresponding
+real-linear map is complex-valued. Do not conjugate those coefficients in JVP
+rules.
+
+This convention is the normative source for tenferro complex VJP behavior.
+Oracle comparisons and finite-difference tests must be interpreted under this
+real-inner-product convention.
+
 ## Owned by this document
 
 - `Primitive` trait signature
@@ -132,6 +161,7 @@ impl<Op: GraphOperation> LinearizedGraph<Op> {
 - Cotangent accumulation rule
 - Linear op rule
 - Primal reuse rule
+- Complex AD convention
 
 Other documents link here for the AD contract; they do not re-state
 these definitions.

--- a/docs/worklogs/2026-06-09-complex-vjp-eigh-oracle.md
+++ b/docs/worklogs/2026-06-09-complex-vjp-eigh-oracle.md
@@ -1,0 +1,73 @@
+# Complex VJP, Eigh DType, And Oracle CI Policy
+
+## Session Summary
+
+Fixed two correctness bugs: complex analytic VJP transpose rules now conjugate
+holomorphic derivative coefficients under the tenferro/tidu real-inner-product
+convention, and public `eigh` returns real eigenvalue tensors for complex
+Hermitian inputs. The PR also records the complex VJP convention in the AD spec
+and documents the intended oracle CI tiers.
+
+## Context Read
+
+- `REPOSITORY_RULES.md`
+- `docs/spec/ad-contract.md`
+- `docs/oracle/index.md`
+- `docs/oracle/tensor-ad-oracles-support.md`
+- Prior worklog `docs/worklogs/2026-06-02-linalg-values-batch-optimizations.md`
+- Local tenferro AD transpose rules and linalg CPU/GPU/extension metadata
+- `tidu-rs` complex AD guide and regression tests
+- Vendored `tensor-ad-oracles` records for representative complex VJP cases
+
+## Decisions Made
+
+- Complex VJP uses the tidu/JAX-style real inner product
+  `<a, b> = Re(conj(a) * b)`. For holomorphic elementwise maps, the transpose
+  multiplies cotangents by `conj(f'(z))`.
+- JVP rules keep the ordinary holomorphic coefficient `f'(z)` and do not
+  conjugate it.
+- Analytic transpose rules for `exp`, `log`, `sin`, `cos`, `tanh`, `sqrt`,
+  `rsqrt`, `expm1`, `log1p`, `pow`, and `div` now conjugate fixed complex
+  derivative coefficients.
+- Public `eigh(C32)` returns `(F32 eigenvalues, C32 eigenvectors)` and
+  public `eigh(C64)` returns `(F64 eigenvalues, C64 eigenvectors)` on CPU,
+  matching the existing GPU path and traced extension contract.
+- Oracle CI policy is split into a PR sentinel tier on standard Linux runners
+  and a post-merge full supported-oracle tier sharded across standard Linux
+  runners.
+
+## Rejected Or Deferred Alternatives
+
+- Did not switch to PyTorch's different complex pullback presentation. The
+  tenferro primitive-rule surface is graph-level `linearize` and
+  `transpose_rule`, and tidu already defines the real-inner-product convention.
+- Did not add a large Linux runner or GPU runner requirement for oracle CI. The
+  chosen policy keeps PR and post-merge oracle replay on standard Linux runners.
+- Did not claim full oracle replay coverage in CI. The historical root-facade
+  replay harness has been removed, so scalar analytic oracle replay remains a
+  follow-up to restore in the owning crate.
+
+## Verification Performed
+
+- `cargo test -p tenferro-ad complex_unary_vjps_conjugate_holomorphic_derivatives --test ad -- --nocapture`
+- `cargo test -p tenferro-ad complex_div_and_pow_vjps_conjugate_holomorphic_coefficients --test ad -- --nocapture`
+- `cargo test -p tenferro-linalg test_batched_complex_eigh --lib -- --nocapture`
+- `cargo test -p tenferro-linalg cpu_linalg_accepts_c32_happy_paths --lib -- --nocapture`
+- `cargo test -p tenferro-linalg traced_metadata_matches_linalg_extension_shapes_and_dtypes --test traced_extension -- --nocapture`
+- `cargo test -p tenferro-internal-ops`
+- `cargo test -p tenferro-ad --test ad`
+- `cargo test -p tenferro-linalg`
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+
+## Remaining Risks
+
+- The scalar analytic tensor-ad-oracles families are present in the vendored
+  database but are still unsupported by the current tenferro replay adapter.
+  The focused regression tests cover the fixed bug until crate-local oracle
+  replay is restored.


### PR DESCRIPTION
## Summary

- Fix complex analytic VJP transpose rules to conjugate holomorphic derivative coefficients under the tenferro/tidu real-inner-product convention.
- Make CPU public `eigh` return real eigenvalue tensors for complex Hermitian inputs, matching the existing GPU path and traced extension metadata.
- Document the complex VJP convention, oracle CI tier policy, and reviewer-facing worklog.

Worklog: `docs/worklogs/2026-06-09-complex-vjp-eigh-oracle.md`

## Root Cause

- Complex AD tests covered scale/conj cases, but not the holomorphic analytic VJP coefficient convention for exp/log/sin/cos/tanh/sqrt/rsqrt/expm1/log1p/div/pow.
- The historical root-facade oracle replay harness has been removed, so scalar analytic oracle rows were not a CI gate.
- CPU complex `eigh` forwarded provider-internal complex eigenvalue tensors instead of enforcing the public real eigenvalue dtype contract.

## Verification

- `cargo test -p tenferro-ad --test ad`
- `cargo test -p tenferro-linalg`
- `cargo test -p tenferro-internal-ops`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`