### PR TITLE
Reuse borrowed executor workspace

### DIFF
--- a/crates/tenferro-ad/tests/ad/reductions_and_indexing.rs
+++ b/crates/tenferro-ad/tests/ad/reductions_and_indexing.rs
@@ -645,6 +645,23 @@ fn jvp_traced_index_select_gathers_tangent() {
     assert_close_slice(get_f64_data(&tangent_y), &[3.5, 1.5, 3.5]);
 }
 
+#[test]
+fn hvp_traced_index_select_repeated_positions_accumulates() {
+    let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
+    let weights =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![10.0, 20.0, 30.0]));
+    let tangent =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![0.5, -1.0, 2.0]));
+
+    let selected = x.index_select(0, &[1, 1, 2]).unwrap();
+    let loss = (&(&selected * &selected) * &weights).reduce_sum(&[0]);
+    let grad = loss.grad(&x).unwrap();
+    let hvp = eval_tensor(grad.jvp(&x, &tangent));
+
+    assert_eq!(hvp.shape(), &[3]);
+    assert_close_slice(get_f64_data(&hvp), &[0.0, -60.0, 120.0]);
+}
+
 /// Build `y = ReduceSum(Scatter(operand, indices, updates, config))`,
 /// where the Scatter output has the same shape as `operand`.
 fn build_scatter_reduce_sum_graph(

--- a/crates/tenferro-runtime/src/graph/executor.rs
+++ b/crates/tenferro-runtime/src/graph/executor.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::mem;
 use std::sync::Arc;
 
 use tenferro_ops::input_key::TensorInputKey;
@@ -674,12 +675,12 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
         inputs: Vec<ExecSlot<'a>>,
     ) -> Result<Vec<Tensor>> {
         validate_exec_input_count(program, inputs.len())?;
-        let mut slot_workspace = Vec::new();
+        let mut slot_workspace = BorrowedSlotWorkspace::new(&mut self.slot_workspace);
         crate::segment::eval_exec_segmented_slots_with_cache_and_workspace(
             &mut self.backend,
             program,
             inputs,
-            &mut slot_workspace,
+            slot_workspace.slots(),
             &mut self.backend_cache,
             Some(&mut self.extension_executor),
         )
@@ -691,12 +692,12 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
         inputs: Vec<ExecSlot<'a>>,
     ) -> Result<Vec<TensorValue>> {
         validate_exec_input_count(program, inputs.len())?;
-        let mut slot_workspace = Vec::new();
+        let mut slot_workspace = BorrowedSlotWorkspace::new(&mut self.slot_workspace);
         crate::segment::eval_exec_segmented_slot_values_with_cache_and_workspace(
             &mut self.backend,
             program,
             inputs,
-            &mut slot_workspace,
+            slot_workspace.slots(),
             &mut self.backend_cache,
             Some(&mut self.extension_executor),
         )
@@ -768,6 +769,62 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
             extensions: self.extension_executor.cache_stats(),
             backend: self.backend_cache.stats(),
         }
+    }
+}
+
+struct BorrowedSlotWorkspace<'workspace, 'input> {
+    target: &'workspace mut Vec<Option<ExecSlot<'static>>>,
+    slots: Option<Vec<Option<ExecSlot<'input>>>>,
+}
+
+impl<'workspace, 'input> BorrowedSlotWorkspace<'workspace, 'input> {
+    fn new(target: &'workspace mut Vec<Option<ExecSlot<'static>>>) -> Self {
+        debug_assert!(
+            target.is_empty(),
+            "executor slot workspace must be empty between runs"
+        );
+        target.clear();
+
+        let mut static_slots = mem::take(target);
+        let ptr = static_slots.as_mut_ptr().cast::<Option<ExecSlot<'input>>>();
+        let len = static_slots.len();
+        let cap = static_slots.capacity();
+        debug_assert_eq!(len, 0);
+        mem::forget(static_slots);
+
+        // SAFETY: `ExecSlot<'static>` and `ExecSlot<'input>` have identical
+        // layout; the allocation is retyped only while the vector length is
+        // zero, so no `ExecSlot` values are live across the lifetime change.
+        let slots = unsafe { Vec::from_raw_parts(ptr, len, cap) };
+        Self {
+            target,
+            slots: Some(slots),
+        }
+    }
+
+    fn slots(&mut self) -> &mut Vec<Option<ExecSlot<'input>>> {
+        self.slots
+            .as_mut()
+            .expect("borrowed slot workspace already restored")
+    }
+}
+
+impl Drop for BorrowedSlotWorkspace<'_, '_> {
+    fn drop(&mut self) {
+        let Some(mut slots) = self.slots.take() else {
+            return;
+        };
+        slots.clear();
+        let ptr = slots.as_mut_ptr().cast::<Option<ExecSlot<'static>>>();
+        let len = slots.len();
+        let cap = slots.capacity();
+        debug_assert_eq!(len, 0);
+        mem::forget(slots);
+
+        // SAFETY: all borrowed `ExecSlot<'input>` values were dropped by
+        // `clear`, and the restored vector is empty. Only the allocation
+        // capacity is retained for the next executor run.
+        *self.target = unsafe { Vec::from_raw_parts(ptr, len, cap) };
     }
 }
 
@@ -1145,3 +1202,6 @@ fn zeros_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
         DType::C64 => Tensor::C64(TypedTensor::zeros(shape)),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-runtime/src/graph/executor/tests.rs
+++ b/crates/tenferro-runtime/src/graph/executor/tests.rs
@@ -1,0 +1,63 @@
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{DType, Tensor, TensorRead, TensorValue, TypedTensor};
+
+use super::GraphExecutor;
+use crate::{GraphCompiler, TracedTensor};
+
+#[test]
+fn borrowed_input_execution_retains_executor_slot_workspace_capacity() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
+    let y = &x + &x;
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(&y, &[(&x, DType::F64, &[4])])
+        .unwrap();
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(
+        vec![4],
+        vec![1.0, 2.0, 3.0, 4.0],
+    ));
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+
+    assert_eq!(executor.slot_workspace.capacity(), 0);
+
+    let outputs = executor
+        .run_many_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&input))])
+        .unwrap();
+
+    assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0, 8.0]);
+    assert_eq!(input.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
+    assert!(
+        executor.slot_workspace.capacity() >= program.exec.n_slots,
+        "borrowed execution should retain reusable slot capacity; capacity={}, n_slots={}",
+        executor.slot_workspace.capacity(),
+        program.exec.n_slots
+    );
+}
+
+#[test]
+fn borrowed_input_value_execution_retains_workspace_and_lazy_output() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let y = x.transpose(&[1, 0]);
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(&y, &[(&x, DType::F64, &[2, 2])])
+        .unwrap();
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(
+        vec![2, 2],
+        vec![1.0, 2.0, 3.0, 4.0],
+    ));
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+
+    let outputs = executor
+        .run_many_values_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&input))])
+        .unwrap();
+
+    assert!(matches!(outputs[0], TensorValue::View(_)));
+    assert_eq!(input.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
+    assert!(
+        executor.slot_workspace.capacity() >= program.exec.n_slots,
+        "borrowed value execution should retain reusable slot capacity; capacity={}, n_slots={}",
+        executor.slot_workspace.capacity(),
+        program.exec.n_slots
+    );
+}

--- a/docs/worklogs/2026-06-10-issues-990-991.md
+++ b/docs/worklogs/2026-06-10-issues-990-991.md
@@ -1,0 +1,81 @@
+# Issues 990 And 991 Batch
+
+## Session Summary
+
+This batch addressed GitHub issues #991 and #990 from `origin/main`
+`a61bc205`.
+
+- #991 had an actionable borrowed-execution workspace issue: owned graph
+  execution reused `GraphExecutor::slot_workspace`, but borrowed/read
+  execution allocated a fresh slot vector per run.
+- #990 was an AD coverage audit. Existing indexing coverage already covered
+  repeated-index VJP/JVP, scatter updates, dynamic slice, dynamic update
+  slice, and clamped dynamic-slice finite differences. The batch added one
+  missing HVP regression for repeated `index_select` accumulation.
+
+## Context Read
+
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `REPOSITORY_RULES.md`
+- shared tensor4all common, Rust, performance, docs/tests, and numerical rules
+- `ai/contribution-workflows/bugfix-pr.md`
+- GitHub issues #991 and #990 bodies
+- `crates/tenferro-runtime/src/graph/executor.rs`
+- `crates/tenferro-runtime/src/segment.rs`
+- `crates/tenferro-runtime/src/exec.rs`
+- `crates/tenferro-ad/tests/ad/reductions_and_indexing.rs`
+- `crates/tenferro-internal-ops/src/ad/indexing.rs`
+
+## Decisions Made
+
+- Reused the existing executor-owned slot workspace for borrowed-input
+  execution instead of adding a second public or private cache. This keeps the
+  allocation owner unchanged and avoids expanding the public runtime API.
+- Added a narrow private `BorrowedSlotWorkspace` guard. The executor field is
+  stored as `Vec<Option<ExecSlot<'static>>>` because owned runs do not retain
+  borrowed references. Borrowed runs need the same allocation at the call's
+  shorter input lifetime. The guard temporarily retypes only an empty vector
+  allocation, clears all borrowed slots before drop, then restores the empty
+  allocation to the executor.
+- Kept borrowed output semantics unchanged. Borrowed inputs are still not
+  silently consumed, and terminal lazy value outputs that must outlive the call
+  still own an appropriate base tensor.
+- For #990, used a nonlinear indexed loss,
+  `sum(weights * index_select(x)^2)`, so the HVP is nonzero and verifies
+  repeated-index accumulation rather than testing inactive zero-Hessian
+  behavior.
+
+## Rejected Or Deferred Alternatives
+
+- A public workspace-capacity accessor was rejected because this is an internal
+  performance contract, not user-facing API.
+- A separate borrowed workspace field was rejected as unnecessary duplication
+  of the same allocation ownership.
+- A linear HVP test for `sum(weights * index_select(x))` was rejected after it
+  correctly produced an inactive JVP under the existing optional-AD contract.
+
+## Verification Performed
+
+- `cargo test -p tenferro-runtime borrowed_input_ -- --nocapture`
+- `cargo test -p tenferro-runtime`
+- `cargo test -p tenferro-ad --test ad hvp_traced_index_select_repeated_positions_accumulates -- --nocapture`
+- `cargo test -p tenferro-ad --test ad reductions_and_indexing`
+- `cargo test -p tenferro-ad --test ad`
+- `cargo clippy -p tenferro-runtime --all-targets -- -D warnings`
+- `cargo clippy -p tenferro-ad --test ad -- -D warnings`
+- `cargo fmt --all --check`
+- `git diff --check`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+
+## Remaining Risks
+
+- The borrowed workspace guard uses unsafe allocation retyping. The safety
+  invariant is local: the vector length is zero when retyped into the borrowed
+  lifetime and zero again before restoring the executor's `'static` allocation.
+  Regression tests cover retained capacity and caller input preservation for
+  borrowed tensor and borrowed lazy-value execution.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #990
Fixes #991

## Summary

- Reuse `GraphExecutor::slot_workspace` for borrowed-input execution through a private guard that temporarily retypes only an empty slot allocation.
- Add runtime regressions for borrowed tensor and borrowed lazy-value execution retaining workspace capacity while preserving caller-owned inputs.
- Add an HVP regression for repeated `index_select` accumulation from the #990 indexing AD coverage audit.

## Work log

- `docs/worklogs/2026-06-10-issues-990-991.md`

## Verification

- `cargo test -p tenferro-runtime borrowed_input_ -- --nocapture`
- `cargo test -p tenferro-runtime`
- `cargo test -p tenferro-ad --test ad hvp_traced_index_select_repeated_positions_accumulates -- --nocapture`
- `cargo test -p tenferro-ad --test ad reductions_and_indexing`
- `cargo test -p tenferro-ad --test ad`
- `cargo clippy -p tenferro-runtime --all-targets -- -D warnings`
- `cargo clippy -p tenferro-ad --test ad -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. N/A: bug fix and coverage audit only.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
