### PR TITLE
[codex] Freeze API conventions and add consistency gate

### DIFF
--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -7,11 +7,12 @@ use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::ExtensionRuleSet;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_runtime::ad_support::{
-    checkpoint_traced_tensor, leaf_input_key, linear_input_key, metadata_scopes_with_new,
+    checkpoint_chain as tensor_checkpoint_chain, checkpoint_tensor,
+    extra_roots as tensor_extra_roots, inputs_map as tensor_inputs_map, leaf_input_key,
+    linear_input_key, metadata_scopes as tensor_metadata_scopes, metadata_scopes_with_new,
     ones_tensor, push_metadata_scope, register_scoped_graph_metadata, registered_meta,
-    tensor_meta_from_tensor, traced_checkpoint_chain, traced_extra_roots, traced_inputs_map,
-    traced_metadata_scopes, traced_resolve_roots, traced_shape_hint, traced_tensor_from_parts,
-    TracedTensorParts,
+    resolve_roots as tensor_resolve_roots, shape_hint as tensor_shape_hint, tensor_from_parts,
+    tensor_meta_from_tensor, TracedTensorParts,
 };
 use tenferro_runtime::{Error, GraphCompiler, GraphExecutor, Result, TracedTensor};
 use tenferro_tensor::TensorBackend;
@@ -385,7 +386,7 @@ impl TracedTensorAdExt for TracedTensor {
             let program = compiler.compile(self)?;
             Arc::new(executor.run(&program)?)
         };
-        checkpoint_traced_tensor(self, data);
+        checkpoint_tensor(self, data);
         Ok(())
     }
 
@@ -434,7 +435,7 @@ fn jvp_optional_result_with_rules(
 ) -> Result<Option<TracedTensor>> {
     let wrt_input_key = leaf_input_key(wrt);
     let output_key = output.graph().values()[output.val].key.clone();
-    let checkpoint_chain = traced_checkpoint_chain(output);
+    let checkpoint_chain = tensor_checkpoint_chain(output);
     let aliases = checkpoint_chain
         .as_ref()
         .map(|chain| chain.collect_aliases())
@@ -443,7 +444,7 @@ fn jvp_optional_result_with_rules(
         .as_ref()
         .map(|chain| chain.collect_graphs())
         .unwrap_or_default();
-    let mut roots = traced_resolve_roots(output);
+    let mut roots = tensor_resolve_roots(output);
     roots.extend(checkpoint_graphs.iter().cloned());
     let view = resolve(roots);
     let mut ad_ctx = shape_guard_context(extension_rules);
@@ -473,7 +474,7 @@ fn jvp_optional_result_with_rules(
         )],
     );
 
-    let mut inputs_map = (*traced_inputs_map(output)).clone();
+    let mut inputs_map = (*tensor_inputs_map(output)).clone();
     if let Some(chain) = &checkpoint_chain {
         inputs_map.extend(chain.collect_inputs());
     }
@@ -487,24 +488,24 @@ fn jvp_optional_result_with_rules(
 
     let mut extra_roots = vec![Arc::clone(output.graph())];
     extra_roots.extend(checkpoint_graphs);
-    extra_roots.extend(traced_extra_roots(output));
+    extra_roots.extend(tensor_extra_roots(output));
 
-    Ok(Some(traced_tensor_from_parts(TracedTensorParts {
+    Ok(Some(tensor_from_parts(TracedTensorParts {
         rank: output.rank,
         dtype: output.dtype,
         graph: Arc::new(linear.into_graph()),
         val: tangent_output,
         data: None,
-        shape_hint: traced_shape_hint(output),
+        shape_hint: tensor_shape_hint(output),
         inputs_map: Arc::new(inputs_map),
         extra_roots,
         checkpoint_chain,
         metadata_scopes: metadata_scopes_with_new(
             metadata_scope,
             [
-                traced_metadata_scopes(output),
-                traced_metadata_scopes(wrt),
-                traced_metadata_scopes(tangent),
+                tensor_metadata_scopes(output),
+                tensor_metadata_scopes(wrt),
+                tensor_metadata_scopes(tangent),
             ],
         ),
     })))
@@ -518,7 +519,7 @@ fn vjp_optional_result_with_rules(
 ) -> Result<Option<TracedTensor>> {
     let wrt_input_key = leaf_input_key(wrt);
     let output_key = output.graph().values()[output.val].key.clone();
-    let checkpoint_chain = traced_checkpoint_chain(output);
+    let checkpoint_chain = tensor_checkpoint_chain(output);
     let aliases = checkpoint_chain
         .as_ref()
         .map(|chain| chain.collect_aliases())
@@ -527,7 +528,7 @@ fn vjp_optional_result_with_rules(
         .as_ref()
         .map(|chain| chain.collect_graphs())
         .unwrap_or_default();
-    let mut roots = traced_resolve_roots(output);
+    let mut roots = tensor_resolve_roots(output);
     roots.extend(checkpoint_graphs.iter().cloned());
     let view = resolve(roots);
     let mut ad_ctx = shape_guard_context(extension_rules);
@@ -573,7 +574,7 @@ fn vjp_optional_result_with_rules(
         return Ok(None);
     };
 
-    let mut inputs_map = (*traced_inputs_map(output)).clone();
+    let mut inputs_map = (*tensor_inputs_map(output)).clone();
     if let Some(chain) = &checkpoint_chain {
         inputs_map.extend(chain.collect_inputs());
     }
@@ -587,15 +588,15 @@ fn vjp_optional_result_with_rules(
 
     let mut extra_roots = vec![Arc::clone(output.graph()), linear_graph];
     extra_roots.extend(checkpoint_graphs);
-    extra_roots.extend(traced_extra_roots(output));
+    extra_roots.extend(tensor_extra_roots(output));
 
-    Ok(Some(traced_tensor_from_parts(TracedTensorParts {
+    Ok(Some(tensor_from_parts(TracedTensorParts {
         rank: wrt.rank,
         dtype: wrt.dtype,
         graph: Arc::new(transposed.into_graph()),
         val: cotangent_output,
         data: None,
-        shape_hint: traced_shape_hint(wrt),
+        shape_hint: tensor_shape_hint(wrt),
         inputs_map: Arc::new(inputs_map),
         extra_roots,
         checkpoint_chain,
@@ -603,9 +604,9 @@ fn vjp_optional_result_with_rules(
             let mut scopes = metadata_scopes_with_new(
                 linear_metadata_scope,
                 [
-                    traced_metadata_scopes(output),
-                    traced_metadata_scopes(wrt),
-                    traced_metadata_scopes(cotangent),
+                    tensor_metadata_scopes(output),
+                    tensor_metadata_scopes(wrt),
+                    tensor_metadata_scopes(cotangent),
                 ],
             );
             push_metadata_scope(&mut scopes, Arc::new(transposed_metadata_scope));

--- a/crates/tenferro-ad/tests/compiler_wiring.rs
+++ b/crates/tenferro-ad/tests/compiler_wiring.rs
@@ -247,8 +247,8 @@ fn compile_std_to_exec_wires_constant_and_convert_ops() {
 
     let program = CompiledProgram {
         instructions: vec![
-            make_instr(StdTensorOp::constant_f64(2.5), vec![], vec![1]),
-            make_instr(StdTensorOp::constant_c64(complex), vec![], vec![2]),
+            make_instr(StdTensorOp::constant(2.5), vec![], vec![1]),
+            make_instr(StdTensorOp::constant(complex), vec![], vec![2]),
             make_instr(
                 StdTensorOp::Convert {
                     from: DType::F64,

--- a/crates/tenferro-internal-ops/src/lib.rs
+++ b/crates/tenferro-internal-ops/src/lib.rs
@@ -11,7 +11,7 @@
 //! use tenferro_ops::{ShapeExtent, SymDim};
 //! use tenferro_ops::std_tensor_op::StdTensorOp;
 //!
-//! let op = StdTensorOp::constant_f64(2.0);
+//! let op = StdTensorOp::constant(2.0_f64);
 //! let extent = ShapeExtent::exact(SymDim::from(3usize));
 //! assert!(matches!(op, StdTensorOp::Constant { .. }));
 //! assert!(extent.is_exact());

--- a/crates/tenferro-internal-ops/src/std_tensor_op.rs
+++ b/crates/tenferro-internal-ops/src/std_tensor_op.rs
@@ -13,128 +13,113 @@ use crate::ext_op::{ext_op_eq, hash_extension, ExtensionOp};
 use crate::input_key::TensorInputKey;
 use tenferro_tensor::{
     CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
+    TensorScalar,
 };
+
+/// Scalar values that can be encoded as tensor constant operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_ops::std_tensor_op::ConstantScalar;
+///
+/// assert_eq!(1.0_f64.constant_bytes(), 1.0_f64.to_le_bytes().to_vec());
+/// ```
+pub trait ConstantScalar: TensorScalar + private::Sealed {
+    /// Encode the scalar value as little-endian constant bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ops::std_tensor_op::ConstantScalar;
+    ///
+    /// assert_eq!(true.constant_bytes(), vec![1]);
+    /// ```
+    fn constant_bytes(self) -> Vec<u8>;
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for f64 {}
+    impl Sealed for f32 {}
+    impl Sealed for i64 {}
+    impl Sealed for i32 {}
+    impl Sealed for bool {}
+    impl Sealed for num_complex::Complex64 {}
+    impl Sealed for num_complex::Complex32 {}
+}
+
+impl ConstantScalar for f64 {
+    fn constant_bytes(self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+}
+
+impl ConstantScalar for f32 {
+    fn constant_bytes(self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+}
+
+impl ConstantScalar for i64 {
+    fn constant_bytes(self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+}
+
+impl ConstantScalar for i32 {
+    fn constant_bytes(self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+}
+
+impl ConstantScalar for bool {
+    fn constant_bytes(self) -> Vec<u8> {
+        vec![u8::from(self)]
+    }
+}
+
+impl ConstantScalar for Complex64 {
+    fn constant_bytes(self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(16);
+        bytes.extend_from_slice(&self.re.to_le_bytes());
+        bytes.extend_from_slice(&self.im.to_le_bytes());
+        bytes
+    }
+}
+
+impl ConstantScalar for Complex32 {
+    fn constant_bytes(self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(8);
+        bytes.extend_from_slice(&self.re.to_le_bytes());
+        bytes.extend_from_slice(&self.im.to_le_bytes());
+        bytes
+    }
+}
 
 tenferro_core_ops::define_std_tensor_op!();
 
 impl StdTensorOp {
-    /// Create an `f64` scalar constant op.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_ops::std_tensor_op::StdTensorOp;
-    ///
-    /// let op = StdTensorOp::constant_f64(1.5);
-    /// ```
-    pub fn constant_f64(value: f64) -> Self {
-        Self::Constant {
-            dtype: DType::F64,
-            bytes: value.to_le_bytes().to_vec(),
-        }
-    }
-
-    /// Create an `f32` scalar constant op.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_ops::std_tensor_op::StdTensorOp;
-    ///
-    /// let op = StdTensorOp::constant_f32(1.5_f32);
-    /// ```
-    pub fn constant_f32(value: f32) -> Self {
-        Self::Constant {
-            dtype: DType::F32,
-            bytes: value.to_le_bytes().to_vec(),
-        }
-    }
-
-    /// Create an `i64` scalar constant op.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_ops::std_tensor_op::StdTensorOp;
-    ///
-    /// let op = StdTensorOp::constant_i64(7);
-    /// ```
-    pub fn constant_i64(value: i64) -> Self {
-        Self::Constant {
-            dtype: DType::I64,
-            bytes: value.to_le_bytes().to_vec(),
-        }
-    }
-
-    /// Create an `i32` scalar constant op.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_ops::std_tensor_op::StdTensorOp;
-    ///
-    /// let op = StdTensorOp::constant_i32(7);
-    /// ```
-    pub fn constant_i32(value: i32) -> Self {
-        Self::Constant {
-            dtype: DType::I32,
-            bytes: value.to_le_bytes().to_vec(),
-        }
-    }
-
-    /// Create a `bool` scalar constant op.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_ops::std_tensor_op::StdTensorOp;
-    ///
-    /// let op = StdTensorOp::constant_bool(true);
-    /// ```
-    pub fn constant_bool(value: bool) -> Self {
-        Self::Constant {
-            dtype: DType::Bool,
-            bytes: vec![u8::from(value)],
-        }
-    }
-
-    /// Create a `Complex64` scalar constant op.
+    /// Create a scalar constant op from any supported tensor scalar.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use num_complex::Complex64;
     /// use tenferro_ops::std_tensor_op::StdTensorOp;
+    /// use tenferro_tensor::DType;
     ///
-    /// let op = StdTensorOp::constant_c64(Complex64::new(1.0, -2.0));
+    /// let real = StdTensorOp::constant(1.5_f64);
+    /// let complex = StdTensorOp::constant(Complex64::new(1.0, -2.0));
+    ///
+    /// assert!(matches!(real, StdTensorOp::Constant { dtype: DType::F64, .. }));
+    /// assert!(matches!(complex, StdTensorOp::Constant { dtype: DType::C64, .. }));
     /// ```
-    pub fn constant_c64(value: Complex64) -> Self {
-        let mut bytes = Vec::with_capacity(16);
-        bytes.extend_from_slice(&value.re.to_le_bytes());
-        bytes.extend_from_slice(&value.im.to_le_bytes());
+    pub fn constant<T: ConstantScalar>(value: T) -> Self {
         Self::Constant {
-            dtype: DType::C64,
-            bytes,
-        }
-    }
-
-    /// Create a `Complex32` scalar constant op.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use num_complex::Complex32;
-    /// use tenferro_ops::std_tensor_op::StdTensorOp;
-    ///
-    /// let op = StdTensorOp::constant_c32(Complex32::new(1.0, -2.0));
-    /// ```
-    pub fn constant_c32(value: Complex32) -> Self {
-        let mut bytes = Vec::with_capacity(8);
-        bytes.extend_from_slice(&value.re.to_le_bytes());
-        bytes.extend_from_slice(&value.im.to_le_bytes());
-        Self::Constant {
-            dtype: DType::C32,
-            bytes,
+            dtype: T::dtype(),
+            bytes: value.constant_bytes(),
         }
     }
 }

--- a/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
@@ -244,7 +244,7 @@ fn test_std_tensor_op_input_output_counts() {
         2
     );
     assert_eq!(StdTensorOp::ReduceSum { axes: vec![0] }.input_count(), 1);
-    assert_eq!(StdTensorOp::constant_f64(1.0).input_count(), 0);
+    assert_eq!(StdTensorOp::constant(1.0).input_count(), 0);
     assert_eq!(
         StdTensorOp::ExtractDiag {
             axis_a: 0,
@@ -310,7 +310,7 @@ fn test_std_tensor_op_input_output_counts() {
     assert_eq!(StdTensorOp::Abs.input_count(), 1);
     assert_eq!(StdTensorOp::Exp.input_count(), 1);
     assert_eq!(StdTensorOp::Log1p.input_count(), 1);
-    assert_eq!(StdTensorOp::constant_f64(1.0).output_count(), 1);
+    assert_eq!(StdTensorOp::constant(1.0).output_count(), 1);
     assert_eq!(
         StdTensorOp::EmbedDiag {
             axis_a: 0,
@@ -666,9 +666,9 @@ fn test_std_tensor_op_hash_covers_remaining_variants() {
     }
 
     let mut lhs = DefaultHasher::new();
-    StdTensorOp::constant_f64(1.25).hash(&mut lhs);
+    StdTensorOp::constant(1.25).hash(&mut lhs);
     let mut rhs = DefaultHasher::new();
-    StdTensorOp::constant_f64(1.25).hash(&mut rhs);
+    StdTensorOp::constant(1.25).hash(&mut rhs);
     assert_eq!(lhs.finish(), rhs.finish());
 }
 
@@ -799,19 +799,40 @@ fn test_std_tensor_op_dynamic_truncate_linearize_uses_static_slice_for_narrowed_
 }
 
 #[test]
-fn test_std_tensor_op_constant_constructors_encode_expected_bytes() {
+fn test_std_tensor_op_generic_constant_constructor_encodes_expected_bytes() {
     assert_eq!(
-        StdTensorOp::constant_f64(1.25),
+        StdTensorOp::constant(1.25_f64),
         StdTensorOp::Constant {
             dtype: DType::F64,
             bytes: 1.25_f64.to_le_bytes().to_vec(),
         }
     );
     assert_eq!(
-        StdTensorOp::constant_f32(1.25),
+        StdTensorOp::constant(1.25_f32),
         StdTensorOp::Constant {
             dtype: DType::F32,
             bytes: 1.25_f32.to_le_bytes().to_vec(),
+        }
+    );
+    assert_eq!(
+        StdTensorOp::constant(7_i64),
+        StdTensorOp::Constant {
+            dtype: DType::I64,
+            bytes: 7_i64.to_le_bytes().to_vec(),
+        }
+    );
+    assert_eq!(
+        StdTensorOp::constant(7_i32),
+        StdTensorOp::Constant {
+            dtype: DType::I32,
+            bytes: 7_i32.to_le_bytes().to_vec(),
+        }
+    );
+    assert_eq!(
+        StdTensorOp::constant(true),
+        StdTensorOp::Constant {
+            dtype: DType::Bool,
+            bytes: vec![1],
         }
     );
 
@@ -820,7 +841,7 @@ fn test_std_tensor_op_constant_constructors_encode_expected_bytes() {
     c64_bytes.extend_from_slice(&c64.re.to_le_bytes());
     c64_bytes.extend_from_slice(&c64.im.to_le_bytes());
     assert_eq!(
-        StdTensorOp::constant_c64(c64),
+        StdTensorOp::constant(c64),
         StdTensorOp::Constant {
             dtype: DType::C64,
             bytes: c64_bytes,
@@ -832,11 +853,35 @@ fn test_std_tensor_op_constant_constructors_encode_expected_bytes() {
     c32_bytes.extend_from_slice(&c32.re.to_le_bytes());
     c32_bytes.extend_from_slice(&c32.im.to_le_bytes());
     assert_eq!(
-        StdTensorOp::constant_c32(c32),
+        StdTensorOp::constant(c32),
         StdTensorOp::Constant {
             dtype: DType::C32,
             bytes: c32_bytes,
         }
+    );
+}
+
+#[test]
+fn generic_constant_constructor_sets_dtype_for_each_scalar() {
+    fn dtype_of(op: StdTensorOp) -> DType {
+        match op {
+            StdTensorOp::Constant { dtype, .. } => dtype,
+            other => panic!("expected constant op, got {other:?}"),
+        }
+    }
+
+    assert_eq!(dtype_of(StdTensorOp::constant(1.0_f64)), DType::F64);
+    assert_eq!(dtype_of(StdTensorOp::constant(1.0_f32)), DType::F32);
+    assert_eq!(dtype_of(StdTensorOp::constant(1_i64)), DType::I64);
+    assert_eq!(dtype_of(StdTensorOp::constant(1_i32)), DType::I32);
+    assert_eq!(dtype_of(StdTensorOp::constant(true)), DType::Bool);
+    assert_eq!(
+        dtype_of(StdTensorOp::constant(Complex64::new(1.0, -2.0))),
+        DType::C64
+    );
+    assert_eq!(
+        dtype_of(StdTensorOp::constant(Complex32::new(1.0, -2.0))),
+        DType::C32
     );
 }
 
@@ -870,7 +915,7 @@ fn test_std_tensor_op_linearize_none_tangent_paths_return_none() {
     assert!(graph.operations().is_empty());
 
     let (constant_result, constant_graph) =
-        run_linearize_case(StdTensorOp::constant_f64(1.0), 0, 0, &[]);
+        run_linearize_case(StdTensorOp::constant(1.0), 0, 0, &[]);
     assert_eq!(constant_result, vec![None]);
     assert!(constant_graph.operations().is_empty());
 }
@@ -1015,7 +1060,7 @@ fn test_std_tensor_op_elementwise_special_cases_are_covered() {
 
 #[test]
 fn test_std_tensor_op_constant_transpose_rule_has_no_inputs_or_ops() {
-    let (result, _, graph) = run_transpose_case(StdTensorOp::constant_f64(1.0), 0, &[], true);
+    let (result, _, graph) = run_transpose_case(StdTensorOp::constant(1.0), 0, &[], true);
     assert!(result.is_empty());
     assert!(graph.operations().is_empty());
 }

--- a/crates/tenferro-linalg/src/ad/rules/support.rs
+++ b/crates/tenferro-linalg/src/ad/rules/support.rs
@@ -147,7 +147,7 @@ pub(super) fn fixed_scale(
     factor: f64,
 ) -> LocalValueId {
     let constant = builder.add_operation(
-        StdTensorOp::constant_f64(factor),
+        StdTensorOp::constant(factor),
         vec![],
         OperationRole::Primary,
     );
@@ -223,7 +223,7 @@ pub(super) fn linear_scale(
     factor: f64,
 ) -> LocalValueId {
     let constant = builder.add_operation(
-        StdTensorOp::constant_f64(factor),
+        StdTensorOp::constant(factor),
         vec![],
         OperationRole::Primary,
     );

--- a/crates/tenferro-runtime/src/ad_support.rs
+++ b/crates/tenferro-runtime/src/ad_support.rs
@@ -35,7 +35,7 @@ pub struct TracedTensorParts {
 }
 
 /// Builds a traced tensor from validated AD transform output.
-pub fn traced_tensor_from_parts(parts: TracedTensorParts) -> TracedTensor {
+pub fn tensor_from_parts(parts: TracedTensorParts) -> TracedTensor {
     TracedTensor {
         id: next_traced_id(),
         rank: parts.rank,
@@ -51,31 +51,31 @@ pub fn traced_tensor_from_parts(parts: TracedTensorParts) -> TracedTensor {
     }
 }
 
-pub fn traced_shape_hint(tensor: &TracedTensor) -> Option<Vec<SymDim>> {
+pub fn shape_hint(tensor: &TracedTensor) -> Option<Vec<SymDim>> {
     tensor.shape_hint.clone()
 }
 
-pub fn traced_inputs_map(tensor: &TracedTensor) -> Arc<HashMap<TensorInputKey, Arc<Tensor>>> {
+pub fn inputs_map(tensor: &TracedTensor) -> Arc<HashMap<TensorInputKey, Arc<Tensor>>> {
     Arc::clone(&tensor.inputs_map)
 }
 
-pub fn traced_extra_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>> {
+pub fn extra_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>> {
     tensor.extra_roots.clone()
 }
 
-pub fn traced_checkpoint_chain(tensor: &TracedTensor) -> Option<Arc<CheckpointNode>> {
+pub fn checkpoint_chain(tensor: &TracedTensor) -> Option<Arc<CheckpointNode>> {
     tensor.checkpoint_chain.clone()
 }
 
-pub fn traced_metadata_scopes(tensor: &TracedTensor) -> &[Arc<RuntimeMetadataScope>] {
+pub fn metadata_scopes(tensor: &TracedTensor) -> &[Arc<RuntimeMetadataScope>] {
     &tensor.metadata_scopes
 }
 
-pub fn traced_resolve_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>> {
+pub fn resolve_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>> {
     tensor.resolve_roots()
 }
 
-pub fn checkpoint_traced_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>) {
+pub fn checkpoint_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>) {
     let old_graph = tensor.graph.clone();
     let old_output_key = old_graph.values()[tensor.val].key.clone();
     let old_inputs = (*tensor.inputs_map).clone();

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -686,13 +686,13 @@ impl TracedTensor {
     /// ```
     pub fn scale_real(&self, factor: f64) -> TracedTensor {
         let op = match self.dtype {
-            DType::F64 => StdTensorOp::constant_f64(factor),
-            DType::F32 => StdTensorOp::constant_f32(factor as f32),
-            DType::I32 => StdTensorOp::constant_i32(round_real_to_i64(factor) as i32),
-            DType::I64 => StdTensorOp::constant_i64(round_real_to_i64(factor)),
-            DType::Bool => StdTensorOp::constant_bool(factor != 0.0),
-            DType::C64 => StdTensorOp::constant_c64(Complex64::new(factor, 0.0)),
-            DType::C32 => StdTensorOp::constant_c32(Complex32::new(factor as f32, 0.0)),
+            DType::F64 => StdTensorOp::constant(factor),
+            DType::F32 => StdTensorOp::constant(factor as f32),
+            DType::I32 => StdTensorOp::constant(round_real_to_i64(factor) as i32),
+            DType::I64 => StdTensorOp::constant(round_real_to_i64(factor)),
+            DType::Bool => StdTensorOp::constant(factor != 0.0),
+            DType::C64 => StdTensorOp::constant(Complex64::new(factor, 0.0)),
+            DType::C32 => StdTensorOp::constant(Complex32::new(factor as f32, 0.0)),
         };
         scale_with_constant(self, op)
     }
@@ -715,10 +715,10 @@ impl TracedTensor {
     /// ```
     pub fn scale_complex(&self, factor: Complex64) -> TracedTensor {
         match self.dtype {
-            DType::C64 => scale_with_constant(self, StdTensorOp::constant_c64(factor)),
+            DType::C64 => scale_with_constant(self, StdTensorOp::constant(factor)),
             DType::C32 => scale_with_constant(
                 self,
-                StdTensorOp::constant_c32(Complex32::new(factor.re as f32, factor.im as f32)),
+                StdTensorOp::constant(Complex32::new(factor.re as f32, factor.im as f32)),
             ),
             DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => {
                 panic!(

--- a/docs/design/api-and-convention-freeze.md
+++ b/docs/design/api-and-convention-freeze.md
@@ -61,6 +61,10 @@ behavior it owns. If the conflict is between current design documents, the
 release cleanup must either resolve the conflict or mark one document as
 historical before relying on it.
 
+API convention rules that should remain stable after the release cleanup live
+in `docs/spec/api-conventions.md`. This design document records the cleanup
+posture, triage workflow, and migration rationale.
+
 ## Crate Ownership
 
 The release API should make crate ownership obvious.

--- a/docs/design/api-and-convention-freeze.md
+++ b/docs/design/api-and-convention-freeze.md
@@ -1,0 +1,269 @@
+# API and Convention Freeze
+
+## Purpose
+
+This document records the clean-break release posture for tenferro-rs API and
+internal-structure cleanup before the first release that treats public APIs as
+durable contracts.
+
+The goal is not to preserve compatibility with pre-release callers. The goal is
+to make the release surface coherent, small, documented, and aligned with crate
+ownership. Compatibility aliases, old names, and public implementation details
+should be removed instead of carried forward when they make the release API less
+clear.
+
+This document is implementation-facing design intent. Normative operation
+semantics, trait signatures, tensor layout rules, backend behavior, AD
+contracts, and extension contracts belong in `docs/spec/`. User workflows and
+examples belong in `docs/guides/` and rustdoc.
+
+## Release Stance
+
+Before the release freeze closes, breaking changes are allowed when they make
+the API or internal structure cleaner. A change is clean when it reduces the
+public surface, moves behavior to the owning crate, removes duplicated
+semantics, or makes device, layout, dtype, backend, AD, cache, or extension
+boundaries explicit.
+
+The release branch should avoid:
+
+- compatibility shims and old-name aliases;
+- public helper APIs that exist only for tests, benchmarks, internal planning,
+  lowering, cache plumbing, backend glue, or sibling-crate reach-through;
+- broad facade paths that hide direct crate ownership;
+- user-facing docs that restate internal implementation details instead of
+  linking to the owning spec or design document;
+- examples that compile but do not verify meaningful behavior.
+
+The release branch should prefer:
+
+- fewer public items with stronger documentation and examples;
+- direct crate imports and explicit feature flags;
+- explicit CPU/GPU transfer, layout, dtype, and materialization boundaries;
+- spec-backed behavior and design-backed ownership decisions;
+- automated checks that make drift visible before merge.
+
+## Source Of Truth
+
+Each durable fact should have one owner.
+
+| Location | Owns |
+| --- | --- |
+| `docs/spec/` | Normative contracts: op semantics, trait signatures, backend behavior, AD contracts, tensor layout rules, extension identity and dispatch. |
+| `docs/design/` | Current implementation design: ownership boundaries, architecture choices, migration rationale, performance design, and review intent. |
+| `docs/worklogs/` | Session-level rationale for completed nontrivial work. These explain why a change was made in one PR, not the long-term rule by themselves. |
+| `docs/plans/` | Historical planning records. They are not updated to match the current release design. |
+| `docs/guides/` and `README.md` | User workflows and public capability summaries. They should not expose internal graph, IR, cache, or backend plumbing details. |
+| rustdoc | Exact public item contracts and minimal examples that compile and run as doctests. |
+
+When two documents conflict, the more specific normative document wins for the
+behavior it owns. If the conflict is between current design documents, the
+release cleanup must either resolve the conflict or mark one document as
+historical before relying on it.
+
+## Crate Ownership
+
+The release API should make crate ownership obvious.
+
+| Crate | Release ownership target |
+| --- | --- |
+| `tenferro-tensor-core` | Host-only dtype tags, scalar traits, rank/layout metadata, compact host tensors, and metadata-only host views. It must not depend on execution backends, graph execution, AD, or GPU runtimes. |
+| `tenferro-tensor` | Runtime dense tensor values, runtime views, placement metadata, backend traits, and backend-parametric tensor contracts. It does not own CPU or GPU kernel implementations. |
+| `tenferro-cpu` | CPU backend implementations, CPU kernels, CPU execution context, provider selection, thread policy, and CPU resource pools. |
+| `tenferro-gpu` | GPU backend implementations, device buffers, explicit upload/download helpers, CubeCL/CUDA integration, GPU launch metadata, and GPU resource ownership. |
+| `tenferro-core-ops` | Internal primitive operation catalog metadata shared by lower layers. |
+| `tenferro-internal-ops` | Internal graph operation vocabulary and graph-level AD rule implementations. |
+| `tenferro-runtime` | Backend-agnostic runtime helpers, traced tensor construction, graph compilation and execution, extension registration, and extension cache storage. |
+| `tenferro-ad` | Eager AD surfaces, eager tensors, AD contexts, traced AD helper traits, and user-facing differentiation APIs. |
+| `tenferro-einsum` | Einsum public API, subscript parsing, contraction planning, extension runtime, extension-owned caches, eager/traced wrappers, and optional AD rule ownership. |
+| `tenferro-linalg` | Linalg public API, extension payloads, linalg backend hooks, CPU linalg kernels, optional CUDA linalg bridge code, eager/traced wrappers, and optional AD rule ownership. |
+| `tenferro-fft` | FFT public API, extension runtime registration, eager/traced wrappers, and FFT-specific execution behavior. |
+
+If an implementation needs a cross-crate bridge, the bridge must be narrower
+than the internal subsystem it exposes. `#[doc(hidden)] pub` is not a substitute
+for an ownership contract; it is still public and should be treated as release
+surface unless a design document names the bridge and explains why it exists.
+
+## Public API Strata
+
+Every exported item should fall into one release stratum.
+
+| Stratum | Meaning | Release requirement |
+| --- | --- | --- |
+| Release API | Intended for downstream users. | Public rustdoc contract, runnable example, accepted owning crate, and guide coverage when it teaches a workflow. |
+| Owner-scoped bridge | Required only because Rust crate boundaries separate owning implementation units. | Narrow API, explicit design rationale, no user-facing guide promotion, and tests at the owning boundary. |
+| Experimental or unsupported | Visible only because a feature is intentionally incomplete or stubbed. | Explicit docs that say what is unsupported and what error is returned. Avoid exporting if a private item is sufficient. |
+| Internal | Used for tests, planning, lowering, dispatch, cache plumbing, provider selection, or backend glue. | `pub(crate)` or private. Move tests or helpers to the owning crate instead of widening visibility. |
+
+The default classification is internal. An item becomes release API only when
+there is a clear downstream use case, the owning crate is correct, the name
+matches release conventions, and the behavior can be documented without
+describing private implementation machinery.
+
+## API Convention Doctrine
+
+Release APIs should follow these naming and shape rules.
+
+- There is no root `tenferro` facade crate. Users import direct crates such as
+  `tenferro_tensor`, `tenferro_cpu`, `tenferro_runtime`, `tenferro_ad`,
+  `tenferro_einsum`, `tenferro_linalg`, and `tenferro_fft`.
+- Standard operation families remain first-class crates, not modules under a
+  broad facade.
+- Tensor operation names are public vocabulary. Owned compact tensor inputs use
+  unsuffixed operation names.
+- `_read` is reserved for APIs that explicitly accept borrowed read-oriented
+  inputs.
+- `_view` is reserved for metadata-only layout operations. Any operation that
+  allocates, canonicalizes, executes kernels, transfers data, or otherwise
+  materializes data must not use `_view`.
+- Flat-buffer constructors, exports, examples, and FFI contracts must say
+  whether data is column-major. Constructor names should encode non-obvious
+  layout expectations.
+- Scalar constructors should prefer generic `TensorScalar`-bounded entry points
+  over per-dtype constructors.
+- Unary single-output traced ops are methods on `TracedTensor`.
+- Binary single-output ops use operator overloads when the operator is natural;
+  otherwise they use methods.
+- Multi-output linalg and decomposition ops are free functions.
+- Einsum is a free function owned by `tenferro-einsum`.
+- Traced tensor methods do not use a `traced_` prefix.
+- User-facing backend features are named for concrete backend families, such as
+  `cuda` and `rocm`. Public extension crates should not expose a vague `gpu`
+  feature.
+- Optional operation-specific AD support belongs behind `autodiff` in the
+  owning operation crate.
+- Result-returning public backend boundaries must return explicit errors for
+  unsupported operation, dtype, or placement combinations. They must not fall
+  back to CPU or transfer tensor payloads implicitly.
+
+## API Inconsistency Detection
+
+The freeze audit must detect API inconsistencies as first-class findings, not
+only missing docs or overly broad visibility.
+
+An API inconsistency exists when two public surfaces expose the same concept but
+diverge without a documented reason in one or more of these dimensions:
+
+- name, suffix, module path, or crate path;
+- method vs free-function shape;
+- owned input vs borrowed/read input shape;
+- typed vs dynamic dtype behavior;
+- eager vs traced behavior;
+- CPU vs GPU placement behavior;
+- error type, error variant, or panic/`Result` boundary;
+- feature flag, optional dependency, or backend availability;
+- layout convention for flat buffers;
+- AD support, unsupported behavior, or fallback behavior;
+- rustdoc examples and guide snippets.
+
+The audit should compare APIs by concept, not by exact spelling. For example,
+`reshape`, `reshape_view`, traced reshape, eager reshape, dynamic tensor
+reshape, backend reshape, and guide examples belong to one concept family even
+when they live in different crates. A difference is acceptable only when the
+owning spec, design doc, or rustdoc contract explains the reason.
+
+A missing counterpart can also be an inconsistency. If a guide, rustdoc page,
+feature flag, trait, or operation matrix implies that a concept is available on
+typed, dynamic, eager, traced, CPU, GPU, or extension surfaces, the audit must
+either find the corresponding API or record the absence as unsupported with an
+explicit owner and error contract.
+
+The first API consistency matrix should cover these surface pairs:
+
+| Surface pair | Detection question |
+| --- | --- |
+| typed tensor vs dynamic tensor | Do constructors, layout assumptions, accessors, and error behavior expose the same concept with compatible names and contracts? |
+| owned tensor ops vs borrowed/read ops | Are `_read` and unsuffixed names used only for their documented input ownership model? |
+| metadata views vs materializing ops | Are `_view` names limited to metadata-only behavior across core, runtime, docs, and examples? |
+| eager vs traced APIs | Do same-concept operations have intentional naming, dtype, shape, AD, and error differences? |
+| runtime extension APIs vs operation crates | Does each extension operation use the owning operation crate as the public import path and register runtime behavior explicitly? |
+| CPU backend vs GPU backend | Do unsupported dtype/op/placement combinations return explicit errors with consistent user guidance? |
+| rustdoc vs guides vs README | Do examples use the same public crate paths, names, layout conventions, and supported capability claims? |
+
+The output of inconsistency detection should be a ledger entry for each root
+cause, not one issue per spelling mismatch. Each entry should record the
+concept family, affected APIs, owner crate, expected convention, current
+divergence, and whether the fix is a rename, hide/remove, docs clarification,
+or design decision.
+
+## Internal Structure Doctrine
+
+Internal cleanup should follow the same ownership rules as the public API.
+
+- Fix behavior at the owning abstraction. Avoid downstream patches around a
+  lower-layer gap.
+- Remove duplicate compatibility paths after the release replacement is in
+  place.
+- Prefer one typed generic implementation with outer dtype dispatch over
+  hand-copied per-dtype bodies.
+- Use macros or small descriptors for wrapper families only when the generated
+  wrappers are genuinely same-shaped and docs, feature gates, and error
+  behavior remain obvious at the call site.
+- Split files by behavior, abstraction, feature, ownership, or public/private
+  API boundary. Do not split solely to lower line count.
+- Keep cache ownership explicit and top-level. Caches need bounds, clear paths,
+  stats, and documented ownership.
+- Keep CPU provider selection inside `tenferro-cpu` and GPU transfer/device
+  behavior inside `tenferro-gpu`.
+- Keep AD rule semantics in graph-level `linearize` and `transpose_rule`
+  surfaces unless a separate accepted design changes that model.
+- Keep tests with the crate that owns the behavior. Do not widen public API
+  only so another crate can test a private helper.
+
+## Documentation Normalization
+
+The release cleanup should normalize documentation before declaring the API
+frozen.
+
+1. Classify active `docs/design/` files as current design, current migration
+   note, or historical context. Historical material should move out of the
+   active design path or clearly say that it is historical.
+2. Ensure each `docs/spec/` page owns a distinct normative area and that other
+   docs link to it instead of restating the same contract.
+3. Ensure `README.md` and `docs/guides/` describe only supported public
+   workflows through direct public crates.
+4. Ensure rustdoc examples compile, run, and assert meaningful behavior.
+5. Ensure GPU, AD, linalg, einsum, and FFT docs distinguish supported,
+   unsupported, and feature-gated behavior with explicit error expectations.
+
+## Audit And Remediation Workflow
+
+The clean-break freeze should proceed in this order:
+
+1. Accept this doctrine as the release cleanup baseline.
+2. Generate or otherwise derive a public API inventory for every workspace
+   crate that exports user-facing or bridge APIs.
+3. Build concept-family consistency matrices for typed, dynamic, eager,
+   traced, backend, extension, rustdoc, guide, and README surfaces.
+4. Classify each public item as release API, owner-scoped bridge,
+   experimental/unsupported, or internal.
+5. Classify each inconsistency or visibility finding as `Auto Fix`,
+   `Verify First`, `Design Gate`, or
+   `Out Of Scope`.
+6. Resolve design-gated decisions before editing code that depends on them.
+7. Apply remediation in coherent batches grouped by ownership and verification
+   path.
+8. Update the owning `docs/spec/`, `docs/design/`, guides, rustdoc, and tests
+   in the same batch as the code change.
+9. Run release gates before declaring the batch complete.
+
+Public API removal, crate-boundary changes, feature flag changes, AD semantics
+changes, and backend support-surface changes are allowed during this freeze,
+but each one needs an explicit owner and verification path.
+
+## Enforcement Targets
+
+The release branch should converge on automated checks for:
+
+- public API inventory diffs;
+- API concept-family consistency matrices;
+- forbidden facade paths and internal crate names in user guides;
+- `_view`, `_read`, feature flag, and traced method naming conventions;
+- missing rustdoc examples on release APIs;
+- doctests and guide snippets that compile and run where hardware allows;
+- docs/spec/design link integrity and source-of-truth ownership;
+- unsupported GPU, AD, linalg, einsum, and FFT behavior returning explicit
+  errors rather than silent fallbacks.
+
+These checks do not replace maintainer review. They make the release doctrine
+cheap to enforce after the cleanup is complete.

--- a/docs/design/api-and-convention-freeze.md
+++ b/docs/design/api-and-convention-freeze.md
@@ -261,6 +261,8 @@ The release branch should converge on automated checks for:
 
 - public API inventory diffs;
 - API concept-family consistency matrices;
+- release-freeze API convention findings via
+  `python3 scripts/check-api-consistency.py --fail-on-findings`;
 - forbidden facade paths and internal crate names in user guides;
 - `_view`, `_read`, feature flag, and traced method naming conventions;
 - missing rustdoc examples on release APIs;

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -8,6 +8,7 @@ architecture see [Architecture](../architecture/). For normative specs see
 
 | Document | Description |
 |----------|-------------|
+| [api-and-convention-freeze.md](./api-and-convention-freeze.md) | Clean-break release posture for public API, API consistency detection, crate ownership, naming conventions, docs ownership, and audit/remediation workflow |
 | [supported-ops.md](./supported-ops.md) | Crate-by-crate inventory of supported primal and AD operations |
 | [tensor.md](./tensor.md) | Tensor representation, ownership model |
 | [tensor-prims.md](./tensor-prims.md) | Tensor backend protocol and execution surface |

--- a/docs/spec/api-conventions.md
+++ b/docs/spec/api-conventions.md
@@ -90,3 +90,13 @@ The default stratum is internal.
 The concept-family matrices emitted by the checker are review aids. A matrix
 difference becomes a finding only when the relevant spec, design doc, or
 rustdoc contract does not explain the difference.
+
+The release-freeze convention gate is:
+
+```bash
+python3 scripts/check-api-consistency.py --fail-on-findings
+```
+
+This command must exit `0` before the API convention freeze is considered
+green. Concept-family matrices remain review aids until a specific matrix rule
+is promoted into this spec.

--- a/docs/spec/api-conventions.md
+++ b/docs/spec/api-conventions.md
@@ -1,0 +1,92 @@
+# API Convention Specification
+
+**Date:** 2026-06-10
+**Parent:** [`../index.md`](../index.md)
+**Related:** [`tensor-semantics.md`](tensor-semantics.md), [`backend-contract.md`](backend-contract.md), [`extension-op.md`](extension-op.md), [`../design/api-and-convention-freeze.md`](../design/api-and-convention-freeze.md)
+
+---
+
+## Purpose
+
+This document is the normative specification for public API naming, module
+shape, feature naming, and documentation-surface checks. It owns the fixed
+rules implemented by `scripts/check-api-consistency.py`.
+
+Release cleanup rationale and migration order live in
+[`../design/api-and-convention-freeze.md`](../design/api-and-convention-freeze.md).
+This file owns the rules that remain after the cleanup is complete.
+
+---
+
+## Public API Strata
+
+Every exported item belongs to one stratum:
+
+| Stratum | Meaning | Requirement |
+| --- | --- | --- |
+| Release API | Intended for downstream users. | Public rustdoc contract and runnable example when the item is callable. |
+| Owner-scoped bridge | Required only because Rust crate boundaries separate owning implementation units. | Narrow API, no guide promotion, and documented owner. |
+| Experimental or unsupported | Visible because an incomplete capability is intentionally exposed. | Explicit unsupported behavior and error contract. |
+| Internal | Tests, planning, lowering, dispatch, cache plumbing, provider selection, or backend glue. | Private or `pub(crate)` unless a documented owner-scoped bridge is required. |
+
+The default stratum is internal.
+
+## Naming Rules
+
+1. There is no root `tenferro` facade crate. User-facing docs and examples must
+   import direct crates such as `tenferro_runtime`, `tenferro_ad`,
+   `tenferro_gpu`, `tenferro_einsum`, `tenferro_linalg`, and `tenferro_fft`.
+2. Tensor operation names use unsuffixed names for owned compact tensor inputs.
+3. `_read` is reserved for APIs that explicitly accept borrowed read-oriented
+   inputs such as `TensorRead`.
+4. `_view` is reserved for metadata-only layout operations. Operations that
+   allocate, canonicalize, execute kernels, transfer data, or materialize data
+   must not use `_view`.
+5. Scalar constructors use generic `TensorScalar`-bounded entry points instead
+   of dtype-specific public functions such as `constant_f64`.
+6. Traced tensor method and free-function names do not use a `traced_` prefix.
+7. Public module namespaces may use `traced_tensor` when they identify the
+   traced tensor surface as a peer of `eager_tensor`. The namespace is a
+   surface stratum, not an operation-name prefix.
+8. User-facing backend features use concrete backend family names such as
+   `cuda` and `rocm`. Public crates must not expose a vague `gpu` feature.
+9. Optional operation-specific AD support belongs behind an `autodiff` feature
+   in the owning operation crate.
+
+## API Shape Rules
+
+1. Unary single-output traced ops are methods on `TracedTensor`.
+2. Binary single-output ops use operator overloads when the operator is natural;
+   otherwise they use methods.
+3. Multi-output linalg and decomposition ops are free functions.
+4. Einsum is a free function owned by `tenferro-einsum`.
+5. Standard operation families are first-class crates, not modules under a
+   broad facade.
+
+## Documentation Checks
+
+1. `README.md`, `docs/guides/`, and `docs/getting-started/` must not reference
+   internal crates, internal graph/IR vocabulary, or deleted public paths.
+2. User-facing examples must use direct public crates and must not rely on a
+   root facade path.
+3. Flat-buffer constructors, exports, examples, and FFI contracts must state or
+   encode column-major layout expectations.
+4. Rustdoc examples for release APIs must compile and run as doctests unless
+   they intentionally use `compile_fail`.
+
+## Checker Mapping
+
+`scripts/check-api-consistency.py` implements these automated checks:
+
+| Check category | Spec rule |
+| --- | --- |
+| `traced_prefix` | Naming rule 6, limited to public function and method names. |
+| `read_suffix_without_read_input` | Naming rule 3. |
+| `per_dtype_constructor` | Naming rule 5. |
+| `public_gpu_feature` | Naming rule 8, limited to published crates. |
+| `facade_path_in_user_docs` | Naming rule 1 and documentation check 2. |
+| `internal_jargon_in_user_docs` | Documentation check 1. |
+
+The concept-family matrices emitted by the checker are review aids. A matrix
+difference becomes a finding only when the relevant spec, design doc, or
+rustdoc contract does not explain the difference.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -12,3 +12,4 @@ link here rather than re-stating.
 | [optimizer-passes.md](./optimizer-passes.md) | Optimization pass algorithms and ordering |
 | [tensor-semantics.md](./tensor-semantics.md) | Tensor type semantics, stride model, contiguity rules |
 | [extension-op.md](./extension-op.md) | ExtensionOp trait contract (identity, AD, dispatch, registry) |
+| [api-conventions.md](./api-conventions.md) | Public API naming, module shape, feature naming, documentation-surface checks, and checker mapping |

--- a/docs/superpowers/plans/2026-06-10-api-consistency-audit.md
+++ b/docs/superpowers/plans/2026-06-10-api-consistency-audit.md
@@ -1,0 +1,173 @@
+# API Consistency Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a repeatable first-pass audit tool that inventories lexically public APIs and reports release-freeze API convention inconsistencies as reviewable candidates.
+
+**Architecture:** Keep the first slice as a repository-local Python script under `scripts/` so it matches existing boundary checks and avoids adding a workspace crate. The script derives lexically public items from `crates/*/src/**/*.rs`, scans user-facing docs and published-crate features, groups same-concept API surfaces, and prints a markdown audit report without modifying source files.
+
+**Tech Stack:** Python 3.11+ standard library (`argparse`, `dataclasses`, `pathlib`, `re`, `tomllib`), existing Cargo workspace layout, existing docs convention from `docs/design/api-and-convention-freeze.md`.
+
+---
+
+### Task 1: Add Public API Consistency Script
+
+**Files:**
+- Create: `scripts/check-api-consistency.py`
+
+- [ ] **Step 1: Create the script skeleton**
+
+Create `scripts/check-api-consistency.py` with:
+
+```python
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import pathlib
+import re
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    tomllib = None
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+@dataclasses.dataclass(frozen=True)
+class PublicItem:
+    crate: str
+    crate_path: pathlib.Path
+    file: pathlib.Path
+    line: int
+    kind: str
+    name: str
+    signature: str
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    category: str
+    location: str
+    evidence: str
+    expected: str
+```
+
+- [ ] **Step 2: Implement workspace discovery**
+
+Add `workspace_crates(root: pathlib.Path) -> list[tuple[str, pathlib.Path]]` that reads the workspace members from `Cargo.toml`, loads each member `Cargo.toml`, and returns library crates only. It must skip `docs/tutorial-code` because it is not a release API crate.
+
+- [ ] **Step 3: Implement public item collection**
+
+Add `collect_public_items(root, crates)` that scans each crate's `src/**/*.rs`, skips path components named `tests`, and records `pub` functions, structs, enums, traits, type aliases, constants, modules, and reexports while excluding `pub(crate)`, `pub(super)`, `pub(self)`, and `pub(in ...)`.
+
+- [ ] **Step 4: Implement convention findings**
+
+Add checks for:
+
+```text
+traced_prefix: public item name starts with traced_
+read_suffix_without_read_input: public function name ends _read but signature does not mention TensorRead or Read
+per_dtype_constructor: public function name looks like from_f32/from_f64/from_i32/from_i64/from_bool/from_c32/from_c64
+public_gpu_feature: a crate Cargo.toml exposes a feature literally named gpu
+facade_path_in_user_docs: README.md or docs/guides/*.md contains tenferro::
+internal_jargon_in_user_docs: README.md or docs/guides/*.md contains internal crate paths or internal graph/IR vocabulary
+```
+
+- [ ] **Step 5: Implement concept-family output**
+
+Group public function names for these concepts and print the affected surfaces:
+
+```python
+CONCEPT_PATTERNS = {
+    "reshape": re.compile(r"reshape"),
+    "transpose": re.compile(r"transpose"),
+    "slice": re.compile(r"slice"),
+    "broadcast": re.compile(r"broadcast"),
+    "matmul/dot_general": re.compile(r"matmul|dot_general"),
+    "reduce": re.compile(r"reduce_(sum|prod|max|min)"),
+    "gather/scatter": re.compile(r"gather|scatter"),
+    "pad/concatenate/reverse": re.compile(r"pad|concatenate|reverse"),
+    "convert": re.compile(r"convert"),
+    "flat-buffer constructors": re.compile(r"from_vec_(col|row)_major|into_vec_(col|row)_major"),
+}
+```
+
+- [ ] **Step 6: Implement CLI**
+
+Support:
+
+```bash
+python3 scripts/check-api-consistency.py
+python3 scripts/check-api-consistency.py --fail-on-findings
+python3 scripts/check-api-consistency.py --output /tmp/api-consistency.md
+```
+
+Default mode exits `0` and prints an audit report. `--fail-on-findings` exits
+`1` when convention findings are present.
+
+### Task 2: Verify Script Behavior
+
+**Files:**
+- Modify: `scripts/check-api-consistency.py`
+
+- [ ] **Step 1: Compile-check Python**
+
+Run:
+
+```bash
+python3 -m py_compile scripts/check-api-consistency.py
+```
+
+Expected: exit code `0`.
+
+- [ ] **Step 2: Run default audit**
+
+Run:
+
+```bash
+python3 scripts/check-api-consistency.py --output /tmp/tenferro-api-consistency.md
+```
+
+Expected: exit code `0`, stdout includes `api-consistency-report:`, and `/tmp/tenferro-api-consistency.md` exists.
+
+- [ ] **Step 3: Run failing check mode**
+
+Run:
+
+```bash
+python3 scripts/check-api-consistency.py --fail-on-findings
+```
+
+Expected: exit code `1` if current API convention findings exist, otherwise `0`. Do not wire this into CI until findings are triaged.
+
+### Task 3: Commit First Audit Tooling Slice
+
+**Files:**
+- Add: `scripts/check-api-consistency.py`
+- Add: `docs/superpowers/plans/2026-06-10-api-consistency-audit.md`
+
+- [ ] **Step 1: Review diff**
+
+Run:
+
+```bash
+git diff -- scripts/check-api-consistency.py docs/superpowers/plans/2026-06-10-api-consistency-audit.md
+```
+
+Expected: only the new script and this plan are changed.
+
+- [ ] **Step 2: Commit**
+
+Run:
+
+```bash
+git add scripts/check-api-consistency.py docs/superpowers/plans/2026-06-10-api-consistency-audit.md
+git commit -m "tools: add api consistency audit"
+```
+
+Expected: commit succeeds.

--- a/docs/superpowers/plans/2026-06-10-api-consistency-remediation.md
+++ b/docs/superpowers/plans/2026-06-10-api-consistency-remediation.md
@@ -1,0 +1,704 @@
+# API Consistency Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce the first API consistency audit from candidate findings to enforceable release-freeze checks backed by a fixed API convention specification under `docs/spec/`.
+
+**Architecture:** Put durable inspection rules in `docs/spec/api-conventions.md`, keep release-cleanup rationale in `docs/design/api-and-convention-freeze.md`, and make `scripts/check-api-consistency.py` implement the spec. Treat `traced_tensor` as an intentional surface namespace paired with `eager_tensor`; then clean hidden AD bridge names and replace dtype-specific internal op constructors with one sealed generic constructor.
+
+**Tech Stack:** Rust workspace crates, `docs/spec/`, `scripts/check-api-consistency.py`, `cargo test`, `cargo doc`, repository design docs, and release-freeze public API rules.
+
+---
+
+## Recommended Order
+
+1. Create `docs/spec/api-conventions.md` as the fixed source of truth for API inspection rules.
+2. Keep `traced_tensor` as a release API namespace because it names the traced surface paired with `eager_tensor`.
+3. Refine `scripts/check-api-consistency.py` so `traced_tensor` module paths stop masking real function-name findings.
+4. Rename the `tenferro_runtime::ad_support` bridge helpers that start with `traced_`.
+5. Replace `StdTensorOp::constant_f64` and peer constructors with `StdTensorOp::constant<T>()`.
+6. Turn `scripts/check-api-consistency.py --fail-on-findings` into a release gate once the report reaches zero convention findings.
+
+This order keeps user-facing namespace churn out of the first cleanup batch and focuses code changes on places where the current names are redundant or copy dtype plumbing.
+
+### Task 1: Establish Fixed API Convention Spec
+
+**Files:**
+- Create: `docs/spec/api-conventions.md`
+- Modify: `docs/spec/index.md`
+- Modify: `docs/design/api-and-convention-freeze.md`
+
+- [ ] **Step 1: Create the normative API convention spec**
+
+Create `docs/spec/api-conventions.md` with:
+
+```markdown
+# API Convention Specification
+
+**Date:** 2026-06-10
+**Parent:** [`../index.md`](../index.md)
+**Related:** [`tensor-semantics.md`](tensor-semantics.md), [`backend-contract.md`](backend-contract.md), [`extension-op.md`](extension-op.md), [`../design/api-and-convention-freeze.md`](../design/api-and-convention-freeze.md)
+
+---
+
+## Purpose
+
+This document is the normative specification for public API naming, module
+shape, feature naming, and documentation-surface checks. It owns the fixed
+rules implemented by `scripts/check-api-consistency.py`.
+
+Release cleanup rationale and migration order live in
+`../design/api-and-convention-freeze.md`. This file owns the rules that remain
+after the cleanup is complete.
+
+---
+
+## Public API Strata
+
+Every exported item belongs to one stratum:
+
+| Stratum | Meaning | Requirement |
+| --- | --- | --- |
+| Release API | Intended for downstream users. | Public rustdoc contract and runnable example when the item is callable. |
+| Owner-scoped bridge | Required only because Rust crate boundaries separate owning implementation units. | Narrow API, no guide promotion, and documented owner. |
+| Experimental or unsupported | Visible because an incomplete capability is intentionally exposed. | Explicit unsupported behavior and error contract. |
+| Internal | Tests, planning, lowering, dispatch, cache plumbing, provider selection, or backend glue. | Private or `pub(crate)` unless a documented owner-scoped bridge is required. |
+
+The default stratum is internal.
+
+## Naming Rules
+
+1. There is no root `tenferro` facade crate. User-facing docs and examples must
+   import direct crates such as `tenferro_runtime`, `tenferro_ad`,
+   `tenferro_gpu`, `tenferro_einsum`, `tenferro_linalg`, and `tenferro_fft`.
+2. Tensor operation names use unsuffixed names for owned compact tensor inputs.
+3. `_read` is reserved for APIs that explicitly accept borrowed read-oriented
+   inputs such as `TensorRead`.
+4. `_view` is reserved for metadata-only layout operations. Operations that
+   allocate, canonicalize, execute kernels, transfer data, or materialize data
+   must not use `_view`.
+5. Scalar constructors use generic `TensorScalar`-bounded entry points instead
+   of dtype-specific public functions such as `constant_f64`.
+6. Traced tensor method and free-function names do not use a `traced_` prefix.
+7. Public module namespaces may use `traced_tensor` when they identify the
+   traced tensor surface as a peer of `eager_tensor`. The namespace is a
+   surface stratum, not an operation-name prefix.
+8. User-facing backend features use concrete backend family names such as
+   `cuda` and `rocm`. Public crates must not expose a vague `gpu` feature.
+9. Optional operation-specific AD support belongs behind an `autodiff` feature
+   in the owning operation crate.
+
+## API Shape Rules
+
+1. Unary single-output traced ops are methods on `TracedTensor`.
+2. Binary single-output ops use operator overloads when the operator is natural;
+   otherwise they use methods.
+3. Multi-output linalg and decomposition ops are free functions.
+4. Einsum is a free function owned by `tenferro-einsum`.
+5. Standard operation families are first-class crates, not modules under a
+   broad facade.
+
+## Documentation Checks
+
+1. `README.md`, `docs/guides/`, and `docs/getting-started/` must not reference
+   internal crates, internal graph/IR vocabulary, or deleted public paths.
+2. User-facing examples must use direct public crates and must not rely on a
+   root facade path.
+3. Flat-buffer constructors, exports, examples, and FFI contracts must state or
+   encode column-major layout expectations.
+4. Rustdoc examples for release APIs must compile and run as doctests unless
+   they intentionally use `compile_fail`.
+
+## Checker Mapping
+
+`scripts/check-api-consistency.py` implements these automated checks:
+
+| Check category | Spec rule |
+| --- | --- |
+| `traced_prefix` | Naming rule 6, limited to public function and method names. |
+| `read_suffix_without_read_input` | Naming rule 3. |
+| `per_dtype_constructor` | Naming rule 5. |
+| `public_gpu_feature` | Naming rule 8, limited to published crates. |
+| `facade_path_in_user_docs` | Naming rule 1 and documentation check 2. |
+| `internal_jargon_in_user_docs` | Documentation check 1. |
+
+The concept-family matrices emitted by the checker are review aids. A matrix
+difference becomes a finding only when the relevant spec, design doc, or
+rustdoc contract does not explain the difference.
+```
+
+- [ ] **Step 2: Register the spec in the spec index**
+
+In `docs/spec/index.md`, add this row to the table:
+
+```markdown
+| [api-conventions.md](./api-conventions.md) | Public API naming, module shape, feature naming, documentation-surface checks, and checker mapping |
+```
+
+- [ ] **Step 3: Point the design doc at the fixed spec**
+
+In `docs/design/api-and-convention-freeze.md`, under `## Source Of Truth`, add:
+
+```markdown
+API convention rules that should remain stable after the release cleanup live
+in `docs/spec/api-conventions.md`. This design document records the cleanup
+posture, triage workflow, and migration rationale.
+```
+
+- [ ] **Step 4: Commit the fixed spec**
+
+Run:
+
+```bash
+git add docs/spec/api-conventions.md docs/spec/index.md docs/design/api-and-convention-freeze.md
+git commit -m "docs: specify api convention rules"
+```
+
+Expected: commit succeeds.
+
+### Task 2: Fix Traced Namespace Audit Semantics
+
+**Files:**
+- Modify: `scripts/check-api-consistency.py`
+
+- [ ] **Step 1: Include getting-started docs in user-facing scans**
+
+In `scripts/check-api-consistency.py`, replace:
+
+```python
+def user_facing_docs(root: pathlib.Path) -> list[pathlib.Path]:
+    docs = [root / "README.md"]
+    guides = root / "docs" / "guides"
+    if guides.exists():
+        docs.extend(sorted(guides.rglob("*.md")))
+    return [path for path in docs if path.exists()]
+```
+
+with:
+
+```python
+def user_facing_docs(root: pathlib.Path) -> list[pathlib.Path]:
+    docs = [root / "README.md"]
+    for relative in ("docs/guides", "docs/getting-started"):
+        directory = root / relative
+        if directory.exists():
+            docs.extend(sorted(directory.rglob("*.md")))
+    return [path for path in docs if path.exists()]
+```
+
+- [ ] **Step 2: Narrow the checker to function names**
+
+In `scripts/check-api-consistency.py`, replace:
+
+```python
+        if item.name.startswith("traced_"):
+            findings.append(
+                Finding(
+                    "traced_prefix",
+                    location,
+                    f"`{item.name}` is public",
+                    "Traced tensor APIs should not use a `traced_` prefix.",
+                )
+            )
+```
+
+with:
+
+```python
+        if item.kind == "fn" and item.name.startswith("traced_"):
+            findings.append(
+                Finding(
+                    "traced_prefix",
+                    location,
+                    f"`{item.name}` is public",
+                    "Traced tensor function and method names should not use a `traced_` prefix.",
+                )
+            )
+```
+
+- [ ] **Step 3: Verify the checker now reports only function-level traced prefixes**
+
+Run:
+
+```bash
+python3 -m py_compile scripts/check-api-consistency.py
+python3 scripts/check-api-consistency.py --output /tmp/tenferro-api-consistency.md
+```
+
+Expected:
+
+```text
+api-consistency-report: 12 crates, 1382 lexically public items, 14 convention findings
+```
+
+The four removed findings are the `pub mod traced_tensor` entries in `tenferro-runtime`, `tenferro-einsum`, `tenferro-linalg`, and `tenferro-fft`.
+
+- [ ] **Step 4: Commit the checker precision change**
+
+Run:
+
+```bash
+git add scripts/check-api-consistency.py
+git commit -m "tools: refine traced namespace audit"
+```
+
+Expected: commit succeeds.
+
+### Task 3: Rename AD Support Bridge Helpers
+
+**Files:**
+- Modify: `crates/tenferro-runtime/src/ad_support.rs`
+- Modify: `crates/tenferro-ad/src/traced.rs`
+
+- [ ] **Step 1: Rename bridge functions at the owning boundary**
+
+In `crates/tenferro-runtime/src/ad_support.rs`, rename these public bridge helpers:
+
+```rust
+pub fn traced_tensor_from_parts(parts: TracedTensorParts) -> TracedTensor
+pub fn traced_shape_hint(tensor: &TracedTensor) -> Option<Vec<SymDim>>
+pub fn traced_inputs_map(tensor: &TracedTensor) -> Arc<HashMap<TensorInputKey, Arc<Tensor>>>
+pub fn traced_extra_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>>
+pub fn traced_checkpoint_chain(tensor: &TracedTensor) -> Option<Arc<CheckpointNode>>
+pub fn traced_metadata_scopes(tensor: &TracedTensor) -> &[Arc<RuntimeMetadataScope>]
+pub fn traced_resolve_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>>
+pub fn checkpoint_traced_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>)
+```
+
+to:
+
+```rust
+pub fn tensor_from_parts(parts: TracedTensorParts) -> TracedTensor
+pub fn shape_hint(tensor: &TracedTensor) -> Option<Vec<SymDim>>
+pub fn inputs_map(tensor: &TracedTensor) -> Arc<HashMap<TensorInputKey, Arc<Tensor>>>
+pub fn extra_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>>
+pub fn checkpoint_chain(tensor: &TracedTensor) -> Option<Arc<CheckpointNode>>
+pub fn metadata_scopes(tensor: &TracedTensor) -> &[Arc<RuntimeMetadataScope>]
+pub fn resolve_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>>
+pub fn checkpoint_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>)
+```
+
+Keep the existing bodies unchanged. The `ad_support` module name already supplies the bridge context, so each helper name can describe the borrowed part.
+
+- [ ] **Step 2: Update `tenferro-ad` imports**
+
+In `crates/tenferro-ad/src/traced.rs`, replace the `ad_support` import group with:
+
+```rust
+use tenferro_runtime::ad_support::{
+    checkpoint_chain, checkpoint_tensor, extra_roots, inputs_map, leaf_input_key,
+    linear_input_key, metadata_scopes, metadata_scopes_with_new, resolve_roots, shape_hint,
+    tensor_from_parts, tensor_meta_from_tensor, TracedTensorParts,
+};
+```
+
+- [ ] **Step 3: Update `tenferro-ad` call sites**
+
+In `crates/tenferro-ad/src/traced.rs`, make these exact replacements:
+
+```text
+checkpoint_traced_tensor( -> checkpoint_tensor(
+traced_checkpoint_chain( -> checkpoint_chain(
+traced_resolve_roots( -> resolve_roots(
+traced_inputs_map( -> inputs_map(
+traced_extra_roots( -> extra_roots(
+traced_tensor_from_parts( -> tensor_from_parts(
+traced_shape_hint( -> shape_hint(
+traced_metadata_scopes( -> metadata_scopes(
+```
+
+- [ ] **Step 4: Verify the AD bridge rename**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test -p tenferro-ad traced
+python3 scripts/check-api-consistency.py --output /tmp/tenferro-api-consistency.md
+```
+
+Expected:
+
+```text
+api-consistency-report: 12 crates, 1382 lexically public items, 7 convention findings
+```
+
+The remaining convention findings are the seven `StdTensorOp::constant_*` constructors.
+
+- [ ] **Step 5: Commit the bridge rename**
+
+Run:
+
+```bash
+git add crates/tenferro-runtime/src/ad_support.rs crates/tenferro-ad/src/traced.rs
+git commit -m "refactor: rename ad support bridge helpers"
+```
+
+Expected: commit succeeds.
+
+### Task 4: Replace Dtype-Specific Constant Constructors
+
+**Files:**
+- Modify: `crates/tenferro-internal-ops/src/std_tensor_op.rs`
+- Modify: `crates/tenferro-internal-ops/src/lib.rs`
+- Modify: `crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs`
+- Modify: `crates/tenferro-runtime/src/traced.rs`
+- Modify: `crates/tenferro-linalg/src/ad/rules/support.rs`
+- Modify: `crates/tenferro-ad/tests/compiler_wiring.rs`
+
+- [ ] **Step 1: Add the sealed scalar encoding trait**
+
+In `crates/tenferro-internal-ops/src/std_tensor_op.rs`, after the imports and before `tenferro_core_ops::define_std_tensor_op!();`, add:
+
+```rust
+/// Scalar values that can be encoded as tensor constant operations.
+pub trait ConstantScalar: tenferro_tensor::TensorScalar + private::Sealed {
+    /// Encode the scalar value as little-endian constant bytes.
+    fn constant_bytes(self) -> Vec<u8>;
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for f64 {}
+    impl Sealed for f32 {}
+    impl Sealed for i64 {}
+    impl Sealed for i32 {}
+    impl Sealed for bool {}
+    impl Sealed for num_complex::Complex64 {}
+    impl Sealed for num_complex::Complex32 {}
+}
+
+impl ConstantScalar for f64 {
+    fn constant_bytes(self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+}
+
+impl ConstantScalar for f32 {
+    fn constant_bytes(self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+}
+
+impl ConstantScalar for i64 {
+    fn constant_bytes(self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+}
+
+impl ConstantScalar for i32 {
+    fn constant_bytes(self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+}
+
+impl ConstantScalar for bool {
+    fn constant_bytes(self) -> Vec<u8> {
+        vec![u8::from(self)]
+    }
+}
+
+impl ConstantScalar for Complex64 {
+    fn constant_bytes(self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(16);
+        bytes.extend_from_slice(&self.re.to_le_bytes());
+        bytes.extend_from_slice(&self.im.to_le_bytes());
+        bytes
+    }
+}
+
+impl ConstantScalar for Complex32 {
+    fn constant_bytes(self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(8);
+        bytes.extend_from_slice(&self.re.to_le_bytes());
+        bytes.extend_from_slice(&self.im.to_le_bytes());
+        bytes
+    }
+}
+```
+
+- [ ] **Step 2: Add the generic constructor**
+
+In the existing `impl StdTensorOp` block, replace all seven `constant_f64`, `constant_f32`, `constant_i64`, `constant_i32`, `constant_bool`, `constant_c64`, and `constant_c32` functions with:
+
+```rust
+    /// Create a scalar constant op from any supported tensor scalar.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use num_complex::Complex64;
+    /// use tenferro_ops::std_tensor_op::StdTensorOp;
+    /// use tenferro_tensor::DType;
+    ///
+    /// let real = StdTensorOp::constant(1.5_f64);
+    /// let complex = StdTensorOp::constant(Complex64::new(1.0, -2.0));
+    ///
+    /// assert_eq!(real.output_dtype(&[]).unwrap(), DType::F64);
+    /// assert_eq!(complex.output_dtype(&[]).unwrap(), DType::C64);
+    /// ```
+    pub fn constant<T: ConstantScalar>(value: T) -> Self {
+        Self::Constant {
+            dtype: T::dtype(),
+            bytes: value.constant_bytes(),
+        }
+    }
+```
+
+- [ ] **Step 3: Update source call sites**
+
+Apply these replacements:
+
+```text
+StdTensorOp::constant_f64(x) -> StdTensorOp::constant(x)
+StdTensorOp::constant_f32(x) -> StdTensorOp::constant(x)
+StdTensorOp::constant_i64(x) -> StdTensorOp::constant(x)
+StdTensorOp::constant_i32(x) -> StdTensorOp::constant(x)
+StdTensorOp::constant_bool(x) -> StdTensorOp::constant(x)
+StdTensorOp::constant_c64(x) -> StdTensorOp::constant(x)
+StdTensorOp::constant_c32(x) -> StdTensorOp::constant(x)
+```
+
+When a literal would become ambiguous, add an explicit suffix, for example:
+
+```rust
+StdTensorOp::constant(1.25_f64)
+StdTensorOp::constant(1.25_f32)
+StdTensorOp::constant(7_i64)
+StdTensorOp::constant(7_i32)
+```
+
+- [ ] **Step 4: Update crate-level docs**
+
+In `crates/tenferro-internal-ops/src/lib.rs`, replace:
+
+```rust
+//! let op = StdTensorOp::constant_f64(2.0);
+```
+
+with:
+
+```rust
+//! let op = StdTensorOp::constant(2.0_f64);
+```
+
+- [ ] **Step 5: Update internal-op tests**
+
+In `crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs`, update each constant constructor call to `StdTensorOp::constant(...)`. Add this test near the existing constant byte tests:
+
+```rust
+#[test]
+fn generic_constant_constructor_sets_dtype_for_each_scalar() {
+    assert_eq!(StdTensorOp::constant(1.0_f64).output_dtype(&[]).unwrap(), DType::F64);
+    assert_eq!(StdTensorOp::constant(1.0_f32).output_dtype(&[]).unwrap(), DType::F32);
+    assert_eq!(StdTensorOp::constant(1_i64).output_dtype(&[]).unwrap(), DType::I64);
+    assert_eq!(StdTensorOp::constant(1_i32).output_dtype(&[]).unwrap(), DType::I32);
+    assert_eq!(StdTensorOp::constant(true).output_dtype(&[]).unwrap(), DType::Bool);
+    assert_eq!(
+        StdTensorOp::constant(Complex64::new(1.0, -2.0))
+            .output_dtype(&[])
+            .unwrap(),
+        DType::C64
+    );
+    assert_eq!(
+        StdTensorOp::constant(Complex32::new(1.0, -2.0))
+            .output_dtype(&[])
+            .unwrap(),
+        DType::C32
+    );
+}
+```
+
+- [ ] **Step 6: Verify constructor cleanup**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test -p tenferro-internal-ops
+cargo test -p tenferro-runtime traced_tensor
+cargo test -p tenferro-ad compiler_wiring
+python3 scripts/check-api-consistency.py --fail-on-findings
+```
+
+Expected: all commands exit `0`, and the final script report contains:
+
+```text
+api-consistency-report: 12 crates, 1376 lexically public items, 0 convention findings
+```
+
+The public item count may differ by one or two if rustdoc-visible trait items are counted differently after formatting; the required invariant is zero convention findings.
+
+- [ ] **Step 7: Commit the constructor cleanup**
+
+Run:
+
+```bash
+git add \
+  crates/tenferro-internal-ops/src/std_tensor_op.rs \
+  crates/tenferro-internal-ops/src/lib.rs \
+  crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs \
+  crates/tenferro-runtime/src/traced.rs \
+  crates/tenferro-linalg/src/ad/rules/support.rs \
+  crates/tenferro-ad/tests/compiler_wiring.rs
+git commit -m "refactor: use generic tensor constant constructor"
+```
+
+Expected: commit succeeds.
+
+### Task 5: Add Release-Gate Documentation
+
+**Files:**
+- Modify: `docs/design/api-and-convention-freeze.md`
+- Modify: `docs/spec/api-conventions.md`
+- Create: `docs/worklogs/2026-06-10-api-consistency-remediation.md`
+
+- [ ] **Step 1: Add the concrete gate command to the design doc**
+
+In `docs/design/api-and-convention-freeze.md`, under `## Enforcement Targets`, add this bullet:
+
+```markdown
+- release-freeze API convention findings via
+  `python3 scripts/check-api-consistency.py --fail-on-findings`;
+```
+
+- [ ] **Step 2: Add the gate command to the fixed spec**
+
+In `docs/spec/api-conventions.md`, under `## Checker Mapping`, after the table, add:
+
+````markdown
+The release-freeze convention gate is:
+
+```bash
+python3 scripts/check-api-consistency.py --fail-on-findings
+```
+
+This command must exit `0` before the API convention freeze is considered
+green. Concept-family matrices remain review aids until a specific matrix rule
+is promoted into this spec.
+````
+
+- [ ] **Step 3: Add the remediation work log**
+
+Create `docs/worklogs/2026-06-10-api-consistency-remediation.md` with:
+
+```markdown
+# API Consistency Remediation Work Log
+
+## Summary
+
+This cleanup made the release-freeze API convention audit enforceable for the
+first detected naming findings.
+
+## Context Read
+
+- `REPOSITORY_RULES.md`
+- `docs/spec/api-conventions.md`
+- `docs/design/api-and-convention-freeze.md`
+- `scripts/check-api-consistency.py`
+- `/tmp/tenferro-api-consistency.md`
+- `crates/tenferro-runtime/src/ad_support.rs`
+- `crates/tenferro-ad/src/traced.rs`
+- `crates/tenferro-internal-ops/src/std_tensor_op.rs`
+
+## Decisions
+
+- Kept `traced_tensor` as a documented namespace paired with `eager_tensor`.
+- Treated `traced_` prefixes on public function names as findings.
+- Renamed `ad_support` bridge helpers because the module name already supplies
+  the traced AD bridge context.
+- Replaced dtype-specific `StdTensorOp::constant_*` constructors with one
+  sealed generic constructor.
+
+## Verification
+
+- `python3 -m py_compile scripts/check-api-consistency.py`
+- `python3 scripts/check-api-consistency.py --fail-on-findings`
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-internal-ops`
+- `cargo test -p tenferro-runtime traced_tensor`
+- `cargo test -p tenferro-ad traced`
+- `cargo test -p tenferro-ad compiler_wiring`
+
+## Residual Risks
+
+The concept-family matrices still need human triage for behavior-level
+differences such as eager vs traced error surfaces, CPU vs GPU unsupported
+paths, and view vs materializing operation boundaries.
+```
+
+- [ ] **Step 4: Verify docs**
+
+Run:
+
+```bash
+python3 scripts/check-doc-snippets.py --root-dir . --check
+cargo doc --workspace --no-deps
+```
+
+Expected: both commands exit `0`.
+
+- [ ] **Step 5: Commit release-gate documentation**
+
+Run:
+
+```bash
+git add docs/design/api-and-convention-freeze.md docs/spec/api-conventions.md docs/worklogs/2026-06-10-api-consistency-remediation.md
+git commit -m "docs: record api consistency remediation gate"
+```
+
+Expected: commit succeeds.
+
+### Task 6: Final Release-Freeze Verification
+
+**Files:**
+- No source edits in this task.
+
+- [ ] **Step 1: Run fast release-freeze checks**
+
+Run:
+
+```bash
+cargo fmt --all --check
+python3 -m py_compile scripts/check-api-consistency.py
+python3 scripts/check-api-consistency.py --fail-on-findings
+python3 scripts/check-doc-snippets.py --root-dir . --check
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 2: Run workspace checks**
+
+Run:
+
+```bash
+cargo test --workspace
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 3: Review remaining concept matrices**
+
+Run:
+
+```bash
+python3 scripts/check-api-consistency.py --output /tmp/tenferro-api-consistency.md
+sed -n '/## Concept-Family Matrices/,$p' /tmp/tenferro-api-consistency.md
+```
+
+Expected: the convention findings section is empty, and concept-family matrices remain review aids for the next cleanup stream.
+
+- [ ] **Step 4: Commit no-op verification state**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no uncommitted files.
+
+Do not create an empty commit.

--- a/docs/worklogs/2026-06-10-api-consistency-remediation.md
+++ b/docs/worklogs/2026-06-10-api-consistency-remediation.md
@@ -1,0 +1,51 @@
+# API Consistency Remediation Work Log
+
+## Summary
+
+This cleanup made the release-freeze API convention audit enforceable for the
+first detected naming findings.
+
+## Context Read
+
+- `AGENTS.md`
+- `REPOSITORY_RULES.md`
+- shared tensor4all agent rules
+- `docs/spec/api-conventions.md`
+- `docs/design/api-and-convention-freeze.md`
+- `scripts/check-api-consistency.py`
+- `/tmp/tenferro-api-consistency.md`
+- `crates/tenferro-runtime/src/ad_support.rs`
+- `crates/tenferro-ad/src/traced.rs`
+- `crates/tenferro-internal-ops/src/std_tensor_op.rs`
+- `crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs`
+
+## Decisions
+
+- Kept `traced_tensor` as a documented namespace paired with `eager_tensor`.
+- Treated `traced_` prefixes on public function names as findings.
+- Renamed `ad_support` bridge helpers because the module name already supplies
+  the traced AD bridge context.
+- Replaced dtype-specific `StdTensorOp::constant_*` constructors with one
+  sealed generic constructor.
+- Added `docs/spec/api-conventions.md` as the fixed source of truth for the
+  checker rules so future changes do not rely on script behavior alone.
+
+## Verification
+
+- `python3 -m py_compile scripts/check-api-consistency.py`
+- `python3 scripts/check-api-consistency.py --output /tmp/tenferro-api-consistency.md`
+- `python3 scripts/check-api-consistency.py --fail-on-findings`
+- `python3 scripts/check-doc-snippets.py --root-dir . --check`
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-internal-ops`
+- `cargo test -p tenferro-runtime traced_tensor`
+- `cargo test -p tenferro-ad traced`
+- `cargo test -p tenferro-ad compiler_wiring`
+- `cargo test -p tenferro-ad --test compiler_wiring`
+- `cargo test -p tenferro-linalg`
+
+## Residual Risks
+
+The concept-family matrices still need human triage for behavior-level
+differences such as eager vs traced error surfaces, CPU vs GPU unsupported
+paths, and view vs materializing operation boundaries.

--- a/scripts/check-api-consistency.py
+++ b/scripts/check-api-consistency.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Generate first-pass API consistency candidates for the release freeze."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import pathlib
+import re
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
+    tomllib = None
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+PUBLIC_RE = re.compile(
+    r'^\s*pub\s+'
+    r'(?!(?:\([^)]*\)|crate\b|super\b|self\b|in\b))'
+    r'(?:(?:async|unsafe|extern\s+"[^"]+")\s+)*'
+    r"(fn|struct|enum|trait|type|const|static|mod|use)\b"
+    r"\s*([A-Za-z_][A-Za-z0-9_]*)?"
+)
+
+PER_DTYPE_CTOR_RE = re.compile(
+    r"^(?:from|new|constant|scalar)_(?:f32|f64|i32|i64|bool|c32|c64)$"
+)
+
+CONCEPT_PATTERNS = {
+    "reshape": re.compile(r"reshape"),
+    "transpose": re.compile(r"transpose"),
+    "slice": re.compile(r"slice"),
+    "broadcast": re.compile(r"broadcast"),
+    "matmul/dot_general": re.compile(r"matmul|dot_general"),
+    "reduce": re.compile(r"reduce_(?:sum|prod|max|min)"),
+    "gather/scatter": re.compile(r"gather|scatter"),
+    "pad/concatenate/reverse": re.compile(r"pad|concatenate|reverse"),
+    "convert": re.compile(r"convert"),
+    "flat-buffer constructors": re.compile(
+        r"(?:from|into|try_into)_vec_(?:col|row)_major"
+    ),
+}
+
+USER_DOC_JARGON = (
+    "tenferro_internal",
+    "tenferro-internal",
+    "computegraph",
+    "ExecOp",
+    "ValueRef",
+    "StableHLO",
+)
+
+MATRIX_EXCLUDED_CRATES = {
+    "tenferro-core-ops",
+    "tenferro-internal-extension-macros",
+    "tenferro-internal-ops",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class CrateInfo:
+    name: str
+    path: pathlib.Path
+    lib_name: str
+    features: frozenset[str]
+    publish: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class PublicItem:
+    crate: str
+    crate_path: pathlib.Path
+    file: pathlib.Path
+    line: int
+    kind: str
+    name: str
+    signature: str
+
+    def location(self, root: pathlib.Path) -> str:
+        return f"{self.file.relative_to(root)}:{self.line}"
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    category: str
+    location: str
+    evidence: str
+    expected: str
+
+
+def load_toml(path: pathlib.Path) -> dict:
+    if tomllib is None:
+        raise RuntimeError("Python 3.11+ is required for tomllib support")
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def workspace_crates(root: pathlib.Path) -> list[CrateInfo]:
+    workspace = load_toml(root / "Cargo.toml")["workspace"]
+    crates: list[CrateInfo] = []
+    for member in workspace["members"]:
+        member_path = root / member
+        manifest_path = member_path / "Cargo.toml"
+        if not manifest_path.exists():
+            continue
+        manifest = load_toml(manifest_path)
+        if "package" not in manifest:
+            continue
+        if member == "docs/tutorial-code":
+            continue
+        if "lib" not in manifest and not (member_path / "src" / "lib.rs").exists():
+            continue
+        package_name = manifest["package"]["name"]
+        lib_name = manifest.get("lib", {}).get("name", package_name.replace("-", "_"))
+        features = frozenset(manifest.get("features", {}).keys())
+        publish_value = manifest["package"].get("publish", True)
+        crates.append(
+            CrateInfo(package_name, member_path, lib_name, features, publish_value is not False)
+        )
+    return crates
+
+
+def rust_source_files(crate_path: pathlib.Path) -> list[pathlib.Path]:
+    files: list[pathlib.Path] = []
+    src = crate_path / "src"
+    for path in sorted(src.rglob("*.rs")):
+        if "tests" in path.relative_to(src).parts or path.name == "tests.rs":
+            continue
+        files.append(path)
+    return files
+
+
+def reexport_name(line: str) -> str:
+    body = line.split("pub use", 1)[1].strip().rstrip(";")
+    body = body.split(" as ")[-1]
+    body = body.rsplit("::", 1)[-1]
+    body = body.strip("{} ")
+    return body or "<reexport>"
+
+
+def signature_from(lines: list[str], start: int) -> str:
+    collected: list[str] = []
+    parens = 0
+    for line in lines[start : min(len(lines), start + 24)]:
+        stripped = line.strip()
+        collected.append(stripped)
+        parens += stripped.count("(") - stripped.count(")")
+        if parens <= 0 and (";" in stripped or "{" in stripped):
+            break
+    return " ".join(part for part in collected if part)
+
+
+def collect_public_items(root: pathlib.Path, crates: list[CrateInfo]) -> list[PublicItem]:
+    items: list[PublicItem] = []
+    for crate in crates:
+        for source in rust_source_files(crate.path):
+            lines = source.read_text(encoding="utf-8").splitlines()
+            for idx, line in enumerate(lines):
+                match = PUBLIC_RE.match(line)
+                if not match:
+                    continue
+                kind = match.group(1)
+                name = match.group(2) or ""
+                if kind == "use":
+                    name = reexport_name(line)
+                if not name:
+                    continue
+                items.append(
+                    PublicItem(
+                        crate=crate.name,
+                        crate_path=crate.path.relative_to(root),
+                        file=source,
+                        line=idx + 1,
+                        kind=kind,
+                        name=name,
+                        signature=signature_from(lines, idx),
+                    )
+                )
+    return items
+
+
+def user_facing_docs(root: pathlib.Path) -> list[pathlib.Path]:
+    docs = [root / "README.md"]
+    guides = root / "docs" / "guides"
+    if guides.exists():
+        docs.extend(sorted(guides.rglob("*.md")))
+    return [path for path in docs if path.exists()]
+
+
+def check_public_items(root: pathlib.Path, items: list[PublicItem]) -> list[Finding]:
+    findings: list[Finding] = []
+    for item in items:
+        location = item.location(root)
+        if item.name.startswith("traced_"):
+            findings.append(
+                Finding(
+                    "traced_prefix",
+                    location,
+                    f"`{item.name}` is public",
+                    "Traced tensor APIs should not use a `traced_` prefix.",
+                )
+            )
+        if item.kind == "fn" and item.name.endswith("_read"):
+            if "TensorRead" not in item.signature and "Read" not in item.signature:
+                findings.append(
+                    Finding(
+                        "read_suffix_without_read_input",
+                        location,
+                        item.signature,
+                        "`_read` is reserved for APIs that explicitly accept read-style inputs.",
+                    )
+                )
+        if item.kind == "fn" and PER_DTYPE_CTOR_RE.match(item.name):
+            findings.append(
+                Finding(
+                    "per_dtype_constructor",
+                    location,
+                    f"`{item.name}` is public",
+                    "Prefer generic TensorScalar-bounded constructors over per-dtype constructors.",
+                )
+            )
+    return findings
+
+
+def check_features(root: pathlib.Path, crates: list[CrateInfo]) -> list[Finding]:
+    findings: list[Finding] = []
+    for crate in crates:
+        if crate.publish and "gpu" in crate.features:
+            findings.append(
+                Finding(
+                    "public_gpu_feature",
+                    f"{crate.path.relative_to(root)}/Cargo.toml",
+                    f"`{crate.name}` exposes a `gpu` feature",
+                    "User-facing backend features should be concrete backend names such as `cuda` or `rocm`.",
+                )
+            )
+    return findings
+
+
+def check_user_docs(root: pathlib.Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for doc in user_facing_docs(root):
+        for line_no, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
+            location = f"{doc.relative_to(root)}:{line_no}"
+            if "tenferro::" in line:
+                findings.append(
+                    Finding(
+                        "facade_path_in_user_docs",
+                        location,
+                        line.strip(),
+                        "User-facing docs should import direct public crates, not a root facade path.",
+                    )
+                )
+            for token in USER_DOC_JARGON:
+                if token in line:
+                    findings.append(
+                        Finding(
+                            "internal_jargon_in_user_docs",
+                            location,
+                            line.strip(),
+                            "User-facing docs should avoid internal crate paths and graph/IR implementation vocabulary.",
+                        )
+                    )
+    return findings
+
+
+def surface_for(item: PublicItem) -> str:
+    signature = f"{item.file.as_posix()} {item.signature}".lower()
+    if item.crate == "tenferro-tensor-core":
+        return "tensor-core"
+    if item.crate == "tenferro-tensor":
+        return "tensor"
+    if item.crate == "tenferro-cpu":
+        return "cpu-backend"
+    if item.crate == "tenferro-gpu":
+        return "gpu-backend"
+    if item.crate == "tenferro-ad" and "eager" in signature:
+        return "eager"
+    if item.crate == "tenferro-ad":
+        return "ad"
+    if item.crate == "tenferro-runtime" and "traced" in signature:
+        return "traced"
+    if item.crate == "tenferro-runtime":
+        return "runtime"
+    if item.crate in {"tenferro-einsum", "tenferro-linalg", "tenferro-fft"}:
+        return "extension"
+    return "other"
+
+
+def concept_groups(items: list[PublicItem]) -> dict[str, list[PublicItem]]:
+    groups: dict[str, list[PublicItem]] = {}
+    functions = [
+        item
+        for item in items
+        if item.kind == "fn" and item.crate not in MATRIX_EXCLUDED_CRATES
+    ]
+    for concept, pattern in CONCEPT_PATTERNS.items():
+        matches = [item for item in functions if pattern.search(item.name)]
+        if matches:
+            groups[concept] = matches
+    return groups
+
+
+def markdown_escape(text: str) -> str:
+    return text.replace("|", "\\|")
+
+
+def render_report(
+    root: pathlib.Path,
+    crates: list[CrateInfo],
+    items: list[PublicItem],
+    findings: list[Finding],
+) -> str:
+    lines: list[str] = []
+    lines.append("# API Consistency Report")
+    lines.append("")
+    lines.append(
+        f"api-consistency-report: {len(crates)} crates, {len(items)} lexically public items, {len(findings)} convention findings"
+    )
+    lines.append("")
+    lines.append("## Convention Findings")
+    lines.append("")
+    if findings:
+        for finding in findings:
+            lines.append(f"### {finding.category}: {finding.location}")
+            lines.append("")
+            lines.append(f"- Evidence: {markdown_escape(finding.evidence)}")
+            lines.append(f"- Expected: {markdown_escape(finding.expected)}")
+            lines.append("")
+    else:
+        lines.append("No convention findings detected by this first-pass script.")
+        lines.append("")
+
+    lines.append("## Concept-Family Matrices")
+    lines.append("")
+    lines.append(
+        "These matrices are candidate review aids. Differences are acceptable when the owning spec, design doc, or rustdoc explains them."
+    )
+    lines.append("")
+    for concept, members in concept_groups(items).items():
+        lines.append(f"### {concept}")
+        lines.append("")
+        lines.append("| Surface | Crate | Item | Location |")
+        lines.append("| --- | --- | --- | --- |")
+        for item in members:
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        markdown_escape(surface_for(item)),
+                        markdown_escape(item.crate),
+                        markdown_escape(f"`{item.name}`"),
+                        markdown_escape(item.location(root)),
+                    ]
+                )
+                + " |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate release-freeze public API consistency candidates."
+    )
+    parser.add_argument("--root-dir", default=ROOT, type=pathlib.Path)
+    parser.add_argument("--output", type=pathlib.Path)
+    parser.add_argument(
+        "--fail-on-findings",
+        action="store_true",
+        help="Exit 1 when convention findings are present.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root_dir.resolve()
+    try:
+        crates = workspace_crates(root)
+        items = collect_public_items(root, crates)
+        findings = [
+            *check_public_items(root, items),
+            *check_features(root, crates),
+            *check_user_docs(root),
+        ]
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    report = render_report(root, crates, items, findings)
+    print(report)
+    if args.output:
+        args.output.write_text(report + "\n", encoding="utf-8")
+
+    if args.fail_on_findings and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-api-consistency.py
+++ b/scripts/check-api-consistency.py
@@ -184,9 +184,10 @@ def collect_public_items(root: pathlib.Path, crates: list[CrateInfo]) -> list[Pu
 
 def user_facing_docs(root: pathlib.Path) -> list[pathlib.Path]:
     docs = [root / "README.md"]
-    guides = root / "docs" / "guides"
-    if guides.exists():
-        docs.extend(sorted(guides.rglob("*.md")))
+    for relative in ("docs/guides", "docs/getting-started"):
+        directory = root / relative
+        if directory.exists():
+            docs.extend(sorted(directory.rglob("*.md")))
     return [path for path in docs if path.exists()]
 
 
@@ -194,13 +195,13 @@ def check_public_items(root: pathlib.Path, items: list[PublicItem]) -> list[Find
     findings: list[Finding] = []
     for item in items:
         location = item.location(root)
-        if item.name.startswith("traced_"):
+        if item.kind == "fn" and item.name.startswith("traced_"):
             findings.append(
                 Finding(
                     "traced_prefix",
                     location,
                     f"`{item.name}` is public",
-                    "Traced tensor APIs should not use a `traced_` prefix.",
+                    "Traced tensor function and method names should not use a `traced_` prefix.",
                 )
             )
         if item.kind == "fn" and item.name.endswith("_read"):


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs release API/convention freeze work; no single issue is closed by this PR.

## Summary

- Record the release API/convention freeze posture in `docs/design/api-and-convention-freeze.md` and make `docs/spec/api-conventions.md` the durable convention source.
- Add `scripts/check-api-consistency.py` as a repeatable first-pass public API convention gate; current branch reports 12 crates, 1378 lexically public items, and 0 convention findings.
- Clean up the first findings: preserve `traced_tensor` as an intentional namespace, rename owner-scoped AD bridge helpers, and replace dtype-specific `StdTensorOp::constant_*` constructors with a sealed generic `StdTensorOp::constant<T>()`.

## Work log

See `docs/worklogs/2026-06-10-api-consistency-remediation.md`.

## Base and branch

- Base branch: `main`
- Base hash: `230fcab65c43c249e4af87af96ff83e99da19c31`
- Head branch: `codex/api-consistency-freeze`
- Head hash: `d6aac228ff9f232609b2bb4774cbd925284390f7`

## Finding ledger

- API convention rules lacked a durable source: fixed by adding `docs/spec/api-conventions.md` and linking it from the spec index.
- API inconsistency detection was manual: fixed by adding `scripts/check-api-consistency.py` with `--fail-on-findings`.
- `traced_` prefix audit flagged namespace-level false positives: narrowed the rule to public function names, preserving `traced_tensor` as the peer namespace to `eager_tensor`.
- Internal AD bridge helpers used traced-prefixed names outside the public traced surface: fixed by renaming hidden bridge helpers to owner-scoped tensor helper names.
- `StdTensorOp` exposed dtype-specific constant constructors: fixed by replacing them with a sealed generic constructor and doctested trait surface.

## Commit grouping

- Docs/spec/worklog commits record release posture, durable convention rules, the remediation plan, and review context.
- Tooling commits add and refine the API consistency checker.
- Refactor commits separately handle AD helper naming and generic constant construction.

## Neighborhood scans

- Checked public traced/eager naming around `traced_tensor` and `eager_tensor` before narrowing the checker rule.
- Updated constant-constructor call sites in runtime, AD compiler wiring, linalg AD support, internal ops tests, and doctests.
- Ran the concept-family matrix output from the checker to keep remaining cross-surface differences review-visible rather than silently expanding the batch.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `python3 -m py_compile scripts/check-api-consistency.py`
- `python3 scripts/check-api-consistency.py --fail-on-findings`
- `python3 scripts/check-doc-snippets.py --root-dir . --check`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `bash scripts/build_docs_site.sh`
- `git diff --check`

## Skipped or environment-specific checks

- Local `bash scripts/build_docs_site.sh` completed, but dependency graph rendering was skipped locally because Graphviz `dot` is not installed. CI installs graphviz before running the docs-site job.
- CUDA ignored tests were not run; this PR does not change CUDA/GPU backend behavior.

## Repository-rules side review

Re-read `REPOSITORY_RULES.md` before PR creation and reviewed the diff against public surface, AD naming, docs/spec source-of-truth, tests, and work-log requirements. No residual in-scope findings remain from this batch.

## Residual risks / follow-ups

- The API checker is intentionally lexical and first-pass; semantic API parity remains a review aid via the emitted concept-family matrix.
- The checker is not wired into CI in this PR; `docs/spec/api-conventions.md` defines `python3 scripts/check-api-consistency.py --fail-on-findings` as the release gate command.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. Not applicable: cleanup/remediation and docs/spec work.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`. Not applicable: batched remediation workflow was used instead.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.