### PR TITLE
[codex] Fix complex AD and linalg dtype issues

### DIFF
--- a/crates/tenferro-ad/src/context.rs
+++ b/crates/tenferro-ad/src/context.rs
@@ -55,6 +55,11 @@ impl AdContext {
 
     /// Gradient of a scalar traced output with respect to a traced input.
     ///
+    /// For complex scalar outputs, tenferro returns the Hermitian-adjoint
+    /// cotangent. To compare seed-`1` scalar gradients with JAX's public
+    /// `grad` values, use the complex conjugate of this result. See
+    /// <https://tensor4all.org/tenferro-rs/guides/complex-ad.html>.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -140,6 +145,11 @@ impl AdContext {
     }
 
     /// Reverse-mode vector-Jacobian product.
+    ///
+    /// Complex cotangents use tenferro's Hermitian real-inner-product
+    /// convention. Non-real complex cotangent seeds therefore need an explicit
+    /// seed-convention comparison when matching JAX. See
+    /// <https://tensor4all.org/tenferro-rs/guides/complex-ad.html>.
     ///
     /// # Examples
     ///

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -870,6 +870,10 @@ impl EagerTensor {
     /// The stored gradient accumulates across repeated `backward()` calls
     /// until it is cleared explicitly.
     ///
+    /// For complex scalar losses, stored gradients use tenferro's
+    /// Hermitian-adjoint cotangent convention. See
+    /// <https://tensor4all.org/tenferro-rs/guides/complex-ad.html>.
+    ///
     /// # Examples
     ///
     /// ```
@@ -984,6 +988,10 @@ impl EagerTensor {
     /// Returns the full cotangent map produced by the reverse pass and also
     /// accumulates into `grad()` for tracked eager tensors reachable from this
     /// output.
+    ///
+    /// For complex scalar outputs, cotangents use tenferro's Hermitian
+    /// real-inner-product convention. See
+    /// <https://tensor4all.org/tenferro-rs/guides/complex-ad.html>.
     ///
     /// # Examples
     ///

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -151,6 +151,11 @@ fn grad_with_optional_rules(
 pub trait TracedTensorAdExt {
     /// Gradient of a scalar output with respect to a traced input.
     ///
+    /// For complex scalar outputs, tenferro returns the Hermitian-adjoint
+    /// cotangent. To compare seed-`1` scalar gradients with JAX's public
+    /// `grad` values, use the complex conjugate of this result. See
+    /// <https://tensor4all.org/tenferro-rs/guides/complex-ad.html>.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -288,6 +293,11 @@ pub trait TracedTensorAdExt {
 
     /// Reverse-mode vector-Jacobian product.
     ///
+    /// Complex cotangents use tenferro's Hermitian real-inner-product
+    /// convention. Non-real complex cotangent seeds therefore need an explicit
+    /// seed-convention comparison when matching JAX. See
+    /// <https://tensor4all.org/tenferro-rs/guides/complex-ad.html>.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -329,6 +339,11 @@ pub trait TracedTensorAdExt {
     fn vjp_optional(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> Option<TracedTensor>;
 
     /// Fallible reverse-mode vector-Jacobian product.
+    ///
+    /// Complex cotangents use tenferro's Hermitian real-inner-product
+    /// convention. Non-real complex cotangent seeds therefore need an explicit
+    /// seed-convention comparison when matching JAX. See
+    /// <https://tensor4all.org/tenferro-rs/guides/complex-ad.html>.
     ///
     /// # Examples
     ///

--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -128,10 +128,7 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
                 primal_in,
                 primal_out,
                 tangent_in,
-                left_side,
-                lower,
-                transpose_a,
-                unit_diagonal,
+                rules::TriangularSolveFlags::new(left_side, lower, transpose_a, unit_diagonal),
                 ctx,
             ),
             LinalgOp::Cholesky => {
@@ -179,10 +176,7 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
                 cotangent_out,
                 inputs,
                 mode,
-                left_side,
-                lower,
-                transpose_a,
-                unit_diagonal,
+                rules::TriangularSolveFlags::new(left_side, lower, transpose_a, unit_diagonal),
                 ctx,
             ),
             LinalgOp::LuSolvePrepared {
@@ -233,10 +227,7 @@ impl PrimitiveRuleBuilder for DynBuilder<'_> {
     }
 }
 
-fn downcast_ad_op<'a>(
-    op: &'a dyn ExtensionOpTrait,
-    kind: ADRuleKind,
-) -> ADRuleResult<&'a LinalgExtensionOp> {
+fn downcast_ad_op(op: &dyn ExtensionOpTrait, kind: ADRuleKind) -> ADRuleResult<&LinalgExtensionOp> {
     op.as_any()
         .downcast_ref::<LinalgExtensionOp>()
         .ok_or_else(|| {

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -18,6 +18,7 @@ mod support;
 pub(crate) use solve::{
     linearize_full_piv_lu_solve, linearize_lu_solve_prepared, linearize_triangular_solve,
     transpose_full_piv_lu_solve, transpose_lu_solve_prepared, transpose_triangular_solve,
+    TriangularSolveFlags,
 };
 use support::*;
 
@@ -137,12 +138,7 @@ pub(crate) fn linearize_lu(
         take_leading_cols_linear(
             builder,
             dl_full,
-            k_size,
-            n_size,
-            batch_shape,
-            l.clone(),
-            &l_shape,
-            rank,
+            LeadingMatrixSlice::new(k_size, n_size, batch_shape, l.clone(), &l_shape, rank),
         )
     } else {
         dl_full
@@ -151,12 +147,7 @@ pub(crate) fn linearize_lu(
         take_leading_rows_linear(
             builder,
             du_full,
-            k_size,
-            m_size,
-            batch_shape,
-            u.clone(),
-            &u_shape,
-            rank,
+            LeadingMatrixSlice::new(k_size, m_size, batch_shape, u.clone(), &u_shape, rank),
         )
     } else {
         du_full
@@ -523,6 +514,7 @@ pub(crate) fn linearize_eigh(
     let matrix_rank = input_shape.len();
     let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
     let w = ValueRef::External(primal_out[0].clone());
+    let w_dtype = ctx.dtype_of(&w);
     let v = ValueRef::External(primal_out[1].clone());
     let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
 
@@ -542,6 +534,7 @@ pub(crate) fn linearize_eigh(
         matrix_rank,
     );
     let dw = extract_diag_linear(builder, projected);
+    let dw = convert_linear_to_dtype(builder, dw, dtype, w_dtype);
 
     let diag_w = embed_diag_fixed(builder, w.clone());
     let ones_mat = one_like_fixed(builder, ValueRef::Local(diag_w));
@@ -562,7 +555,8 @@ pub(crate) fn linearize_eigh(
     let eps_sq = fixed_scale(builder, ValueRef::Local(ones_mat), eps * eps);
     let safe_diff = fixed_add(builder, ValueRef::Local(diff_sq), ValueRef::Local(eps_sq));
     let f = fixed_div(builder, ValueRef::Local(diff), ValueRef::Local(safe_diff));
-    let fm = hadamard_fixed_linear(builder, ValueRef::Local(f), projected);
+    let f = convert_fixed_ref_to_dtype(builder, ValueRef::Local(f), w_dtype, dtype);
+    let fm = hadamard_fixed_linear(builder, f, projected);
     let dv = matmul_linear(
         builder,
         v,

--- a/crates/tenferro-linalg/src/ad/rules/solve.rs
+++ b/crates/tenferro-linalg/src/ad/rules/solve.rs
@@ -8,15 +8,52 @@ use crate::extension::LinalgOp;
 use super::support::*;
 use super::{conjugate_linear_if_dtype_complex, conjugate_primal_if_dtype_complex, linalg_std_op};
 
+#[derive(Clone, Copy)]
+pub(crate) struct TriangularSolveFlags {
+    pub(crate) left_side: bool,
+    pub(crate) lower: bool,
+    pub(crate) transpose_a: bool,
+    pub(crate) unit_diagonal: bool,
+}
+
+impl TriangularSolveFlags {
+    pub(crate) fn new(
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> Self {
+        Self {
+            left_side,
+            lower,
+            transpose_a,
+            unit_diagonal,
+        }
+    }
+
+    fn transposed(self) -> Self {
+        Self {
+            transpose_a: !self.transpose_a,
+            ..self
+        }
+    }
+
+    fn std_op(self) -> StdTensorOp {
+        linalg_std_op(LinalgOp::TriangularSolve {
+            left_side: self.left_side,
+            lower: self.lower,
+            transpose_a: self.transpose_a,
+            unit_diagonal: self.unit_diagonal,
+        })
+    }
+}
+
 pub(crate) fn linearize_triangular_solve(
     builder: &mut dyn PrimitiveRuleBuilder,
     primal_in: &[ValueKey<StdTensorOp>],
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
-    left_side: bool,
-    lower: bool,
-    transpose_a: bool,
-    unit_diagonal: bool,
+    flags: TriangularSolveFlags,
     ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     // Equation: op(A) @ X = B  (left_side=true)
@@ -43,27 +80,13 @@ pub(crate) fn linearize_triangular_solve(
         "linearize_triangular_solve: rank mismatch between lhs and rhs"
     );
     let rank = lhs_rank;
-    let rhs_tangent = triangular_solve_rhs_tangent(
-        builder,
-        primal_out,
-        tangent_in,
-        left_side,
-        lower,
-        transpose_a,
-        unit_diagonal,
-        rank,
-    );
+    let rhs_tangent = triangular_solve_rhs_tangent(builder, primal_out, tangent_in, flags, rank);
     let Some(rhs_tangent) = rhs_tangent else {
         return vec![None];
     };
 
     let out = builder.add_operation(
-        linalg_std_op(LinalgOp::TriangularSolve {
-            left_side,
-            lower,
-            transpose_a,
-            unit_diagonal,
-        }),
+        flags.std_op(),
         vec![
             ValueRef::External(primal_in[0].clone()),
             ValueRef::Local(rhs_tangent),
@@ -241,18 +264,15 @@ fn triangular_solve_rhs_tangent(
     builder: &mut dyn PrimitiveRuleBuilder,
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
-    left_side: bool,
-    lower: bool,
-    transpose_a: bool,
-    unit_diagonal: bool,
+    flags: TriangularSolveFlags,
     rank: usize,
 ) -> Option<LocalValueId> {
     let mut rhs_tangent = tangent_in[1];
 
     if let Some(da) = tangent_in[0] {
-        let da = project_triangular_operand_linear(builder, da, lower, unit_diagonal);
+        let da = project_triangular_operand_linear(builder, da, flags.lower, flags.unit_diagonal);
         // d(op(A)) = op(dA), with op = identity or transpose.
-        let d_op_a = if transpose_a {
+        let d_op_a = if flags.transpose_a {
             transpose_matrix_linear(builder, da, rank)
         } else {
             da
@@ -260,7 +280,7 @@ fn triangular_solve_rhs_tangent(
 
         // Correction = d(op(A)) @ X  or  X @ d(op(A))
         let x = ValueRef::External(primal_out[0].clone());
-        let correction = if left_side {
+        let correction = if flags.left_side {
             matmul_linear(builder, ValueRef::Local(d_op_a), x, vec![true, false], rank)
         } else {
             matmul_linear(builder, x, ValueRef::Local(d_op_a), vec![false, true], rank)
@@ -280,10 +300,7 @@ pub(crate) fn transpose_triangular_solve(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
-    left_side: bool,
-    lower: bool,
-    transpose_a: bool,
-    unit_diagonal: bool,
+    flags: TriangularSolveFlags,
     ctx: &mut ShapeGuardContext,
 ) -> Vec<Option<LocalValueId>> {
     let Some(ct) = cotangent_out[0] else {
@@ -298,12 +315,7 @@ pub(crate) fn transpose_triangular_solve(
         let dtype = ctx.dtype_of(&inputs[0]);
         let conjugated_a = conjugate_primal_if_dtype_complex(builder, inputs[0].clone(), dtype);
         let out = builder.add_operation(
-            linalg_std_op(LinalgOp::TriangularSolve {
-                left_side,
-                lower,
-                transpose_a: !transpose_a,
-                unit_diagonal,
-            }),
+            flags.transposed().std_op(),
             vec![conjugated_a, ValueRef::Local(ct)],
             OperationRole::Linearized {
                 active_mask: vec![false, true],
@@ -314,10 +326,10 @@ pub(crate) fn transpose_triangular_solve(
             let rank = ctx.shape_of(&inputs[0]).len();
             let solution = builder.add_operation(
                 linalg_std_op(LinalgOp::TriangularSolve {
-                    left_side,
-                    lower,
-                    transpose_a,
-                    unit_diagonal,
+                    left_side: flags.left_side,
+                    lower: flags.lower,
+                    transpose_a: flags.transpose_a,
+                    unit_diagonal: flags.unit_diagonal,
                 }),
                 inputs.to_vec(),
                 OperationRole::Primary,
@@ -326,13 +338,17 @@ pub(crate) fn transpose_triangular_solve(
                 builder,
                 rhs_cotangent,
                 ValueRef::Local(solution),
-                left_side,
-                transpose_a,
+                flags.left_side,
+                flags.transpose_a,
                 rank,
                 dtype,
             );
-            let matrix_cotangent =
-                project_triangular_operand_linear(builder, matrix_cotangent, lower, unit_diagonal);
+            let matrix_cotangent = project_triangular_operand_linear(
+                builder,
+                matrix_cotangent,
+                flags.lower,
+                flags.unit_diagonal,
+            );
             result[0] = Some(matrix_cotangent);
         }
         if active_mask[1] {

--- a/crates/tenferro-linalg/src/ad/rules/support.rs
+++ b/crates/tenferro-linalg/src/ad/rules/support.rs
@@ -141,6 +141,26 @@ pub(super) fn fixed_div(
     fixed_binary(builder, StdTensorOp::Div, lhs, rhs)
 }
 
+pub(super) fn convert_fixed_ref_to_dtype(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+    from: DType,
+    to: DType,
+) -> ValueRef<StdTensorOp> {
+    if from == to {
+        return input;
+    }
+    ValueRef::Local(
+        builder.add_operation(
+            StdTensorOp::Convert { from, to },
+            vec![input],
+            OperationRole::Linearized {
+                active_mask: vec![false],
+            },
+        )[0],
+    )
+}
+
 pub(super) fn fixed_scale(
     builder: &mut dyn PrimitiveRuleBuilder,
     input: ValueRef<StdTensorOp>,
@@ -255,6 +275,24 @@ pub(super) fn linear_div_fixed(
         vec![ValueRef::Local(lhs), rhs],
         OperationRole::Linearized {
             active_mask: vec![true, false],
+        },
+    )[0]
+}
+
+pub(super) fn convert_linear_to_dtype(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
+    from: DType,
+    to: DType,
+) -> LocalValueId {
+    if from == to {
+        return input;
+    }
+    builder.add_operation(
+        StdTensorOp::Convert { from, to },
+        vec![ValueRef::Local(input)],
+        OperationRole::Linearized {
+            active_mask: vec![true],
         },
     )[0]
 }
@@ -662,45 +700,76 @@ pub(super) fn augment_upper_to_square_fixed(
     )
 }
 
+pub(super) struct LeadingMatrixSlice<'a> {
+    leading: usize,
+    total: usize,
+    batch_shape: &'a [DimExpr],
+    anchor: ValueRef<StdTensorOp>,
+    anchor_shape: &'a [DimExpr],
+    rank: usize,
+}
+
+impl<'a> LeadingMatrixSlice<'a> {
+    pub(super) fn new(
+        leading: usize,
+        total: usize,
+        batch_shape: &'a [DimExpr],
+        anchor: ValueRef<StdTensorOp>,
+        anchor_shape: &'a [DimExpr],
+        rank: usize,
+    ) -> Self {
+        Self {
+            leading,
+            total,
+            batch_shape,
+            anchor,
+            anchor_shape,
+            rank,
+        }
+    }
+}
+
 pub(super) fn take_leading_cols_linear(
     builder: &mut dyn PrimitiveRuleBuilder,
     input: LocalValueId,
-    cols: usize,
-    total_cols: usize,
-    batch_shape: &[DimExpr],
-    anchor: ValueRef<StdTensorOp>,
-    anchor_shape: &[DimExpr],
-    rank: usize,
+    spec: LeadingMatrixSlice<'_>,
 ) -> LocalValueId {
-    let selector =
-        leading_column_selector_fixed(builder, cols, total_cols, batch_shape, anchor, anchor_shape);
-    let selector_t = transpose_matrix_fixed(builder, ValueRef::Local(selector), rank);
+    let selector = leading_column_selector_fixed(
+        builder,
+        spec.leading,
+        spec.total,
+        spec.batch_shape,
+        spec.anchor,
+        spec.anchor_shape,
+    );
+    let selector_t = transpose_matrix_fixed(builder, ValueRef::Local(selector), spec.rank);
     matmul_linear(
         builder,
         ValueRef::Local(input),
         ValueRef::Local(selector_t),
         vec![true, false],
-        rank,
+        spec.rank,
     )
 }
 
 pub(super) fn take_leading_rows_linear(
     builder: &mut dyn PrimitiveRuleBuilder,
     input: LocalValueId,
-    rows: usize,
-    total_rows: usize,
-    batch_shape: &[DimExpr],
-    anchor: ValueRef<StdTensorOp>,
-    anchor_shape: &[DimExpr],
-    rank: usize,
+    spec: LeadingMatrixSlice<'_>,
 ) -> LocalValueId {
-    let selector =
-        leading_column_selector_fixed(builder, rows, total_rows, batch_shape, anchor, anchor_shape);
+    let selector = leading_column_selector_fixed(
+        builder,
+        spec.leading,
+        spec.total,
+        spec.batch_shape,
+        spec.anchor,
+        spec.anchor_shape,
+    );
     matmul_linear(
         builder,
         ValueRef::Local(selector),
         ValueRef::Local(input),
         vec![false, true],
-        rank,
+        spec.rank,
     )
 }

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -463,9 +463,9 @@ impl LinalgBackend for CpuBackend {
                         Tensor::F64(t) => linalg::faer::svd(ctx.as_ref(), buffers, t)
                             .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
                         Tensor::C32(t) => linalg::faer::svd(ctx.as_ref(), buffers, t)
-                            .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
+                            .and_then(svd_c32_outputs_to_public_tensors),
                         Tensor::C64(t) => linalg::faer::svd(ctx.as_ref(), buffers, t)
-                            .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+                            .and_then(svd_c64_outputs_to_public_tensors),
                         _ => Err(unsupported_dtype("svd", input.dtype())),
                     })
                 }
@@ -483,9 +483,9 @@ impl LinalgBackend for CpuBackend {
                         Tensor::F64(t) => linalg::blas::svd(buffers, t)
                             .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
                         Tensor::C32(t) => linalg::blas::svd(buffers, t)
-                            .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
+                            .and_then(svd_c32_outputs_to_public_tensors),
                         Tensor::C64(t) => linalg::blas::svd(buffers, t)
-                            .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+                            .and_then(svd_c64_outputs_to_public_tensors),
                         _ => Err(unsupported_dtype("svd", input.dtype())),
                     })
                 }
@@ -987,6 +987,50 @@ fn complex64_real_part_tensor(values: TypedTensor<Complex64>) -> TypedTensor<f64
     );
     out.set_placement(values.placement().clone());
     out
+}
+
+fn svd_output_count_error(count: usize) -> Error {
+    Error::backend_failure("svd", format!("expected 3 outputs, got {count}"))
+}
+
+fn svd_c32_outputs_to_public_tensors(
+    outputs: Vec<TypedTensor<Complex32>>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    let count = outputs.len();
+    let mut outputs = outputs.into_iter();
+    match (
+        outputs.next(),
+        outputs.next(),
+        outputs.next(),
+        outputs.next(),
+    ) {
+        (Some(u), Some(values), Some(vt), None) => Ok(vec![
+            Tensor::C32(u),
+            Tensor::F32(complex32_real_part_tensor(values)),
+            Tensor::C32(vt),
+        ]),
+        _ => Err(svd_output_count_error(count)),
+    }
+}
+
+fn svd_c64_outputs_to_public_tensors(
+    outputs: Vec<TypedTensor<Complex64>>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    let count = outputs.len();
+    let mut outputs = outputs.into_iter();
+    match (
+        outputs.next(),
+        outputs.next(),
+        outputs.next(),
+        outputs.next(),
+    ) {
+        (Some(u), Some(values), Some(vt), None) => Ok(vec![
+            Tensor::C64(u),
+            Tensor::F64(complex64_real_part_tensor(values)),
+            Tensor::C64(vt),
+        ]),
+        _ => Err(svd_output_count_error(count)),
+    }
 }
 
 fn eigh_c32_outputs_to_public_tensors(outputs: Vec<TypedTensor<Complex32>>) -> Vec<Tensor> {

--- a/crates/tenferro-linalg/src/cpu/tests/dtype.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/dtype.rs
@@ -297,9 +297,18 @@ fn cpu_linalg_accepts_c32_happy_paths() {
     );
 
     let svd = backend.svd(&input).unwrap();
+    assert_eq!(svd[0].dtype(), DType::C32);
+    assert_eq!(svd[1].dtype(), DType::F32);
+    assert_eq!(svd[2].dtype(), DType::C32);
     assert_c32_slice_close(
         &matmul_c32(
-            &matmul_c32(c32_data(&svd[0]), &diag_c32(c32_data(&svd[1])), 3, 2, 2),
+            &matmul_c32(
+                c32_data(&svd[0]),
+                &diag_c32_from_real(f32_data(&svd[1])),
+                3,
+                2,
+                2,
+            ),
             c32_data(&svd[2]),
             3,
             2,

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -535,14 +535,23 @@ fn test_complex_svd() {
     let out = backend.svd(&input).unwrap();
 
     assert_eq!(out.len(), 3);
+    assert_eq!(out[0].dtype(), DType::C64);
+    assert_eq!(out[1].dtype(), DType::F64);
+    assert_eq!(out[2].dtype(), DType::C64);
     assert_eq!(out[0].shape(), &[3, 2]);
     assert_eq!(out[1].shape(), &[2]);
     assert_eq!(out[2].shape(), &[2, 2]);
 
     let u = matrix_c64_from_tensor(&out[0], 3, 2);
-    let s = vector_c64_from_tensor(&out[1], 2);
+    let s = vector_f64_from_tensor(&out[1], 2);
     let vt = matrix_c64_from_tensor(&out[2], 2, 2);
-    let recon = matmul_c64(&matmul_c64(&u, &diag_c64(&s), 3, 2, 2), &vt, 3, 2, 2);
+    let recon = matmul_c64(
+        &matmul_c64(&u, &diag_c64_from_real(&s), 3, 2, 2),
+        &vt,
+        3,
+        2,
+        2,
+    );
     for (actual, expected) in recon.iter().zip(input_data.iter()) {
         assert_c64_close_tol(*actual, *expected, 1.0e-9);
     }

--- a/crates/tenferro-linalg/src/cpu/tests/mod.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/mod.rs
@@ -219,6 +219,14 @@ fn batch_vector_f64_from_tensor(t: &Tensor, len: usize, batch_idx: usize) -> Vec
     out
 }
 
+fn vector_f64_from_tensor(t: &Tensor, len: usize) -> Vec<f64> {
+    let mut out = vec![0.0; len];
+    for (i, value) in out.iter_mut().enumerate().take(len) {
+        *value = get_f64(t, &[i]);
+    }
+    out
+}
+
 fn matrix_c64_from_tensor(t: &Tensor, rows: usize, cols: usize) -> Vec<Complex64> {
     let mut out = vec![Complex64::new(0.0, 0.0); rows * cols];
     for j in 0..cols {

--- a/crates/tenferro-linalg/tests/traced_ad_explicit.rs
+++ b/crates/tenferro-linalg/tests/traced_ad_explicit.rs
@@ -2,11 +2,15 @@
 
 use tenferro_ad::AdContext;
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
 use tenferro_tensor::TypedTensor;
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+}
+
+fn c64_tensor(shape: Vec<usize>, data: Vec<num_complex::Complex64>) -> Tensor {
+    Tensor::C64(TypedTensor::from_vec_col_major(shape, data))
 }
 
 fn get_f64_data(tensor: &Tensor) -> &[f64] {
@@ -152,7 +156,7 @@ fn svd_values_grad_matches_finite_diff() {
 
     let actual = get_f64_data(&out);
     assert_eq!(actual.len(), data.len());
-    for idx in 0..data.len() {
+    for (idx, actual_value) in actual.iter().enumerate().take(data.len()) {
         let expected = finite_diff_scalar(
             |xs| {
                 let input =
@@ -164,11 +168,11 @@ fn svd_values_grad_matches_finite_diff() {
             idx,
             1.0e-6,
         );
-        let diff = (actual[idx] - expected).abs();
+        let diff = (*actual_value - expected).abs();
         assert!(
             diff <= 1.0e-4,
             "idx {idx}: expected {expected}, got {}, diff {diff}",
-            actual[idx]
+            actual_value
         );
     }
 }
@@ -546,6 +550,29 @@ fn solve_and_triangular_solve_grad_use_extension_transpose_rules() {
         assert_eq!(result.shape(), &[2, 1]);
         assert_eq!(get_f64_data(result), &[0.5, 0.25]);
     }
+}
+
+#[test]
+fn complex_eigh_values_grad_executes_with_complex_input_dtype() {
+    let ad = ad_context();
+    let h = TracedTensor::from_tensor_concrete_shape(c64_tensor(
+        vec![2, 2],
+        vec![
+            num_complex::Complex64::new(3.0, 0.0),
+            num_complex::Complex64::new(0.2, -0.4),
+            num_complex::Complex64::new(0.2, 0.4),
+            num_complex::Complex64::new(2.0, 0.0),
+        ],
+    ));
+    let (values, _vectors) = tenferro_linalg::eigh(&h).unwrap();
+    let loss = values.reduce_sum(&[0]);
+
+    let grad = ad.grad(&loss, &h).unwrap();
+    let out = eval(&grad);
+
+    assert_eq!(out.dtype(), DType::C64);
+    assert_eq!(out.shape(), &[2, 2]);
+    assert_finite_tensor(&out);
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/traced_extension.rs
@@ -60,6 +60,40 @@ fn svd_executes_after_runtime_registration() {
 }
 
 #[test]
+fn complex_svd_runtime_singular_values_match_traced_real_dtype() {
+    let a = TracedTensor::from_tensor_concrete_shape(Tensor::C64(TypedTensor::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(3.0, 0.5),
+            Complex64::new(0.2, -0.4),
+            Complex64::new(-0.1, 0.3),
+            Complex64::new(2.0, -0.2),
+        ],
+    )));
+    let (_u, s, _vt) = tenferro_linalg::svd(&a).unwrap();
+    assert_eq!(s.dtype, DType::F64);
+
+    let weights = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
+        vec![2],
+        vec![0.5_f64, 2.0],
+    ));
+    let weighted = &s * &weights;
+
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile_many(&[&s, &weighted]).unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor
+        .register_extension(tenferro_linalg::register_runtime)
+        .unwrap();
+    let outputs = executor.run_many(&program).unwrap();
+
+    assert_eq!(outputs[0].dtype(), DType::F64);
+    assert_eq!(outputs[1].dtype(), DType::F64);
+    assert_eq!(outputs[0].shape(), &[2]);
+    assert_eq!(outputs[1].shape(), &[2]);
+}
+
+#[test]
 fn missing_runtime_reports_linalg_family() {
     let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
         vec![2, 2],

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -49,6 +49,7 @@ website:
           - text: "FFT (extension)"
             href: guides/tenferro-fft.md
           - guides/autodiff.md
+          - guides/complex-ad.md
           - guides/devices-and-gpu.md
           - guides/memory-order.md
           - text: "Parallelism and Caching"

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -85,6 +85,12 @@ tracked, it also matches the scalar loss `loss.backward()` workflow with
 accumulation semantics. Traced tenferro is the API for `torch.autograd.grad`,
 `jax.grad`, `jax.vjp`, `jax.jvp`, and higher-order compositions such as HVPs.
 
+For complex reverse-mode AD, tenferro uses a Hermitian real-inner-product
+cotangent representation. When comparing scalar `grad` values to JAX, the
+JAX-like value is `conj(tenferro_grad)` for the same scalar seed-`1`
+calculation. See [Complex Autodiff](../guides/complex-ad.md) for the full
+convention and VJP seed comparison.
+
 ### Compiler and executor ownership
 
 In tenferro, graph lowering state and backend runtime state are separate. That

--- a/docs/guides/autodiff.md
+++ b/docs/guides/autodiff.md
@@ -14,6 +14,10 @@ explicitly. For eager forward execution and scalar loss accumulation semantics, 
 - `jvp` for Jacobian-vector products
 - Higher-order AD via composition, such as `jvp(grad(f))` for HVPs
 
+For complex tensors, reverse-mode cotangents use tenferro's Hermitian
+real-inner-product convention. See [Complex Autodiff](complex-ad.md) before
+comparing `grad` or `vjp` values directly against JAX.
+
 Use `tenferro_ad::AdContext` to own the AD rule set used by a transform. Core
 tensor primitive rules are always available. Extension crates can provide owned
 JVP/VJP rule sets for their operations; `tenferro-linalg` exposes these through

--- a/docs/guides/complex-ad.md
+++ b/docs/guides/complex-ad.md
@@ -1,0 +1,134 @@
+# Complex Autodiff
+
+tenferro supports complex JVP, VJP, and scalar-loss gradient workflows, but
+complex reverse-mode values need one convention choice that is easy to miss
+when comparing against JAX.
+
+tenferro reverse mode represents cotangents under the Hermitian real inner
+product:
+
+```text
+<a, b> = Re(conj(a) * b)
+```
+
+For a holomorphic scalar map `y = f(z)`, this means:
+
+```text
+JVP: dy = f'(z) * dz
+VJP: dz_bar = y_bar * conj(f'(z))
+```
+
+So `grad` with the default scalar seed `1` returns the Hermitian-adjoint
+cotangent. For scalar seed-`1` cases, JAX's public `grad` presentation is the
+complex conjugate of tenferro's value:
+
+```text
+jax_like_grad = conj(tenferro_grad)
+```
+
+This is a representation difference for reverse-mode cotangents, not a local
+AD-rule failure. JVPs are directional derivatives and do not have this public
+cotangent-encoding ambiguity.
+
+## Examples
+
+The example below demonstrates:
+
+- `grad(sum(exp(z)))`, where tenferro returns `conj(exp(z))`,
+- `grad(sum(abs(z)^2))`, where tenferro returns `2z`,
+- a VJP with a non-real complex cotangent seed.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/complex_ad_convention.rs -->
+```rust
+use num_complex::{Complex64, ComplexFloat};
+use tenferro_ad::TracedTensorAdExt;
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+
+const TOL: f64 = 1.0e-12;
+
+fn assert_complex_close(actual: Complex64, expected: Complex64) {
+    let error = (actual - expected).norm();
+    assert!(
+        error < TOL,
+        "actual={actual}, expected={expected}, error={error}"
+    );
+}
+
+fn assert_complex_slice_close(actual: &[Complex64], expected: &[Complex64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (&actual, &expected) in actual.iter().zip(expected) {
+        assert_complex_close(actual, expected);
+    }
+}
+
+fn run(tensor: &TracedTensor) -> Result<Tensor, tenferro_runtime::Error> {
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(tensor)?;
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor.run(&program)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let z_data = vec![
+        Complex64::new(0.0, std::f64::consts::FRAC_PI_2),
+        Complex64::new(std::f64::consts::LN_2, 0.0),
+    ];
+    let z = TracedTensor::from_vec_col_major(vec![2], z_data.clone());
+
+    let holomorphic_loss = z.exp().reduce_sum(&[0]);
+    let tenferro_grad = holomorphic_loss.grad(&z)?;
+    let tenferro_grad_value = run(&tenferro_grad)?;
+    let expected_grad: Vec<_> = z_data.iter().map(|z| z.exp().conj()).collect();
+    assert_complex_slice_close(
+        tenferro_grad_value.as_slice::<Complex64>().unwrap(),
+        &expected_grad,
+    );
+
+    let magnitude = z.abs();
+    let real_loss = (&magnitude * &magnitude).reduce_sum(&[0]);
+    let real_loss_grad = real_loss.grad(&z)?;
+    let real_loss_grad_value = run(&real_loss_grad)?;
+    let expected_real_loss_grad: Vec<_> = z_data.iter().map(|z| *z * 2.0).collect();
+    assert_complex_slice_close(
+        real_loss_grad_value.as_slice::<Complex64>().unwrap(),
+        &expected_real_loss_grad,
+    );
+
+    let scalar_z = TracedTensor::from_vec_col_major(
+        vec![1],
+        vec![Complex64::new(0.0, std::f64::consts::FRAC_PI_2)],
+    );
+    let y = scalar_z.exp();
+    let seed = Complex64::new(2.0, -3.0);
+    let cotangent = TracedTensor::from_vec_col_major(vec![1], vec![seed]);
+    let vjp = y.vjp(&scalar_z, &cotangent);
+    let vjp_value = run(&vjp)?;
+    let expected_vjp = seed
+        * Complex64::new(0.0, std::f64::consts::FRAC_PI_2)
+            .exp()
+            .conj();
+    assert_complex_close(vjp_value.as_slice::<Complex64>().unwrap()[0], expected_vjp);
+
+    Ok(())
+}
+```
+<!-- end-snippet-source -->
+
+For non-real complex VJP cotangent seeds, the seed is part of the convention
+comparison. Calling tenferro with seed `y_bar` computes
+`y_bar * conj(f'(z))`. If you want to compare to a JAX-style public seed `c`
+for the same holomorphic scalar map, compare against
+`conj(tenferro_vjp(conj(c)))`.
+
+## Where This Matters
+
+Use this convention note when comparing:
+
+- `TracedTensorAdExt::grad` and `AdContext::grad` on complex scalar outputs,
+- `vjp` with complex cotangent seeds,
+- eager `EagerTensor::backward()` and stored `grad()` values for complex
+  scalar losses.
+
+For real-valued code, or for JVPs viewed as directional derivatives, there is
+no extra conjugation step to apply when comparing values.

--- a/docs/tutorial-code/Cargo.toml
+++ b/docs/tutorial-code/Cargo.toml
@@ -11,6 +11,7 @@ cpu-faer = ["tenferro-ad/cpu-faer", "tenferro-cpu/cpu-faer"]
 cpu-blas = ["tenferro-ad/cpu-blas", "tenferro-cpu/cpu-blas"]
 
 [dependencies]
+num-complex.workspace = true
 tenferro-ad = { path = "../../crates/tenferro-ad", default-features = false }
 tenferro-cpu = { path = "../../crates/tenferro-cpu", default-features = false }
 tenferro-runtime = { path = "../../crates/tenferro-runtime", default-features = false }
@@ -26,3 +27,7 @@ path = "src/bin/eager_autodiff_pytorch_style.rs"
 [[bin]]
 name = "traced_autodiff_jax_style"
 path = "src/bin/traced_autodiff_jax_style.rs"
+
+[[bin]]
+name = "complex_ad_convention"
+path = "src/bin/complex_ad_convention.rs"

--- a/docs/tutorial-code/src/bin/complex_ad_convention.rs
+++ b/docs/tutorial-code/src/bin/complex_ad_convention.rs
@@ -1,0 +1,72 @@
+use num_complex::{Complex64, ComplexFloat};
+use tenferro_ad::TracedTensorAdExt;
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+
+const TOL: f64 = 1.0e-12;
+
+fn assert_complex_close(actual: Complex64, expected: Complex64) {
+    let error = (actual - expected).norm();
+    assert!(
+        error < TOL,
+        "actual={actual}, expected={expected}, error={error}"
+    );
+}
+
+fn assert_complex_slice_close(actual: &[Complex64], expected: &[Complex64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (&actual, &expected) in actual.iter().zip(expected) {
+        assert_complex_close(actual, expected);
+    }
+}
+
+fn run(tensor: &TracedTensor) -> Result<Tensor, tenferro_runtime::Error> {
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(tensor)?;
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor.run(&program)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let z_data = vec![
+        Complex64::new(0.0, std::f64::consts::FRAC_PI_2),
+        Complex64::new(std::f64::consts::LN_2, 0.0),
+    ];
+    let z = TracedTensor::from_vec_col_major(vec![2], z_data.clone());
+
+    let holomorphic_loss = z.exp().reduce_sum(&[0]);
+    let tenferro_grad = holomorphic_loss.grad(&z)?;
+    let tenferro_grad_value = run(&tenferro_grad)?;
+    let expected_grad: Vec<_> = z_data.iter().map(|z| z.exp().conj()).collect();
+    assert_complex_slice_close(
+        tenferro_grad_value.as_slice::<Complex64>().unwrap(),
+        &expected_grad,
+    );
+
+    let magnitude = z.abs();
+    let real_loss = (&magnitude * &magnitude).reduce_sum(&[0]);
+    let real_loss_grad = real_loss.grad(&z)?;
+    let real_loss_grad_value = run(&real_loss_grad)?;
+    let expected_real_loss_grad: Vec<_> = z_data.iter().map(|z| *z * 2.0).collect();
+    assert_complex_slice_close(
+        real_loss_grad_value.as_slice::<Complex64>().unwrap(),
+        &expected_real_loss_grad,
+    );
+
+    let scalar_z = TracedTensor::from_vec_col_major(
+        vec![1],
+        vec![Complex64::new(0.0, std::f64::consts::FRAC_PI_2)],
+    );
+    let y = scalar_z.exp();
+    let seed = Complex64::new(2.0, -3.0);
+    let cotangent = TracedTensor::from_vec_col_major(vec![1], vec![seed]);
+    let vjp = y.vjp(&scalar_z, &cotangent);
+    let vjp_value = run(&vjp)?;
+    let expected_vjp = seed
+        * Complex64::new(0.0, std::f64::consts::FRAC_PI_2)
+            .exp()
+            .conj();
+    assert_complex_close(vjp_value.as_slice::<Complex64>().unwrap()[0], expected_vjp);
+
+    Ok(())
+}

--- a/docs/tutorial-code/tests/tutorial_binaries.rs
+++ b/docs/tutorial-code/tests/tutorial_binaries.rs
@@ -27,4 +27,8 @@ fn tutorial_binaries_run_successfully() {
         "traced_autodiff_jax_style",
         env!("CARGO_BIN_EXE_traced_autodiff_jax_style"),
     );
+    run_tutorial(
+        "complex_ad_convention",
+        env!("CARGO_BIN_EXE_complex_ad_convention"),
+    );
 }

--- a/docs/worklogs/2026-06-11-issues-994-996.md
+++ b/docs/worklogs/2026-06-11-issues-994-996.md
@@ -1,0 +1,95 @@
+# Issues 994, 995, And 996 Batch
+
+## Session Summary
+
+This batch addressed GitHub issues #994, #995, and #996 from `origin/main`
+`1bedb0fb`.
+
+- #994 requested public documentation for the complex reverse-mode AD
+  convention, including the Hermitian real inner product, scalar seed-`1`
+  comparison to JAX, and non-real VJP seed comparison.
+- #995 reported that CPU complex `svd` returned the singular-value tensor as a
+  complex runtime tensor even though the traced metadata and public contract
+  expose singular values as real.
+- #996 reported a complex `eigh` reverse-AD dtype mismatch after complex
+  eigenvalues became real public tensors. The linearized `eigh` rule mixed real
+  eigenvalue tangents and gap matrices with complex projected vector terms.
+- The batch also fixed pre-existing clippy warnings surfaced by the repository
+  CI command while preparing the PR.
+
+## Context Read
+
+- `AGENTS.md`
+- `README.md`
+- `REPOSITORY_RULES.md`
+- shared tensor4all common, Rust, performance, docs/tests, and numerical rules
+- `ai/contribution-workflows/bugfix-pr.md`
+- `docs/spec/ad-contract.md`
+- GitHub issues #994, #995, and #996 bodies
+- `crates/tenferro-linalg/src/cpu/backend.rs`
+- `crates/tenferro-linalg/src/ad/rules/mod.rs`
+- `crates/tenferro-linalg/src/ad/rules/support.rs`
+- linalg CPU dtype, traced extension, and traced AD regression tests
+- `docs/tutorial-code/` executable documentation harness
+
+## Decisions Made
+
+- Kept the lower SVD provider traits unchanged. They still return homogeneous
+  `Vec<TypedTensor<T>>` values, and the CPU backend boundary converts only the
+  public singular-value tensor from complex storage to the matching real dtype.
+  This mirrors the existing complex `eigh` boundary conversion and avoids a
+  broader provider-trait refactor.
+- Made `linearize_eigh` explicit about the real/complex boundary. Eigenvalue
+  tangents are converted to the eigenvalue dtype, while the fixed eigenvalue
+  gap matrix is converted back to the input dtype before it multiplies complex
+  projected-vector terms.
+- Documented the existing complex AD convention instead of changing semantics:
+  reverse mode uses `<a, b> = Re(conj(a) * b)`, holomorphic JVPs use
+  `f'(z) * dz`, and holomorphic VJPs use `y_bar * conj(f'(z))`.
+- Added the public guide as executable tutorial-code-backed documentation, so
+  the examples for `grad(sum(exp(z)))`, `grad(sum(abs(z)^2))`, and non-real VJP
+  seeds are checked by the tutorial binary harness.
+- Added short API-doc pointers from traced and eager AD surfaces to the public
+  complex AD guide rather than duplicating the full convention in every doc
+  comment.
+- Removed pre-existing clippy warnings by grouping triangular-solve AD flags
+  and leading-matrix-slice metadata into internal helper structs, eliding an
+  unnecessary lifetime, and replacing a range-index test loop with iteration.
+
+## Rejected Or Deferred Alternatives
+
+- Did not refactor the CPU SVD provider interface to return heterogeneous
+  output types. The issue was at the public backend boundary and could be fixed
+  there with lower risk.
+- Did not change tenferro's complex reverse-mode convention to match another
+  library's public presentation. The existing AD spec remains the normative
+  source of truth.
+- Did not add new public APIs or AD semantics. The batch fixes dtype handling
+  and documents the existing convention.
+
+## Verification Performed
+
+- `cargo test -p tenferro-linalg cpu_linalg_accepts_c32_happy_paths`
+- `cargo test -p tenferro-linalg --test traced_extension complex_svd_runtime_singular_values_match_traced_real_dtype -- --exact`
+- `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit complex_eigh_values_grad_executes_with_complex_input_dtype -- --exact`
+- `cargo test -p tenferro-linalg --test traced_extension`
+- `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit`
+- `cargo test -p tenferro-linalg --features autodiff`
+- `cargo run -p tenferro-tutorial-code --bin complex_ad_convention`
+- `cargo test -p tenferro-tutorial-code`
+- `cargo test -p tenferro-ad --doc`
+- `python3 scripts/check-doc-snippets.py`
+- `python3 scripts/check-doc-snippets.py --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all --check`
+- `git diff --check`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+
+## Remaining Risks
+
+- CUDA ignored tests were not run because this batch does not change CUDA
+  kernels and ordinary CI does not execute ignored GPU tests.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #994
Fixes #995
Fixes #996

## Summary

- Document the public complex reverse-mode AD convention, including the Hermitian real inner product, scalar seed-`1` JAX comparison, and non-real VJP seed comparison.
- Return real singular-value tensors from CPU complex SVD (`C32 -> F32`, `C64 -> F64`) so runtime values match traced metadata and downstream real operations.
- Fix complex `eigh` reverse-AD dtype boundaries by converting eigenvalue tangents to the real eigenvalue dtype and gap matrices back to the complex input dtype where needed.
- Clear pre-existing workspace clippy `-D warnings` failures by grouping internal linalg AD helper arguments, eliding an unnecessary lifetime, and replacing one range-index loop.

## Work log

- `docs/worklogs/2026-06-11-issues-994-996.md`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.

## Verification

- `cargo test -p tenferro-linalg cpu_linalg_accepts_c32_happy_paths`
- `cargo test -p tenferro-linalg --test traced_extension complex_svd_runtime_singular_values_match_traced_real_dtype -- --exact`
- `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit complex_eigh_values_grad_executes_with_complex_input_dtype -- --exact`
- `cargo test -p tenferro-linalg --features autodiff`
- `cargo run -p tenferro-tutorial-code --bin complex_ad_convention`
- `cargo test -p tenferro-tutorial-code`
- `cargo test -p tenferro-ad --doc`
- `python3 scripts/check-doc-snippets.py --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
