### PR TITLE
[codex] Batch AI issue remediation

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -359,9 +359,9 @@ Tests follow implementation ownership.
 - CPU provider features are additive. At least one of `cpu-faer` or `cpu-blas`
   must be enabled; enabling both is valid and must compile. `CpuBackend` owns
   the runtime provider selection. `CpuBackend::new()` selects the default
-  compiled provider (`cpu-faer` when present), and explicit constructors or
-  application configuration select BLAS/LAPACK when that provider is compiled
-  and linked.
+  compiled provider (BLAS/LAPACK when `cpu-blas` is compiled, otherwise
+  `cpu-faer`), and explicit constructors or application configuration select a
+  different compiled provider when needed.
 
 ### Tensor Core Data Model
 

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -16,7 +16,7 @@ use tenferro_runtime::ad_support::{
 };
 use tenferro_runtime::{Error, GraphCompiler, GraphExecutor, Result, TracedTensor};
 use tenferro_tensor::TensorBackend;
-use tidu::{try_linear_transpose, try_linearize};
+use tidu::{try_linear_transpose, try_linearize, ADRuleError};
 
 static NEXT_DIFF_PASS_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -39,6 +39,14 @@ fn shape_guard_context(extension_rules: Option<&ExtensionRuleSet>) -> ShapeGuard
     match extension_rules {
         Some(rules) => ctx.with_extension_rules(rules.clone()),
         None => ctx,
+    }
+}
+
+fn vjp_error_from_linearize(err: ADRuleError) -> Error {
+    match err {
+        ADRuleError::Unsupported { op, .. } => {
+            Error::Internal(format!("unsupported vjp AD rule for {op}"))
+        }
     }
 }
 
@@ -555,7 +563,7 @@ fn vjp_optional_result_with_rules(
         &mut ad_ctx,
         &aliases,
     )
-    .map_err(|err| Error::Internal(err.to_string()))?;
+    .map_err(vjp_error_from_linearize)?;
     if linear.tangent_outputs()[0].is_none() {
         return Ok(None);
     }

--- a/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
+++ b/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
@@ -113,7 +113,13 @@ fn apply_eager_rejects_mismatched_output_count() {
         Err(err) => err,
     };
 
-    assert!(err.to_string().contains("expected 2 eager outputs"));
+    let message = err.to_string();
+    assert!(
+        message.contains("tenferro-tests.bad_output_count.v1"),
+        "{message}"
+    );
+    assert!(message.contains("runtime returned 1 outputs"), "{message}");
+    assert!(message.contains("op declared 2 outputs"), "{message}");
 }
 
 #[test]

--- a/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
+++ b/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
@@ -81,6 +81,26 @@ fn apply_eager_reports_missing_extension_runtime() {
 }
 
 #[test]
+fn apply_eager_untracked_forward_returns_untracked_result() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    register_test_eager_runtime(&ctx, "tenferro-tests.scale_by_2.v1");
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        ctx,
+    );
+
+    let y = apply_eager(Arc::new(TestScaleBy2), &[&x])
+        .expect("untracked eager extension apply")
+        .into_iter()
+        .next()
+        .expect("single eager extension output");
+
+    assert!(!y.tracks_grad());
+    assert_eq!(y.shape(), &[3]);
+    assert_eq!(f64_slice(y.data()), &[2.0, 4.0, 6.0]);
+}
+
+#[test]
 fn graph_executor_reports_missing_extension_runtime() {
     let x = TracedTensor::from_vec_col_major(vec![1], vec![1.0_f64]);
     let y = apply(Arc::new(TestScaleBy2), &[&x])

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -393,7 +393,7 @@ impl ExtensionAdRuleTrait for FftAdRule {
         let fft_op = fft_payload(op, ADRuleKind::Jvp)?;
         if !matches!(fft_op.kind, FftKind::C2C { .. }) {
             return Err(ADRuleError::unsupported(
-                FFT_EXTENSION_FAMILY_ID,
+                fft_ad_family_id(fft_op.kind),
                 ADRuleKind::Jvp,
             ));
         }
@@ -425,7 +425,7 @@ impl ExtensionAdRuleTrait for FftAdRule {
         let fft_op = fft_payload(op, ADRuleKind::Transpose)?;
         if !matches!(fft_op.kind, FftKind::C2C { .. }) {
             return Err(ADRuleError::unsupported(
-                FFT_EXTENSION_FAMILY_ID,
+                fft_ad_family_id(fft_op.kind),
                 ADRuleKind::Transpose,
             ));
         }
@@ -713,6 +713,15 @@ fn fft_op_name(kind: FftKind) -> &'static str {
         FftKind::C2C { forward: false } => "ifft",
         FftKind::R2C { .. } => "rfft",
         FftKind::C2R => "irfft",
+    }
+}
+
+#[cfg(feature = "autodiff")]
+fn fft_ad_family_id(kind: FftKind) -> &'static str {
+    match kind {
+        FftKind::C2C { .. } => FFT_EXTENSION_FAMILY_ID,
+        FftKind::R2C { .. } => "tenferro-fft.rfft.v1",
+        FftKind::C2R => "tenferro-fft.irfft.v1",
     }
 }
 

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -428,3 +428,62 @@ fn ifft_c64_vjp_uses_forward_transform_with_adjoint_normalization() {
         ],
     );
 }
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn rfft_vjp_unsupported_error_names_rfft_and_vjp() {
+    let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let cotangent = TracedTensor::from_vec_col_major(
+        vec![3],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.5, -1.0),
+            Complex64::new(2.0, 0.0),
+        ],
+    );
+
+    let y = rfft(&x, None, -1, FftNorm::Backward).unwrap();
+    let err = match y.vjp_optional_result(&x, &cotangent) {
+        Ok(_) => panic!("rfft VJP should remain unsupported"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+
+    assert!(
+        message.contains("unsupported vjp AD rule for tenferro-fft.rfft.v1"),
+        "{message}"
+    );
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn irfft_jvp_unsupported_error_names_irfft_and_jvp() {
+    let spectrum = TracedTensor::from_vec_col_major(
+        vec![3],
+        vec![
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+        ],
+    );
+    let tangent = TracedTensor::from_vec_col_major(
+        vec![3],
+        vec![
+            Complex64::new(0.0, 0.0),
+            Complex64::new(1.0, -0.5),
+            Complex64::new(0.0, 0.0),
+        ],
+    );
+
+    let y = irfft(&spectrum, Some(4), -1, FftNorm::Backward).unwrap();
+    let err = match y.jvp_optional_result(&spectrum, &tangent) {
+        Ok(_) => panic!("irfft JVP should remain unsupported"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+
+    assert!(
+        message.contains("unsupported jvp AD rule for tenferro-fft.irfft.v1"),
+        "{message}"
+    );
+}

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -44,9 +44,15 @@ pub trait LinalgBackend: TensorBackend {
     }
 
     /// Compute complete-pivot LU outputs `(P, L, U, Q, parity)`.
+    ///
+    /// The reconstruction convention is `A = P * L * U * Q`. `parity` is a
+    /// rank-0 `F64` tensor containing `1.0` or `-1.0`.
     fn full_piv_lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
     /// Solve a linear system through the complete-pivot LU path.
+    ///
+    /// With `transpose_a = false`, this solves `A * x = b`. With
+    /// `transpose_a = true`, this solves `A^T * x = b`.
     fn full_piv_lu_solve(
         &mut self,
         a: &Tensor,
@@ -96,9 +102,15 @@ pub trait LinalgBackend: TensorBackend {
     }
 
     /// Compute public QR outputs `(Q, R)`.
+    ///
+    /// QR is thin: for an `m x n` input, `Q` has shape `m x min(m, n)` and
+    /// `R` has shape `min(m, n) x n`.
     fn qr(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
     /// Compute public Hermitian eigendecomposition outputs `(values, vectors)`.
+    ///
+    /// The returned vector order is `[values, vectors]`, where `values` has
+    /// shape `[n]` and `vectors` has shape `[n, n]`.
     fn eigh(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
     #[doc(hidden)]

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -812,6 +812,7 @@ impl LinalgBackend for CpuBackend {
     fn solve(&mut self, a: &Tensor, b: &Tensor) -> tenferro_tensor::Result<Tensor> {
         ensure_host_tensor("solve", a)?;
         ensure_host_tensor("solve", b)?;
+        ensure_supported_linalg_pair("solve", a, b)?;
         if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
             return Ok(zeros_like_tensor(b));
         }

--- a/crates/tenferro-linalg/tests/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/backend_errors.rs
@@ -536,6 +536,34 @@ fn cpu_linalg_rejects_backend_rhs_before_zero_dim_fast_paths() {
 }
 
 #[test]
+fn solve_rejects_invalid_dtype_pairs_before_zero_dim_fast_path() {
+    let mut backend = CpuBackend::new();
+    let f64_a = f64_tensor(vec![0, 0], Vec::new());
+    let c64_b = c64_tensor(vec![0, 1], Vec::new());
+    let i32_a = i32_tensor(vec![0, 0], Vec::new());
+    let i32_b = i32_tensor(vec![0, 1], Vec::new());
+
+    let err = backend.solve(&f64_a, &c64_b).unwrap_err();
+    assert!(matches!(
+        err,
+        Error::DTypeMismatch {
+            op: "solve",
+            lhs: DType::F64,
+            rhs: DType::C64,
+        }
+    ));
+
+    let err = backend.solve(&i32_a, &i32_b).unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "solve",
+            ref message,
+        } if message.contains("unsupported dtype I32")
+    ));
+}
+
+#[test]
 fn cholesky_rejects_rank_less_than_two_even_when_zero_dim() {
     let input = f64_tensor(vec![0], Vec::new());
     let mut backend = CpuBackend::new();

--- a/crates/tenferro-runtime/src/exec.rs
+++ b/crates/tenferro-runtime/src/exec.rs
@@ -98,19 +98,19 @@ impl<'a> ExecSlot<'a> {
         }
     }
 
-    pub(crate) fn into_tensor(self) -> Tensor {
+    pub(crate) fn into_tensor(self) -> Result<Tensor> {
         match self {
-            Self::Owned(tensor) => tensor,
-            Self::Value(value) => value.to_tensor(),
-            Self::Read(read) => read.to_tensor(),
+            Self::Owned(tensor) => Ok(tensor),
+            Self::Value(value) => Ok(value.try_to_tensor()?),
+            Self::Read(read) => Ok(read.try_to_tensor()?),
         }
     }
 
-    pub(crate) fn into_value(self) -> TensorValue {
+    pub(crate) fn into_value(self) -> Result<TensorValue> {
         match self {
-            Self::Owned(tensor) => TensorValue::from_tensor(tensor),
-            Self::Value(value) => value,
-            Self::Read(read) => TensorValue::from_tensor(read.to_tensor()),
+            Self::Owned(tensor) => Ok(TensorValue::from_tensor(tensor)),
+            Self::Value(value) => Ok(value),
+            Self::Read(read) => Ok(TensorValue::from_tensor(read.try_to_tensor()?)),
         }
     }
 }
@@ -165,10 +165,10 @@ pub(crate) fn collect_outputs_from<'input>(
         .output_slots
         .iter()
         .map(|&slot| {
-            slots[slot]
+            let value = slots[slot]
                 .take()
-                .map(ExecSlot::into_tensor)
-                .ok_or(TensorError::MissingValue { slot }.into())
+                .ok_or(TensorError::MissingValue { slot })?;
+            value.into_tensor()
         })
         .collect()
 }
@@ -181,10 +181,10 @@ pub(crate) fn collect_output_values_from<'input>(
         .output_slots
         .iter()
         .map(|&slot| {
-            slots[slot]
+            let value = slots[slot]
                 .take()
-                .map(ExecSlot::into_value)
-                .ok_or(TensorError::MissingValue { slot }.into())
+                .ok_or(TensorError::MissingValue { slot })?;
+            value.into_value()
         })
         .collect()
 }
@@ -271,10 +271,10 @@ fn tensor_value_for_lazy_view<'input>(
     consume: bool,
 ) -> Result<TensorValue> {
     if consume {
-        return slots[slot]
+        let value = slots[slot]
             .take()
-            .map(ExecSlot::into_value)
-            .ok_or(TensorError::MissingValue { slot }.into());
+            .ok_or(TensorError::MissingValue { slot })?;
+        return value.into_value();
     }
 
     match slots[slot].take() {
@@ -290,7 +290,7 @@ fn tensor_value_for_lazy_view<'input>(
             Ok(output)
         }
         Some(ExecSlot::Read(read)) => {
-            let output = TensorValue::from_tensor(read.to_tensor());
+            let output = TensorValue::from_tensor(read.try_to_tensor()?);
             slots[slot] = Some(ExecSlot::Read(read));
             Ok(output)
         }

--- a/crates/tenferro-runtime/src/extension.rs
+++ b/crates/tenferro-runtime/src/extension.rs
@@ -27,7 +27,7 @@ use tenferro_ops::SymDim;
 use tenferro_tensor::{Tensor, TensorBackend};
 
 use crate::checkpoint::CheckpointNode;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::metadata::{push_metadata_scope, register_scoped_graph_metadata};
 use crate::traced::{next_traced_id, TracedTensor};
 
@@ -192,6 +192,13 @@ pub fn apply_expanded_graph(
         .map(|t| ValueRef::External(t.graph.values()[t.val].key.clone()))
         .collect();
     let outputs = build(&mut builder, &op_inputs)?;
+    if outputs.len() != output_metas.len() {
+        return Err(Error::Internal(format!(
+            "extension expanded graph returned {} outputs for {} output metadata entries",
+            outputs.len(),
+            output_metas.len()
+        )));
+    }
     builder.set_outputs(outputs.clone());
     let graph = Arc::new(builder.build());
     Ok(traced_outputs_from_graph(

--- a/crates/tenferro-runtime/src/extension/tests.rs
+++ b/crates/tenferro-runtime/src/extension/tests.rs
@@ -26,3 +26,20 @@ fn apply_expanded_graph_builds_standard_op_without_extension() {
         .iter()
         .all(|node| !matches!(node.operation, StdTensorOp::Extension(_))));
 }
+
+#[test]
+fn apply_expanded_graph_rejects_output_metadata_count_mismatch() {
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+
+    let result = apply_expanded_graph(&[&x], vec![], |builder, inputs| {
+        Ok(builder.add_operation(StdTensorOp::Neg, inputs.to_vec(), OperationRole::Primary))
+    });
+    let Err(err) = result else {
+        panic!("expanded graph output metadata mismatch should error");
+    };
+
+    let message = err.to_string();
+    assert!(message.contains("expanded graph"), "{message}");
+    assert!(message.contains("returned 1 outputs"), "{message}");
+    assert!(message.contains("0 output metadata entries"), "{message}");
+}

--- a/crates/tenferro-runtime/src/extension_runtime.rs
+++ b/crates/tenferro-runtime/src/extension_runtime.rs
@@ -142,7 +142,7 @@ pub trait ExtensionRuntime<B: TensorBackend + 'static>: Debug + Send + Sync + 's
         inputs: &[TensorRead<'_>],
         ctx: &mut ExtensionExecutionContext<'_, B>,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        let concrete_inputs = concrete_tensor_reads(inputs);
+        let concrete_inputs = concrete_tensor_reads(inputs)?;
         let input_refs: Vec<&Tensor> = concrete_inputs
             .iter()
             .map(ConcreteTensorRead::tensor)
@@ -165,14 +165,36 @@ impl ConcreteTensorRead<'_> {
     }
 }
 
-fn concrete_tensor_reads<'a>(inputs: &[TensorRead<'a>]) -> Vec<ConcreteTensorRead<'a>> {
-    inputs
-        .iter()
-        .map(|input| match input {
+fn concrete_tensor_reads<'a>(
+    inputs: &[TensorRead<'a>],
+) -> tenferro_tensor::Result<Vec<ConcreteTensorRead<'a>>> {
+    let mut concrete_inputs = Vec::with_capacity(inputs.len());
+    for input in inputs {
+        concrete_inputs.push(match input {
             TensorRead::Tensor(tensor) => ConcreteTensorRead::Borrowed(tensor),
-            TensorRead::View(view) => ConcreteTensorRead::Owned(Box::new(view.to_tensor())),
-        })
-        .collect()
+            TensorRead::View(view) => ConcreteTensorRead::Owned(Box::new(view.try_to_tensor()?)),
+        });
+    }
+    Ok(concrete_inputs)
+}
+
+fn validate_runtime_output_count(
+    op: &dyn ExtensionOp,
+    outputs: Vec<Tensor>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    let expected = op.output_count();
+    if outputs.len() != expected {
+        return Err(tenferro_tensor::Error::InvalidConfig {
+            op: "extension",
+            message: format!(
+                "family_id {:?}: runtime returned {} outputs but op declared {} outputs",
+                op.family_id(),
+                outputs.len(),
+                expected
+            ),
+        });
+    }
+    Ok(outputs)
 }
 
 /// Registry of backend-specific extension runtime executors.
@@ -318,7 +340,7 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
             });
         };
         let mut ctx = ExtensionExecutionContext::new(backend, &mut self.caches);
-        executor.execute(op, inputs, &mut ctx)
+        validate_runtime_output_count(op, executor.execute(op, inputs, &mut ctx)?)
     }
 
     /// Execute an extension using borrowed tensor reads.
@@ -425,7 +447,7 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
             });
         };
         let mut ctx = ExtensionExecutionContext::new(backend, &mut self.caches);
-        executor.execute_reads(op, inputs, &mut ctx)
+        validate_runtime_output_count(op, executor.execute_reads(op, inputs, &mut ctx)?)
     }
 
     /// Clear every runtime extension cache entry.

--- a/crates/tenferro-runtime/tests/extension_runtime.rs
+++ b/crates/tenferro-runtime/tests/extension_runtime.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::hash::Hasher;
 use std::num::NonZeroUsize;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use tenferro_cpu::CpuBackend;
@@ -10,7 +11,10 @@ use tenferro_runtime::{
     ExtensionCacheKey, ExtensionCacheLimits, ExtensionCacheSelector, ExtensionExecutionContext,
     ExtensionExecutor, ExtensionRegistry, ExtensionRuntime, ExtensionRuntimeRegistryError,
 };
-use tenferro_tensor::{DType, Tensor, TensorOwnedView, TensorRead};
+use tenferro_tensor::{
+    Buffer, BufferHandle, DType, MemoryKind, Placement, Tensor, TensorOwnedView, TensorRead,
+    TypedTensor,
+};
 
 #[derive(Clone, Debug)]
 struct IdentityRuntimeOp {
@@ -88,6 +92,29 @@ impl ExtensionRuntime<CpuBackend> for IdentityRuntime {
     }
 }
 
+#[derive(Debug)]
+struct WrongOutputCountRuntime {
+    family: &'static str,
+    return_count: usize,
+}
+
+impl ExtensionRuntime<CpuBackend> for WrongOutputCountRuntime {
+    fn family_id(&self) -> &'static str {
+        self.family
+    }
+
+    fn execute(
+        &self,
+        _op: &dyn ExtensionOp,
+        inputs: &[&Tensor],
+        _ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Ok(std::iter::repeat_with(|| inputs[0].clone())
+            .take(self.return_count)
+            .collect())
+    }
+}
+
 #[test]
 fn extension_registry_rejects_malformed_and_is_idempotent() {
     let mut registry = ExtensionRegistry::<CpuBackend>::new();
@@ -151,6 +178,100 @@ fn extension_executor_executes_registered_runtime_and_manages_caches() {
 
     executor.clear_caches();
     assert_eq!(executor.cache_stats().entries, 0);
+}
+
+#[test]
+fn extension_executor_rejects_runtime_output_count_mismatch() {
+    let family = "runtime.output-count.v1";
+    let mut registry = ExtensionRegistry::<CpuBackend>::new();
+    registry
+        .register(Arc::new(WrongOutputCountRuntime {
+            family,
+            return_count: 0,
+        }))
+        .expect("runtime registration");
+    let mut executor = ExtensionExecutor::with_parts(registry, Default::default());
+    let mut backend = CpuBackend::new();
+    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]);
+
+    let err = executor
+        .execute(&mut backend, &IdentityRuntimeOp { family }, &[&input])
+        .expect_err("runtime output count mismatch should error");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("family_id \"runtime.output-count.v1\""),
+        "{message}"
+    );
+    assert!(message.contains("returned 0 outputs"), "{message}");
+    assert!(message.contains("declared 1 outputs"), "{message}");
+}
+
+#[test]
+fn extension_executor_rejects_read_runtime_output_count_mismatch() {
+    let family = "runtime.read-output-count.v1";
+    let mut registry = ExtensionRegistry::<CpuBackend>::new();
+    registry
+        .register(Arc::new(WrongOutputCountRuntime {
+            family,
+            return_count: 2,
+        }))
+        .expect("runtime registration");
+    let mut executor = ExtensionExecutor::with_parts(registry, Default::default());
+    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]);
+    let read = TensorRead::from_tensor(&input);
+    let mut backend = CpuBackend::new();
+
+    let err = executor
+        .execute_reads(&mut backend, &IdentityRuntimeOp { family }, &[read])
+        .expect_err("runtime read output count mismatch should error");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("family_id \"runtime.read-output-count.v1\""),
+        "{message}"
+    );
+    assert!(message.contains("returned 2 outputs"), "{message}");
+    assert!(message.contains("declared 1 outputs"), "{message}");
+}
+
+#[test]
+fn extension_executor_read_fallback_reports_backend_view_materialization_error_without_panic() {
+    let family = "runtime.backend-view.v1";
+    let mut registry = ExtensionRegistry::<CpuBackend>::new();
+    registry
+        .register(Arc::new(IdentityRuntime { family }))
+        .expect("runtime registration");
+    let mut executor = ExtensionExecutor::with_parts(registry, Default::default());
+    let base = Arc::new(Tensor::F64(TypedTensor::<f64>::from_buffer_col_major(
+        vec![1],
+        Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(91, 1))),
+        Placement {
+            memory_kind: MemoryKind::Device,
+            device: None,
+        },
+    )));
+    let view = TensorOwnedView::from_tensor(base);
+    let read = view.tensor_read();
+    let mut backend = CpuBackend::new();
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        executor.execute_reads(&mut backend, &IdentityRuntimeOp { family }, &[read])
+    }));
+
+    assert!(
+        result.is_ok(),
+        "backend view materialization should return Err, not panic"
+    );
+    let err = result
+        .unwrap()
+        .expect_err("backend view materialization should error");
+    let message = err.to_string();
+    assert!(
+        message.contains("backend buffers cannot be materialized"),
+        "{message}"
+    );
+    assert!(message.contains("download explicitly first"), "{message}");
 }
 
 #[test]

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -554,8 +554,8 @@ pub trait TensorDot: TensorElementwise {
         match (lhs.as_tensor(), rhs.as_tensor()) {
             (Some(lhs), Some(rhs)) => self.dot_general(lhs, rhs, config),
             _ => {
-                let lhs = lhs.to_tensor();
-                let rhs = rhs.to_tensor();
+                let lhs = lhs.try_to_tensor()?;
+                let rhs = rhs.try_to_tensor()?;
                 self.dot_general(&lhs, &rhs, config)
             }
         }
@@ -609,14 +609,14 @@ pub trait TensorDot: TensorElementwise {
         let lhs_ref = if let Some(tensor) = lhs.as_tensor() {
             tensor
         } else {
-            lhs_tmp = lhs.to_tensor();
+            lhs_tmp = lhs.try_to_tensor()?;
             &lhs_tmp
         };
         let rhs_tmp;
         let rhs_ref = if let Some(tensor) = rhs.as_tensor() {
             tensor
         } else {
-            rhs_tmp = rhs.to_tensor();
+            rhs_tmp = rhs.try_to_tensor()?;
             &rhs_tmp
         };
         self.dot_general_with_conj(lhs_ref, rhs_ref, config, lhs_conj, rhs_conj)
@@ -655,8 +655,8 @@ pub trait SessionCachedDot: TensorDot {
         match (lhs.as_tensor(), rhs.as_tensor()) {
             (Some(lhs), Some(rhs)) => self.dot_general_cached(cache_slot, lhs, rhs, config),
             _ => {
-                let lhs = lhs.to_tensor();
-                let rhs = rhs.to_tensor();
+                let lhs = lhs.try_to_tensor()?;
+                let rhs = rhs.try_to_tensor()?;
                 self.dot_general_cached(cache_slot, &lhs, &rhs, config)
             }
         }
@@ -697,14 +697,14 @@ pub trait SessionCachedDot: TensorDot {
         let lhs_ref = if let Some(tensor) = lhs.as_tensor() {
             tensor
         } else {
-            lhs_tmp = lhs.to_tensor();
+            lhs_tmp = lhs.try_to_tensor()?;
             &lhs_tmp
         };
         let rhs_tmp;
         let rhs_ref = if let Some(tensor) = rhs.as_tensor() {
             tensor
         } else {
-            rhs_tmp = rhs.to_tensor();
+            rhs_tmp = rhs.try_to_tensor()?;
             &rhs_tmp
         };
         self.dot_general_with_conj_cached(cache_slot, lhs_ref, rhs_ref, config, lhs_conj, rhs_conj)
@@ -917,8 +917,8 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
         match (lhs.as_tensor(), rhs.as_tensor()) {
             (Some(lhs), Some(rhs)) => self.dot_general_cached(cache, cache_slot, lhs, rhs, config),
             _ => {
-                let lhs = lhs.to_tensor();
-                let rhs = rhs.to_tensor();
+                let lhs = lhs.try_to_tensor()?;
+                let rhs = rhs.try_to_tensor()?;
                 self.dot_general_cached(cache, cache_slot, &lhs, &rhs, config)
             }
         }
@@ -961,14 +961,14 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
         let lhs_ref = if let Some(tensor) = lhs.as_tensor() {
             tensor
         } else {
-            lhs_tmp = lhs.to_tensor();
+            lhs_tmp = lhs.try_to_tensor()?;
             &lhs_tmp
         };
         let rhs_tmp;
         let rhs_ref = if let Some(tensor) = rhs.as_tensor() {
             tensor
         } else {
-            rhs_tmp = rhs.to_tensor();
+            rhs_tmp = rhs.try_to_tensor()?;
             &rhs_tmp
         };
         self.dot_general_with_conj_cached(

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -2212,7 +2212,29 @@ impl TensorOwnedView {
     }
 
     pub fn to_tensor(&self) -> Tensor {
-        self.tensor_view().to_tensor()
+        self.try_to_tensor()
+            .unwrap_or_else(|err| panic!("TensorOwnedView::to_tensor failed: {err}"))
+    }
+
+    /// Try to materialize this owned view into an owned compact tensor.
+    ///
+    /// This returns an explicit error for backend-backed views because no
+    /// backend context is available for an implicit download.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::sync::Arc;
+    /// use tenferro_tensor::{Tensor, TensorOwnedView};
+    ///
+    /// let base = Arc::new(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]));
+    /// let view = TensorOwnedView::from_tensor(base);
+    /// let tensor = view.try_to_tensor()?;
+    /// assert_eq!(tensor.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn try_to_tensor(&self) -> crate::Result<Tensor> {
+        self.tensor_view().try_to_tensor()
     }
 
     pub fn transpose_view(&self, axes: impl AsRef<[usize]>) -> crate::Result<Self> {
@@ -2350,9 +2372,32 @@ impl TensorValue {
     }
 
     pub fn to_tensor(&self) -> Tensor {
+        self.try_to_tensor()
+            .unwrap_or_else(|err| panic!("TensorValue::to_tensor failed: {err}"))
+    }
+
+    /// Try to materialize this tensor value into an owned compact tensor.
+    ///
+    /// Compact tensor values are cloned. Lazy host views are materialized.
+    /// Backend-backed views return an explicit error instead of panicking.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{Tensor, TensorValue};
+    ///
+    /// let value = TensorValue::from_tensor(Tensor::from_vec_col_major(
+    ///     vec![2],
+    ///     vec![1.0_f64, 2.0],
+    /// ));
+    /// let tensor = value.try_to_tensor()?;
+    /// assert_eq!(tensor.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn try_to_tensor(&self) -> crate::Result<Tensor> {
         match self {
-            Self::Tensor(tensor) => tensor.as_ref().clone(),
-            Self::View(view) => view.to_tensor(),
+            Self::Tensor(tensor) => Ok(tensor.as_ref().clone()),
+            Self::View(view) => view.try_to_tensor(),
         }
     }
 
@@ -2745,35 +2790,50 @@ impl<'a> TensorView<'a> {
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     pub fn to_tensor(&self) -> Tensor {
+        self.try_to_tensor()
+            .unwrap_or_else(|err| panic!("TensorView::to_tensor failed: {err}"))
+    }
+
+    /// Try to materialize this host view into an owned tensor.
+    ///
+    /// This is the checked counterpart to [`TensorView::to_tensor`]. It clones
+    /// host view data but returns an explicit error for backend-backed views
+    /// because there is no backend context available for download.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{DType, TensorView};
+    ///
+    /// let data = [1.0_f64, 2.0];
+    /// let view = TensorView::f64(&[2], &data)?;
+    /// let tensor = view.try_to_tensor()?;
+    /// assert_eq!(tensor.dtype(), DType::F64);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn try_to_tensor(&self) -> crate::Result<Tensor> {
         match self {
-            Self::F32(t) => match materialize_typed_view_col_major(t, "TensorView::to_tensor") {
-                Ok(tensor) => Tensor::F32(tensor),
-                Err(err) => panic!("TensorView::to_tensor failed: {err}"),
-            },
-            Self::F64(t) => match materialize_typed_view_col_major(t, "TensorView::to_tensor") {
-                Ok(tensor) => Tensor::F64(tensor),
-                Err(err) => panic!("TensorView::to_tensor failed: {err}"),
-            },
-            Self::I32(t) => match materialize_typed_view_col_major(t, "TensorView::to_tensor") {
-                Ok(tensor) => Tensor::I32(tensor),
-                Err(err) => panic!("TensorView::to_tensor failed: {err}"),
-            },
-            Self::I64(t) => match materialize_typed_view_col_major(t, "TensorView::to_tensor") {
-                Ok(tensor) => Tensor::I64(tensor),
-                Err(err) => panic!("TensorView::to_tensor failed: {err}"),
-            },
-            Self::Bool(t) => match materialize_typed_view_col_major(t, "TensorView::to_tensor") {
-                Ok(tensor) => Tensor::Bool(tensor),
-                Err(err) => panic!("TensorView::to_tensor failed: {err}"),
-            },
-            Self::C32(t) => match materialize_typed_view_col_major(t, "TensorView::to_tensor") {
-                Ok(tensor) => Tensor::C32(tensor),
-                Err(err) => panic!("TensorView::to_tensor failed: {err}"),
-            },
-            Self::C64(t) => match materialize_typed_view_col_major(t, "TensorView::to_tensor") {
-                Ok(tensor) => Tensor::C64(tensor),
-                Err(err) => panic!("TensorView::to_tensor failed: {err}"),
-            },
+            Self::F32(t) => {
+                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::F32)
+            }
+            Self::F64(t) => {
+                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::F64)
+            }
+            Self::I32(t) => {
+                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::I32)
+            }
+            Self::I64(t) => {
+                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::I64)
+            }
+            Self::Bool(t) => {
+                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::Bool)
+            }
+            Self::C32(t) => {
+                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::C32)
+            }
+            Self::C64(t) => {
+                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::C64)
+            }
         }
     }
 }
@@ -2831,9 +2891,31 @@ impl<'a> TensorRead<'a> {
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     pub fn to_tensor(&self) -> Tensor {
+        self.try_to_tensor()
+            .unwrap_or_else(|err| panic!("TensorRead::to_tensor failed: {err}"))
+    }
+
+    /// Try to convert an owned tensor reference or host view into an owned tensor.
+    ///
+    /// This is the checked counterpart to [`TensorRead::to_tensor`]. It clones
+    /// owned tensor inputs and materializes host views, but returns an explicit
+    /// error for backend-backed views.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{TensorRead, TensorView};
+    ///
+    /// let data = [1_i32, 2, 3];
+    /// let read = TensorRead::from_view(TensorView::i32(&[3], &data)?);
+    /// let tensor = read.try_to_tensor()?;
+    /// assert_eq!(tensor.shape(), &[3]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn try_to_tensor(&self) -> crate::Result<Tensor> {
         match self {
-            Self::Tensor(tensor) => (*tensor).clone(),
-            Self::View(view) => view.to_tensor(),
+            Self::Tensor(tensor) => Ok((*tensor).clone()),
+            Self::View(view) => view.try_to_tensor(),
         }
     }
 }

--- a/docs/design/linalg-prims.md
+++ b/docs/design/linalg-prims.md
@@ -1,8 +1,10 @@
 # Linalg Prims
 
-`tenferro-linalg-prims` defines the backend-facing tensor linalg contracts used
-by `tenferro-linalg`. It is intentionally narrower than a full public linalg
-API surface.
+This file keeps the historical `linalg-prims.md` name, but the current
+workspace no longer has a separate `tenferro-linalg-prims` crate. The
+backend-facing tensor linalg contracts are owned by
+`tenferro-linalg::backend::LinalgBackend` and implemented by backend crates
+such as `tenferro-cpu` and `tenferro-gpu`.
 
 ## Why This Crate Exists
 
@@ -11,16 +13,17 @@ The redesign separates two concerns that were previously coupled:
 - public/composite tensor linalg APIs
 - backend-facing structured kernel contracts
 
-`tenferro-linalg` owns the first. `tenferro-linalg-prims` owns the second.
-
-This keeps `tenferro-prims` focused on semiring/scalar execution substrate and
-prevents `einsum-only` or tropical backends from inheriting linalg-specific
-requirements.
+`tenferro-linalg` owns both the public linalg API and the linalg extension
+runtime, while `LinalgBackend` defines the narrower backend kernel surface.
+Core scalar, analytic, structural, and contraction vocabulary lives in
+`tenferro-core-ops` and is executed through `tenferro-tensor::TensorBackend`.
+This prevents generic tensor backends and operation-family crates from
+inheriting linalg-specific requirements.
 
 ## What Belongs Here
 
-Only operations that naturally map to structured backend kernels belong in
-`tenferro-linalg-prims`.
+Only operations that naturally map to structured backend kernels belong in the
+`LinalgBackend` contract.
 
 Current kernel basis:
 
@@ -56,8 +59,8 @@ Examples:
 - `vander`
 
 These are public linalg operations, but they are not backend kernel contracts.
-They should lower through tensor structural ops, semiring/scalar prims, and
-the smaller kernel basis above.
+They should lower through tensor structural ops, core `StdTensorOp` families,
+operation-family runtimes, and the smaller kernel basis above.
 
 ## Relation to `tenferro-linalg`
 
@@ -65,30 +68,32 @@ the smaller kernel basis above.
 
 1. validate public API contracts
 2. normalize shape/axis options
-3. lower composites to prims or linalg-prims
+3. lower composites to core tensor ops or `LinalgBackend` kernels
 4. expose structured public results
 
 `tenferro-linalg` should not directly branch on backend types or contain
 backend-specific execution kernels.
 
-## Relation to `tenferro-prims`
+## Relation to Core Tensor Ops
 
-The two crates are peers, not parent/child abstractions.
+The linalg backend contract is peer to the core tensor backend contract, not a
+parent/child abstraction.
 
-- `tenferro-prims` covers semiring, scalar, and analytic execution families
-- `tenferro-linalg-prims` covers structured factorization and solve kernels
+- `StdTensorOp` / `ExecOp` cover scalar, analytic, structural, reduction, and
+  contraction execution vocabulary
+- `LinalgBackend` covers structured factorization and solve kernels
 
 High-level linalg code may depend on both families:
 
-- semiring/scalar prims for composites
-- linalg-prims for factorization kernels
+- core tensor ops for composites
+- `LinalgBackend` for factorization kernels
 
 ## Current Status
 
-The crate exists and is wired into backend implementations as the canonical
-backend-facing linalg contract. Some concrete backends still use local helper
-modules internally, but those helpers now sit behind `tenferro-linalg-prims`
-instead of acting as a competing public abstraction.
+`LinalgBackend` exists and is wired into backend implementations as the
+canonical backend-facing linalg contract. Some concrete backends still use
+local helper modules internally, but those helpers sit behind `LinalgBackend`
+instead of acting as competing public abstractions.
 
 The scalar side is intentionally split:
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -16,6 +16,10 @@ tenferro-runtime = { path = "/path/to/tenferro-rs/crates/tenferro-runtime" }
 tenferro-cpu = { path = "/path/to/tenferro-rs/crates/tenferro-cpu" }
 ```
 
+The first build still needs network access unless dependencies are already
+vendored or cached. The workspace pins git dependencies and uses crates.io
+packages even when the tenferro crates themselves are local path dependencies.
+
 With default features, this compiles the `cpu-faer` provider, so
 `CpuBackend::new()` uses faer. To use the LAPACK/BLAS CPU provider, enable
 `cpu-blas` and link a BLAS/LAPACK provider from the build environment:
@@ -55,6 +59,13 @@ framework provider.
 Add `tenferro-ad`, `tenferro-einsum`, `tenferro-linalg`, `tenferro-fft`, or
 `tenferro-gpu` when a workflow needs those layers. Enable `autodiff` on
 operation crates such as `tenferro-linalg` when extension AD rules are needed.
+For CPU-only eager or traced AD, add:
+
+```toml
+[dependencies]
+tenferro-ad = { path = "/path/to/tenferro-rs/crates/tenferro-ad" }
+```
+
 Enable concrete backend features such as `cuda` on each crate that needs GPU
 support:
 

--- a/docs/guides/autodiff.md
+++ b/docs/guides/autodiff.md
@@ -9,6 +9,21 @@ This page focuses on traced graph workflows that you compile and execute
 explicitly. For eager forward execution and scalar loss accumulation semantics, see
 [Eager Operations](eager-operations.md).
 
+## Setup
+
+```toml
+[dependencies]
+tenferro-ad = { path = "../crates/tenferro-ad" }
+tenferro-runtime = { path = "../crates/tenferro-runtime" }
+tenferro-cpu = { path = "../crates/tenferro-cpu" }
+```
+
+Extension AD examples also need that extension crate's AD feature. For linalg:
+
+```toml
+tenferro-linalg = { path = "../crates/tenferro-linalg", features = ["autodiff"] }
+```
+
 - `grad` for reverse mode on scalar losses
 - `vjp` for vector-Jacobian products
 - `jvp` for Jacobian-vector products
@@ -22,6 +37,20 @@ Use `tenferro_ad::AdContext` to own the AD rule set used by a transform. Core
 tensor primitive rules are always available. Extension crates can provide owned
 JVP/VJP rule sets for their operations; `tenferro-linalg` exposes these through
 its `autodiff` feature.
+
+## `AdContext` And `TracedTensorAdExt`
+
+There are two public traced-AD entry points over the same graph transforms:
+
+| Entry point | Use when |
+| --- | --- |
+| `AdContext` | You want explicit ownership of the rule set, especially when adding extension AD rules such as `tenferro_linalg::ad_rules()`. |
+| `TracedTensorAdExt` | You want compact method syntax such as `loss.grad(&x)?`, `y.vjp(&x, &ct)`, or `y.jvp(&x, &dx)` for small core-rule examples. |
+
+Prefer `AdContext` in reusable code and in examples that depend on extension
+rules. The extension trait is convenience syntax for the same traced transforms;
+the [JAX-style traced tutorial](../tutorials/traced-autodiff-jax-style.md) uses
+it to keep the first example short.
 
 ## Reverse-mode gradient with `grad`
 
@@ -97,6 +126,11 @@ let program = compiler.compile(&ct_a).unwrap();
 let mut executor = GraphExecutor::new(CpuBackend::new());
 let result = executor.run(&program).unwrap();
 assert_eq!(result.shape(), &[2, 3]);
+// For y = A * B, the cotangent with respect to A is cotangent * B^T.
+assert_eq!(
+    result.as_slice::<f64>().unwrap(),
+    &[0.875, 2.75, -1.0625, 0.0, 2.75, 5.0],
+);
 ```
 
 ## Jacobian-vector product with `jvp`
@@ -128,6 +162,11 @@ let program = compiler.compile(&dy).unwrap();
 let mut executor = GraphExecutor::new(CpuBackend::new());
 let result = executor.run(&program).unwrap();
 assert_eq!(result.shape(), &[2, 2]);
+// For y = A * B, the directional derivative with respect to A is dA * B.
+assert_eq!(
+    result.as_slice::<f64>().unwrap(),
+    &[4.25, -2.25, 7.4375, -3.75],
+);
 ```
 
 ## Extension AD Rules

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -9,11 +9,24 @@ gradient accumulation and `backward()`.
 
 ## Setup
 
+```toml
+[dependencies]
+tenferro-runtime = { path = "../crates/tenferro-runtime" }
+tenferro-cpu = { path = "../crates/tenferro-cpu" }
+tenferro-tensor = { path = "../crates/tenferro-tensor" }
+tenferro-ad = { path = "../crates/tenferro-ad" }
+tenferro-linalg = { path = "../crates/tenferro-linalg" }
+tenferro-einsum = { path = "../crates/tenferro-einsum", features = ["autodiff"] }
+```
+
+Most direct tensor examples start by importing the CPU backend and concrete
+tensor types:
+
 ```rust
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{Tensor, TypedTensor};
 
-let mut ctx = CpuBackend::new();
+let mut backend = CpuBackend::new();
 ```
 
 Every direct tensor operation requires a backend context. `CpuBackend` is the
@@ -32,6 +45,22 @@ the first layer to consider when you want compile-time dtype safety, optional
 rank typing, or typed data that may live on the host or in backend-owned
 storage. Einsum is
 provided by the separate `tenferro-einsum` standard extension.
+
+Tracked `EagerTensor` values support the differentiable method surface most
+loss functions need:
+
+| Category | `EagerTensor` methods |
+| --- | --- |
+| Elementwise | `add`, `mul`, `neg`, `exp` |
+| Reduction | `reduce_sum`, `reduce_prod`, `reduce_max`, `reduce_min` |
+| Matrix products | `matmul`, `dot_general`, `dot_general_with_conj` |
+| Shape/layout | `reshape`, `transpose`, `broadcast_in_dim`, `slice`, `pad`, `reverse`, `concatenate` |
+| Indexing/diagonal | `gather`, `scatter`, `dynamic_slice`, `extract_diag`, `embed_diag`, `tril`, `triu` |
+| DType | `convert` |
+
+Operation-family crates add their own eager helpers. For example,
+`tenferro_linalg::eager_tensor` owns linalg eager helpers and
+`tenferro_einsum::eager_tensor` owns eager einsum.
 
 For CUDA, eager means the operation is submitted immediately. It does not mean
 the host waits after every GPU kernel. Host synchronization happens at
@@ -76,13 +105,13 @@ not silently upload CPU tensors or download CUDA tensors.
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{tensor, Tensor};
 
-let mut ctx = CpuBackend::new();
+let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
 let b = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]);
 
-let sum = tensor::add(&a, &b, &mut ctx).unwrap();
-let product = tensor::mul(&a, &b, &mut ctx).unwrap();
-let negated = tensor::neg(&a, &mut ctx).unwrap();
+let sum = tensor::add(&a, &b, &mut backend).unwrap();
+let product = tensor::mul(&a, &b, &mut backend).unwrap();
+let negated = tensor::neg(&a, &mut backend).unwrap();
 
 assert_eq!(sum.as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
 assert_eq!(product.as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
@@ -96,7 +125,7 @@ use tenferro_linalg::LinalgBackend;
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{tensor, Tensor};
 
-let mut ctx = CpuBackend::new();
+let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![3, 3], vec![
     2.0_f64, 1.0, 0.0,
     1.0, 3.0, 1.0,
@@ -104,20 +133,20 @@ let a = Tensor::from_vec_col_major(vec![3, 3], vec![
 ]);
 
 // SVD
-let svd = LinalgBackend::svd(&mut ctx, &a).unwrap();
+let svd = LinalgBackend::svd(&mut backend, &a).unwrap();
 
 // QR
-let qr = LinalgBackend::qr(&mut ctx, &a).unwrap();
+let qr = LinalgBackend::qr(&mut backend, &a).unwrap();
 
 // Cholesky (for positive definite matrices)
-let chol = LinalgBackend::cholesky(&mut ctx, &a).unwrap();
+let chol = LinalgBackend::cholesky(&mut backend, &a).unwrap();
 
 // Eigendecomposition (symmetric)
-let eigh = LinalgBackend::eigh(&mut ctx, &a).unwrap();
+let eigh = LinalgBackend::eigh(&mut backend, &a).unwrap();
 
 // Solve Ax = b
 let b = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-let x = LinalgBackend::solve(&mut ctx, &a, &b).unwrap();
+let x = LinalgBackend::solve(&mut backend, &a, &b).unwrap();
 
 let s = &svd[1];
 assert_eq!(s.shape(), &[3]);
@@ -136,19 +165,19 @@ assert_eq!(x.shape(), &[3]);
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{tensor, Tensor};
 
-let mut ctx = CpuBackend::new();
+let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
 // Transpose
-let at = tensor::transpose(&a, &[1, 0], &mut ctx).unwrap();
+let at = tensor::transpose(&a, &[1, 0], &mut backend).unwrap();
 assert_eq!(at.shape(), &[3, 2]);
 
 // Reshape
-let flat = tensor::reshape(&a, &[6], &mut ctx).unwrap();
+let flat = tensor::reshape(&a, &[6], &mut backend).unwrap();
 assert_eq!(flat.shape(), &[6]);
 
 // Reduce
-let col_sum = tensor::reduce_sum(&a, &[0], &mut ctx).unwrap();
+let col_sum = tensor::reduce_sum(&a, &[0], &mut backend).unwrap();
 assert_eq!(col_sum.shape(), &[3]);
 ```
 
@@ -215,6 +244,32 @@ assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
 ctx.clear_grads();
 assert!(x.grad().is_none());
 assert!(y.grad().is_none());
+```
+
+`matmul` participates in the same eager reverse-mode workflow:
+
+```rust
+use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+use tenferro_cpu::CpuBackend;
+
+let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+let a = EagerTensor::requires_grad_in(
+    Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+    ctx.clone(),
+);
+let x = EagerTensor::requires_grad_in(
+    Tensor::from_vec_col_major(vec![2, 1], vec![5.0_f64, 6.0]),
+    ctx.clone(),
+);
+
+let y = a.matmul(&x).unwrap();
+assert_eq!(y.data().as_slice::<f64>().unwrap(), &[23.0, 34.0]);
+
+let loss = (&y * &y).reduce_sum(&[0, 1]).unwrap();
+assert_eq!(loss.data().as_slice::<f64>().unwrap(), &[1685.0]);
+
+loss.backward().unwrap();
+assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[182.0, 410.0]);
 ```
 
 ## When To Use Each Immediate Layer

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -10,8 +10,12 @@ extension ops.
 ```toml
 [dependencies]
 tenferro-runtime = { path = "../crates/tenferro-runtime" }
-tenferro-einsum = { path = "../crates/tenferro-einsum" }
+tenferro-cpu = { path = "../crates/tenferro-cpu" }
+tenferro-ad = { path = "../crates/tenferro-ad" }
+tenferro-einsum = { path = "../crates/tenferro-einsum", features = ["autodiff"] }
 ```
+
+Graph-only users can omit `tenferro-ad` and the `autodiff` feature.
 
 ## Traced Matrix Multiply
 
@@ -47,6 +51,9 @@ assert_eq!(result.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 
 With the `autodiff` feature, `tenferro-einsum` also exposes immediate
 `EagerTensor` execution.
+The `"i->ii"` form embeds a vector on a diagonal. This is a tenferro extension
+to the common NumPy/PyTorch einsum surface; NumPy rejects repeated output
+labels in that form.
 
 ```rust
 use tenferro_ad::{EagerRuntime, Tensor};
@@ -59,7 +66,15 @@ let outer = tenferro_einsum::eager_tensor::einsum(&[&u, &v], "i,j->ij").unwrap()
 let diag = tenferro_einsum::eager_tensor::einsum(&[&v], "i->ii").unwrap();
 
 assert_eq!(outer.data().shape(), &[2, 3]);
+assert_eq!(
+    outer.data().as_slice::<f64>().unwrap(),
+    &[3.0, 6.0, 4.0, 8.0, 5.0, 10.0],
+);
 assert_eq!(diag.data().shape(), &[3, 3]);
+assert_eq!(
+    diag.data().as_slice::<f64>().unwrap(),
+    &[3.0, 0.0, 0.0, 0.0, 4.0, 0.0, 0.0, 0.0, 5.0],
+);
 ```
 
 ## Tensordot Sugar
@@ -71,14 +86,36 @@ right tensor. `TensorDotAxes::Axes` accepts explicit axis pairs, including
 negative axes.
 
 ```rust
-use tenferro_runtime::TracedTensor;
+use tenferro_cpu::CpuBackend;
 use tenferro_einsum::{traced_tensor, TensorDotAxes};
+use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
 
-let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-let rhs = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
+let lhs = TracedTensor::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+);
+let rhs = TracedTensor::from_vec_col_major(
+    vec![3, 4],
+    vec![
+        1.0_f64, 2.0, 3.0,
+        4.0, 5.0, 6.0,
+        7.0, 8.0, 9.0,
+        10.0, 11.0, 12.0,
+    ],
+);
 let out = traced_tensor::tensordot(&lhs, &rhs, TensorDotAxes::Count(1)).unwrap();
 
 assert_eq!(out.rank, 2);
+let mut compiler = GraphCompiler::new();
+let program = compiler.compile(&out).unwrap();
+let mut executor = GraphExecutor::new(CpuBackend::new());
+let result = executor.run(&program).unwrap();
+
+assert_eq!(result.shape(), &[2, 4]);
+assert_eq!(
+    result.as_slice::<f64>().unwrap(),
+    &[22.0, 28.0, 49.0, 64.0, 76.0, 100.0, 103.0, 136.0],
+);
 ```
 
 ## Optimization Controls

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -6,6 +6,24 @@ immediate forward execution under an `EagerRuntime`, and `TracedTensor` helpers
 when the operation should be part of a graph, `grad`/`vjp`/`jvp`, or repeated
 compile/run workflow.
 
+## Setup
+
+```toml
+[dependencies]
+tenferro-runtime = { path = "../crates/tenferro-runtime" }
+tenferro-cpu = { path = "../crates/tenferro-cpu" }
+tenferro-linalg = { path = "../crates/tenferro-linalg" }
+```
+
+Eager linalg helpers and linalg AD rules also require `tenferro-ad` and the
+`tenferro-linalg` `autodiff` feature. Add `tenferro-ad` and replace the basic
+`tenferro-linalg` line with:
+
+```toml
+tenferro-ad = { path = "../crates/tenferro-ad" }
+tenferro-linalg = { path = "../crates/tenferro-linalg", features = ["autodiff"] }
+```
+
 ## Layer Coverage
 
 | Layer | Linear algebra style |
@@ -17,6 +35,26 @@ compile/run workflow.
 CUDA is a backend/device choice for supported `Tensor`, `EagerTensor`, and
 `TracedTensor` paths. It is not a separate linear algebra layer. See
 [Devices and GPU](devices-and-gpu.md) for the CUDA support table.
+
+## Operation Surface
+
+| Operation family | Concrete backend | Eager helper | Traced helper |
+| --- | --- | --- | --- |
+| Dense solve | `solve` | `solve` | `solve` |
+| Triangular solve | `triangular_solve` | `triangular_solve` | `triangular_solve` |
+| Cholesky | `cholesky` | `cholesky` | `cholesky` |
+| SVD | `svd` | `svd` | `svd` |
+| QR | `qr` | `qr` | `qr` |
+| Hermitian eigen | `eigh` | `eigh` | `eigh`, `eigvalsh` |
+| General eigen | `eig` | `eig` | `eig`, `eigvals` |
+| LU | `lu` | `lu` | `lu` |
+| Complete-pivot LU | `full_piv_lu`, `full_piv_lu_solve` | `full_piv_lu`, `full_piv_lu_solve` | `full_piv_lu`, `full_piv_lu_solve` |
+| Pseudoinverse | `pinv` | - | `pinv`, `pinv_with_rtol` |
+| Determinants | `det`, `slogdet` | - | `det`, `slogdet` |
+| Norms | `norm` | - | `norm` |
+
+Concrete methods are exposed by `LinalgBackend`; eager and traced helpers live
+under `tenferro_linalg::eager_tensor` and `tenferro_linalg::traced_tensor`.
 
 ## Concrete Solve
 
@@ -40,15 +78,26 @@ assert_eq!(x.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
 ```rust
 use tenferro_linalg::LinalgBackend;
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::Tensor;
+use tenferro_runtime::{tensor, Tensor};
+
+fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
+    lhs.as_slice::<f64>()
+        .unwrap()
+        .iter()
+        .zip(rhs.as_slice::<f64>().unwrap())
+        .map(|(lhs, rhs)| (lhs - rhs).abs())
+        .fold(0.0, f64::max)
+}
 
 let mut backend = CpuBackend::new();
-let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 0.0, 0.0, 9.0]);
+let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]);
 
 let factor = LinalgBackend::cholesky(&mut backend, &a).unwrap();
+let factor_t = tensor::transpose(&factor, &[1, 0], &mut backend).unwrap();
+let reconstructed = tensor::matmul(&factor, &factor_t, &mut backend).unwrap();
 
 assert_eq!(factor.shape(), &[2, 2]);
-assert_eq!(factor.as_slice::<f64>().unwrap(), &[2.0, 0.0, 0.0, 3.0]);
+assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
 ```
 
 ## Direct Decompositions
@@ -58,8 +107,8 @@ or typed tensors for direct execution without autodiff, eager tensors when the r
 should be produced immediately under an `EagerRuntime`, and traced helpers when
 the operation belongs in a reusable graph. Use tracked eager tensors only when
 the result should remain connected to a scalar loss `backward()` pass.
-For linalg eager helpers or linalg AD rules, enable `tenferro-linalg`'s
-`autodiff` feature.
+For linalg eager helpers or linalg AD rules, add the `tenferro-ad` dependency
+and enable `tenferro-linalg`'s `autodiff` feature.
 
 When traced graph AD must linearize through linalg extension ops, include the
 owned rule set in an explicit context:
@@ -78,10 +127,19 @@ let ad = AdContext::builder()
 ```rust
 use tenferro_linalg::LinalgBackend;
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::Tensor;
+use tenferro_runtime::{tensor, Tensor};
+
+fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
+    lhs.as_slice::<f64>()
+        .unwrap()
+        .iter()
+        .zip(rhs.as_slice::<f64>().unwrap())
+        .map(|(lhs, rhs)| (lhs - rhs).abs())
+        .fold(0.0, f64::max)
+}
 
 let mut backend = CpuBackend::new();
-let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]);
+let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
 let outputs = LinalgBackend::svd(&mut backend, &a).unwrap();
 let u = &outputs[0];
 let s = &outputs[1];
@@ -90,9 +148,15 @@ let vt = &outputs[2];
 assert_eq!(u.shape(), &[2, 2]);
 assert_eq!(vt.shape(), &[2, 2]);
 
-let mut singular_values = s.as_slice::<f64>().unwrap().to_vec();
-singular_values.sort_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap());
-assert_eq!(singular_values, vec![1.0, 2.0]);
+let s_values = s.as_slice::<f64>().unwrap();
+let sigma = Tensor::from_vec_col_major(
+    vec![2, 2],
+    vec![s_values[0], 0.0, 0.0, s_values[1]],
+);
+let us = tensor::matmul(u, &sigma, &mut backend).unwrap();
+let reconstructed = tensor::matmul(&us, vt, &mut backend).unwrap();
+
+assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
 ```
 
 ## QR decomposition
@@ -100,35 +164,80 @@ assert_eq!(singular_values, vec![1.0, 2.0]);
 ```rust
 use tenferro_linalg::LinalgBackend;
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::Tensor;
+use tenferro_runtime::{tensor, Tensor};
+
+fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
+    lhs.as_slice::<f64>()
+        .unwrap()
+        .iter()
+        .zip(rhs.as_slice::<f64>().unwrap())
+        .map(|(lhs, rhs)| (lhs - rhs).abs())
+        .fold(0.0, f64::max)
+}
 
 let mut backend = CpuBackend::new();
-let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]);
+let a = Tensor::from_vec_col_major(
+    vec![4, 3],
+    vec![
+        1.0_f64, 4.0, 7.0, 2.0,
+        2.0, 5.0, 8.0, 3.0,
+        3.0, 6.0, 10.0, 5.0,
+    ],
+);
 let outputs = LinalgBackend::qr(&mut backend, &a).unwrap();
 let q = &outputs[0];
 let r = &outputs[1];
 
-assert_eq!(q.shape(), &[2, 2]);
-assert_eq!(r.shape(), &[2, 2]);
-assert_eq!(q.as_slice::<f64>().unwrap(), &[1.0, 0.0, 0.0, 1.0]);
-assert_eq!(r.as_slice::<f64>().unwrap(), &[1.0, 0.0, 0.0, 1.0]);
+assert_eq!(q.shape(), &[4, 3]);
+assert_eq!(r.shape(), &[3, 3]);
+
+let reconstructed = tensor::matmul(q, r, &mut backend).unwrap();
+let qt = tensor::transpose(q, &[1, 0], &mut backend).unwrap();
+let qtq = tensor::matmul(&qt, q, &mut backend).unwrap();
+let identity = Tensor::from_vec_col_major(
+    vec![3, 3],
+    vec![1.0_f64, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+);
+
+assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
+assert!(max_abs_diff(&qtq, &identity) < 1.0e-12);
 ```
 
 ## Hermitian eigenvalue decomposition
 
 ```rust
-use tenferro_ad::{EagerRuntime, Tensor};
+use tenferro_linalg::LinalgBackend;
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{tensor, Tensor};
 
-let ctx = EagerRuntime::new();
-let a = ctx.variable_from(Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]));
-let (values, vectors) = tenferro_linalg::eager_tensor::eigh(&a).unwrap();
+fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
+    lhs.as_slice::<f64>()
+        .unwrap()
+        .iter()
+        .zip(rhs.as_slice::<f64>().unwrap())
+        .map(|(lhs, rhs)| (lhs - rhs).abs())
+        .fold(0.0, f64::max)
+}
 
-assert_eq!(values.data().shape(), &[2]);
-assert_eq!(vectors.data().shape(), &[2, 2]);
+let mut backend = CpuBackend::new();
+let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 1.0, 1.0, 2.0]);
+let outputs = LinalgBackend::eigh(&mut backend, &a).unwrap();
+let values = &outputs[0];
+let vectors = &outputs[1];
 
-let mut eigenvalues = values.data().as_slice::<f64>().unwrap().to_vec();
-eigenvalues.sort_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap());
-assert_eq!(eigenvalues, vec![1.0, 3.0]);
+assert_eq!(values.shape(), &[2]);
+assert_eq!(vectors.shape(), &[2, 2]);
+
+let value_slice = values.as_slice::<f64>().unwrap();
+let diagonal = Tensor::from_vec_col_major(
+    vec![2, 2],
+    vec![value_slice[0], 0.0, 0.0, value_slice[1]],
+);
+let vd = tensor::matmul(vectors, &diagonal, &mut backend).unwrap();
+let vt = tensor::transpose(vectors, &[1, 0], &mut backend).unwrap();
+let reconstructed = tensor::matmul(&vd, &vt, &mut backend).unwrap();
+
+assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
 ```
 
 ## Traced Cholesky Factorization
@@ -174,22 +283,52 @@ assert_eq!(result.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
 
 ## Complete-Pivot LU Solve
 
+`full_piv_lu` returns `(P, L, U, Q, parity)` with the reconstruction convention
+`A = P * L * U * Q`. The `parity` output is a rank-0 `F64` tensor containing
+`1.0` or `-1.0`. `full_piv_lu_solve(..., false)` solves `A * x = b`; passing
+`true` solves `A^T * x = b`.
+
 ```rust
 use tenferro_linalg::LinalgBackend;
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::Tensor;
+use tenferro_runtime::{tensor, Tensor};
+
+fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
+    lhs.as_slice::<f64>()
+        .unwrap()
+        .iter()
+        .zip(rhs.as_slice::<f64>().unwrap())
+        .map(|(lhs, rhs)| (lhs - rhs).abs())
+        .fold(0.0, f64::max)
+}
 
 let mut backend = CpuBackend::new();
-let a = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]);
-let b = Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0]);
+let a = Tensor::from_vec_col_major(
+    vec![4, 4],
+    vec![
+        0.0_f64, 4.0, 7.0, 1.0,
+        2.0, 5.0, 8.0, 0.0,
+        3.0, 6.0, 10.0, 2.0,
+        1.0, 2.0, 3.0, 4.0,
+    ],
+);
+let b = Tensor::from_vec_col_major(vec![4, 1], vec![1.0_f64, 2.0, 3.0, 4.0]);
 
 let outputs = LinalgBackend::full_piv_lu(&mut backend, &a).unwrap();
 let p = &outputs[0];
+let l = &outputs[1];
+let u = &outputs[2];
+let q = &outputs[3];
 let parity = &outputs[4];
+let pl = tensor::matmul(p, l, &mut backend).unwrap();
+let plu = tensor::matmul(&pl, u, &mut backend).unwrap();
+let reconstructed = tensor::matmul(&plu, q, &mut backend).unwrap();
 let x = LinalgBackend::full_piv_lu_solve(&mut backend, &a, &b, false).unwrap();
 
-assert_eq!(p.shape(), &[2, 2]);
+assert_eq!(p.shape(), &[4, 4]);
+assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
 assert_eq!(parity.shape(), &[] as &[usize]);
-assert_eq!(x.shape(), &[2, 1]);
-assert_eq!(x.as_slice::<f64>().unwrap(), &[4.0, -1.0]);
+let parity_value = parity.as_slice::<f64>().unwrap()[0];
+assert!(parity_value == 1.0 || parity_value == -1.0);
+assert_eq!(x.shape(), &[4, 1]);
 ```

--- a/docs/guides/tenferro-fft.md
+++ b/docs/guides/tenferro-fft.md
@@ -9,6 +9,16 @@ by `rustfft` through tenferro extension operations. The public functions are
 ordinary Rust wrappers, so most users do not need to work with the lower-level
 extension machinery directly.
 
+## Setup
+
+```toml
+[dependencies]
+num-complex = "0.4"
+tenferro-runtime = { path = "../crates/tenferro-runtime" }
+tenferro-cpu = { path = "../crates/tenferro-cpu" }
+tenferro-fft = { path = "../crates/tenferro-fft" }
+```
+
 ## Current API
 
 The initial API mirrors the common PyTorch and JAX one-dimensional FFT
@@ -73,8 +83,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 For real-input transforms, the transformed axis follows the standard
 half-spectrum shape rule: input length `n` produces `n / 2 + 1` complex values
-using integer division. Inverse real transforms need an explicit output length
-when odd and even original signal sizes would otherwise be ambiguous.
+using integer division. When `irfft` receives `n = None`, it infers the output
+length as `2 * (input_len - 1)`. That matches even-length round trips; for odd
+original lengths it silently returns one element too short, so pass
+`Some(original_len)`.
 
 ## Planned Extensions
 
@@ -106,6 +118,17 @@ FFT is linear, so the extension can support AD through registered extension
 rules. The current package registers JVP/VJP rules for complex-to-complex
 `fft` and `ifft`: the tangent or cotangent is transformed with the same
 extension op and normalization.
+
+AD examples require `tenferro-ad` and the `tenferro-fft` `autodiff` feature.
+Add `tenferro-ad` and replace the basic `tenferro-fft` line with:
+
+```toml
+tenferro-ad = { path = "../crates/tenferro-ad" }
+tenferro-fft = { path = "../crates/tenferro-fft", features = ["autodiff"] }
+```
+
+Use `AdContext` for explicit extension-rule ownership, or import
+`tenferro_ad::TracedTensorAdExt` for the compact traced AD method syntax.
 
 Real-to-complex and complex-to-real AD are not enabled yet. They require the
 usual Hermitian symmetry handling so cotangents match the half-spectrum

--- a/docs/guides/tensor-operations.md
+++ b/docs/guides/tensor-operations.md
@@ -6,6 +6,16 @@ available through different tensor APIs depending on whether you need
 computation without autodiff, eager forward execution with optional
 `backward()` on scalar losses, or traced graph execution.
 
+## Setup
+
+```toml
+[dependencies]
+tenferro-runtime = { path = "../crates/tenferro-runtime" }
+tenferro-cpu = { path = "../crates/tenferro-cpu" }
+tenferro-tensor = { path = "../crates/tenferro-tensor" }
+tenferro-ad = { path = "../crates/tenferro-ad" }
+```
+
 ## Layer Coverage
 
 Choose the tensor API first, then choose the operation entry point.
@@ -299,11 +309,15 @@ let a = Tensor::from_vec_col_major(
     vec![2, 3],
     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 );
+// Logical matrix:
+// [[1.0, 3.0, 5.0],
+//  [2.0, 4.0, 6.0]]
 let row_sums = tensor::reduce_sum(&a, &[1], &mut backend).unwrap();
 let total = tensor::reduce_sum(&a, &[0, 1], &mut backend).unwrap();
 
 assert_eq!(row_sums.shape(), &[2]);
 assert_eq!(row_sums.as_slice::<f64>().unwrap(), &[9.0, 12.0]);
 assert_eq!(total.shape(), &[] as &[usize]);
+// Rank-0 tensors hold one scalar element; as_slice() returns a length-1 slice.
 assert_eq!(total.as_slice::<f64>().unwrap(), &[21.0]);
 ```

--- a/docs/reference/jax-stablehlo-needed.md
+++ b/docs/reference/jax-stablehlo-needed.md
@@ -42,9 +42,11 @@ The most relevant source files were:
 
 - `tenferro-rs/docs/design/supported-ops.md`
 - `tenferro-rs/docs/design/tensor-prims.md`
-- `tenferro-rs/tenferro-prims/src/families/*.rs`
+- `tenferro-rs/crates/tenferro-core-ops/src/catalog.rs`
+- `tenferro-rs/crates/tenferro-tensor/src/backend.rs`
+- `tenferro-rs/crates/tenferro-einsum/src/`
 - `tenferro-rs/crates/tenferro-linalg/src/lib.rs`
-- `tenferro-rs/crates/tenferro-linalg/src/prims_bridge.rs`
+- `tenferro-rs/crates/tenferro-linalg/src/backend.rs`
 - `jax/jax/_src/interpreters/ad.py`
 - `jax/jax/_src/numpy/einsum.py`
 - `jax/jax/_src/lax/control_flow/solves.py`
@@ -120,27 +122,25 @@ These exist today, but they are **tensor/view APIs**, not first-class
 tensor primitives with their own `linearize` / `transpose_rule`
 implementations.
 
-### Execution families in `tenferro-prims`
+### Execution families in the current runtime crates
 
-Current `tenferro-prims` is organized by backend execution families:
+The current workspace no longer has a separate `tenferro-prims` crate. Core
+execution vocabulary is represented by `StdTensorOp` / `ExecOp` in
+`tenferro-core-ops` and the runtime compiler, while backend execution is
+provided through `tenferro-tensor::TensorBackend` implementations such as
+`tenferro-cpu` and `tenferro-gpu`.
 
-- `TensorSemiringCore`
-  - `BatchedGemm`
+- contraction and semiring-oriented paths
+  - `DotGeneral`
   - `ReduceSum`
-  - `Trace`
-  - `AntiTrace`
-  - `AntiDiag`
-  - `MakeContiguous`
-- `TensorSemiringFastPath`
-  - `Contract`
-  - `ElementwiseBinary::{Add, Mul}`
-- `TensorScalarPrims`
+  - extension families such as `tenferro-einsum`
+- scalar and elementwise operations
   - unary: `Neg`, `Conj`, `Abs`, `Reciprocal`, `Real`, `Imag`, `Square`
   - binary: `Add`, `Sub`, `Mul`, `Div`, `Maximum`, `Minimum`,
     `Greater`, `GreaterEqual`, `ClampMin`, `ClampMax`
   - ternary: `Where`
   - reductions: `Sum`, `Prod`, `Mean`, `Max`, `Min`
-- `TensorAnalyticPrims`
+- analytic operations
   - unary: `Sqrt`, `Rsqrt`, `Exp`, `Expm1`, `Ceil`, `Log`, `Log1p`, `Sin`,
     `Cos`, `Tan`, `Tanh`, `Asin`, `Acos`, `Atan`, `Sinh`, `Cosh`, `Asinh`,
     `Acosh`, `Atanh`

--- a/docs/reference/libtorch.md
+++ b/docs/reference/libtorch.md
@@ -747,16 +747,15 @@ implemented.
 
 | PyTorch Feature | tenferro Crate | Notes |
 |---|---|---|
-| **Tensor type, storage, views** | `tenferro-tensor` | `Tensor<T>`, `DataBuffer<T>`, view ops |
-| **Device enum, errors** | `tenferro-internal-device` | `Device`, `Error`/`Result` |
-| **Algebra dispatch** | `tenferro-algebra` | `HasAlgebra`, `Semiring` (compile-time, not runtime) |
-| **Execution prim families (GEMM, reduce, pointwise)** | `tenferro-prims` | `TensorSemiringCore/FastPath`, `TensorScalarPrims`, `TensorAnalyticPrims` |
+| **Tensor type, storage, views** | `tenferro-tensor` | `Tensor`, `TypedTensor<T, R>`, typed views |
+| **Device placement, errors** | `tenferro-tensor`, `tenferro-gpu` | `Placement`, `DeviceKind`, `DeviceId`, backend errors |
+| **Core op vocabulary and dispatch** | `tenferro-core-ops`, `tenferro-runtime`, `tenferro-tensor` | `StdTensorOp`, `ExecOp`, `TensorBackend`, `BackendSession` |
+| **CPU/GPU execution** | `tenferro-cpu`, `tenferro-gpu` | CPU provider selection and CubeCL/CUDA backend support |
 | **Einsum with contraction tree** | `tenferro-einsum` | `Subscripts`, `ContractionTree`, opt_einsum-style optimization |
 | **Linalg decompositions + AD** | `tenferro-linalg` | SVD/QR/LU/eigen with `(m, n, *)` col-major convention |
-| **AD core traits** | `chainrules-core` | `Differentiable`, `ReverseRule`, `ForwardRule` |
-| **AD tape engine** | `tidu` | `Tape`, `TrackedValue`, `DualValue`, `pullback` |
-| **C FFI** | `tenferro-capi` | Opaque handles, DLPack interop |
-| **Tropical algebras** | `tenferro-ext-tropical` | MaxPlus, MinPlus, MaxMul |
+| **AD APIs and rules** | `tenferro-ad`, `tenferro-internal-ops` | Eager/traced AD surfaces and primitive rule implementations |
+| **C FFI** | planned `tenferro-capi` | Opaque handles and DLPack interop are design-only in this workspace |
+| **Tropical algebras** | out-of-tree extension | Extension-op family example, not an in-workspace crate |
 
 ### Key Design Differences from PyTorch
 
@@ -766,7 +765,7 @@ implemented.
 | **Batch convention** | `(*, m, n)` — last 2 dims | `(m, n, *)` — first 2 dims |
 | **Type dispatch** | Runtime (dynamic dtype/device) | Compile-time generics `Tensor<T>` |
 | **Algebra dispatch** | N/A (always standard arithmetic) | semiring-family traits parameterized by algebra |
-| **AD system** | Integrated (autograd built into Tensor) | Separated (chainrules-core + chainrules + tidu) |
+| **AD system** | Integrated (autograd built into Tensor) | Separated into `tenferro-ad` surfaces and internal primitive rules |
 | **Backend dispatch** | Runtime dispatcher with dispatch keys | Trait-based static dispatch |
 
 ---

--- a/docs/reference/pytorch-dense-cpu-parity.md
+++ b/docs/reference/pytorch-dense-cpu-parity.md
@@ -41,10 +41,10 @@ Status labels in the matrix use:
 | Family | Primal | VJP | JVP | Oracle-HVP | CPU/GPU generic | Layer-clean | Notes |
 |--------|--------|-----|-----|------------|-----------------|-------------|-------|
 | Structural (`tenferro-tensor`) | Yes | Partial | Partial | No | Yes | Yes | tenferro exposes metadata-only view APIs such as `transpose_view`, `slice_view`, `reshape_view`, broadcast views, and diagonal views; AD coverage is not yet documented as a first-class family surface |
-| Semiring core / fast path (`tenferro-prims`) | Yes | Partial | Partial | Yes | Partial | Yes | `einsum` is strong, `Permute` is gone from the prim surface, and semiring execution now routes directly through the family contracts; the remaining gap is GPU capability breadth, not legacy layering |
-| Scalar (`TensorScalarPrims`) | Partial | Partial | Partial | No | Partial | Partial | CPU phase 1 now executes unary `Neg/Conj/Abs/Reciprocal/Real/Imag/Square`, binary `Add/Sub/Mul/Div/Maximum/Minimum/Clamp*`, and reductions `Sum/Prod/Mean/Max/Min`; predicate/select tensor ops such as `where` are still absent |
-| Analytic (`TensorAnalyticPrims`) | Partial | Partial | Partial | No | Partial | Partial | CPU phase 1 now executes unary `Sqrt/Rsqrt/Exp/Expm1/Log/Log1p/Sin/Cos/Tan/Tanh/Asin/Acos/Atan/Sinh/Cosh/Asinh/Acosh/Atanh`, binary `Pow/Atan2/Hypot/Xlogy`, and reductions `Var/Std`; GPU custom-kernel coverage is still absent |
-| Linalg kernel (`tenferro-linalg-prims`) | Yes | Partial | Partial | Partial | Partial | Partial | Solve/factorization kernels exist and now gate on backend-generic `KernelLinalgScalar`; the remaining gap is backend breadth, not CPU-named scalar contracts |
+| Semiring core / fast path (`tenferro-core-ops` + `tenferro-einsum`) | Yes | Partial | Partial | Yes | Partial | Yes | `einsum` is strong, `Permute` is gone from the core op surface, and semiring execution now routes through `StdTensorOp` / `ExecOp` plus operation-family runtimes; the remaining gap is GPU capability breadth, not legacy layering |
+| Scalar (`StdTensorOp` elementwise/reduction ops) | Partial | Partial | Partial | No | Partial | Partial | CPU phase 1 now executes unary `Neg/Conj/Abs/Reciprocal/Real/Imag/Square`, binary `Add/Sub/Mul/Div/Maximum/Minimum/Clamp*`, and reductions `Sum/Prod/Mean/Max/Min`; predicate/select tensor ops such as `where` are still absent |
+| Analytic (`StdTensorOp` analytic ops) | Partial | Partial | Partial | No | Partial | Partial | CPU phase 1 now executes unary `Sqrt/Rsqrt/Exp/Expm1/Log/Log1p/Sin/Cos/Tan/Tanh/Asin/Acos/Atan/Sinh/Cosh/Asinh/Acosh/Atanh`, binary `Pow/Atan2/Hypot/Xlogy`, and reductions `Var/Std`; GPU custom-kernel coverage is still absent |
+| Linalg kernel (`tenferro-linalg::backend::LinalgBackend`) | Yes | Partial | Partial | Partial | Partial | Partial | Solve/factorization kernels exist and now gate through backend-generic linalg/runtime contracts; the remaining gap is backend breadth, not CPU-named scalar contracts |
 | Linalg composite (`tenferro-linalg`) | Yes | Partial | Partial | Partial | Partial | Partial | Public coverage is broad and production entrypoints are capability-driven; the remaining gap is that several composites still bottom out in CPU-only kernels because broader backend support is missing |
 | Dyadtensor / AD surface | Partial | Partial | Partial | Partial | Partial | Partial | Eager builders now cover scalar/analytic unary, binary, and reduction families including `add`, `atan2`, `pow`, `hypot`, `exp`, `log`, `sin`, `cos`, `tanh`, `asin`, `acos`, `atan`, hyperbolic families, `sum`, `mean`, `var`, and `std`; predicate/select families are still missing and some AD families remain CPU-complete only |
 
@@ -54,7 +54,8 @@ Status labels in the matrix use:
   dense pointwise / reduction substrate.
 - `primal` and `AD` coverage are uneven in different ways:
   `tenferro-linalg` is broad on primal surface but uneven on VJP/JVP/HVP, while
-  `tenferro-prims` is still missing much of the scalar/analytic substrate.
+  the current `StdTensorOp` / backend surface is still missing parts of the
+  scalar/analytic substrate.
 - `CPU/GPU generic` and `layer-clean` are separate axes on purpose.
   Several families already work on CPU but still leak CPU-only runtime choices
   into public or mid-level APIs.
@@ -76,7 +77,7 @@ These are tensor metadata or view operations and should not be execution prims.
 
 ### Semiring family
 
-Owned by `tenferro-prims`:
+Owned by `tenferro-core-ops` / `tenferro-einsum` and backend dispatch:
 
 - `einsum`, `matmul`, `bmm`, `tensordot`
 - semiring-valid `trace`
@@ -87,7 +88,7 @@ tropical backends.
 
 ### Scalar family
 
-Owned by `TensorScalarPrims`:
+Owned by `StdTensorOp` elementwise/reduction operations:
 
 - pointwise arithmetic such as `add`, `sub`, `mul`, `div`
 - pointwise scalar ops such as `neg`, `conj`, `real`, `imag`, `abs`,
@@ -102,7 +103,7 @@ prevents a clean `where` family and branch-select AD rules.
 
 ### Analytic family
 
-Owned by `TensorAnalyticPrims`:
+Owned by `StdTensorOp` analytic operations:
 
 - `sqrt`, `rsqrt`, `exp`, `expm1`, `log`, `log1p`
 - trigonometric / hyperbolic families
@@ -111,7 +112,7 @@ Owned by `TensorAnalyticPrims`:
 
 ### Linalg kernel family
 
-Owned by `tenferro-linalg-prims`:
+Owned by `tenferro-linalg::backend::LinalgBackend`:
 
 - `solve`, `solve_triangular`
 - `qr`, `svd`, `lu_factor`, `cholesky`
@@ -131,12 +132,13 @@ Owned by `tenferro-linalg`:
 - shape-normalized families such as `svdvals`, `eigvals`, `eigvalsh`,
   `matrix_norm`, and `vector_norm`
 
-These are public APIs that should lower through structural ops, semiring/scalar
-prims, and the smaller linalg kernel basis.
+These are public APIs that should lower through structural ops, core
+`StdTensorOp` families, operation-family runtimes, and the smaller linalg
+kernel basis.
 
 ### Dyadtensor / AD surface
 
-Owned by `extension/tenferro` and `chainrules`:
+Owned by `tenferro-ad`, `tenferro-runtime`, and operation-family AD rules:
 
 - reverse / forward / HVP entry points over `einsum`
 - eager builder APIs for linalg results
@@ -149,7 +151,7 @@ pointwise family comparable to PyTorch eager tensor math.
 
 ### 1. Dense scalar and analytic substrate is real on CPU, but still incomplete in breadth
 
-`TensorScalarPrims` and `TensorAnalyticPrims` now have dedicated CPU planning
+`StdTensorOp` scalar and analytic families now have dedicated CPU planning
 and execution. The remaining gap is breadth, not existence:
 
 - predicate/select tensor ops such as `where` are still absent
@@ -161,7 +163,7 @@ and execution. The remaining gap is breadth, not existence:
 The current design keeps axis reordering in `tenferro-tensor` as metadata-only
 `transpose_view` operations and uses explicit contiguous/canonicalization
 boundaries for execution. The old materializing `Permute` primitive has now
-been removed from `tenferro-prims`, which aligns the public substrate with the
+been removed from the core op surface, which aligns the public substrate with the
 intended semiring-core design.
 
 ### 3. `tenferro-linalg` is public/composite in design and production, but backend breadth is uneven
@@ -171,7 +173,7 @@ capability-driven. The remaining issue is not legacy layering; it is that some
 composite paths still bottom out in CPU-only kernels because broader backend
 coverage has not landed yet.
 
-### 4. `tenferro-linalg-prims` now separates backend-generic kernel scalars from LAPACK-specific helpers
+### 4. `tenferro-linalg` now separates backend-generic kernel scalars from LAPACK-specific helpers
 
 The backend contract now distinguishes:
 
@@ -184,7 +186,7 @@ conversion details.
 
 ### 5. Dyadtensor runtime is generic at the API boundary, but backend coverage is still mixed
 
-`extension/tenferro` now routes high-level primal and AD entrypoints
+`tenferro-ad` and operation-family crates now route high-level primal and AD entrypoints
 through runtime-dispatch helpers rather than CPU-specific production shortcuts.
 The remaining gap is that several families are only implemented deeply enough
 for CPU today, so unsupported backends still fail truthfully on capability.
@@ -203,10 +205,10 @@ still unsupported, including `det`, `eig`, `eigvals`, `eigvalsh`,
 
 ### Substrate gaps
 
-- Expand `TensorScalarPrims` beyond the phase-1 unary/binary/reduction subset
+- Expand `StdTensorOp` scalar coverage beyond the phase-1 unary/binary/reduction subset
 - Add a dedicated predicate/select substrate so `where` and branch-select AD
   families can land without smuggling boolean semantics into scalar core traits
-- Broaden `TensorAnalyticPrims` surface and expose the remaining user-facing
+- Broaden `StdTensorOp` analytic coverage and expose the remaining user-facing
   analytic wrappers such as `xlogy`
 - Keep the structural/materialization split stable as additional semiring fast
   paths land
@@ -234,11 +236,11 @@ still unsupported, including `det`, `eig`, `eigvals`, `eigvalsh`,
 ## Issue Traceability
 
 - `#443`: the workspace architecture references must reflect the split among
-  `tenferro-prims`, `tenferro-linalg-prims`, and `tenferro-linalg`
+  `tenferro-core-ops`, `tenferro-einsum`, and `tenferro-linalg`
 - `#444`: the new scalar and analytic family traits need rustdoc that explains
   current support and reserved vocabulary
 - `#445`: the LAPACK-specific eig helper split belongs in
-  `tenferro-linalg-prims`, not in the generic scalar contract
+  `tenferro-linalg`, not in the generic scalar contract
 - `#446`: this audit document is the durable repo artifact that records the
   family matrix, layer findings, and backlog
 - `#441`: remains open because the substrate redesign is larger than this audit

--- a/docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs
+++ b/docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs
@@ -13,7 +13,7 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let runtime = EagerRuntime::new();
-    let x = runtime.variable_from(Tensor::from_vec_row_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let x = runtime.variable_from(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
 
     let prediction = &x * &x;
     let loss = prediction.reduce_sum(&[0])?;

--- a/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
+++ b/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
@@ -21,7 +21,7 @@ fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runti
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let x = TracedTensor::from_vec_row_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
     let y = (&x * &x).reduce_sum(&[0]);
 
     let y_value = run(&y)?;
@@ -33,7 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(grad_value.shape(), &[3]);
     assert_close(grad_value.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 
-    let tangent = TracedTensor::from_vec_row_major(vec![3], vec![0.1_f64, 1.0, -2.0]);
+    let tangent = TracedTensor::from_vec_col_major(vec![3], vec![0.1_f64, 1.0, -2.0]);
     let directional = y.jvp(&x, &tangent);
     let directional_value = run(&directional)?;
     assert_eq!(directional_value.shape(), &[]);

--- a/docs/tutorials/eager-autodiff-pytorch-style.md
+++ b/docs/tutorials/eager-autodiff-pytorch-style.md
@@ -24,7 +24,7 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let runtime = EagerRuntime::new();
-    let x = runtime.variable_from(Tensor::from_vec_row_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let x = runtime.variable_from(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
 
     let prediction = &x * &x;
     let loss = prediction.reduce_sum(&[0])?;

--- a/docs/tutorials/traced-autodiff-jax-style.md
+++ b/docs/tutorials/traced-autodiff-jax-style.md
@@ -33,7 +33,7 @@ fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runti
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let x = TracedTensor::from_vec_row_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
     let y = (&x * &x).reduce_sum(&[0]);
 
     let y_value = run(&y)?;
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(grad_value.shape(), &[3]);
     assert_close(grad_value.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 
-    let tangent = TracedTensor::from_vec_row_major(vec![3], vec![0.1_f64, 1.0, -2.0]);
+    let tangent = TracedTensor::from_vec_col_major(vec![3], vec![0.1_f64, 1.0, -2.0]);
     let directional = y.jvp(&x, &tangent);
     let directional_value = run(&directional)?;
     assert_eq!(directional_value.shape(), &[]);

--- a/docs/worklogs/2026-06-12-ai-doc-issue-batch.md
+++ b/docs/worklogs/2026-06-12-ai-doc-issue-batch.md
@@ -1,0 +1,82 @@
+# AI Documentation Issue Batch
+
+## Session Summary
+
+This batch addressed the recent AI-reported GitHub issues #1002 through #1014
+from a branch based on `origin/main`. The work was initially requested as a
+local-only fix batch and was later promoted into a draft PR after the local
+batch had been verified.
+
+- Clarified traced and eager AD guide setup, `AdContext` versus
+  `TracedTensorAdExt`, and added concrete VJP/JVP value assertions.
+- Updated tutorial-code snippets to use column-major constructors consistently.
+- Documented eager operation method coverage and added a reverse-mode `matmul`
+  example.
+- Expanded linalg guide coverage for operation surfaces, decomposition output
+  ordering, reconstruction examples, QR/eigh shape contracts, and complete-pivot
+  LU conventions.
+- Added dependency setup and value assertions across einsum, FFT, tensor, and
+  getting-started docs.
+- Fixed FFT unsupported AD error messages so `rfft` VJP and `irfft` JVP report
+  the failing operation family and AD path accurately.
+
+## Context Read
+
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `REPOSITORY_RULES.md`
+- shared tensor4all common, Rust, performance, numerical, docs/tests, and
+  repository rules
+- `ai/contribution-workflows/bugfix-pr.md`
+- GitHub issues #1002 through #1014
+- AD traced and eager docs and tutorial-code harness
+- FFT AD rule implementation and regression tests
+- linalg backend API docs and linalg public guide
+- einsum, tensor operations, FFT, and getting-started guides
+
+## Decisions Made
+
+- Kept the FFT behavior unchanged and fixed only the unsupported-error
+  reporting path. `rfft` and `irfft` AD remain unsupported until Hermitian
+  half-spectrum rules are implemented.
+- Mapped VJP errors from the linearization phase to VJP wording at the public
+  traced AD boundary, while preserving JVP wording for direct JVP failures.
+- Treated guide snippets as executable examples where practical by adding
+  concrete value assertions and reconstruction checks instead of shape-only
+  assertions.
+- Added dependency snippets directly to the affected guides rather than
+  assuming readers have already followed the getting-started page.
+
+## Rejected Or Deferred Alternatives
+
+- Did not add new AD rules, public APIs, dependencies, or backend behavior.
+- Kept PR preparation deferred during the initial local-only pass. The branch
+  was later promoted to a draft PR after the user changed direction.
+- Did not run the full release workspace test, coverage, or clippy checklist
+  because the requested scope was a local batch fix and the touched code path
+  was covered by targeted tests.
+
+## Verification Performed
+
+- `cargo fmt --all`
+- `python3 scripts/check-doc-snippets.py`
+- `cargo test -p tenferro-tutorial-code`
+- `cargo test -p tenferro-linalg --doc`
+- `cargo test -p tenferro-fft --features autodiff --test fft_ops unsupported_error_names`
+- `python3 scripts/check-doc-snippets.py --check`
+- `cargo fmt --all --check`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `cargo test -p tenferro-einsum --features autodiff tensordot`
+- `cargo test -p tenferro-linalg full_piv_lu`
+- `cargo test -p tenferro-ad --doc`
+- `cargo test -p tenferro-fft --features autodiff --test fft_ops`
+- `git diff --check`
+
+## Remaining Risks
+
+- Markdown guide examples are not all compiled by an automated markdown
+  doctest harness; verification relied on existing tutorial-code, doctests,
+  package tests, and docs site checks.
+- Full release workspace tests, coverage, and clippy were not run in this local
+  no-PR pass.

--- a/docs/worklogs/2026-06-12-issue-1000-remediation.md
+++ b/docs/worklogs/2026-06-12-issue-1000-remediation.md
@@ -1,0 +1,111 @@
+# Issue 1000 Remediation Slice
+
+## Session Summary
+
+This slice addressed the concrete Auto Fix items from GitHub issue #1000 that
+could be verified against the current tree without changing public API, AD
+semantics, GPU support claims, coverage policy, or performance design. The
+work started as a local no-PR pass and was later promoted into the same draft
+PR as the AI documentation issue batch.
+
+- Fixed `CpuBackend::solve` so invalid dtype pairs are rejected before the
+  zero-dimension fast path.
+- Hardened extension direct execution boundaries so registered runtimes cannot
+  silently return fewer or more outputs than the declaring `ExtensionOp`.
+- Hardened `apply_expanded_graph` so graph-build output metadata count
+  mismatches return a typed runtime error instead of silently truncating.
+- Added checked tensor/view materialization helpers and used them at runtime
+  `Result` boundaries that previously could panic on backend-backed views.
+- Aligned `REPOSITORY_RULES.md` with the current CPU provider default:
+  `CpuBackend::new()` selects BLAS/LAPACK when `cpu-blas` is compiled,
+  otherwise faer.
+- Updated active reference/design docs that still described retired
+  `tenferro-prims`, `tenferro-linalg-prims`, and `tenferro-internal-device`
+  crate boundaries as if those crates existed in the current workspace.
+- Recorded a classification ledger for the broader #1000 findings so the
+  umbrella issue is not treated as fully closed by this narrow fix.
+
+## Context Read
+
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `REPOSITORY_RULES.md`
+- `ai/contribution-workflows/repository-remediation.md`
+- GitHub issue #1000 body
+- `crates/tenferro-linalg/src/cpu/backend.rs`
+- `crates/tenferro-linalg/tests/backend_errors.rs`
+- `crates/tenferro-cpu/src/backend.rs`
+- `crates/tenferro-runtime/src/extension.rs`
+- `crates/tenferro-runtime/src/extension_runtime.rs`
+- `crates/tenferro-runtime/src/exec.rs`
+- `crates/tenferro-tensor/src/types.rs`
+- `crates/tenferro-tensor/src/backend.rs`
+- `docs/reference/jax-stablehlo-needed.md`
+- `docs/reference/libtorch.md`
+- `docs/reference/pytorch-dense-cpu-parity.md`
+- `docs/design/linalg-prims.md`
+- `docs/getting-started/index.md`
+
+## Classification Ledger
+
+| #1000 finding | Classification | Current action |
+| --- | --- | --- |
+| Active AD rules exceed oracle/replay coverage | Verify First / Deferred | Not changed here. #987 already tracks full-pivot LU oracle work; broader oracle/support alignment needs its own focused slice. |
+| CUDA placement and backend-buffer diagnostics | Verify First / Deferred | Not changed here. Needs GPU/feature-aware behavior tests for host, wrong-device, zero-length, and unsupported-dtype ordering. |
+| CPU/GPU performance and hidden materialization risks | Verify First / Deferred | Not changed here. Needs scale-sensitive tests or benchmarks before remediation. |
+| Public API and extension-boundary panic or invariant-loss risks | Mixed / Partially fixed | Added reduced repro tests and fixes for extension output-count mismatches, expanded-graph output metadata mismatches, and backend-view materialization through `Result` boundaries. Other non-`Result` public panic APIs such as operator overloads and `dot_general` remain verify-first/deferred. |
+| CPU `solve` empty-shape path bypasses dtype-pair validation | Auto Fix / Fixed | Added regression coverage and moved dtype-pair validation before the zero-dimension fast path. |
+| CPU provider rule drift | Auto Fix / Fixed | Updated `REPOSITORY_RULES.md` to match current `CpuBackendKind::default_compiled()`. |
+| Guide dependency drift for einsum/FFT/basic guides | Stale in current branch | Addressed earlier in the same local batch for #1011-#1014. |
+| Broad docs/tooling drift around unmarked snippets and stale reference docs | Mixed / Partially fixed | Updated active reference/design docs that named retired crate boundaries. Snippet/tooling expansion is still deferred. |
+
+## Decisions Made
+
+- Kept `ensure_supported_linalg_pair` as the single validation helper for
+  `solve`, matching `lu_solve_prepared` and the linalg dtype contract.
+- Did not change the unsupported-dtype error shape. Same unsupported integer
+  dtype pairs still return the existing backend failure message; mixed dtype
+  pairs return `DTypeMismatch`.
+- Kept existing panic-capable convenience APIs such as `TensorView::to_tensor`
+  for compatibility, but added checked counterparts (`try_to_tensor`) and used
+  those at `Result` boundaries.
+- Did not add a new public `try_dot_general` or change operator-overload
+  semantics; those would be broader public API decisions.
+- Did not attempt to close #1000 as a whole. The issue remains an umbrella
+  backlog with multiple verify-first or design-gated findings.
+
+## Verification Performed
+
+- RED: `cargo test -p tenferro-linalg --test backend_errors solve_rejects_invalid_dtype_pairs_before_zero_dim_fast_path`
+  failed because `solve` returned `Ok(C64 empty)` for `F64`/`C64` empty inputs.
+- GREEN: `cargo test -p tenferro-linalg --test backend_errors solve_rejects_invalid_dtype_pairs_before_zero_dim_fast_path`
+- `cargo fmt --all`
+- `cargo test -p tenferro-linalg --test backend_errors`
+- RED: `cargo test -p tenferro-runtime --test extension_runtime output_count_mismatch`
+  failed because direct runtime execution returned `Ok` with the wrong output count.
+- RED: `cargo test -p tenferro-runtime extension::tests::apply_expanded_graph_rejects_output_metadata_count_mismatch`
+  failed because `apply_expanded_graph` returned `Ok(vec![])`.
+- RED: `cargo test -p tenferro-runtime --test extension_runtime backend_view_materialization`
+  failed because backend-backed view materialization panicked before returning `Err`.
+- GREEN: `cargo test -p tenferro-runtime --test extension_runtime output_count_mismatch`
+- GREEN: `cargo test -p tenferro-runtime extension::tests::apply_expanded_graph_rejects_output_metadata_count_mismatch`
+- GREEN: `cargo test -p tenferro-runtime --test extension_runtime backend_view_materialization`
+- `cargo test -p tenferro-runtime --test extension_runtime`
+- `cargo test -p tenferro-runtime --lib extension::tests`
+- `cargo test -p tenferro-runtime --test runtime_public_api`
+- `cargo test -p tenferro-runtime --test graph_default_input_placement`
+- `cargo test -p tenferro-tensor types_tests`
+- `cargo test -p tenferro-tensor --doc`
+- `cargo test -p tenferro-cpu --test runtime_error_tests`
+- `cargo fmt --all --check`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-doc-snippets.py --check`
+- `python3 scripts/check-docs-site.py`
+- `git diff --check`
+
+## Remaining Risks
+
+- Full #1000 remediation is incomplete by design. GPU, AD oracle,
+  performance/materialization, non-`Result` public API panic, and broader
+  docs/tooling findings need separate focused tests or design gates before
+  implementation.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs #1000

Closes #1002
Closes #1003
Closes #1004
Closes #1005
Closes #1006
Closes #1007
Closes #1008
Closes #1009
Closes #1010
Closes #1011
Closes #1012
Closes #1013
Closes #1014

## Summary

This PR batches the AI-reported documentation and source-risk remediation work that was prepared locally.

- Updates AD, eager operations, tensor operations, einsum, FFT, linalg, getting-started, and tutorial docs with current crate usage, dependency snippets, column-major examples, and concrete assertions.
- Fixes FFT unsupported AD error wording so public VJP/JVP failures identify the operation family and AD path accurately.
- Fixes CPU `solve` validation so invalid dtype pairs are rejected before the zero-dimension fast path.
- Hardens extension/runtime boundaries by checking direct extension runtime output counts, expanded-graph output metadata counts, and backend-backed view materialization at `Result` boundaries.
- Aligns active design/reference docs and `REPOSITORY_RULES.md` with the current crate split and CPU provider default.

For #1000, this intentionally handles the confirmed/low-risk slices only. GPU diagnostics, AD oracle coverage, and performance/materialization findings remain verify-first items requiring focused tests, hardware, benchmarks, or design work before implementation.

## Work log

- `docs/worklogs/2026-06-12-ai-doc-issue-batch.md`
- `docs/worklogs/2026-06-12-issue-1000-remediation.md`

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/check-doc-snippets.py`
- `python3 scripts/check-doc-snippets.py --check`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test -p tenferro-tutorial-code`
- `cargo test -p tenferro-linalg --doc`
- `cargo test -p tenferro-linalg full_piv_lu`
- `cargo test -p tenferro-linalg --test backend_errors`
- `cargo test -p tenferro-ad --doc`
- `cargo test -p tenferro-einsum --features autodiff tensordot`
- `cargo test -p tenferro-fft --features autodiff --test fft_ops`
- `cargo test -p tenferro-runtime --test extension_runtime`
- `cargo test -p tenferro-runtime --lib extension::tests`
- `cargo test -p tenferro-runtime --test runtime_public_api`
- `cargo test -p tenferro-runtime --test graph_default_input_placement`
- `cargo test -p tenferro-tensor types_tests`
- `cargo test -p tenferro-tensor --doc`
- `cargo test -p tenferro-cpu --test runtime_error_tests`

Not run locally:

- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- GPU/CUDA ignored tests

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. Not applicable; this is bug/docs/remediation work.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
