### PR TITLE
docs: add Diagram Consistency rule to REPOSITORY_RULES.md

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -522,6 +522,20 @@ Tests follow implementation ownership.
   explicitly show upload/download boundaries, and assert downloaded CPU results
   for at least one supported operation.
 
+### Diagram Consistency
+
+- Diagrams in docs and `README.md` (SVG under `docs/assets/`, ASCII diagrams
+  in design, architecture, and spec pages) are part of the documented surface:
+  crate names, layer assignments, dependency directions, and public entry
+  points shown in a diagram must match the current implementation.
+- A PR that adds, removes, renames, or re-layers a crate, or changes an
+  extension or backend boundary shown in a diagram, must update the affected
+  diagrams in the same PR.
+- Stale diagrams are worse than missing diagrams. Delete a diagram rather than
+  leave it inaccurate.
+- Diagrams follow the same source-of-truth rule as text: show boundaries and
+  dependencies, not internal implementation detail that the source code owns.
+
 ### Doc Examples
 
 - Doc examples (`/// # Examples`) must NOT use `ignore` or `no_run` attributes.


### PR DESCRIPTION
## Summary

Adds a `### Diagram Consistency` subsection under `## Documentation Policy` in `REPOSITORY_RULES.md`:

- Diagrams (SVG under `docs/assets/`, ASCII diagrams in design/architecture/spec pages, `README.md`) are part of the documented surface and must match the current crate set, layer assignments, dependency directions, and public entry points.
- A PR that changes a boundary shown in a diagram must update the affected diagrams in the same PR.
- Stale diagrams are worse than missing diagrams — delete rather than leave inaccurate.
- Diagrams follow the same source-of-truth rule as text: boundaries and dependencies, not internals.

## Context

Maintenance guard for the architecture-overview SVG proposed in #1020 (item C7), generalized to the two existing SVGs (`docs/assets/execution-models.svg`, `docs/assets/tensor-layer-decision.svg`) and ASCII diagrams. Markdown-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)