### PR TITLE
docs: improve onboarding and docs site checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,5 +105,9 @@ jobs:
             sudo DEBIAN_FRONTEND=noninteractive apt-get update
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends graphviz
           fi
+      - name: Run docs script tests
+        run: |
+          python3 scripts/test-check-docs-site.py
+          python3 scripts/test-doc-consistency.py
       - name: Build docs site
         run: bash scripts/build_docs_site.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ Additionally, verify the following before pushing:
 - **Clippy parity**: Run clippy locally with the same command and options as the repository CI `clippy` job; do not use a relaxed local variant.
 - **Side review**: Re-read `REPOSITORY_RULES.md` and review the local diff against repository rules before creating a PR. Fix any findings, or explicitly document residual risks.
 - **Sample code verification**: All code examples in `README.md` and `docs/getting-started/` must compile and run correctly. Extract and test any changed examples.
-- **Design document updates**: When code changes affect architecture or specifications, update the corresponding documents in `docs/architecture/`, `docs/spec/`, or `docs/design/`. Stale documentation is worse than no documentation.
+- **Design document updates**: When code changes affect architecture or specifications, update the corresponding documents in `docs/architecture/`, `docs/spec/`, or `docs/design/`, and update any affected diagrams under `docs/assets/` or embedded in Markdown. Stale documentation is worse than no documentation.
 - **Work log updates**: For nontrivial refactors, cleanup streams, AI-assisted implementation, or explicit tradeoff decisions, add or update a work log under `docs/worklogs/` and link it from the PR body.
 
 ### PR Creation Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,8 +298,10 @@ Layer 3: tenferro-runtime  - Concrete tensor helpers, traced tensors, graph comp
          tenferro-linalg   - Linear algebra traced APIs, eager helpers, extension runtime,
                              optional linalg AD rules
          tenferro-fft      - FFT extension runtime and public FFT APIs
-Layer 2: tenferro-tensor   - Dense runtime tensors, backend traits, CPU backend,
-                             core execution kernels
+Layer 2: tenferro-tensor   - Dense runtime tensors, backend traits,
+                             backend-independent contracts
+         tenferro-cpu      - CPU backend, execution sessions, kernels,
+                             buffer pools
          tenferro-gpu      - CubeCL/CUDA backend and GPU transfer helpers
 Layer 1: tenferro-tensor-core - Host-only tensor data model, dtype tags,
                                 scalar trait, metadata-only views
@@ -312,9 +314,9 @@ Internal: tenferro-core-ops  - Internal core primitive operation catalog
 tensor type, and owns graph transforms such as `linearize` and
 `linear_transpose`.
 `tenferro-tensor-core` owns the lightweight host tensor data model.
-`tenferro-tensor` owns concrete dense runtime value types and CPU backend
-execution surface. `tenferro-gpu` owns CubeCL/CUDA backend code and transfer
-helpers.
+`tenferro-tensor` owns concrete dense runtime value types and
+backend-independent tensor contracts. `tenferro-cpu` owns CPU backend
+execution. `tenferro-gpu` owns CubeCL/CUDA backend code and transfer helpers.
 `tenferro-internal-ops/src/ad/` is the semantic source of truth for core
 primitive AD rules. `tenferro-runtime` owns traced graph construction,
 lowering, execution, extension registration, and cache ownership. `tenferro-ad`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ help.
 - Validate numerical behavior with tests, oracle data, invariants, residual
   checks, provenance checks, and reproducible benchmarks.
 
+## When tenferro Is a Good Fit
+
+tenferro-rs is designed for workloads where tensor shapes are not always fixed
+before execution. If your computation involves runtime-dependent ranks,
+threshold-based filtering, data-dependent iteration counts, or shape-parametric
+models, tenferro's traced execution can reuse a compiled program while resolving
+the concrete sizes at runtime.
+
+| tenferro is a good fit when | XLA/JAX may be a better fit when |
+| --- | --- |
+| Shapes depend on runtime values | All shapes are static and known before compilation |
+| Small-to-medium batched linear algebra with AD | Large static-shape matmul or contraction throughput dominates |
+| You need `grad`, `vjp`, `jvp`, or HVP workflows in Rust | You can use Python as the host language |
+| You are building a Rust-native tensor application | You need the mature compiler and ecosystem around JAX today |
+| You need extension points for custom algebra or operation families | You only need standard tensor operations |
+
+The planned optional XLA backend in
+[#984](https://github.com/tensor4all/tenferro-rs/issues/984) is intended for
+static-shape traced graphs. Dynamic-shape graphs remain the native runtime's
+core use case.
+
+![tenferro-rs architecture overview](docs/assets/tenferro-architecture.svg)
+
 ## Which API Should I Use?
 
 | If your workflow needs | Start with |
@@ -111,6 +134,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 The full guides, tutorials, API reference, architecture notes, and
 specifications live at <https://tensor4all.org/tenferro-rs/>. Start with
 Getting Started if you are using tenferro-rs for the first time.
+
+- [Design: dynamic and symbolic shapes](https://tensor4all.org/tenferro-rs/design/dynamic-symbolic-shapes.html)
+  explains how tenferro represents runtime-dependent dimensions in traced
+  programs.
 
 Official benchmark suites and result tooling live in
 [`tensor4all/tenferro-benchmark`](https://github.com/tensor4all/tenferro-benchmark).

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -485,8 +485,13 @@ Tests follow implementation ownership.
 ### Source of Truth
 
 - **Source code** is the source of truth for internal design (op catalog, backend contract, AD rules, compilation pipeline).
-- **Online docs** are user-facing only — how to use the explicit runtime, AD,
-  tensor, GPU, and standard operation crates.
+- **Online docs** are primarily user-facing — how to use the explicit runtime,
+  AD, tensor, GPU, and standard operation crates.
+- The online **Internals section** is the exception for implementation-oriented
+  readers: it may publish curated architecture, specification, and active
+  design notes when those pages are linked from rendered docs. Historical
+  `docs/plans/` records stay offline unless a maintainer explicitly decides
+  otherwise.
 - **AGENTS.md** is the entry point for developers and AI agents. It contains pointers to source code locations.
 - Do NOT duplicate source-code-level information in online docs. If it can be learned by reading the source, put a pointer instead of a copy.
 - Development assumes AI agentic coding. Keep machine-readable sources (code + doc comments) authoritative.

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -11,6 +11,7 @@ project:
     - internals/**/*.md
     - architecture/**/*.md
     - spec/**/*.md
+    - design/**/*.md
 
 format:
   html:
@@ -74,6 +75,28 @@ website:
               - architecture/primitive-ad.md
               - architecture/tidu.md
               - architecture/ad-pipeline.md
+          - section: "Design Notes"
+            contents:
+              - design/index.md
+              - design/api-and-convention-freeze.md
+              - design/supported-ops.md
+              - design/tensor.md
+              - design/tensor-prims.md
+              - design/algebra.md
+              - design/einsum.md
+              - design/contraction-pipeline.md
+              - design/dot-general-overhead.md
+              - design/dynamic-symbolic-shapes.md
+              - design/exec-session.md
+              - design/gpu-backend-design.md
+              - design/inplace-indexing.md
+              - design/linalg.md
+              - design/linalg-prims.md
+              - design/refactor-roadmap-912.md
+              - design/capi.md
+              - design/capi-error-handling.md
+              - design/testing.md
+              - design/review-decision-records.md
           - section: "Specification"
             contents:
               - spec/index.md

--- a/docs/architecture/tenferro-crates.md
+++ b/docs/architecture/tenferro-crates.md
@@ -24,6 +24,8 @@ The design goal is to keep these concerns separate:
 - first-class operation families such as einsum, linalg, and FFT
 - internal graph operation vocabulary and primitive metadata
 
+![tenferro-rs architecture overview](../assets/tenferro-architecture.svg)
+
 ## II. Current Workspace Crates
 
 | Crate | Role |

--- a/docs/assets/tenferro-architecture.svg
+++ b/docs/assets/tenferro-architecture.svg
@@ -1,0 +1,119 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 540" role="img" aria-labelledby="tf-arch-title tf-arch-desc">
+  <title id="tf-arch-title">tenferro-rs architecture overview</title>
+  <desc id="tf-arch-desc">Four-layer crate stack with user entry points on top, external foundations on the left, and operation-family crates on the right all plugging into the same ExtensionOp registry of tenferro-runtime.</desc>
+  <defs>
+    <marker id="arr" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0 0 L 9 3.5 L 0 7 z" fill="#334155"/>
+    </marker>
+    <style>
+      .box { fill: #f8fafc; stroke: #64748b; stroke-width: 1.5; }
+      .fam { fill: #dbeafe; stroke: #2563eb; stroke-width: 1.5; }
+      .ext { fill: #ffffff; stroke: #94a3b8; stroke-width: 1.3; stroke-dasharray: 5 4; }
+      .name { font: 700 13px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; text-anchor: middle; }
+      .sub { font: 11px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; text-anchor: middle; }
+      .tag { font: 700 10px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #94a3b8; }
+      .hdr { font: 700 11px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; text-anchor: middle; letter-spacing: 0.4px; }
+      .cap { font: italic 12px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #334155; text-anchor: middle; }
+      .leg { font: 11px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+      .dep { stroke: #334155; stroke-width: 1.6; marker-end: url(#arr); fill: none; }
+      .use { stroke: #64748b; stroke-width: 1.2; stroke-dasharray: 4 4; marker-end: url(#arr); fill: none; }
+      .bus { stroke: #2563eb; stroke-width: 1.6; fill: none; }
+      .busa { stroke: #2563eb; stroke-width: 1.6; marker-end: url(#arr); fill: none; }
+    </style>
+  </defs>
+
+  <text x="460" y="22" class="hdr">USER ENTRY POINTS</text>
+  <rect x="260" y="30" width="128" height="52" rx="6" class="box"/>
+  <text x="324" y="52" class="name" style="font-size:12px">TypedTensor · Tensor</text>
+  <text x="324" y="69" class="sub">no AD</text>
+  <rect x="396" y="30" width="128" height="52" rx="6" class="box"/>
+  <text x="460" y="52" class="name" style="font-size:12px">EagerTensor</text>
+  <text x="460" y="69" class="sub">.backward()</text>
+  <rect x="532" y="30" width="128" height="52" rx="6" class="box"/>
+  <text x="596" y="52" class="name" style="font-size:12px">TracedTensor</text>
+  <text x="596" y="69" class="sub">grad · vjp · jvp</text>
+
+  <line x1="460" y1="84" x2="460" y2="106" class="dep"/>
+
+  <rect x="260" y="110" width="400" height="56" rx="6" class="box"/>
+  <text x="272" y="126" class="tag">L4</text>
+  <text x="460" y="134" class="name">tenferro-ad</text>
+  <text x="460" y="152" class="sub">eager + traced autodiff</text>
+
+  <line x1="460" y1="168" x2="460" y2="192" class="dep"/>
+
+  <rect x="260" y="196" width="400" height="84" rx="6" class="box"/>
+  <text x="272" y="212" class="tag">L3</text>
+  <text x="400" y="230" class="name">tenferro-runtime</text>
+  <text x="400" y="250" class="sub">trace → compile → execute</text>
+  <rect x="556" y="224" width="96" height="30" rx="5" class="fam"/>
+  <text x="604" y="243" class="sub" style="font-weight:700">ExtensionOp</text>
+
+  <line x1="460" y1="282" x2="460" y2="304" class="dep"/>
+
+  <rect x="260" y="308" width="235" height="68" rx="6" class="box"/>
+  <text x="272" y="324" class="tag">L2</text>
+  <text x="377" y="330" class="name">tenferro-tensor</text>
+  <text x="377" y="347" class="sub">dense tensors · backend traits</text>
+  <text x="377" y="363" class="sub" style="font-size:10px">CPU: faer | BLAS/LAPACK</text>
+  <rect x="510" y="308" width="150" height="68" rx="6" class="box"/>
+  <text x="585" y="330" class="name">tenferro-gpu</text>
+  <text x="585" y="347" class="sub">CubeCL · CUDA</text>
+  <text x="585" y="363" class="sub" style="font-size:10px">cuTENSOR/cuSOLVER/cuBLAS</text>
+  <line x1="508" y1="342" x2="499" y2="342" class="dep"/>
+
+  <line x1="377" y1="378" x2="377" y2="400" class="dep"/>
+
+  <rect x="260" y="404" width="400" height="52" rx="6" class="box"/>
+  <text x="272" y="420" class="tag">L1</text>
+  <text x="460" y="426" class="name">tenferro-tensor-core</text>
+  <text x="460" y="444" class="sub">host-only data model · zero deps</text>
+
+  <text x="120" y="108" class="hdr">FOUNDATIONS</text>
+  <rect x="20" y="120" width="200" height="52" rx="6" class="ext"/>
+  <text x="120" y="140" class="name">tidu-rs</text>
+  <text x="120" y="157" class="sub">linearize · linear_transpose</text>
+  <rect x="20" y="196" width="200" height="52" rx="6" class="ext"/>
+  <text x="120" y="216" class="name">computegraph-rs</text>
+  <text x="120" y="233" class="sub">generic graph engine</text>
+  <rect x="20" y="308" width="200" height="52" rx="6" class="ext"/>
+  <text x="120" y="328" class="name">strided-rs</text>
+  <text x="120" y="345" class="sub">strided views · CPU kernels</text>
+  <line x1="222" y1="146" x2="256" y2="146" class="use"/>
+  <line x1="222" y1="222" x2="256" y2="222" class="use"/>
+  <line x1="222" y1="334" x2="256" y2="334" class="use"/>
+
+  <text x="850" y="102" class="hdr">OPERATION FAMILIES</text>
+  <rect x="720" y="110" width="260" height="56" rx="6" class="fam"/>
+  <text x="850" y="132" class="name">tenferro-einsum</text>
+  <text x="850" y="149" class="sub">contraction trees (omeco) · AD rule</text>
+  <rect x="720" y="182" width="260" height="56" rx="6" class="fam"/>
+  <text x="850" y="204" class="name">tenferro-linalg</text>
+  <text x="850" y="221" class="sub">svd · qr · solve · AD rules</text>
+  <rect x="720" y="254" width="260" height="56" rx="6" class="fam"/>
+  <text x="850" y="276" class="name">tenferro-fft</text>
+  <text x="850" y="293" class="sub">fft · rfft · irfft</text>
+  <rect x="720" y="326" width="260" height="56" rx="6" class="fam"/>
+  <text x="850" y="348" class="name">tropical (ext/)</text>
+  <text x="850" y="365" class="sub">tropical semiring example</text>
+  <rect x="720" y="398" width="260" height="56" rx="6" class="ext"/>
+  <text x="850" y="420" class="name">your-crate</text>
+  <text x="850" y="437" class="sub">sparse ops? custom algebra?</text>
+
+  <line x1="700" y1="138" x2="700" y2="426" class="bus"/>
+  <line x1="718" y1="138" x2="700" y2="138" class="bus"/>
+  <line x1="718" y1="210" x2="700" y2="210" class="bus"/>
+  <line x1="718" y1="282" x2="700" y2="282" class="bus"/>
+  <line x1="718" y1="354" x2="700" y2="354" class="bus"/>
+  <line x1="718" y1="426" x2="700" y2="426" class="bus"/>
+  <line x1="700" y1="239" x2="656" y2="239" class="busa"/>
+
+  <rect x="260" y="480" width="14" height="14" rx="3" class="box"/>
+  <text x="282" y="491" class="leg">workspace crates</text>
+  <rect x="400" y="480" width="14" height="14" rx="3" class="fam"/>
+  <text x="422" y="491" class="leg">operation families (ExtensionOp)</text>
+  <rect x="630" y="480" width="14" height="14" rx="3" class="ext"/>
+  <text x="652" y="491" class="leg">external workspaces / your code</text>
+
+  <text x="500" y="524" class="cap">einsum, linalg, and FFT are not built-ins — they register through the same public ExtensionOp interface available to any crate.</text>
+</svg>

--- a/docs/assets/tenferro-architecture.svg
+++ b/docs/assets/tenferro-architecture.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 540" role="img" aria-labelledby="tf-arch-title tf-arch-desc">
   <title id="tf-arch-title">tenferro-rs architecture overview</title>
-  <desc id="tf-arch-desc">Four-layer crate stack with user entry points on top, external foundations on the left, and operation-family crates on the right all plugging into the same ExtensionOp registry of tenferro-runtime.</desc>
+  <desc id="tf-arch-desc">Four-layer crate stack with user entry points on top, external foundations on the left, CPU and GPU backends in layer two, and operation-family crates on the right all plugging into the same ExtensionOp registry of tenferro-runtime.</desc>
   <defs>
     <marker id="arr" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="strokeWidth">
       <path d="M 0 0 L 9 3.5 L 0 7 z" fill="#334155"/>
@@ -21,6 +21,8 @@
       .busa { stroke: #2563eb; stroke-width: 1.6; marker-end: url(#arr); fill: none; }
     </style>
   </defs>
+
+  <rect width="100%" height="100%" fill="#ffffff"/>
 
   <text x="460" y="22" class="hdr">USER ENTRY POINTS</text>
   <rect x="260" y="30" width="128" height="52" rx="6" class="box"/>
@@ -51,16 +53,19 @@
 
   <line x1="460" y1="282" x2="460" y2="304" class="dep"/>
 
-  <rect x="260" y="308" width="235" height="68" rx="6" class="box"/>
+  <rect x="260" y="308" width="125" height="68" rx="6" class="box"/>
   <text x="272" y="324" class="tag">L2</text>
-  <text x="377" y="330" class="name">tenferro-tensor</text>
-  <text x="377" y="347" class="sub">dense tensors · backend traits</text>
-  <text x="377" y="363" class="sub" style="font-size:10px">CPU: faer | BLAS/LAPACK</text>
-  <rect x="510" y="308" width="150" height="68" rx="6" class="box"/>
-  <text x="585" y="330" class="name">tenferro-gpu</text>
-  <text x="585" y="347" class="sub">CubeCL · CUDA</text>
-  <text x="585" y="363" class="sub" style="font-size:10px">cuTENSOR/cuSOLVER/cuBLAS</text>
-  <line x1="508" y1="342" x2="499" y2="342" class="dep"/>
+  <text x="322" y="330" class="name" style="font-size:12px">tenferro-tensor</text>
+  <text x="322" y="347" class="sub">dense tensors</text>
+  <text x="322" y="363" class="sub">backend traits</text>
+  <rect x="395" y="308" width="125" height="68" rx="6" class="box"/>
+  <text x="457" y="330" class="name" style="font-size:12px">tenferro-cpu</text>
+  <text x="457" y="347" class="sub">CPU backend</text>
+  <text x="457" y="363" class="sub" style="font-size:9px">faer | BLAS/LAPACK</text>
+  <rect x="530" y="308" width="130" height="68" rx="6" class="box"/>
+  <text x="595" y="330" class="name" style="font-size:12px">tenferro-gpu</text>
+  <text x="595" y="347" class="sub">CubeCL · CUDA</text>
+  <text x="595" y="363" class="sub" style="font-size:9px">cuTENSOR/cuSOLVER</text>
 
   <line x1="377" y1="378" x2="377" y2="400" class="dep"/>
 

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -17,7 +17,7 @@ migration notes live under [Plans](../plans/), not this active design index.
 | [einsum.md](./einsum.md) | Einsum public API, N-ary contraction tree, algebra dispatch |
 | [contraction-pipeline.md](./contraction-pipeline.md) | Binary contraction pipeline, copy elision |
 | [dot-general-overhead.md](./dot-general-overhead.md) | Fixed-cost analysis for many small `dot_general` contractions |
-| [dynamic-symbolic-shapes.md](./dynamic-symbolic-shapes.md) | Dynamic and symbolic shape metadata contract |
+| [dynamic-symbolic-shapes.md](./dynamic-symbolic-shapes.md) | Dynamic and symbolic shape metadata contract. Covers `DynamicTruncate`, `transpose_scatter`, symbolic `slice_sizes`, and the `Exact`/`UpperBound`/`Unknown` extent model. This is the key design doc for understanding how tenferro differs from XLA-style shape-specialized compilation. |
 | [gpu-backend-design.md](./gpu-backend-design.md) | GPU backend architecture |
 | [inplace-indexing.md](./inplace-indexing.md) | Partial in-place updates design |
 | [linalg.md](./linalg.md) | Linalg public/composite layer |

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -5,6 +5,22 @@ optional `backward()` on scalar losses, traced graph execution, `grad`, `vjp`,
 and `jvp` on traced graphs, einsum, linear algebra, and CUDA execution through
 the feature-gated CUDA backend.
 
+## Mental Model
+
+tenferro has three independent choices. Pick the smallest tensor layer that
+matches the program, decide whether work should run immediately or through a
+compiled traced program, then choose a CPU or CUDA backend explicitly.
+
+| Choice | Question | Common starting point |
+| --- | --- | --- |
+| Tensor layer | What kind of value do I pass around? | `TypedTensor<T>` for typed CPU values, `Tensor` for runtime dtype |
+| Execution model | When does computation run? | Direct/eager for ordinary code, traced for `grad`, `vjp`, `jvp`, or reuse |
+| Backend/device | Where does computation run? | `CpuBackend`; upload/download explicitly for CUDA |
+
+CUDA, eager execution, and traced graphs are not competing APIs. They compose
+when a workflow needs them, but the first CPU program below only needs the
+runtime crate and CPU backend.
+
 ## Setup
 
 Start with the runtime crate and CPU backend crate. Use a local checkout while
@@ -105,6 +121,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 <!-- end-snippet-source -->
+
+Expected output: the program exits silently because the shape and value
+assertions pass.
 
 ## Next Steps
 

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -71,6 +71,21 @@ CUDA support targets NVIDIA CUDA. See
 [Devices and GPU](../guides/devices-and-gpu.md) for the current coverage and
 setup commands.
 
+### Dynamic shapes and static-shape specialization
+
+JAX/XLA specializes compiled programs to known shapes. That is a strong fit for
+large static-shape workloads where compiler optimization dominates. tenferro's
+native traced runtime is built for the complementary case: programs whose
+output sizes may depend on runtime values, such as thresholded or truncated
+linear algebra.
+
+When shapes are static, the proposed optional XLA backend
+([#984](https://github.com/tensor4all/tenferro-rs/issues/984)) may eventually
+route traced programs to XLA. When ranks or extents are value-dependent,
+tenferro keeps dynamic shape metadata in the traced program and resolves the
+concrete sizes during execution. See
+[Dynamic and Symbolic Shape Metadata](../design/dynamic-symbolic-shapes.md).
+
 ### Lazy traced execution
 
 PyTorch users usually expect every operation to execute immediately. JAX users

--- a/docs/guides/execution-models.md
+++ b/docs/guides/execution-models.md
@@ -44,6 +44,20 @@ graphs, symbolic inputs, graph optimization, and repeated execution. The
 executor backend decides whether the compiled program runs on CPU or CUDA for
 supported operations.
 
+### Dynamic Shapes in Traced Mode
+
+Traced programs can carry shape metadata whose exact size is resolved at
+execution time. That lets operations such as truncated SVD return a rank chosen
+from the input values and still feed later traced operations without re-tracing
+or padding to a fixed rank.
+
+This is the main difference from shape-specialized compilation systems such as
+JAX/XLA. Static-shape workloads can benefit from aggressive specialization;
+runtime-rank workflows need a representation that keeps exact, upper-bound, or
+unknown extents in the program until dispatch. See
+[Dynamic and Symbolic Shape Metadata](../design/dynamic-symbolic-shapes.md) for
+the implementation contract.
+
 ## Why Support Both?
 
 Eager and traced serve different workflows on the same tensor stack.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,8 @@ The project covers both ordinary tensor computation and autodiff workflows.
 Start with the smallest API that solves your problem, then add autodiff, graph
 compilation, or CUDA only when the workflow needs them.
 
+![tenferro-rs architecture overview](assets/tenferro-architecture.svg)
+
 ## Where To Start
 
 | Workflow | Start with |
@@ -20,6 +22,7 @@ compilation, or CUDA only when the workflow needs them.
 | Understanding direct, eager, and traced execution | [Execution Models](guides/execution-models.md) |
 | Column-major storage and row-major import/export | [Memory Order](guides/memory-order.md) |
 | CPU and CUDA backend behavior | [Devices and GPU](guides/devices-and-gpu.md) |
+| Runtime-dependent dimensions in traced graphs | [Dynamic and symbolic shapes](design/dynamic-symbolic-shapes.md) |
 | API documentation for every crate | [API Reference](api/index.md) |
 
 ## First CPU Example

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -101,17 +101,17 @@ print("</ul>")
 PY
 }
 
-echo "[1/7] Checking user-facing snippets"
+echo "[1/8] Checking user-facing snippets"
 python3 "$ROOT_DIR/scripts/check-doc-snippets.py" --root-dir "$ROOT_DIR" --check
 
-echo "[2/7] Building rustdoc"
+echo "[2/8] Building rustdoc"
 rm -rf "$DOC_ROOT"
 cargo doc --workspace --no-deps
 
-echo "[3/7] Copying rustdoc output"
+echo "[3/8] Copying rustdoc output"
 cp -a "$DOC_ROOT/." "$API_DIR/"
 
-echo "[4/7] Generating optional dependency graph"
+echo "[4/8] Generating optional dependency graph"
 if [[ -x "$ROOT_DIR/scripts/gen_dep_graph.py" || -f "$ROOT_DIR/scripts/gen_dep_graph.py" ]]; then
   if command -v dot >/dev/null 2>&1; then
     python3 "$ROOT_DIR/scripts/gen_dep_graph.py" --root-dir "$ROOT_DIR" | dot -Tsvg > "$API_DIR/dep_graph.svg"
@@ -126,7 +126,7 @@ else
   echo "  No scripts/gen_dep_graph.py found; skipping dependency graph."
 fi
 
-echo "[5/7] Rendering API landing page"
+echo "[5/8] Rendering API landing page"
 OVERVIEW_HTML="$(render_overview_html)"
 CRATE_INVENTORY_HTML="$(render_crate_inventory_html)"
 {
@@ -160,9 +160,7 @@ HEADER
 FOOTER
 } >"$API_DIR/index.html"
 
-python3 "$ROOT_DIR/scripts/check-docs-site.py" --root-dir "$ROOT_DIR" --site-index "$API_DIR/index.html"
-
-echo "[6/7] Rendering design docs if configured"
+echo "[6/8] Rendering design docs if configured"
 if [[ -f "$ROOT_DIR/docs/_quarto.yml" ]]; then
   if command -v quarto >/dev/null 2>&1; then
     quarto render "$ROOT_DIR/docs"
@@ -177,7 +175,10 @@ else
   echo "  No docs/_quarto.yml found; skipping design docs render."
 fi
 
-echo "[7/7] Verifying site top page"
+echo "[7/8] Verifying docs site links and API inventory"
+python3 "$ROOT_DIR/scripts/check-docs-site.py" --root-dir "$ROOT_DIR" --site-index "$API_DIR/index.html"
+
+echo "[8/8] Verifying site top page"
 REPO_TITLE="$(basename "$ROOT_DIR")"
 if [[ -f "$OUT_DIR/index.html" ]]; then
   echo "  Using Quarto-rendered site index."

--- a/scripts/check-docs-site.py
+++ b/scripts/check-docs-site.py
@@ -72,6 +72,8 @@ def rendered_html_pages(site_root: pathlib.Path) -> list[pathlib.Path]:
 
 
 def missing_rendered_html_links(site_root: pathlib.Path) -> list[tuple[pathlib.Path, str, pathlib.Path]]:
+    # This check intentionally starts with rendered page-to-page links. Asset
+    # link validation can be added here once docs-site asset ownership settles.
     missing: list[tuple[pathlib.Path, str, pathlib.Path]] = []
     for page in rendered_html_pages(site_root):
         for href in sorted(rendered_page_links(page)):

--- a/scripts/check-docs-site.py
+++ b/scripts/check-docs-site.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 import sys
 from html.parser import HTMLParser
+from urllib.parse import unquote, urlsplit
 
 try:
     import tomllib
@@ -29,12 +30,73 @@ class LinkCollector(HTMLParser):
             self.links.add(match.group(1))
 
 
+class RenderedPageLinkCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: set[str] = set()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "a":
+            return
+        href = dict(attrs).get("href") or ""
+        if href:
+            self.links.add(href)
+
+
+def rendered_page_links(path: pathlib.Path) -> set[str]:
+    parser = RenderedPageLinkCollector()
+    parser.feed(path.read_text(encoding="utf-8"))
+    return parser.links
+
+
+def is_external_href(href: str) -> bool:
+    parsed = urlsplit(href)
+    if parsed.scheme or parsed.netloc:
+        return True
+    return href.startswith("#") or href.startswith("/")
+
+
+def rendered_html_pages(site_root: pathlib.Path) -> list[pathlib.Path]:
+    if not site_root.exists():
+        return []
+    pages: list[pathlib.Path] = []
+    for path in sorted(site_root.rglob("*.html")):
+        try:
+            relative = path.relative_to(site_root)
+        except ValueError:
+            continue
+        if relative.parts and relative.parts[0] == "api":
+            continue
+        pages.append(path)
+    return pages
+
+
+def missing_rendered_html_links(site_root: pathlib.Path) -> list[tuple[pathlib.Path, str, pathlib.Path]]:
+    missing: list[tuple[pathlib.Path, str, pathlib.Path]] = []
+    for page in rendered_html_pages(site_root):
+        for href in sorted(rendered_page_links(page)):
+            if is_external_href(href):
+                continue
+            parsed = urlsplit(href)
+            if not parsed.path or not parsed.path.endswith(".html"):
+                continue
+            target = (page.parent / unquote(parsed.path)).resolve()
+            try:
+                target.relative_to(site_root)
+            except ValueError:
+                continue
+            if not target.is_file():
+                missing.append((page, href, target))
+    return missing
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Verify docs-site completeness for workspace library crates.")
     parser.add_argument("--root-dir", default=".", help="Repository root (default: current directory)")
     parser.add_argument("--doc-root", help="Rustdoc output directory (default: <root>/target/doc)")
     parser.add_argument("--api-index-md", help="Markdown API index (default: <root>/docs/api/index.md if it exists)")
     parser.add_argument("--site-index", help="Rendered API landing page HTML (default: <root>/target/docs-site/api/index.html if it exists)")
+    parser.add_argument("--docs-site-root", help="Rendered Quarto site root (default: <root>/target/docs-site)")
     parser.add_argument("--quiet", action="store_true", help="Suppress success output")
     return parser.parse_args()
 
@@ -122,6 +184,11 @@ def main() -> int:
     doc_root = pathlib.Path(args.doc_root) if args.doc_root else root / "target" / "doc"
     api_index_md = pathlib.Path(args.api_index_md) if args.api_index_md else root / "docs" / "api" / "index.md"
     site_index = pathlib.Path(args.site_index) if args.site_index else root / "target" / "docs-site" / "api" / "index.html"
+    docs_site_root = (
+        pathlib.Path(args.docs_site_root).resolve()
+        if args.docs_site_root
+        else root / "target" / "docs-site"
+    )
 
     crates = load_workspace_libs(root)
     missing_doc = [pkg for _member, pkg, doc_dir in crates if not (doc_root / doc_dir / "index.html").exists()]
@@ -147,6 +214,15 @@ def main() -> int:
             for pkg in missing_links:
                 print(f"- {pkg}", file=sys.stderr)
             return 1
+
+    missing_site_links = missing_rendered_html_links(docs_site_root)
+    if missing_site_links:
+        print("rendered docs links outside the rendered docs set:", file=sys.stderr)
+        for source, href, target in missing_site_links:
+            source_rel = source.relative_to(docs_site_root)
+            target_rel = target.relative_to(docs_site_root)
+            print(f"- {source_rel}: {href} -> {target_rel}", file=sys.stderr)
+        return 1
 
     if not args.quiet:
         print(f"docs-site-ok: {len(crates)} workspace library crates verified")

--- a/scripts/test-check-docs-site.py
+++ b/scripts/test-check-docs-site.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def write(path: pathlib.Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
+
+
+def make_minimal_docs_root(root: pathlib.Path) -> None:
+    write(
+        root / "Cargo.toml",
+        """
+        [workspace]
+        members = ["crates/demo"]
+        """,
+    )
+    write(
+        root / "crates/demo/Cargo.toml",
+        """
+        [package]
+        name = "demo-crate"
+        version = "0.1.0"
+        edition = "2021"
+
+        [lib]
+        name = "demo_crate"
+        """,
+    )
+    write(root / "crates/demo/src/lib.rs", "pub fn demo() {}\n")
+    write(root / "target/doc/demo_crate/index.html", "<html></html>\n")
+    write(root / "target/docs-site/api/index.html", '<a href="../demo_crate/index.html">demo</a>\n')
+    write(
+        root / "scripts/check-doc-snippets.py",
+        """
+        #!/usr/bin/env python3
+        raise SystemExit(0)
+        """,
+    )
+    write(
+        root / "docs/_quarto.yml",
+        """
+        project:
+          type: website
+          render:
+            - index.md
+            - spec/**/*.md
+        """,
+    )
+    write(root / "docs/index.md", "# Home\n")
+    write(root / "docs/spec/extension-op.md", "[dynamic shapes](../design/dynamic-symbolic-shapes.md)\n")
+    write(
+        root / "target/docs-site/spec/extension-op.html",
+        '<a href="../design/dynamic-symbolic-shapes.html">dynamic shapes</a>\n',
+    )
+
+
+def test_rendered_internal_link_outside_render_set_fails() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        fake_root = pathlib.Path(tmp)
+        make_minimal_docs_root(fake_root)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "scripts" / "check-docs-site.py"),
+                "--root-dir",
+                str(fake_root),
+                "--quiet",
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        assert result.returncode != 0, "rendered links outside the Quarto render set should fail"
+        assert "outside the rendered docs set" in result.stderr
+
+
+if __name__ == "__main__":
+    test_rendered_internal_link_outside_render_set_fails()

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import xml.etree.ElementTree as ET
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_architecture_svg_lists_cpu_crate_and_background() -> None:
+    svg_path = ROOT / "docs/assets/tenferro-architecture.svg"
+    text = svg_path.read_text(encoding="utf-8")
+
+    ET.parse(svg_path)
+    assert '<rect width="100%" height="100%" fill="#ffffff"/>' in text
+    assert "tenferro-cpu" in text
+    assert "CPU backend" in text
+    assert text.index("tenferro-cpu") < text.index("faer | BLAS/LAPACK")
+
+    tensor_section = text[text.index("tenferro-tensor") : text.index("tenferro-cpu")]
+    assert "faer | BLAS/LAPACK" not in tensor_section
+
+
+def test_agents_layer_diagram_lists_cpu_crate() -> None:
+    text = read("AGENTS.md")
+
+    assert "tenferro-cpu" in text
+    assert "tenferro-tensor   - Dense runtime tensors, backend traits, CPU backend" not in text
+    assert "tenferro-tensor   - Dense runtime tensors, backend traits" in text
+
+
+def test_docs_ci_runs_docs_script_tests() -> None:
+    text = read(".github/workflows/ci.yml")
+
+    assert "python3 scripts/test-check-docs-site.py" in text
+    assert "python3 scripts/test-doc-consistency.py" in text
+
+
+def test_documentation_policy_matches_rendered_internals() -> None:
+    text = read("REPOSITORY_RULES.md")
+    normalized = " ".join(text.split())
+
+    assert "**Online docs** are primarily user-facing" in normalized
+    assert "**Internals section**" in normalized
+    assert "architecture, specification, and active design notes" in normalized
+
+
+def main() -> int:
+    for test in [
+        test_architecture_svg_lists_cpu_crate_and_background,
+        test_agents_layer_diagram_lists_cpu_crate,
+        test_docs_ci_runs_docs_script_tests,
+        test_documentation_policy_matches_rendered_internals,
+    ]:
+        test()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Publish the active design notes in the Quarto docs site and add generated-site link checking.
- Improve #1019 positioning/signposting: README fit guidance, dynamic-shape links, execution-model notes, design index, and PyTorch/JAX mapping language.
- Improve #1020 onboarding/docs-site quality: Getting Started mental model and expected output, architecture SVG, consistency checks, and docs-site regression tests.
- Align architecture diagrams and repository policy with the independent `tenferro-cpu` crate.

## Scope
- Addresses #1019 section 6.1-6.5.
- Addresses #1020 C1, C5, C6, and C7.
- Leaves #1020 C2-C4 for follow-up work: tutorial expansion and crate-level rustdoc coverage.

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
