### PR TITLE
Add WebGPU CubeK dot_general backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,17 @@ lapack-inject = "0.1.2"
 # Match CubeCL's CUDA API floor. CUDA 12.8 is the oldest cudarc binding set
 # that exposes the driver symbols used by the current cubecl-cuda revision.
 cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12080"] }
-cubecl = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692", features = ["cuda"] }
+cubecl = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692", default-features = false }
 cubecl-cuda = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
+cubecl-common = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
 cubecl-runtime = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
+cubecl-wgpu = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
+cubek-matmul = { version = "0.2.0", default-features = false }
+cubek-std = { version = "0.2.0", default-features = false }
 sha2 = "0.10"
 omeco = "0.2.4"
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7" }
+
+[patch.crates-io]
+cubecl = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
+cubecl-common = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ general-purpose tensor workflows.
 The project aims to provide a Rust-native tensor stack for typed tensor
 computation, immediate execution with optional `backward()`, traced graph
 execution, automatic differentiation, linear algebra, einsum, FFT, and explicit
-CPU/CUDA backend control.
+CPU, CUDA, and experimental WebGPU backend control.
 
 tenferro-rs is influenced by JAX and PyTorch in its split between immediate
 execution, traced graphs, and AD. It is also influenced by the Julia numerical
@@ -28,7 +28,8 @@ help.
 - Keep tensor types and operation crates modular, rather than building one
   all-in-one tensor type.
 - Let users choose the lowest API that solves their problem. Autodiff, traced
-  graphs, CUDA, linalg, einsum, and FFT are opt-in capabilities.
+  graphs, CUDA, experimental WebGPU, linalg, einsum, and FFT are opt-in
+  capabilities.
 - Stay aligned with established numerical computing conventions where they
   fit: Rust's crate ecosystem, column-major conventions from Fortran, Julia,
   MATLAB, and LAPACK-oriented workflows, and Rust numerics crates such as
@@ -100,7 +101,7 @@ tenferro-rs is for the projects that want this kind of stack natively in Rust.
 | Runtime dtype selection or direct backend dispatch | `Tensor` with an explicit backend |
 | Immediate execution in one runtime, optionally with `backward()` on scalar losses | `EagerTensor` and `EagerRuntime` |
 | `grad`, `vjp`, and `jvp` on traced graphs, graph reuse, or repeated compile/run execution | `TracedTensor`, `GraphCompiler`, and `GraphExecutor<B>` |
-| CUDA execution | The same tensor API plus explicit CUDA upload/download and supported CUDA backend features |
+| CUDA or experimental WebGPU execution | The same tensor API plus explicit GPU upload/download and supported provider backend features |
 
 ## Crates
 
@@ -112,7 +113,7 @@ tenferro-rs is a multi-crate workspace. There is intentionally no `tenferro` fac
 | --- | --- |
 | `tenferro-tensor` | Tensor values, typed tensors, views, dtype/runtime tensor contracts, and backend traits |
 | `tenferro-cpu` | CPU backend execution |
-| `tenferro-gpu` | CUDA backend support, ROCm feature stub, and explicit device transfers |
+| `tenferro-gpu` | CUDA backend support, experimental WebGPU support, future ROCm substrate, and explicit device transfers |
 | `tenferro-runtime` | Eager/traced execution, graph compilation, and extension runtime support |
 | `tenferro-ad` | Automatic differentiation |
 

--- a/crates/tenferro-ad/Cargo.toml
+++ b/crates/tenferro-ad/Cargo.toml
@@ -31,6 +31,7 @@ blas-mkl = [
     "tenferro-cpu/blas-mkl",
 ]
 cuda = ["dep:tenferro-gpu", "tenferro-gpu/cuda"]
+webgpu = ["dep:tenferro-gpu", "tenferro-gpu/webgpu"]
 rocm = ["dep:tenferro-gpu", "tenferro-gpu/rocm"]
 
 [dependencies]

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -10,7 +10,9 @@ use crate::extension_runtime::{ExtensionExecutor, ExtensionRuntimeRegistryError}
 use computegraph::ValueKey;
 use tenferro_cpu::CpuBackend;
 #[cfg(feature = "cuda")]
-use tenferro_gpu::CubeclBackend;
+use tenferro_gpu::CudaBackend;
+#[cfg(feature = "webgpu")]
+use tenferro_gpu::WebGpuBackend;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ExtensionRuleSet;
@@ -247,14 +249,14 @@ impl EagerRuntime {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_gpu::CubeclBackend;
+    /// use tenferro_gpu::CudaBackend;
     /// use tenferro_ad::EagerRuntime;
     ///
-    /// let _ctor: fn(CubeclBackend) -> std::sync::Arc<EagerRuntime> =
+    /// let _ctor: fn(CudaBackend) -> std::sync::Arc<EagerRuntime> =
     ///     EagerRuntime::with_cuda_backend;
     /// ```
     #[cfg(feature = "cuda")]
-    pub fn with_cuda_backend(backend: CubeclBackend) -> Arc<Self> {
+    pub fn with_cuda_backend(backend: CudaBackend) -> Arc<Self> {
         Arc::new(Self::from_backend(EagerBackend::cuda(backend)))
     }
 
@@ -264,15 +266,50 @@ impl EagerRuntime {
     ///
     /// ```rust
     /// use tenferro_ad::{AdContext, EagerRuntime};
-    /// use tenferro_gpu::CubeclBackend;
+    /// use tenferro_gpu::CudaBackend;
     ///
-    /// let _ctor: fn(CubeclBackend, &AdContext) -> std::sync::Arc<EagerRuntime> =
+    /// let _ctor: fn(CudaBackend, &AdContext) -> std::sync::Arc<EagerRuntime> =
     ///     EagerRuntime::with_cuda_backend_and_ad_context;
     /// ```
     #[cfg(feature = "cuda")]
-    pub fn with_cuda_backend_and_ad_context(backend: CubeclBackend, ad: &AdContext) -> Arc<Self> {
+    pub fn with_cuda_backend_and_ad_context(backend: CudaBackend, ad: &AdContext) -> Arc<Self> {
         Arc::new(Self::from_backend_with_extension_rules(
             EagerBackend::cuda(backend),
+            Some(ad.extension_rule_set()),
+        ))
+    }
+
+    /// Create a shared eager execution context from a configured WebGPU backend.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ad::EagerRuntime;
+    /// use tenferro_gpu::WebGpuBackend;
+    ///
+    /// let _ctor: fn(WebGpuBackend) -> std::sync::Arc<EagerRuntime> =
+    ///     EagerRuntime::with_webgpu_backend;
+    /// ```
+    #[cfg(feature = "webgpu")]
+    pub fn with_webgpu_backend(backend: WebGpuBackend) -> Arc<Self> {
+        Arc::new(Self::from_backend(EagerBackend::webgpu(backend)))
+    }
+
+    /// Create a shared WebGPU eager context with explicit AD extension rules.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ad::{AdContext, EagerRuntime};
+    /// use tenferro_gpu::WebGpuBackend;
+    ///
+    /// let _ctor: fn(WebGpuBackend, &AdContext) -> std::sync::Arc<EagerRuntime> =
+    ///     EagerRuntime::with_webgpu_backend_and_ad_context;
+    /// ```
+    #[cfg(feature = "webgpu")]
+    pub fn with_webgpu_backend_and_ad_context(backend: WebGpuBackend, ad: &AdContext) -> Arc<Self> {
+        Arc::new(Self::from_backend_with_extension_rules(
+            EagerBackend::webgpu(backend),
             Some(ad.extension_rule_set()),
         ))
     }
@@ -367,7 +404,8 @@ impl EagerRuntime {
 
     /// Block the current thread until backend work submitted by this eager runtime completes.
     ///
-    /// CPU runtimes return immediately. CUDA runtimes synchronize the current backend stream.
+    /// CPU runtimes return immediately. CUDA and WebGPU runtimes synchronize
+    /// their current backend work queue.
     ///
     /// # Examples
     ///

--- a/crates/tenferro-ad/src/eager_backend.rs
+++ b/crates/tenferro-ad/src/eager_backend.rs
@@ -1,6 +1,8 @@
 use tenferro_cpu::CpuBackend;
 #[cfg(feature = "cuda")]
-use tenferro_gpu::CubeclBackend;
+use tenferro_gpu::CudaBackend;
+#[cfg(feature = "webgpu")]
+use tenferro_gpu::WebGpuBackend;
 use tenferro_tensor::backend::ElementwiseFusionPlan;
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir, DType,
@@ -13,7 +15,9 @@ use tenferro_tensor::{
 pub enum EagerBackend {
     Cpu(CpuBackend),
     #[cfg(feature = "cuda")]
-    Cuda(CubeclBackend),
+    Cuda(CudaBackend),
+    #[cfg(feature = "webgpu")]
+    WebGpu(WebGpuBackend),
 }
 
 impl EagerBackend {
@@ -22,8 +26,13 @@ impl EagerBackend {
     }
 
     #[cfg(feature = "cuda")]
-    pub(crate) fn cuda(backend: CubeclBackend) -> Self {
+    pub(crate) fn cuda(backend: CudaBackend) -> Self {
         Self::Cuda(backend)
+    }
+
+    #[cfg(feature = "webgpu")]
+    pub(crate) fn webgpu(backend: WebGpuBackend) -> Self {
+        Self::WebGpu(backend)
     }
 
     pub(crate) fn synchronize(&mut self) -> TensorResult<()> {
@@ -31,6 +40,8 @@ impl EagerBackend {
             Self::Cpu(_) => Ok(()),
             #[cfg(feature = "cuda")]
             Self::Cuda(backend) => backend.runtime().synchronize(),
+            #[cfg(feature = "webgpu")]
+            Self::WebGpu(backend) => backend.synchronize(),
         }
     }
 }
@@ -41,6 +52,8 @@ macro_rules! dispatch {
             EagerBackend::Cpu(backend) => backend.$method($($arg),*),
             #[cfg(feature = "cuda")]
             EagerBackend::Cuda(backend) => backend.$method($($arg),*),
+            #[cfg(feature = "webgpu")]
+            EagerBackend::WebGpu(backend) => backend.$method($($arg),*),
         }
     };
 }

--- a/crates/tenferro-ad/tests/eager_runtime_api.rs
+++ b/crates/tenferro-ad/tests/eager_runtime_api.rs
@@ -1,5 +1,7 @@
 use tenferro_ad::{EagerRuntime, EagerTensor};
 use tenferro_cpu::CpuBackend;
+#[cfg(feature = "webgpu")]
+use tenferro_gpu::WebGpuBackend;
 use tenferro_runtime::Tensor;
 
 #[test]
@@ -23,4 +25,11 @@ fn eager_runtime_synchronize_is_available_and_cpu_noop() {
     let runtime = EagerRuntime::with_cpu_backend(CpuBackend::new());
 
     runtime.synchronize().unwrap();
+}
+
+#[cfg(feature = "webgpu")]
+#[test]
+fn eager_runtime_accepts_webgpu_backend_constructor() {
+    let _ctor: fn(WebGpuBackend) -> std::sync::Arc<EagerRuntime> =
+        EagerRuntime::with_webgpu_backend;
 }

--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -38,6 +38,7 @@ blas-mkl = [
     "tenferro-cpu/blas-mkl",
 ]
 cuda = ["tenferro-ad?/cuda", "tenferro-internal-ops/cuda"]
+webgpu = ["tenferro-ad?/webgpu", "tenferro-internal-ops/webgpu"]
 rocm = ["tenferro-ad?/rocm", "tenferro-internal-ops/rocm"]
 
 [dependencies]
@@ -56,6 +57,7 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.1.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.1.0", default-features = false }
 criterion.workspace = true
 num-complex.workspace = true
 

--- a/crates/tenferro-einsum/tests/webgpu_eager_tensor.rs
+++ b/crates/tenferro-einsum/tests/webgpu_eager_tensor.rs
@@ -1,0 +1,232 @@
+#![cfg(all(feature = "autodiff", feature = "webgpu"))]
+
+use num_complex::Complex32;
+use tenferro_ad::{EagerRuntime, EagerTensor};
+use tenferro_einsum::eager_tensor::einsum as eager_einsum;
+use tenferro_gpu::{download_webgpu_tensor, upload_webgpu_tensor, webgpu_available};
+use tenferro_gpu::{WebGpuBackend, WebGpuRuntime};
+use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+
+fn matmul2_col_major(lhs: &[Complex32], rhs: &[Complex32]) -> [Complex32; 4] {
+    let a00 = lhs[0];
+    let a10 = lhs[1];
+    let a01 = lhs[2];
+    let a11 = lhs[3];
+    let b00 = rhs[0];
+    let b10 = rhs[1];
+    let b01 = rhs[2];
+    let b11 = rhs[3];
+    [
+        a00 * b00 + a01 * b10,
+        a10 * b00 + a11 * b10,
+        a00 * b01 + a01 * b11,
+        a10 * b01 + a11 * b11,
+    ]
+}
+
+fn assert_complex_close(actual: &[Complex32], expected: &[Complex32]) {
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert!(
+            (actual.re - expected.re).abs() <= 1e-4,
+            "real mismatch: actual={actual:?} expected={expected:?}"
+        );
+        assert!(
+            (actual.im - expected.im).abs() <= 1e-4,
+            "imag mismatch: actual={actual:?} expected={expected:?}"
+        );
+    }
+}
+
+fn batched_matmul_f32_reference() -> Vec<f32> {
+    vec![58.0, 139.0, 64.0, 154.0, 5800.0, 13900.0, 6400.0, 15400.0]
+}
+
+fn assert_f32_close(actual: &[f32], expected: &[f32]) {
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert!(
+            (actual - expected).abs() <= 1e-4,
+            "f32 mismatch: actual={actual} expected={expected}"
+        );
+    }
+}
+
+#[test]
+fn eager_tensor_einsum_runs_rank2_f32_matmul_on_webgpu_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let runtime = WebGpuRuntime::new_default().unwrap();
+    let ctx = EagerRuntime::with_webgpu_backend(WebGpuBackend::from_runtime(runtime.clone()));
+    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]);
+    let lhs =
+        EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &lhs).unwrap(), ctx.clone());
+    let rhs = EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &rhs).unwrap(), ctx);
+
+    let out = eager_einsum(&[&lhs, &rhs], "ij,jk->ik").unwrap();
+    let host = download_webgpu_tensor(&runtime, out.data()).unwrap();
+
+    assert_eq!(host.shape(), &[2, 2]);
+    let actual = host.as_slice::<f32>().unwrap();
+    let expected = [58.0_f32, 139.0, 64.0, 154.0];
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert!((actual - expected).abs() <= 1e-4);
+    }
+}
+
+#[test]
+fn eager_tensor_einsum_runs_batched_f32_matmul_on_webgpu_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let runtime = WebGpuRuntime::new_default().unwrap();
+    let ctx = EagerRuntime::with_webgpu_backend(WebGpuBackend::from_runtime(runtime.clone()));
+    let lhs = Tensor::from_vec_col_major(
+        vec![2, 3, 2],
+        vec![
+            1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0, 10.0, 40.0, 20.0, 50.0, 30.0, 60.0,
+        ],
+    );
+    let rhs = Tensor::from_vec_col_major(
+        vec![3, 2, 2],
+        vec![
+            7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0, 70.0, 90.0, 110.0, 80.0, 100.0, 120.0,
+        ],
+    );
+    let lhs =
+        EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &lhs).unwrap(), ctx.clone());
+    let rhs = EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &rhs).unwrap(), ctx);
+
+    let out = eager_einsum(&[&lhs, &rhs], "ikb,kjb->ijb").unwrap();
+    let host = download_webgpu_tensor(&runtime, out.data()).unwrap();
+
+    assert_eq!(host.shape(), &[2, 2, 2]);
+    assert_f32_close(
+        host.as_slice::<f32>().unwrap(),
+        &batched_matmul_f32_reference(),
+    );
+}
+
+#[test]
+fn eager_tensor_einsum_runs_rank2_c32_matmul_on_webgpu_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let runtime = WebGpuRuntime::new_default().unwrap();
+    let ctx = EagerRuntime::with_webgpu_backend(WebGpuBackend::from_runtime(runtime.clone()));
+    let lhs_data = vec![
+        Complex32::new(1.0, 0.5),
+        Complex32::new(2.0, -1.0),
+        Complex32::new(3.0, 0.25),
+        Complex32::new(4.0, 1.0),
+    ];
+    let rhs_data = vec![
+        Complex32::new(5.0, -0.5),
+        Complex32::new(6.0, 0.25),
+        Complex32::new(7.0, 1.0),
+        Complex32::new(8.0, -0.75),
+    ];
+    let lhs = Tensor::from_vec_col_major(vec![2, 2], lhs_data.clone());
+    let rhs = Tensor::from_vec_col_major(vec![2, 2], rhs_data.clone());
+    let lhs =
+        EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &lhs).unwrap(), ctx.clone());
+    let rhs = EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &rhs).unwrap(), ctx);
+
+    let out = eager_einsum(&[&lhs, &rhs], "ij,jk->ik").unwrap();
+    let host = download_webgpu_tensor(&runtime, out.data()).unwrap();
+
+    assert_eq!(host.shape(), &[2, 2]);
+    let actual = host.as_slice::<Complex32>().unwrap();
+    let expected = matmul2_col_major(&lhs_data, &rhs_data);
+    assert_complex_close(actual, &expected);
+}
+
+#[test]
+fn traced_einsum_runs_rank2_f32_matmul_on_webgpu_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let lhs = TracedTensor::input_concrete_shape(DType::F32, &[2, 3]);
+    let rhs = TracedTensor::input_concrete_shape(DType::F32, &[3, 2]);
+    let mut compiler = GraphCompiler::new();
+    let out = tenferro_einsum::einsum(&mut compiler, &[&lhs, &rhs], "ij,jk->ik").unwrap();
+    let program = compiler
+        .compile_with_input_specs(
+            &out,
+            &[(&lhs, DType::F32, &[2, 3]), (&rhs, DType::F32, &[3, 2])],
+        )
+        .unwrap();
+    let runtime = WebGpuRuntime::new_default().unwrap();
+    let lhs_host = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let rhs_host =
+        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]);
+    let lhs_gpu = upload_webgpu_tensor(&runtime, &lhs_host).unwrap();
+    let rhs_gpu = upload_webgpu_tensor(&runtime, &rhs_host).unwrap();
+    let mut executor = GraphExecutor::new(WebGpuBackend::from_runtime(runtime.clone()));
+
+    let out = executor
+        .run_with_inputs(&program, &[(&lhs, &lhs_gpu), (&rhs, &rhs_gpu)])
+        .unwrap();
+    executor.backend().synchronize().unwrap();
+    let host = download_webgpu_tensor(executor.backend().runtime(), &out).unwrap();
+
+    assert_eq!(host.shape(), &[2, 2]);
+    let actual = host.as_slice::<f32>().unwrap();
+    let expected = [58.0_f32, 139.0, 64.0, 154.0];
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert!((actual - expected).abs() <= 1e-4);
+    }
+}
+
+#[test]
+fn traced_einsum_runs_batched_f32_matmul_on_webgpu_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let lhs = TracedTensor::input_concrete_shape(DType::F32, &[2, 3, 2]);
+    let rhs = TracedTensor::input_concrete_shape(DType::F32, &[3, 2, 2]);
+    let mut compiler = GraphCompiler::new();
+    let out = tenferro_einsum::einsum(&mut compiler, &[&lhs, &rhs], "ikb,kjb->ijb").unwrap();
+    let program = compiler
+        .compile_with_input_specs(
+            &out,
+            &[
+                (&lhs, DType::F32, &[2, 3, 2]),
+                (&rhs, DType::F32, &[3, 2, 2]),
+            ],
+        )
+        .unwrap();
+    let runtime = WebGpuRuntime::new_default().unwrap();
+    let lhs_host = Tensor::from_vec_col_major(
+        vec![2, 3, 2],
+        vec![
+            1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0, 10.0, 40.0, 20.0, 50.0, 30.0, 60.0,
+        ],
+    );
+    let rhs_host = Tensor::from_vec_col_major(
+        vec![3, 2, 2],
+        vec![
+            7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0, 70.0, 90.0, 110.0, 80.0, 100.0, 120.0,
+        ],
+    );
+    let lhs_gpu = upload_webgpu_tensor(&runtime, &lhs_host).unwrap();
+    let rhs_gpu = upload_webgpu_tensor(&runtime, &rhs_host).unwrap();
+    let mut executor = GraphExecutor::new(WebGpuBackend::from_runtime(runtime.clone()));
+
+    let out = executor
+        .run_with_inputs(&program, &[(&lhs, &lhs_gpu), (&rhs, &rhs_gpu)])
+        .unwrap();
+    executor.backend().synchronize().unwrap();
+    let host = download_webgpu_tensor(executor.backend().runtime(), &out).unwrap();
+
+    assert_eq!(host.shape(), &[2, 2, 2]);
+    assert_f32_close(
+        host.as_slice::<f32>().unwrap(),
+        &batched_matmul_f32_reference(),
+    );
+}

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -8,7 +8,7 @@ publish.workspace = true
 readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "CubeCL/CUDA backend and GPU transfer helpers for tenferro tensors."
+description = "CubeCL-backed CUDA and WebGPU provider backends for tenferro tensors."
 
 [lib]
 name = "tenferro_gpu"
@@ -21,7 +21,26 @@ blas-openblas = ["tenferro-cpu/blas-openblas"]
 blas-accelerate = ["tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-cpu/blas-mkl"]
 cpu-reference = []
-cuda = ["dep:cubecl", "dep:cubecl-cuda", "dep:cubecl-runtime", "dep:cudarc"]
+cuda = [
+    "dep:cubecl",
+    "cubecl/std",
+    "cubecl/stdlib",
+    "cubecl/cuda",
+    "dep:cubecl-cuda",
+    "dep:cubecl-runtime",
+    "dep:cudarc",
+]
+webgpu = [
+    "dep:cubecl",
+    "cubecl/std",
+    "cubecl/stdlib",
+    "cubecl/wgpu",
+    "dep:cubecl-common",
+    "dep:cubecl-runtime",
+    "dep:cubecl-wgpu",
+    "dep:cubek-matmul",
+    "dep:cubek-std",
+]
 rocm = []
 
 [dependencies]
@@ -29,11 +48,16 @@ tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.1.0" }
 tenferro-tensor = { path = "../tenferro-tensor", version = "0.1.0", default-features = false }
 cubecl = { workspace = true, optional = true }
 cubecl-cuda = { workspace = true, optional = true }
+cubecl-common = { workspace = true, optional = true }
 cubecl-runtime = { workspace = true, optional = true }
+cubecl-wgpu = { workspace = true, optional = true }
+cubek-matmul = { workspace = true, optional = true }
+cubek-std = { workspace = true, optional = true }
 cudarc = { workspace = true, optional = true }
 libloading.workspace = true
 num-complex.workspace = true
 num-traits.workspace = true
+smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/tenferro-gpu/src/lib.rs
+++ b/crates/tenferro-gpu/src/lib.rs
@@ -5,11 +5,11 @@
 //! ```rust
 //! #[cfg(feature = "cuda")]
 //! {
-//!     use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CubeclBackend};
+//!     use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CudaBackend};
 //!     use tenferro_tensor::{Tensor, TensorElementwise};
 //!
 //!     if gpu_available() {
-//!         let mut backend = CubeclBackend::new(0).unwrap();
+//!         let mut backend = CudaBackend::new(0).unwrap();
 //!         let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
 //!         let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
 //!         let gpu_a = upload_tensor(backend.runtime(), &a).unwrap();
@@ -28,14 +28,22 @@ use std::any::Any;
 mod cubecl;
 #[cfg(feature = "cuda")]
 mod kernels;
+#[cfg(feature = "webgpu")]
+mod webgpu;
 
 #[cfg(feature = "cuda")]
 pub use cubecl::{
     device_ptr, download_tensor, gpu_available, upload_tensor, CubeclBackend, CubeclRuntime,
 };
 #[cfg(feature = "cuda")]
+pub use cubecl::{CubeclBackend as CudaBackend, CubeclRuntime as CudaRuntime};
+#[cfg(feature = "cuda")]
 #[doc(hidden)]
 pub use cubecl::{CudaExtensionCache, CudaExtensionCacheGuard};
+#[cfg(feature = "webgpu")]
+pub use webgpu::{
+    download_webgpu_tensor, upload_webgpu_tensor, webgpu_available, WebGpuBackend, WebGpuRuntime,
+};
 
 #[cfg(feature = "cuda")]
 #[doc(hidden)]
@@ -44,7 +52,7 @@ pub mod cuda_interop {
     pub use crate::cubecl::{CudaExtensionCache, CudaExtensionCacheGuard};
 }
 
-#[cfg(feature = "cuda")]
+#[cfg(any(feature = "cuda", feature = "webgpu"))]
 use tenferro_tensor::*;
 
 #[cfg(feature = "cuda")]

--- a/crates/tenferro-gpu/src/webgpu/gemm.rs
+++ b/crates/tenferro-gpu/src/webgpu/gemm.rs
@@ -1,0 +1,592 @@
+use cubecl::prelude::{CubeElement, CubePrimitive};
+use cubecl_wgpu::WgpuRuntime;
+use cubek_matmul::{definition::MatmulElems, launch::Strategy};
+use cubek_std::InputBinding;
+use num_complex::Complex32;
+use smallvec::SmallVec;
+
+use super::{
+    alloc_output, comptime_sequence, cube_count_for_len, cube_dim_1d, ensure_resident_on_runtime,
+    kernels, typed_tensor_array_arg, typed_tensor_array_arg_as, typed_tensor_binding_with_layout,
+    WebGpuBackend,
+};
+use crate::{col_major_strides, DotGeneralConfig, Error, Tensor, TypedTensor};
+
+const DOT_GENERAL_OP: &str = "webgpu_dot_general";
+
+type AxisVec = SmallVec<[usize; 8]>;
+type ShapeVec = SmallVec<[usize; 8]>;
+
+#[derive(Clone, Debug)]
+struct DotGeneralPlan {
+    lhs_free: AxisVec,
+    rhs_free: AxisVec,
+    lhs_contract: AxisVec,
+    rhs_contract: AxisVec,
+    lhs_batch: AxisVec,
+    rhs_batch: AxisVec,
+    output_shape: Vec<usize>,
+    lhs_cubek_shape: Vec<usize>,
+    rhs_cubek_shape: Vec<usize>,
+    out_cubek_shape: Vec<usize>,
+    lhs_cubek_strides: Option<Vec<usize>>,
+    rhs_cubek_strides: Option<Vec<usize>>,
+    out_cubek_strides: Vec<usize>,
+    k: usize,
+}
+
+struct PreparedOperand<T> {
+    tensor: TypedTensor<T>,
+    shape: Vec<usize>,
+    strides: Vec<usize>,
+}
+
+fn dtype_mismatch(op: &'static str, lhs: &Tensor, rhs: &Tensor) -> Error {
+    Error::DTypeMismatch {
+        op,
+        lhs: lhs.dtype(),
+        rhs: rhs.dtype(),
+    }
+}
+
+fn checked_product(label: &str, dims: &[usize]) -> crate::Result<usize> {
+    dims.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim).ok_or_else(|| {
+            Error::backend_failure(
+                DOT_GENERAL_OP,
+                format!("{label} product overflow for dimensions {dims:?}"),
+            )
+        })
+    })
+}
+
+fn axes_shape(shape: &[usize], axes: &[usize]) -> ShapeVec {
+    axes.iter().map(|&axis| shape[axis]).collect()
+}
+
+fn free_axes(rank: usize, contracting: &[usize], batch: &[usize]) -> AxisVec {
+    (0..rank)
+        .filter(|axis| !contracting.contains(axis) && !batch.contains(axis))
+        .collect()
+}
+
+fn dense_strides(shape: &[usize]) -> crate::Result<Vec<usize>> {
+    col_major_strides(shape)
+        .into_iter()
+        .map(|stride| {
+            usize::try_from(stride).map_err(|_| {
+                Error::backend_failure(
+                    DOT_GENERAL_OP,
+                    format!("negative stride is not valid for dense shape {shape:?}"),
+                )
+            })
+        })
+        .collect()
+}
+
+fn flattened_group_stride(shape: &[usize], strides: &[usize], axes: &[usize]) -> Option<usize> {
+    let Some((&first, rest)) = axes.split_first() else {
+        return Some(1);
+    };
+    let mut previous = first;
+    for &axis in rest {
+        if axis != previous + 1 {
+            return None;
+        }
+        if strides[axis] != strides[previous].checked_mul(shape[previous])? {
+            return None;
+        }
+        previous = axis;
+    }
+    Some(strides[first])
+}
+
+fn input_cubek_strides(
+    input_shape: &[usize],
+    batch_axes: &[usize],
+    row_axes: &[usize],
+    col_axes: &[usize],
+) -> crate::Result<Option<Vec<usize>>> {
+    let dense = dense_strides(input_shape)?;
+    let Some(row_stride) = flattened_group_stride(input_shape, &dense, row_axes) else {
+        return Ok(None);
+    };
+    let Some(col_stride) = flattened_group_stride(input_shape, &dense, col_axes) else {
+        return Ok(None);
+    };
+
+    let mut strides = Vec::with_capacity(batch_axes.len() + 2);
+    strides.extend(batch_axes.iter().map(|&axis| dense[axis]));
+    strides.push(row_stride);
+    strides.push(col_stride);
+    Ok(Some(strides))
+}
+
+fn dense_layout_strides(shape: &[usize]) -> crate::Result<Vec<usize>> {
+    dense_strides(shape)
+}
+
+fn output_cubek_strides(m: usize, n: usize, batch_shape: &[usize]) -> crate::Result<Vec<usize>> {
+    let mn = m.checked_mul(n).ok_or_else(|| {
+        Error::backend_failure(
+            DOT_GENERAL_OP,
+            format!("output matrix product overflow for M={m} N={n}"),
+        )
+    })?;
+    let mut next_batch_stride = mn;
+    let mut strides = Vec::with_capacity(batch_shape.len() + 2);
+    for &dim in batch_shape {
+        strides.push(next_batch_stride);
+        next_batch_stride = next_batch_stride.checked_mul(dim).ok_or_else(|| {
+            Error::backend_failure(
+                DOT_GENERAL_OP,
+                format!("output batch stride overflow for batch shape {batch_shape:?}"),
+            )
+        })?;
+    }
+    strides.push(1);
+    strides.push(m);
+    Ok(strides)
+}
+
+fn cube_shape(batch_shape: &[usize], rows: usize, cols: usize) -> Vec<usize> {
+    let mut shape = Vec::with_capacity(batch_shape.len() + 2);
+    shape.extend_from_slice(batch_shape);
+    shape.push(rows);
+    shape.push(cols);
+    shape
+}
+
+fn build_dot_general_plan(
+    lhs_shape: &[usize],
+    rhs_shape: &[usize],
+    config: &DotGeneralConfig,
+) -> crate::Result<DotGeneralPlan> {
+    config
+        .validate_dims_with_ranks(lhs_shape.len(), rhs_shape.len())
+        .map_err(|message| Error::InvalidConfig {
+            op: DOT_GENERAL_OP,
+            message,
+        })?;
+
+    let lhs_free = free_axes(
+        lhs_shape.len(),
+        &config.lhs_contracting_dims,
+        &config.lhs_batch_dims,
+    );
+    let rhs_free = free_axes(
+        rhs_shape.len(),
+        &config.rhs_contracting_dims,
+        &config.rhs_batch_dims,
+    );
+    let lhs_contract: AxisVec = config.lhs_contracting_dims.iter().copied().collect();
+    let rhs_contract: AxisVec = config.rhs_contracting_dims.iter().copied().collect();
+    let lhs_batch: AxisVec = config.lhs_batch_dims.iter().copied().collect();
+    let rhs_batch: AxisVec = config.rhs_batch_dims.iter().copied().collect();
+
+    for (&lhs_axis, &rhs_axis) in lhs_contract.iter().zip(&rhs_contract) {
+        let lhs_dim = lhs_shape[lhs_axis];
+        let rhs_dim = rhs_shape[rhs_axis];
+        if lhs_dim != rhs_dim {
+            return Err(Error::InvalidConfig {
+                op: DOT_GENERAL_OP,
+                message: format!(
+                    "contracting dim size mismatch: lhs axis {lhs_axis}={lhs_dim} rhs axis {rhs_axis}={rhs_dim}"
+                ),
+            });
+        }
+    }
+    for (&lhs_axis, &rhs_axis) in lhs_batch.iter().zip(&rhs_batch) {
+        let lhs_dim = lhs_shape[lhs_axis];
+        let rhs_dim = rhs_shape[rhs_axis];
+        if lhs_dim != rhs_dim {
+            return Err(Error::InvalidConfig {
+                op: DOT_GENERAL_OP,
+                message: format!(
+                    "batch dim size mismatch: lhs axis {lhs_axis}={lhs_dim} rhs axis {rhs_axis}={rhs_dim}"
+                ),
+            });
+        }
+    }
+
+    let lhs_free_shape = axes_shape(lhs_shape, &lhs_free);
+    let rhs_free_shape = axes_shape(rhs_shape, &rhs_free);
+    let contract_shape = axes_shape(lhs_shape, &lhs_contract);
+    let batch_shape = axes_shape(lhs_shape, &lhs_batch);
+    let m = checked_product("lhs free", &lhs_free_shape)?;
+    let n = checked_product("rhs free", &rhs_free_shape)?;
+    let k = checked_product("contracting", &contract_shape)?;
+
+    let mut output_shape =
+        Vec::with_capacity(lhs_free_shape.len() + rhs_free_shape.len() + batch_shape.len());
+    output_shape.extend(lhs_free_shape.iter().copied());
+    output_shape.extend(rhs_free_shape.iter().copied());
+    output_shape.extend(batch_shape.iter().copied());
+
+    let lhs_cubek_shape = cube_shape(&batch_shape, m, k);
+    let rhs_cubek_shape = cube_shape(&batch_shape, k, n);
+    let out_cubek_shape = cube_shape(&batch_shape, m, n);
+    let lhs_cubek_strides = input_cubek_strides(lhs_shape, &lhs_batch, &lhs_free, &lhs_contract)?;
+    let rhs_cubek_strides = input_cubek_strides(rhs_shape, &rhs_batch, &rhs_contract, &rhs_free)?;
+    let out_cubek_strides = output_cubek_strides(m, n, &batch_shape)?;
+
+    Ok(DotGeneralPlan {
+        lhs_free,
+        rhs_free,
+        lhs_contract,
+        rhs_contract,
+        lhs_batch,
+        rhs_batch,
+        output_shape,
+        lhs_cubek_shape,
+        rhs_cubek_shape,
+        out_cubek_shape,
+        lhs_cubek_strides,
+        rhs_cubek_strides,
+        out_cubek_strides,
+        k,
+    })
+}
+
+fn pack_lhs_operand<T>(
+    backend: &WebGpuBackend,
+    input: &TypedTensor<T>,
+    plan: &DotGeneralPlan,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: CubePrimitive + CubeElement + Clone + Send + Sync + 'static,
+{
+    let output = alloc_output::<T>(backend.runtime(), &plan.lhs_cubek_shape, DOT_GENERAL_OP)?;
+    let len = output.n_elements();
+    if len == 0 {
+        return Ok(output);
+    }
+
+    let output_strides = dense_layout_strides(&plan.lhs_cubek_shape)?;
+    let input_strides = dense_layout_strides(input.shape())?;
+    let output_binding = typed_tensor_binding_with_layout(
+        &output,
+        &plan.lhs_cubek_shape,
+        &output_strides,
+        DOT_GENERAL_OP,
+    )?;
+    let input_binding =
+        typed_tensor_binding_with_layout(input, input.shape(), &input_strides, DOT_GENERAL_OP)?;
+
+    unsafe {
+        // SAFETY: The planner validates that free, contracting, and batch axes
+        // partition the input rank. Both tensor bindings cover their backing
+        // allocations exactly, and the kernel writes one packed output element
+        // per guarded launch position.
+        kernels::pack_lhs_dot_general::launch_unchecked::<T, WgpuRuntime>(
+            backend.runtime().client(),
+            cube_count_for_len(len),
+            cube_dim_1d(),
+            output_binding.into_tensor_arg(),
+            input_binding.into_tensor_arg(),
+            comptime_sequence(&plan.lhs_free),
+            comptime_sequence(&plan.lhs_contract),
+            comptime_sequence(&plan.lhs_batch),
+            input.shape().len(),
+            plan.lhs_cubek_shape.len(),
+        );
+    }
+
+    Ok(output)
+}
+
+fn pack_rhs_operand<T>(
+    backend: &WebGpuBackend,
+    input: &TypedTensor<T>,
+    plan: &DotGeneralPlan,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: CubePrimitive + CubeElement + Clone + Send + Sync + 'static,
+{
+    let output = alloc_output::<T>(backend.runtime(), &plan.rhs_cubek_shape, DOT_GENERAL_OP)?;
+    let len = output.n_elements();
+    if len == 0 {
+        return Ok(output);
+    }
+
+    let output_strides = dense_layout_strides(&plan.rhs_cubek_shape)?;
+    let input_strides = dense_layout_strides(input.shape())?;
+    let output_binding = typed_tensor_binding_with_layout(
+        &output,
+        &plan.rhs_cubek_shape,
+        &output_strides,
+        DOT_GENERAL_OP,
+    )?;
+    let input_binding =
+        typed_tensor_binding_with_layout(input, input.shape(), &input_strides, DOT_GENERAL_OP)?;
+
+    unsafe {
+        // SAFETY: Same invariant as the lhs pack launch, with rhs axes mapped
+        // to CubeK `[batch..., K, N]` order.
+        kernels::pack_rhs_dot_general::launch_unchecked::<T, WgpuRuntime>(
+            backend.runtime().client(),
+            cube_count_for_len(len),
+            cube_dim_1d(),
+            output_binding.into_tensor_arg(),
+            input_binding.into_tensor_arg(),
+            comptime_sequence(&plan.rhs_contract),
+            comptime_sequence(&plan.rhs_free),
+            comptime_sequence(&plan.rhs_batch),
+            input.shape().len(),
+            plan.rhs_cubek_shape.len(),
+        );
+    }
+
+    Ok(output)
+}
+
+fn prepare_lhs_operand<T>(
+    backend: &WebGpuBackend,
+    input: &TypedTensor<T>,
+    plan: &DotGeneralPlan,
+) -> crate::Result<PreparedOperand<T>>
+where
+    T: CubePrimitive + CubeElement + Clone + Send + Sync + 'static,
+{
+    let tensor = match &plan.lhs_cubek_strides {
+        Some(strides) => {
+            return Ok(PreparedOperand {
+                tensor: input.clone(),
+                shape: plan.lhs_cubek_shape.clone(),
+                strides: strides.clone(),
+            });
+        }
+        None => pack_lhs_operand(backend, input, plan)?,
+    };
+    Ok(PreparedOperand {
+        tensor,
+        shape: plan.lhs_cubek_shape.clone(),
+        strides: dense_layout_strides(&plan.lhs_cubek_shape)?,
+    })
+}
+
+fn prepare_rhs_operand<T>(
+    backend: &WebGpuBackend,
+    input: &TypedTensor<T>,
+    plan: &DotGeneralPlan,
+) -> crate::Result<PreparedOperand<T>>
+where
+    T: CubePrimitive + CubeElement + Clone + Send + Sync + 'static,
+{
+    let tensor = match &plan.rhs_cubek_strides {
+        Some(strides) => {
+            return Ok(PreparedOperand {
+                tensor: input.clone(),
+                shape: plan.rhs_cubek_shape.clone(),
+                strides: strides.clone(),
+            });
+        }
+        None => pack_rhs_operand(backend, input, plan)?,
+    };
+    Ok(PreparedOperand {
+        tensor,
+        shape: plan.rhs_cubek_shape.clone(),
+        strides: dense_layout_strides(&plan.rhs_cubek_shape)?,
+    })
+}
+
+fn dot_general_f32(
+    backend: &WebGpuBackend,
+    lhs: &TypedTensor<f32>,
+    rhs: &TypedTensor<f32>,
+    config: &DotGeneralConfig,
+) -> crate::Result<TypedTensor<f32>> {
+    let plan = build_dot_general_plan(lhs.shape(), rhs.shape(), config)?;
+    ensure_resident_on_runtime(backend.runtime(), lhs, DOT_GENERAL_OP)?;
+    ensure_resident_on_runtime(backend.runtime(), rhs, DOT_GENERAL_OP)?;
+
+    let output = alloc_output::<f32>(backend.runtime(), &plan.output_shape, DOT_GENERAL_OP)?;
+    if output.n_elements() == 0 {
+        return Ok(output);
+    }
+    if plan.k == 0 {
+        return Err(Error::backend_failure(
+            DOT_GENERAL_OP,
+            "WebGPU CubeK matmul does not support zero-sized contracting dimensions yet",
+        ));
+    }
+    let lhs = prepare_lhs_operand(backend, lhs, &plan)?;
+    let rhs = prepare_rhs_operand(backend, rhs, &plan)?;
+
+    let dtype = f32::as_type_native_unchecked().storage_type();
+    let lhs_binding = InputBinding::new(
+        typed_tensor_binding_with_layout(&lhs.tensor, &lhs.shape, &lhs.strides, DOT_GENERAL_OP)?,
+        dtype,
+    );
+    let rhs_binding = InputBinding::new(
+        typed_tensor_binding_with_layout(&rhs.tensor, &rhs.shape, &rhs.strides, DOT_GENERAL_OP)?,
+        dtype,
+    );
+    let output_binding = typed_tensor_binding_with_layout(
+        &output,
+        &plan.out_cubek_shape,
+        &plan.out_cubek_strides,
+        DOT_GENERAL_OP,
+    )?;
+    let mut dtypes = MatmulElems::from_single_dtype(f32::as_type_native_unchecked());
+
+    cubek_matmul::launch::launch_ref(
+        &Strategy::Naive,
+        backend.runtime().client(),
+        lhs_binding,
+        rhs_binding,
+        output_binding,
+        &mut dtypes,
+    )
+    .map_err(|err| Error::backend_failure(DOT_GENERAL_OP, format!("{err:?}")))?;
+
+    Ok(output)
+}
+
+fn extract_c32_part(
+    backend: &WebGpuBackend,
+    input: &TypedTensor<Complex32>,
+    real: bool,
+) -> crate::Result<TypedTensor<f32>> {
+    ensure_resident_on_runtime(backend.runtime(), input, DOT_GENERAL_OP)?;
+    let output = alloc_output::<f32>(backend.runtime(), input.shape(), DOT_GENERAL_OP)?;
+    let len = output.n_elements();
+    if len == 0 {
+        return Ok(output);
+    }
+
+    let output_arg = typed_tensor_array_arg(&output, DOT_GENERAL_OP)?;
+    let input_part_len = len.checked_mul(2).ok_or_else(|| {
+        Error::backend_failure(DOT_GENERAL_OP, "complex input part length overflow")
+    })?;
+    let input_arg =
+        typed_tensor_array_arg_as::<Complex32, f32>(input, input_part_len, DOT_GENERAL_OP)?;
+    if real {
+        unsafe {
+            // SAFETY: Both array args are validated against compact dense
+            // tensors. The input is reinterpreted as `2 * len` f32 parts, and
+            // the kernel guards writes with `ABSOLUTE_POS < out.len()`.
+            kernels::extract_c32_real::launch_unchecked::<WgpuRuntime>(
+                backend.runtime().client(),
+                cube_count_for_len(len),
+                cube_dim_1d(),
+                output_arg,
+                input_arg,
+            );
+        }
+    } else {
+        unsafe {
+            // SAFETY: Same invariant as the real-part launch above.
+            kernels::extract_c32_imag::launch_unchecked::<WgpuRuntime>(
+                backend.runtime().client(),
+                cube_count_for_len(len),
+                cube_dim_1d(),
+                output_arg,
+                input_arg,
+            );
+        }
+    }
+    Ok(output)
+}
+
+fn compose_c32_from_products(
+    backend: &WebGpuBackend,
+    real_pos: &TypedTensor<f32>,
+    real_neg: &TypedTensor<f32>,
+    imag_left: &TypedTensor<f32>,
+    imag_right: &TypedTensor<f32>,
+) -> crate::Result<TypedTensor<Complex32>> {
+    let shape = real_pos.shape();
+    if real_neg.shape() != shape || imag_left.shape() != shape || imag_right.shape() != shape {
+        return Err(Error::ShapeMismatch {
+            op: DOT_GENERAL_OP,
+            lhs: shape.to_vec(),
+            rhs: real_neg.shape().to_vec(),
+        });
+    }
+    ensure_resident_on_runtime(backend.runtime(), real_pos, DOT_GENERAL_OP)?;
+    ensure_resident_on_runtime(backend.runtime(), real_neg, DOT_GENERAL_OP)?;
+    ensure_resident_on_runtime(backend.runtime(), imag_left, DOT_GENERAL_OP)?;
+    ensure_resident_on_runtime(backend.runtime(), imag_right, DOT_GENERAL_OP)?;
+
+    let output = alloc_output::<Complex32>(backend.runtime(), shape, DOT_GENERAL_OP)?;
+    let len = output.n_elements();
+    if len == 0 {
+        return Ok(output);
+    }
+
+    let output_part_len = len.checked_mul(2).ok_or_else(|| {
+        Error::backend_failure(DOT_GENERAL_OP, "complex output part length overflow")
+    })?;
+    let output_arg =
+        typed_tensor_array_arg_as::<Complex32, f32>(&output, output_part_len, DOT_GENERAL_OP)?;
+    let real_pos_arg = typed_tensor_array_arg(real_pos, DOT_GENERAL_OP)?;
+    let real_neg_arg = typed_tensor_array_arg(real_neg, DOT_GENERAL_OP)?;
+    let imag_left_arg = typed_tensor_array_arg(imag_left, DOT_GENERAL_OP)?;
+    let imag_right_arg = typed_tensor_array_arg(imag_right, DOT_GENERAL_OP)?;
+
+    unsafe {
+        // SAFETY: All input products and the complex output are compact dense
+        // tensors with identical logical element counts. The compose kernel
+        // writes two scalar parts per output position and guards the launch
+        // domain with `ABSOLUTE_POS < real_pos.len()`.
+        kernels::compose_c32_parts_from_products::launch_unchecked::<WgpuRuntime>(
+            backend.runtime().client(),
+            cube_count_for_len(len),
+            cube_dim_1d(),
+            output_arg,
+            real_pos_arg,
+            real_neg_arg,
+            imag_left_arg,
+            imag_right_arg,
+        );
+    }
+
+    Ok(output)
+}
+
+fn dot_general_c32(
+    backend: &WebGpuBackend,
+    lhs: &TypedTensor<Complex32>,
+    rhs: &TypedTensor<Complex32>,
+    config: &DotGeneralConfig,
+) -> crate::Result<TypedTensor<Complex32>> {
+    build_dot_general_plan(lhs.shape(), rhs.shape(), config)?;
+
+    let lhs_real = extract_c32_part(backend, lhs, true)?;
+    let lhs_imag = extract_c32_part(backend, lhs, false)?;
+    let rhs_real = extract_c32_part(backend, rhs, true)?;
+    let rhs_imag = extract_c32_part(backend, rhs, false)?;
+
+    let real_pos = dot_general_f32(backend, &lhs_real, &rhs_real, config)?;
+    let real_neg = dot_general_f32(backend, &lhs_imag, &rhs_imag, config)?;
+    let imag_left = dot_general_f32(backend, &lhs_real, &rhs_imag, config)?;
+    let imag_right = dot_general_f32(backend, &lhs_imag, &rhs_real, config)?;
+
+    compose_c32_from_products(backend, &real_pos, &real_neg, &imag_left, &imag_right)
+}
+
+pub(super) fn dot_general(
+    backend: &WebGpuBackend,
+    lhs: &Tensor,
+    rhs: &Tensor,
+    config: &DotGeneralConfig,
+) -> crate::Result<Tensor> {
+    match (lhs, rhs) {
+        (Tensor::F32(lhs), Tensor::F32(rhs)) => {
+            dot_general_f32(backend, lhs, rhs, config).map(Tensor::F32)
+        }
+        (Tensor::F64(_), Tensor::F64(_)) => Err(Error::backend_failure(
+            DOT_GENERAL_OP,
+            "WebGPU CubeK matmul currently supports f32 real inputs; f64 is not available in the initial WebGPU path",
+        )),
+        (Tensor::C32(lhs), Tensor::C32(rhs)) => {
+            dot_general_c32(backend, lhs, rhs, config).map(Tensor::C32)
+        }
+        (Tensor::C64(_), Tensor::C64(_)) => Err(Error::backend_failure(
+            DOT_GENERAL_OP,
+            "WebGPU complex64 matmul requires f64 support and is not available in the initial WebGPU path",
+        )),
+        _ => Err(dtype_mismatch(DOT_GENERAL_OP, lhs, rhs)),
+    }
+}

--- a/crates/tenferro-gpu/src/webgpu/kernels.rs
+++ b/crates/tenferro-gpu/src/webgpu/kernels.rs
@@ -1,0 +1,122 @@
+use cubecl::prelude::*;
+
+#[cube(launch_unchecked)]
+pub fn extract_c32_real(out: &mut Array<f32>, input_parts: &Array<f32>) {
+    if ABSOLUTE_POS < out.len() {
+        out[ABSOLUTE_POS] = input_parts[ABSOLUTE_POS * 2];
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn extract_c32_imag(out: &mut Array<f32>, input_parts: &Array<f32>) {
+    if ABSOLUTE_POS < out.len() {
+        out[ABSOLUTE_POS] = input_parts[ABSOLUTE_POS * 2 + 1];
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn compose_c32_parts_from_products(
+    out_parts: &mut Array<f32>,
+    real_pos: &Array<f32>,
+    real_neg: &Array<f32>,
+    imag_left: &Array<f32>,
+    imag_right: &Array<f32>,
+) {
+    if ABSOLUTE_POS < real_pos.len() {
+        let out_pos = ABSOLUTE_POS * 2;
+        out_parts[out_pos] = real_pos[ABSOLUTE_POS] - real_neg[ABSOLUTE_POS];
+        out_parts[out_pos + 1] = imag_left[ABSOLUTE_POS] + imag_right[ABSOLUTE_POS];
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn pack_lhs_dot_general<E: CubePrimitive>(
+    out: &mut Tensor<E>,
+    input: &Tensor<E>,
+    #[comptime] free_axes: Sequence<usize>,
+    #[comptime] contract_axes: Sequence<usize>,
+    #[comptime] batch_axes: Sequence<usize>,
+    #[comptime] input_rank: usize,
+    #[comptime] out_rank: usize,
+) {
+    if ABSOLUTE_POS < out.len() {
+        let mut input_idx = Array::<usize>::new(input_rank);
+
+        #[unroll]
+        for batch_pos in 0..batch_axes.len() {
+            let input_axis = comptime! { *batch_axes.index(batch_pos) };
+            input_idx[input_axis] = out.coordinate(ABSOLUTE_POS, batch_pos);
+        }
+
+        let mut free_flat = out.coordinate(ABSOLUTE_POS, out_rank - 2);
+        #[unroll]
+        for pos in 0..free_axes.len() {
+            let input_axis = comptime! { *free_axes.index(pos) };
+            let dim = input.shape(input_axis);
+            input_idx[input_axis] = free_flat % dim;
+            free_flat /= dim;
+        }
+
+        let mut contract_flat = out.coordinate(ABSOLUTE_POS, out_rank - 1);
+        #[unroll]
+        for pos in 0..contract_axes.len() {
+            let input_axis = comptime! { *contract_axes.index(pos) };
+            let dim = input.shape(input_axis);
+            input_idx[input_axis] = contract_flat % dim;
+            contract_flat /= dim;
+        }
+
+        let mut input_offset = 0usize;
+        #[unroll]
+        for axis in 0..input_rank {
+            input_offset += input_idx[axis] * input.stride(axis);
+        }
+        out[ABSOLUTE_POS] = input[input_offset];
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn pack_rhs_dot_general<E: CubePrimitive>(
+    out: &mut Tensor<E>,
+    input: &Tensor<E>,
+    #[comptime] contract_axes: Sequence<usize>,
+    #[comptime] free_axes: Sequence<usize>,
+    #[comptime] batch_axes: Sequence<usize>,
+    #[comptime] input_rank: usize,
+    #[comptime] out_rank: usize,
+) {
+    if ABSOLUTE_POS < out.len() {
+        let mut input_idx = Array::<usize>::new(input_rank);
+
+        #[unroll]
+        for batch_pos in 0..batch_axes.len() {
+            let input_axis = comptime! { *batch_axes.index(batch_pos) };
+            input_idx[input_axis] = out.coordinate(ABSOLUTE_POS, batch_pos);
+        }
+
+        let mut contract_flat = out.coordinate(ABSOLUTE_POS, out_rank - 2);
+        #[unroll]
+        for pos in 0..contract_axes.len() {
+            let input_axis = comptime! { *contract_axes.index(pos) };
+            let dim = input.shape(input_axis);
+            input_idx[input_axis] = contract_flat % dim;
+            contract_flat /= dim;
+        }
+
+        let mut free_flat = out.coordinate(ABSOLUTE_POS, out_rank - 1);
+        #[unroll]
+        for pos in 0..free_axes.len() {
+            let input_axis = comptime! { *free_axes.index(pos) };
+            let dim = input.shape(input_axis);
+            input_idx[input_axis] = free_flat % dim;
+            free_flat /= dim;
+        }
+
+        let mut input_offset = 0usize;
+        #[unroll]
+        for axis in 0..input_rank {
+            input_offset += input_idx[axis] * input.stride(axis);
+        }
+        out[ABSOLUTE_POS] = input[input_offset];
+    }
+}

--- a/crates/tenferro-gpu/src/webgpu/memory.rs
+++ b/crates/tenferro-gpu/src/webgpu/memory.rs
@@ -1,0 +1,173 @@
+use cubecl::client::ComputeClient;
+use cubecl::prelude::CubeElement;
+use cubecl_wgpu::WgpuRuntime;
+use num_complex::{Complex32, Complex64};
+use std::sync::Arc;
+
+use super::{webgpu_handle_from_backend, webgpu_placement, WebGpuBuffer, WebGpuRuntime};
+use crate::{Buffer, Tensor, TypedTensor};
+
+/// Upload a host tensor into a CubeCL-managed WebGPU allocation.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_gpu::{upload_webgpu_tensor, WebGpuRuntime};
+/// use tenferro_tensor::{Result, Tensor};
+///
+/// let _upload: fn(&WebGpuRuntime, &Tensor) -> Result<Tensor> = upload_webgpu_tensor;
+/// ```
+pub fn upload_webgpu_tensor(rt: &WebGpuRuntime, tensor: &Tensor) -> crate::Result<Tensor> {
+    let client = rt.client();
+    match tensor {
+        Tensor::F64(t) => upload_typed::<f64>(client, rt.device_ordinal(), t).map(Tensor::F64),
+        Tensor::F32(t) => upload_typed::<f32>(client, rt.device_ordinal(), t).map(Tensor::F32),
+        Tensor::I32(t) => upload_typed::<i32>(client, rt.device_ordinal(), t).map(Tensor::I32),
+        Tensor::I64(t) => upload_typed::<i64>(client, rt.device_ordinal(), t).map(Tensor::I64),
+        Tensor::Bool(t) => upload_bool(client, rt.device_ordinal(), t).map(Tensor::Bool),
+        Tensor::C64(t) => {
+            upload_typed::<Complex64>(client, rt.device_ordinal(), t).map(Tensor::C64)
+        }
+        Tensor::C32(t) => {
+            upload_typed::<Complex32>(client, rt.device_ordinal(), t).map(Tensor::C32)
+        }
+    }
+}
+
+/// Download a CubeCL-managed WebGPU tensor back to host memory.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_gpu::{download_webgpu_tensor, WebGpuRuntime};
+/// use tenferro_tensor::{Result, Tensor};
+///
+/// let _download: fn(&WebGpuRuntime, &Tensor) -> Result<Tensor> = download_webgpu_tensor;
+/// ```
+pub fn download_webgpu_tensor(rt: &WebGpuRuntime, tensor: &Tensor) -> crate::Result<Tensor> {
+    let client = rt.client();
+    match tensor {
+        Tensor::F64(t) => download_typed::<f64>(client, t).map(Tensor::F64),
+        Tensor::F32(t) => download_typed::<f32>(client, t).map(Tensor::F32),
+        Tensor::I32(t) => download_typed::<i32>(client, t).map(Tensor::I32),
+        Tensor::I64(t) => download_typed::<i64>(client, t).map(Tensor::I64),
+        Tensor::Bool(t) => download_bool(client, t).map(Tensor::Bool),
+        Tensor::C64(t) => download_typed::<Complex64>(client, t).map(Tensor::C64),
+        Tensor::C32(t) => download_typed::<Complex32>(client, t).map(Tensor::C32),
+    }
+}
+
+pub(super) fn upload_typed<T: CubeElement + Clone + Send + Sync + 'static>(
+    client: &ComputeClient<WgpuRuntime>,
+    device_ordinal: usize,
+    typed: &TypedTensor<T>,
+) -> crate::Result<TypedTensor<T>> {
+    let host_data = match typed.buffer() {
+        Buffer::Host(data) => data,
+        Buffer::Backend(buffer) => {
+            return Err(crate::Error::backend_failure(
+                "webgpu_upload",
+                format!(
+                    "expected host buffer, got `{}` backend buffer",
+                    buffer.backend_family()
+                ),
+            ));
+        }
+    };
+
+    let handle = client.create_from_slice(T::as_bytes(host_data));
+    Ok(TypedTensor::from_buffer_col_major(
+        typed.shape().to_vec(),
+        Buffer::Backend(Arc::new(WebGpuBuffer::new(handle, host_data.len()))),
+        webgpu_placement(device_ordinal),
+    ))
+}
+
+pub(super) fn download_typed<T: CubeElement + Clone + 'static>(
+    client: &ComputeClient<WgpuRuntime>,
+    typed: &TypedTensor<T>,
+) -> crate::Result<TypedTensor<T>> {
+    let handle = match typed.buffer() {
+        Buffer::Host(_) => {
+            return Err(crate::Error::backend_failure(
+                "webgpu_download",
+                "expected WebGPU backend buffer",
+            ));
+        }
+        Buffer::Backend(buffer) => webgpu_handle_from_backend(buffer.as_ref(), "webgpu_download")?,
+    };
+
+    if typed.n_elements() == 0 {
+        return Ok(TypedTensor::from_vec_col_major(
+            typed.shape().to_vec(),
+            Vec::new(),
+        ));
+    }
+
+    let bytes = client
+        .read_one(handle)
+        .map_err(|err| crate::Error::backend_failure("webgpu_download", format!("{err:?}")))?;
+    let data = T::from_bytes(&bytes).to_vec();
+    Ok(TypedTensor::from_vec_col_major(
+        typed.shape().to_vec(),
+        data,
+    ))
+}
+
+fn upload_bool(
+    client: &ComputeClient<WgpuRuntime>,
+    device_ordinal: usize,
+    typed: &TypedTensor<bool>,
+) -> crate::Result<TypedTensor<bool>> {
+    let host_data = match typed.buffer() {
+        Buffer::Host(data) => data,
+        Buffer::Backend(buffer) => {
+            return Err(crate::Error::backend_failure(
+                "webgpu_upload",
+                format!(
+                    "expected host buffer, got `{}` backend buffer",
+                    buffer.backend_family()
+                ),
+            ));
+        }
+    };
+
+    let bytes: Vec<u8> = host_data.iter().map(|&value| u8::from(value)).collect();
+    let handle = client.create_from_slice(&bytes);
+    Ok(TypedTensor::from_buffer_col_major(
+        typed.shape().to_vec(),
+        Buffer::Backend(Arc::new(WebGpuBuffer::new(handle, host_data.len()))),
+        webgpu_placement(device_ordinal),
+    ))
+}
+
+fn download_bool(
+    client: &ComputeClient<WgpuRuntime>,
+    typed: &TypedTensor<bool>,
+) -> crate::Result<TypedTensor<bool>> {
+    let handle = match typed.buffer() {
+        Buffer::Host(_) => {
+            return Err(crate::Error::backend_failure(
+                "webgpu_download",
+                "expected WebGPU backend buffer",
+            ));
+        }
+        Buffer::Backend(buffer) => webgpu_handle_from_backend(buffer.as_ref(), "webgpu_download")?,
+    };
+
+    if typed.n_elements() == 0 {
+        return Ok(TypedTensor::from_vec_col_major(
+            typed.shape().to_vec(),
+            Vec::new(),
+        ));
+    }
+
+    let bytes = client
+        .read_one(handle)
+        .map_err(|err| crate::Error::backend_failure("webgpu_download", format!("{err:?}")))?;
+    let data = bytes.iter().map(|&byte| byte != 0).collect();
+    Ok(TypedTensor::from_vec_col_major(
+        typed.shape().to_vec(),
+        data,
+    ))
+}

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -1,0 +1,713 @@
+//! CubeCL WebGPU provider runtime and backend skeleton.
+
+use cubecl::prelude::{
+    ArrayArg, CubeCount, CubeDim, CubeElement, CubeType, Sequence, TensorBinding,
+};
+use cubecl_wgpu::WgpuRuntime;
+use std::sync::Arc;
+
+use crate::{
+    BackendBuffer, BackendCachedDot, BackendRuntimeCache, BackendSessionHost, Buffer, CompareDir,
+    DType, DeviceId, DeviceKind, DotGeneralConfig, Error, GatherConfig, GpuBackendKind, MemoryKind,
+    PadConfig, Placement, ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend,
+    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorReduction, TensorStructural, TypedTensor,
+};
+
+const DEFAULT_CUBE_DIM_X: u32 = 256;
+
+mod gemm;
+mod kernels;
+mod memory;
+mod runtime;
+
+pub use memory::{download_webgpu_tensor, upload_webgpu_tensor};
+pub use runtime::{webgpu_available, WebGpuRuntime};
+
+/// CubeCL-managed WebGPU buffer stored behind tensor backend-buffer trait objects.
+#[derive(Clone)]
+pub(crate) struct WebGpuBuffer<T> {
+    handle: cubecl_runtime::server::Handle,
+    len: usize,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> std::fmt::Debug for WebGpuBuffer<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebGpuBuffer")
+            .field("len", &self.len)
+            .finish()
+    }
+}
+
+impl<T> WebGpuBuffer<T> {
+    fn new(handle: cubecl_runtime::server::Handle, len: usize) -> Self {
+        Self {
+            handle,
+            len,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    fn handle(&self) -> &cubecl_runtime::server::Handle {
+        &self.handle
+    }
+
+    fn element_len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<T: Send + Sync + 'static> BackendBuffer<T> for WebGpuBuffer<T> {
+    fn backend_family(&self) -> &'static str {
+        "cubecl-webgpu"
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+fn webgpu_handle_from_backend<T: 'static>(
+    buffer: &dyn BackendBuffer<T>,
+    op: &'static str,
+) -> crate::Result<cubecl_runtime::server::Handle> {
+    buffer
+        .as_any()
+        .downcast_ref::<WebGpuBuffer<T>>()
+        .map(|buffer| buffer.handle().clone())
+        .ok_or_else(|| {
+            crate::Error::backend_failure(
+                op,
+                format!(
+                    "expected WebGPU backend buffer, got `{}` backend buffer",
+                    buffer.backend_family()
+                ),
+            )
+        })
+}
+
+fn checked_shape_product(op: &'static str, shape: &[usize]) -> crate::Result<usize> {
+    shape
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or_else(|| {
+            Error::backend_failure(op, format!("shape product overflow for shape {shape:?}"))
+        })
+}
+
+fn cube_count_for_len(len: usize) -> CubeCount {
+    let cubes = len.div_ceil(DEFAULT_CUBE_DIM_X as usize) as u32;
+    CubeCount::Static(cubes.max(1), 1, 1)
+}
+
+fn cube_dim_1d() -> CubeDim {
+    CubeDim::new_1d(DEFAULT_CUBE_DIM_X)
+}
+
+fn comptime_sequence<T: CubeType>(values: &[T]) -> Sequence<T>
+where
+    T: Clone,
+{
+    let mut out = Sequence::new();
+    for value in values {
+        out.push(value.clone());
+    }
+    out
+}
+
+fn validate_webgpu_buffer_len<T>(
+    tensor: &TypedTensor<T>,
+    buffer: &WebGpuBuffer<T>,
+    op: &'static str,
+) -> crate::Result<()> {
+    let expected_len = checked_shape_product(op, tensor.shape())?;
+    let actual_len = buffer.element_len();
+    if expected_len != actual_len {
+        return Err(Error::backend_failure(
+            op,
+            format!(
+                "expected shape product {expected_len} elements, actual WebGpuBuffer::len {actual_len}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn webgpu_buffer<'a, T: 'static>(
+    tensor: &'a TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<&'a WebGpuBuffer<T>> {
+    match tensor.buffer() {
+        Buffer::Host(_) => Err(Error::backend_failure(
+            op,
+            "expected WebGPU tensor, got host tensor. \
+             Use upload_webgpu_tensor() to transfer to WebGPU before calling WebGPU ops.",
+        )),
+        Buffer::Backend(buffer) => buffer
+            .as_any()
+            .downcast_ref::<WebGpuBuffer<T>>()
+            .ok_or_else(|| {
+                Error::backend_failure(
+                    op,
+                    format!(
+                        "expected WebGPU tensor, got backend buffer family `{}`",
+                        buffer.backend_family()
+                    ),
+                )
+            }),
+    }
+}
+
+fn typed_tensor_binding_with_layout<T: CubeElement + Clone>(
+    tensor: &TypedTensor<T>,
+    shape: &[usize],
+    strides: &[usize],
+    op: &'static str,
+) -> crate::Result<TensorBinding<WgpuRuntime>> {
+    if shape.len() != strides.len() {
+        return Err(Error::backend_failure(
+            op,
+            format!(
+                "WebGPU tensor binding layout rank mismatch: shape rank {} stride rank {}",
+                shape.len(),
+                strides.len()
+            ),
+        ));
+    }
+    let buffer = webgpu_buffer(tensor, op)?;
+    validate_webgpu_buffer_len(tensor, buffer, op)?;
+    let layout_len = checked_shape_product(op, shape)?;
+    if layout_len != buffer.element_len() {
+        return Err(Error::backend_failure(
+            op,
+            format!(
+                "WebGPU tensor binding layout covers {layout_len} elements, backing buffer has {}",
+                buffer.element_len()
+            ),
+        ));
+    }
+
+    let (shape, strides) = if shape.is_empty() {
+        (vec![1], vec![1])
+    } else {
+        (shape.to_vec(), strides.to_vec())
+    };
+
+    // SAFETY: The tensor buffer is a validated WebGPU allocation for `tensor`.
+    // The caller-provided shape/stride metadata is checked to cover exactly the
+    // same element count, so CubeCL logical indexing remains inside the backing
+    // allocation.
+    Ok(unsafe {
+        TensorBinding::from_raw_parts(buffer.handle().clone(), strides.into(), shape.into())
+    })
+}
+
+fn typed_tensor_array_arg<T: CubeElement + Clone>(
+    tensor: &TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<ArrayArg<WgpuRuntime>> {
+    let buffer = webgpu_buffer(tensor, op)?;
+    validate_webgpu_buffer_len(tensor, buffer, op)?;
+
+    // SAFETY: `validate_webgpu_buffer_len` proves the dense tensor shape
+    // matches the backing allocation length. Raw linear kernels using this
+    // helper guard their output domain with `ABSOLUTE_POS < out.len()`.
+    Ok(unsafe { ArrayArg::from_raw_parts(buffer.handle().clone(), buffer.element_len()) })
+}
+
+fn typed_tensor_array_arg_as<T, U>(
+    tensor: &TypedTensor<T>,
+    len: usize,
+    op: &'static str,
+) -> crate::Result<ArrayArg<WgpuRuntime>>
+where
+    T: CubeElement + Clone,
+    U: CubeElement + Clone,
+{
+    let buffer = webgpu_buffer(tensor, op)?;
+    validate_webgpu_buffer_len(tensor, buffer, op)?;
+    let requested_bytes = len.checked_mul(core::mem::size_of::<U>()).ok_or_else(|| {
+        Error::backend_failure(
+            op,
+            format!("reinterpreted WebGPU array length overflow for len {len}"),
+        )
+    })?;
+    let available_bytes = buffer
+        .element_len()
+        .checked_mul(core::mem::size_of::<T>())
+        .ok_or_else(|| {
+            Error::backend_failure(
+                op,
+                format!(
+                    "WebGPU buffer byte length overflow for {} elements",
+                    buffer.element_len()
+                ),
+            )
+        })?;
+    if requested_bytes > available_bytes {
+        return Err(Error::backend_failure(
+            op,
+            format!(
+                "reinterpreted WebGPU array needs {requested_bytes} bytes, buffer has {available_bytes}"
+            ),
+        ));
+    }
+
+    // SAFETY: The tensor shape was validated against the backing allocation,
+    // and the byte-size check proves the requested scalar view remains within
+    // the same allocation.
+    Ok(unsafe { ArrayArg::from_raw_parts(buffer.handle().clone(), len) })
+}
+
+fn ensure_resident_on_runtime<T: 'static>(
+    rt: &WebGpuRuntime,
+    tensor: &TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<()> {
+    webgpu_buffer(tensor, op)?;
+    ensure_placement_resident_on_runtime(rt, tensor.placement(), op)
+}
+
+fn ensure_placement_resident_on_runtime(
+    rt: &WebGpuRuntime,
+    placement: &Placement,
+    op: &'static str,
+) -> crate::Result<()> {
+    if !matches!(&placement.memory_kind, MemoryKind::Device) {
+        return Err(Error::backend_failure(
+            op,
+            format!(
+                "expected WebGPU tensor placement, got {:?}",
+                placement.memory_kind
+            ),
+        ));
+    }
+    match &placement.device {
+        Some(device)
+            if device.kind == DeviceKind::Gpu(GpuBackendKind::WebGpu)
+                && device.ordinal == rt.device_ordinal() =>
+        {
+            Ok(())
+        }
+        Some(device) => Err(Error::backend_failure(
+            op,
+            format!(
+                "expected WebGPU tensor resident on webgpu:{}, got {:?}:{}",
+                rt.device_ordinal(),
+                device.kind,
+                device.ordinal
+            ),
+        )),
+        None => Err(Error::backend_failure(
+            op,
+            format!(
+                "expected WebGPU tensor resident on webgpu:{}, got missing device metadata",
+                rt.device_ordinal()
+            ),
+        )),
+    }
+}
+
+fn typed_from_webgpu<T: Send + Sync + 'static>(
+    shape: Vec<usize>,
+    buffer: WebGpuBuffer<T>,
+    device_ordinal: usize,
+) -> TypedTensor<T> {
+    TypedTensor::from_buffer_col_major(
+        shape,
+        Buffer::Backend(Arc::new(buffer)),
+        webgpu_placement(device_ordinal),
+    )
+}
+
+fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
+    rt: &WebGpuRuntime,
+    shape: &[usize],
+    op: &'static str,
+) -> crate::Result<TypedTensor<T>> {
+    let len = checked_shape_product(op, shape)?;
+    let bytes = len.checked_mul(core::mem::size_of::<T>()).ok_or_else(|| {
+        Error::backend_failure(
+            op,
+            format!("WebGPU output byte length overflow for shape {shape:?}"),
+        )
+    })?;
+    let handle = rt.client().empty(bytes);
+    Ok(typed_from_webgpu(
+        shape.to_vec(),
+        WebGpuBuffer::new(handle, len),
+        rt.device_ordinal(),
+    ))
+}
+
+fn webgpu_placement(device_ordinal: usize) -> Placement {
+    Placement {
+        memory_kind: MemoryKind::Device,
+        device: Some(DeviceId {
+            kind: DeviceKind::Gpu(GpuBackendKind::WebGpu),
+            ordinal: device_ordinal,
+        }),
+    }
+}
+
+/// CubeCL WebGPU tensor backend.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_gpu::WebGpuBackend;
+///
+/// let _ctor: fn(usize) -> tenferro_tensor::Result<WebGpuBackend> = WebGpuBackend::new;
+/// ```
+pub struct WebGpuBackend {
+    runtime: WebGpuRuntime,
+}
+
+impl WebGpuBackend {
+    /// Initialize a WebGPU backend for a discrete GPU ordinal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::WebGpuBackend;
+    ///
+    /// let _ctor: fn(usize) -> tenferro_tensor::Result<WebGpuBackend> = WebGpuBackend::new;
+    /// ```
+    pub fn new(device_ordinal: usize) -> crate::Result<Self> {
+        WebGpuRuntime::new(device_ordinal).map(Self::from_runtime)
+    }
+
+    /// Initialize a WebGPU backend using CubeCL's default adapter selection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::WebGpuBackend;
+    ///
+    /// let _ctor: fn() -> tenferro_tensor::Result<WebGpuBackend> = WebGpuBackend::new_default;
+    /// ```
+    pub fn new_default() -> crate::Result<Self> {
+        WebGpuRuntime::new_default().map(Self::from_runtime)
+    }
+
+    /// Build a WebGPU backend from an initialized runtime.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::{WebGpuBackend, WebGpuRuntime};
+    ///
+    /// let _from_runtime: fn(WebGpuRuntime) -> WebGpuBackend = WebGpuBackend::from_runtime;
+    /// ```
+    pub fn from_runtime(runtime: WebGpuRuntime) -> Self {
+        Self { runtime }
+    }
+
+    /// Return this backend's WebGPU runtime.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::{WebGpuBackend, WebGpuRuntime};
+    ///
+    /// let _runtime: fn(&WebGpuBackend) -> &WebGpuRuntime = WebGpuBackend::runtime;
+    /// ```
+    pub fn runtime(&self) -> &WebGpuRuntime {
+        &self.runtime
+    }
+
+    /// Block until queued WebGPU work completes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::WebGpuBackend;
+    ///
+    /// let _sync: fn(&WebGpuBackend) -> tenferro_tensor::Result<()> = WebGpuBackend::synchronize;
+    /// ```
+    pub fn synchronize(&self) -> crate::Result<()> {
+        self.runtime.synchronize()
+    }
+}
+
+fn unsupported_op(op: &'static str) -> crate::Error {
+    crate::Error::backend_failure(
+        op,
+        "WebGPU backend does not support this operation yet; upload/download explicitly and use a supported backend operation",
+    )
+}
+
+macro_rules! unsupported {
+    ($op:literal) => {
+        Err(unsupported_op($op))
+    };
+}
+
+impl TensorElementwise for WebGpuBackend {
+    fn add(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_add")
+    }
+
+    fn mul(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_mul")
+    }
+
+    fn neg(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_neg")
+    }
+
+    fn conj(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_conj")
+    }
+
+    fn div(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_div")
+    }
+
+    fn abs(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_abs")
+    }
+
+    fn sign(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_sign")
+    }
+
+    fn maximum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_maximum")
+    }
+
+    fn minimum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_minimum")
+    }
+
+    fn compare(
+        &mut self,
+        _lhs: &Tensor,
+        _rhs: &Tensor,
+        _dir: &CompareDir,
+    ) -> crate::Result<Tensor> {
+        unsupported!("webgpu_compare")
+    }
+
+    fn select(
+        &mut self,
+        _pred: &Tensor,
+        _on_true: &Tensor,
+        _on_false: &Tensor,
+    ) -> crate::Result<Tensor> {
+        unsupported!("webgpu_select")
+    }
+
+    fn clamp(
+        &mut self,
+        _input: &Tensor,
+        _lower: &Tensor,
+        _upper: &Tensor,
+    ) -> crate::Result<Tensor> {
+        unsupported!("webgpu_clamp")
+    }
+}
+
+impl TensorAnalytic for WebGpuBackend {
+    fn exp(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_exp")
+    }
+
+    fn log(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_log")
+    }
+
+    fn sin(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_sin")
+    }
+
+    fn cos(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_cos")
+    }
+
+    fn tanh(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_tanh")
+    }
+
+    fn sqrt(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_sqrt")
+    }
+
+    fn rsqrt(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_rsqrt")
+    }
+
+    fn pow(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_pow")
+    }
+
+    fn expm1(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_expm1")
+    }
+
+    fn log1p(&mut self, _input: &Tensor) -> crate::Result<Tensor> {
+        unsupported!("webgpu_log1p")
+    }
+}
+
+impl TensorStructural for WebGpuBackend {
+    fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> crate::Result<Tensor> {
+        unsupported!("webgpu_transpose")
+    }
+
+    fn reshape(&mut self, _input: &Tensor, _shape: &[usize]) -> crate::Result<Tensor> {
+        unsupported!("webgpu_reshape")
+    }
+
+    fn broadcast_in_dim(
+        &mut self,
+        _input: &Tensor,
+        _shape: &[usize],
+        _dims: &[usize],
+    ) -> crate::Result<Tensor> {
+        unsupported!("webgpu_broadcast_in_dim")
+    }
+
+    fn convert(&mut self, _input: &Tensor, _to: DType) -> crate::Result<Tensor> {
+        unsupported!("webgpu_convert")
+    }
+
+    fn extract_diagonal(
+        &mut self,
+        _input: &Tensor,
+        _axis_a: usize,
+        _axis_b: usize,
+    ) -> crate::Result<Tensor> {
+        unsupported!("webgpu_extract_diagonal")
+    }
+
+    fn embed_diagonal(
+        &mut self,
+        _input: &Tensor,
+        _axis_a: usize,
+        _axis_b: usize,
+    ) -> crate::Result<Tensor> {
+        unsupported!("webgpu_embed_diagonal")
+    }
+
+    fn tril(&mut self, _input: &Tensor, _k: i64) -> crate::Result<Tensor> {
+        unsupported!("webgpu_tril")
+    }
+
+    fn triu(&mut self, _input: &Tensor, _k: i64) -> crate::Result<Tensor> {
+        unsupported!("webgpu_triu")
+    }
+}
+
+impl TensorReduction for WebGpuBackend {
+    fn reduce_sum(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
+        unsupported!("webgpu_reduce_sum")
+    }
+
+    fn reduce_prod(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
+        unsupported!("webgpu_reduce_prod")
+    }
+
+    fn reduce_max(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
+        unsupported!("webgpu_reduce_max")
+    }
+
+    fn reduce_min(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
+        unsupported!("webgpu_reduce_min")
+    }
+}
+
+impl TensorDot for WebGpuBackend {
+    fn dot_general(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        gemm::dot_general(self, lhs, rhs, config)
+    }
+}
+
+impl TensorIndexing for WebGpuBackend {
+    fn gather(
+        &mut self,
+        _operand: &Tensor,
+        _start_indices: &Tensor,
+        _config: &GatherConfig,
+    ) -> crate::Result<Tensor> {
+        unsupported!("webgpu_gather")
+    }
+
+    fn scatter(
+        &mut self,
+        _operand: &Tensor,
+        _scatter_indices: &Tensor,
+        _updates: &Tensor,
+        _config: &ScatterConfig,
+    ) -> crate::Result<Tensor> {
+        unsupported!("webgpu_scatter")
+    }
+
+    fn slice(&mut self, _input: &Tensor, _config: &SliceConfig) -> crate::Result<Tensor> {
+        unsupported!("webgpu_slice")
+    }
+
+    fn dynamic_slice(
+        &mut self,
+        _input: &Tensor,
+        _starts: &Tensor,
+        _slice_sizes: &[usize],
+    ) -> crate::Result<Tensor> {
+        unsupported!("webgpu_dynamic_slice")
+    }
+
+    fn dynamic_update_slice(
+        &mut self,
+        _operand: &Tensor,
+        _update: &Tensor,
+        _starts: &Tensor,
+    ) -> crate::Result<Tensor> {
+        unsupported!("webgpu_dynamic_update_slice")
+    }
+
+    fn pad(&mut self, _input: &Tensor, _config: &PadConfig) -> crate::Result<Tensor> {
+        unsupported!("webgpu_pad")
+    }
+
+    fn concatenate(&mut self, _inputs: &[&Tensor], _axis: usize) -> crate::Result<Tensor> {
+        unsupported!("webgpu_concatenate")
+    }
+
+    fn reverse(&mut self, _input: &Tensor, _axes: &[usize]) -> crate::Result<Tensor> {
+        unsupported!("webgpu_reverse")
+    }
+}
+
+impl TensorFusion for WebGpuBackend {}
+
+impl TensorBuffer for WebGpuBackend {}
+
+impl TensorDeviceTransfer for WebGpuBackend {
+    fn download_to_host(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
+        download_webgpu_tensor(self.runtime(), tensor)
+    }
+
+    fn upload_host_tensor(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
+        upload_webgpu_tensor(self.runtime(), tensor)
+    }
+}
+
+impl BackendRuntimeCache for WebGpuBackend {
+    type RuntimeCache = ();
+}
+
+impl BackendCachedDot for WebGpuBackend {}
+
+impl BackendSessionHost for WebGpuBackend {}
+
+impl TensorBackend for WebGpuBackend {}

--- a/crates/tenferro-gpu/src/webgpu/runtime.rs
+++ b/crates/tenferro-gpu/src/webgpu/runtime.rs
@@ -1,0 +1,113 @@
+use cubecl::client::ComputeClient;
+use cubecl::Runtime;
+use cubecl_common::future;
+use cubecl_wgpu::{WgpuDevice, WgpuRuntime};
+
+/// Returns `true` if a WebGPU adapter is available for CubeCL.
+///
+/// Use this in test helpers to skip WebGPU tests on machines without an
+/// adapter.
+pub fn webgpu_available() -> bool {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let device = WgpuDevice::DefaultDevice;
+        let _ = WgpuRuntime::client(&device);
+    }))
+    .is_ok()
+}
+
+/// CubeCL WebGPU runtime wrapper.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_gpu::WebGpuRuntime;
+///
+/// let _ctor: fn(usize) -> tenferro_tensor::Result<WebGpuRuntime> = WebGpuRuntime::new;
+/// let _sync: fn(&WebGpuRuntime) -> tenferro_tensor::Result<()> =
+///     WebGpuRuntime::synchronize;
+/// ```
+#[derive(Clone)]
+pub struct WebGpuRuntime {
+    client: ComputeClient<WgpuRuntime>,
+    device_ordinal: usize,
+}
+
+impl WebGpuRuntime {
+    /// Initialize the CubeCL WebGPU runtime for a discrete GPU ordinal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::WebGpuRuntime;
+    ///
+    /// let _ctor: fn(usize) -> tenferro_tensor::Result<WebGpuRuntime> = WebGpuRuntime::new;
+    /// ```
+    pub fn new(device_ordinal: usize) -> crate::Result<Self> {
+        Self::from_device(WgpuDevice::DiscreteGpu(device_ordinal), device_ordinal)
+    }
+
+    /// Initialize the CubeCL WebGPU runtime using CubeCL's default adapter selection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::WebGpuRuntime;
+    ///
+    /// let _ctor: fn() -> tenferro_tensor::Result<WebGpuRuntime> = WebGpuRuntime::new_default;
+    /// ```
+    pub fn new_default() -> crate::Result<Self> {
+        Self::from_device(WgpuDevice::DefaultDevice, 0)
+    }
+
+    fn from_device(device: WgpuDevice, device_ordinal: usize) -> crate::Result<Self> {
+        let client = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            WgpuRuntime::client(&device)
+        }))
+        .map_err(|payload| {
+            crate::Error::backend_failure(
+                "webgpu_runtime_init",
+                format!("failed to initialize CubeCL WebGPU runtime: {payload:?}"),
+            )
+        })?;
+        Ok(Self {
+            client,
+            device_ordinal,
+        })
+    }
+
+    pub(crate) fn client(&self) -> &ComputeClient<WgpuRuntime> {
+        &self.client
+    }
+
+    /// Return the WebGPU device ordinal requested at construction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::WebGpuRuntime;
+    ///
+    /// let _device_ordinal: fn(&WebGpuRuntime) -> usize = WebGpuRuntime::device_ordinal;
+    /// ```
+    pub fn device_ordinal(&self) -> usize {
+        self.device_ordinal
+    }
+
+    /// Block the current thread until work submitted to the WebGPU queue completes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::WebGpuRuntime;
+    ///
+    /// let _sync: fn(&WebGpuRuntime) -> tenferro_tensor::Result<()> =
+    ///     WebGpuRuntime::synchronize;
+    /// ```
+    pub fn synchronize(&self) -> crate::Result<()> {
+        const OP: &str = "webgpu_runtime_synchronize";
+        self.client
+            .flush()
+            .map_err(|err| crate::Error::backend_failure(OP, format!("{err:?}")))?;
+        future::block_on(self.client.sync())
+            .map_err(|err| crate::Error::backend_failure(OP, format!("{err:?}")))
+    }
+}

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -7,6 +7,32 @@ fn repo_file(path: &str) -> String {
     std::fs::read_to_string(root).expect("source file must be readable")
 }
 
+fn repo_file_if_exists(path: &str) -> Option<String> {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.push("../..");
+    root.push(path);
+    std::fs::read_to_string(root).ok()
+}
+
+fn feature_block(manifest: &str, name: &str) -> String {
+    let prefix = format!("{name} = [");
+    let mut block = String::new();
+    let mut in_block = false;
+    for line in manifest.lines() {
+        if line.trim_start().starts_with(&prefix) {
+            in_block = true;
+        }
+        if in_block {
+            block.push_str(line);
+            block.push('\n');
+            if line.trim_end().ends_with(']') {
+                return block;
+            }
+        }
+    }
+    panic!("{name} feature must be declared")
+}
+
 #[test]
 fn cubecl_implementation_module_is_not_public_api() {
     let lib_rs = repo_file("crates/tenferro-gpu/src/lib.rs");
@@ -35,5 +61,168 @@ fn cubecl_implementation_module_is_not_public_api() {
     assert!(
         !cubecl_mod.contains("pub mod interop;"),
         "interop bridge should be re-exported from the crate root, not from the implementation module"
+    );
+}
+
+#[test]
+fn gpu_backend_features_are_explicit_and_additive() {
+    let manifest = repo_file("crates/tenferro-gpu/Cargo.toml");
+
+    let default_feature = feature_block(&manifest, "default");
+    assert!(
+        !default_feature.contains("cuda")
+            && !default_feature.contains("webgpu")
+            && !default_feature.contains("rocm"),
+        "GPU backend providers must not be enabled by default"
+    );
+    assert!(
+        !manifest.contains("\ngpu = ["),
+        "tenferro-gpu should expose concrete backend features, not a vague gpu alias"
+    );
+
+    let cuda_feature = feature_block(&manifest, "cuda");
+    assert!(
+        cuda_feature.contains("dep:cubecl-cuda") && cuda_feature.contains("dep:cudarc"),
+        "cuda feature must own CUDA-specific runtime dependencies"
+    );
+
+    let webgpu_feature = feature_block(&manifest, "webgpu");
+    assert!(
+        webgpu_feature.contains("dep:cubecl-wgpu"),
+        "webgpu feature must own the CubeCL WGPU runtime dependency"
+    );
+    assert!(
+        !webgpu_feature.contains("dep:cubecl-cuda") && !webgpu_feature.contains("dep:cudarc"),
+        "webgpu feature must not pull CUDA-only dependencies"
+    );
+}
+
+#[test]
+fn downstream_gpu_features_are_explicit_and_additive() {
+    for manifest_path in [
+        "crates/tenferro-ad/Cargo.toml",
+        "crates/tenferro-einsum/Cargo.toml",
+    ] {
+        let manifest = repo_file(manifest_path);
+        let default_feature = feature_block(&manifest, "default");
+        assert!(
+            !default_feature.contains("cuda")
+                && !default_feature.contains("webgpu")
+                && !default_feature.contains("rocm"),
+            "{manifest_path} must not enable GPU providers by default"
+        );
+        assert!(
+            !manifest.contains("\ngpu = ["),
+            "{manifest_path} should expose concrete backend features, not a vague gpu alias"
+        );
+        assert!(
+            feature_block(&manifest, "cuda").contains("cuda"),
+            "{manifest_path} should keep an explicit cuda feature"
+        );
+        assert!(
+            feature_block(&manifest, "webgpu").contains("webgpu"),
+            "{manifest_path} should expose an explicit webgpu feature"
+        );
+    }
+}
+
+#[test]
+fn public_backend_names_are_provider_specific() {
+    let lib_rs = repo_file("crates/tenferro-gpu/src/lib.rs");
+    assert!(
+        lib_rs.contains("CudaBackend"),
+        "CUDA backend should have an explicit public CudaBackend name"
+    );
+    assert!(
+        lib_rs.contains("WebGpuBackend"),
+        "WebGPU backend should have an explicit public WebGpuBackend name"
+    );
+    assert!(
+        lib_rs.contains("CubeclBackend"),
+        "the existing CubeclBackend compatibility name should remain while downstream users migrate"
+    );
+}
+
+#[test]
+fn cuda_dot_general_stays_cutensor_backed_and_not_cubek_rewired() {
+    let cuda_gemm = repo_file("crates/tenferro-gpu/src/cubecl/gemm.rs");
+    assert!(
+        cuda_gemm.contains("cutensor.contract("),
+        "CUDA dot_general must remain cuTENSOR-backed in this work"
+    );
+    assert!(
+        cuda_gemm.contains("alloc_workspace(backend.runtime(), workspace_size)")
+            && cuda_gemm.contains("Plan::new(cutensor, &op_desc"),
+        "CUDA workspace and plan flow must remain visible"
+    );
+    assert!(
+        !cuda_gemm.contains("cubek_matmul") && !cuda_gemm.contains("DotGeneralPlan"),
+        "WebGPU planner/CubeK changes must not rewrite the CUDA algorithm"
+    );
+    assert!(
+        !cuda_gemm.contains("GpuScratchPool"),
+        "common GPU scratch-pool design must not be wired into CUDA GEMM in this work"
+    );
+}
+
+#[test]
+fn webgpu_dot_general_is_cubek_backed() {
+    let manifest = repo_file("crates/tenferro-gpu/Cargo.toml");
+    let webgpu_feature = feature_block(&manifest, "webgpu");
+    assert!(
+        webgpu_feature.contains("dep:cubek-matmul") && webgpu_feature.contains("dep:cubek-std"),
+        "webgpu dot_general must opt into CubeK matmul dependencies explicitly"
+    );
+
+    let webgpu_mod = repo_file("crates/tenferro-gpu/src/webgpu/mod.rs");
+    let webgpu_gemm =
+        repo_file_if_exists("crates/tenferro-gpu/src/webgpu/gemm.rs").unwrap_or_default();
+    assert!(
+        !webgpu_mod.contains("unsupported!(\"webgpu_dot_general\")"),
+        "WebGPU dot_general should dispatch a real matmul path instead of an unsupported stub"
+    );
+    assert!(
+        webgpu_mod.contains("cubek_matmul::launch::launch_ref")
+            || webgpu_gemm.contains("cubek_matmul::launch::launch_ref"),
+        "WebGPU dot_general should route matmul through CubeK launch_ref"
+    );
+}
+
+#[test]
+fn webgpu_provider_keeps_runtime_transfer_and_gemm_boundaries_split() {
+    let webgpu_mod = repo_file("crates/tenferro-gpu/src/webgpu/mod.rs");
+
+    for module in ["gemm", "kernels", "memory", "runtime"] {
+        assert!(
+            webgpu_mod.contains(&format!("mod {module};")),
+            "WebGPU provider should keep `{module}` behind a dedicated module boundary"
+        );
+    }
+
+    assert!(
+        !webgpu_mod.contains("cubek_matmul::launch::launch_ref"),
+        "CubeK matmul launch details should live in the WebGPU GEMM module"
+    );
+    assert!(
+        !webgpu_mod.contains("pub struct WebGpuRuntime"),
+        "WebGPU runtime initialization should live in the runtime module"
+    );
+    assert!(
+        !webgpu_mod.contains("pub fn upload_webgpu_tensor")
+            && !webgpu_mod.contains("pub fn download_webgpu_tensor"),
+        "WebGPU transfer helpers should live in the memory module"
+    );
+}
+
+#[test]
+fn webgpu_allocation_uses_checked_shape_products() {
+    let webgpu_mod = repo_file("crates/tenferro-gpu/src/webgpu/mod.rs");
+    assert!(
+        webgpu_mod.contains("checked_shape_product(op, shape)?"),
+        "WebGPU output allocation must validate shape products with checked arithmetic"
+    );
+    assert!(
+        !webgpu_mod.contains("shape.iter().product()"),
+        "WebGPU output allocation must not use unchecked shape product arithmetic"
     );
 }

--- a/crates/tenferro-gpu/tests/webgpu_backend_contract.rs
+++ b/crates/tenferro-gpu/tests/webgpu_backend_contract.rs
@@ -1,0 +1,26 @@
+#![cfg(feature = "webgpu")]
+
+use tenferro_gpu::{download_webgpu_tensor, upload_webgpu_tensor, WebGpuBackend, WebGpuRuntime};
+use tenferro_tensor::{
+    DotGeneralConfig, Result, Tensor, TensorBackend, TensorDeviceTransfer, TensorDot,
+};
+
+fn assert_tensor_backend<B: TensorBackend>() {}
+
+#[test]
+fn webgpu_backend_implements_tensor_backend_contract() {
+    assert_tensor_backend::<WebGpuBackend>();
+
+    let _upload: fn(&mut WebGpuBackend, &Tensor) -> Result<Tensor> =
+        <WebGpuBackend as TensorDeviceTransfer>::upload_host_tensor;
+    let _download: fn(&mut WebGpuBackend, &Tensor) -> Result<Tensor> =
+        <WebGpuBackend as TensorDeviceTransfer>::download_to_host;
+    let _dot: fn(&mut WebGpuBackend, &Tensor, &Tensor, &DotGeneralConfig) -> Result<Tensor> =
+        <WebGpuBackend as TensorDot>::dot_general;
+}
+
+#[test]
+fn webgpu_transfer_helpers_are_provider_specific() {
+    let _upload: fn(&WebGpuRuntime, &Tensor) -> Result<Tensor> = upload_webgpu_tensor;
+    let _download: fn(&WebGpuRuntime, &Tensor) -> Result<Tensor> = download_webgpu_tensor;
+}

--- a/crates/tenferro-gpu/tests/webgpu_matmul_runtime.rs
+++ b/crates/tenferro-gpu/tests/webgpu_matmul_runtime.rs
@@ -1,0 +1,309 @@
+#![cfg(feature = "webgpu")]
+
+use num_complex::{Complex32, Complex64};
+use tenferro_gpu::{webgpu_available, WebGpuBackend};
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorDeviceTransfer, TensorDot};
+
+fn matmul2_col_major(lhs: &[Complex32], rhs: &[Complex32]) -> [Complex32; 4] {
+    let a00 = lhs[0];
+    let a10 = lhs[1];
+    let a01 = lhs[2];
+    let a11 = lhs[3];
+    let b00 = rhs[0];
+    let b10 = rhs[1];
+    let b01 = rhs[2];
+    let b11 = rhs[3];
+    [
+        a00 * b00 + a01 * b10,
+        a10 * b00 + a11 * b10,
+        a00 * b01 + a01 * b11,
+        a10 * b01 + a11 * b11,
+    ]
+}
+
+fn assert_complex_close(actual: &[Complex32], expected: &[Complex32]) {
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert!(
+            (actual.re - expected.re).abs() <= 1e-4,
+            "real mismatch: actual={actual:?} expected={expected:?}"
+        );
+        assert!(
+            (actual.im - expected.im).abs() <= 1e-4,
+            "imag mismatch: actual={actual:?} expected={expected:?}"
+        );
+    }
+}
+
+fn noncontiguous_lhs_free_axes_reference(lhs: &[f32], rhs: &[f32]) -> Vec<f32> {
+    let mut out = vec![0.0_f32; 2 * 2 * 2];
+    for n in 0..2 {
+        for m1 in 0..2 {
+            for m0 in 0..2 {
+                let mut acc = 0.0_f32;
+                for k in 0..3 {
+                    let lhs_offset = m0 + 2 * k + 2 * 3 * m1;
+                    let rhs_offset = k + 3 * n;
+                    acc += lhs[lhs_offset] * rhs[rhs_offset];
+                }
+                let out_offset = m0 + 2 * m1 + 2 * 2 * n;
+                out[out_offset] = acc;
+            }
+        }
+    }
+    out
+}
+
+fn batched_matmul_c32_reference(lhs: &[Complex32], rhs: &[Complex32]) -> Vec<Complex32> {
+    let mut out = vec![Complex32::new(0.0, 0.0); 2 * 2 * 2];
+    for batch in 0..2 {
+        for n in 0..2 {
+            for m in 0..2 {
+                let mut acc = Complex32::new(0.0, 0.0);
+                for k in 0..3 {
+                    let lhs_offset = m + 2 * k + 2 * 3 * batch;
+                    let rhs_offset = k + 3 * n + 3 * 2 * batch;
+                    acc += lhs[lhs_offset] * rhs[rhs_offset];
+                }
+                let out_offset = m + 2 * n + 2 * 2 * batch;
+                out[out_offset] = acc;
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn webgpu_dot_general_runs_rank2_f32_matmul_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]);
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let gpu_lhs = backend.upload_host_tensor(&lhs).unwrap();
+    let gpu_rhs = backend.upload_host_tensor(&rhs).unwrap();
+    let gpu_out = backend.dot_general(&gpu_lhs, &gpu_rhs, &config).unwrap();
+    let out = backend.download_to_host(&gpu_out).unwrap();
+
+    assert_eq!(out.shape(), &[2, 2]);
+    let actual = out.as_slice::<f32>().unwrap();
+    let expected = [58.0_f32, 139.0, 64.0, 154.0];
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert!((actual - expected).abs() <= 1e-4);
+    }
+}
+
+#[test]
+fn webgpu_dot_general_supports_batched_f32_contract_shape_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let lhs = Tensor::from_vec_col_major(
+        vec![2, 3, 2],
+        vec![
+            1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0, 10.0, 40.0, 20.0, 50.0, 30.0, 60.0,
+        ],
+    );
+    let rhs = Tensor::from_vec_col_major(
+        vec![3, 2, 2],
+        vec![
+            7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0, 70.0, 90.0, 110.0, 80.0, 100.0, 120.0,
+        ],
+    );
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![2],
+        rhs_batch_dims: vec![2],
+    };
+
+    let gpu_lhs = backend.upload_host_tensor(&lhs).unwrap();
+    let gpu_rhs = backend.upload_host_tensor(&rhs).unwrap();
+    let gpu_out = backend.dot_general(&gpu_lhs, &gpu_rhs, &config).unwrap();
+    let out = backend.download_to_host(&gpu_out).unwrap();
+
+    assert_eq!(out.shape(), &[2, 2, 2]);
+    let actual = out.as_slice::<f32>().unwrap();
+    let expected = [
+        58.0_f32, 139.0, 64.0, 154.0, 5800.0, 13900.0, 6400.0, 15400.0,
+    ];
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert!((actual - expected).abs() <= 1e-4);
+    }
+}
+
+#[test]
+fn webgpu_dot_general_packs_noncontiguous_lhs_free_axes_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let lhs_data = vec![
+        1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0, 10.0, 40.0, 20.0, 50.0, 30.0, 60.0,
+    ];
+    let rhs_data = vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0];
+    let lhs = Tensor::from_vec_col_major(vec![2, 3, 2], lhs_data.clone());
+    let rhs = Tensor::from_vec_col_major(vec![3, 2], rhs_data.clone());
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let gpu_lhs = backend.upload_host_tensor(&lhs).unwrap();
+    let gpu_rhs = backend.upload_host_tensor(&rhs).unwrap();
+    let gpu_out = backend.dot_general(&gpu_lhs, &gpu_rhs, &config).unwrap();
+    let out = backend.download_to_host(&gpu_out).unwrap();
+
+    assert_eq!(out.shape(), &[2, 2, 2]);
+    let actual = out.as_slice::<f32>().unwrap();
+    let expected = noncontiguous_lhs_free_axes_reference(&lhs_data, &rhs_data);
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert!((actual - expected).abs() <= 1e-4);
+    }
+}
+
+#[test]
+fn webgpu_dot_general_supports_batched_c32_contract_shape_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let lhs_data = vec![
+        Complex32::new(1.0, 0.5),
+        Complex32::new(4.0, -1.0),
+        Complex32::new(2.0, 0.25),
+        Complex32::new(5.0, 1.0),
+        Complex32::new(3.0, -0.75),
+        Complex32::new(6.0, 0.5),
+        Complex32::new(10.0, 0.5),
+        Complex32::new(40.0, -1.0),
+        Complex32::new(20.0, 0.25),
+        Complex32::new(50.0, 1.0),
+        Complex32::new(30.0, -0.75),
+        Complex32::new(60.0, 0.5),
+    ];
+    let rhs_data = vec![
+        Complex32::new(7.0, -0.5),
+        Complex32::new(9.0, 0.25),
+        Complex32::new(11.0, 1.0),
+        Complex32::new(8.0, -0.75),
+        Complex32::new(10.0, 0.5),
+        Complex32::new(12.0, -0.25),
+        Complex32::new(70.0, -0.5),
+        Complex32::new(90.0, 0.25),
+        Complex32::new(110.0, 1.0),
+        Complex32::new(80.0, -0.75),
+        Complex32::new(100.0, 0.5),
+        Complex32::new(120.0, -0.25),
+    ];
+    let lhs = Tensor::from_vec_col_major(vec![2, 3, 2], lhs_data.clone());
+    let rhs = Tensor::from_vec_col_major(vec![3, 2, 2], rhs_data.clone());
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![2],
+        rhs_batch_dims: vec![2],
+    };
+
+    let gpu_lhs = backend.upload_host_tensor(&lhs).unwrap();
+    let gpu_rhs = backend.upload_host_tensor(&rhs).unwrap();
+    let gpu_out = backend.dot_general(&gpu_lhs, &gpu_rhs, &config).unwrap();
+    let out = backend.download_to_host(&gpu_out).unwrap();
+
+    assert_eq!(out.shape(), &[2, 2, 2]);
+    let actual = out.as_slice::<Complex32>().unwrap();
+    let expected = batched_matmul_c32_reference(&lhs_data, &rhs_data);
+    assert_complex_close(actual, &expected);
+}
+
+#[test]
+fn webgpu_dot_general_rejects_f64_and_c64_without_cpu_fallback_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let lhs_f64 = Tensor::from_vec_col_major(vec![1, 1], vec![1.0_f64]);
+    let rhs_f64 = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64]);
+    let lhs_f64 = backend.upload_host_tensor(&lhs_f64).unwrap();
+    let rhs_f64 = backend.upload_host_tensor(&rhs_f64).unwrap();
+    let err = backend
+        .dot_general(&lhs_f64, &rhs_f64, &config)
+        .expect_err("f64 WebGPU dot_general must stay unsupported");
+    assert!(
+        err.to_string().contains("WebGPU"),
+        "unexpected f64 error: {err}"
+    );
+
+    let lhs_c64 = Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.5)]);
+    let rhs_c64 = Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(2.0, -0.25)]);
+    let lhs_c64 = backend.upload_host_tensor(&lhs_c64).unwrap();
+    let rhs_c64 = backend.upload_host_tensor(&rhs_c64).unwrap();
+    let err = backend
+        .dot_general(&lhs_c64, &rhs_c64, &config)
+        .expect_err("c64 WebGPU dot_general must stay unsupported");
+    assert!(
+        err.to_string().contains("WebGPU"),
+        "unexpected c64 error: {err}"
+    );
+}
+
+#[test]
+fn webgpu_dot_general_runs_rank2_c32_matmul_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let lhs_data = vec![
+        Complex32::new(1.0, 0.5),
+        Complex32::new(2.0, -1.0),
+        Complex32::new(3.0, 0.25),
+        Complex32::new(4.0, 1.0),
+    ];
+    let rhs_data = vec![
+        Complex32::new(5.0, -0.5),
+        Complex32::new(6.0, 0.25),
+        Complex32::new(7.0, 1.0),
+        Complex32::new(8.0, -0.75),
+    ];
+    let lhs = Tensor::from_vec_col_major(vec![2, 2], lhs_data.clone());
+    let rhs = Tensor::from_vec_col_major(vec![2, 2], rhs_data.clone());
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let gpu_lhs = backend.upload_host_tensor(&lhs).unwrap();
+    let gpu_rhs = backend.upload_host_tensor(&rhs).unwrap();
+    let gpu_out = backend.dot_general(&gpu_lhs, &gpu_rhs, &config).unwrap();
+    let out = backend.download_to_host(&gpu_out).unwrap();
+
+    assert_eq!(out.shape(), &[2, 2]);
+    let actual = out.as_slice::<Complex32>().unwrap();
+    let expected = matmul2_col_major(&lhs_data, &rhs_data);
+    assert_complex_close(actual, &expected);
+}

--- a/crates/tenferro-internal-ops/Cargo.toml
+++ b/crates/tenferro-internal-ops/Cargo.toml
@@ -18,6 +18,7 @@ default = ["autodiff"]
 autodiff = ["dep:tidu"]
 gpu = []
 cuda = ["gpu"]
+webgpu = ["gpu"]
 rocm = ["gpu"]
 
 [dependencies]

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -258,6 +258,21 @@ fn device_model_has_typed_hashable_device_ids() {
 }
 
 #[test]
+fn device_model_has_first_class_webgpu_backend_kind() {
+    let cuda = DeviceId {
+        kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+        ordinal: 0,
+    };
+    let webgpu = DeviceId {
+        kind: DeviceKind::Gpu(GpuBackendKind::WebGpu),
+        ordinal: 0,
+    };
+
+    assert_ne!(webgpu, cuda);
+    assert_eq!(format!("{:?}", webgpu.kind), "Gpu(WebGpu)");
+}
+
+#[test]
 fn default_placement_is_unpinned_host_without_device() {
     let tensor = TypedTensor::<f64>::zeros(vec![2]);
 

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -56,10 +56,13 @@ pub enum DeviceKind {
 /// use tenferro_tensor::GpuBackendKind;
 ///
 /// let kind = GpuBackendKind::Cuda;
+/// let webgpu = GpuBackendKind::WebGpu;
+/// assert_ne!(kind, webgpu);
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum GpuBackendKind {
     Cuda,
+    WebGpu,
     Rocm,
     Other(String),
 }

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -1,11 +1,21 @@
 # GPU Backend Design
 
-This document is developer-facing. Public user docs describe the GPU surface as
-the CUDA backend exposed from `tenferro_gpu::{CubeclBackend,
-upload_tensor, download_tensor}`. The active implementation behind that public
-surface lives in `crates/tenferro-gpu/src/cubecl/`, gated by the `cuda` feature. It
-targets NVIDIA CUDA devices through CubeCL and CubeCL-CUDA, with CUDA library
-support for cuTENSOR, cuSOLVER, and cuBLAS.
+This document is developer-facing. Public user docs describe GPU providers as
+explicit backend choices. CUDA is exposed as `tenferro_gpu::CudaBackend`, with
+`CubeclBackend` retained as a backwards-compatible CUDA alias while downstream
+users migrate. WebGPU is exposed as `tenferro_gpu::WebGpuBackend`. Backend
+features are additive provider choices: `cuda` and `webgpu` are both explicit,
+neither is enabled by default as a GPU provider, and downstream crates may
+enable either or both. Eager and operation crates should propagate the same
+concrete feature names instead of introducing default GPU providers or a vague
+public `gpu` feature.
+
+The active CUDA implementation lives in `crates/tenferro-gpu/src/cubecl/`,
+gated by the `cuda` feature. It targets NVIDIA CUDA devices through CubeCL and
+CubeCL-CUDA, with CUDA library support for cuTENSOR, cuSOLVER, and cuBLAS. The
+WebGPU implementation lives in a separate provider module, gated by the
+`webgpu` feature, and targets CubeCL-WGPU without depending on CUDA runtime or
+CUDA library bindings.
 
 CUDA GPU support is implemented through the feature-gated CubeCL backend across
 the concrete tensor, eager, and traced execution surfaces. Coverage includes
@@ -15,7 +25,13 @@ Performance optimization is still active work. The remaining unsupported CUDA
 cases are operation-specific: `eig`, `full_piv_lu`, `full_piv_lu_solve`,
 `dynamic_update_slice`, integer numeric/linalg gaps, `Bool` kernel gaps beyond
 transfer and reshape, and selected complex analytic or ordering operations.
-HIP/ROCm is still a feature stub rather than a supported execution path.
+WebGPU is being introduced incrementally. The implemented path covers explicit
+transfer plus `F32` `dot_general` through a CubeK BGEMM planner. `C32` GEMM is
+implemented by decomposing complex contractions into real `F32` matmul
+operations on the same WebGPU provider. `F64`, `C64`, zero-contracting-size
+matmul, and non-matmul tensor ops remain explicit unsupported paths rather than
+CPU fallbacks. HIP/ROCm is still a reserved feature stub rather than a
+supported execution path.
 
 See also:
 
@@ -39,7 +55,7 @@ crates/tenferro-gpu/src/kernels/
     reduce/                reduction validation, launch helpers, and kernels
 
 crates/tenferro-gpu/src/cubecl/
-    mod.rs                 CubeclBackend and TensorBackend implementation
+    mod.rs                 CUDA backend and TensorBackend implementation
     runtime.rs             CubeCL/CUDA runtime initialization and synchronization
     memory.rs              upload_tensor, download_tensor, device pointer bridge
     dispatch.rs            private shared launch helpers and dtype dispatch
@@ -49,12 +65,22 @@ crates/tenferro-gpu/src/cubecl/
     linalg.rs              cuSOLVER/cuBLAS-backed linalg support
     ffi/                   runtime-loaded CUDA library bindings
     tests/                 ignored GPU tests
+
+crates/tenferro-gpu/src/webgpu/
+    mod.rs                 WebGpuBackend provider facade and shared buffer helpers
+    runtime.rs             CubeCL-WGPU runtime initialization and synchronization
+    memory.rs              upload_webgpu_tensor and download_webgpu_tensor
+    gemm.rs                CubeK-backed F32/C32 dot_general planner and launch support
+    kernels.rs             WebGPU-private pack, split, and compose kernels
 ```
 
-The public backend type is `tenferro_gpu::CubeclBackend`. There are no
-separate in-tree `CudaBackend` and `RocmBackend` implementations. CUDA is
-selected by enabling the `cuda` feature, which depends on the workspace-pinned
-CubeCL fork and the CubeCL CUDA runtime.
+The provider-specific public backend types are `tenferro_gpu::CudaBackend` and
+`tenferro_gpu::WebGpuBackend`. `CubeclBackend` remains a compatibility alias for
+`CudaBackend`; new code should use provider-specific names. CUDA is selected by
+enabling the `cuda` feature, which depends on the workspace-pinned CubeCL fork
+and the CubeCL CUDA runtime. WebGPU is selected by enabling the `webgpu`
+feature, which depends on CubeCL-WGPU and the CubeK matmul provider. Enabling
+both features must compile and must not merge the two runtime types.
 
 ## Kernel Ownership
 
@@ -70,11 +96,14 @@ concerns rather than reusable static kernels.
 
 ## Dependency Source
 
-The workspace intentionally depends on the `tensor4all/cubecl` fork:
+The workspace intentionally depends on the `tensor4all/cubecl` fork. CUDA and
+WebGPU runtime dependencies are feature-owned by `tenferro-gpu`; the workspace
+dependency declaration must not force CUDA for WebGPU-only builds:
 
 ```toml
-cubecl = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692", features = ["cuda"] }
+cubecl = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692", default-features = false }
 cubecl-cuda = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
+cubecl-wgpu = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
 cubecl-runtime = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
 ```
 
@@ -82,21 +111,42 @@ Keep this fork dependency until upstream CubeCL has the required support and the
 workspace is deliberately migrated. Do not replace it with crates.io CubeCL as
 part of unrelated GPU or documentation work.
 
+CubeK matmul integration should branch from the CubeK release paired to CubeCL
+0.10.0: start from CubeK `v0.2.0` / `cubek-matmul 0.2.0`. If complex GEMM or
+WebGPU fixes require a tensor4all fork, publish tensor4all-owned CubeK crates
+from that branch rather than vendoring CubeK into this repository. Local
+development may use a sibling checkout, but committed tenferro manifests should
+use workspace dependencies or a deliberate crates.io/git dependency.
+
 ## Runtime And Library Loading
 
-`CubeclRuntime::new(device_ordinal)` initializes CUDA and creates the CubeCL
-CUDA client for one device. GPU kernels are JIT-compiled by CubeCL, so local
-CUDA toolkit configuration matters.
+`CudaRuntime::new(device_ordinal)` initializes CUDA and creates the CubeCL CUDA
+client for one device. `CubeclRuntime` remains a compatibility alias for
+`CudaRuntime`. GPU kernels are JIT-compiled by CubeCL, so local CUDA toolkit
+configuration matters.
 
-`CubeclRuntime::synchronize()` is the explicit host-side barrier for direct GPU
+`WebGpuRuntime::new(device_ordinal)` creates a CubeCL-WGPU client for a WebGPU
+adapter. WebGPU runtime initialization must not call CUDA driver/runtime APIs,
+load CUDA libraries, or require CUDA environment variables.
+
+Future ROCm support should follow the same explicit-provider model, but it must
+not require ROCm libraries to be present for a binary that merely includes the
+reserved `rocm` feature. The intended substrate is a CubeCL HIP fork or patch
+that runtime-loads HIP libraries with the same discipline as the CUDA FFI layer.
+Until that loader-backed substrate is implemented and tested on ROCm hardware,
+tenferro must keep ROCm unavailable as an execution backend and must not publish
+a ROCm quickstart.
+
+`CudaRuntime::synchronize()` is the explicit host-side barrier for direct CUDA
 backend code. It synchronizes the current CubeCL CUDA stream and does not
-download tensor data. Higher-level eager CUDA execution exposes the same barrier
-through `EagerRuntime::synchronize()`, with CPU eager runtimes treating the call
-as a no-op.
+download tensor data. `WebGpuRuntime::synchronize()` is the corresponding
+WebGPU queue/device barrier. Higher-level eager GPU execution exposes the same
+barrier through `EagerRuntime::synchronize()`, with CPU eager runtimes treating
+the call as a no-op.
 
-cuTENSOR, cuSOLVER, and cuBLAS are loaded lazily through the FFI layer. The
-backend first uses default soname/path candidates and allows explicit override
-with these variables:
+cuTENSOR, cuSOLVER, and cuBLAS are CUDA-only and are loaded lazily through the
+CUDA FFI layer. The CUDA backend first uses default soname/path candidates and
+allows explicit override with these variables:
 
 | Variable | Library |
 | --- | --- |
@@ -114,18 +164,42 @@ Local GPU test runs should also set:
 
 ## Runtime Cache Ownership
 
-`CubeclBackend` owns CUDA extension backend-state caches. Extension crates may
+`CudaBackend` owns CUDA extension backend-state caches. Extension crates may
 store type-indexed CUDA handles or plans through
-`CubeclBackend::cuda_extension_cache()`, but the backend remains the lifetime
+`CudaBackend::cuda_extension_cache()`, but the backend remains the lifetime
 and resource owner.
 
 The CUDA extension cache has a bounded default capacity of 16 type entries.
 Applications can configure it with
-`CubeclBackend::set_cuda_extension_cache_max_entries`, clear it with
-`CubeclBackend::clear_cuda_extension_cache`, and inspect retained entries and
-logical retained bytes with `CubeclBackend::cuda_extension_cache_stats`.
+`CudaBackend::set_cuda_extension_cache_max_entries`, clear it with
+`CudaBackend::clear_cuda_extension_cache`, and inspect retained entries and
+logical retained bytes with `CudaBackend::cuda_extension_cache_stats`.
 Retained bytes are estimates of cache-owned payloads, not process RSS or
 allocator arena usage.
+
+WebGPU provider caches must be owned by `WebGpuBackend` or a WebGPU runtime
+cache object with the same bounded-default, clear, configure, and stats
+requirements before they become long-lived.
+
+GPU scratch-buffer pools should eventually expose a provider-independent stats
+shape across CUDA, WebGPU, and future ROCm:
+
+| Field | Meaning |
+| --- | --- |
+| `retained_buffers` | Number of buffers currently retained by the pool |
+| `retained_bytes` | Logical bytes retained by the pool |
+| `acquire_calls` | Total acquire requests |
+| `release_calls` | Total release requests |
+| `reuse_hits` | Acquires served from retained buffers |
+| `allocation_misses` | Acquires requiring a new allocation |
+| `evictions` | Retained buffers dropped because of pool limits |
+| `high_water_retained_bytes` | Peak logical retained bytes |
+
+This common stats design is future direction only. It must not be introduced by
+rewriting existing CUDA contraction allocation behavior. CUDA `dot_general`
+continues to allocate cuTENSOR workspace through the existing runtime client
+path, and this WebGPU work does not alter CUDA buffer pools, CUDA scratch
+reuse, or CUDA library-call algorithms.
 
 ## Operation-Crate Interop Boundary
 
@@ -179,9 +253,14 @@ and no implicit global shape state.
   extents or strides.
 - `#[comptime]` is reserved for operation attributes and algorithm
   configuration. This includes attributes such as transpose `perm`,
-  broadcast/gather/scatter dimension-number mappings, static slice strides,
-  axis sets, reduce strategy, and kernel blueprints. Different attribute values
-  may compile as different CubeCL specializations.
+  broadcast/gather/scatter dimension-number mappings, static slice step
+  attributes, axis sets, reduce strategy, and kernel blueprints. Different
+  attribute values may compile as different CubeCL specializations.
+- Do not pass tensor shape extents, strides, buffer lengths, flattened products,
+  or other runtime tensor sizes as `#[comptime]` parameters. The WebGPU
+  `dot_general` pack kernels pass only axis-role lists and rank as compile-time
+  launch attributes; shape and stride values are read from `TensorBinding`
+  metadata inside the kernel.
 - Permute-like operations should canonicalize their launch attributes where the
   transformation is mathematically identical. In particular, adjacent axes that
   stay contiguous in column-major layout should be fused before choosing the
@@ -236,14 +315,14 @@ API boundaries. Callers upload tensors before GPU backend operations and
 download results explicitly when host access is needed.
 
 Same-placement canonicalization is allowed: host views may be copied into host
-compact tensors, and CUDA views may be copied into CUDA compact tensors. It is
-not a transfer mechanism.
+compact tensors, and GPU views may be copied into compact tensors on the same
+GPU provider. It is not a transfer mechanism.
 
 ```text
-use tenferro_gpu::{download_tensor, upload_tensor, CubeclBackend};
+use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
 use tenferro_tensor::{Tensor, TensorBackend};
 
-let mut backend = CubeclBackend::new(0)?;
+let mut backend = CudaBackend::new(0)?;
 let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
 let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
 
@@ -265,6 +344,7 @@ Error behavior:
 | GPU op receives a CPU tensor | `Error::BackendFailure` with an upload hint |
 | CPU op receives a GPU tensor | `Error::BackendFailure` with a download hint for `Result` APIs |
 | `TypedTensor::host_data()` on a GPU buffer | panic with a diagnostic |
+| CUDA op receives a WebGPU tensor, or WebGPU op receives a CUDA tensor | `Error::BackendFailure` naming the expected provider |
 
 ## Implemented Coverage
 
@@ -298,12 +378,22 @@ General eigendecomposition (`eig`, LAPACK `dgeev` style) is not provided by
 cuSOLVER. The CUDA backend returns `BackendFailure`; users must explicitly
 download to CPU and call the CPU backend.
 
+The WebGPU backend currently has narrower coverage:
+
+| Category | WebGPU status |
+| --- | --- |
+| Allocation/transfer | WebGPU allocation, upload, and download for `F64`, `F32`, `I32`, `I64`, `Bool`, `C64`, and `C32` tensors |
+| Real contraction | CubeK/CubeCL-backed `F32` `dot_general` through a BGEMM planner, including batched and same-device packed operand layouts covered by tests |
+| Complex contraction | `C32` `dot_general` through four real `F32` CubeK matmuls and WebGPU-local split/compose kernels |
+| Deferred contraction coverage | `F64`, `C64`, zero-contracting-size matmul, and broader planner stress coverage |
+| Other tensor ops | Explicit unsupported `BackendFailure`; no CPU fallback and no hidden provider transfer |
+
 ## Unsupported And Deferred Work
 
 The following are intentionally outside the current batch:
 
 - GPU benchmark work,
-- HIP/ROCm implementation,
+- HIP/ROCm execution backend implementation,
 - replacing the CubeCL fork,
 - selected complex analytic kernels and ordering operations,
 - CUDA implementations for `full_piv_lu`, `full_piv_lu_solve`, and
@@ -311,12 +401,14 @@ The following are intentionally outside the current batch:
 - integer numeric/linalg CUDA kernels beyond structural and reduction paths,
 - `Bool` CUDA kernels beyond allocation, upload/download, and metadata-only
   reshape,
-- changing the public placement contract.
+- changing the public placement contract,
+- WebGPU elementwise, reduction, indexing, and linalg kernels beyond explicit
+  transfer and CubeK-backed `F32`/`C32` contraction.
 
 ## Tests
 
-GPU tests are ignored so regular CPU-only test runs remain portable. Run them on
-a CUDA machine with:
+CUDA GPU tests are ignored so regular CPU-only test runs remain portable. Run
+them on a CUDA machine with:
 
 ```sh
 CUBECL_DEBUG_LOG=0 \
@@ -326,3 +418,8 @@ LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:/usr/lib/x86_64-linux-gnu/libcutensor
 ```
 
 These tests are correctness tests, not benchmarks.
+
+WebGPU provider tests should have two layers: portable source/feature contract
+tests that run in ordinary CI, and adapter-optional runtime tests that return
+early when no WebGPU adapter is available. Runtime tests must compare meaningful
+tensor values or residuals, not only shapes.

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -3,36 +3,52 @@
 tenferro follows the PyTorch convention: no implicit CPU/GPU transfer. A tensor
 must already live on the device required by the backend operation.
 
-CUDA is a backend/device choice, not a separate tensor type. The same concrete,
-eager, and traced APIs can run supported CUDA operations when tensors are
-explicitly uploaded to CUDA memory and the executor/backend is CUDA-backed.
+CUDA and WebGPU are backend/device choices, not separate tensor types. The same
+concrete, eager, and traced APIs can run supported GPU operations when tensors
+are explicitly uploaded to the selected provider and the executor/backend uses
+the same provider.
 
-CUDA support targets NVIDIA CUDA. AMD/ROCm is not a
-supported execution path yet.
+CUDA support targets NVIDIA CUDA. WebGPU support is experimental and currently
+focused on explicit transfer plus limited `dot_general`/einsum coverage.
+AMD/ROCm is not a supported execution path yet.
+
+## Provider Matrix
+
+| Provider | Status | Feature | Notes |
+| --- | --- | --- | --- |
+| CPU | Supported | default CPU provider features | Host execution |
+| CUDA | Supported | `cuda` | NVIDIA CUDA through CubeCL-CUDA plus CUDA libraries |
+| WebGPU | Experimental | `webgpu` | Explicit transfer and limited `dot_general`/einsum coverage |
+| ROCm | Not supported for execution | `rocm` reserved | Future compile-only substrate; no runtime quickstart |
 
 ## Transfer Model
 
 | Boundary | What happens |
 | --- | --- |
 | CPU tensor to CUDA backend | Upload first with `tenferro_gpu::upload_tensor` |
+| CPU tensor to WebGPU backend | Upload first with `tenferro_gpu::upload_webgpu_tensor` |
 | CUDA tensor to CUDA backend | Runs on CUDA for supported op/dtype combinations |
+| WebGPU tensor to WebGPU backend | Runs on WebGPU for supported op/dtype combinations |
 | CUDA tensor to CPU backend | `Result`-returning CPU backend ops fail; download first |
-| CUDA tensor to host inspection | Direct host slice APIs panic; download first |
+| WebGPU tensor to CPU backend | `Result`-returning CPU backend ops fail; download first |
+| GPU tensor to host inspection | Direct host slice APIs panic; download first |
 | Unsupported CUDA op or dtype | Error, not silent CPU fallback |
+| Unsupported WebGPU op or dtype | Error, not silent CPU fallback |
 
-Keep tensors on CUDA across a CUDA workload. Download only when the host needs
-to inspect values or hand data to CPU-only code.
+Keep tensors on one GPU provider across a GPU workload. Download only when the
+host needs to inspect values or hand data to CPU-only code.
 
 View compaction follows the same rule. A CUDA backend may copy a CUDA view into
-compact CUDA memory, and host code may copy a host view into compact host
-memory, but tenferro does not use that copy as a hidden CPU/GPU transfer.
+compact CUDA memory, a WebGPU backend may copy a WebGPU view into compact
+WebGPU memory, and host code may copy a host view into compact host memory, but
+tenferro does not use that copy as a hidden CPU/GPU transfer.
 
 ## Eager GPU Synchronization
 
-Eager CUDA execution submits work immediately and returns a CUDA-resident
+Eager GPU execution submits work immediately and returns a provider-resident
 `Tensor` handle. Normal kernel launches do not imply host synchronization after
-every op. Subsequent CUDA ops can consume the returned handle on the same
-backend stream.
+every op. Subsequent GPU ops can consume the returned handle on the same
+backend stream or queue.
 
 The host waits when a value is downloaded or otherwise inspected on the host.
 Some library-backed operations also synchronize internally when they must read
@@ -40,8 +56,9 @@ device-side status.
 
 Use `EagerRuntime::synchronize()` when code needs an explicit host-side barrier
 for the eager runtime. CPU runtimes return immediately; CUDA runtimes wait for
-the current backend stream. Direct GPU backend code can call
-`CubeclRuntime::synchronize()` through `backend.runtime()`.
+the current backend stream, and WebGPU runtimes wait for the WebGPU queue.
+Direct GPU backend code can call the provider runtime's `synchronize()` through
+`backend.runtime()`.
 
 For a time-axis diagram, see [Execution Models](execution-models.md).
 
@@ -136,7 +153,26 @@ Legend:
 | `cholesky`, `triangular_solve`, `lu`, `svd`, `qr`, `eigh`, `solve` | `F32`, `F64`, `C32`, `C64` | cuSOLVER/cuBLAS-backed; integer and `Bool` dtypes are not implemented |
 | `full_piv_lu`, `full_piv_lu_solve` | No CUDA implementation | Returns an error |
 | General `eig` | No CUDA implementation | cuSOLVER does not provide LAPACK `dgeev`-style general eigendecomposition; download to CPU explicitly |
-| AMD/ROCm | No supported backend | ROCm remains a feature stub |
+| AMD/ROCm | No supported execution backend | ROCm remains reserved for future loader-backed work |
+
+## WebGPU Coverage
+
+The WebGPU backend is experimental. It uses the same tensor APIs as CUDA and
+CPU, but its operation coverage is intentionally much narrower. Unsupported
+rows return explicit errors and do not fall back to CPU.
+
+| Operation or family | WebGPU dtype support | Notes |
+| --- | --- | --- |
+| Allocation, upload, download | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Explicit CPU/WebGPU transfer only |
+| `dot_general` | `F32`, `C32` | CubeK-backed BGEMM planner; supports rank-2, batched, and same-device packed operand layouts covered by tests |
+| Binary einsum lowering to `dot_general` | `F32`, `C32` | Eager `F32`/`C32` and traced `F32` paths are covered when inputs are explicitly uploaded to WebGPU |
+| `dot_general` with zero contracting size | No WebGPU implementation | Returns an error until CubeK behavior is validated |
+| `dot_general` for `F64`, `C64` | No WebGPU implementation | Returns an error; no CPU fallback |
+| Elementwise and analytic ops | No WebGPU implementation | Returns an error |
+| Reductions | No WebGPU implementation | Returns an error |
+| Structural/indexing ops beyond transfer-owned allocation metadata | No WebGPU implementation | Returns an error |
+| Linalg | No WebGPU implementation | Returns an error |
+| ROCm | No supported execution backend | No ROCm quickstart is provided |
 
 If cuTENSOR, cuSOLVER, or cuBLAS are installed outside normal dynamic-linker
 paths, set `TENFERRO_CUTENSOR_PATH`, `TENFERRO_CUSOLVER_PATH`, or

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,12 +2,12 @@
 
 tenferro is a dense tensor computation stack for Rust users who want typed
 tensor computation, PyTorch-like immediate execution with `backward()`,
-JAX-like traced graphs, einsum, linear algebra, and explicit CPU/CUDA backend
-control.
+JAX-like traced graphs, einsum, linear algebra, and explicit CPU, CUDA, and
+experimental WebGPU backend control.
 
 The project covers both ordinary tensor computation and autodiff workflows.
 Start with the smallest API that solves your problem, then add autodiff, graph
-compilation, or CUDA only when the workflow needs them.
+compilation, CUDA, or experimental WebGPU only when the workflow needs them.
 
 ![tenferro-rs architecture overview](assets/tenferro-architecture.svg)
 
@@ -21,7 +21,7 @@ compilation, or CUDA only when the workflow needs them.
 | Choosing between `TypedTensor`, `Tensor`, `EagerTensor`, and `TracedTensor` | [Choosing a Tensor API](guides/choosing-an-api.md) |
 | Understanding direct, eager, and traced execution | [Execution Models](guides/execution-models.md) |
 | Column-major storage and row-major import/export | [Memory Order](guides/memory-order.md) |
-| CPU and CUDA backend behavior | [Devices and GPU](guides/devices-and-gpu.md) |
+| CPU, CUDA, and experimental WebGPU backend behavior | [Devices and GPU](guides/devices-and-gpu.md) |
 | Runtime-dependent dimensions in traced graphs | [Dynamic and symbolic shapes](design/dynamic-symbolic-shapes.md) |
 | API documentation for every crate | [API Reference](api/index.md) |
 
@@ -50,14 +50,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Mental Model
 
-tenferro has three independent choices. CUDA, eager execution, and traced
-graphs are not competing APIs; they answer different questions.
+tenferro has three independent choices. GPU providers, eager execution, and
+traced graphs are not competing APIs; they answer different questions.
 
 | Choice | Question | Options |
 | --- | --- | --- |
 | Tensor API | What kind of value do I pass around? | `TypedTensor<T>`, `Tensor`, `EagerTensor`, `TracedTensor` |
 | Execution timing | When does computation run? | Direct backend call, immediate eager execution, traced compile/run |
-| Backend/device | Where does computation run? | CPU backend or CUDA backend, with explicit transfer |
+| Backend/device | Where does computation run? | CPU, CUDA, or experimental WebGPU backend, with explicit transfer |
 
 Most code without autodiff starts with `TypedTensor<T>` when the scalar type is
 known at compile time, or `Tensor` when dtype must be selected at runtime.

--- a/docs/superpowers/plans/2026-06-13-webgpu-complex-gemm.md
+++ b/docs/superpowers/plans/2026-06-13-webgpu-complex-gemm.md
@@ -1,0 +1,254 @@
+# WebGPU Complex GEMM Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans or superpowers:subagent-driven-development to execute this plan task by task. Use test-driven-development for behavior changes.
+
+**Goal:** Complete explicit CUDA/WebGPU provider support without changing CUDA performance behavior, then broaden WebGPU `dot_general`/einsum from rank-2 real matmul to batched real and complex GEMM through a clean planner.
+
+**Architecture:** `CudaBackend` remains the existing cuTENSOR/cuSOLVER/cuBLAS-backed provider. `WebGpuBackend` remains a separate CubeCL-WGPU provider and lowers tenferro `DotGeneralConfig` into CubeK-compatible BGEMM views. When the input layout cannot be represented as a CubeK `[batch..., M, K]` or `[batch..., K, N]` tensor through shape/stride metadata, WebGPU performs an explicit same-device pack kernel. There are no hidden CPU transfers and no CPU fallback paths.
+
+**Tech Stack:** Rust 2021, CubeCL, CubeCL-WGPU, CubeK `cubek-matmul 0.2.0`, `smallvec`, tenferro tensor/runtime/einsum/ad crates, Quarto docs.
+
+---
+
+## Scope And Contracts
+
+- Execution worktree: `/home/shinaoka/.config/superpowers/worktrees/tenferro-rs/webgpu-complex-gemm`.
+- Existing dirty files are treated as in-progress work and must not be reverted blindly.
+- Do not make per-task commits from this plan; use focused diffs and verification checkpoints. Commit creation is a separate maintainer decision after the full scope is reviewed.
+- CUDA performance-preservation contract: do not alter CUDA algorithm selection, cuTENSOR/cuBLAS/cuSOLVER dispatch, packing, workspace allocation, runtime cache, buffer pools, or scratch reuse behavior.
+- Feature contract: GPU provider features are explicit and additive: `cuda` and `webgpu`. Do not add a public `gpu` alias and do not enable a GPU provider by default.
+- Public provider names: downstream code should see `CudaBackend` and `WebGpuBackend` as concrete providers. `CubeclBackend` may remain as a CUDA compatibility alias.
+- `DotGeneralConfig` output contract remains `[lhs_free..., rhs_free..., batch...]`.
+- CubeK adapter contract: CubeK receives `[batch..., M, K]`, `[batch..., K, N]`, and `[batch..., M, N]`, where `M`, `K`, and `N` are flattened products derived by the planner.
+- Transfer contract: unsupported WebGPU and ROCm paths return explicit backend errors; they do not download, upload, or call CPU implementations behind the user's back.
+- ROCm contract for this pass: document the runtime-loaded HIP substrate direction, but keep ROCm unavailable as an execution backend.
+
+## DotGeneral Lowering Design
+
+- Build one private `DotGeneralPlan` in `crates/tenferro-gpu/src/webgpu/gemm.rs`.
+- The planner validates ranks with `DotGeneralConfig::validate_dims_with_ranks`, then validates paired contracting sizes and paired batch sizes.
+- `lhs_free` and `rhs_free` are the non-contracting, non-batch axes in natural axis order.
+- `lhs_contract` and `rhs_contract` preserve the paired order from `DotGeneralConfig`.
+- `lhs_batch` and `rhs_batch` preserve the paired order from `DotGeneralConfig`.
+- `M = product(lhs_free_shape)`, `N = product(rhs_free_shape)`, `K = product(contract_shape)`.
+- `output_shape = lhs_free_shape + rhs_free_shape + batch_shape`.
+- `lhs_cubek_shape = batch_shape + [M, K]`; `rhs_cubek_shape = batch_shape + [K, N]`; `out_cubek_shape = batch_shape + [M, N]`.
+- Output binding writes directly into tenferro's compact output order with CubeK strides `[M * N * batch_prefix..., 1, M]`.
+- Metadata-only input binding is allowed when the flattened free or contract axis group is contiguous in the source tensor layout and ordered the same way the planner unflattens that group.
+- Otherwise allocate a WebGPU scratch tensor with the CubeK shape and run a same-device pack kernel before launching CubeK.
+- Zero output elements return an allocated empty output. Zero contracting size remains an explicit WebGPU unsupported error until CubeK support is verified.
+
+## Phase 1: Real WebGPU DotGeneral And Provider Contracts
+
+### Task 1: Lock CUDA And Feature Contracts
+
+**Files:**
+- `crates/tenferro-gpu/tests/public_surface_contract.rs`
+- `crates/tenferro-gpu/Cargo.toml`
+
+- [x] Add `smallvec.workspace = true` under `tenferro-gpu` dependencies for planner metadata.
+- [x] Add a contract test named `cuda_dot_general_stays_cutensor_backed_and_not_cubek_rewired`.
+- [x] The test reads `crates/tenferro-gpu/src/cubecl/gemm.rs` and asserts:
+  - it contains `cutensor.contract(`,
+  - it contains `alloc_workspace(backend.runtime(), workspace_size)`,
+  - it contains `Plan::new(cutensor, &op_desc`,
+  - it does not contain `cubek_matmul`,
+  - it does not contain `DotGeneralPlan`.
+- [x] Run:
+
+```bash
+cargo test -p tenferro-gpu --test public_surface_contract cuda_dot_general_stays_cutensor_backed_and_not_cubek_rewired
+```
+
+Expected: pass. This is a characterization contract for existing CUDA behavior, so it may pass immediately.
+
+### Task 2: Add Batched Real WebGPU DotGeneral
+
+**Files:**
+- `crates/tenferro-gpu/src/webgpu/gemm.rs`
+- `crates/tenferro-gpu/src/webgpu/mod.rs`
+- `crates/tenferro-gpu/tests/webgpu_matmul_runtime.rs`
+
+- [x] Add a WebGPU runtime test named `webgpu_dot_general_supports_batched_f32_contract_shape`.
+- [x] Test shape:
+  - lhs shape `[2, 3, 2]` with `lhs_contracting_dims=[1]`, `lhs_batch_dims=[2]`,
+  - rhs shape `[3, 2, 2]` with `rhs_contracting_dims=[0]`, `rhs_batch_dims=[2]`,
+  - output shape `[2, 2, 2]`.
+- [x] Expected compact column-major F32 values:
+
+```text
+[58.0, 139.0, 64.0, 154.0, 5800.0, 13900.0, 6400.0, 15400.0]
+```
+
+- [x] Verify the test fails before implementation because the current WebGPU path rejects batch dims.
+- [x] Add `SmallVec` planner structs and a `build_dot_general_plan` helper.
+- [x] Add crate-private WebGPU binding helper for custom shape/stride metadata rather than exposing a public low-level API.
+- [x] Replace `validate_rank2_matmul` in the F32 path with planner-based validation and CubeK binding.
+- [x] Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime webgpu_dot_general_supports_batched_f32_contract_shape
+```
+
+Expected: pass on machines with a WebGPU adapter, or return early through `webgpu_available()`.
+
+### Task 3: Add WebGPU Pack Path For Non-Metadata Layouts
+
+**Files:**
+- `crates/tenferro-gpu/src/webgpu/kernels.rs`
+- `crates/tenferro-gpu/src/webgpu/gemm.rs`
+- `crates/tenferro-gpu/src/webgpu/mod.rs`
+- `crates/tenferro-gpu/tests/webgpu_matmul_runtime.rs`
+
+- [x] Add a WebGPU runtime test named `webgpu_dot_general_packs_noncontiguous_lhs_free_axes`.
+- [x] Test shape:
+  - lhs shape `[2, 3, 2]`, contracting axis `[1]`, free axes `[0, 2]`,
+  - rhs shape `[3, 2]`, contracting axis `[0]`, free axis `[1]`,
+  - output shape `[2, 2, 2]`.
+- [x] Choose small known F32 values and compute the expected output in the test with a compact host reference loop over `(m0, m1, n, k)`.
+- [x] Verify the test fails before the pack path is implemented.
+- [x] Add `pack_lhs_dot_general` and `pack_rhs_dot_general` kernels using `Tensor<E>` metadata, `ABSOLUTE_POS < out.len()`, and one output element per worker.
+- [x] Kernel mapping:
+  - LHS out axes are `[batch..., M, K]`; unflatten `M` over `lhs_free`, unflatten `K` over `lhs_contract`, copy batch coordinates through `lhs_batch`.
+  - RHS out axes are `[batch..., K, N]`; unflatten `K` over `rhs_contract`, unflatten `N` over `rhs_free`, copy batch coordinates through `rhs_batch`.
+- [x] Add host-side binding selection:
+  - use metadata-only custom shape/stride binding when each flattened group is representable,
+  - otherwise allocate scratch with `alloc_output`, launch the pack kernel, and bind the packed scratch.
+- [x] Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime
+```
+
+Expected: pass on machines with a WebGPU adapter, or return early through `webgpu_available()`.
+
+## Phase 2: Complex GEMM, ROCm Direction, And User Docs
+
+### Task 4: Route WebGPU C32 Through The Same Planner
+
+**Files:**
+- `crates/tenferro-gpu/src/webgpu/gemm.rs`
+- `crates/tenferro-gpu/tests/webgpu_matmul_runtime.rs`
+- `crates/tenferro-einsum/tests/webgpu_eager_tensor.rs`
+
+- [x] Add a batched `C32` WebGPU `dot_general` test using the Task 2 shape pattern.
+- [x] Compute expected values in the test with `Complex32` host multiplication and a single compact comparison helper.
+- [x] Update `dot_general_c32` so the split real tensors reuse the same planner and pack/binding path as F32.
+- [x] Add assertions that WebGPU `F64` and `C64` `dot_general` return explicit WebGPU backend errors.
+- [x] Extend eager/traced WebGPU einsum coverage to one batched or non-rank-2-free case that lowers to supported `dot_general`.
+- [x] Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime
+cargo test -p tenferro-einsum --no-default-features --features autodiff,webgpu,cpu-faer --test webgpu_eager_tensor
+```
+
+Expected: pass on machines with a WebGPU adapter, or return early through `webgpu_available()`.
+
+### Task 5: Document Common GPU Scratch Pool Direction
+
+**Files:**
+- `docs/design/gpu-backend-design.md`
+- `docs/worklogs/2026-06-13-webgpu-complex-gemm.md`
+- `crates/tenferro-gpu/tests/public_surface_contract.rs`
+
+- [x] Record that a future GPU scratch-pool stats API should be common across CUDA, WebGPU, and future ROCm.
+- [x] Name the future common stats fields:
+
+```text
+retained_buffers
+retained_bytes
+acquire_calls
+release_calls
+reuse_hits
+allocation_misses
+evictions
+high_water_retained_bytes
+```
+
+- [x] State that this implementation does not alter CUDA allocation, workspace, or buffer-pool behavior.
+- [x] Add a source-contract assertion that `cubecl/gemm.rs` still uses the existing CUDA workspace flow and does not wire a new `GpuScratchPool`.
+
+### Task 6: Record ROCm Compile-Only Direction
+
+**Files:**
+- `docs/design/gpu-backend-design.md`
+- `docs/guides/devices-and-gpu.md`
+- `docs/worklogs/2026-06-13-webgpu-complex-gemm.md`
+
+- [x] Document that future ROCm support should use a CubeCL HIP fork/patch with runtime-loaded HIP libraries, so one binary can remain usable without ROCm installed.
+- [x] State that ROCm remains unavailable as a tenferro execution backend until the loader-backed substrate is implemented and tested.
+- [x] Keep user docs free of a ROCm quickstart.
+
+### Task 7: Update README And Online User Docs
+
+**Files:**
+- `README.md`
+- `docs/index.md`
+- `docs/guides/devices-and-gpu.md`
+
+- [x] Update README GPU wording from CUDA-only phrasing to explicit CPU, CUDA, and experimental WebGPU backend control where user-facing.
+- [x] Update the `tenferro-gpu` crate row to mention CUDA, experimental WebGPU, future ROCm substrate, and explicit device transfers.
+- [x] Add or update the provider matrix:
+
+```markdown
+| Provider | Status | Feature | Notes |
+| --- | --- | --- | --- |
+| CPU | Supported | default CPU provider features | Host execution |
+| CUDA | Supported | `cuda` | NVIDIA CUDA through CubeCL-CUDA plus CUDA libraries |
+| WebGPU | Experimental | `webgpu` | Explicit transfer and limited `dot_general`/einsum coverage |
+| ROCm | Not supported for execution | `rocm` reserved | Future compile-only substrate; no runtime quickstart |
+```
+
+- [x] Keep the CUDA coverage table intact.
+- [x] Add WebGPU coverage rows for allocation/upload/download, `F32` and `C32` `dot_general`, eager/traced binary einsum that lowers to supported `dot_general`, and explicit unsupported rows for `F64`, `C64`, elementwise, reductions, indexing, and linalg.
+- [x] Run:
+
+```bash
+python3 scripts/check-docs-site.py
+```
+
+Expected: pass.
+
+### Task 8: Final Verification And Worklog
+
+**Files:**
+- All modified source and docs.
+- `docs/worklogs/2026-06-13-webgpu-complex-gemm.md`
+
+- [x] Run formatting:
+
+```bash
+cargo fmt --all --check
+```
+
+- [x] If formatting fails, run `cargo fmt --all`, then rerun the check.
+- [x] Run source checks:
+
+```bash
+cargo test -p tenferro-gpu --test public_surface_contract
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_backend_contract
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime
+cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer
+cargo check -p tenferro-ad --no-default-features --features cuda,webgpu,cpu-faer
+cargo check -p tenferro-einsum --no-default-features --features autodiff,cuda,webgpu,cpu-faer
+```
+
+- [x] Run docs and diff checks:
+
+```bash
+python3 scripts/check-docs-site.py
+git diff --check
+```
+
+- [x] Update the worklog with design decisions, verification output, hardware availability, and remaining risks.
+
+## Self-Review Checklist
+
+- [x] CUDA source and algorithm behavior are not changed.
+- [x] WebGPU and CUDA are still split by provider feature and provider type.
+- [x] WebGPU `dot_general` covers real batched BGEMM before complex BGEMM.
+- [x] Complex WebGPU GEMM reuses the real planner path.
+- [x] Pack kernels are same-device WebGPU kernels with output-domain launches.
+- [x] Docs truthfully distinguish supported CUDA, experimental WebGPU, and unavailable ROCm execution.
+- [x] The plan contains concrete tests, commands, files, and expected outcomes.

--- a/docs/worklogs/2026-06-13-webgpu-complex-gemm.md
+++ b/docs/worklogs/2026-06-13-webgpu-complex-gemm.md
@@ -1,0 +1,167 @@
+# WebGPU And Complex GEMM Implementation
+
+Date: 2026-06-13
+
+## Session Summary
+
+This work adds a first-class WebGPU provider path to `tenferro-gpu` while
+keeping CUDA and WebGPU as explicit additive provider features. It introduces
+`WebGpuBackend`/`WebGpuRuntime`, preserves `CudaBackend` plus the existing
+`CubeclBackend` compatibility alias, and adds `GpuBackendKind::WebGpu` for
+placement metadata.
+
+`tenferro-ad` now accepts `WebGpuBackend` through `EagerRuntime`, and
+`tenferro-einsum` propagates an explicit additive `webgpu` feature so eager and
+traced binary einsum can execute supported WebGPU matmul paths after callers
+explicitly upload input tensors.
+
+The implemented WebGPU operation path covers explicit upload/download,
+`F32` `dot_general` through a CubeK BGEMM planner, and `C32` `dot_general`
+through WebGPU-local real/imag split, four real `F32` CubeK matmuls, and
+WebGPU-local compose. The planner maps tenferro output order
+`[lhs_free..., rhs_free..., batch...]` to CubeK `[batch..., M, K]`,
+`[batch..., K, N]`, and `[batch..., M, N]`. Non-metadata operand layouts are
+packed on the same WebGPU provider. `F64`, `C64`, zero-contracting-size matmul,
+and non-matmul tensor ops remain explicit unsupported paths.
+
+## Context Read
+
+- `AGENTS.md`
+- `REPOSITORY_RULES.md`
+- shared tensor4all agent rules for common, Rust, performance, numerical, and
+  docs/tests work
+- `docs/design/gpu-backend-design.md`
+- `crates/tenferro-gpu/src/lib.rs`
+- `crates/tenferro-gpu/src/cubecl/dispatch.rs`
+- `crates/tenferro-gpu/src/cubecl/gemm.rs`
+- `crates/tenferro-gpu/src/cubecl/memory.rs`
+- `crates/tenferro-gpu/tests/public_surface_contract.rs`
+- `crates/tenferro-gpu/src/webgpu/gemm.rs`
+- `crates/tenferro-gpu/src/webgpu/kernels.rs`
+- `crates/tenferro-ad/src/eager.rs`
+- `crates/tenferro-ad/src/eager_backend.rs`
+- `crates/tenferro-einsum/src/eager_tensor.rs`
+- `crates/tenferro-tensor/src/types.rs`
+- `cubek-matmul 0.2.0`
+- `cubek-std 0.2.0`
+- the workspace-pinned `tensor4all/cubecl` revision
+
+## Decisions Made
+
+- Did not add a default WebGPU feature or a generic `gpu` alias. Downstream
+  users must choose `cuda`, `webgpu`, or both, matching the explicit provider
+  style used for CPU BLAS/faer choices.
+- Propagated `webgpu` through `tenferro-ad` and `tenferro-einsum` as a
+  concrete provider feature, without making it a default and without making it
+  imply a CPU provider when defaults are disabled.
+- Added `EagerBackend::WebGpu` and `EagerRuntime::with_webgpu_backend` so eager
+  execution delegates through the backend trait surface instead of adding
+  einsum-specific WebGPU dispatch.
+- Kept CUDA runtime/library bindings out of the WebGPU feature. WebGPU depends
+  on CubeCL-WGPU and CubeK matmul only.
+- Added `[patch.crates-io]` entries for `cubecl` and `cubecl-common` so
+  `cubek-matmul`/`cubek-std` use the same tensor4all CubeCL source as
+  tenferro. Without this, Cargo builds registry CubeCL and git CubeCL together,
+  making `TensorBinding`, `ComputeClient`, and `StorageType` different Rust
+  types.
+- Started CubeK integration from `cubek-matmul 0.2.0`, the CubeK release paired
+  to CubeCL 0.10.0. Any future tensor4all CubeK fork should branch from that
+  point and be published as tensor4all-owned crates rather than vendored into
+  tenferro.
+- Implemented WebGPU `C32` GEMM as real `F32` decomposition instead of using
+  CubeCL complex core operations. The active WGPU runtime did not advertise
+  `c32` Core complex support for `real_val`/`imag_val`, so split/compose uses
+  raw `f32` parts views of `Complex32` allocations.
+- Kept `C64` unsupported in the initial WebGPU path because it requires `F64`
+  support that is not part of the WebGPU matmul implementation.
+- Added a private WebGPU `DotGeneralPlan` rather than exposing CubeK layout
+  details as public API. The planner validates dimensions once, flattens free
+  and contracting axes, and binds CubeK views with runtime shape/stride
+  metadata.
+- Kept tensor shape extents, strides, buffer lengths, and flattened products
+  out of CubeCL `#[comptime]` parameters. Pack kernels use only axis role lists
+  and rank as compile-time launch attributes; shape and stride values are read
+  from `TensorBinding` metadata in the kernel.
+- Added WebGPU-local pack kernels for operand layouts that cannot be expressed
+  as metadata-only `[batch..., M, K]` or `[batch..., K, N]` CubeK views. These
+  kernels launch over the packed output domain and write one element per worker.
+- Split the WebGPU provider into explicit `runtime`, `memory`, `gemm`, and
+  `kernels` modules. `mod.rs` remains the backend facade plus shared buffer
+  validation helpers, while CubeK launch details stay in `gemm.rs`.
+- Kept WebGPU allocation helpers fallible: shape products and output byte
+  lengths are checked before creating device allocations.
+- Kept traced WebGPU graph execution aligned with the existing no-hidden-transfer
+  contract: non-scalar graph inputs must be explicitly uploaded and bound as
+  WebGPU tensors before execution.
+- Recorded common future GPU scratch-pool stats fields, but did not wire a new
+  scratch pool into CUDA GEMM. CUDA cuTENSOR workspace allocation remains on
+  the existing path.
+- Recorded future ROCm direction as a CubeCL HIP fork or patch with
+  runtime-loaded HIP libraries. ROCm remains unavailable as an execution backend
+  in this work.
+
+## Rejected Or Deferred Alternatives
+
+- Did not make WebGPU the default GPU provider. That would surprise downstream
+  builds and prevent explicit provider selection.
+- Did not hide unsupported WebGPU ops behind CPU fallback. Host/device movement
+  remains explicit.
+- Did not try CubeK `Strategy::Auto` for WebGPU yet. The initial provider path
+  uses `Strategy::Naive`; tuning and adapter-specific selection should be
+  benchmarked separately.
+- Did not add WebGPU elementwise, reduction, indexing, or linalg kernels.
+- Did not expose ROCm execution or a ROCm quickstart without loader-backed HIP
+  runtime support and hardware validation.
+- Did not add GPU tutorial code in this PR. Follow-up issue
+  <https://github.com/tensor4all/tenferro-rs/issues/1046> tracks GPU tutorials
+  and running GPU tutorial examples on GPU-capable CI runners.
+
+## Verification Performed
+
+- RED/GREEN: `cargo test -p tenferro-tensor device_model_has_first_class_webgpu_backend_kind`
+- RED/GREEN: `cargo test -p tenferro-gpu --test public_surface_contract`
+- RED/GREEN: `cargo test -p tenferro-gpu --test public_surface_contract downstream_gpu_features_are_explicit_and_additive`
+- RED/GREEN: `cargo test -p tenferro-gpu --test public_surface_contract`
+  for the WebGPU runtime/transfer/GEMM module-boundary source contract.
+- RED/GREEN: `cargo test -p tenferro-ad --no-default-features --features webgpu,cpu-faer --test eager_runtime_api eager_runtime_accepts_webgpu_backend_constructor`
+- RED/GREEN: `cargo test -p tenferro-einsum --no-default-features --features autodiff,webgpu,cpu-faer --test webgpu_eager_tensor`
+  for eager WebGPU `F32`/`C32` binary einsum and traced WebGPU `F32` binary
+  einsum with explicit WebGPU input bindings.
+- RED/GREEN: `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_backend_contract`
+- RED/GREEN: `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime webgpu_dot_general_runs_rank2_c32_matmul_when_adapter_available -- --nocapture`
+- RED/GREEN: `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime webgpu_dot_general_supports_batched_f32_contract_shape_when_adapter_available`
+- RED/GREEN: `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime webgpu_dot_general_packs_noncontiguous_lhs_free_axes_when_adapter_available`
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-gpu --test public_surface_contract`
+- `cargo test -p tenferro-gpu --test public_surface_contract`
+  includes the WebGPU checked-allocation source contract.
+- `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_backend_contract`
+- `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime`
+- `cargo test -p tenferro-einsum --no-default-features --features autodiff,webgpu,cpu-faer --test webgpu_eager_tensor`
+- `cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer`
+- `cargo check -p tenferro-ad --no-default-features --features cuda,webgpu,cpu-faer`
+- `cargo check -p tenferro-einsum --no-default-features --features autodiff,cuda,webgpu,cpu-faer`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `git diff --check`
+
+The local machine had a working WebGPU adapter, so the WebGPU runtime tests ran
+the backend paths instead of returning early.
+
+## Remaining Risks
+
+- WebGPU `dot_general` supports `F32` and `C32` through CubeK BGEMM planning,
+  but planner stress coverage is still narrower than CUDA coverage.
+- `C32` uses four real matmuls and split/compose kernels; performance has not
+  been benchmarked.
+- WebGPU zero-contracting-size matmul remains unsupported until CubeK behavior
+  is validated.
+- CUDA runtime tests and CUDA benchmarks were not run in this pass; the contract
+  was to preserve CUDA implementation behavior, not to benchmark it.
+- ROCm hardware was not available and ROCm remains an unavailable execution
+  backend.


### PR DESCRIPTION
## Summary

- Add explicit WebGPU provider support through `WebGpuBackend`/`WebGpuRuntime`, WebGPU upload/download helpers, and `webgpu` feature propagation through eager AD and einsum.
- Add WebGPU `dot_general` lowering through a private CubeK BGEMM planner for `F32` and `C32`, including batched layouts and same-provider pack kernels when CubeK metadata views are not enough.
- Keep CUDA behavior unchanged by preserving the existing cuTENSOR path and adding source contracts that prevent this work from rewiring CUDA GEMM or buffer-pool behavior.
- Update README, user GPU docs, and developer GPU design docs for explicit CUDA/WebGPU provider selection, WebGPU coverage, ROCm future direction, and common future GPU pool stats.

Work log: `docs/worklogs/2026-06-13-webgpu-complex-gemm.md`
Follow-up: #1046 tracks GPU tutorial expansion and running GPU tutorial examples on GPU-capable CI runners.

## Verification

- `cargo fmt --all --check`
- `cargo test -p tenferro-gpu --test public_surface_contract`
- `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_backend_contract`
- `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime`
- `cargo test -p tenferro-einsum --no-default-features --features autodiff,webgpu,cpu-faer --test webgpu_eager_tensor`
- `cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer`
- `cargo check -p tenferro-ad --no-default-features --features cuda,webgpu,cpu-faer`
- `cargo check -p tenferro-einsum --no-default-features --features autodiff,cuda,webgpu,cpu-faer`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `git diff --check`

## Notes

- CUDA runtime tests and benchmarks were not run locally. This PR is intentionally source-contracted to avoid changing CUDA GEMM algorithms, library dispatch, workspace allocation, or scratch/buffer-pool behavior.
- ROCm remains unavailable as an execution backend; this PR only records the future loader-backed direction.
