### PR TITLE
feat: route WebGPU complex GEMM through CubeK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ cubecl-cuda = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec1
 cubecl-common = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
 cubecl-runtime = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
 cubecl-wgpu = { git = "https://github.com/tensor4all/cubecl.git", rev = "f5e5ec178f9aebca9362b829ffef708f720ff692" }
-cubek-matmul = { version = "0.2.0", default-features = false }
-cubek-std = { version = "0.2.0", default-features = false }
+cubek-matmul = { git = "https://github.com/tensor4all/cubek.git", rev = "7a42081f3f18578014a8b2656ea6a6c79c7fa9be", default-features = false }
+cubek-std = { git = "https://github.com/tensor4all/cubek.git", rev = "7a42081f3f18578014a8b2656ea6a6c79c7fa9be", default-features = false }
 sha2 = "0.10"
 omeco = "0.2.4"
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7" }

--- a/crates/tenferro-gpu/src/webgpu/gemm.rs
+++ b/crates/tenferro-gpu/src/webgpu/gemm.rs
@@ -1,14 +1,16 @@
 use cubecl::prelude::{CubeElement, CubePrimitive};
 use cubecl_wgpu::WgpuRuntime;
-use cubek_matmul::{definition::MatmulElems, launch::Strategy};
+use cubek_matmul::{
+    definition::MatmulElems,
+    launch::{launch_c32_ref, launch_ref, ComplexMatmulOptions, Strategy},
+};
 use cubek_std::InputBinding;
 use num_complex::Complex32;
 use smallvec::SmallVec;
 
 use super::{
     alloc_output, comptime_sequence, cube_count_for_len, cube_dim_1d, ensure_resident_on_runtime,
-    kernels, typed_tensor_array_arg, typed_tensor_array_arg_as, typed_tensor_binding_with_layout,
-    WebGpuBackend,
+    kernels, typed_tensor_binding_with_layout, WebGpuBackend,
 };
 use crate::{col_major_strides, DotGeneralConfig, Error, Tensor, TypedTensor};
 
@@ -430,7 +432,7 @@ fn dot_general_f32(
     )?;
     let mut dtypes = MatmulElems::from_single_dtype(f32::as_type_native_unchecked());
 
-    cubek_matmul::launch::launch_ref(
+    launch_ref(
         &Strategy::Naive,
         backend.runtime().client(),
         lhs_binding,
@@ -443,134 +445,69 @@ fn dot_general_f32(
     Ok(output)
 }
 
-fn extract_c32_part(
-    backend: &WebGpuBackend,
-    input: &TypedTensor<Complex32>,
-    real: bool,
-) -> crate::Result<TypedTensor<f32>> {
-    ensure_resident_on_runtime(backend.runtime(), input, DOT_GENERAL_OP)?;
-    let output = alloc_output::<f32>(backend.runtime(), input.shape(), DOT_GENERAL_OP)?;
-    let len = output.n_elements();
-    if len == 0 {
-        return Ok(output);
-    }
-
-    let output_arg = typed_tensor_array_arg(&output, DOT_GENERAL_OP)?;
-    let input_part_len = len.checked_mul(2).ok_or_else(|| {
-        Error::backend_failure(DOT_GENERAL_OP, "complex input part length overflow")
-    })?;
-    let input_arg =
-        typed_tensor_array_arg_as::<Complex32, f32>(input, input_part_len, DOT_GENERAL_OP)?;
-    if real {
-        unsafe {
-            // SAFETY: Both array args are validated against compact dense
-            // tensors. The input is reinterpreted as `2 * len` f32 parts, and
-            // the kernel guards writes with `ABSOLUTE_POS < out.len()`.
-            kernels::extract_c32_real::launch_unchecked::<WgpuRuntime>(
-                backend.runtime().client(),
-                cube_count_for_len(len),
-                cube_dim_1d(),
-                output_arg,
-                input_arg,
-            );
-        }
-    } else {
-        unsafe {
-            // SAFETY: Same invariant as the real-part launch above.
-            kernels::extract_c32_imag::launch_unchecked::<WgpuRuntime>(
-                backend.runtime().client(),
-                cube_count_for_len(len),
-                cube_dim_1d(),
-                output_arg,
-                input_arg,
-            );
-        }
-    }
-    Ok(output)
-}
-
-fn compose_c32_from_products(
-    backend: &WebGpuBackend,
-    real_pos: &TypedTensor<f32>,
-    real_neg: &TypedTensor<f32>,
-    imag_left: &TypedTensor<f32>,
-    imag_right: &TypedTensor<f32>,
-) -> crate::Result<TypedTensor<Complex32>> {
-    let shape = real_pos.shape();
-    if real_neg.shape() != shape || imag_left.shape() != shape || imag_right.shape() != shape {
-        return Err(Error::ShapeMismatch {
-            op: DOT_GENERAL_OP,
-            lhs: shape.to_vec(),
-            rhs: real_neg.shape().to_vec(),
-        });
-    }
-    ensure_resident_on_runtime(backend.runtime(), real_pos, DOT_GENERAL_OP)?;
-    ensure_resident_on_runtime(backend.runtime(), real_neg, DOT_GENERAL_OP)?;
-    ensure_resident_on_runtime(backend.runtime(), imag_left, DOT_GENERAL_OP)?;
-    ensure_resident_on_runtime(backend.runtime(), imag_right, DOT_GENERAL_OP)?;
-
-    let output = alloc_output::<Complex32>(backend.runtime(), shape, DOT_GENERAL_OP)?;
-    let len = output.n_elements();
-    if len == 0 {
-        return Ok(output);
-    }
-
-    let output_part_len = len.checked_mul(2).ok_or_else(|| {
-        Error::backend_failure(DOT_GENERAL_OP, "complex output part length overflow")
-    })?;
-    let output_arg =
-        typed_tensor_array_arg_as::<Complex32, f32>(&output, output_part_len, DOT_GENERAL_OP)?;
-    let real_pos_arg = typed_tensor_array_arg(real_pos, DOT_GENERAL_OP)?;
-    let real_neg_arg = typed_tensor_array_arg(real_neg, DOT_GENERAL_OP)?;
-    let imag_left_arg = typed_tensor_array_arg(imag_left, DOT_GENERAL_OP)?;
-    let imag_right_arg = typed_tensor_array_arg(imag_right, DOT_GENERAL_OP)?;
-
-    unsafe {
-        // SAFETY: All input products and the complex output are compact dense
-        // tensors with identical logical element counts. The compose kernel
-        // writes two scalar parts per output position and guards the launch
-        // domain with `ABSOLUTE_POS < real_pos.len()`.
-        kernels::compose_c32_parts_from_products::launch_unchecked::<WgpuRuntime>(
-            backend.runtime().client(),
-            cube_count_for_len(len),
-            cube_dim_1d(),
-            output_arg,
-            real_pos_arg,
-            real_neg_arg,
-            imag_left_arg,
-            imag_right_arg,
-        );
-    }
-
-    Ok(output)
-}
-
 fn dot_general_c32(
     backend: &WebGpuBackend,
     lhs: &TypedTensor<Complex32>,
     rhs: &TypedTensor<Complex32>,
     config: &DotGeneralConfig,
+    lhs_conj: bool,
+    rhs_conj: bool,
 ) -> crate::Result<TypedTensor<Complex32>> {
-    build_dot_general_plan(lhs.shape(), rhs.shape(), config)?;
+    let plan = build_dot_general_plan(lhs.shape(), rhs.shape(), config)?;
+    ensure_resident_on_runtime(backend.runtime(), lhs, DOT_GENERAL_OP)?;
+    ensure_resident_on_runtime(backend.runtime(), rhs, DOT_GENERAL_OP)?;
 
-    let lhs_real = extract_c32_part(backend, lhs, true)?;
-    let lhs_imag = extract_c32_part(backend, lhs, false)?;
-    let rhs_real = extract_c32_part(backend, rhs, true)?;
-    let rhs_imag = extract_c32_part(backend, rhs, false)?;
+    let output = alloc_output::<Complex32>(backend.runtime(), &plan.output_shape, DOT_GENERAL_OP)?;
+    if output.n_elements() == 0 {
+        return Ok(output);
+    }
+    if plan.k == 0 {
+        return Err(Error::backend_failure(
+            DOT_GENERAL_OP,
+            "WebGPU CubeK matmul does not support zero-sized contracting dimensions yet",
+        ));
+    }
+    let lhs = prepare_lhs_operand(backend, lhs, &plan)?;
+    let rhs = prepare_rhs_operand(backend, rhs, &plan)?;
 
-    let real_pos = dot_general_f32(backend, &lhs_real, &rhs_real, config)?;
-    let real_neg = dot_general_f32(backend, &lhs_imag, &rhs_imag, config)?;
-    let imag_left = dot_general_f32(backend, &lhs_real, &rhs_imag, config)?;
-    let imag_right = dot_general_f32(backend, &lhs_imag, &rhs_real, config)?;
+    let dtype = Complex32::as_type_native_unchecked().storage_type();
+    let lhs_binding = InputBinding::new(
+        typed_tensor_binding_with_layout(&lhs.tensor, &lhs.shape, &lhs.strides, DOT_GENERAL_OP)?,
+        dtype,
+    );
+    let rhs_binding = InputBinding::new(
+        typed_tensor_binding_with_layout(&rhs.tensor, &rhs.shape, &rhs.strides, DOT_GENERAL_OP)?,
+        dtype,
+    );
+    let output_binding = typed_tensor_binding_with_layout(
+        &output,
+        &plan.out_cubek_shape,
+        &plan.out_cubek_strides,
+        DOT_GENERAL_OP,
+    )?;
+    let mut dtypes = MatmulElems::from_single_dtype(Complex32::as_type_native_unchecked());
 
-    compose_c32_from_products(backend, &real_pos, &real_neg, &imag_left, &imag_right)
+    launch_c32_ref(
+        &Strategy::Naive,
+        backend.runtime().client(),
+        lhs_binding,
+        rhs_binding,
+        output_binding,
+        &mut dtypes,
+        ComplexMatmulOptions { lhs_conj, rhs_conj },
+    )
+    .map_err(|err| Error::backend_failure(DOT_GENERAL_OP, format!("{err:?}")))?;
+
+    Ok(output)
 }
 
-pub(super) fn dot_general(
+pub(super) fn dot_general_with_conj(
     backend: &WebGpuBackend,
     lhs: &Tensor,
     rhs: &Tensor,
     config: &DotGeneralConfig,
+    lhs_conj: bool,
+    rhs_conj: bool,
 ) -> crate::Result<Tensor> {
     match (lhs, rhs) {
         (Tensor::F32(lhs), Tensor::F32(rhs)) => {
@@ -581,7 +518,7 @@ pub(super) fn dot_general(
             "WebGPU CubeK matmul currently supports f32 real inputs; f64 is not available in the initial WebGPU path",
         )),
         (Tensor::C32(lhs), Tensor::C32(rhs)) => {
-            dot_general_c32(backend, lhs, rhs, config).map(Tensor::C32)
+            dot_general_c32(backend, lhs, rhs, config, lhs_conj, rhs_conj).map(Tensor::C32)
         }
         (Tensor::C64(_), Tensor::C64(_)) => Err(Error::backend_failure(
             DOT_GENERAL_OP,
@@ -589,4 +526,13 @@ pub(super) fn dot_general(
         )),
         _ => Err(dtype_mismatch(DOT_GENERAL_OP, lhs, rhs)),
     }
+}
+
+pub(super) fn dot_general(
+    backend: &WebGpuBackend,
+    lhs: &Tensor,
+    rhs: &Tensor,
+    config: &DotGeneralConfig,
+) -> crate::Result<Tensor> {
+    dot_general_with_conj(backend, lhs, rhs, config, false, false)
 }

--- a/crates/tenferro-gpu/src/webgpu/kernels.rs
+++ b/crates/tenferro-gpu/src/webgpu/kernels.rs
@@ -1,35 +1,6 @@
 use cubecl::prelude::*;
 
 #[cube(launch_unchecked)]
-pub fn extract_c32_real(out: &mut Array<f32>, input_parts: &Array<f32>) {
-    if ABSOLUTE_POS < out.len() {
-        out[ABSOLUTE_POS] = input_parts[ABSOLUTE_POS * 2];
-    }
-}
-
-#[cube(launch_unchecked)]
-pub fn extract_c32_imag(out: &mut Array<f32>, input_parts: &Array<f32>) {
-    if ABSOLUTE_POS < out.len() {
-        out[ABSOLUTE_POS] = input_parts[ABSOLUTE_POS * 2 + 1];
-    }
-}
-
-#[cube(launch_unchecked)]
-pub fn compose_c32_parts_from_products(
-    out_parts: &mut Array<f32>,
-    real_pos: &Array<f32>,
-    real_neg: &Array<f32>,
-    imag_left: &Array<f32>,
-    imag_right: &Array<f32>,
-) {
-    if ABSOLUTE_POS < real_pos.len() {
-        let out_pos = ABSOLUTE_POS * 2;
-        out_parts[out_pos] = real_pos[ABSOLUTE_POS] - real_neg[ABSOLUTE_POS];
-        out_parts[out_pos + 1] = imag_left[ABSOLUTE_POS] + imag_right[ABSOLUTE_POS];
-    }
-}
-
-#[cube(launch_unchecked)]
 pub fn pack_lhs_dot_general<E: CubePrimitive>(
     out: &mut Tensor<E>,
     input: &Tensor<E>,

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -1,8 +1,6 @@
 //! CubeCL WebGPU provider runtime and backend skeleton.
 
-use cubecl::prelude::{
-    ArrayArg, CubeCount, CubeDim, CubeElement, CubeType, Sequence, TensorBinding,
-};
+use cubecl::prelude::{CubeCount, CubeDim, CubeElement, CubeType, Sequence, TensorBinding};
 use cubecl_wgpu::WgpuRuntime;
 use std::sync::Arc;
 
@@ -205,63 +203,6 @@ fn typed_tensor_binding_with_layout<T: CubeElement + Clone>(
     Ok(unsafe {
         TensorBinding::from_raw_parts(buffer.handle().clone(), strides.into(), shape.into())
     })
-}
-
-fn typed_tensor_array_arg<T: CubeElement + Clone>(
-    tensor: &TypedTensor<T>,
-    op: &'static str,
-) -> crate::Result<ArrayArg<WgpuRuntime>> {
-    let buffer = webgpu_buffer(tensor, op)?;
-    validate_webgpu_buffer_len(tensor, buffer, op)?;
-
-    // SAFETY: `validate_webgpu_buffer_len` proves the dense tensor shape
-    // matches the backing allocation length. Raw linear kernels using this
-    // helper guard their output domain with `ABSOLUTE_POS < out.len()`.
-    Ok(unsafe { ArrayArg::from_raw_parts(buffer.handle().clone(), buffer.element_len()) })
-}
-
-fn typed_tensor_array_arg_as<T, U>(
-    tensor: &TypedTensor<T>,
-    len: usize,
-    op: &'static str,
-) -> crate::Result<ArrayArg<WgpuRuntime>>
-where
-    T: CubeElement + Clone,
-    U: CubeElement + Clone,
-{
-    let buffer = webgpu_buffer(tensor, op)?;
-    validate_webgpu_buffer_len(tensor, buffer, op)?;
-    let requested_bytes = len.checked_mul(core::mem::size_of::<U>()).ok_or_else(|| {
-        Error::backend_failure(
-            op,
-            format!("reinterpreted WebGPU array length overflow for len {len}"),
-        )
-    })?;
-    let available_bytes = buffer
-        .element_len()
-        .checked_mul(core::mem::size_of::<T>())
-        .ok_or_else(|| {
-            Error::backend_failure(
-                op,
-                format!(
-                    "WebGPU buffer byte length overflow for {} elements",
-                    buffer.element_len()
-                ),
-            )
-        })?;
-    if requested_bytes > available_bytes {
-        return Err(Error::backend_failure(
-            op,
-            format!(
-                "reinterpreted WebGPU array needs {requested_bytes} bytes, buffer has {available_bytes}"
-            ),
-        ));
-    }
-
-    // SAFETY: The tensor shape was validated against the backing allocation,
-    // and the byte-size check proves the requested scalar view remains within
-    // the same allocation.
-    Ok(unsafe { ArrayArg::from_raw_parts(buffer.handle().clone(), len) })
 }
 
 fn ensure_resident_on_runtime<T: 'static>(
@@ -630,6 +571,17 @@ impl TensorDot for WebGpuBackend {
         config: &DotGeneralConfig,
     ) -> crate::Result<Tensor> {
         gemm::dot_general(self, lhs, rhs, config)
+    }
+
+    fn dot_general_with_conj(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+        lhs_conj: bool,
+        rhs_conj: bool,
+    ) -> crate::Result<Tensor> {
+        gemm::dot_general_with_conj(self, lhs, rhs, config, lhs_conj, rhs_conj)
     }
 }
 

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -183,8 +183,28 @@ fn webgpu_dot_general_is_cubek_backed() {
     );
     assert!(
         webgpu_mod.contains("cubek_matmul::launch::launch_ref")
-            || webgpu_gemm.contains("cubek_matmul::launch::launch_ref"),
+            || webgpu_gemm.contains("cubek_matmul") && webgpu_gemm.contains("launch_ref("),
         "WebGPU dot_general should route matmul through CubeK launch_ref"
+    );
+}
+
+#[test]
+fn webgpu_c32_dot_general_with_conj_uses_cubek_complex_api() {
+    let webgpu_gemm =
+        repo_file_if_exists("crates/tenferro-gpu/src/webgpu/gemm.rs").unwrap_or_default();
+    let webgpu_kernels =
+        repo_file_if_exists("crates/tenferro-gpu/src/webgpu/kernels.rs").unwrap_or_default();
+    assert!(
+        webgpu_gemm.contains("launch_c32_ref"),
+        "WebGPU C32 matmul must route through CubeK complex GEMM API"
+    );
+    assert!(
+        !webgpu_gemm.contains("compose_c32_from_products"),
+        "tenferro WebGPU must not own complex GEMM compose lowering"
+    );
+    assert!(
+        !webgpu_kernels.contains("compose_c32_parts_from_products"),
+        "complex GEMM split/compose kernels belong in CubeK"
     );
 }
 

--- a/crates/tenferro-gpu/tests/webgpu_matmul_runtime.rs
+++ b/crates/tenferro-gpu/tests/webgpu_matmul_runtime.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "webgpu")]
 
 use num_complex::{Complex32, Complex64};
+use tenferro_cpu::CpuBackend;
 use tenferro_gpu::{webgpu_available, WebGpuBackend};
 use tenferro_tensor::{DotGeneralConfig, Tensor, TensorDeviceTransfer, TensorDot};
 
@@ -22,16 +23,92 @@ fn matmul2_col_major(lhs: &[Complex32], rhs: &[Complex32]) -> [Complex32; 4] {
 }
 
 fn assert_complex_close(actual: &[Complex32], expected: &[Complex32]) {
-    for (actual, expected) in actual.iter().zip(expected) {
-        assert!(
-            (actual.re - expected.re).abs() <= 1e-4,
-            "real mismatch: actual={actual:?} expected={expected:?}"
-        );
-        assert!(
-            (actual.im - expected.im).abs() <= 1e-4,
-            "imag mismatch: actual={actual:?} expected={expected:?}"
-        );
+    assert_eq!(actual.len(), expected.len());
+    let max_error = actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| {
+            (actual.re - expected.re)
+                .abs()
+                .max((actual.im - expected.im).abs())
+        })
+        .fold(0.0_f32, f32::max);
+    assert!(
+        max_error <= 1e-4,
+        "max complex mismatch {max_error} exceeds tolerance\nactual={actual:?}\nexpected={expected:?}"
+    );
+}
+
+fn assert_f32_close(actual: &[f32], expected: &[f32]) {
+    assert_eq!(actual.len(), expected.len());
+    let max_error = actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| (actual - expected).abs())
+        .fold(0.0_f32, f32::max);
+    assert!(
+        max_error <= 1e-4,
+        "max f32 mismatch {max_error} exceeds tolerance\nactual={actual:?}\nexpected={expected:?}"
+    );
+}
+
+fn dot_general_config_for_shapes(lhs_shape: &[usize], rhs_shape: &[usize]) -> DotGeneralConfig {
+    if lhs_shape.len() == 3 && rhs_shape.len() == 3 {
+        DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![2],
+            rhs_batch_dims: vec![2],
+        }
+    } else {
+        DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        }
     }
+}
+
+fn c32_values(len: usize, seed: f32) -> Vec<Complex32> {
+    (0..len)
+        .map(|index| {
+            let x = seed + index as f32 * 0.375;
+            Complex32::new(x, 0.25 - 0.5 * x)
+        })
+        .collect()
+}
+
+fn assert_c32_dot_general_with_conj_matches_cpu(
+    backend: &mut WebGpuBackend,
+    lhs_conj: bool,
+    rhs_conj: bool,
+    lhs_shape: Vec<usize>,
+    rhs_shape: Vec<usize>,
+) {
+    let lhs_len = lhs_shape.iter().product();
+    let rhs_len = rhs_shape.iter().product();
+    let lhs = Tensor::from_vec_col_major(lhs_shape.clone(), c32_values(lhs_len, 0.25));
+    let rhs = Tensor::from_vec_col_major(rhs_shape.clone(), c32_values(rhs_len, -0.75));
+    let config = dot_general_config_for_shapes(&lhs_shape, &rhs_shape);
+
+    let mut cpu = CpuBackend::new();
+    let expected = cpu
+        .dot_general_with_conj(&lhs, &rhs, &config, lhs_conj, rhs_conj)
+        .unwrap();
+
+    let gpu_lhs = backend.upload_host_tensor(&lhs).unwrap();
+    let gpu_rhs = backend.upload_host_tensor(&rhs).unwrap();
+    let gpu_out = backend
+        .dot_general_with_conj(&gpu_lhs, &gpu_rhs, &config, lhs_conj, rhs_conj)
+        .unwrap();
+    let out = backend.download_to_host(&gpu_out).unwrap();
+
+    assert_eq!(out.shape(), expected.shape());
+    assert_complex_close(
+        out.as_slice::<Complex32>().unwrap(),
+        expected.as_slice::<Complex32>().unwrap(),
+    );
 }
 
 fn noncontiguous_lhs_free_axes_reference(lhs: &[f32], rhs: &[f32]) -> Vec<f32> {
@@ -70,6 +147,77 @@ fn batched_matmul_c32_reference(lhs: &[Complex32], rhs: &[Complex32]) -> Vec<Com
         }
     }
     out
+}
+
+#[test]
+fn webgpu_c32_dot_general_with_lhs_conj_matches_cpu_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    assert_c32_dot_general_with_conj_matches_cpu(&mut backend, true, false, vec![2, 3], vec![3, 2]);
+}
+
+#[test]
+fn webgpu_c32_dot_general_with_rhs_conj_matches_cpu_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    assert_c32_dot_general_with_conj_matches_cpu(&mut backend, false, true, vec![2, 3], vec![3, 2]);
+}
+
+#[test]
+fn webgpu_c32_batched_dot_general_with_both_conj_matches_cpu_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    assert_c32_dot_general_with_conj_matches_cpu(
+        &mut backend,
+        true,
+        true,
+        vec![2, 3, 2],
+        vec![3, 2, 2],
+    );
+}
+
+#[test]
+fn webgpu_f32_dot_general_with_conj_is_identity_when_adapter_available() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]);
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let mut cpu = CpuBackend::new();
+    let expected = cpu
+        .dot_general_with_conj(&lhs, &rhs, &config, true, true)
+        .unwrap();
+
+    let gpu_lhs = backend.upload_host_tensor(&lhs).unwrap();
+    let gpu_rhs = backend.upload_host_tensor(&rhs).unwrap();
+    let gpu_out = backend
+        .dot_general_with_conj(&gpu_lhs, &gpu_rhs, &config, true, true)
+        .unwrap();
+    let out = backend.download_to_host(&gpu_out).unwrap();
+
+    assert_eq!(out.shape(), expected.shape());
+    assert_f32_close(
+        out.as_slice::<f32>().unwrap(),
+        expected.as_slice::<f32>().unwrap(),
+    );
 }
 
 #[test]

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -27,11 +27,11 @@ cases are operation-specific: `eig`, `full_piv_lu`, `full_piv_lu_solve`,
 transfer and reshape, and selected complex analytic or ordering operations.
 WebGPU is being introduced incrementally. The implemented path covers explicit
 transfer plus `F32` `dot_general` through a CubeK BGEMM planner. `C32` GEMM is
-implemented by decomposing complex contractions into real `F32` matmul
-operations on the same WebGPU provider. `F64`, `C64`, zero-contracting-size
-matmul, and non-matmul tensor ops remain explicit unsupported paths rather than
-CPU fallbacks. HIP/ROCm is still a reserved feature stub rather than a
-supported execution path.
+implemented through a CubeK-owned complex GEMM launch API that lowers to real
+`F32` matmuls and handles conjugation flags. `F64`, `C64`,
+zero-contracting-size matmul, and non-matmul tensor ops remain explicit
+unsupported paths rather than CPU fallbacks. HIP/ROCm is still a reserved
+feature stub rather than a supported execution path.
 
 See also:
 
@@ -71,7 +71,7 @@ crates/tenferro-gpu/src/webgpu/
     runtime.rs             CubeCL-WGPU runtime initialization and synchronization
     memory.rs              upload_webgpu_tensor and download_webgpu_tensor
     gemm.rs                CubeK-backed F32/C32 dot_general planner and launch support
-    kernels.rs             WebGPU-private pack, split, and compose kernels
+    kernels.rs             WebGPU-private dot_general pack kernels
 ```
 
 The provider-specific public backend types are `tenferro_gpu::CudaBackend` and
@@ -384,7 +384,7 @@ The WebGPU backend currently has narrower coverage:
 | --- | --- |
 | Allocation/transfer | WebGPU allocation, upload, and download for `F64`, `F32`, `I32`, `I64`, `Bool`, `C64`, and `C32` tensors |
 | Real contraction | CubeK/CubeCL-backed `F32` `dot_general` through a BGEMM planner, including batched and same-device packed operand layouts covered by tests |
-| Complex contraction | `C32` `dot_general` through four real `F32` CubeK matmuls and WebGPU-local split/compose kernels |
+| Complex contraction | `C32` `dot_general` and `dot_general_with_conj` through a CubeK-owned complex GEMM API. tenferro normalizes `DotGeneralConfig` into CubeK-compatible batched matmul bindings; CubeK owns temporary real buffers, split/compose kernels, conjugation signs, and future native complex-kernel replacement |
 | Deferred contraction coverage | `F64`, `C64`, zero-contracting-size matmul, and broader planner stress coverage |
 | Other tensor ops | Explicit unsupported `BackendFailure`; no CPU fallback and no hidden provider transfer |
 

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -164,7 +164,7 @@ rows return explicit errors and do not fall back to CPU.
 | Operation or family | WebGPU dtype support | Notes |
 | --- | --- | --- |
 | Allocation, upload, download | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Explicit CPU/WebGPU transfer only |
-| `dot_general` | `F32`, `C32` | CubeK-backed BGEMM planner; supports rank-2, batched, and same-device packed operand layouts covered by tests |
+| `dot_general`, `dot_general_with_conj` | `F32`, `C32` | CubeK-backed BGEMM planner; `C32` conjugation is handled by the CubeK complex GEMM API. Supports rank-2, batched, and same-device packed operand layouts covered by tests |
 | Binary einsum lowering to `dot_general` | `F32`, `C32` | Eager `F32`/`C32` and traced `F32` paths are covered when inputs are explicitly uploaded to WebGPU |
 | `dot_general` with zero contracting size | No WebGPU implementation | Returns an error until CubeK behavior is validated |
 | `dot_general` for `F64`, `C64` | No WebGPU implementation | Returns an error; no CPU fallback |

--- a/docs/superpowers/plans/2026-06-13-cubek-complex-gemm-api.md
+++ b/docs/superpowers/plans/2026-06-13-cubek-complex-gemm-api.md
@@ -1,0 +1,69 @@
+# CubeK Complex GEMM API Implementation Plan
+
+## Goal
+
+Add CubeK-owned `C32` GEMM support with conjugation flags, then route tenferro
+WebGPU `dot_general` and `dot_general_with_conj` through that API without
+changing CUDA behavior.
+
+## Boundaries
+
+- CubeK owns complex GEMM semantics, temporary real buffers, split/compose
+  kernels, conjugation signs, and future native complex-kernel replacement.
+- tenferro owns `DotGeneralConfig` planning, WebGPU operand packing, provider
+  dispatch, and user-facing documentation.
+- CUDA `dot_general` remains cuTENSOR-backed. Do not change CUDA descriptors,
+  workspace allocation, buffer pools, or algorithm selection.
+- No hidden CPU transfers or CPU fallback are allowed.
+- CubeCL kernels may use rank and operation attributes as `#[comptime]`, but
+  not tensor shape extents, strides, buffer lengths, or flattened products.
+- `C64` remains unsupported for WebGPU until the real `F64` WebGPU path exists.
+
+## Phase 1: CubeK
+
+1. Branch CubeK from the release used by tenferro: `v0.2.0` /
+   `cubek-matmul 0.2.0`.
+2. Add `ComplexMatmulOptions { lhs_conj, rhs_conj }`.
+3. Add `launch_c32_ref` as an additive public API; keep real `launch_ref`
+   compatible.
+4. Implement initial `C32` lowering through four real `F32` matmuls.
+5. Keep split/compose kernels in CubeK and launch over logical tensor domains
+   using runtime shape/stride metadata.
+6. Cover no-conj, lhs-conj, rhs-conj, both-conj, batched, and strided binding
+   cases in CubeK tests.
+7. Publish the CubeK commit through an addressable non-local Git source before
+   pinning tenferro to it.
+
+## Phase 2: tenferro
+
+1. Pin `cubek-matmul` and `cubek-std` to the CubeK fork commit; do not commit a
+   local path dependency.
+2. Add WebGPU runtime tests for:
+   - `C32` rank-2 `dot_general_with_conj` with lhs conjugation;
+   - `C32` rank-2 `dot_general_with_conj` with rhs conjugation;
+   - batched `C32` `dot_general_with_conj` with both inputs conjugated;
+   - `F32` `dot_general_with_conj` as a real no-op.
+3. Add a source contract that requires WebGPU `C32` matmul to call
+   `launch_c32_ref` and rejects tenferro-local complex compose kernels.
+4. Refactor `crates/tenferro-gpu/src/webgpu/gemm.rs` so `dot_general` delegates
+   to `dot_general_with_conj(..., false, false)`.
+5. Route `C32` through CubeK `launch_c32_ref`; leave `F32` on CubeK
+   `launch_ref`.
+6. Remove WebGPU-local complex split/compose kernels and raw complex
+   reinterpretation helpers.
+7. Override `TensorDot::dot_general_with_conj` for `WebGpuBackend`.
+8. Update `docs/design/gpu-backend-design.md`,
+   `docs/guides/devices-and-gpu.md`, and a work log under `docs/worklogs/`.
+
+## Verification Scope
+
+Run focused checks before PR:
+
+- CubeK `cubek-matmul` complex tests and full matmul test target.
+- tenferro WebGPU runtime tests for the new `dot_general_with_conj` cases.
+- tenferro GPU public-surface contract tests.
+- tenferro GPU feature compile checks for `webgpu`, `cuda`, and combined
+  `cuda,webgpu` where possible.
+- `cargo fmt --all --check`, `git diff --check`, and docs-site checks.
+
+Full workspace release tests and coverage remain the repository-wide PR gate.

--- a/docs/superpowers/specs/2026-06-13-cubek-complex-gemm-api-design.md
+++ b/docs/superpowers/specs/2026-06-13-cubek-complex-gemm-api-design.md
@@ -1,0 +1,196 @@
+# CubeK Complex GEMM API Design
+
+## Context
+
+The first WebGPU `dot_general` implementation in tenferro lowers `F32` and
+`C32` contractions through CubeK real matmul. That implementation proves the
+WebGPU provider split and planner shape, but it keeps complex GEMM decomposition
+inside tenferro. That is the wrong long-term ownership boundary.
+
+Complex matrix multiplication is a matmul-provider concern. Tenferro should
+normalize tensor contraction metadata and call a backend matmul provider. CubeK
+should own complex GEMM semantics, including optional conjugation, temporary
+real buffers, and the real-GEMM lowering used before native complex kernels
+exist.
+
+This design supersedes the tenferro-local complex decomposition direction in
+`docs/superpowers/plans/2026-06-13-webgpu-complex-gemm.md` for new work.
+
+## Goals
+
+- Add a CubeK-owned `C32` complex GEMM entry point with `lhs_conj` and
+  `rhs_conj` semantic attributes.
+- Keep the existing CubeK real `launch_ref` API compatible for downstream
+  users.
+- Make tenferro `WebGpuBackend::dot_general` and
+  `WebGpuBackend::dot_general_with_conj` call the CubeK complex GEMM API for
+  `C32` inputs instead of owning the complex lowering.
+- Preserve the CUDA performance contract: no changes to CUDA cuTENSOR,
+  cuBLAS, cuSOLVER, workspace allocation, buffer pools, or algorithm selection.
+- Avoid hidden CPU transfers or CPU fallback. All WebGPU complex GEMM work stays
+  on the WebGPU provider.
+
+## Non-Goals
+
+- Do not add `C64` WebGPU GEMM before CubeK and CubeCL-WGPU have a supported
+  `F64` path.
+- Do not make general WebGPU elementwise coverage a dependency of
+  `dot_general_with_conj`. Elementwise `conj` should be implemented later, but
+  complex GEMM conjugation belongs to the GEMM API.
+- Do not add a vague public `gpu` feature or enable a GPU provider by default.
+- Do not vendor CubeK source into tenferro.
+
+## Repository Boundary
+
+Clone and patch CubeK as a sibling project:
+
+```text
+~/tensor4all/cubek
+```
+
+Start from the CubeK release series already used by tenferro:
+
+```text
+cubek-matmul 0.2.0
+cubek-std 0.2.0
+cubecl 0.10.0
+```
+
+The preferred long-term distribution is tensor4all-owned CubeK crates published
+from that branch. During development, tenferro may use a git dependency or
+`[patch.crates-io]` pointing at the tensor4all CubeK fork. The committed
+tenferro dependency must be deliberate and documented; a local path dependency
+is not acceptable in a PR.
+
+## CubeK API Shape
+
+Add an additive complex GEMM API rather than changing the meaning of real
+`launch_ref`.
+
+```rust
+pub struct ComplexMatmulOptions {
+    pub lhs_conj: bool,
+    pub rhs_conj: bool,
+}
+
+pub fn launch_c32_ref<R: Runtime>(
+    strategy: &Strategy,
+    client: &ComputeClient<R>,
+    lhs: InputBinding<R>,
+    rhs: InputBinding<R>,
+    out: TensorBinding<R>,
+    options: ComplexMatmulOptions,
+) -> Result<(), MatmulSetupError>;
+```
+
+The exact function name can be adjusted to match CubeK naming conventions, but
+the public contract must make these points explicit:
+
+- The input and output buffers are interleaved `C32` values.
+- Shapes follow the existing CubeK batched matmul convention:
+  `[batch..., M, K]`, `[batch..., K, N]`, `[batch..., M, N]`.
+- `lhs_conj` and `rhs_conj` are complex-only semantic attributes.
+- Real GEMM remains available through the existing real API.
+- Unsupported dtype or layout combinations return explicit setup errors.
+
+Do not add `conj` flags to real `launch_ref` as if real GEMM had meaningful
+conjugation semantics.
+
+## CubeK Initial Lowering
+
+The first CubeK implementation can lower `C32` GEMM to four real `F32` GEMMs:
+
+```text
+A = Ar + i Ai
+B = Br + i Bi
+
+si = lhs_conj ? -1 : +1
+sj = rhs_conj ? -1 : +1
+
+real = dot(Ar, Br) - si * sj * dot(Ai, Bi)
+imag = sj * dot(Ar, Bi) + si * dot(Ai, Br)
+```
+
+CubeK owns the temporary `F32` buffers, extraction kernels, compose kernel, and
+future replacement by native complex kernels or fused epilogues. The lowering
+must launch over tensor-sized output domains and must not use single-worker
+tensor loops.
+
+The conjugation signs are operation attributes. Passing them as compile-time
+kernel options is acceptable because they are not runtime shape or stride
+metadata.
+
+## Tenferro Integration
+
+Tenferro keeps the `DotGeneralConfig` planner. Its responsibilities are:
+
+- validate ranks, paired batch dims, and paired contracting dims;
+- compute `M`, `K`, `N`, batch shape, and tenferro output shape;
+- expose CubeK-compatible bindings for `[batch..., M, K]`,
+  `[batch..., K, N]`, and `[batch..., M, N]`;
+- pack same-device WebGPU scratch tensors only when layout metadata cannot
+  represent the required CubeK view;
+- dispatch `F32` to CubeK real GEMM;
+- dispatch `C32` to CubeK complex GEMM with `lhs_conj` and `rhs_conj`;
+- return explicit unsupported errors for `F64`, `C64`, and zero-contracting
+  cases until support is verified.
+
+`WebGpuBackend` must override `TensorDot::dot_general_with_conj`. For `F32`,
+conjugation is identity and should reuse the real path. For `C32`, it forwards
+the flags to CubeK. It must not implement this by calling general WebGPU
+`conj` first.
+
+## Error Handling
+
+CubeK errors should distinguish setup failures from runtime launch failures
+where the current CubeK error model allows it. Tenferro maps CubeK errors into
+`Error::BackendFailure` with operation names that mention WebGPU dot/general
+matmul and include enough detail to diagnose unsupported dtype, layout, or
+runtime problems.
+
+No WebGPU complex GEMM path may silently download tensors, upload tensors, or
+fall back to CPU.
+
+## Tests
+
+CubeK should gain provider-level tests for:
+
+- `C32` rank-2 GEMM without conjugation;
+- `C32` batched GEMM without conjugation;
+- `lhs_conj`, `rhs_conj`, and both-conjugated `C32` GEMM;
+- layout cases matching existing real matmul coverage where feasible;
+- explicit unsupported dtype or shape errors.
+
+Tenferro should gain WebGPU tests for:
+
+- `C32` `dot_general_with_conj` with `lhs_conj`;
+- `C32` `dot_general_with_conj` with `rhs_conj`;
+- batched `C32` `dot_general_with_conj`;
+- `F32` `dot_general_with_conj` routing as identity;
+- CUDA source contract tests proving the CUDA cuTENSOR path is not rewired to
+  CubeK.
+
+Tests that require a WebGPU adapter should use the existing WebGPU availability
+guard. CPU reference calculations are allowed in tests, not in backend
+execution.
+
+## Documentation
+
+Update tenferro developer docs to state that WebGPU complex GEMM semantics are
+owned by CubeK. User docs should describe observable support only:
+
+- WebGPU supports explicit transfer plus experimental `F32` and `C32`
+  `dot_general`/einsum coverage.
+- Conjugated complex `dot_general` is supported for `C32` once this design is
+  implemented.
+- `C64`, `F64`, broad elementwise, reductions, indexing, and linalg remain
+  explicit unsupported WebGPU paths unless separately implemented.
+
+CubeK docs should document the complex GEMM API as a real matmul extension, not
+as a tenferro-specific helper.
+
+## Open Follow-Up
+
+General WebGPU elementwise coverage remains a separate issue. `conj` is a basic
+operation and should be implemented for WebGPU tensors, but complex GEMM
+conjugation should not depend on that path.

--- a/docs/worklogs/2026-06-13-cubek-complex-gemm-api.md
+++ b/docs/worklogs/2026-06-13-cubek-complex-gemm-api.md
@@ -1,0 +1,67 @@
+# CubeK Complex GEMM API Work Log
+
+## Summary
+
+This change moves WebGPU `C32` complex GEMM semantics from tenferro-local
+lowering into CubeK and wires `WebGpuBackend::dot_general_with_conj` through the
+new CubeK API. CUDA contraction code is intentionally unchanged.
+
+## Context Read
+
+- `AGENTS.md`
+- `REPOSITORY_RULES.md`
+- `docs/design/gpu-backend-design.md`
+- `docs/guides/devices-and-gpu.md`
+- `docs/superpowers/plans/2026-06-13-cubek-complex-gemm-api.md`
+- CubeK `cubek-matmul` launch API and complex GEMM tests
+- tenferro WebGPU dot-general planner and runtime tests
+
+## Decisions
+
+- CubeK owns `C32` split/compose, temporary real buffers, and conjugation signs.
+- tenferro keeps only `DotGeneralConfig` normalization, operand packing, and
+  provider dispatch.
+- `C64` remains unsupported until the real `F64` WebGPU matmul path exists.
+- General WebGPU elementwise `conj` remains a follow-up and is not required for
+  complex GEMM conjugation.
+- CUDA `dot_general` algorithms, cuTENSOR descriptors, workspace allocation, and
+  buffer-pool behavior were left unchanged.
+
+## Verification
+
+- `cargo test -p cubek-matmul --test lib complex`
+- `cargo test -p cubek-matmul --test lib`
+- `cargo fmt --all --check` in the CubeK worktree
+- `git diff --check` in the CubeK worktree
+- `cargo test -p tenferro-gpu --test public_surface_contract webgpu_c32_dot_general_with_conj_uses_cubek_complex_api -- --nocapture`
+- `cargo test -p tenferro-gpu --features webgpu webgpu_c32_dot_general_with_lhs_conj_matches_cpu_when_adapter_available -- --nocapture`
+- `cargo test -p tenferro-gpu --features webgpu webgpu_c32_dot_general_with -- --nocapture`
+- `cargo test -p tenferro-gpu --features webgpu webgpu_f32_dot_general_with_conj_is_identity_when_adapter_available -- --nocapture`
+- `cargo test -p tenferro-gpu --features webgpu webgpu_c32_batched_dot_general_with_both_conj_matches_cpu_when_adapter_available -- --nocapture`
+- `cargo test -p tenferro-gpu --features webgpu --test webgpu_matmul_runtime -- --nocapture`
+- `cargo test -p tenferro-tensor tests::backend_default_read_tests::default_read_methods_delegate_owned_tensors_and_reject_views -- --nocapture`
+- `cargo test -p tenferro-cpu test_dot_general_with_conj_matches_materialized_complex_matmul -- --nocapture`
+- `cargo check -p tenferro-gpu --no-default-features --features webgpu,cpu-faer`
+- `cargo check -p tenferro-gpu --no-default-features --features cuda,cpu-faer`
+- `cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer`
+- `cargo check -p tenferro-einsum --no-default-features --features autodiff,webgpu,cpu-faer`
+- `cargo check -p tenferro-einsum --no-default-features --features autodiff,cuda,webgpu,cpu-faer`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `cargo fmt --all --check`
+- `git diff --check`
+
+## Residual Risks
+
+- Runtime performance still uses four real `F32` GEMMs for `C32`; native complex
+  kernels or fused epilogues are future CubeK work.
+- WebGPU runtime tests depend on adapter availability and return early on
+  ordinary runners without an adapter.
+- The tenferro dependency is pinned to a tensor4all CubeK fork commit until
+  CubeK complex GEMM support is upstreamed or published as tensor4all-owned
+  crates.


### PR DESCRIPTION
## Summary

- Pin `cubek-matmul`/`cubek-std` to the tensor4all CubeK fork commit that adds `launch_c32_ref`.
- Route WebGPU `C32` `dot_general` and `dot_general_with_conj` through CubeK's complex GEMM API.
- Remove tenferro-local WebGPU complex split/compose kernels and raw complex reinterpretation helpers.
- Update WebGPU runtime/source-contract tests and GPU docs for `dot_general_with_conj`.

Closes #1045.
Closes #1048.

## Design Notes

- CubeK commit: https://github.com/tensor4all/cubek/commit/7a42081f3f18578014a8b2656ea6a6c79c7fa9be
- Work log: `docs/worklogs/2026-06-13-cubek-complex-gemm-api.md`
- CUDA contraction code is intentionally unchanged: cuTENSOR descriptors, workspace allocation, CUDA buffer pools, and CUDA algorithms are not modified.
- WebGPU still owns only `DotGeneralConfig` normalization and operand packing. CubeK owns `C32` temporary real buffers, split/compose kernels, and conjugation signs.
- No GPU tutorial examples are added in this PR; GPU tutorial execution remains a follow-up CI/docs task.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo check -p tenferro-gpu --no-default-features --features webgpu,cpu-faer`
- `cargo check -p tenferro-gpu --no-default-features --features cuda,cpu-faer`
- `cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer`
- `cargo check -p tenferro-einsum --no-default-features --features autodiff,webgpu,cpu-faer`
- `cargo check -p tenferro-einsum --no-default-features --features autodiff,cuda,webgpu,cpu-faer`
- `cargo test -p tenferro-gpu --features webgpu --test webgpu_matmul_runtime -- --nocapture`
- `cargo test -p tenferro-gpu --test public_surface_contract`
- `cargo test -p tenferro-tensor tests::backend_default_read_tests::default_read_methods_delegate_owned_tensors_and_reject_views -- --nocapture`
- `cargo test -p tenferro-cpu test_dot_general_with_conj_matches_materialized_complex_matmul -- --nocapture`
- CubeK fork: `cargo fmt --all --check`
- CubeK fork: `git diff --check`
- CubeK fork: `cargo test -p cubek-matmul --test lib complex`
- CubeK fork: `cargo test -p cubek-matmul --test lib`
