### PR TITLE
Fix recent bug batch and add Debug summaries

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -19,6 +19,11 @@ rules from `tensor4all-agent-rules`.
 - Keep the public API intentionally small. Prefer `pub(crate)` for types,
   functions, traits, modules, fields, and helper constructors unless external
   users are expected to call them directly.
+- Public types should implement `Debug`. Prefer `derive(Debug)` when the output
+  is cheap, useful, and does not expose unstable internals. Use a hand-written
+  summary for graph, runtime, cache, tensor, backend, or FFI wrapper types when
+  derived output would materialize data, dump large buffers, leak internal
+  representation details, or make future implementation changes harder.
 - Do not make implementation details public just because another module needs
   them. First consider whether the code belongs in the same crate/module, or
   whether a narrower crate-private helper is the right abstraction.

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::env;
+use std::fmt;
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -168,7 +169,7 @@ pub struct EagerRuntimeCacheStats {
 /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
 /// let x = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![1], vec![1.0_f64]), ctx.clone());
 /// let y = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]), ctx);
-/// let z = &x + &y;
+/// let z = x.add(&y).unwrap();
 ///
 /// assert_eq!(z.data().as_slice::<f64>().unwrap(), &[3.0]);
 /// ```
@@ -484,7 +485,7 @@ impl EagerRuntime {
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
     /// let y = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx.clone());
-    /// let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+    /// let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     /// let _ = loss.backward().unwrap();
     ///
     /// ctx.clear_grads();
@@ -605,9 +606,9 @@ impl EagerRuntime {
 ///
 /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
 /// let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx);
-/// let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+/// let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
 /// let _cotangents = loss.backward().unwrap();
-/// let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+/// let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
 /// let _cotangents = loss.backward().unwrap();
 ///
 /// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0, 12.0]);
@@ -627,27 +628,16 @@ pub struct EagerTensor {
     pub(crate) ctx: Arc<EagerRuntime>,
 }
 
-impl std::ops::Add for &EagerTensor {
-    type Output = EagerTensor;
-
-    fn add(self, rhs: &EagerTensor) -> Self::Output {
-        EagerTensor::add(self, rhs).unwrap_or_else(|err| panic!("eager add failed: {}", err))
-    }
-}
-
-impl std::ops::Mul for &EagerTensor {
-    type Output = EagerTensor;
-
-    fn mul(self, rhs: &EagerTensor) -> Self::Output {
-        EagerTensor::mul(self, rhs).unwrap_or_else(|err| panic!("eager mul failed: {}", err))
-    }
-}
-
-impl std::ops::Neg for &EagerTensor {
-    type Output = EagerTensor;
-
-    fn neg(self) -> Self::Output {
-        EagerTensor::neg(self).unwrap_or_else(|err| panic!("eager neg failed: {}", err))
+impl fmt::Debug for EagerTensor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EagerTensor")
+            .field("dtype", &self.dtype())
+            .field("shape", &self.shape())
+            .field("key", &self.key)
+            .field("requires_grad", &self.requires_grad)
+            .field("has_trace", &self.trace.is_some())
+            .field("ctx_id", &self.ctx_id())
+            .finish_non_exhaustive()
     }
 }
 
@@ -945,7 +935,7 @@ impl EagerTensor {
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx.clone());
     /// let y = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]), ctx);
-    /// let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+    /// let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     /// let _ = loss.backward().unwrap();
     ///
     /// x.clear_grad();
@@ -1039,9 +1029,9 @@ impl EagerTensor {
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]), ctx);
-    /// let loss = (&x + &x).reduce_sum(&[0]).unwrap();
+    /// let loss = x.add(&x).unwrap().reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
-    /// let loss = (&x + &x).reduce_sum(&[0]).unwrap();
+    /// let loss = x.add(&x).unwrap().reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
     ///
     /// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 4.0, 4.0]);

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -180,6 +180,38 @@ pub struct EagerRuntime {
     grad_slots: Mutex<HashMap<ValueKey<StdTensorOp>, WeakGradSlot>>,
 }
 
+impl fmt::Debug for EagerRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("EagerRuntime");
+        match self.backend.try_lock() {
+            Ok(backend) => {
+                debug.field("backend", &*backend);
+            }
+            Err(_) => {
+                debug.field("backend", &"<locked>");
+            }
+        }
+        match self.extension_executor.try_lock() {
+            Ok(executor) => {
+                debug.field("extension_executor", &*executor);
+            }
+            Err(_) => {
+                debug.field("extension_executor", &"<locked>");
+            }
+        }
+        debug.field("has_extension_rules", &self.extension_rules.is_some());
+        match self.grad_slots.try_lock() {
+            Ok(slots) => {
+                debug.field("grad_slots_len", &slots.len());
+            }
+            Err(_) => {
+                debug.field("grad_slots_len", &"<locked>");
+            }
+        }
+        debug.finish_non_exhaustive()
+    }
+}
+
 impl EagerRuntime {
     fn from_backend(backend: EagerBackend) -> Self {
         Self::from_backend_with_extension_rules(backend, None)

--- a/crates/tenferro-ad/src/eager_backend.rs
+++ b/crates/tenferro-ad/src/eager_backend.rs
@@ -20,6 +20,18 @@ pub enum EagerBackend {
     WebGpu(WebGpuBackend),
 }
 
+impl std::fmt::Debug for EagerBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Cpu(backend) => f.debug_tuple("Cpu").field(backend).finish(),
+            #[cfg(feature = "cuda")]
+            Self::Cuda(backend) => f.debug_tuple("Cuda").field(backend).finish(),
+            #[cfg(feature = "webgpu")]
+            Self::WebGpu(backend) => f.debug_tuple("WebGpu").field(backend).finish(),
+        }
+    }
+}
+
 impl EagerBackend {
     pub(crate) fn cpu(backend: CpuBackend) -> Self {
         Self::Cpu(backend)

--- a/crates/tenferro-ad/src/eager_builder.rs
+++ b/crates/tenferro-ad/src/eager_builder.rs
@@ -152,3 +152,6 @@ fn zero_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor
         .upload_host_tensor(&host)
         .unwrap_or_else(|err| panic!("eager primitive zero_like upload failed: {}", err))
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-ad/src/eager_builder.rs
+++ b/crates/tenferro-ad/src/eager_builder.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
 use crate::extension_runtime::ExtensionExecutor;
@@ -15,6 +16,17 @@ pub struct EagerPrimitiveBuilder<'a, B: TensorBackend + 'static> {
     pub extension_executor: Option<&'a mut ExtensionExecutor<B>>,
     pub external_data: HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     pub results: Vec<Arc<Tensor>>,
+}
+
+impl<B: TensorBackend + 'static> fmt::Debug for EagerPrimitiveBuilder<'_, B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EagerPrimitiveBuilder")
+            .field("backend_type", &std::any::type_name::<B>())
+            .field("has_extension_executor", &self.extension_executor.is_some())
+            .field("external_data_len", &self.external_data.len())
+            .field("results_len", &self.results.len())
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a, B: TensorBackend + 'static> EagerPrimitiveBuilder<'a, B> {

--- a/crates/tenferro-ad/src/eager_builder/tests.rs
+++ b/crates/tenferro-ad/src/eager_builder/tests.rs
@@ -1,0 +1,34 @@
+use std::sync::Arc;
+
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::Tensor;
+
+use crate::extension_runtime::ExtensionExecutor;
+
+use super::EagerPrimitiveBuilder;
+
+#[test]
+fn debug_summarizes_builder_without_tensor_payloads() {
+    let mut backend = CpuBackend::new();
+    let mut builder = EagerPrimitiveBuilder::new(&mut backend);
+    let id = builder.push_tensor(Arc::new(Tensor::from_vec_col_major(vec![1], vec![1.0_f64])));
+    let _tensor = builder.tensor(id);
+
+    let debug = format!("{builder:?}");
+
+    assert!(debug.contains("EagerPrimitiveBuilder"));
+    assert!(debug.contains("backend_type"));
+    assert!(debug.contains("has_extension_executor: false"));
+    assert!(debug.contains("results_len: 1"));
+}
+
+#[test]
+fn debug_reports_extension_executor_presence() {
+    let mut backend = CpuBackend::new();
+    let mut executor = ExtensionExecutor::<CpuBackend>::new();
+    let builder = EagerPrimitiveBuilder::with_extension_executor(&mut backend, &mut executor);
+
+    let debug = format!("{builder:?}");
+
+    assert!(debug.contains("has_extension_executor: true"));
+}

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -247,11 +247,11 @@ pub trait TracedTensorAdExt {
     /// let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]);
     /// let tangent = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]);
     /// let y = &x * &x;
-    /// let dy = y.jvp(&x, &tangent);
+    /// let dy = y.jvp(&x, &tangent).unwrap();
     ///
     /// assert_eq!(eval(&dy).as_slice::<f64>().unwrap(), &[12.0]);
     /// ```
-    fn jvp(&self, wrt: &TracedTensor, tangent: &TracedTensor) -> TracedTensor;
+    fn jvp(&self, wrt: &TracedTensor, tangent: &TracedTensor) -> Result<TracedTensor>;
 
     /// Like [`jvp`](Self::jvp), but returns `None` when `wrt` is inactive.
     ///
@@ -266,11 +266,19 @@ pub trait TracedTensorAdExt {
     /// let tangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]);
     /// let loss = &y * &y;
     ///
-    /// assert!(loss.jvp_optional(&x, &tangent).is_none());
+    /// assert!(loss.jvp_optional(&x, &tangent).unwrap().is_none());
     /// ```
-    fn jvp_optional(&self, wrt: &TracedTensor, tangent: &TracedTensor) -> Option<TracedTensor>;
+    fn jvp_optional(
+        &self,
+        wrt: &TracedTensor,
+        tangent: &TracedTensor,
+    ) -> Result<Option<TracedTensor>>;
 
     /// Fallible forward-mode Jacobian-vector product.
+    ///
+    /// This is an alias for [`jvp_optional`](Self::jvp_optional), retained for
+    /// callers that adopted the explicit fallible name before the compact
+    /// method became fallible.
     ///
     /// # Examples
     ///
@@ -323,11 +331,11 @@ pub trait TracedTensorAdExt {
     /// let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]);
     /// let cotangent = TracedTensor::from_vec_col_major(vec![], vec![0.5_f64]);
     /// let y = &x * &x;
-    /// let dx = y.vjp(&x, &cotangent);
+    /// let dx = y.vjp(&x, &cotangent).unwrap();
     ///
     /// assert_eq!(eval(&dx).as_slice::<f64>().unwrap(), &[3.0]);
     /// ```
-    fn vjp(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> TracedTensor;
+    fn vjp(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> Result<TracedTensor>;
 
     /// Like [`vjp`](Self::vjp), but returns `None` when `wrt` is inactive.
     ///
@@ -342,11 +350,19 @@ pub trait TracedTensorAdExt {
     /// let cotangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]);
     /// let loss = &y * &y;
     ///
-    /// assert!(loss.vjp_optional(&x, &cotangent).is_none());
+    /// assert!(loss.vjp_optional(&x, &cotangent).unwrap().is_none());
     /// ```
-    fn vjp_optional(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> Option<TracedTensor>;
+    fn vjp_optional(
+        &self,
+        wrt: &TracedTensor,
+        cotangent: &TracedTensor,
+    ) -> Result<Option<TracedTensor>>;
 
     /// Fallible reverse-mode vector-Jacobian product.
+    ///
+    /// This is an alias for [`vjp_optional`](Self::vjp_optional), retained for
+    /// callers that adopted the explicit fallible name before the compact
+    /// method became fallible.
     ///
     /// Complex cotangents use tenferro's Hermitian real-inner-product
     /// convention. Non-real complex cotangent seeds therefore need an explicit
@@ -413,14 +429,21 @@ impl TracedTensorAdExt for TracedTensor {
         Ok(())
     }
 
-    fn jvp(&self, wrt: &TracedTensor, tangent: &TracedTensor) -> TracedTensor {
-        self.jvp_optional(wrt, tangent)
-            .unwrap_or_else(|| panic!("jvp output is inactive for {:?}", leaf_input_key(wrt)))
+    fn jvp(&self, wrt: &TracedTensor, tangent: &TracedTensor) -> Result<TracedTensor> {
+        self.jvp_optional(wrt, tangent)?.ok_or_else(|| {
+            Error::Internal(format!(
+                "jvp output is inactive for {:?}",
+                leaf_input_key(wrt)
+            ))
+        })
     }
 
-    fn jvp_optional(&self, wrt: &TracedTensor, tangent: &TracedTensor) -> Option<TracedTensor> {
+    fn jvp_optional(
+        &self,
+        wrt: &TracedTensor,
+        tangent: &TracedTensor,
+    ) -> Result<Option<TracedTensor>> {
         self.jvp_optional_result(wrt, tangent)
-            .unwrap_or_else(|err| panic!("{err}"))
     }
 
     fn jvp_optional_result(
@@ -431,14 +454,21 @@ impl TracedTensorAdExt for TracedTensor {
         jvp_optional_result_with_rules(self, wrt, tangent, None)
     }
 
-    fn vjp(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> TracedTensor {
-        self.vjp_optional(wrt, cotangent)
-            .unwrap_or_else(|| panic!("vjp output is inactive for {:?}", leaf_input_key(wrt)))
+    fn vjp(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> Result<TracedTensor> {
+        self.vjp_optional(wrt, cotangent)?.ok_or_else(|| {
+            Error::Internal(format!(
+                "vjp output is inactive for {:?}",
+                leaf_input_key(wrt)
+            ))
+        })
     }
 
-    fn vjp_optional(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> Option<TracedTensor> {
+    fn vjp_optional(
+        &self,
+        wrt: &TracedTensor,
+        cotangent: &TracedTensor,
+    ) -> Result<Option<TracedTensor>> {
         self.vjp_optional_result(wrt, cotangent)
-            .unwrap_or_else(|err| panic!("{err}"))
     }
 
     fn vjp_optional_result(

--- a/crates/tenferro-ad/tests/ad.rs
+++ b/crates/tenferro-ad/tests/ad.rs
@@ -181,7 +181,7 @@ fn register_graph_metadata_for_test(
         for (&output_id, extents) in op_node
             .outputs
             .iter()
-            .zip(infer_output_extents(&op_node.operation, &input_shape_refs))
+            .zip(infer_output_extents(&op_node.operation, &input_shape_refs).unwrap())
         {
             let resolved_extents = extents
                 .into_iter()
@@ -251,7 +251,7 @@ fn eval_graph_outputs(
             _ => panic!("expected input key"),
         })
         .collect();
-    let exec = compile_std_to_exec(&compiled, &input_dtypes, &input_shapes);
+    let exec = compile_std_to_exec(&compiled, &input_dtypes, &input_shapes).unwrap();
     let mut executor = GraphExecutor::new(CpuBackend::new());
     executor.eval_exec_ir(&exec, inputs).unwrap()
 }
@@ -876,7 +876,7 @@ fn jvp_extract_diag() {
     ));
 
     let diag = a.extract_diag(0, 1);
-    let jvp = diag.jvp(&a, &da);
+    let jvp = diag.jvp(&a, &da).unwrap();
 
     let result = eval_tensor(jvp);
     assert_eq!(result.shape(), &[3]);
@@ -889,7 +889,7 @@ fn jvp_embed_diag() {
     let dx = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![0.5, -1.0, 2.0]));
 
     let diag = x.embed_diag(0, 1);
-    let jvp = diag.jvp(&x, &dx);
+    let jvp = diag.jvp(&x, &dx).unwrap();
 
     let result = eval_tensor(jvp);
     assert_eq!(result.shape(), &[3, 3]);
@@ -1048,7 +1048,7 @@ fn jvp_elementwise_mul() {
     let dx = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 0.0, 0.0]));
 
     let prod = &x * &y;
-    let jvp = prod.jvp(&x, &dx);
+    let jvp = prod.jvp(&x, &dx).unwrap();
 
     let result = eval_tensor(jvp);
     assert_close_slice(get_f64_data(&result), &[4.0, 0.0, 0.0]);
@@ -1061,7 +1061,7 @@ fn jvp_elementwise_mul_y_tangent() {
     let dy = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![0.0, -1.0, 2.0]));
 
     let prod = &x * &y;
-    let jvp = prod.jvp(&y, &dy);
+    let jvp = prod.jvp(&y, &dy).unwrap();
 
     let result = eval_tensor(jvp);
     assert_close_slice(get_f64_data(&result), &[0.0, -2.0, 6.0]);
@@ -1074,7 +1074,7 @@ fn jvp_elementwise_add_y_tangent() {
     let dy = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![0.5, -1.0, 2.0]));
 
     let sum = &x + &y;
-    let jvp = sum.jvp(&y, &dy);
+    let jvp = sum.jvp(&y, &dy).unwrap();
 
     let result = eval_tensor(jvp);
     assert_close_slice(get_f64_data(&result), &[0.5, -1.0, 2.0]);
@@ -1170,11 +1170,11 @@ fn complex_abs_ad_matches_jax_real_output_convention() {
 
     let x = TracedTensor::from_tensor_concrete_shape(c64_tensor(vec![2], input_data.clone()));
     let dx = TracedTensor::from_tensor_concrete_shape(c64_tensor(vec![2], tangent_data.clone()));
-    let dy = x.abs().jvp(&x, &dx);
+    let dy = x.abs().jvp(&x, &dx).unwrap();
 
     let cotangent =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], cotangent_data.clone()));
-    let grad = x.abs().vjp(&x, &cotangent);
+    let grad = x.abs().vjp(&x, &cotangent).unwrap();
 
     let results =
         run_many_traced_with(&mut GraphExecutor::new(CpuBackend::new()), &[&dy, &grad]).unwrap();
@@ -1215,8 +1215,8 @@ fn complex_sign_ad_is_zero_like_jax() {
     ));
 
     let signed = x.sign();
-    let tangent = signed.jvp(&x, &dx);
-    let grad = signed.vjp(&x, &cotangent);
+    let tangent = signed.jvp(&x, &dx).unwrap();
+    let grad = signed.vjp(&x, &cotangent).unwrap();
 
     let results = run_many_traced_with(
         &mut GraphExecutor::new(CpuBackend::new()),
@@ -1237,16 +1237,16 @@ fn elementwise_extrema_ties_split_cotangents_like_jax() {
     let cotangent = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![4.0, 6.0]));
     let maximum = traced_tensor::maximum(&x, &y);
 
-    let max_jvp_x = maximum.jvp(&x, &dx);
-    let max_jvp_y = maximum.jvp(&y, &dy);
-    let max_vjp_x = maximum.vjp(&x, &cotangent);
-    let max_vjp_y = maximum.vjp(&y, &cotangent);
+    let max_jvp_x = maximum.jvp(&x, &dx).unwrap();
+    let max_jvp_y = maximum.jvp(&y, &dy).unwrap();
+    let max_vjp_x = maximum.vjp(&x, &cotangent).unwrap();
+    let max_vjp_y = maximum.vjp(&y, &cotangent).unwrap();
 
     let min_lhs = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![2.0, 3.0]));
     let min_rhs = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![2.0, 4.0]));
     let minimum = traced_tensor::minimum(&min_lhs, &min_rhs);
-    let min_vjp_lhs = minimum.vjp(&min_lhs, &cotangent);
-    let min_vjp_rhs = minimum.vjp(&min_rhs, &cotangent);
+    let min_vjp_lhs = minimum.vjp(&min_lhs, &cotangent).unwrap();
+    let min_vjp_rhs = minimum.vjp(&min_rhs, &cotangent).unwrap();
 
     let results = run_many_traced_with(
         &mut GraphExecutor::new(CpuBackend::new()),
@@ -1287,12 +1287,12 @@ fn clamp_ad_uses_strict_jax_boundary_masks() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![10.0, 20.0, 30.0, 40.0]));
 
     let clamped = traced_tensor::clamp(&input, &lower, &upper);
-    let input_jvp = clamped.jvp(&input, &d_input);
-    let lower_jvp = clamped.jvp(&lower, &d_lower);
-    let upper_jvp = clamped.jvp(&upper, &d_upper);
-    let input_vjp = clamped.vjp(&input, &cotangent);
-    let lower_vjp = clamped.vjp(&lower, &cotangent);
-    let upper_vjp = clamped.vjp(&upper, &cotangent);
+    let input_jvp = clamped.jvp(&input, &d_input).unwrap();
+    let lower_jvp = clamped.jvp(&lower, &d_lower).unwrap();
+    let upper_jvp = clamped.jvp(&upper, &d_upper).unwrap();
+    let input_vjp = clamped.vjp(&input, &cotangent).unwrap();
+    let lower_vjp = clamped.vjp(&lower, &cotangent).unwrap();
+    let upper_vjp = clamped.vjp(&upper, &cotangent).unwrap();
 
     let results = run_many_traced_with(
         &mut GraphExecutor::new(CpuBackend::new()),
@@ -1322,8 +1322,8 @@ fn complex_div_and_pow_vjps_conjugate_holomorphic_coefficients() {
         TracedTensor::from_tensor_concrete_shape(c64_tensor(vec![2], cotangent_data.clone()));
     let quotient = x.div(&y);
 
-    let div_vjp_x = eval_tensor(quotient.vjp(&x, &cotangent));
-    let div_vjp_y = eval_tensor(quotient.vjp(&y, &cotangent));
+    let div_vjp_x = eval_tensor(quotient.vjp(&x, &cotangent).unwrap());
+    let div_vjp_y = eval_tensor(quotient.vjp(&y, &cotangent).unwrap());
 
     let expected_div_x: Vec<_> = y_data
         .iter()
@@ -1340,8 +1340,8 @@ fn complex_div_and_pow_vjps_conjugate_holomorphic_coefficients() {
     assert_close_slice_c64(get_c64_data(&div_vjp_y), &expected_div_y);
 
     let pow = x.pow(&y);
-    let pow_vjp_x = eval_tensor(pow.vjp(&x, &cotangent));
-    let pow_vjp_y = eval_tensor(pow.vjp(&y, &cotangent));
+    let pow_vjp_x = eval_tensor(pow.vjp(&x, &cotangent).unwrap());
+    let pow_vjp_y = eval_tensor(pow.vjp(&y, &cotangent).unwrap());
 
     let expected_pow_x: Vec<_> = x_data
         .iter()
@@ -1763,8 +1763,8 @@ fn convert_eval_jvp_and_vjp_follow_real_complex_adjoint_rules() {
     ));
 
     let roundtrip = x.convert(DType::C64).convert(DType::F64);
-    let jvp = x.convert(DType::C64).jvp(&x, &dx);
-    let vjp = x.convert(DType::C64).vjp(&x, &cotangent);
+    let jvp = x.convert(DType::C64).jvp(&x, &dx).unwrap();
+    let vjp = x.convert(DType::C64).vjp(&x, &cotangent).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let results = run_many_traced_with(&mut engine, &[&roundtrip, &jvp, &vjp]).unwrap();
@@ -1877,7 +1877,7 @@ fn vjp_matmul() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![1.0, 1.0, 1.0, 1.0]));
 
     let y = a.dot_general(&b, matmul_config());
-    let vjp = y.vjp(&a, &cotangent);
+    let vjp = y.vjp(&a, &cotangent).unwrap();
 
     let result = eval_tensor(vjp);
     assert_close_slice(get_f64_data(&result), &[5.0, 5.0, 7.0, 7.0, 9.0, 9.0]);

--- a/crates/tenferro-ad/tests/ad/reductions_and_indexing.rs
+++ b/crates/tenferro-ad/tests/ad/reductions_and_indexing.rs
@@ -639,7 +639,7 @@ fn jvp_traced_index_select_gathers_tangent() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![0.5, 1.5, 2.5, 3.5]));
 
     let y = x.index_select(0, &[3, 1, 3]).unwrap();
-    let tangent_y = eval_tensor(y.jvp(&x, &tangent));
+    let tangent_y = eval_tensor(y.jvp(&x, &tangent).unwrap());
 
     assert_eq!(tangent_y.shape(), &[3]);
     assert_close_slice(get_f64_data(&tangent_y), &[3.5, 1.5, 3.5]);
@@ -656,7 +656,7 @@ fn hvp_traced_index_select_repeated_positions_accumulates() {
     let selected = x.index_select(0, &[1, 1, 2]).unwrap();
     let loss = (&(&selected * &selected) * &weights).reduce_sum(&[0]);
     let grad = loss.grad(&x).unwrap();
-    let hvp = eval_tensor(grad.jvp(&x, &tangent));
+    let hvp = eval_tensor(grad.jvp(&x, &tangent).unwrap());
 
     assert_eq!(hvp.shape(), &[3]);
     assert_close_slice(get_f64_data(&hvp), &[0.0, -60.0, 120.0]);

--- a/crates/tenferro-ad/tests/ad_structural_primitives.rs
+++ b/crates/tenferro-ad/tests/ad_structural_primitives.rs
@@ -83,7 +83,7 @@ fn eager_maximum_and_minimum_gradients_match_finite_diff() {
         .unwrap()
         .reduce_sum(&[0])
         .unwrap();
-    let loss = &max_loss + &min_loss;
+    let loss = max_loss.add(&min_loss).unwrap();
     let _ = loss.backward().unwrap();
 
     let grad_x = x.grad().unwrap();

--- a/crates/tenferro-ad/tests/checkpoint.rs
+++ b/crates/tenferro-ad/tests/checkpoint.rs
@@ -86,7 +86,7 @@ fn checkpoint_hvp_correct() {
 
     let grad = z.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_scalar(1.0));
-    let hv = grad.jvp(&x, &v);
+    let hv = grad.jvp(&x, &v).unwrap();
     let hv_value = get_f64_scalar(&eval_tensor(hv));
     let expected = 12.0 * x_value * x_value;
     assert!(

--- a/crates/tenferro-ad/tests/compiler_wiring.rs
+++ b/crates/tenferro-ad/tests/compiler_wiring.rs
@@ -66,7 +66,8 @@ fn compile_std_to_exec_wires_remaining_simple_ops() {
         &program,
         &[DType::F64, DType::F64, DType::F64],
         &[dim_shape(&[2, 2]), dim_shape(&[2, 2]), dim_shape(&[2, 2])],
-    );
+    )
+    .unwrap();
 
     assert!(matches!(
         exec.instructions[0].op,
@@ -147,7 +148,8 @@ fn compile_std_to_exec_wires_indexing_ops() {
         &program,
         &[DType::F64, DType::F64, DType::F64],
         &[dim_shape(&[4, 3]), dim_shape(&[2, 1]), dim_shape(&[3])],
-    );
+    )
+    .unwrap();
 
     assert!(matches!(
         exec.instructions[0].op,
@@ -200,7 +202,8 @@ fn compile_std_to_exec_does_not_treat_dynamic_truncate_bound_as_exact() {
         &program,
         &[DType::F64, DType::F64],
         &[dim_shape(&[5]), Vec::new()],
-    );
+    )
+    .unwrap();
 
     assert_eq!(exec.instructions.len(), 1);
     assert_eq!(exec.output_slots, vec![2]);
@@ -230,7 +233,7 @@ fn compile_std_to_exec_marks_unresolvable_extent_unknown() {
         n_slots: 2,
     };
 
-    let exec = compile_std_to_exec(&program, &[DType::F64], &[Vec::new()]);
+    let exec = compile_std_to_exec(&program, &[DType::F64], &[Vec::new()]).unwrap();
 
     assert_eq!(
         exec.instructions[0].output_extents[0][0],
@@ -263,7 +266,7 @@ fn compile_std_to_exec_wires_constant_and_convert_ops() {
         n_slots: 4,
     };
 
-    let exec = compile_std_to_exec(&program, &[DType::F64], &[dim_shape(&[2])]);
+    let exec = compile_std_to_exec(&program, &[DType::F64], &[dim_shape(&[2])]).unwrap();
 
     assert!(matches!(
         exec.instructions[0].op,

--- a/crates/tenferro-ad/tests/dynamic_truncate.rs
+++ b/crates/tenferro-ad/tests/dynamic_truncate.rs
@@ -172,7 +172,7 @@ fn dynamic_truncate_jvp_correct() {
     let loss = (&truncated * &truncated).reduce_sum(&[0]);
 
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![1.0; 5]));
-    let jvp_result = loss.jvp(&x, &v);
+    let jvp_result = loss.jvp(&x, &v).unwrap();
     let jvp_value = get_f64_data(&jvp_result.run_with(&mut engine).unwrap())[0];
     assert!(
         (jvp_value - 12.0).abs() < TOL,
@@ -194,7 +194,7 @@ fn dynamic_truncate_hvp_correct() {
 
     let grad = loss.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![1.0; 5]));
-    let hv = grad.jvp(&x, &v);
+    let hv = grad.jvp(&x, &v).unwrap();
     let hv_data = get_f64_data(&hv.run_with(&mut engine).unwrap());
 
     assert_eq!(hv_data.len(), 5);
@@ -245,7 +245,7 @@ fn dynamic_truncate_hvp_finite_diff() {
     let loss = (&truncated * &truncated).reduce_sum(&[0]);
     let grad = loss.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], v_data));
-    let hv = grad.jvp(&x, &v);
+    let hv = grad.jvp(&x, &v).unwrap();
     let hv_data = get_f64_data(&hv.run_with(&mut engine).unwrap());
 
     for (index, (actual, expected)) in hv_data.iter().zip(&fd_hv).enumerate() {
@@ -287,7 +287,7 @@ fn pad_to_match_jvp_correct() {
     let loss = (&padded * &padded).reduce_sum(&[0]);
 
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 1.0, 1.0]));
-    let jvp_result = loss.jvp(&x, &v);
+    let jvp_result = loss.jvp(&x, &v).unwrap();
     let jvp_val = get_f64_data(&jvp_result.run_with(&mut engine).unwrap())[0];
     // dot(grad, v) = 2+4+6 = 12
     assert!((jvp_val - 12.0).abs() < TOL, "jvp={jvp_val}, expected=12");
@@ -306,7 +306,7 @@ fn pad_to_match_hvp_correct() {
 
     let grad = loss.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 1.0, 1.0]));
-    let hv = grad.jvp(&x, &v);
+    let hv = grad.jvp(&x, &v).unwrap();
     let hv_data = get_f64_data(&hv.run_with(&mut engine).unwrap());
 
     for (i, val) in hv_data.iter().enumerate() {

--- a/crates/tenferro-ad/tests/eager_runtime_api.rs
+++ b/crates/tenferro-ad/tests/eager_runtime_api.rs
@@ -11,7 +11,7 @@ fn eager_runtime_replaces_eager_context_public_name() {
         Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
         runtime.clone(),
     );
-    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
 
     loss.backward().unwrap();
 

--- a/crates/tenferro-ad/tests/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/eager_tensor.rs
@@ -157,7 +157,7 @@ fn matrix_eager_input_uses_column_major_values() {
         Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]),
         test_ctx(),
     );
-    let y = &x + &x;
+    let y = x.add(&x).unwrap();
 
     assert_eq!(y.data().shape(), &[2, 3]);
     assert_eq!(f64_data(y.data()), &[2.0, 8.0, 4.0, 10.0, 6.0, 12.0]);
@@ -170,14 +170,14 @@ fn untracked_eager_intermediate_can_later_feed_tracked_ad() {
         Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
         ctx.clone(),
     );
-    let scale = &plain + &plain;
+    let scale = plain.add(&plain).unwrap();
     assert!(!scale.tracks_grad());
 
     let x = EagerTensor::requires_grad_in(
         Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]),
         ctx,
     );
-    let loss = (&x * &scale).reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&scale).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
     assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
@@ -367,7 +367,7 @@ fn eager_index_select_repeated_positions_accumulates_grad() {
     );
 
     let selected = x.index_select(0, &[1, 1, 2]).unwrap();
-    let loss = (&selected * &weights).reduce_sum(&[0]).unwrap();
+    let loss = selected.mul(&weights).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
     assert_close_slice(
@@ -384,7 +384,7 @@ fn eager_x_squared_gradient_matches_finite_difference() {
         Tensor::from_vec_col_major(vec![3], x_data.clone()),
         test_ctx(),
     );
-    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
     let grad = x.grad().unwrap();
 
@@ -408,11 +408,11 @@ fn eager_repeated_backward_accumulates_across_calls() {
         test_ctx(),
     );
 
-    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
     assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
 
-    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
     assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[4.0, 8.0, 12.0], TOL);
 }
@@ -473,7 +473,7 @@ fn eager_fan_out_accumulates_gradient() {
         Tensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]),
         test_ctx(),
     );
-    let loss = (&x + &x).reduce_sum(&[0]).unwrap();
+    let loss = x.add(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
     let grad = x.grad().unwrap();
@@ -492,7 +492,7 @@ fn eager_clear_grad_resets_only_one_leaf() {
         ctx.clone(),
     );
 
-    let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
     x.clear_grad();
@@ -500,7 +500,7 @@ fn eager_clear_grad_resets_only_one_leaf() {
     assert!(x.grad().is_none());
     assert_close_slice(f64_data(y.grad().unwrap().as_ref()), &[1.0, 2.0, 3.0], TOL);
 
-    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
     assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
@@ -519,7 +519,7 @@ fn eager_context_clear_grads_resets_all_live_leaves() {
         ctx.clone(),
     );
 
-    let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
     ctx.clear_grads();
@@ -527,7 +527,7 @@ fn eager_context_clear_grads_resets_all_live_leaves() {
     assert!(x.grad().is_none());
     assert!(y.grad().is_none());
 
-    let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
     assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[4.0, 5.0, 6.0], TOL);
@@ -546,11 +546,11 @@ fn eager_unrelated_backward_keeps_existing_leaf_grad() {
         ctx.clone(),
     );
 
-    let loss_x = (&x * &x).reduce_sum(&[0]).unwrap();
+    let loss_x = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss_x.backward().unwrap();
     assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
 
-    let loss_y = (&y * &y).reduce_sum(&[0]).unwrap();
+    let loss_y = y.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss_y.backward().unwrap();
 
     assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
@@ -591,7 +591,7 @@ fn eager_context_and_tensor_are_backend_erased_public_types() {
 
     let ctx: Arc<EagerRuntime> = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1));
     let x = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]));
-    let loss = (&x * &x).reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     loss.backward().unwrap();
 
     assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
@@ -604,7 +604,7 @@ fn eager_detach_cuts_one_gradient_path() {
         test_ctx(),
     );
     let detached = x.detach();
-    let loss = (&detached * &x).reduce_sum(&[0]).unwrap();
+    let loss = detached.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
     let grad = x.grad().unwrap();
@@ -622,7 +622,7 @@ fn eager_untracked_tensor_behaves_like_plain_tensor() {
         Tensor::from_vec_col_major(vec![3], vec![4.0, 5.0, 6.0]),
         test_ctx(),
     );
-    let z = &x * &y;
+    let z = x.mul(&y).unwrap();
 
     assert_close_slice(f64_data(z.data()), &[4.0, 10.0, 18.0], TOL);
     assert!(x.grad().is_none());

--- a/crates/tenferro-ad/tests/fallible_api.rs
+++ b/crates/tenferro-ad/tests/fallible_api.rs
@@ -1,0 +1,37 @@
+use tenferro_ad::{EagerRuntime, EagerTensor, TracedTensorAdExt};
+use tenferro_runtime::TracedTensor;
+use tenferro_tensor::{Error as TensorError, Tensor};
+
+#[test]
+fn traced_jvp_vjp_return_errors_for_inactive_inputs() {
+    let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]);
+    let y = TracedTensor::from_vec_col_major(vec![], vec![4.0_f64]);
+    let tangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]);
+    let cotangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]);
+    let loss = &y * &y;
+
+    let _ = loss.jvp(&x, &tangent).unwrap_err();
+    let _ = loss.vjp(&x, &cotangent).unwrap_err();
+    assert!(loss.jvp_optional(&x, &tangent).unwrap().is_none());
+    assert!(loss.vjp_optional(&x, &cotangent).unwrap().is_none());
+}
+
+#[test]
+fn eager_binary_methods_return_shape_errors() {
+    let ctx = EagerRuntime::new();
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        ctx.clone(),
+    );
+    let y = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        ctx,
+    );
+
+    let err = x.add(&y).unwrap_err();
+
+    assert!(matches!(
+        err,
+        tenferro_ad::Error::TensorRuntime(TensorError::ShapeMismatch { op: "add", .. })
+    ));
+}

--- a/crates/tenferro-ad/tests/gpu_ad_tests.rs
+++ b/crates/tenferro-ad/tests/gpu_ad_tests.rs
@@ -112,8 +112,8 @@ fn test_gpu_matmul_vjp() {
     let cotangent_cpu = TracedTensor::from_tensor_concrete_shape(cotangent_host.clone());
     let mut cpu_engine = GraphExecutor::new(CpuBackend::new());
     let y_cpu = matmul(&a_cpu, &b_cpu);
-    let mut grad_a_cpu = y_cpu.vjp(&a_cpu, &cotangent_cpu);
-    let mut grad_b_cpu = y_cpu.vjp(&b_cpu, &cotangent_cpu);
+    let mut grad_a_cpu = y_cpu.vjp(&a_cpu, &cotangent_cpu).unwrap();
+    let mut grad_b_cpu = y_cpu.vjp(&b_cpu, &cotangent_cpu).unwrap();
     let cpu_grad_a = eval_cpu_tensor(&mut cpu_engine, &mut grad_a_cpu);
     let cpu_grad_b = eval_cpu_tensor(&mut cpu_engine, &mut grad_b_cpu);
 
@@ -123,8 +123,8 @@ fn test_gpu_matmul_vjp() {
     let cotangent_gpu = upload_traced(&gpu_backend, &cotangent_host);
     let mut gpu_engine = GraphExecutor::new(gpu_backend);
     let y_gpu = matmul(&a_gpu, &b_gpu);
-    let mut grad_a_gpu = y_gpu.vjp(&a_gpu, &cotangent_gpu);
-    let mut grad_b_gpu = y_gpu.vjp(&b_gpu, &cotangent_gpu);
+    let mut grad_a_gpu = y_gpu.vjp(&a_gpu, &cotangent_gpu).unwrap();
+    let mut grad_b_gpu = y_gpu.vjp(&b_gpu, &cotangent_gpu).unwrap();
     let gpu_grad_a = eval_gpu_tensor(&mut gpu_engine, &mut grad_a_gpu);
     let gpu_grad_b = eval_gpu_tensor(&mut gpu_engine, &mut grad_b_gpu);
 

--- a/crates/tenferro-ad/tests/hvp.rs
+++ b/crates/tenferro-ad/tests/hvp.rs
@@ -86,7 +86,7 @@ fn hvp_for_scalar_cubic() {
 
     let g = y.grad(&x).unwrap(); // reverse: f'(x) = 3x^2
     let v = TracedTensor::from_tensor_concrete_shape(f64_scalar(1.0));
-    let hv = g.jvp(&x, &v); // forward-of-reverse: f''(x)
+    let hv = g.jvp(&x, &v).unwrap(); // forward-of-reverse: f''(x)
 
     let hv_tensor = eval_tensor(hv);
     let hv_val = get_f64_data(&hv_tensor)[0];
@@ -111,7 +111,7 @@ fn hvp_for_scalar_exp_sin() {
 
     let g = y.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_scalar(1.0));
-    let hv = g.jvp(&x, &v);
+    let hv = g.jvp(&x, &v).unwrap();
 
     let hv_tensor = eval_tensor(hv);
     let hv_val = get_f64_data(&hv_tensor)[0];
@@ -138,7 +138,7 @@ fn hvp_for_vector_exp_sum() {
 
     let g = y.grad(&x).unwrap(); // shape [n]
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![n], v_data.clone()));
-    let hv = g.jvp(&x, &v); // FoR: shape [n]
+    let hv = g.jvp(&x, &v).unwrap(); // FoR: shape [n]
 
     let hv_tensor = eval_tensor(hv);
     let hv_val = get_f64_data(&hv_tensor);
@@ -173,7 +173,7 @@ fn hvp_for_quadratic_form() {
     let y = vector_dot(&x, &ax);
 
     let g = y.grad(&x).unwrap();
-    let hv = g.jvp(&x, &v);
+    let hv = g.jvp(&x, &v).unwrap();
 
     let hv_tensor = eval_tensor(hv);
     let hv_val = get_f64_data(&hv_tensor);

--- a/crates/tenferro-ad/tests/shape_inference.rs
+++ b/crates/tenferro-ad/tests/shape_inference.rs
@@ -1,11 +1,25 @@
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeExtent;
-use tenferro_runtime::extension::{infer_output_extents, infer_output_shapes};
+use tenferro_runtime::extension::{
+    infer_output_extents as try_infer_output_extents,
+    infer_output_shapes as try_infer_output_shapes,
+};
 use tenferro_tensor::{DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig};
 
 fn cst(n: usize) -> DimExpr {
     DimExpr::Const(n)
+}
+
+fn infer_output_shapes(op: &StdTensorOp, input_shapes: &[&[DimExpr]]) -> Vec<Vec<DimExpr>> {
+    try_infer_output_shapes(op, input_shapes).unwrap()
+}
+
+fn infer_output_extents(
+    op: &StdTensorOp,
+    input_shapes: &[&[DimExpr]],
+) -> Vec<Vec<ShapeExtent<DimExpr>>> {
+    try_infer_output_extents(op, input_shapes).unwrap()
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -1,6 +1,7 @@
 use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::env;
+use std::fmt;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -223,6 +224,17 @@ pub struct CpuBackend {
     pub(crate) ctx: Arc<CpuContext>,
     pub(crate) buffers: BufferPool,
     kind: CpuBackendKind,
+}
+
+impl fmt::Debug for CpuBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CpuBackend")
+            .field("kind", &self.kind)
+            .field("num_threads", &self.num_threads())
+            .field("buffer_pool_cache_stats", &self.buffer_pool_cache_stats())
+            .field("buffer_pool_limit_bytes", &self.buffer_pool_limit_bytes())
+            .finish_non_exhaustive()
+    }
 }
 
 impl CpuBackend {

--- a/crates/tenferro-cpu/src/buffer_pool.rs
+++ b/crates/tenferro-cpu/src/buffer_pool.rs
@@ -14,6 +14,7 @@
 
 use std::collections::BTreeMap;
 use std::env;
+use std::fmt;
 use std::mem::size_of;
 
 use num_complex::{Complex32, Complex64};
@@ -73,6 +74,18 @@ pub struct BufferPool {
     c32_pool: BTreeMap<usize, Vec<Vec<Complex32>>>,
     retained_capacity_bytes: usize,
     max_retained_capacity_bytes: usize,
+}
+
+impl fmt::Debug for BufferPool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BufferPool")
+            .field("stats", &self.stats())
+            .field(
+                "max_retained_capacity_bytes",
+                &self.max_retained_capacity_bytes,
+            )
+            .finish_non_exhaustive()
+    }
 }
 
 /// Scalar types supported by [`BufferPool`].

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -1,5 +1,6 @@
 use num_traits::{One, Zero};
 use smallvec::{Array, SmallVec};
+use std::fmt;
 use std::mem::size_of;
 
 use crate::buffer_pool::{BufferPool, PoolScalar};
@@ -198,6 +199,15 @@ impl GemmAnalysisCacheSlot {
 pub struct GemmAnalysisCache {
     slots: Vec<GemmAnalysisCacheSlot>,
     max_slots: usize,
+}
+
+impl fmt::Debug for GemmAnalysisCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GemmAnalysisCache")
+            .field("slots_len", &self.slots.len())
+            .field("max_slots", &self.max_slots)
+            .finish_non_exhaustive()
+    }
 }
 
 impl GemmAnalysisCache {

--- a/crates/tenferro-cpu/src/inject.rs
+++ b/crates/tenferro-cpu/src/inject.rs
@@ -81,6 +81,15 @@ pub enum ProviderRegistrationError {
     /// The underlying inject crate returned an unknown status code.
     #[error("{symbol} provider registration returned status {status}")]
     UnknownStatus { symbol: &'static str, status: i32 },
+    /// A raw provider pointer cannot be represented as the requested function pointer type.
+    #[error(
+        "{symbol} provider pointer size {pointer_size} does not match function pointer size {function_pointer_size}"
+    )]
+    FunctionPointerSizeMismatch {
+        symbol: &'static str,
+        pointer_size: usize,
+        function_pointer_size: usize,
+    },
 }
 
 // --- Raw-pointer provider sets -------------------------------------------
@@ -623,16 +632,36 @@ macro_rules! register_lapack_symbol {
         }
         let status = match $abi {
             ProviderAbi::Lp64 => {
-                let f = unsafe { std::mem::transmute::<*const std::ffi::c_void, $lp64_ty>(raw) };
+                let f = unsafe { cast_provider_function_pointer::<$lp64_ty>($symbol, raw)? };
                 unsafe { $lp64_reg(f) }
             }
             ProviderAbi::Ilp64 => {
-                let f = unsafe { std::mem::transmute::<*const std::ffi::c_void, $ilp64_ty>(raw) };
+                let f = unsafe { cast_provider_function_pointer::<$ilp64_ty>($symbol, raw)? };
                 unsafe { $ilp64_reg(f) }
             }
         };
         lapack_registration_status($symbol, status)?;
     }};
+}
+
+unsafe fn cast_provider_function_pointer<F: Copy>(
+    symbol: &'static str,
+    raw: *const c_void,
+) -> Result<F, ProviderRegistrationError> {
+    let pointer_size = std::mem::size_of::<*const c_void>();
+    let function_pointer_size = std::mem::size_of::<F>();
+    if pointer_size != function_pointer_size {
+        return Err(ProviderRegistrationError::FunctionPointerSizeMismatch {
+            symbol,
+            pointer_size,
+            function_pointer_size,
+        });
+    }
+
+    // SAFETY: Callers provide a non-null provider symbol pointer for the exact
+    // LAPACK ABI type `F`. The size check above rejects targets where an opaque
+    // provider pointer cannot be represented as that function pointer type.
+    Ok(unsafe { std::mem::transmute_copy::<*const c_void, F>(&raw) })
 }
 
 /// Register LAPACK provider pointers with a selected ABI.
@@ -1043,4 +1072,25 @@ pub unsafe fn register_lapack_provider_ptrs(
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_function_pointer_cast_rejects_size_mismatch() {
+        let err = unsafe {
+            cast_provider_function_pointer::<[usize; 2]>("dgesvd", 1usize as *const c_void)
+        }
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ProviderRegistrationError::FunctionPointerSizeMismatch {
+                symbol: "dgesvd",
+                ..
+            }
+        ));
+    }
 }

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -1107,7 +1107,8 @@ fn build_runtime_exec_program<B: TensorBackend>(
         &input_dtypes,
         &input_shapes,
         compiler_options,
-    );
+    )
+    .map_err(|err| tenferro_tensor::Error::backend_failure("einsum_extension", err.to_string()))?;
     Ok(CachedRuntimeExecProgram {
         program,
         input_indices,

--- a/crates/tenferro-einsum/src/optimize.rs
+++ b/crates/tenferro-einsum/src/optimize.rs
@@ -40,6 +40,7 @@ use crate::{
 ///
 /// assert_eq!(out.try_concrete_shape(), Some(vec![2, 2]));
 /// ```
+#[derive(Debug)]
 pub enum EinsumOptimize {
     /// Automatic optimization via omeco TreeSA.
     Auto(ContractionOptimizerOptions),

--- a/crates/tenferro-einsum/src/planning/tree.rs
+++ b/crates/tenferro-einsum/src/planning/tree.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::mem::{size_of, size_of_val};
 
 use omeco::{
@@ -101,6 +102,19 @@ pub struct ContractionTree {
     pub(crate) operand_subs: Vec<Vec<u32>>,
     /// Pre-compiled step plans (cached to avoid recomputation per execute call).
     pub(crate) step_plans: Vec<StepPlan>,
+}
+
+impl fmt::Debug for ContractionTree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContractionTree")
+            .field("input_count", &self.subscripts.inputs.len())
+            .field("output_rank", &self.subscripts.output.len())
+            .field("steps_len", &self.steps.len())
+            .field("size_dict_len", &self.size_dict.len())
+            .field("operand_subs_len", &self.operand_subs.len())
+            .field("step_plans_len", &self.step_plans.len())
+            .finish_non_exhaustive()
+    }
 }
 
 impl ContractionTree {

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -379,7 +379,7 @@ fn fft_c64_jvp_applies_fft_to_tangent() {
     );
 
     let y = fft(&x, None, -1, FftNorm::Backward).unwrap();
-    let dy = y.jvp(&x, &dx);
+    let dy = y.jvp(&x, &dx).unwrap();
     let out = run(&dy);
 
     assert_c64_close(
@@ -412,7 +412,7 @@ fn fft_c64_jvp_matches_finite_diff() {
     let dx = TracedTensor::from_vec_col_major(vec![4], tangent_data.clone());
 
     let y = fft(&x, None, -1, FftNorm::Backward).unwrap();
-    let dy = y.jvp(&x, &dx);
+    let dy = y.jvp(&x, &dx).unwrap();
     let out = run(&dy);
 
     let expected = finite_diff_c64_directional(
@@ -451,7 +451,7 @@ fn fft_c64_vjp_uses_inverse_transform_with_adjoint_normalization() {
     );
 
     let y = fft(&x, None, -1, FftNorm::Backward).unwrap();
-    let dx = y.vjp(&x, &cotangent);
+    let dx = y.vjp(&x, &cotangent).unwrap();
     let out = run(&dx);
 
     assert_c64_close(
@@ -488,7 +488,7 @@ fn ifft_c64_vjp_uses_forward_transform_with_adjoint_normalization() {
     );
 
     let y = ifft(&x, None, -1, FftNorm::Backward).unwrap();
-    let dx = y.vjp(&x, &cotangent);
+    let dx = y.vjp(&x, &cotangent).unwrap();
     let out = run(&dx);
 
     assert_c64_close(

--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -12,9 +12,18 @@ use crate::types::{
 
 pub(crate) const DEFAULT_CUBE_DIM_X: u32 = 256;
 
-pub(crate) fn cube_count_for_len(len: usize) -> CubeCount {
-    let cubes = len.div_ceil(DEFAULT_CUBE_DIM_X as usize) as u32;
-    CubeCount::Static(cubes.max(1), 1, 1)
+pub(crate) fn cube_count_for_len(len: usize) -> crate::Result<CubeCount> {
+    let cubes = len.div_ceil(DEFAULT_CUBE_DIM_X as usize);
+    let cubes = u32::try_from(cubes).map_err(|_| {
+        crate::Error::backend_failure(
+            "cube_count_for_len",
+            format!(
+                "1D CubeCL launch for {len} elements requires {cubes} cubes, \
+                 which exceeds u32::MAX"
+            ),
+        )
+    })?;
+    Ok(CubeCount::Static(cubes.max(1), 1, 1))
 }
 
 pub(crate) fn cube_dim_1d() -> CubeDim {
@@ -440,7 +449,7 @@ where
     // `ABSOLUTE_POS < out.len()`.
     launch(
         client,
-        cube_count_for_len(len),
+        cube_count_for_len(len)?,
         cube_dim_1d(),
         output_arg,
         input_arg,
@@ -481,7 +490,7 @@ where
     // launched index domain before mapping logical indices.
     launch(
         client,
-        cube_count_for_len(len),
+        cube_count_for_len(len)?,
         cube_dim_1d(),
         output_arg,
         input_arg,
@@ -586,7 +595,7 @@ where
     // with `ABSOLUTE_POS < out.len()`.
     launch(
         client,
-        cube_count_for_len(len),
+        cube_count_for_len(len)?,
         cube_dim_1d(),
         output_arg,
         lhs_arg,
@@ -630,7 +639,7 @@ where
     // guards with `ABSOLUTE_POS < out.len()`.
     launch(
         client,
-        cube_count_for_len(len),
+        cube_count_for_len(len)?,
         cube_dim_1d(),
         output_arg,
         lhs_arg,
@@ -677,7 +686,7 @@ where
     // index domain.
     launch(
         client,
-        cube_count_for_len(len),
+        cube_count_for_len(len)?,
         cube_dim_1d(),
         output_arg,
         lhs_arg,
@@ -725,7 +734,7 @@ where
     // matching the Array<bool> kernel view.
     launch(
         client,
-        cube_count_for_len(len),
+        cube_count_for_len(len)?,
         cube_dim_1d(),
         output_arg,
         pred_arg,
@@ -779,7 +788,7 @@ where
     // this helper guard with `ABSOLUTE_POS < out.len()`.
     launch(
         client,
-        cube_count_for_len(len),
+        cube_count_for_len(len)?,
         cube_dim_1d(),
         output_arg,
         a_arg,

--- a/crates/tenferro-gpu/src/cubecl/fusion/launch.rs
+++ b/crates/tenferro-gpu/src/cubecl/fusion/launch.rs
@@ -61,7 +61,7 @@ where
         // launches over `classified.n_elements`, and guards the body with
         // `ABSOLUTE_POS < out.len()`.
         launcher.launch_unchecked(
-            cube_count_for_len(classified.n_elements),
+            cube_count_for_len(classified.n_elements)?,
             kernel,
             runtime.client(),
         );

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -315,7 +315,7 @@ where
         rt,
         &output,
         OP,
-        cube_count_for_len(output.n_elements()),
+        cube_count_for_len(output.n_elements())?,
         cube_dim_1d(),
         |client, count, dim, out| unsafe {
             structural::fill_zero_kernel::launch_unchecked::<T, CudaRuntime>(

--- a/crates/tenferro-gpu/src/cubecl/interop.rs
+++ b/crates/tenferro-gpu/src/cubecl/interop.rs
@@ -6,6 +6,7 @@
 //! representation on `CubeclRuntime` or `CubeclBuffer` themselves.
 
 use std::ffi::c_void;
+use std::fmt;
 
 use cubecl::client::ComputeClient;
 use cubecl::prelude::{ArrayArg, CubeCount, CubeDim, CubeElement, TensorBinding};
@@ -19,6 +20,15 @@ use super::{dispatch, CubeclRuntime};
 pub struct DeviceByteBuffer {
     handle: Option<cubecl_runtime::server::Handle>,
     ptr: *mut c_void,
+}
+
+impl fmt::Debug for DeviceByteBuffer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeviceByteBuffer")
+            .field("is_empty", &self.is_empty())
+            .field("ptr", &self.ptr)
+            .finish_non_exhaustive()
+    }
 }
 
 impl DeviceByteBuffer {

--- a/crates/tenferro-gpu/src/cubecl/interop.rs
+++ b/crates/tenferro-gpu/src/cubecl/interop.rs
@@ -66,7 +66,7 @@ pub fn raw_cuda_stream(rt: &CubeclRuntime, op: &'static str) -> crate::Result<u6
 }
 
 /// Return the launch cube count for a one-dimensional kernel domain.
-pub fn cube_count_for_len(len: usize) -> CubeCount {
+pub fn cube_count_for_len(len: usize) -> crate::Result<CubeCount> {
     dispatch::cube_count_for_len(len)
 }
 

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -79,6 +79,7 @@
 use std::any::{Any, TypeId};
 use std::cell::OnceCell;
 use std::collections::{HashMap, VecDeque};
+use std::fmt;
 use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -234,10 +235,29 @@ pub struct CubeclBackend {
     rt: CubeclRuntime,
 }
 
+impl fmt::Debug for CubeclBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CubeclBackend")
+            .field("runtime", &self.rt)
+            .field("cuda_extension_cache", &self.extension_cache)
+            .field("cutensor_initialized", &self.cutensor.get().is_some())
+            .finish_non_exhaustive()
+    }
+}
+
 /// Type-indexed cache for CUDA extension-owned backend state.
 #[doc(hidden)]
 pub struct CudaExtensionCache {
     inner: Mutex<CudaExtensionCacheInner>,
+}
+
+impl fmt::Debug for CudaExtensionCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CudaExtensionCache")
+            .field("max_entries", &self.max_entries())
+            .field("stats", &self.stats())
+            .finish_non_exhaustive()
+    }
 }
 
 const DEFAULT_CUDA_EXTENSION_CACHE_MAX_ENTRIES: usize = 16;
@@ -419,6 +439,21 @@ pub struct CudaExtensionCacheGuard<'a, T> {
     inner: MutexGuard<'a, CudaExtensionCacheInner>,
     type_id: TypeId,
     _marker: std::marker::PhantomData<&'a T>,
+}
+
+impl<T: 'static> fmt::Debug for CudaExtensionCacheGuard<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let retained_bytes = self
+            .inner
+            .entries
+            .get(&self.type_id)
+            .map(|entry| entry.retained_bytes)
+            .unwrap_or(0);
+        f.debug_struct("CudaExtensionCacheGuard")
+            .field("value_type", &std::any::type_name::<T>())
+            .field("retained_bytes", &retained_bytes)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<T: 'static> Deref for CudaExtensionCacheGuard<'_, T> {

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -647,7 +647,7 @@ impl CubeclBackend {
             // domain covers every logical output element exactly once.
             structural::view_to_contiguous_kernel::launch_unchecked::<T, CudaRuntime>(
                 self.runtime().client(),
-                cube_count_for_len(len),
+                cube_count_for_len(len)?,
                 cube_dim_1d(),
                 output_arg.into_tensor_arg(),
                 input_arg,
@@ -697,7 +697,7 @@ impl CubeclBackend {
             // and destination logical coordinate exactly once.
             structural::contiguous_to_view_kernel::launch_unchecked::<T, CudaRuntime>(
                 self.runtime().client(),
-                cube_count_for_len(len),
+                cube_count_for_len(len)?,
                 cube_dim_1d(),
                 dst_arg,
                 src_arg.into_tensor_arg(),
@@ -742,12 +742,13 @@ impl CubeclBackend {
                 // positions and guards with `ABSOLUTE_POS < input.len()`.
                 structural::convert_f32_to_c32_raw::launch_unchecked::<CudaRuntime>(
                     client,
-                    cube_count_for_len(n),
+                    cube_count_for_len(n)?,
                     cube_dim_1d(),
                     out,
                     input,
                 );
             }
+            Ok(())
         })
     }
 
@@ -763,12 +764,13 @@ impl CubeclBackend {
                 // positions and guards with `ABSOLUTE_POS < input.len()`.
                 structural::convert_f32_to_c64_raw::launch_unchecked::<CudaRuntime>(
                     client,
-                    cube_count_for_len(n),
+                    cube_count_for_len(n)?,
                     cube_dim_1d(),
                     out,
                     input,
                 );
             }
+            Ok(())
         })
     }
 
@@ -784,12 +786,13 @@ impl CubeclBackend {
                 // positions and guards with `ABSOLUTE_POS < input.len()`.
                 structural::convert_f64_to_c32_raw::launch_unchecked::<CudaRuntime>(
                     client,
-                    cube_count_for_len(n),
+                    cube_count_for_len(n)?,
                     cube_dim_1d(),
                     out,
                     input,
                 );
             }
+            Ok(())
         })
     }
 
@@ -805,12 +808,13 @@ impl CubeclBackend {
                 // positions and guards with `ABSOLUTE_POS < input.len()`.
                 structural::convert_f64_to_c64_raw::launch_unchecked::<CudaRuntime>(
                     client,
-                    cube_count_for_len(n),
+                    cube_count_for_len(n)?,
                     cube_dim_1d(),
                     out,
                     input,
                 );
             }
+            Ok(())
         })
     }
 
@@ -826,7 +830,7 @@ impl CubeclBackend {
             ArrayArg<CudaRuntime>,
             ArrayArg<CudaRuntime>,
             usize,
-        ),
+        ) -> crate::Result<()>,
     ) -> crate::Result<TypedTensor<OutComplex>>
     where
         InFloat: CubeElement + Clone,
@@ -847,7 +851,7 @@ impl CubeclBackend {
         // SAFETY: The checked raw-array helpers prove that `input_arg` covers
         // exactly the dense input shape and `output_parts` covers the complete
         // real/imaginary scalar representation of the output allocation.
-        launch(self.runtime().client(), output_parts, input_arg, n);
+        launch(self.runtime().client(), output_parts, input_arg, n)?;
         Ok(output)
     }
 
@@ -988,7 +992,7 @@ impl CubeclBackend {
             self.runtime(),
             &output,
             "embed_diagonal",
-            cube_count_for_len(output.n_elements()),
+            cube_count_for_len(output.n_elements())?,
             cube_dim_1d(),
             |client, count, dim, out| unsafe {
                 structural::fill_zero_kernel::launch_unchecked::<T, CudaRuntime>(
@@ -1001,7 +1005,7 @@ impl CubeclBackend {
             &output,
             input,
             "embed_diagonal",
-            cube_count_for_len(input.n_elements()),
+            cube_count_for_len(input.n_elements())?,
             cube_dim_1d(),
             |client, count, dim, out, input_arg| unsafe {
                 diagonal::embed_diagonal_copy_kernel::launch_unchecked::<T, CudaRuntime>(
@@ -1431,7 +1435,7 @@ impl CubeclBackend {
                 &output,
                 input,
                 "concatenate",
-                cube_count_for_len(input.n_elements()),
+                cube_count_for_len(input.n_elements())?,
                 cube_dim_1d(),
                 |client, count, dim, out, input_arg| unsafe {
                     structural::concatenate_copy_kernel::launch_unchecked::<T, CudaRuntime>(
@@ -1516,7 +1520,7 @@ impl CubeclBackend {
             &output,
             operand,
             "scatter",
-            cube_count_for_len(output.n_elements()),
+            cube_count_for_len(output.n_elements())?,
             cube_dim_1d(),
             |client, count, dim, out_arg, operand_arg| unsafe {
                 indexing::scatter_copy_kernel::launch_unchecked::<T, CudaRuntime>(
@@ -1547,7 +1551,7 @@ impl CubeclBackend {
             // update through the validated metadata before indexing.
             indexing::scatter_float_kernel::launch_unchecked::<T, I, CudaRuntime>(
                 client,
-                cube_count_for_len(update_len),
+                cube_count_for_len(update_len)?,
                 cube_dim_1d(),
                 output_arg.into_tensor_arg(),
                 operand_arg.into_tensor_arg(),
@@ -1593,7 +1597,7 @@ impl CubeclBackend {
             &output,
             operand,
             "scatter",
-            cube_count_for_len(output.n_elements()),
+            cube_count_for_len(output.n_elements())?,
             cube_dim_1d(),
             |client, count, dim, out_arg, operand_arg| unsafe {
                 indexing::scatter_copy_kernel::launch_unchecked::<T, CudaRuntime>(
@@ -1635,7 +1639,7 @@ impl CubeclBackend {
             // validated metadata.
             indexing::scatter_complex_kernel::launch_unchecked::<T, F, I, CudaRuntime>(
                 client,
-                cube_count_for_len(update_len),
+                cube_count_for_len(update_len)?,
                 cube_dim_1d(),
                 output_parts,
                 operand_arg.into_tensor_arg(),

--- a/crates/tenferro-gpu/src/cubecl/runtime.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime.rs
@@ -1,5 +1,7 @@
 //! CubeCL CUDA runtime initialization and synchronization.
 
+use std::fmt;
+
 use cubecl::client::ComputeClient;
 use cubecl::stream_id::StreamId;
 use cubecl::Runtime;
@@ -34,6 +36,14 @@ pub struct CubeclRuntime {
     device_ordinal: usize,
     cuda_device: CUdevice,
     cuda_context: CUcontext,
+}
+
+impl fmt::Debug for CubeclRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CubeclRuntime")
+            .field("device_ordinal", &self.device_ordinal)
+            .finish_non_exhaustive()
+    }
 }
 
 // CUDA primary contexts and CubeCL clients are owned handles. Backend methods

--- a/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
@@ -28,6 +28,20 @@ macro_rules! gpu_test {
     };
 }
 
+#[test]
+fn cube_count_for_len_rejects_u32_overflow() {
+    let len = (u32::MAX as usize + 1) * super::super::dispatch::DEFAULT_CUBE_DIM_X as usize;
+    let err = super::super::dispatch::cube_count_for_len(len).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "cube_count_for_len",
+            ref message,
+        } if message.contains("exceeds u32::MAX")
+    ));
+}
+
 gpu_test!(test_runtime_init, {
     let rt = CubeclRuntime::new(0);
     assert!(rt.is_ok(), "CubeCL runtime should init on device 0");

--- a/crates/tenferro-gpu/src/webgpu/gemm.rs
+++ b/crates/tenferro-gpu/src/webgpu/gemm.rs
@@ -282,7 +282,7 @@ where
         // per guarded launch position.
         kernels::pack_lhs_dot_general::launch_unchecked::<T, WgpuRuntime>(
             backend.runtime().client(),
-            cube_count_for_len(len),
+            cube_count_for_len(len)?,
             cube_dim_1d(),
             output_binding.into_tensor_arg(),
             input_binding.into_tensor_arg(),
@@ -327,7 +327,7 @@ where
         // to CubeK `[batch..., K, N]` order.
         kernels::pack_rhs_dot_general::launch_unchecked::<T, WgpuRuntime>(
             backend.runtime().client(),
-            cube_count_for_len(len),
+            cube_count_for_len(len)?,
             cube_dim_1d(),
             output_binding.into_tensor_arg(),
             input_binding.into_tensor_arg(),

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -98,9 +98,18 @@ fn checked_shape_product(op: &'static str, shape: &[usize]) -> crate::Result<usi
         })
 }
 
-fn cube_count_for_len(len: usize) -> CubeCount {
-    let cubes = len.div_ceil(DEFAULT_CUBE_DIM_X as usize) as u32;
-    CubeCount::Static(cubes.max(1), 1, 1)
+fn cube_count_for_len(len: usize) -> crate::Result<CubeCount> {
+    let cubes = len.div_ceil(DEFAULT_CUBE_DIM_X as usize);
+    let cubes = u32::try_from(cubes).map_err(|_| {
+        Error::backend_failure(
+            "cube_count_for_len",
+            format!(
+                "1D WebGPU launch for {len} elements requires {cubes} cubes, \
+                 which exceeds u32::MAX"
+            ),
+        )
+    })?;
+    Ok(CubeCount::Static(cubes.max(1), 1, 1))
 }
 
 fn cube_dim_1d() -> CubeDim {

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -2,6 +2,7 @@
 
 use cubecl::prelude::{CubeCount, CubeDim, CubeElement, CubeType, Sequence, TensorBinding};
 use cubecl_wgpu::WgpuRuntime;
+use std::fmt;
 use std::sync::Arc;
 
 use crate::{
@@ -316,6 +317,14 @@ fn webgpu_placement(device_ordinal: usize) -> Placement {
 /// ```
 pub struct WebGpuBackend {
     runtime: WebGpuRuntime,
+}
+
+impl fmt::Debug for WebGpuBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WebGpuBackend")
+            .field("runtime", &self.runtime)
+            .finish_non_exhaustive()
+    }
 }
 
 impl WebGpuBackend {

--- a/crates/tenferro-gpu/src/webgpu/runtime.rs
+++ b/crates/tenferro-gpu/src/webgpu/runtime.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use cubecl::client::ComputeClient;
 use cubecl::Runtime;
 use cubecl_common::future;
@@ -30,6 +32,14 @@ pub fn webgpu_available() -> bool {
 pub struct WebGpuRuntime {
     client: ComputeClient<WgpuRuntime>,
     device_ordinal: usize,
+}
+
+impl fmt::Debug for WebGpuRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WebGpuRuntime")
+            .field("device_ordinal", &self.device_ordinal)
+            .finish_non_exhaustive()
+    }
 }
 
 impl WebGpuRuntime {

--- a/crates/tenferro-internal-ops/src/ad/contraction.rs
+++ b/crates/tenferro-internal-ops/src/ad/contraction.rs
@@ -1,5 +1,6 @@
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{CompareDir, DType, DotGeneralConfig};
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::support::{
@@ -18,7 +19,7 @@ pub fn linearize_dot_general(
     tangent_in: &[Option<LocalValueId>],
     config: &DotGeneralConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let lhs_rank = ctx
         .shape_of(&ValueRef::External(primal_in[0].clone()))
         .len();
@@ -27,11 +28,9 @@ pub fn linearize_dot_general(
         .len();
     config
         .validate_dims_with_ranks(lhs_rank, rhs_rank)
-        .unwrap_or_else(|err| {
-            panic!(
-                "invalid DotGeneral config during linearize: {err} (lhs_rank={lhs_rank}, rhs_rank={rhs_rank})"
-            )
-        });
+        .map_err(|err| ad_rule_error(format!(
+            "invalid DotGeneral config during linearize: {err} (lhs_rank={lhs_rank}, rhs_rank={rhs_rank})"
+        ), ADRuleKind::Jvp))?;
     let lhs_dtype = dtype_of_or_real(ctx, &ValueRef::External(primal_in[0].clone()));
     let rhs_dtype = dtype_of_or_real(ctx, &ValueRef::External(primal_in[1].clone()));
     let output_dtype = promote_dtype(lhs_dtype, rhs_dtype);
@@ -78,8 +77,8 @@ pub fn linearize_dot_general(
     }
 
     match terms.as_slice() {
-        [] => vec![None],
-        [only] => vec![Some(*only)],
+        [] => Ok(vec![None]),
+        [only] => Ok(vec![Some(*only)]),
         [lhs, rhs] => {
             let sum = builder.add_operation(
                 StdTensorOp::Add,
@@ -88,7 +87,7 @@ pub fn linearize_dot_general(
                     active_mask: vec![true, true],
                 },
             );
-            vec![Some(sum[0])]
+            Ok(vec![Some(sum[0])])
         }
         _ => unreachable!("dot_general linearization creates at most two terms"),
     }
@@ -231,10 +230,10 @@ pub fn transpose_dot_general(
     mode: &OperationRole,
     config: &DotGeneralConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
-        None => return vec![None, None],
+        None => return Ok(vec![None, None]),
     };
 
     let lhs_rank = ctx.shape_of(&inputs[0]).len();
@@ -245,19 +244,25 @@ pub fn transpose_dot_general(
 
     let active_mask = match mode {
         OperationRole::Linearized { active_mask } => active_mask,
-        OperationRole::Primary => return vec![None, None],
+        OperationRole::Primary => return Ok(vec![None, None]),
     };
+
+    config
+        .validate_dims_with_ranks(lhs_rank, rhs_rank)
+        .map_err(|err| ad_rule_error(format!(
+            "invalid DotGeneral config during transpose: {err} (lhs_rank={lhs_rank}, rhs_rank={rhs_rank})"
+        ), ADRuleKind::Transpose))?;
 
     let lhs_free = compute_free_dims(
         lhs_rank,
         &config.lhs_contracting_dims,
         &config.lhs_batch_dims,
-    );
+    )?;
     let rhs_free = compute_free_dims(
         rhs_rank,
         &config.rhs_contracting_dims,
         &config.rhs_batch_dims,
-    );
+    )?;
     let output_rank = config.lhs_batch_dims.len() + lhs_free.len() + rhs_free.len();
     let cotangent = normalize_scalar_cotangent(builder, ct, output_rank);
 
@@ -267,7 +272,7 @@ pub fn transpose_dot_general(
         let rhs_conj = conjugate_primal_if_complex(builder, inputs[1].clone(), ctx);
         let rhs_conj = convert_fixed_ref_to_dtype(builder, rhs_conj, rhs_dtype, output_dtype);
         let (transpose_config, new_lhs_rank, new_rhs_rank, perm) =
-            transpose_plan_for_lhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free);
+            transpose_plan_for_lhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free)?;
         let out = builder.add_operation(
             StdTensorOp::DotGeneral {
                 config: transpose_config,
@@ -291,7 +296,7 @@ pub fn transpose_dot_general(
         let lhs_conj = conjugate_primal_if_complex(builder, inputs[0].clone(), ctx);
         let lhs_conj = convert_fixed_ref_to_dtype(builder, lhs_conj, lhs_dtype, output_dtype);
         let (transpose_config, new_lhs_rank, new_rhs_rank, perm) =
-            transpose_plan_for_rhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free);
+            transpose_plan_for_rhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free)?;
         let out = builder.add_operation(
             StdTensorOp::DotGeneral {
                 config: transpose_config,
@@ -311,7 +316,7 @@ pub fn transpose_dot_general(
         ));
     }
 
-    result
+    Ok(result)
 }
 
 pub fn transpose_reduce_sum(
@@ -513,16 +518,32 @@ pub fn transpose_reduce_chooser(
     }
 }
 
-fn compute_free_dims(rank: usize, contracting: &[usize], batch: &[usize]) -> Vec<usize> {
+fn compute_free_dims(
+    rank: usize,
+    contracting: &[usize],
+    batch: &[usize],
+) -> ADRuleResult<Vec<usize>> {
     let mut is_bound = vec![false; rank];
     for &dim in batch {
+        if dim >= rank {
+            return Err(ad_rule_error(
+                format!("batch dimension {dim} out of bounds for rank {rank}"),
+                ADRuleKind::Transpose,
+            ));
+        }
         is_bound[dim] = true;
     }
     for &dim in contracting {
+        if dim >= rank {
+            return Err(ad_rule_error(
+                format!("contracting dimension {dim} out of bounds for rank {rank}"),
+                ADRuleKind::Transpose,
+            ));
+        }
         is_bound[dim] = true;
     }
 
-    (0..rank).filter(|&dim| !is_bound[dim]).collect()
+    Ok((0..rank).filter(|&dim| !is_bound[dim]).collect())
 }
 
 fn kept_dims(rank: usize, axes: &[usize]) -> Vec<usize> {
@@ -835,18 +856,18 @@ fn transpose_plan_for_lhs(
     rhs_rank: usize,
     lhs_free: &[usize],
     rhs_free: &[usize],
-) -> (
+) -> ADRuleResult<(
     DotGeneralConfig,
     /* new_lhs_rank */ usize,
     /* new_rhs_rank */ usize,
     Vec<usize>,
-) {
+)> {
     let n_batch = config.lhs_batch_dims.len();
     let output_rank = lhs_free.len() + rhs_free.len() + n_batch;
     let ct_rhs_free_positions: Vec<usize> =
         (lhs_free.len()..lhs_free.len() + rhs_free.len()).collect();
 
-    let rhs_contracting_order = compute_free_dims(rhs_rank, rhs_free, &config.rhs_batch_dims);
+    let rhs_contracting_order = compute_free_dims(rhs_rank, rhs_free, &config.rhs_batch_dims)?;
     let mut result_order = Vec::with_capacity(lhs_rank);
     result_order.extend(lhs_free.iter().copied());
     for rhs_dim in rhs_contracting_order {
@@ -854,7 +875,12 @@ fn transpose_plan_for_lhs(
             .rhs_contracting_dims
             .iter()
             .position(|&dim| dim == rhs_dim)
-            .expect("rhs contracting dimension must be paired");
+            .ok_or_else(|| {
+                ad_rule_error(
+                    format!("rhs contracting dimension {rhs_dim} has no lhs pair during transpose"),
+                    ADRuleKind::Transpose,
+                )
+            })?;
         result_order.push(config.lhs_contracting_dims[pair_idx]);
     }
     result_order.extend(config.lhs_batch_dims.iter().copied());
@@ -865,12 +891,12 @@ fn transpose_plan_for_lhs(
         lhs_batch_dims: (lhs_free.len() + rhs_free.len()..output_rank).collect(),
         rhs_batch_dims: config.rhs_batch_dims.clone(),
     };
-    (
+    Ok((
         new_config,
         output_rank,
         rhs_rank,
         permutation_to_original_order(lhs_rank, &result_order),
-    )
+    ))
 }
 
 fn transpose_plan_for_rhs(
@@ -879,23 +905,28 @@ fn transpose_plan_for_rhs(
     rhs_rank: usize,
     lhs_free: &[usize],
     rhs_free: &[usize],
-) -> (
+) -> ADRuleResult<(
     DotGeneralConfig,
     /* new_lhs_rank */ usize,
     /* new_rhs_rank */ usize,
     Vec<usize>,
-) {
+)> {
     let n_batch = config.lhs_batch_dims.len();
     let ct_lhs_free_positions: Vec<usize> = (0..lhs_free.len()).collect();
 
-    let lhs_contracting_order = compute_free_dims(lhs_rank, lhs_free, &config.lhs_batch_dims);
+    let lhs_contracting_order = compute_free_dims(lhs_rank, lhs_free, &config.lhs_batch_dims)?;
     let mut result_order = Vec::with_capacity(rhs_rank);
     for lhs_dim in lhs_contracting_order {
         let pair_idx = config
             .lhs_contracting_dims
             .iter()
             .position(|&dim| dim == lhs_dim)
-            .expect("lhs contracting dimension must be paired");
+            .ok_or_else(|| {
+                ad_rule_error(
+                    format!("lhs contracting dimension {lhs_dim} has no rhs pair during transpose"),
+                    ADRuleKind::Transpose,
+                )
+            })?;
         result_order.push(config.rhs_contracting_dims[pair_idx]);
     }
     result_order.extend(rhs_free.iter().copied());
@@ -908,12 +939,12 @@ fn transpose_plan_for_rhs(
         lhs_batch_dims: config.lhs_batch_dims.clone(),
         rhs_batch_dims: (lhs_free.len() + rhs_free.len()..output_rank).collect(),
     };
-    (
+    Ok((
         new_config,
         lhs_rank,
         output_rank,
         permutation_to_original_order(rhs_rank, &result_order),
-    )
+    ))
 }
 
 fn permutation_to_original_order(rank: usize, result_order: &[usize]) -> Vec<usize> {
@@ -922,6 +953,10 @@ fn permutation_to_original_order(rank: usize, result_order: &[usize]) -> Vec<usi
         perm[original_dim] = result_axis;
     }
     perm
+}
+
+fn ad_rule_error(message: impl Into<String>, kind: ADRuleKind) -> ADRuleError {
+    ADRuleError::unsupported(message.into(), kind)
 }
 
 fn add_transpose_if_needed(

--- a/crates/tenferro-internal-ops/src/ad/registry.rs
+++ b/crates/tenferro-internal-ops/src/ad/registry.rs
@@ -739,9 +739,7 @@ fn linearize_dot_general(
     let StdTensorOp::DotGeneral { config } = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(contraction::linearize_dot_general(
-        builder, primal_in, tangent_in, config, ctx,
-    ))
+    contraction::linearize_dot_general(builder, primal_in, tangent_in, config, ctx)
 }
 
 fn transpose_dot_general(
@@ -755,14 +753,7 @@ fn transpose_dot_general(
     let StdTensorOp::DotGeneral { config } = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(contraction::transpose_dot_general(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        config,
-        ctx,
-    ))
+    contraction::transpose_dot_general(builder, cotangent_out, inputs, mode, config, ctx)
 }
 
 fn linearize_reduce_sum(

--- a/crates/tenferro-internal-ops/src/ad/tests/contraction_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/contraction_tests.rs
@@ -1,0 +1,47 @@
+use computegraph::graph::GraphBuilder;
+use computegraph::types::{OperationRole, ValueRef};
+use tenferro_tensor::{DType, DotGeneralConfig};
+use tidu::ADRuleKind;
+
+use crate::ad::context::ShapeGuardContext;
+use crate::input_key::TensorInputKey;
+use crate::std_tensor_op::StdTensorOp;
+
+fn tensor_input(id: u64) -> TensorInputKey {
+    TensorInputKey::User { id }
+}
+
+#[test]
+fn dot_general_transpose_rejects_out_of_bounds_dims_without_panicking() {
+    let lhs = super::input_key(1);
+    let rhs = super::input_key(2);
+    let mut ctx = ShapeGuardContext::default();
+    ctx.insert_metadata(lhs.clone(), super::meta(DType::F64, &[2, 2]));
+    ctx.insert_metadata(rhs.clone(), super::meta(DType::F64, &[2, 2]));
+
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let cotangent = builder.add_input(tensor_input(3));
+    let op = StdTensorOp::DotGeneral {
+        config: DotGeneralConfig {
+            lhs_contracting_dims: vec![2],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        },
+    };
+
+    let err = op
+        .try_linear_transpose_rule(
+            &mut builder,
+            &[Some(cotangent)],
+            &[ValueRef::External(lhs), ValueRef::External(rhs)],
+            &OperationRole::Linearized {
+                active_mask: vec![true, true],
+            },
+            &mut ctx,
+        )
+        .unwrap_err();
+
+    assert_eq!(err.rule(), ADRuleKind::Transpose);
+    assert!(err.to_string().contains("lhs_rank=2"));
+}

--- a/crates/tenferro-internal-ops/src/ad/tests/mod.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/mod.rs
@@ -12,6 +12,8 @@ use crate::std_tensor_op::StdTensorOp;
 use crate::{SymDim, TensorMeta};
 
 #[cfg(feature = "autodiff")]
+mod contraction_tests;
+#[cfg(feature = "autodiff")]
 mod elementwise_tests;
 #[cfg(feature = "autodiff")]
 mod indexing_tests;

--- a/crates/tenferro-linalg/src/gpu/ffi/cusolver.rs
+++ b/crates/tenferro-linalg/src/gpu/ffi/cusolver.rs
@@ -1,4 +1,5 @@
 use std::ffi::c_void;
+use std::fmt;
 use std::os::raw::c_char;
 use std::sync::Arc;
 
@@ -34,7 +35,7 @@ const CUSOLVER_STATUS_SUCCESS: CusolverStatus = 0;
 const CUBLAS_STATUS_SUCCESS: CublasStatus = 0;
 
 #[repr(i32)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum CudaDataType {
     F32,
     F64,
@@ -43,28 +44,28 @@ pub enum CudaDataType {
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum CublasFillMode {
     Lower = 0,
     Upper = 1,
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum CublasDiagType {
     NonUnit = 0,
     Unit = 1,
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum CublasSideMode {
     Left = 0,
     Right = 1,
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum CublasOperation {
     N = 0,
     T = 1,
@@ -72,7 +73,7 @@ pub enum CublasOperation {
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum CusolverEigMode {
     NoVector = 0,
     Vector = 1,
@@ -1145,11 +1146,28 @@ pub struct CusolverDnHandle {
     raw: CusolverDnHandleRaw,
 }
 
+impl fmt::Debug for CusolverDnHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CusolverDnHandle")
+            .field("loaded", &true)
+            .finish_non_exhaustive()
+    }
+}
+
 unsafe impl Send for CusolverDnHandle {}
 
 pub struct GesvdjInfo<'a> {
     handle: &'a CusolverDnHandle,
     raw: GesvdjInfoRaw,
+}
+
+impl fmt::Debug for GesvdjInfo<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GesvdjInfo")
+            .field("handle", &self.handle)
+            .field("initialized", &true)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> GesvdjInfo<'a> {
@@ -2059,6 +2077,14 @@ pub struct CublasHandle {
     raw: CublasHandleRaw,
 }
 
+impl fmt::Debug for CublasHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CublasHandle")
+            .field("loaded", &true)
+            .finish_non_exhaustive()
+    }
+}
+
 unsafe impl Send for CublasHandle {}
 
 impl CublasHandle {
@@ -2244,6 +2270,15 @@ impl Drop for CublasHandle {
 pub struct CudaLinalgHandles {
     cusolver: CusolverDnHandle,
     cublas: CublasHandle,
+}
+
+impl fmt::Debug for CudaLinalgHandles {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CudaLinalgHandles")
+            .field("cusolver", &self.cusolver)
+            .field("cublas", &self.cublas)
+            .finish_non_exhaustive()
+    }
 }
 
 impl CudaLinalgHandles {

--- a/crates/tenferro-linalg/src/gpu/linalg.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg.rs
@@ -915,10 +915,11 @@ where
     }
     let vt_arg = typed_tensor_binding(vt, op)?;
     let v_arg = typed_tensor_binding(v, op)?;
+    let launch_count = cube_count_for_len(vt.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::svd_v_to_vt_real::launch_unchecked::<T, CudaRuntime>(
             client,
-            cube_count_for_len(vt.n_elements()),
+            launch_count,
             cube_dim_1d(),
             vt_arg.into_tensor_arg(),
             v_arg.into_tensor_arg(),
@@ -942,10 +943,11 @@ where
     }
     let vt_arg = typed_tensor_binding(vt, op)?;
     let v_arg = typed_tensor_binding(v, op)?;
+    let launch_count = cube_count_for_len(vt.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::svd_v_to_vt_complex::launch_unchecked::<T, CudaRuntime>(
             client,
-            cube_count_for_len(vt.n_elements()),
+            launch_count,
             cube_dim_1d(),
             vt_arg.into_tensor_arg(),
             v_arg.into_tensor_arg(),
@@ -1587,10 +1589,11 @@ where
     let parity_arg = typed_tensor_binding(&parity, "lu")?;
     let work_arg = typed_tensor_binding(lu, "lu")?;
     let pivots_arg = typed_tensor_array_arg(pivots, "lu")?;
+    let launch_count = cube_count_for_len(launch_len)?;
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::lu_extract_outputs::launch_unchecked::<T, CudaRuntime>(
             client,
-            cube_count_for_len(launch_len),
+            launch_count,
             cube_dim_1d(),
             p_arg.into_tensor_arg(),
             l_arg.into_tensor_arg(),
@@ -1619,10 +1622,11 @@ where
     let parity = alloc_output::<T>(rt, batch_shape);
     let parity_arg = typed_tensor_binding(&parity, "lu_factor")?;
     let pivots_arg = typed_tensor_array_arg(pivots, "lu_factor")?;
+    let launch_count = cube_count_for_len(parity.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::lu_parity::launch_unchecked::<T, CudaRuntime>(
             client,
-            cube_count_for_len(parity.n_elements()),
+            launch_count,
             cube_dim_1d(),
             parity_arg.into_tensor_arg(),
             pivots_arg,
@@ -1643,10 +1647,11 @@ where
 {
     let out = alloc_output::<T>(rt, shape);
     let out_arg = typed_tensor_binding(&out, op)?;
+    let launch_count = cube_count_for_len(out.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::fill_one_kernel::launch_unchecked::<T, CudaRuntime>(
             client,
-            cube_count_for_len(out.n_elements()),
+            launch_count,
             cube_dim_1d(),
             out_arg.into_tensor_arg(),
         );
@@ -1672,10 +1677,11 @@ where
     let out_arg = typed_tensor_binding(&out, "lu_solve_prepared")?;
     let input_arg = typed_tensor_binding(input, "lu_solve_prepared")?;
     let pivots_arg = typed_tensor_array_arg(pivots, "lu_solve_prepared")?;
+    let launch_count = cube_count_for_len(out.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::lu_apply_pivots::launch_unchecked::<T, CudaRuntime>(
             client,
-            cube_count_for_len(out.n_elements()),
+            launch_count,
             cube_dim_1d(),
             out_arg.into_tensor_arg(),
             input_arg.into_tensor_arg(),

--- a/crates/tenferro-runtime/src/ad_support.rs
+++ b/crates/tenferro-runtime/src/ad_support.rs
@@ -171,3 +171,6 @@ pub fn ones_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
         DType::C64 => Tensor::C64(TypedTensor::ones(shape)),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-runtime/src/ad_support.rs
+++ b/crates/tenferro-runtime/src/ad_support.rs
@@ -1,6 +1,7 @@
 //! Internal support surface used by `tenferro-ad`.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
 use computegraph::graph::Graph;
@@ -32,6 +33,22 @@ pub struct TracedTensorParts {
     pub extra_roots: Vec<Arc<Graph<StdTensorOp>>>,
     pub checkpoint_chain: Option<Arc<CheckpointNode>>,
     pub metadata_scopes: Vec<Arc<RuntimeMetadataScope>>,
+}
+
+impl fmt::Debug for TracedTensorParts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TracedTensorParts")
+            .field("rank", &self.rank)
+            .field("dtype", &self.dtype)
+            .field("val", &self.val)
+            .field("has_data", &self.data.is_some())
+            .field("shape_hint", &self.shape_hint)
+            .field("inputs_len", &self.inputs_map.len())
+            .field("extra_roots_len", &self.extra_roots.len())
+            .field("has_checkpoint_chain", &self.checkpoint_chain.is_some())
+            .field("metadata_scopes_len", &self.metadata_scopes.len())
+            .finish_non_exhaustive()
+    }
 }
 
 /// Builds a traced tensor from validated AD transform output.

--- a/crates/tenferro-runtime/src/ad_support/tests.rs
+++ b/crates/tenferro-runtime/src/ad_support/tests.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use computegraph::graph::GraphBuilder;
+use computegraph::types::ValueKey;
+use tenferro_tensor::{DType, Tensor};
+
+use crate::sym_dim::SymDim;
+
+use super::{fresh_input_key, tensor_from_parts, TracedTensorParts};
+
+#[test]
+fn traced_tensor_parts_debug_summarizes_without_graph_payload() {
+    let input_key = fresh_input_key();
+    let mut builder = GraphBuilder::new();
+    let val = builder.add_input(input_key.clone());
+    builder.set_outputs(vec![val]);
+    let graph = Arc::new(builder.build());
+    let data = Arc::new(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]));
+    let inputs_map = Arc::new(HashMap::from([(input_key, Arc::clone(&data))]));
+    let parts = TracedTensorParts {
+        rank: 1,
+        dtype: DType::F64,
+        graph,
+        val,
+        data: Some(data),
+        shape_hint: Some(vec![SymDim::from(1)]),
+        inputs_map,
+        extra_roots: Vec::new(),
+        checkpoint_chain: None,
+        metadata_scopes: Vec::new(),
+    };
+
+    let debug = format!("{parts:?}");
+
+    assert!(debug.contains("TracedTensorParts"));
+    assert!(debug.contains("rank: 1"));
+    assert!(debug.contains("has_data: true"));
+    assert!(debug.contains("inputs_len: 1"));
+    assert!(debug.contains("extra_roots_len: 0"));
+}
+
+#[test]
+fn tensor_from_parts_preserves_summary_fields() {
+    let input_key = fresh_input_key();
+    let mut builder = GraphBuilder::new();
+    let val = builder.add_input(input_key.clone());
+    builder.set_outputs(vec![val]);
+    let graph = Arc::new(builder.build());
+    let data = Arc::new(Tensor::from_vec_col_major(vec![1], vec![3.0_f64]));
+    let inputs_map = Arc::new(HashMap::from([(input_key.clone(), Arc::clone(&data))]));
+    let parts = TracedTensorParts {
+        rank: 1,
+        dtype: DType::F64,
+        graph,
+        val,
+        data: Some(data),
+        shape_hint: Some(vec![SymDim::from(1)]),
+        inputs_map,
+        extra_roots: Vec::new(),
+        checkpoint_chain: None,
+        metadata_scopes: Vec::new(),
+    };
+
+    let tensor = tensor_from_parts(parts);
+
+    assert_eq!(tensor.rank, 1);
+    assert_eq!(tensor.dtype, DType::F64);
+    assert!(matches!(
+        tensor.graph.values()[tensor.val].key,
+        ValueKey::Input(_)
+    ));
+}

--- a/crates/tenferro-runtime/src/checkpoint.rs
+++ b/crates/tenferro-runtime/src/checkpoint.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
 use computegraph::graph::Graph;
@@ -14,6 +15,17 @@ pub struct CheckpointNode {
     pub alias_target: ValueKey<StdTensorOp>,
     pub old_inputs: HashMap<TensorInputKey, Arc<Tensor>>,
     pub prev: Option<Arc<CheckpointNode>>,
+}
+
+impl fmt::Debug for CheckpointNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CheckpointNode")
+            .field("alias_key", &self.alias_key)
+            .field("alias_target", &self.alias_target)
+            .field("old_inputs_len", &self.old_inputs.len())
+            .field("has_prev", &self.prev.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 impl CheckpointNode {

--- a/crates/tenferro-runtime/src/compiler/mod.rs
+++ b/crates/tenferro-runtime/src/compiler/mod.rs
@@ -8,6 +8,7 @@ use tenferro_tensor::{DType, DotGeneralConfig};
 use crate::shape_infer::{
     infer_extension_output_meta, infer_output_dtype, infer_output_extents, infer_output_shapes,
 };
+use crate::{Error, Result};
 
 use super::exec::{ExecInstruction, ExecOp, ExecProgram};
 
@@ -20,7 +21,7 @@ pub fn compile_std_to_exec(
     prog: &CompiledProgram<StdTensorOp>,
     input_dtypes: &[DType],
     input_shapes: &[Vec<DimExpr>],
-) -> ExecProgram {
+) -> Result<ExecProgram> {
     compile_std_to_exec_with_options(prog, input_dtypes, input_shapes, CompilerOptions::default())
 }
 
@@ -29,17 +30,21 @@ pub fn compile_std_to_exec_with_options(
     input_dtypes: &[DType],
     input_shapes: &[Vec<DimExpr>],
     options: CompilerOptions,
-) -> ExecProgram {
-    assert_eq!(
-        prog.input_slots.len(),
-        input_dtypes.len(),
-        "compile_std_to_exec: input dtype count must match input slot count"
-    );
-    assert_eq!(
-        prog.input_slots.len(),
-        input_shapes.len(),
-        "compile_std_to_exec: input shape count must match input slot count"
-    );
+) -> Result<ExecProgram> {
+    if prog.input_slots.len() != input_dtypes.len() {
+        return Err(invalid_compiled_graph(format!(
+            "input dtype count {} must match input slot count {}",
+            input_dtypes.len(),
+            prog.input_slots.len()
+        )));
+    }
+    if prog.input_slots.len() != input_shapes.len() {
+        return Err(invalid_compiled_graph(format!(
+            "input shape count {} must match input slot count {}",
+            input_shapes.len(),
+            prog.input_slots.len()
+        )));
+    }
 
     let mut slot_dtypes: Vec<Option<DType>> = vec![None; prog.n_slots];
     let mut slot_shapes: Vec<Option<Vec<DimExpr>>> = vec![None; prog.n_slots];
@@ -59,29 +64,32 @@ pub fn compile_std_to_exec_with_options(
                 .inputs
                 .iter()
                 .map(|&slot| {
-                    slot_dtypes[slot].unwrap_or_else(|| {
-                        panic!("compile_std_to_exec: missing dtype for slot {slot}")
-                    })
+                    slot_dtypes
+                        .get(slot)
+                        .and_then(|dtype| *dtype)
+                        .ok_or_else(|| missing_slot_meta("dtype", slot))
                 })
-                .collect();
+                .collect::<Result<_>>()?;
             let input_shapes_refs: Vec<&[DimExpr]> = instr
                 .inputs
                 .iter()
                 .map(|&slot| {
-                    slot_shapes[slot].as_deref().unwrap_or_else(|| {
-                        panic!("compile_std_to_exec: missing shape for slot {slot}")
-                    })
+                    slot_shapes
+                        .get(slot)
+                        .and_then(|shape| shape.as_deref())
+                        .ok_or_else(|| missing_slot_meta("shape", slot))
                 })
-                .collect();
+                .collect::<Result<_>>()?;
             let input_extents_refs: Vec<&[ShapeExtent<DimExpr>]> = instr
                 .inputs
                 .iter()
                 .map(|&slot| {
-                    slot_extents[slot].as_deref().unwrap_or_else(|| {
-                        panic!("compile_std_to_exec: missing extents for slot {slot}")
-                    })
+                    slot_extents
+                        .get(slot)
+                        .and_then(|extents| extents.as_deref())
+                        .ok_or_else(|| missing_slot_meta("extents", slot))
                 })
-                .collect();
+                .collect::<Result<_>>()?;
 
             let (output_dtypes, output_shapes, output_extents) =
                 if let StdTensorOp::Extension(ext) = &instr.operation {
@@ -89,16 +97,15 @@ pub fn compile_std_to_exec_with_options(
                         ext.as_ref(),
                         &input_dtypes,
                         &input_shapes_refs,
-                    );
-                    assert_eq!(
-                        metas.len(),
-                        instr.outputs.len(),
-                        "compile_std_to_exec: extension family_id={:?} \
-                         inferred {} output metas for {} output slots",
-                        ext.family_id(),
-                        metas.len(),
-                        instr.outputs.len()
-                    );
+                    )?;
+                    if metas.len() != instr.outputs.len() {
+                        return Err(invalid_compiled_graph(format!(
+                            "extension family_id={:?} inferred {} output metas for {} output slots",
+                            ext.family_id(),
+                            metas.len(),
+                            instr.outputs.len()
+                        )));
+                    }
                     let dtypes: Vec<DType> = metas.iter().map(|(dtype, _)| *dtype).collect();
                     let shapes: Vec<Vec<DimExpr>> =
                         metas.into_iter().map(|(_dtype, shape)| shape).collect();
@@ -106,33 +113,33 @@ pub fn compile_std_to_exec_with_options(
                     (dtypes, shapes, extents)
                 } else {
                     let dtype = infer_output_dtype(&instr.operation, &input_dtypes);
-                    let shapes = infer_output_shapes(&instr.operation, &input_shapes_refs);
-                    let extents = infer_output_extents(&instr.operation, &input_shapes_refs);
-                    assert_eq!(
-                        shapes.len(),
-                        instr.outputs.len(),
-                        "compile_std_to_exec: {:?} inferred {} output shapes for {} output slots",
-                        instr.operation,
-                        shapes.len(),
-                        instr.outputs.len()
-                    );
-                    assert_eq!(
-                        extents.len(),
-                        instr.outputs.len(),
-                        "compile_std_to_exec: {:?} inferred {} output extents for {} output slots",
-                        instr.operation,
-                        extents.len(),
-                        instr.outputs.len()
-                    );
+                    let shapes = infer_output_shapes(&instr.operation, &input_shapes_refs)?;
+                    let extents = infer_output_extents(&instr.operation, &input_shapes_refs)?;
+                    if shapes.len() != instr.outputs.len() {
+                        return Err(invalid_compiled_graph(format!(
+                            "{:?} inferred {} output shapes for {} output slots",
+                            instr.operation,
+                            shapes.len(),
+                            instr.outputs.len()
+                        )));
+                    }
+                    if extents.len() != instr.outputs.len() {
+                        return Err(invalid_compiled_graph(format!(
+                            "{:?} inferred {} output extents for {} output slots",
+                            instr.operation,
+                            extents.len(),
+                            instr.outputs.len()
+                        )));
+                    }
                     let resolved_extents =
-                        resolve_output_extents(extents, &input_shapes_refs, &input_extents_refs);
+                        resolve_output_extents(extents, &input_shapes_refs, &input_extents_refs)?;
                     (vec![dtype; instr.outputs.len()], shapes, resolved_extents)
                 };
 
             let instruction_dtype = output_dtypes
                 .first()
                 .copied()
-                .unwrap_or_else(|| panic!("compile_std_to_exec: instruction has no outputs"));
+                .ok_or_else(|| invalid_compiled_graph("instruction has no outputs"))?;
             for (((slot, dtype), shape), extents) in instr
                 .outputs
                 .iter()
@@ -140,12 +147,18 @@ pub fn compile_std_to_exec_with_options(
                 .zip(output_shapes.iter())
                 .zip(output_extents.iter())
             {
-                slot_dtypes[*slot] = Some(*dtype);
+                let Some(slot_dtype) = slot_dtypes.get_mut(*slot) else {
+                    return Err(invalid_compiled_graph(format!(
+                        "output slot {} is outside slot table of length {}",
+                        slot, prog.n_slots
+                    )));
+                };
+                *slot_dtype = Some(*dtype);
                 slot_shapes[*slot] = Some(shape.clone());
                 slot_extents[*slot] = Some(extents.clone());
             }
 
-            ExecInstruction {
+            Ok(ExecInstruction {
                 op: ExecOp::from_std_tensor_op(&instr.operation),
                 input_slots: instr.inputs.clone(),
                 output_slots: instr.outputs.clone(),
@@ -153,9 +166,9 @@ pub fn compile_std_to_exec_with_options(
                 output_shapes: output_shapes.into(),
                 output_extents: output_extents.into(),
                 last_use: Vec::new(),
-            }
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
 
     let mut program = ExecProgram {
         instructions,
@@ -163,8 +176,18 @@ pub fn compile_std_to_exec_with_options(
         output_slots: prog.output_slots.clone(),
         n_slots: prog.n_slots,
     };
-    optimizer::optimize_exec_program(&mut program, input_dtypes, input_shapes, options.optimizer);
-    program
+    optimizer::optimize_exec_program(&mut program, input_dtypes, input_shapes, options.optimizer)?;
+    Ok(program)
+}
+
+fn invalid_compiled_graph(message: impl Into<String>) -> Error {
+    Error::InvalidCompiledGraph {
+        message: message.into(),
+    }
+}
+
+fn missing_slot_meta(kind: &'static str, slot: usize) -> Error {
+    invalid_compiled_graph(format!("missing {kind} for slot {slot}"))
 }
 
 pub(super) fn exact_extents_from_shape(shape: &[DimExpr]) -> Vec<ShapeExtent<DimExpr>> {
@@ -182,7 +205,7 @@ fn resolve_output_extents(
     extents: Vec<Vec<ShapeExtent<DimExpr>>>,
     input_shapes: &[&[DimExpr]],
     input_extents: &[&[ShapeExtent<DimExpr>]],
-) -> Vec<Vec<ShapeExtent<DimExpr>>> {
+) -> Result<Vec<Vec<ShapeExtent<DimExpr>>>> {
     extents
         .into_iter()
         .map(|shape_extents| {
@@ -198,64 +221,65 @@ fn resolve_extent(
     extent: ShapeExtent<DimExpr>,
     input_shapes: &[&[DimExpr]],
     input_extents: &[&[ShapeExtent<DimExpr>]],
-) -> ShapeExtent<DimExpr> {
+) -> Result<ShapeExtent<DimExpr>> {
     match extent {
         ShapeExtent::Exact(dim) => match dim_expr_extent_kind(&dim, input_extents) {
-            ExtentKind::Exact => ShapeExtent::exact(resolve_dim_expr(&dim, input_shapes)),
-            ExtentKind::UpperBound => {
-                ShapeExtent::upper_bound(resolve_dim_expr(&dim, input_shapes))
-            }
-            ExtentKind::Unknown => ShapeExtent::unknown(),
+            ExtentKind::Exact => Ok(ShapeExtent::exact(resolve_dim_expr(&dim, input_shapes)?)),
+            ExtentKind::UpperBound => Ok(ShapeExtent::upper_bound(resolve_dim_expr(
+                &dim,
+                input_shapes,
+            )?)),
+            ExtentKind::Unknown => Ok(ShapeExtent::unknown()),
         },
         ShapeExtent::UpperBound(dim) => match dim_expr_extent_kind(&dim, input_extents) {
-            ExtentKind::Unknown => ShapeExtent::unknown(),
-            ExtentKind::Exact | ExtentKind::UpperBound => {
-                ShapeExtent::upper_bound(resolve_dim_expr(&dim, input_shapes))
-            }
+            ExtentKind::Unknown => Ok(ShapeExtent::unknown()),
+            ExtentKind::Exact | ExtentKind::UpperBound => Ok(ShapeExtent::upper_bound(
+                resolve_dim_expr(&dim, input_shapes)?,
+            )),
         },
-        ShapeExtent::Unknown => ShapeExtent::unknown(),
+        ShapeExtent::Unknown => Ok(ShapeExtent::unknown()),
     }
 }
 
-fn resolve_dim_expr(expr: &DimExpr, input_shapes: &[&[DimExpr]]) -> DimExpr {
+fn resolve_dim_expr(expr: &DimExpr, input_shapes: &[&[DimExpr]]) -> Result<DimExpr> {
     match expr {
-        DimExpr::Const(value) => DimExpr::Const(*value),
+        DimExpr::Const(value) => Ok(DimExpr::Const(*value)),
         DimExpr::InputDim { input_idx, axis } => input_shapes
             .get(*input_idx)
             .and_then(|shape| shape.get(*axis))
             .cloned()
-            .unwrap_or_else(|| {
-                panic!(
-                    "compile_std_to_exec: InputDim({}, {}) cannot be resolved from {} input shapes",
+            .ok_or_else(|| {
+                invalid_compiled_graph(format!(
+                    "InputDim({}, {}) cannot be resolved from {} input shapes",
                     input_idx,
                     axis,
                     input_shapes.len()
-                )
+                ))
             }),
-        DimExpr::Add(a, b) => DimExpr::add(
-            resolve_dim_expr(a, input_shapes),
-            resolve_dim_expr(b, input_shapes),
-        ),
-        DimExpr::Sub(a, b) => DimExpr::sub(
-            resolve_dim_expr(a, input_shapes),
-            resolve_dim_expr(b, input_shapes),
-        ),
-        DimExpr::Mul(a, b) => DimExpr::mul(
-            resolve_dim_expr(a, input_shapes),
-            resolve_dim_expr(b, input_shapes),
-        ),
-        DimExpr::FloorDiv(a, b) => DimExpr::floor_div(
-            resolve_dim_expr(a, input_shapes),
-            resolve_dim_expr(b, input_shapes),
-        ),
-        DimExpr::Min(a, b) => DimExpr::min(
-            resolve_dim_expr(a, input_shapes),
-            resolve_dim_expr(b, input_shapes),
-        ),
-        DimExpr::Max(a, b) => DimExpr::max(
-            resolve_dim_expr(a, input_shapes),
-            resolve_dim_expr(b, input_shapes),
-        ),
+        DimExpr::Add(a, b) => Ok(DimExpr::add(
+            resolve_dim_expr(a, input_shapes)?,
+            resolve_dim_expr(b, input_shapes)?,
+        )),
+        DimExpr::Sub(a, b) => Ok(DimExpr::sub(
+            resolve_dim_expr(a, input_shapes)?,
+            resolve_dim_expr(b, input_shapes)?,
+        )),
+        DimExpr::Mul(a, b) => Ok(DimExpr::mul(
+            resolve_dim_expr(a, input_shapes)?,
+            resolve_dim_expr(b, input_shapes)?,
+        )),
+        DimExpr::FloorDiv(a, b) => Ok(DimExpr::floor_div(
+            resolve_dim_expr(a, input_shapes)?,
+            resolve_dim_expr(b, input_shapes)?,
+        )),
+        DimExpr::Min(a, b) => Ok(DimExpr::min(
+            resolve_dim_expr(a, input_shapes)?,
+            resolve_dim_expr(b, input_shapes)?,
+        )),
+        DimExpr::Max(a, b) => Ok(DimExpr::max(
+            resolve_dim_expr(a, input_shapes)?,
+            resolve_dim_expr(b, input_shapes)?,
+        )),
     }
 }
 
@@ -348,31 +372,36 @@ pub(crate) fn conj_sinking(
     program: &mut ExecProgram,
     input_dtypes: &[DType],
     input_shapes: &[Vec<DimExpr>],
-) {
-    assert_eq!(
-        program.input_slots.len(),
-        input_dtypes.len(),
-        "conj_sinking: input dtype count must match input slot count"
-    );
-    assert_eq!(
-        program.input_slots.len(),
-        input_shapes.len(),
-        "conj_sinking: input shape count must match input slot count"
-    );
+) -> Result<()> {
+    if program.input_slots.len() != input_dtypes.len() {
+        return Err(invalid_compiled_graph(format!(
+            "conj_sinking input dtype count {} must match input slot count {}",
+            input_dtypes.len(),
+            program.input_slots.len()
+        )));
+    }
+    if program.input_slots.len() != input_shapes.len() {
+        return Err(invalid_compiled_graph(format!(
+            "conj_sinking input shape count {} must match input slot count {}",
+            input_shapes.len(),
+            program.input_slots.len()
+        )));
+    }
 
     loop {
-        if !conj_sinking_one_pass(program, input_dtypes, input_shapes) {
+        if !conj_sinking_one_pass(program, input_dtypes, input_shapes)? {
             break;
         }
     }
+    Ok(())
 }
 
 fn conj_sinking_one_pass(
     program: &mut ExecProgram,
     input_dtypes: &[DType],
     input_shapes: &[Vec<DimExpr>],
-) -> bool {
-    let mut slot_meta = collect_slot_meta(program, input_dtypes, input_shapes);
+) -> Result<bool> {
+    let mut slot_meta = collect_slot_meta(program, input_dtypes, input_shapes)?;
     let mut redirect: Vec<usize> = (0..program.n_slots).collect();
     let mut producer_by_slot: ProducerMap = vec![None; program.n_slots];
     let mut conj_cache: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
@@ -411,7 +440,7 @@ fn conj_sinking_one_pass(
                             n_slots: &mut program.n_slots,
                             redirect: &mut redirect,
                         }
-                        .ensure_conj_slot(input_slot);
+                        .ensure_conj_slot(input_slot)?;
                     }
                     instr.op = producer.op;
                     instr.input_slots = input_slots;
@@ -428,24 +457,30 @@ fn conj_sinking_one_pass(
         *slot = resolve_slot_redirect(*slot, &redirect);
     }
     program.instructions = new_instructions;
-    changed
+    Ok(changed)
 }
 
 fn collect_slot_meta(
     program: &ExecProgram,
     input_dtypes: &[DType],
     input_shapes: &[Vec<DimExpr>],
-) -> Vec<Option<SlotMeta>> {
+) -> Result<Vec<Option<SlotMeta>>> {
     let mut slot_meta = vec![None; program.n_slots];
     for (index, &slot) in program.input_slots.iter().enumerate() {
-        slot_meta[slot] = Some(SlotMeta {
+        let Some(meta_slot) = slot_meta.get_mut(slot) else {
+            return Err(invalid_compiled_graph(format!(
+                "input slot {} is outside slot table of length {}",
+                slot, program.n_slots
+            )));
+        };
+        *meta_slot = Some(SlotMeta {
             dtype: input_dtypes[index],
             shape: input_shapes[index].clone(),
             extents: exact_extents_from_shape(&input_shapes[index]),
         });
     }
     for instr in &program.instructions {
-        let output_dtypes = instruction_output_dtypes(instr, &slot_meta);
+        let output_dtypes = instruction_output_dtypes(instr, &slot_meta)?;
         for (((&slot, dtype), shape), extents) in instr
             .output_slots
             .iter()
@@ -453,55 +488,62 @@ fn collect_slot_meta(
             .zip(instr.output_shapes.iter())
             .zip(instr.output_extents.iter())
         {
-            slot_meta[slot] = Some(SlotMeta {
+            let Some(meta_slot) = slot_meta.get_mut(slot) else {
+                return Err(invalid_compiled_graph(format!(
+                    "output slot {} is outside slot table of length {}",
+                    slot, program.n_slots
+                )));
+            };
+            *meta_slot = Some(SlotMeta {
                 dtype: *dtype,
                 shape: shape.clone(),
                 extents: extents.clone(),
             });
         }
     }
-    slot_meta
+    Ok(slot_meta)
 }
 
 fn instruction_output_dtypes(
     instr: &ExecInstruction,
     slot_meta: &[Option<SlotMeta>],
-) -> Vec<DType> {
+) -> Result<Vec<DType>> {
     let ExecOp::Extension(ext) = &instr.op else {
-        return vec![instr.dtype; instr.output_slots.len()];
+        return Ok(vec![instr.dtype; instr.output_slots.len()]);
     };
     let input_dtypes: Vec<DType> = instr
         .input_slots
         .iter()
         .map(|&slot| {
-            slot_meta[slot]
-                .as_ref()
-                .unwrap_or_else(|| panic!("collect_slot_meta: missing dtype for slot {slot}"))
-                .dtype
+            slot_meta
+                .get(slot)
+                .and_then(Option::as_ref)
+                .ok_or_else(|| missing_slot_meta("dtype", slot))
+                .map(|meta| meta.dtype)
         })
-        .collect();
+        .collect::<Result<_>>()?;
     let input_shapes: Vec<Vec<DimExpr>> = instr
         .input_slots
         .iter()
         .map(|&slot| {
-            slot_meta[slot]
-                .as_ref()
-                .unwrap_or_else(|| panic!("collect_slot_meta: missing shape for slot {slot}"))
-                .shape
-                .clone()
+            slot_meta
+                .get(slot)
+                .and_then(Option::as_ref)
+                .ok_or_else(|| missing_slot_meta("shape", slot))
+                .map(|meta| meta.shape.clone())
         })
-        .collect();
+        .collect::<Result<_>>()?;
     let input_shape_refs: Vec<&[DimExpr]> = input_shapes.iter().map(Vec::as_slice).collect();
-    let metas = infer_extension_output_meta(ext.as_ref(), &input_dtypes, &input_shape_refs);
-    assert_eq!(
-        metas.len(),
-        instr.output_slots.len(),
-        "collect_slot_meta: extension family_id={:?} inferred {} output metas for {} output slots",
-        ext.family_id(),
-        metas.len(),
-        instr.output_slots.len()
-    );
-    metas.into_iter().map(|(dtype, _shape)| dtype).collect()
+    let metas = infer_extension_output_meta(ext.as_ref(), &input_dtypes, &input_shape_refs)?;
+    if metas.len() != instr.output_slots.len() {
+        return Err(invalid_compiled_graph(format!(
+            "extension family_id={:?} inferred {} output metas for {} output slots",
+            ext.family_id(),
+            metas.len(),
+            instr.output_slots.len()
+        )));
+    }
+    Ok(metas.into_iter().map(|(dtype, _shape)| dtype).collect())
 }
 
 struct ConjSinkingState<'a> {
@@ -514,20 +556,26 @@ struct ConjSinkingState<'a> {
 }
 
 impl ConjSinkingState<'_> {
-    fn ensure_conj_slot(&mut self, slot: usize) -> usize {
+    fn ensure_conj_slot(&mut self, slot: usize) -> Result<usize> {
         let slot = resolve_slot_redirect(slot, self.redirect);
         if let Some(producer) = producer_for_slot(self.producer_by_slot, slot) {
             if matches!(producer.op, ExecOp::Conj) && producer.input_slots.len() == 1 {
-                return resolve_slot_redirect(producer.input_slots[0], self.redirect);
+                return Ok(resolve_slot_redirect(
+                    producer.input_slots[0],
+                    self.redirect,
+                ));
             }
         }
         if let Some(&conj_slot) = self.conj_cache.get(&slot) {
-            return conj_slot;
+            return Ok(conj_slot);
         }
 
-        let meta = self.slot_meta[slot]
-            .clone()
-            .unwrap_or_else(|| panic!("conj_sinking: missing metadata for slot {slot}"));
+        let meta = self
+            .slot_meta
+            .get(slot)
+            .and_then(Option::as_ref)
+            .cloned()
+            .ok_or_else(|| missing_slot_meta("metadata", slot))?;
         let output_slot = *self.n_slots;
         *self.n_slots += 1;
         self.redirect.push(output_slot);
@@ -545,7 +593,7 @@ impl ConjSinkingState<'_> {
         record_producer(self.producer_by_slot, &instr);
         self.new_instructions.push(instr);
         self.conj_cache.insert(slot, output_slot);
-        output_slot
+        Ok(output_slot)
     }
 }
 

--- a/crates/tenferro-runtime/src/compiler/optimizer/mod.rs
+++ b/crates/tenferro-runtime/src/compiler/optimizer/mod.rs
@@ -2,6 +2,7 @@ use tenferro_ops::dim_expr::DimExpr;
 use tenferro_tensor::DType;
 
 use crate::exec::ExecProgram;
+use crate::Result;
 
 use super::options::OptimizerConfig;
 
@@ -11,8 +12,8 @@ pub fn optimize_exec_program(
     input_dtypes: &[DType],
     input_shapes: &[Vec<DimExpr>],
     config: OptimizerConfig,
-) {
-    super::conj_sinking(program, input_dtypes, input_shapes);
+) -> Result<()> {
+    super::conj_sinking(program, input_dtypes, input_shapes)?;
     super::dot_dimension_sorter(program);
     if config.algebraic_layout_simplifier {
         super::algebraic_layout_simplifier(program);
@@ -30,4 +31,5 @@ pub fn optimize_exec_program(
     }
     super::eliminate_dead_code(program);
     super::populate_last_use(program);
+    Ok(())
 }

--- a/crates/tenferro-runtime/src/compiler/tests.rs
+++ b/crates/tenferro-runtime/src/compiler/tests.rs
@@ -4,7 +4,7 @@ use super::{
     layout_chain_transpose_folding, transpose_folding, CompilerOptions, OptimizerConfig,
 };
 use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
-use crate::GraphExecutor;
+use crate::{Error, GraphExecutor};
 use computegraph::compile::{CompiledProgram, Instruction};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -107,12 +107,54 @@ fn compile_default_options_match_default_entrypoint() {
 
     let dtypes = [DType::F64, DType::F64];
     let shapes = [dim_shape(&[2, 3]), dim_shape(&[3, 4])];
-    let default = compile_std_to_exec(&program, &dtypes, &shapes);
+    let default = compile_std_to_exec(&program, &dtypes, &shapes).unwrap();
     let explicit =
-        compile_std_to_exec_with_options(&program, &dtypes, &shapes, CompilerOptions::default());
+        compile_std_to_exec_with_options(&program, &dtypes, &shapes, CompilerOptions::default())
+            .unwrap();
 
     assert_eq!(default.instructions.len(), explicit.instructions.len());
     assert_eq!(default.n_slots, explicit.n_slots);
+}
+
+#[test]
+fn compile_reports_missing_slot_metadata_as_error() {
+    let program = CompiledProgram {
+        instructions: vec![make_std_instr(StdTensorOp::Neg, vec![1], vec![2])],
+        input_slots: vec![0],
+        output_slots: vec![2],
+        n_slots: 3,
+    };
+
+    let err = compile_std_to_exec(&program, &[DType::F64], &[dim_shape(&[2])]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::InvalidCompiledGraph { ref message }
+            if message.contains("missing dtype for slot 1")
+    ));
+}
+
+#[test]
+fn compile_reports_incompatible_broadcast_as_error() {
+    let program = CompiledProgram {
+        instructions: vec![make_std_instr(StdTensorOp::Add, vec![0, 1], vec![2])],
+        input_slots: vec![0, 1],
+        output_slots: vec![2],
+        n_slots: 3,
+    };
+
+    let err = compile_std_to_exec(
+        &program,
+        &[DType::F64, DType::F64],
+        &[dim_shape(&[2]), dim_shape(&[3])],
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::InvalidCompiledGraph { ref message }
+            if message.contains("incompatible Add/Mul broadcast dimensions: 2 and 3")
+    ));
 }
 
 #[test]
@@ -264,7 +306,7 @@ fn dot_decomposer_is_disabled_by_default_and_opt_in() {
     let dtypes = [DType::F64, DType::F64];
     let shapes = [dim_shape(&[2, 3, 4]), dim_shape(&[4, 5])];
 
-    let default_exec = compile_std_to_exec(&program, &dtypes, &shapes);
+    let default_exec = compile_std_to_exec(&program, &dtypes, &shapes).unwrap();
     assert_eq!(
         default_exec
             .instructions
@@ -288,7 +330,8 @@ fn dot_decomposer_is_disabled_by_default_and_opt_in() {
                 ..OptimizerConfig::default()
             },
         },
-    );
+    )
+    .unwrap();
     assert!(decomposed
         .instructions
         .iter()
@@ -481,7 +524,7 @@ fn test_conj_sinking_pushes_through_transpose() {
     );
     let mut program = make_exec_program(vec![transpose, conj], vec![0], vec![2], 3);
 
-    conj_sinking(&mut program, &[DType::C64], &[dim_shape(&[2, 3])]);
+    conj_sinking(&mut program, &[DType::C64], &[dim_shape(&[2, 3])]).unwrap();
     eliminate_dead_code(&mut program);
 
     assert_eq!(program.instructions.len(), 2);
@@ -518,7 +561,7 @@ fn test_conj_sinking_cancels_double_conj() {
     );
     let mut program = make_exec_program(vec![conj_a, conj_b], vec![0], vec![2], 3);
 
-    conj_sinking(&mut program, &[DType::C64], &[dim_shape(&[2])]);
+    conj_sinking(&mut program, &[DType::C64], &[dim_shape(&[2])]).unwrap();
     eliminate_dead_code(&mut program);
 
     assert_eq!(program.output_slots, vec![0]);
@@ -543,7 +586,7 @@ fn test_conj_sinking_does_not_push_convert_onto_i64() {
     );
     let mut program = make_exec_program(vec![convert_i64_to_f64, conj], vec![0], vec![2], 3);
 
-    conj_sinking(&mut program, &[DType::I64], &[dim_shape(&[2])]);
+    conj_sinking(&mut program, &[DType::I64], &[dim_shape(&[2])]).unwrap();
 
     assert_eq!(program.instructions.len(), 2);
     assert!(matches!(
@@ -572,7 +615,7 @@ fn test_conj_sinking_does_not_push_convert_to_i64() {
     );
     let mut program = make_exec_program(vec![convert_f64_to_i64, conj], vec![0], vec![2], 3);
 
-    conj_sinking(&mut program, &[DType::F64], &[dim_shape(&[2])]);
+    conj_sinking(&mut program, &[DType::F64], &[dim_shape(&[2])]).unwrap();
 
     assert_eq!(program.instructions.len(), 2);
     assert!(matches!(
@@ -618,7 +661,8 @@ fn test_conj_sinking_preserves_transpose_folding_path_to_dot_conj() {
         &mut program,
         &[DType::C64, DType::C64],
         &[dim_shape(&[2, 3]), dim_shape(&[3, 4])],
-    );
+    )
+    .unwrap();
     transpose_folding(&mut program);
     dot_conj_folding(&mut program);
     eliminate_dead_code(&mut program);
@@ -713,7 +757,8 @@ fn test_full_pipeline_matmul() {
         &program,
         &[DType::F64, DType::F64],
         &[dim_shape(&[2, 3]), dim_shape(&[3, 4])],
-    );
+    )
+    .unwrap();
 
     assert_eq!(exec.instructions.len(), 1);
     match &exec.instructions[0].op {
@@ -760,7 +805,8 @@ fn test_full_pipeline_transpose_matmul() {
         &program,
         &[DType::F64, DType::F64],
         &[dim_shape(&[3, 2]), dim_shape(&[3, 4])],
-    );
+    )
+    .unwrap();
 
     // `transpose_folding` absorbs the Transpose into DotGeneral dim-numbers.
     // The compiled pipeline leaves the non-canonical DotGeneral for the backend
@@ -815,7 +861,8 @@ fn test_full_pipeline_dot_absorbs_conj_without_layout_materialization() {
         &program,
         &[DType::C64, DType::C64],
         &[dim_shape(&[2, 3]), dim_shape(&[3, 4, 5])],
-    );
+    )
+    .unwrap();
 
     assert!(
         exec.instructions
@@ -902,7 +949,8 @@ fn test_full_pipeline_multi_free_dim_decomp_runs_correctly() {
         &program,
         &[DType::F64, DType::F64],
         &[dim_shape(&[2, 3, 4]), dim_shape(&[4, 5])],
-    );
+    )
+    .unwrap();
 
     // Build concrete inputs: LHS = sequential 0..24, reshaped as [2, 3, 4];
     //                       RHS = sequential 0..20, reshaped as [4, 5].

--- a/crates/tenferro-runtime/src/error.rs
+++ b/crates/tenferro-runtime/src/error.rs
@@ -98,6 +98,13 @@ pub enum Error {
         message: String,
     },
 
+    /// Lowering rejected an inconsistent compiled graph.
+    #[error("invalid compiled graph: {message}")]
+    InvalidCompiledGraph {
+        /// Validation failure details.
+        message: String,
+    },
+
     /// An unexpected internal error.
     #[error("internal error: {0}")]
     Internal(String),

--- a/crates/tenferro-runtime/src/extension_cache.rs
+++ b/crates/tenferro-runtime/src/extension_cache.rs
@@ -5,6 +5,7 @@
 //! explicit bounded cache ownership.
 
 use std::any::Any;
+use std::fmt;
 use std::num::NonZeroUsize;
 
 use lru::LruCache;
@@ -187,6 +188,15 @@ struct ExtensionCacheEntry {
 pub struct ExtensionCacheStore {
     limits: ExtensionCacheLimits,
     entries: LruCache<ExtensionCacheKey, ExtensionCacheEntry>,
+}
+
+impl fmt::Debug for ExtensionCacheStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExtensionCacheStore")
+            .field("limits", &self.limits)
+            .field("stats", &self.stats(ExtensionCacheSelector::All))
+            .finish_non_exhaustive()
+    }
 }
 
 impl ExtensionCacheStore {

--- a/crates/tenferro-runtime/src/extension_runtime.rs
+++ b/crates/tenferro-runtime/src/extension_runtime.rs
@@ -6,7 +6,7 @@
 //! tensor backend implementation.
 
 use std::collections::HashMap;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -28,6 +28,15 @@ pub enum ExtensionRuntimeRegistryError {
 pub struct ExtensionExecutionContext<'a, B: TensorBackend> {
     backend: &'a mut B,
     caches: &'a mut ExtensionCacheStore,
+}
+
+impl<B: TensorBackend> fmt::Debug for ExtensionExecutionContext<'_, B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExtensionExecutionContext")
+            .field("backend_type", &std::any::type_name::<B>())
+            .field("caches", &self.caches)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a, B: TensorBackend> ExtensionExecutionContext<'a, B> {
@@ -202,6 +211,18 @@ pub struct ExtensionRegistry<B: TensorBackend + 'static> {
     executors: HashMap<&'static str, Arc<dyn ExtensionRuntime<B>>>,
 }
 
+impl<B: TensorBackend + 'static> fmt::Debug for ExtensionRegistry<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut families = self.executors.keys().copied().collect::<Vec<_>>();
+        families.sort_unstable();
+        f.debug_struct("ExtensionRegistry")
+            .field("backend_type", &std::any::type_name::<B>())
+            .field("len", &self.executors.len())
+            .field("families", &families)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<B: TensorBackend + 'static> ExtensionRegistry<B> {
     /// Create an empty extension runtime registry.
     ///
@@ -272,6 +293,16 @@ pub struct ExtensionExecutor<B: TensorBackend + 'static> {
     registry: ExtensionRegistry<B>,
     caches: ExtensionCacheStore,
     _backend: PhantomData<fn() -> B>,
+}
+
+impl<B: TensorBackend + 'static> fmt::Debug for ExtensionExecutor<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExtensionExecutor")
+            .field("backend_type", &std::any::type_name::<B>())
+            .field("registry", &self.registry)
+            .field("caches", &self.caches)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<B: TensorBackend + 'static> ExtensionExecutor<B> {

--- a/crates/tenferro-runtime/src/graph/compiler.rs
+++ b/crates/tenferro-runtime/src/graph/compiler.rs
@@ -408,7 +408,7 @@ impl GraphCompiler {
             &input_dtypes,
             &input_shapes,
             self.compiler_options,
-        );
+        )?;
         let exec = self.get_or_compile(exec);
         Ok(GraphProgram::new(exec, descriptors))
     }

--- a/crates/tenferro-runtime/src/graph/compiler.rs
+++ b/crates/tenferro-runtime/src/graph/compiler.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -50,6 +51,17 @@ pub struct GraphCompiler {
     compile_cache: LruCache<CacheKey, ExecProgram>,
     extension_cache: ExtensionCacheStore,
     compiler_options: CompilerOptions,
+}
+
+impl fmt::Debug for GraphCompiler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GraphCompiler")
+            .field("cache_stats", &self.cache_stats())
+            .field("compile_cache_capacity", &self.compile_cache_capacity())
+            .field("compiler_options", &self.compiler_options)
+            .field("extension_cache", &self.extension_cache)
+            .finish_non_exhaustive()
+    }
 }
 
 impl GraphCompiler {

--- a/crates/tenferro-runtime/src/graph/executor.rs
+++ b/crates/tenferro-runtime/src/graph/executor.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::mem;
 use std::sync::Arc;
 
@@ -40,6 +41,16 @@ pub struct GraphExecutor<B: TensorBackend + 'static> {
     backend_cache: B::RuntimeCache,
     extension_executor: ExtensionExecutor<B>,
     slot_workspace: Vec<Option<ExecSlot<'static>>>,
+}
+
+impl<B: TensorBackend + 'static> fmt::Debug for GraphExecutor<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GraphExecutor")
+            .field("backend_type", &std::any::type_name::<B>())
+            .field("cache_stats", &self.cache_stats())
+            .field("slot_workspace_len", &self.slot_workspace.len())
+            .finish_non_exhaustive()
+    }
 }
 
 impl<B: TensorBackend + 'static> GraphExecutor<B> {

--- a/crates/tenferro-runtime/src/metadata.rs
+++ b/crates/tenferro-runtime/src/metadata.rs
@@ -13,6 +13,7 @@ use tenferro_tensor::DType;
 use tenferro_tensor::Tensor;
 
 use crate::shape_infer::{infer_extension_output_meta, infer_output_dtype, infer_output_extents};
+use crate::{Error, Result};
 
 pub type MetadataScope = GlobalMetadataScope;
 
@@ -59,7 +60,16 @@ pub fn register_scoped_graph_metadata(
     graph: &Graph<StdTensorOp>,
     seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
 ) -> MetadataScope {
-    register_scoped_global_metadata_batch(graph_metadata_registrations(graph, None, seeded))
+    try_register_scoped_graph_metadata(graph, seeded).unwrap_or_else(|err| panic!("{err}"))
+}
+
+pub(crate) fn try_register_scoped_graph_metadata(
+    graph: &Graph<StdTensorOp>,
+    seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
+) -> Result<MetadataScope> {
+    Ok(register_scoped_global_metadata_batch(
+        graph_metadata_registrations(graph, None, seeded)?,
+    ))
 }
 
 pub fn register_scoped_live_graph_metadata(
@@ -67,10 +77,17 @@ pub fn register_scoped_live_graph_metadata(
     live_values: &HashSet<LocalValueId>,
     seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
 ) -> MetadataScope {
-    register_scoped_global_metadata_batch(graph_metadata_registrations(
-        graph,
-        Some(live_values),
-        seeded,
+    try_register_scoped_live_graph_metadata(graph, live_values, seeded)
+        .unwrap_or_else(|err| panic!("{err}"))
+}
+
+pub(crate) fn try_register_scoped_live_graph_metadata(
+    graph: &Graph<StdTensorOp>,
+    live_values: &HashSet<LocalValueId>,
+    seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
+) -> Result<MetadataScope> {
+    Ok(register_scoped_global_metadata_batch(
+        graph_metadata_registrations(graph, Some(live_values), seeded)?,
     ))
 }
 
@@ -129,7 +146,7 @@ fn graph_metadata_registrations(
     graph: &Graph<StdTensorOp>,
     live_values: Option<&HashSet<LocalValueId>>,
     seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
-) -> Vec<(ValueKey<StdTensorOp>, TensorMeta)> {
+) -> Result<Vec<(ValueKey<StdTensorOp>, TensorMeta)>> {
     let seeded: Vec<_> = seeded.into_iter().collect();
     // Start from just the seeded inputs. External keys not in `seeded` are
     // resolved on demand via a single-key lookup against the global
@@ -163,16 +180,11 @@ fn graph_metadata_registrations(
                     .get(key)
                     .cloned()
                     .or_else(|| lookup_global_metadata(key))
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "metadata registration: missing input metadata for {:?}",
-                            key
-                        )
-                    })
+                    .ok_or_else(|| metadata_error(format!("missing input metadata for {:?}", key)))
             })
-            .collect();
+            .collect::<Result<_>>()?;
 
-        let output_metas = infer_output_metas(&op_node.operation, &input_metas);
+        let output_metas = infer_output_metas(&op_node.operation, &input_metas)?;
         for (&output_id, meta) in op_node.outputs.iter().zip(output_metas) {
             let key = graph.values()[output_id].key.clone();
             known.insert(key.clone(), meta.clone());
@@ -180,10 +192,10 @@ fn graph_metadata_registrations(
         }
     }
 
-    registrations
+    Ok(registrations)
 }
 
-fn infer_output_metas(op: &StdTensorOp, input_metas: &[TensorMeta]) -> Vec<TensorMeta> {
+fn infer_output_metas(op: &StdTensorOp, input_metas: &[TensorMeta]) -> Result<Vec<TensorMeta>> {
     let input_shape_exprs: Vec<Vec<DimExpr>> = input_metas
         .iter()
         .enumerate()
@@ -193,12 +205,12 @@ fn infer_output_metas(op: &StdTensorOp, input_metas: &[TensorMeta]) -> Vec<Tenso
     let input_dtypes: Vec<DType> = input_metas.iter().map(|meta| meta.dtype).collect();
 
     if let StdTensorOp::Extension(ext) = op {
-        let metas = infer_extension_output_meta(ext.as_ref(), &input_dtypes, &input_shape_refs);
+        let metas = infer_extension_output_meta(ext.as_ref(), &input_dtypes, &input_shape_refs)?;
         let resolved_inputs: Vec<&[SymDim]> = input_metas
             .iter()
             .map(|meta| meta.shape.as_slice())
             .collect();
-        return metas
+        return Ok(metas
             .into_iter()
             .map(|(dtype, shape)| {
                 tensor_meta(
@@ -209,11 +221,11 @@ fn infer_output_metas(op: &StdTensorOp, input_metas: &[TensorMeta]) -> Vec<Tenso
                         .collect(),
                 )
             })
-            .collect();
+            .collect());
     }
 
     let output_dtype = infer_output_dtype(op, &input_dtypes);
-    infer_output_extents(op, &input_shape_refs)
+    Ok(infer_output_extents(op, &input_shape_refs)?
         .into_iter()
         .map(|extents| {
             let resolved_inputs: Vec<&[SymDim]> = input_metas
@@ -226,5 +238,11 @@ fn infer_output_metas(op: &StdTensorOp, input_metas: &[TensorMeta]) -> Vec<Tenso
                 .collect();
             TensorMeta::with_extents(output_dtype, resolved_extents)
         })
-        .collect()
+        .collect())
+}
+
+fn metadata_error(message: impl Into<String>) -> Error {
+    Error::InvalidCompiledGraph {
+        message: format!("metadata registration: {}", message.into()),
+    }
 }

--- a/crates/tenferro-runtime/src/shape_infer.rs
+++ b/crates/tenferro-runtime/src/shape_infer.rs
@@ -10,6 +10,8 @@ use tenferro_ops::sym_dim::SymDim;
 use tenferro_ops::ShapeExtent;
 use tenferro_tensor::{DType, DotGeneralConfig, GatherConfig, PadConfig, SliceConfig};
 
+use crate::{Error, Result};
+
 /// Promote two dtypes to the narrowest common dtype that avoids silent
 /// precision loss, following the policy defined in [#811].
 ///
@@ -169,16 +171,19 @@ fn real_dtype_for_abs(dtype: DType) -> DType {
 /// Returns a vector of shapes (one per output slot). For single-output ops,
 /// the vector has length 1. Multi-output extension ops return one entry per
 /// output.
-pub fn infer_output_shapes(op: &StdTensorOp, input_shapes: &[&[DimExpr]]) -> Vec<Vec<DimExpr>> {
-    match op {
+pub fn infer_output_shapes(
+    op: &StdTensorOp,
+    input_shapes: &[&[DimExpr]],
+) -> Result<Vec<Vec<DimExpr>>> {
+    let shapes = match op {
         StdTensorOp::Add => vec![same_or_scalar_broadcast_shape(
-            require_input(op, input_shapes, 0),
-            require_input(op, input_shapes, 1),
-        )],
+            require_input(op, input_shapes, 0)?,
+            require_input(op, input_shapes, 1)?,
+        )?],
         StdTensorOp::Mul => vec![same_or_scalar_broadcast_shape(
-            require_input(op, input_shapes, 0),
-            require_input(op, input_shapes, 1),
-        )],
+            require_input(op, input_shapes, 0)?,
+            require_input(op, input_shapes, 1)?,
+        )?],
         StdTensorOp::Neg
         | StdTensorOp::Conj
         | StdTensorOp::Div
@@ -204,10 +209,10 @@ pub fn infer_output_shapes(op: &StdTensorOp, input_shapes: &[&[DimExpr]]) -> Vec
         | StdTensorOp::Triu { .. }
         | StdTensorOp::Reverse { .. }
         | StdTensorOp::Scatter(_) => {
-            vec![require_input(op, input_shapes, 0).to_vec()]
+            vec![require_input(op, input_shapes, 0)?.to_vec()]
         }
         StdTensorOp::Transpose { perm } => {
-            vec![permute_shape(require_input(op, input_shapes, 0), perm)]
+            vec![permute_shape(require_input(op, input_shapes, 0)?, perm)]
         }
         StdTensorOp::Reshape { to_shape, .. } => vec![to_shape.clone()],
         StdTensorOp::BroadcastInDim { shape, .. } => vec![shape.clone()],
@@ -216,25 +221,25 @@ pub fn infer_output_shapes(op: &StdTensorOp, input_shapes: &[&[DimExpr]]) -> Vec
         | StdTensorOp::ReduceProd { axes, .. }
         | StdTensorOp::ReduceMax { axes, .. }
         | StdTensorOp::ReduceMin { axes, .. } => {
-            vec![reduced_shape(require_input(op, input_shapes, 0), axes)]
+            vec![reduced_shape(require_input(op, input_shapes, 0)?, axes)]
         }
         StdTensorOp::ExtractDiag { axis_a, axis_b } => {
             vec![extract_diag_shape(
-                require_input(op, input_shapes, 0),
+                require_input(op, input_shapes, 0)?,
                 *axis_a,
                 *axis_b,
             )]
         }
         StdTensorOp::EmbedDiag { axis_a, axis_b } => {
             vec![embed_diag_shape(
-                require_input(op, input_shapes, 0),
+                require_input(op, input_shapes, 0)?,
                 *axis_a,
                 *axis_b,
             )]
         }
         StdTensorOp::Gather(config) => vec![gather_shape(
-            require_input(op, input_shapes, 0),
-            require_input(op, input_shapes, 1),
+            require_input(op, input_shapes, 0)?,
+            require_input(op, input_shapes, 1)?,
             config,
         )],
         StdTensorOp::GatherDynamicSliceSizes {
@@ -249,46 +254,50 @@ pub fn infer_output_shapes(op: &StdTensorOp, input_shapes: &[&[DimExpr]]) -> Vec
                 .map(|dim| resolve_dim_expr_from_shapes(dim, input_shapes))
                 .collect();
             vec![gather_shape_from_slice_sizes(
-                require_input(op, input_shapes, 0),
-                require_input(op, input_shapes, 1),
+                require_input(op, input_shapes, 0)?,
+                require_input(op, input_shapes, 1)?,
                 offset_dims,
                 collapsed_slice_dims,
                 *index_vector_dim,
                 &resolved_slice_sizes,
             )]
         }
-        StdTensorOp::Slice(config) => vec![slice_shape(require_input(op, input_shapes, 0), config)],
+        StdTensorOp::Slice(config) => {
+            vec![slice_shape(require_input(op, input_shapes, 0)?, config)]
+        }
         StdTensorOp::DynamicSlice { slice_sizes } => {
             vec![slice_sizes.iter().copied().map(DimExpr::Const).collect()]
         }
-        StdTensorOp::DynamicUpdateSlice => vec![require_input(op, input_shapes, 0).to_vec()],
-        StdTensorOp::Pad(config) => vec![pad_shape(require_input(op, input_shapes, 0), config)],
+        StdTensorOp::DynamicUpdateSlice => vec![require_input(op, input_shapes, 0)?.to_vec()],
+        StdTensorOp::Pad(config) => vec![pad_shape(require_input(op, input_shapes, 0)?, config)],
         StdTensorOp::DotGeneral { config, .. } => vec![dot_general_shape(
-            require_input(op, input_shapes, 0),
-            require_input(op, input_shapes, 1),
+            require_input(op, input_shapes, 0)?,
+            require_input(op, input_shapes, 1)?,
             config,
         )],
         StdTensorOp::Concatenate { axis, .. } => vec![concatenate_shape(input_shapes, *axis)],
         StdTensorOp::ShapeOf { .. } => vec![Vec::new()],
         StdTensorOp::DynamicTruncate { axis } => {
-            let shape = require_input(op, input_shapes, 0).to_vec();
-            assert!(
-                *axis < shape.len(),
-                "DynamicTruncate axis {axis} out of bounds for rank {}",
-                shape.len()
-            );
+            let shape = require_input(op, input_shapes, 0)?.to_vec();
+            if *axis >= shape.len() {
+                return Err(shape_infer_error(format!(
+                    "DynamicTruncate axis {axis} out of bounds for rank {}",
+                    shape.len()
+                )));
+            }
             vec![shape]
         }
         StdTensorOp::PadToMatch { axis } => vec![pad_to_match_shape(
-            require_input(op, input_shapes, 0),
-            require_input(op, input_shapes, 1),
+            require_input(op, input_shapes, 0)?,
+            require_input(op, input_shapes, 1)?,
             *axis,
         )],
         StdTensorOp::Extension(ext) => {
-            let metas = infer_extension_output_meta(ext.as_ref(), &[], input_shapes);
+            let metas = infer_extension_output_meta(ext.as_ref(), &[], input_shapes)?;
             metas.into_iter().map(|(_dtype, shape)| shape).collect()
         }
-    }
+    };
+    Ok(shapes)
 }
 
 /// Infer output shape extents for a single instruction.
@@ -300,23 +309,24 @@ pub fn infer_output_shapes(op: &StdTensorOp, input_shapes: &[&[DimExpr]]) -> Vec
 pub fn infer_output_extents(
     op: &StdTensorOp,
     input_shapes: &[&[DimExpr]],
-) -> Vec<Vec<ShapeExtent<DimExpr>>> {
+) -> Result<Vec<Vec<ShapeExtent<DimExpr>>>> {
     match op {
         StdTensorOp::DynamicTruncate { axis } => {
-            let shape = require_input(op, input_shapes, 0);
-            assert!(
-                *axis < shape.len(),
-                "DynamicTruncate axis {axis} out of bounds for rank {}",
-                shape.len()
-            );
+            let shape = require_input(op, input_shapes, 0)?;
+            if *axis >= shape.len() {
+                return Err(shape_infer_error(format!(
+                    "DynamicTruncate axis {axis} out of bounds for rank {}",
+                    shape.len()
+                )));
+            }
             let mut extents: Vec<_> = shape.iter().cloned().map(ShapeExtent::exact).collect();
             extents[*axis] = ShapeExtent::upper_bound(shape[*axis].clone());
-            vec![extents]
+            Ok(vec![extents])
         }
-        _ => infer_output_shapes(op, input_shapes)
+        _ => Ok(infer_output_shapes(op, input_shapes)?
             .into_iter()
             .map(|shape| shape.into_iter().map(ShapeExtent::exact).collect())
-            .collect(),
+            .collect()),
     }
 }
 
@@ -334,7 +344,7 @@ pub fn infer_extension_output_meta(
     op: &dyn ExtensionOp,
     input_dtypes: &[DType],
     input_shapes: &[&[DimExpr]],
-) -> Vec<(DType, Vec<DimExpr>)> {
+) -> Result<Vec<(DType, Vec<DimExpr>)>> {
     // Build per-input SymDim representations using the input index as the
     // synthetic tensor id. This preserves DimExpr::InputDim ↔ SymDim::TensorAxis
     // round-trips; the tensor_id namespace is local to this call.
@@ -363,16 +373,16 @@ pub fn infer_extension_output_meta(
             let dim_exprs: Vec<DimExpr> = shape
                 .iter()
                 .map(|dim| {
-                    dim.to_dim_expr(&tensor_map).unwrap_or_else(|err| {
-                        panic!(
-                            "ExtensionOp::infer_output_meta for family {:?} \
-                             returned a SymDim that cannot be converted to DimExpr: {err}",
-                            op.family_id(),
-                        )
+                    dim.to_dim_expr(&tensor_map).map_err(|err| {
+                        shape_infer_error(format!(
+                            "ExtensionOp::infer_output_meta for family {:?} returned a SymDim \
+                             that cannot be converted to DimExpr: {err}",
+                            op.family_id()
+                        ))
                     })
                 })
-                .collect();
-            (dtype, dim_exprs)
+                .collect::<Result<_>>()?;
+            Ok((dtype, dim_exprs))
         })
         .collect()
 }
@@ -414,12 +424,12 @@ fn require_input<'a>(
     op: &StdTensorOp,
     input_shapes: &'a [&[DimExpr]],
     idx: usize,
-) -> &'a [DimExpr] {
-    input_shapes.get(idx).copied().unwrap_or_else(|| {
-        panic!(
+) -> Result<&'a [DimExpr]> {
+    input_shapes.get(idx).copied().ok_or_else(|| {
+        shape_infer_error(format!(
             "{op:?} expects input index {idx}, got {} input shapes",
             input_shapes.len()
-        )
+        ))
     })
 }
 
@@ -483,15 +493,18 @@ fn reduced_shape(input_shape: &[DimExpr], axes: &[usize]) -> Vec<DimExpr> {
         .collect()
 }
 
-fn same_or_scalar_broadcast_shape(lhs_shape: &[DimExpr], rhs_shape: &[DimExpr]) -> Vec<DimExpr> {
+fn same_or_scalar_broadcast_shape(
+    lhs_shape: &[DimExpr],
+    rhs_shape: &[DimExpr],
+) -> Result<Vec<DimExpr>> {
     let rank = lhs_shape.len().max(rhs_shape.len());
     let mut out = Vec::with_capacity(rank);
     for axis in 0..rank {
         let lhs_dim = broadcast_aligned_dim(lhs_shape, rank, axis);
         let rhs_dim = broadcast_aligned_dim(rhs_shape, rank, axis);
-        out.push(broadcast_dim(lhs_dim, rhs_dim));
+        out.push(broadcast_dim(lhs_dim, rhs_dim)?);
     }
-    out
+    Ok(out)
 }
 
 fn broadcast_aligned_dim(shape: &[DimExpr], output_rank: usize, output_axis: usize) -> DimExpr {
@@ -502,17 +515,23 @@ fn broadcast_aligned_dim(shape: &[DimExpr], output_rank: usize, output_axis: usi
     }
 }
 
-fn broadcast_dim(lhs: DimExpr, rhs: DimExpr) -> DimExpr {
+fn broadcast_dim(lhs: DimExpr, rhs: DimExpr) -> Result<DimExpr> {
     if lhs == rhs {
-        return lhs;
+        return Ok(lhs);
     }
     match (&lhs, &rhs) {
-        (DimExpr::Const(1), _) => rhs,
-        (_, DimExpr::Const(1)) => lhs,
-        (DimExpr::Const(lhs_value), DimExpr::Const(rhs_value)) => {
-            panic!("incompatible Add/Mul broadcast dimensions: {lhs_value} and {rhs_value}")
-        }
-        _ => dim_max(lhs, rhs),
+        (DimExpr::Const(1), _) => Ok(rhs),
+        (_, DimExpr::Const(1)) => Ok(lhs),
+        (DimExpr::Const(lhs_value), DimExpr::Const(rhs_value)) => Err(shape_infer_error(format!(
+            "incompatible Add/Mul broadcast dimensions: {lhs_value} and {rhs_value}"
+        ))),
+        _ => Ok(dim_max(lhs, rhs)),
+    }
+}
+
+fn shape_infer_error(message: impl Into<String>) -> Error {
+    Error::InvalidCompiledGraph {
+        message: message.into(),
     }
 }
 

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -50,6 +51,19 @@ pub struct TracedTensor {
     pub(crate) extra_roots: Vec<Arc<Graph<StdTensorOp>>>,
     pub(crate) checkpoint_chain: Option<Arc<CheckpointNode>>,
     pub(crate) metadata_scopes: Vec<Arc<MetadataScope>>,
+}
+
+impl fmt::Debug for TracedTensor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TracedTensor")
+            .field("id", &self.id)
+            .field("rank", &self.rank)
+            .field("dtype", &self.dtype)
+            .field("val", &self.val)
+            .field("shape_hint", &self.shape_hint)
+            .field("has_data", &self.data.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 pub(crate) fn try_concrete_shape(tensor: &TracedTensor) -> Option<Vec<usize>> {

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -12,7 +12,7 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 | Concrete result | `torch.Tensor` | `jax.Array` | `Tensor` returned by `GraphExecutor::run` |
 | Execution | Eager by default | Eager arrays, often staged with `jit` | Eager (`Tensor` / `EagerTensor`) or lazy traced (`TracedTensor` + `GraphCompiler` + `GraphExecutor`) |
 | Eager forward and gradients | eager ops plus `loss.backward()` | — | `EagerTensor` forward ops, with `backward()` for tracked scalar losses |
-| Transform AD | `torch.autograd.grad(...)` | `jax.grad`, `jax.vjp`, `jax.jvp`, `hvp` via composition | `loss.grad(&x)`, `.vjp()`, `.jvp()`; HVP via composition |
+| Transform AD | `torch.autograd.grad(...)` | `jax.grad`, `jax.vjp`, `jax.jvp`, `hvp` via composition | `loss.grad(&x)`, `.vjp()?`, `.jvp()?`; HVP via composition |
 | Device/runtime | Device is attached to tensors | Device is attached to arrays | Backend lives in direct tensor calls, `EagerRuntime`, or `GraphExecutor` |
 | CUDA execution | `x.to("cuda")` | `jax.device_put(x)` | `tenferro_gpu::upload_tensor(...)` and `download_tensor(...)` |
 | Matrix contraction | `torch.einsum` | `jnp.einsum` | `tenferro_einsum::traced_tensor::einsum` standard extension |
@@ -35,8 +35,8 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 | Solve | `torch.linalg.solve(a, b)` | `jnp.linalg.solve(a, b)` | `tenferro_linalg::LinalgBackend::solve(&mut ctx, &a, &b)?` | `tenferro_linalg::traced_tensor::solve(&a, &b)?` |
 | Scalar-loss backward | `loss.backward()` | — | `loss.backward()` on `EagerTensor` | — |
 | Reverse-mode grad | `torch.autograd.grad(loss, x)` | `jax.grad(f)(x)` | — | `loss.grad(&x)` |
-| VJP | `torch.autograd.grad(..., grad_outputs=...)` | `jax.vjp` | — | `y.vjp(&x, &cotangent)` |
-| JVP | `torch.func.jvp` | `jax.jvp` | — | `y.jvp(&x, &tangent)` |
+| VJP | `torch.autograd.grad(..., grad_outputs=...)` | `jax.vjp` | — | `y.vjp(&x, &cotangent)?` |
+| JVP | `torch.func.jvp` | `jax.jvp` | — | `y.jvp(&x, &tangent)?` |
 
 ## Key differences
 

--- a/docs/guides/autodiff.md
+++ b/docs/guides/autodiff.md
@@ -45,7 +45,7 @@ There are two public traced-AD entry points over the same graph transforms:
 | Entry point | Use when |
 | --- | --- |
 | `AdContext` | You want explicit ownership of the rule set, especially when adding extension AD rules such as `tenferro_linalg::ad_rules()`. |
-| `TracedTensorAdExt` | You want compact method syntax such as `loss.grad(&x)?`, `y.vjp(&x, &ct)`, or `y.jvp(&x, &dx)` for small core-rule examples. |
+| `TracedTensorAdExt` | You want compact method syntax such as `loss.grad(&x)?`, `y.vjp(&x, &ct)?`, or `y.jvp(&x, &dx)?` for small core-rule examples. |
 
 Prefer `AdContext` in reusable code and in examples that depend on extension
 rules. The extension trait is convenience syntax for the same traced transforms;

--- a/docs/guides/complex-ad.md
+++ b/docs/guides/complex-ad.md
@@ -102,7 +102,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let y = scalar_z.exp();
     let seed = Complex64::new(2.0, -3.0);
     let cotangent = TracedTensor::from_vec_col_major(vec![1], vec![seed]);
-    let vjp = y.vjp(&scalar_z, &cotangent);
+    let vjp = y.vjp(&scalar_z, &cotangent)?;
     let vjp_value = run(&vjp)?;
     let expected_vjp = seed
         * Complex64::new(0.0, std::f64::consts::FRAC_PI_2)

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -226,18 +226,18 @@ let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
 let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]), ctx.clone());
 let y = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]), ctx.clone());
 
-let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
 loss.backward().unwrap();
 assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
 
-let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
 loss.backward().unwrap();
 assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[6.0, 8.0]);
 
 x.clear_grad();
 assert!(x.grad().is_none());
 
-let loss = (&x * &y).reduce_sum(&[0]).unwrap();
+let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
 loss.backward().unwrap();
 assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
 
@@ -265,7 +265,7 @@ let x = EagerTensor::requires_grad_in(
 let y = a.matmul(&x).unwrap();
 assert_eq!(y.data().as_slice::<f64>().unwrap(), &[23.0, 34.0]);
 
-let loss = (&y * &y).reduce_sum(&[0, 1]).unwrap();
+let loss = y.mul(&y).unwrap().reduce_sum(&[0, 1]).unwrap();
 assert_eq!(loss.data().as_slice::<f64>().unwrap(), &[1685.0]);
 
 loss.backward().unwrap();

--- a/docs/tutorial-code/src/bin/complex_ad_convention.rs
+++ b/docs/tutorial-code/src/bin/complex_ad_convention.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let y = scalar_z.exp();
     let seed = Complex64::new(2.0, -3.0);
     let cotangent = TracedTensor::from_vec_col_major(vec![1], vec![seed]);
-    let vjp = y.vjp(&scalar_z, &cotangent);
+    let vjp = y.vjp(&scalar_z, &cotangent)?;
     let vjp_value = run(&vjp)?;
     let expected_vjp = seed
         * Complex64::new(0.0, std::f64::consts::FRAC_PI_2)

--- a/docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs
+++ b/docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let runtime = EagerRuntime::new();
     let x = runtime.variable_from(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
 
-    let prediction = &x * &x;
+    let prediction = x.mul(&x).unwrap();
     let loss = prediction.reduce_sum(&[0])?;
 
     assert_eq!(loss.data().shape(), &[]);

--- a/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
+++ b/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_close(grad_value.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 
     let tangent = TracedTensor::from_vec_col_major(vec![3], vec![0.1_f64, 1.0, -2.0]);
-    let directional = y.jvp(&x, &tangent);
+    let directional = y.jvp(&x, &tangent)?;
     let directional_value = run(&directional)?;
     assert_eq!(directional_value.shape(), &[]);
     assert_close(directional_value.as_slice::<f64>().unwrap(), &[-7.8]);

--- a/docs/tutorials/eager-autodiff-pytorch-style.md
+++ b/docs/tutorials/eager-autodiff-pytorch-style.md
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let runtime = EagerRuntime::new();
     let x = runtime.variable_from(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
 
-    let prediction = &x * &x;
+    let prediction = x.mul(&x).unwrap();
     let loss = prediction.reduce_sum(&[0])?;
 
     assert_eq!(loss.data().shape(), &[]);

--- a/docs/tutorials/traced-autodiff-jax-style.md
+++ b/docs/tutorials/traced-autodiff-jax-style.md
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_close(grad_value.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 
     let tangent = TracedTensor::from_vec_col_major(vec![3], vec![0.1_f64, 1.0, -2.0]);
-    let directional = y.jvp(&x, &tangent);
+    let directional = y.jvp(&x, &tangent)?;
     let directional_value = run(&directional)?;
     assert_eq!(directional_value.shape(), &[]);
     assert_close(directional_value.as_slice::<f64>().unwrap(), &[-7.8]);

--- a/docs/worklogs/2026-06-14-recent-bug-batch.md
+++ b/docs/worklogs/2026-06-14-recent-bug-batch.md
@@ -1,0 +1,60 @@
+# Recent Bug Batch
+
+## Summary
+
+Fixed the recent panic/invalid-behavior bug batch covering issues #1027 through
+#1033 on one branch. The changes keep the public behavior fallible at API
+boundaries, add focused regression tests, and avoid broad rewrites outside the
+affected layers.
+
+## Context Read
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, `CONTRIBUTING.md`
+- `ai/contribution-workflows/bugfix-pr.md`
+- Recent GitHub issue bodies for #1027, #1028, #1029, #1030, #1031, #1032, and
+  #1033
+- Affected modules in `tenferro-ad`, `tenferro-runtime`,
+  `tenferro-internal-ops`, `tenferro-cpu`, `tenferro-gpu`, `tenferro-einsum`,
+  `tenferro-linalg`, and `tenferro-fft`
+
+## Decisions
+
+- Removed eager `Add`/`Mul`/`Neg` operator overloads instead of preserving
+  panic-based convenience operators. Eager callers now use existing fallible
+  methods such as `add`, `mul`, and `neg`.
+- Made traced `jvp`, `vjp`, and optional variants return `Result`, preserving
+  optional semantics for inactive outputs without panicking.
+- Added compact hand-written `Debug` implementations for `EagerTensor` and
+  `TracedTensor`, and recorded the public-type `Debug` rule in
+  `REPOSITORY_RULES.md`.
+- Propagated `InvalidCompiledGraph` through graph compilation and shape
+  inference for missing slot metadata and incompatible broadcast dimensions.
+- Validated `DotGeneral` AD transpose dimensions at the rule boundary and
+  returned `ADRuleError` rather than panicking.
+- Added explicit overflow rejection for CubeCL/WebGPU launch cube counts instead
+  of truncating to `u32`.
+- Replaced raw LAPACK provider pointer `transmute` with a checked helper using
+  `transmute_copy` after a size check. This keeps the unavoidable FFI conversion
+  localized and error-producing.
+
+## Deferred
+
+- A full repository-wide audit of public types missing `Debug` is intentionally
+  deferred to a follow-up issue. This PR only adds `Debug` where needed by the
+  current fallible API work.
+- Existing shape-inference config assertions for gather/slice/pad are outside
+  this batch's issue scope and remain unchanged.
+
+## Verification
+
+- `cargo fmt --all --check`
+- `cargo check -p tenferro-runtime --tests`
+- `cargo check -p tenferro-ad --tests`
+- `cargo check -p tenferro-internal-ops -p tenferro-cpu -p tenferro-gpu -p tenferro-einsum -p tenferro-linalg -p tenferro-fft --tests`
+- `cargo check -p tenferro-ad -p tenferro-fft --features tenferro-fft/autodiff --tests`
+- `cargo check -p tenferro-tutorial-code --bins`
+- `cargo check --workspace --all-targets`
+- `cargo test --workspace --release`
+
+Coverage, clippy parity, generated docs, and docs-site checks were not run in
+this time-focused batch pass.

--- a/docs/worklogs/2026-06-14-recent-bug-batch.md
+++ b/docs/worklogs/2026-06-14-recent-bug-batch.md
@@ -27,6 +27,10 @@ affected layers.
 - Added compact hand-written `Debug` implementations for `EagerTensor` and
   `TracedTensor`, and recorded the public-type `Debug` rule in
   `REPOSITORY_RULES.md`.
+- Extended the same `Debug` rule across public runtime/backend/cache/FFI wrapper
+  types in this PR. Types with cheap structural state use derived `Debug`; types
+  owning graphs, tensors, runtime handles, caches, or backend state use compact
+  summaries.
 - Propagated `InvalidCompiledGraph` through graph compilation and shape
   inference for missing slot metadata and incompatible broadcast dimensions.
 - Validated `DotGeneral` AD transpose dimensions at the rule boundary and
@@ -39,9 +43,6 @@ affected layers.
 
 ## Deferred
 
-- A full repository-wide audit of public types missing `Debug` is intentionally
-  deferred to a follow-up issue. This PR only adds `Debug` where needed by the
-  current fallible API work.
 - Existing shape-inference config assertions for gather/slice/pad are outside
   this batch's issue scope and remain unchanged.
 
@@ -54,6 +55,9 @@ affected layers.
 - `cargo check -p tenferro-ad -p tenferro-fft --features tenferro-fft/autodiff --tests`
 - `cargo check -p tenferro-tutorial-code --bins`
 - `cargo check --workspace --all-targets`
+- `cargo check -p tenferro-gpu --features cuda,webgpu --all-targets`
+- `cargo check -p tenferro-ad --features cuda,webgpu --all-targets`
+- `cargo check -p tenferro-linalg --features cuda --all-targets`
 - `cargo test --workspace --release`
 
 Coverage, clippy parity, generated docs, and docs-site checks were not run in


### PR DESCRIPTION
## Summary

Fixes the recent bug batch in one PR with separated commits:

- make eager/traced AD failure paths explicit instead of panic-prone operator or unwrap behavior
- report invalid compiled graph metadata and shape inference failures as runtime errors
- validate `DotGeneral` AD dimensions before transpose-rule construction
- guard CPU provider function-pointer casts before FFI transmute-copy
- reject overflowing CUDA/WebGPU launch cube counts instead of truncating
- add `Debug` for public runtime/backend/cache/FFI wrapper types using compact summaries where derived output would expose internals or large state
- record the public-type `Debug` rule in `REPOSITORY_RULES.md`

Work log: `docs/worklogs/2026-06-14-recent-bug-batch.md`

Fixes #1027
Fixes #1028
Fixes #1029
Fixes #1030
Fixes #1031
Fixes #1032
Fixes #1033
Closes #1051

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo check -p tenferro-gpu --features cuda,webgpu --all-targets`
- `cargo check -p tenferro-ad --features cuda,webgpu --all-targets`
- `cargo check -p tenferro-linalg --features cuda --all-targets`
- `cargo test --workspace --release`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`

Clippy parity is delegated to the PR `clippy` job for this time-focused pass.
