### PR TITLE
[codex] Fix terasaki bug report batch

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -47,6 +47,31 @@ rules from `tensor4all-agent-rules`.
   `transpose_view`, `slice_view`, or `reshape_view`. Do not use `_view` for
   operations that allocate, canonicalize, execute kernels, or transfer data.
 
+## Public Boundary Safety Audits
+
+- User-reachable tensor, runtime, eager, traced, CPU, GPU, and extension APIs
+  must validate input-derived shape, axis, dtype, padding, slice, gather,
+  scatter, and linalg config before no-op shortcuts, allocation, launch planning,
+  or FFI calls. Review fast paths and zero-size returns with the same scrutiny as
+  the main path.
+- Shape products, byte lengths, strides, offsets, launch sizes, padding extents,
+  and FFI dimensions must use checked arithmetic before conversion to `usize`,
+  `i32`, `u32`, pointer offsets, or allocation sizes. Audits should search for
+  `shape.iter().product`, `* size_of`, `as usize`, `as i32`, `as u32`,
+  `stride *=`, and unchecked `+`/`*` on shape-derived values.
+- Publicly reachable library paths must not turn invalid user input into
+  `panic`, `unwrap`, `expect`, unchecked indexing, poisoned-lock unwraps, or
+  debug-only assertions. If an invariant is truly internal, keep it close to the
+  proof; otherwise return a typed error.
+- Parallel operation surfaces must keep validation and promotion semantics in
+  parity across owned/read, eager/traced, CPU/GPU, and extension wrapper paths.
+  A bug in one surface should trigger an audit of the corresponding surfaces
+  before the fix is considered complete.
+- Every non-trivial binary under `docs/tutorial-code/src/bin/` should be covered
+  by a runnable tutorial test unless the example is explicitly compile-only or
+  hardware-gated. Markdown snippets copied from those binaries must stay synced
+  with the executable source.
+
 ## Wrapper DRY And Codegen
 
 - Do not assume tensor, eager, traced, and extension wrapper surfaces are fully

--- a/crates/tenferro-ad/src/eager_exec.rs
+++ b/crates/tenferro-ad/src/eager_exec.rs
@@ -648,9 +648,12 @@ fn exec_standard_op_on_tensors<B: TensorBackend>(
                 vec![exec.select(inputs[0], b.tensor(), c.tensor())?]
             }
             StdTensorOp::Clamp => {
-                let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
-                let (a, c) = promote_binary(exec, a.tensor(), inputs[2], op)?;
-                vec![exec.clamp(a.tensor(), b.tensor(), c.tensor())?]
+                let value_dtype =
+                    crate::shape_infer::promote_dtypes(inputs.iter().map(|t| t.dtype()));
+                let input = promote_to_dtype(exec, inputs[0], value_dtype)?;
+                let lower = promote_to_dtype(exec, inputs[1], value_dtype)?;
+                let upper = promote_to_dtype(exec, inputs[2], value_dtype)?;
+                vec![exec.clamp(input.tensor(), lower.tensor(), upper.tensor())?]
             }
             StdTensorOp::Concatenate { axis, .. } => {
                 let promoted = crate::shape_infer::promote_dtypes(inputs.iter().map(|t| t.dtype()));

--- a/crates/tenferro-ad/tests/eager_tensor/context_and_promotion.rs
+++ b/crates/tenferro-ad/tests/eager_tensor/context_and_promotion.rs
@@ -196,6 +196,26 @@ fn promote_i64_mul_c64_eager() {
 }
 
 #[test]
+fn clamp_promotes_all_three_operands_to_common_dtype() {
+    let ctx = test_ctx();
+    let input = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]),
+        ctx.clone(),
+    );
+    let lower = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![0.0_f32, 0.0]),
+        ctx.clone(),
+    );
+    let upper =
+        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![1.5_f64, 1.5]), ctx);
+
+    let out = input.clamp(&lower, &upper).unwrap();
+
+    assert_eq!(out.dtype(), DType::F64);
+    assert_eq!(out.data().as_slice::<f64>().unwrap(), &[1.0, 1.5]);
+}
+
+#[test]
 fn promote_f32_add_f64_eager() {
     let ctx = test_ctx();
     let a = EagerTensor::from_tensor_in(

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -131,13 +131,17 @@ fn advance_col_major_index(index: &mut [usize], shape: &[usize]) {
     }
 }
 
-fn pooled_filled_tensor<T>(buffers: &mut BufferPool, shape: Vec<usize>, fill: T) -> TypedTensor<T>
+fn pooled_filled_tensor<T>(
+    buffers: &mut BufferPool,
+    shape: Vec<usize>,
+    fill: T,
+) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + PoolScalar,
 {
-    let mut out = pooled_uninit_tensor(buffers, shape);
+    let mut out = pooled_uninit_tensor(buffers, shape)?;
     out.host_data_mut().fill(fill);
-    out
+    Ok(out)
 }
 
 fn clone_host_tensor_from_pool<T>(
@@ -148,7 +152,7 @@ fn clone_host_tensor_from_pool<T>(
 where
     T: Copy + Clone + PoolScalar,
 {
-    let mut out = pooled_uninit_tensor(buffers, tensor.shape().to_vec());
+    let mut out = pooled_uninit_tensor(buffers, tensor.shape().to_vec())?;
     out.host_data_mut()
         .copy_from_slice(typed_host_data(op, tensor)?);
     Ok(out)
@@ -378,7 +382,7 @@ fn typed_slice<T: Copy + Clone + PoolScalar>(
         })
         .collect::<crate::Result<Vec<_>>>()?;
 
-    let mut out = pooled_uninit_tensor(buffers, out_shape.clone());
+    let mut out = pooled_uninit_tensor(buffers, out_shape.clone())?;
     let mut out_idx = vec![0usize; rank];
     let mut in_idx = vec![0usize; rank];
 
@@ -476,12 +480,10 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar>(
         })
         .collect();
 
-    let out_len: usize = out_shape.iter().product();
-    let mut out = pooled_uninit_tensor(buffers, out_shape.clone());
+    let mut out = pooled_uninit_tensor(buffers, out_shape.clone())?;
     let mut out_idx = vec![0usize; rank];
     let mut in_idx = vec![0usize; rank];
 
-    debug_assert_eq!(out.n_elements(), out_len);
     for out_value in out.host_data_mut().iter_mut() {
         let concat_idx = out_idx[axis];
         let input_pos = segment_ends.partition_point(|&end| concat_idx >= end);
@@ -525,7 +527,7 @@ fn typed_reverse<T: Copy + Clone + PoolScalar>(
         reverse_axis[axis] = true;
     }
 
-    let mut out = pooled_uninit_tensor(buffers, input_shape.to_vec());
+    let mut out = pooled_uninit_tensor(buffers, input_shape.to_vec())?;
     let mut out_idx = vec![0usize; rank];
     let mut in_idx = vec![0usize; rank];
 
@@ -786,6 +788,17 @@ fn typed_gather<T: Copy + Clone + PoolScalar>(
             seen[dim] = true;
         }
     }
+    for &dim in &config.collapsed_slice_dims {
+        if config.slice_sizes[dim] != 1 {
+            return Err(crate::Error::InvalidConfig {
+                op: "gather",
+                message: format!(
+                    "collapsed slice dimension {dim} must have slice_size == 1, got {}",
+                    config.slice_sizes[dim]
+                ),
+            });
+        }
+    }
 
     let index_size =
         try_index_vector_size("gather", &start_indices.shape, config.index_vector_dim)?;
@@ -886,7 +899,7 @@ fn typed_gather<T: Copy + Clone + PoolScalar>(
         let _ = component;
     }
 
-    let mut out = pooled_uninit_tensor(buffers, out_shape.clone());
+    let mut out = pooled_uninit_tensor(buffers, out_shape.clone())?;
     let mut out_idx = vec![0usize; out_rank];
     let mut batch_idx = vec![0usize; batch_shape.len()];
     let mut operand_idx = vec![0usize; rank];
@@ -1216,7 +1229,7 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar>(
     }
 
     let out_shape = slice_sizes.to_vec();
-    let mut out = pooled_uninit_tensor(buffers, out_shape.clone());
+    let mut out = pooled_uninit_tensor(buffers, out_shape.clone())?;
     let mut out_idx = vec![0usize; out_shape.len()];
     let mut input_idx = vec![0usize; out_shape.len()];
 
@@ -1334,12 +1347,42 @@ fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
                 message: format!("interior padding must be non-negative on axis {axis}"),
             });
         }
+        if config.edge_padding_low[axis] < 0 || config.edge_padding_high[axis] < 0 {
+            return Err(crate::Error::InvalidConfig {
+                op: "pad",
+                message: format!("edge padding must be non-negative on axis {axis}"),
+            });
+        }
+        let input_extent_i64 =
+            i64::try_from(input_extent).map_err(|_| crate::Error::InvalidConfig {
+                op: "pad",
+                message: format!("input extent on axis {axis} does not fit in i64"),
+            })?;
+        let spacing = config.interior_padding[axis]
+            .checked_add(1)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "pad",
+                message: format!("interior padding overflow on axis {axis}"),
+            })?;
         let base = if input_extent == 0 {
             0
         } else {
-            (input_extent as i64 - 1) * (config.interior_padding[axis] + 1) + 1
+            input_extent_i64
+                .checked_sub(1)
+                .and_then(|extent| extent.checked_mul(spacing))
+                .and_then(|extent| extent.checked_add(1))
+                .ok_or_else(|| crate::Error::InvalidConfig {
+                    op: "pad",
+                    message: format!("padded input extent overflow on axis {axis}"),
+                })?
         };
-        let dim = config.edge_padding_low[axis] + config.edge_padding_high[axis] + base;
+        let dim = config.edge_padding_low[axis]
+            .checked_add(config.edge_padding_high[axis])
+            .and_then(|edge| edge.checked_add(base))
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "pad",
+                message: format!("output dimension overflow on axis {axis}"),
+            })?;
         out_shape.push(
             usize::try_from(dim).map_err(|_| crate::Error::InvalidConfig {
                 op: "pad",
@@ -1348,7 +1391,7 @@ fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
         );
     }
 
-    let mut out = pooled_filled_tensor(buffers, out_shape.clone(), fill);
+    let mut out = pooled_filled_tensor(buffers, out_shape.clone(), fill)?;
     let mut input_idx = vec![0usize; input_shape.len()];
     let mut out_idx = vec![0usize; input_shape.len()];
 

--- a/crates/tenferro-cpu/src/indexing_alloc.rs
+++ b/crates/tenferro-cpu/src/indexing_alloc.rs
@@ -1,13 +1,25 @@
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::TypedTensor;
 
-pub(crate) fn pooled_uninit_tensor<T>(buffers: &mut BufferPool, shape: Vec<usize>) -> TypedTensor<T>
+fn checked_shape_product(op: &'static str, shape: &[usize]) -> crate::Result<usize> {
+    shape
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or_else(|| {
+            crate::Error::backend_failure(op, format!("shape product overflow for {shape:?}"))
+        })
+}
+
+pub(crate) fn pooled_uninit_tensor<T>(
+    buffers: &mut BufferPool,
+    shape: Vec<usize>,
+) -> crate::Result<TypedTensor<T>>
 where
     T: Clone + PoolScalar,
 {
-    let len = shape.iter().product();
+    let len = checked_shape_product("cpu_pooled_output", &shape)?;
     // SAFETY: callers use this helper only for outputs that are fully written
     // before any read.
     let data = unsafe { T::pool_acquire(buffers, len) };
-    TypedTensor::from_vec_col_major(shape, data)
+    Ok(TypedTensor::from_vec_col_major(shape, data))
 }

--- a/crates/tenferro-cpu/src/inject.rs
+++ b/crates/tenferro-cpu/src/inject.rs
@@ -323,8 +323,9 @@ impl LapackProviderPtrSet {
 /// use tenferro_cpu::inject::{register_blas_gemm_fn_ptrs, BlasGemmFnPtrSet};
 ///
 /// unsafe {
-///     register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet::new());
+///     register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet::new())?;
 /// }
+/// # Ok::<(), tenferro_cpu::inject::ProviderRegistrationError>(())
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct BlasGemmFnPtrSet {
@@ -372,8 +373,9 @@ impl BlasGemmFnPtrSet {
 /// };
 ///
 /// unsafe {
-///     register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet::new());
+///     register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet::new())?;
 /// }
+/// # Ok::<(), tenferro_cpu::inject::ProviderRegistrationError>(())
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct LapackFullPivLuFnPtrSet {
@@ -455,8 +457,8 @@ fn lapack_registration_status(
 
 /// Register CBLAS GEMM function pointers in one call.
 ///
-/// This is a thin bulk wrapper over `cblas-inject`'s per-symbol
-/// `register_*` functions.
+/// This is a thin bulk wrapper over `cblas-inject`'s LP64 registration
+/// entry points.
 ///
 /// # Safety
 ///
@@ -469,22 +471,30 @@ fn lapack_registration_status(
 /// use tenferro_cpu::inject::{register_blas_gemm_fn_ptrs, BlasGemmFnPtrSet};
 ///
 /// unsafe {
-///     register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet::new());
+///     register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet::new())?;
 /// }
+/// # Ok::<(), tenferro_cpu::inject::ProviderRegistrationError>(())
 /// ```
-pub unsafe fn register_blas_gemm_fn_ptrs(ptrs: BlasGemmFnPtrSet) {
+pub unsafe fn register_blas_gemm_fn_ptrs(
+    ptrs: BlasGemmFnPtrSet,
+) -> Result<(), ProviderRegistrationError> {
     if let Some(f) = ptrs.sgemm {
-        unsafe { cblas_inject::register_sgemm(f) };
+        let status = unsafe { cblas_inject::cblas_inject_register_sgemm_lp64(f as *const c_void) };
+        blas_registration_status("sgemm", status)?;
     }
     if let Some(f) = ptrs.dgemm {
-        unsafe { cblas_inject::register_dgemm(f) };
+        let status = unsafe { cblas_inject::cblas_inject_register_dgemm_lp64(f as *const c_void) };
+        blas_registration_status("dgemm", status)?;
     }
     if let Some(f) = ptrs.cgemm {
-        unsafe { cblas_inject::register_cgemm(f) };
+        let status = unsafe { cblas_inject::cblas_inject_register_cgemm_lp64(f as *const c_void) };
+        blas_registration_status("cgemm", status)?;
     }
     if let Some(f) = ptrs.zgemm {
-        unsafe { cblas_inject::register_zgemm(f) };
+        let status = unsafe { cblas_inject::cblas_inject_register_zgemm_lp64(f as *const c_void) };
+        blas_registration_status("zgemm", status)?;
     }
+    Ok(())
 }
 
 /// Register LAPACK complete-pivoting LU function pointers in one call.
@@ -505,34 +515,46 @@ pub unsafe fn register_blas_gemm_fn_ptrs(ptrs: BlasGemmFnPtrSet) {
 /// };
 ///
 /// unsafe {
-///     register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet::new());
+///     register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet::new())?;
 /// }
+/// # Ok::<(), tenferro_cpu::inject::ProviderRegistrationError>(())
 /// ```
-pub unsafe fn register_lapack_full_piv_lu_fn_ptrs(ptrs: LapackFullPivLuFnPtrSet) {
+pub unsafe fn register_lapack_full_piv_lu_fn_ptrs(
+    ptrs: LapackFullPivLuFnPtrSet,
+) -> Result<(), ProviderRegistrationError> {
     if let Some(f) = ptrs.sgetc2 {
-        unsafe { lapack_inject::register_sgetc2_lp64(f) };
+        let status = unsafe { lapack_inject::register_sgetc2_lp64(f) };
+        lapack_registration_status("sgetc2", status)?;
     }
     if let Some(f) = ptrs.sgesc2 {
-        unsafe { lapack_inject::register_sgesc2_lp64(f) };
+        let status = unsafe { lapack_inject::register_sgesc2_lp64(f) };
+        lapack_registration_status("sgesc2", status)?;
     }
     if let Some(f) = ptrs.dgetc2 {
-        unsafe { lapack_inject::register_dgetc2_lp64(f) };
+        let status = unsafe { lapack_inject::register_dgetc2_lp64(f) };
+        lapack_registration_status("dgetc2", status)?;
     }
     if let Some(f) = ptrs.dgesc2 {
-        unsafe { lapack_inject::register_dgesc2_lp64(f) };
+        let status = unsafe { lapack_inject::register_dgesc2_lp64(f) };
+        lapack_registration_status("dgesc2", status)?;
     }
     if let Some(f) = ptrs.cgetc2 {
-        unsafe { lapack_inject::register_cgetc2_lp64(f) };
+        let status = unsafe { lapack_inject::register_cgetc2_lp64(f) };
+        lapack_registration_status("cgetc2", status)?;
     }
     if let Some(f) = ptrs.cgesc2 {
-        unsafe { lapack_inject::register_cgesc2_lp64(f) };
+        let status = unsafe { lapack_inject::register_cgesc2_lp64(f) };
+        lapack_registration_status("cgesc2", status)?;
     }
     if let Some(f) = ptrs.zgetc2 {
-        unsafe { lapack_inject::register_zgetc2_lp64(f) };
+        let status = unsafe { lapack_inject::register_zgetc2_lp64(f) };
+        lapack_registration_status("zgetc2", status)?;
     }
     if let Some(f) = ptrs.zgesc2 {
-        unsafe { lapack_inject::register_zgesc2_lp64(f) };
+        let status = unsafe { lapack_inject::register_zgesc2_lp64(f) };
+        lapack_registration_status("zgesc2", status)?;
     }
+    Ok(())
 }
 
 // --- Raw-pointer BLAS GEMM registration ----------------------------------
@@ -1091,6 +1113,32 @@ mod tests {
                 symbol: "dgesvd",
                 ..
             }
+        ));
+    }
+
+    #[test]
+    fn typed_registration_status_helpers_report_errors() {
+        assert!(matches!(
+            blas_registration_status("dgemm", 2),
+            Err(ProviderRegistrationError::AlreadyRegistered { symbol: "dgemm" })
+        ));
+        assert!(matches!(
+            blas_registration_status("dgemm", 9),
+            Err(ProviderRegistrationError::UnknownStatus {
+                symbol: "dgemm",
+                status: 9
+            })
+        ));
+        assert!(matches!(
+            lapack_registration_status("dgetc2", 2),
+            Err(ProviderRegistrationError::AlreadyRegistered { symbol: "dgetc2" })
+        ));
+        assert!(matches!(
+            lapack_registration_status("dgetc2", 9),
+            Err(ProviderRegistrationError::UnknownStatus {
+                symbol: "dgetc2",
+                status: 9
+            })
         ));
     }
 }

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -196,6 +196,7 @@ pub(crate) fn reduce_prod_read(input: TensorRead<'_>, axes: &[usize]) -> crate::
 }
 
 pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+    validate_axes("reduce_max", axes, input.shape().len())?;
     if axes.is_empty() {
         return Ok(input.clone());
     }
@@ -213,6 +214,7 @@ pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
 }
 
 pub(crate) fn reduce_max_read(input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
+    validate_axes("reduce_max", axes, input.shape().len())?;
     if axes.is_empty() {
         return match input {
             TensorRead::Tensor(input) => {
@@ -252,6 +254,7 @@ pub(crate) fn reduce_max_read(input: TensorRead<'_>, axes: &[usize]) -> crate::R
 }
 
 pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+    validate_axes("reduce_min", axes, input.shape().len())?;
     if axes.is_empty() {
         return Ok(input.clone());
     }
@@ -269,6 +272,7 @@ pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
 }
 
 pub(crate) fn reduce_min_read(input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
+    validate_axes("reduce_min", axes, input.shape().len())?;
     if axes.is_empty() {
         return match input {
             TensorRead::Tensor(input) => {

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -286,3 +286,5 @@ mod dot_structural_analytic;
 mod elementwise_reduction_helpers;
 #[path = "tests/cpu_tests/indexing.rs"]
 mod indexing;
+#[path = "tests/cpu_indexing_coverage_tests.rs"]
+mod indexing_coverage;

--- a/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
@@ -1,8 +1,8 @@
 use num_complex::{Complex32, Complex64};
 
+use crate::{dynamic_slice, gather, pad, scatter, CpuBackend};
 use tenferro_tensor::{BackendSessionHost, TensorIndexing};
 use tenferro_tensor::{DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig};
-use crate::{dynamic_slice, gather, pad, scatter, CpuBackend};
 use tenferro_tensor::{Tensor, TypedTensor};
 
 fn simple_gather_config() -> GatherConfig {
@@ -439,6 +439,17 @@ fn cpu_indexing_validation_covers_error_branches() {
         ),
         "pad",
     );
+    expect_invalid_config(
+        backend.pad(
+            &input,
+            &PadConfig {
+                edge_padding_low: vec![-1],
+                edge_padding_high: vec![1],
+                interior_padding: vec![0],
+            },
+        ),
+        "pad",
+    );
 
     let operand_2d = Tensor::F64(TypedTensor::from_vec_col_major(
         vec![2, 2],
@@ -489,6 +500,10 @@ fn cpu_indexing_validation_covers_error_branches() {
     let mut gather_cfg = valid_gather_2d_config();
     gather_cfg.collapsed_slice_dims = vec![0, 0];
     expect_duplicate_axis(gather(&operand_2d, &idx, &gather_cfg), "gather");
+
+    let mut gather_cfg = valid_gather_2d_config();
+    gather_cfg.slice_sizes = vec![2, 1];
+    expect_invalid_config(gather(&operand_2d, &idx, &gather_cfg), "gather");
 
     let mut gather_cfg = valid_gather_2d_config();
     gather_cfg.start_index_map = vec![0, 1];

--- a/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
@@ -812,6 +812,22 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
             ..
         })
     ));
+
+    let real = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]));
+    assert!(matches!(
+        reduce_max(&real, &[2]),
+        Err(crate::Error::AxisOutOfBounds {
+            op: "reduce_max",
+            ..
+        })
+    ));
+    assert!(matches!(
+        reduce_min(&real, &[0, 0]),
+        Err(crate::Error::DuplicateAxis {
+            op: "reduce_min",
+            ..
+        })
+    ));
 }
 
 #[test]

--- a/crates/tenferro-cpu/tests/inject_tests.rs
+++ b/crates/tenferro-cpu/tests/inject_tests.rs
@@ -24,12 +24,14 @@ fn register_test_ptrs_once() {
         register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet {
             dgemm: Some(test_dgemm),
             ..BlasGemmFnPtrSet::new()
-        });
+        })
+        .expect("test dgemm registration should succeed");
         register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet {
             dgetc2: Some(test_dgetc2),
             dgesc2: Some(test_dgesc2),
             ..LapackFullPivLuFnPtrSet::new()
-        });
+        })
+        .expect("test dgetc2/dgesc2 registration should succeed");
         register_lapack_provider_ptrs(
             ProviderAbi::Lp64,
             LapackProviderPtrSet {

--- a/crates/tenferro-cpu/tests/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/runtime_error_tests.rs
@@ -16,6 +16,13 @@ fn f32_tensor(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
     Tensor::F32(TypedTensor::from_vec_col_major(shape, data))
 }
 
+fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+    let start = source.find(start).expect("section start should exist");
+    let tail = &source[start..];
+    let end = tail.find(end).expect("section end should exist");
+    &tail[..end]
+}
+
 fn backend_f64_tensor(shape: Vec<usize>) -> Tensor {
     let len = shape.iter().product();
     Tensor::F64(TypedTensor::from_buffer_col_major(
@@ -89,6 +96,59 @@ fn cpu_linalg_dispatch_does_not_use_panic_catching_as_error_handling() {
         !backend_dispatch.contains("catch_unwind"),
         "CPU backend error handling should not depend on panic unwinding"
     );
+}
+
+#[test]
+fn cpu_pooled_output_allocation_uses_checked_shape_product() {
+    let indexing_alloc = include_str!("../src/indexing_alloc.rs");
+    assert!(
+        indexing_alloc.contains("checked_shape_product(\"cpu_pooled_output\", &shape)?"),
+        "CPU pooled output allocation must reject shape-product overflow"
+    );
+    assert!(
+        !indexing_alloc.contains("let len = shape.iter().product();"),
+        "CPU pooled output allocation must not use unchecked shape.iter().product()"
+    );
+}
+
+#[test]
+fn cpu_reduce_max_min_validate_axes_before_empty_fast_path() {
+    let reduction = include_str!("../src/reduction.rs");
+    for (start, end, op) in [
+        (
+            "pub fn reduce_max",
+            "pub(crate) fn reduce_max_read",
+            "reduce_max",
+        ),
+        (
+            "pub(crate) fn reduce_max_read",
+            "pub fn reduce_min",
+            "reduce_max",
+        ),
+        (
+            "pub fn reduce_min",
+            "pub(crate) fn reduce_min_read",
+            "reduce_min",
+        ),
+        (
+            "pub(crate) fn reduce_min_read",
+            "fn typed_reduce<",
+            "reduce_min",
+        ),
+    ] {
+        let section = source_section(reduction, start, end);
+        let validate = format!("validate_axes(\"{op}\", axes, input.shape().len())?;");
+        let validate_pos = section
+            .find(&validate)
+            .unwrap_or_else(|| panic!("{start} should validate axes"));
+        let empty_pos = section
+            .find("if axes.is_empty()")
+            .unwrap_or_else(|| panic!("{start} should have an empty-axis fast path"));
+        assert!(
+            validate_pos < empty_pos,
+            "{start} must validate axes before empty-axis fast path"
+        );
+    }
 }
 
 #[test]

--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -298,24 +298,33 @@ pub(crate) fn typed_from_cubecl<T: Send + Sync + 'static>(
 pub(crate) fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
     rt: &CubeclRuntime,
     shape: &[usize],
-) -> TypedTensor<T> {
-    let len: usize = shape.iter().product();
-    let handle = rt.client().empty(len * core::mem::size_of::<T>());
-    typed_from_cubecl(
+) -> crate::Result<TypedTensor<T>> {
+    let len = checked_shape_product("cubecl_alloc_output", shape)?;
+    let byte_len = len.checked_mul(core::mem::size_of::<T>()).ok_or_else(|| {
+        crate::Error::backend_failure(
+            "cubecl_alloc_output",
+            format!("output byte length overflow for shape {shape:?}"),
+        )
+    })?;
+    let handle = rt.client().empty(byte_len);
+    Ok(typed_from_cubecl(
         shape.to_vec(),
         CubeclBuffer::new(handle, len),
         rt.device_ordinal(),
-    )
+    ))
 }
 
-pub(crate) fn alloc_bool_output(rt: &CubeclRuntime, shape: &[usize]) -> TypedTensor<bool> {
-    let len: usize = shape.iter().product();
+pub(crate) fn alloc_bool_output(
+    rt: &CubeclRuntime,
+    shape: &[usize],
+) -> crate::Result<TypedTensor<bool>> {
+    let len = checked_shape_product("cubecl_alloc_bool_output", shape)?;
     let handle = rt.client().empty(len);
-    typed_from_cubecl(
+    Ok(typed_from_cubecl(
         shape.to_vec(),
         CubeclBuffer::new(handle, len),
         rt.device_ordinal(),
-    )
+    ))
 }
 
 pub(crate) fn typed_tensor_array_arg<T: CubeElement + Clone>(
@@ -432,7 +441,7 @@ where
     TOut: CubeElement + Clone,
 {
     validate_raw_unary_shapes(input, out_shape, op)?;
-    let output = alloc_output::<TOut>(rt, out_shape);
+    let output = alloc_output::<TOut>(rt, out_shape)?;
     let len = output.n_elements();
     ensure_resident_on_runtime(rt, input, op)?;
     let input_arg = typed_tensor_array_arg(input, op)?;
@@ -474,7 +483,7 @@ where
     TIn: CubeElement + Clone,
     TOut: CubeElement + Clone,
 {
-    let output = alloc_output::<TOut>(rt, out_shape);
+    let output = alloc_output::<TOut>(rt, out_shape)?;
     let len = output.n_elements();
     ensure_resident_on_runtime(rt, input, op)?;
     let input_arg = typed_tensor_binding(input, op)?;
@@ -576,7 +585,7 @@ where
     TOut: CubeElement + Clone,
 {
     validate_raw_binary_shapes(lhs, rhs, out_shape, op)?;
-    let output = alloc_output::<TOut>(rt, out_shape);
+    let output = alloc_output::<TOut>(rt, out_shape)?;
     let len = output.n_elements();
     ensure_resident_on_runtime(rt, lhs, op)?;
     ensure_resident_on_runtime(rt, rhs, op)?;
@@ -623,7 +632,7 @@ where
     T: CubeElement + Clone,
 {
     validate_raw_binary_shapes(lhs, rhs, out_shape, op)?;
-    let output = alloc_bool_output(rt, out_shape);
+    let output = alloc_bool_output(rt, out_shape)?;
     let len = output.n_elements();
     ensure_resident_on_runtime(rt, lhs, op)?;
     ensure_resident_on_runtime(rt, rhs, op)?;
@@ -668,7 +677,7 @@ where
     TRhs: CubeElement + Clone,
     TOut: CubeElement + Clone,
 {
-    let output = alloc_output::<TOut>(rt, out_shape);
+    let output = alloc_output::<TOut>(rt, out_shape)?;
     let len = output.n_elements();
     ensure_resident_on_runtime(rt, lhs, op)?;
     ensure_resident_on_runtime(rt, rhs, op)?;
@@ -716,7 +725,7 @@ where
     T: CubeElement + Clone,
 {
     validate_raw_ternary_shapes(pred, on_true, on_false, out_shape, op)?;
-    let output = alloc_output::<T>(rt, out_shape);
+    let output = alloc_output::<T>(rt, out_shape)?;
     let len = output.n_elements();
     ensure_resident_on_runtime(rt, pred, op)?;
     ensure_resident_on_runtime(rt, on_true, op)?;
@@ -768,7 +777,7 @@ where
     TOut: CubeElement + Clone,
 {
     validate_raw_ternary_shapes(a, b, c, out_shape, op)?;
-    let output = alloc_output::<TOut>(rt, out_shape);
+    let output = alloc_output::<TOut>(rt, out_shape)?;
     let len = output.n_elements();
     ensure_resident_on_runtime(rt, a, op)?;
     ensure_resident_on_runtime(rt, b, op)?;

--- a/crates/tenferro-gpu/src/cubecl/fusion/launch.rs
+++ b/crates/tenferro-gpu/src/cubecl/fusion/launch.rs
@@ -20,7 +20,7 @@ where
 {
     let mut outputs = Vec::with_capacity(classified.plan.outputs().len());
     for _ in classified.plan.outputs() {
-        outputs.push(alloc_output::<T>(runtime, &classified.output_shape));
+        outputs.push(alloc_output::<T>(runtime, &classified.output_shape)?);
     }
     let mut input_args = Vec::with_capacity(classified.inputs.len());
     for input in &classified.inputs {

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -172,7 +172,7 @@ where
     backend.runtime().set_current_cuda_context(OP)?;
     validate_dot_general(lhs, rhs, config)?;
     let layout = build_layout(lhs, rhs, config)?;
-    let output = alloc_output::<T>(backend.runtime(), &layout.output_shape);
+    let output = alloc_output::<T>(backend.runtime(), &layout.output_shape)?;
     if output.n_elements() == 0 {
         return Ok(output);
     }
@@ -234,7 +234,7 @@ where
     let rhs_ptr = typed_device_ptr(backend.runtime(), rhs)?;
     let output_ptr = typed_device_ptr(backend.runtime(), &output)?;
 
-    let accumulator = alloc_output::<T>(backend.runtime(), &layout.output_shape);
+    let accumulator = alloc_output::<T>(backend.runtime(), &layout.output_shape)?;
     let accumulator_ptr = typed_device_ptr(backend.runtime(), &accumulator)?;
 
     let alpha = T::one();
@@ -310,7 +310,7 @@ fn zero_alloc<T>(rt: &CubeclRuntime, shape: &[usize]) -> crate::Result<TypedTens
 where
     T: CutensorScalar,
 {
-    let output = alloc_output::<T>(rt, shape);
+    let output = alloc_output::<T>(rt, shape)?;
     launch_nullary_into(
         rt,
         &output,

--- a/crates/tenferro-gpu/src/cubecl/interop.rs
+++ b/crates/tenferro-gpu/src/cubecl/interop.rs
@@ -89,7 +89,7 @@ pub fn cube_dim_1d() -> CubeDim {
 pub fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
     rt: &CubeclRuntime,
     shape: &[usize],
-) -> TypedTensor<T> {
+) -> crate::Result<TypedTensor<T>> {
     dispatch::alloc_output(rt, shape)
 }
 

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -873,7 +873,7 @@ impl CubeclBackend {
         OutFloat: CubeElement + Clone,
     {
         let n = input.n_elements();
-        let output = alloc_output::<OutComplex>(self.runtime(), input.shape());
+        let output = alloc_output::<OutComplex>(self.runtime(), input.shape())?;
         if n == 0 {
             return Ok(output);
         }
@@ -1022,7 +1022,7 @@ impl CubeclBackend {
         T: CubeElement + CubePrimitive + Clone,
     {
         let output_shape = embed_diagonal_shape(input.shape(), axis_a, axis_b)?;
-        let output = alloc_output::<T>(self.runtime(), &output_shape);
+        let output = alloc_output::<T>(self.runtime(), &output_shape)?;
         launch_nullary_into(
             self.runtime(),
             &output,
@@ -1134,7 +1134,7 @@ impl CubeclBackend {
         T: CubeElement + Clone,
     {
         let output_shape = reduction_keepdims_shape(input.shape(), axis);
-        let output = alloc_output::<T>(self.runtime(), &output_shape);
+        let output = alloc_output::<T>(self.runtime(), &output_shape)?;
         if output.n_elements() == 0 {
             return Ok(output);
         }
@@ -1462,7 +1462,7 @@ impl CubeclBackend {
         T: CubeElement + CubePrimitive + Clone,
     {
         let output_shape = concatenate_output_shape(inputs, axis)?;
-        let output = alloc_output::<T>(self.runtime(), &output_shape);
+        let output = alloc_output::<T>(self.runtime(), &output_shape)?;
         let mut offset = 0usize;
         for input in inputs {
             launch_unary_tensor_into(
@@ -1545,7 +1545,7 @@ impl CubeclBackend {
             updates.shape(),
             config,
         )?;
-        let output = alloc_output::<T>(self.runtime(), operand.shape());
+        let output = alloc_output::<T>(self.runtime(), operand.shape())?;
         if output.n_elements() == 0 {
             return Ok(output);
         }
@@ -1622,7 +1622,7 @@ impl CubeclBackend {
             updates.shape(),
             config,
         )?;
-        let output = alloc_output::<T>(self.runtime(), operand.shape());
+        let output = alloc_output::<T>(self.runtime(), operand.shape())?;
         if output.n_elements() == 0 {
             return Ok(output);
         }

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -235,6 +235,23 @@ fn webgpu_provider_keeps_runtime_transfer_and_gemm_boundaries_split() {
 }
 
 #[test]
+fn cubecl_output_allocations_use_checked_shape_products() {
+    let dispatch = repo_file("crates/tenferro-gpu/src/cubecl/dispatch.rs");
+    assert!(
+        dispatch.contains("let len = checked_shape_product(\"cubecl_alloc_output\", shape)?;"),
+        "CubeCL typed output allocation must reject shape-product overflow"
+    );
+    assert!(
+        dispatch.contains("let len = checked_shape_product(\"cubecl_alloc_bool_output\", shape)?;"),
+        "CubeCL bool output allocation must reject shape-product overflow"
+    );
+    assert!(
+        !dispatch.contains("let len: usize = shape.iter().product();"),
+        "CubeCL output allocation must not use unchecked shape.iter().product()"
+    );
+}
+
+#[test]
 fn webgpu_allocation_uses_checked_shape_products() {
     let webgpu_mod = repo_file("crates/tenferro-gpu/src/webgpu/mod.rs");
     assert!(

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -440,6 +440,12 @@ fn factor_getc2<T: LapackFullPivLu>(
     let mut info = 0;
     T::getc2(n_i32, data, n_i32, &mut ipiv, &mut jpiv, &mut info);
     check_lapack_info(op, "getc2", info.min(0))?;
+    if info > 0 {
+        return Err(tenferro_tensor::Error::backend_failure(
+            op,
+            "matrix is singular",
+        ));
+    }
     Ok((ipiv, jpiv, info))
 }
 

--- a/crates/tenferro-linalg/src/gpu/linalg.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg.rs
@@ -519,7 +519,7 @@ where
     ensure_cubecl_resident_typed(OP, input)?;
     let n = square_matrix_dim(OP, input.shape())?;
     if has_zero_dim(input.shape()) {
-        return Ok(alloc_output(backend.runtime(), input.shape()));
+        return Ok(alloc_output(backend.runtime(), input.shape())?);
     }
 
     let work = clone_device_tensor(backend.runtime(), input, OP)?;
@@ -540,7 +540,7 @@ where
         OP,
     )?;
     let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
-    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
     let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let matrix_stride = n * n;
 
@@ -614,7 +614,7 @@ where
     let n = square_matrix_dim(op, a.shape())?;
     validate_triangular_rhs(op, a.shape(), b.shape(), left_side)?;
     if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
-        return Ok(alloc_output(backend.runtime(), b.shape()));
+        return Ok(alloc_output(backend.runtime(), b.shape())?);
     }
 
     let out = clone_device_tensor(backend.runtime(), b, op)?;
@@ -764,8 +764,8 @@ where
     let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
     let mut pivot_shape = vec![k];
     pivot_shape.extend_from_slice(&input.shape()[2..]);
-    let pivots = alloc_output::<i32>(backend.runtime(), &pivot_shape);
-    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let pivots = alloc_output::<i32>(backend.runtime(), &pivot_shape)?;
+    let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
     let pivots_ptr = typed_device_ptr(backend.runtime(), &pivots, OP)?;
     let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let matrix_stride = m * n;
@@ -825,7 +825,7 @@ where
     ensure_cubecl_resident_typed(OP, b)?;
     validate_lu_solve_prepared_shapes(packed_lu.shape(), pivots.shape(), b.shape())?;
     if has_zero_dim(packed_lu.shape()) || has_zero_dim(b.shape()) {
-        return Ok(alloc_output(backend.runtime(), b.shape()));
+        return Ok(alloc_output(backend.runtime(), b.shape())?);
     }
 
     match (transpose_a, conjugate_a) {
@@ -882,7 +882,7 @@ fn copy_svd_v_to_vt_real<T>(
 where
     T: LinalgScalar,
 {
-    let vt = alloc_output::<T>(rt, vt_shape);
+    let vt = alloc_output::<T>(rt, vt_shape)?;
     launch_svd_v_to_vt_real(rt, v, &vt, op)?;
     Ok(vt)
 }
@@ -896,7 +896,7 @@ fn copy_svd_v_to_vt_complex<T>(
 where
     T: LinalgScalar + ComplexCore,
 {
-    let vt = alloc_output::<T>(rt, vt_shape);
+    let vt = alloc_output::<T>(rt, vt_shape)?;
     launch_svd_v_to_vt_complex(rt, v, &vt, op)?;
     Ok(vt)
 }
@@ -983,15 +983,15 @@ where
     vt_shape.extend_from_slice(batch_shape);
     if has_zero_dim(input.shape()) {
         return Ok((
-            alloc_output(backend.runtime(), &u_shape),
-            alloc_output(backend.runtime(), &s_shape),
-            alloc_output(backend.runtime(), &vt_shape),
+            alloc_output(backend.runtime(), &u_shape)?,
+            alloc_output(backend.runtime(), &s_shape)?,
+            alloc_output(backend.runtime(), &vt_shape)?,
         ));
     }
 
     let work = clone_device_tensor(backend.runtime(), input, OP)?;
-    let u = alloc_output::<T>(backend.runtime(), &u_shape);
-    let s = alloc_output::<<T as LinalgScalar>::Real>(backend.runtime(), &s_shape);
+    let u = alloc_output::<T>(backend.runtime(), &u_shape)?;
+    let s = alloc_output::<<T as LinalgScalar>::Real>(backend.runtime(), &s_shape)?;
     let m_i32 = as_i32(m, OP, "m")?;
     let n_i32 = as_i32(n, OP, "n")?;
     let lda = as_i32(m, OP, "lda")?;
@@ -1005,7 +1005,7 @@ where
         SvdDriver::Gesvdj => {
             let mut v_shape = vec![n, k];
             v_shape.extend_from_slice(batch_shape);
-            let v = alloc_output::<T>(backend.runtime(), &v_shape);
+            let v = alloc_output::<T>(backend.runtime(), &v_shape)?;
             {
                 let handles = linalg_handles(backend)?;
                 let stream = raw_stream(backend.runtime(), OP)?;
@@ -1034,7 +1034,7 @@ where
                     OP,
                 )?;
                 let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
-                let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+                let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
                 let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
                 let v_stride = n * k;
 
@@ -1073,7 +1073,7 @@ where
             Ok((u, s, vt))
         }
         SvdDriver::Gesvd => {
-            let vt = alloc_output::<T>(backend.runtime(), &vt_shape);
+            let vt = alloc_output::<T>(backend.runtime(), &vt_shape)?;
             let handles = linalg_handles(backend)?;
             let stream = raw_stream(backend.runtime(), OP)?;
             handles.cusolver().set_stream(stream, OP)?;
@@ -1096,7 +1096,7 @@ where
             } else {
                 Workspace::none()
             };
-            let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+            let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
             let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
             let vt_stride = k * n;
             let job = b'S' as c_char;
@@ -1153,11 +1153,11 @@ where
     let mut s_shape = vec![k];
     s_shape.extend_from_slice(batch_shape);
     if has_zero_dim(input.shape()) {
-        return Ok(alloc_output(backend.runtime(), &s_shape));
+        return Ok(alloc_output(backend.runtime(), &s_shape)?);
     }
 
     let work = clone_device_tensor(backend.runtime(), input, OP)?;
-    let s = alloc_output::<T::Real>(backend.runtime(), &s_shape);
+    let s = alloc_output::<T::Real>(backend.runtime(), &s_shape)?;
     let m_i32 = as_i32(m, OP, "m")?;
     let n_i32 = as_i32(n, OP, "n")?;
     let lda = as_i32(m, OP, "lda")?;
@@ -1171,8 +1171,8 @@ where
             u_shape.extend_from_slice(batch_shape);
             let mut v_shape = vec![n, k];
             v_shape.extend_from_slice(batch_shape);
-            let u = alloc_output::<T>(backend.runtime(), &u_shape);
-            let v = alloc_output::<T>(backend.runtime(), &v_shape);
+            let u = alloc_output::<T>(backend.runtime(), &u_shape)?;
+            let v = alloc_output::<T>(backend.runtime(), &v_shape)?;
             let handles = linalg_handles(backend)?;
             let stream = raw_stream(backend.runtime(), OP)?;
             handles.cusolver().set_stream(stream, OP)?;
@@ -1199,7 +1199,7 @@ where
                 OP,
             )?;
             let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
-            let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+            let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
             let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
             let u_stride = m * k;
             let v_stride = n * k;
@@ -1255,7 +1255,7 @@ where
             } else {
                 Workspace::none()
             };
-            let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+            let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
             let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
             let job = b'N' as c_char;
 
@@ -1311,13 +1311,13 @@ where
     r_shape.extend_from_slice(batch_shape);
     if has_zero_dim(input.shape()) {
         return Ok((
-            alloc_output(backend.runtime(), &q_shape),
-            alloc_output(backend.runtime(), &r_shape),
+            alloc_output(backend.runtime(), &q_shape)?,
+            alloc_output(backend.runtime(), &r_shape)?,
         ));
     }
 
     let work = clone_device_tensor(backend.runtime(), input, OP)?;
-    let q = alloc_output::<T>(backend.runtime(), &q_shape);
+    let q = alloc_output::<T>(backend.runtime(), &q_shape)?;
     let handles = linalg_handles(backend)?;
     let stream = raw_stream(backend.runtime(), OP)?;
     handles.cusolver().set_stream(stream, OP)?;
@@ -1346,8 +1346,8 @@ where
     )?;
     let orgqr_workspace = alloc_workspace_elems::<T>(backend.runtime(), orgqr_lwork, OP)?;
     let batch_total = batch_count(batch_shape);
-    let geqrf_info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
-    let orgqr_info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let geqrf_info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
+    let orgqr_info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
     let geqrf_info_ptr = typed_device_ptr(backend.runtime(), &geqrf_info, OP)?;
     let orgqr_info_ptr = typed_device_ptr(backend.runtime(), &orgqr_info, OP)?;
     let work_stride = m * n;
@@ -1421,13 +1421,13 @@ where
     values_shape.extend_from_slice(batch_shape);
     if has_zero_dim(input.shape()) {
         return Ok((
-            alloc_output(backend.runtime(), &values_shape),
-            alloc_output(backend.runtime(), input.shape()),
+            alloc_output(backend.runtime(), &values_shape)?,
+            alloc_output(backend.runtime(), input.shape())?,
         ));
     }
 
     let work = clone_device_tensor(backend.runtime(), input, OP)?;
-    let values = alloc_output::<T::Real>(backend.runtime(), &values_shape);
+    let values = alloc_output::<T::Real>(backend.runtime(), &values_shape)?;
     let handles = linalg_handles(backend)?;
     let stream = raw_stream(backend.runtime(), OP)?;
     handles.cusolver().set_stream(stream, OP)?;
@@ -1448,7 +1448,7 @@ where
     )?;
     let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
     let batch_total = batch_count(batch_shape);
-    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
     let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let matrix_stride = n * n;
     let values_stride = n;
@@ -1494,11 +1494,11 @@ where
     let mut values_shape = vec![n];
     values_shape.extend_from_slice(batch_shape);
     if has_zero_dim(input.shape()) {
-        return Ok(alloc_output(backend.runtime(), &values_shape));
+        return Ok(alloc_output(backend.runtime(), &values_shape)?);
     }
 
     let work = clone_device_tensor(backend.runtime(), input, OP)?;
-    let values = alloc_output::<T::Real>(backend.runtime(), &values_shape);
+    let values = alloc_output::<T::Real>(backend.runtime(), &values_shape)?;
     let handles = linalg_handles(backend)?;
     let stream = raw_stream(backend.runtime(), OP)?;
     handles.cusolver().set_stream(stream, OP)?;
@@ -1519,7 +1519,7 @@ where
     )?;
     let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
     let batch_total = batch_count(batch_shape);
-    let info = alloc_output::<i32>(backend.runtime(), &[batch_total]);
+    let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
     let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
     let matrix_stride = n * n;
     let values_stride = n;
@@ -1574,10 +1574,10 @@ where
     u_shape.extend_from_slice(batch_shape);
     let parity_shape = batch_shape.to_vec();
 
-    let p = alloc_output::<T>(rt, &p_shape);
-    let l = alloc_output::<T>(rt, &l_shape);
-    let u = alloc_output::<T>(rt, &u_shape);
-    let parity = alloc_output::<T>(rt, &parity_shape);
+    let p = alloc_output::<T>(rt, &p_shape)?;
+    let l = alloc_output::<T>(rt, &l_shape)?;
+    let u = alloc_output::<T>(rt, &u_shape)?;
+    let parity = alloc_output::<T>(rt, &parity_shape)?;
     let launch_len = p
         .n_elements()
         .max(l.n_elements())
@@ -1619,7 +1619,7 @@ fn build_lu_parity_device<T>(
 where
     T: LinalgScalar,
 {
-    let parity = alloc_output::<T>(rt, batch_shape);
+    let parity = alloc_output::<T>(rt, batch_shape)?;
     let parity_arg = typed_tensor_binding(&parity, "lu_factor")?;
     let pivots_arg = typed_tensor_array_arg(pivots, "lu_factor")?;
     let launch_count = cube_count_for_len(parity.n_elements())?;
@@ -1645,7 +1645,7 @@ fn fill_one_device_tensor<T>(
 where
     T: LinalgScalar,
 {
-    let out = alloc_output::<T>(rt, shape);
+    let out = alloc_output::<T>(rt, shape)?;
     let out_arg = typed_tensor_binding(&out, op)?;
     let launch_count = cube_count_for_len(out.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
@@ -1669,7 +1669,7 @@ fn apply_lu_pivots_typed<T>(
 where
     T: LinalgScalar,
 {
-    let out = alloc_output::<T>(rt, input.shape());
+    let out = alloc_output::<T>(rt, input.shape())?;
     if out.n_elements() == 0 {
         return Ok(out);
     }
@@ -1711,8 +1711,8 @@ where
     let parity_shape = batch_shape.to_vec();
     let parity = fill_one_device_tensor(rt, &parity_shape, "lu_factor")?;
     Ok((
-        alloc_output(rt, shape),
-        alloc_output(rt, &pivot_shape),
+        alloc_output(rt, shape)?,
+        alloc_output(rt, &pivot_shape)?,
         parity,
     ))
 }
@@ -1757,7 +1757,7 @@ fn clone_device_tensor<T>(
 where
     T: CubeElement + CubePrimitive + Copy + Clone,
 {
-    let out = alloc_output(rt, tensor.shape());
+    let out = alloc_output(rt, tensor.shape())?;
     if out.n_elements() == 0 {
         return Ok(out);
     }
@@ -1976,10 +1976,10 @@ fn zero_like_linalg_device_tensor(
     op: &'static str,
 ) -> Result<Tensor> {
     match input {
-        Tensor::F32(t) => Ok(Tensor::F32(alloc_output(rt, t.shape()))),
-        Tensor::F64(t) => Ok(Tensor::F64(alloc_output(rt, t.shape()))),
-        Tensor::C32(t) => Ok(Tensor::C32(alloc_output(rt, t.shape()))),
-        Tensor::C64(t) => Ok(Tensor::C64(alloc_output(rt, t.shape()))),
+        Tensor::F32(t) => Ok(Tensor::F32(alloc_output(rt, t.shape())?)),
+        Tensor::F64(t) => Ok(Tensor::F64(alloc_output(rt, t.shape())?)),
+        Tensor::C32(t) => Ok(Tensor::C32(alloc_output(rt, t.shape())?)),
+        Tensor::C64(t) => Ok(Tensor::C64(alloc_output(rt, t.shape())?)),
         Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
             Err(unsupported_linalg_dtype(op, input))
         }

--- a/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
@@ -12,6 +12,18 @@ fn cpu_lapack_helpers_source() -> String {
     .unwrap_or_else(|err| panic!("LAPACK helper source should be readable: {err}"))
 }
 
+fn cpu_lapack_full_piv_lu_source() -> String {
+    fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("cpu")
+            .join("linalg")
+            .join("lapack_linalg")
+            .join("full_piv_lu.rs"),
+    )
+    .unwrap_or_else(|err| panic!("LAPACK full_piv_lu source should be readable: {err}"))
+}
+
 fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
     let start_idx = source
         .find(start)
@@ -53,4 +65,23 @@ fn lapack_batched_helpers_reuse_input_scratch_instead_of_copying_per_batch() {
             "LAPACK batched helpers should reuse pooled input scratch via {needle}"
         );
     }
+}
+
+#[test]
+fn lapack_full_piv_lu_rejects_positive_getc2_info() {
+    let source = cpu_lapack_full_piv_lu_source();
+    let factor = source_section(&source, "fn factor_getc2", "fn full_piv_lu_2d");
+
+    assert!(
+        factor.contains("check_lapack_info(op, \"getc2\", info.min(0))?;"),
+        "factor_getc2 should still report negative LAPACK argument errors"
+    );
+    assert!(
+        factor.contains("if info > 0"),
+        "factor_getc2 should not discard positive getc2 singularity info"
+    );
+    assert!(
+        factor.contains("matrix is singular"),
+        "positive getc2 info should be reported as a singular matrix"
+    );
 }

--- a/crates/tenferro-linalg/tests/full_piv_lu.rs
+++ b/crates/tenferro-linalg/tests/full_piv_lu.rs
@@ -93,6 +93,23 @@ fn full_piv_lu_uses_column_pivot_when_max_pivot_is_off_column() {
     assert_close(&f64_data(&u)[..1], &[100.0]);
 }
 
+#[cfg(feature = "cpu-blas")]
+#[test]
+fn full_piv_lu_blas_rejects_singular_matrix() {
+    let a = f64_tensor(vec![2, 2], vec![1.0, 2.0, 2.0, 4.0]);
+    let mut backend = CpuBackend::with_kind(tenferro_cpu::CpuBackendKind::Blas).unwrap();
+
+    let err = backend.full_piv_lu(&a).unwrap_err();
+
+    assert!(matches!(
+        err,
+        tenferro_tensor::Error::BackendFailure {
+            op: "full_piv_lu",
+            ref message,
+        } if message.contains("singular")
+    ));
+}
+
 #[test]
 fn full_piv_lu_solve_returns_expected_solution() {
     let a = f64_tensor(vec![2, 2], vec![0.0, 2.0, 1.0, 3.0]);

--- a/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -353,8 +353,8 @@ fn gpu_svd_uses_jax_compatible_default_driver_selection() {
     }
 
     for needle in [
-        "let u = alloc_output::<T>(backend.runtime(), &u_shape);",
-        "let v = alloc_output::<T>(backend.runtime(), &v_shape);",
+        "let u = alloc_output::<T>(backend.runtime(), &u_shape)?;",
+        "let v = alloc_output::<T>(backend.runtime(), &v_shape)?;",
         "CusolverEigMode::NoVector",
         "batch_u",
         "batch_v",

--- a/crates/tenferro-linalg/tests/inject_dual_abi_tests.rs
+++ b/crates/tenferro-linalg/tests/inject_dual_abi_tests.rs
@@ -4,13 +4,13 @@ use std::ffi::c_char;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
 
-use tenferro_cpu::CpuBackend;
-use tenferro_linalg::LinalgBackend;
-use tenferro_tensor::inject::{
+use tenferro_cpu::inject::{
     register_blas_gemm_provider_ptrs, register_lapack_provider_ptrs, BlasGemmProviderPtrSet,
     LapackProviderPtrSet, ProviderAbi, ProviderRegistrationError,
 };
-use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
+use tenferro_cpu::CpuBackend;
+use tenferro_linalg::LinalgBackend;
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorDot, TypedTensor};
 
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 

--- a/crates/tenferro-linalg/tests/inject_tests.rs
+++ b/crates/tenferro-linalg/tests/inject_tests.rs
@@ -4,13 +4,13 @@ use std::ffi::{c_char, c_void};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, Once};
 
-use tenferro_cpu::CpuBackend;
-use tenferro_linalg::LinalgBackend;
-use tenferro_tensor::inject::{
+use tenferro_cpu::inject::{
     register_blas_gemm_fn_ptrs, register_lapack_full_piv_lu_fn_ptrs, register_lapack_provider_ptrs,
     BlasGemmFnPtrSet, LapackFullPivLuFnPtrSet, LapackProviderPtrSet, ProviderAbi,
 };
-use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
+use tenferro_cpu::CpuBackend;
+use tenferro_linalg::LinalgBackend;
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorDot, TypedTensor};
 
 static REGISTER_ONCE: Once = Once::new();
 static TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -25,12 +25,14 @@ fn register_test_ptrs_once() {
         register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet {
             dgemm: Some(test_dgemm),
             ..BlasGemmFnPtrSet::new()
-        });
+        })
+        .expect("test dgemm registration should succeed");
         register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet {
             dgetc2: Some(test_dgetc2),
             dgesc2: Some(test_dgesc2),
             ..LapackFullPivLuFnPtrSet::new()
-        });
+        })
+        .expect("test dgetc2/dgesc2 registration should succeed");
         register_lapack_provider_ptrs(
             ProviderAbi::Lp64,
             LapackProviderPtrSet {

--- a/crates/tenferro-runtime/src/graph/compiler.rs
+++ b/crates/tenferro-runtime/src/graph/compiler.rs
@@ -452,7 +452,7 @@ fn validate_placeholder_spec(
             binding_index: index,
         });
     }
-    let _ = placeholder.input_key().ok_or(Error::UnexpectedBinding {
+    placeholder.input_key().ok_or(Error::UnexpectedBinding {
         binding_index: index,
     })?;
 

--- a/crates/tenferro-runtime/src/graph/executor/tests.rs
+++ b/crates/tenferro-runtime/src/graph/executor/tests.rs
@@ -2,7 +2,7 @@ use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{DType, Tensor, TensorRead, TensorValue, TypedTensor};
 
 use super::GraphExecutor;
-use crate::{GraphCompiler, TracedTensor};
+use crate::{Error, GraphCompiler, TracedTensor};
 
 #[test]
 fn borrowed_input_execution_retains_executor_slot_workspace_capacity() {
@@ -60,4 +60,17 @@ fn borrowed_input_value_execution_retains_workspace_and_lazy_output() {
         executor.slot_workspace.capacity(),
         program.exec.n_slots
     );
+}
+
+#[test]
+fn compile_with_input_specs_rejects_computed_placeholder_specs() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
+    let y = &x + &x;
+    let mut compiler = GraphCompiler::new();
+
+    let err = compiler
+        .compile_with_input_specs(&y, &[(&y, DType::F64, &[2])])
+        .unwrap_err();
+
+    assert!(matches!(err, Error::UnexpectedBinding { binding_index: 0 }));
 }

--- a/docs/tutorial-code/Cargo.toml
+++ b/docs/tutorial-code/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 
 [features]
 default = ["cpu-faer"]
-cpu-faer = ["tenferro-ad/cpu-faer", "tenferro-cpu/cpu-faer"]
-cpu-blas = ["tenferro-ad/cpu-blas", "tenferro-cpu/cpu-blas"]
+cpu-faer = ["tenferro-ad/cpu-faer", "tenferro-cpu/cpu-faer", "tenferro-linalg/cpu-faer"]
+cpu-blas = ["tenferro-ad/cpu-blas", "tenferro-cpu/cpu-blas", "tenferro-linalg/cpu-blas"]
 
 [dependencies]
 num-complex.workspace = true

--- a/docs/tutorial-code/src/bin/dynamic_shape_truncated_svd.rs
+++ b/docs/tutorial-code/src/bin/dynamic_shape_truncated_svd.rs
@@ -1,5 +1,7 @@
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{CompareDir, DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use tenferro_runtime::{
+    CompareDir, DType, GraphCompiler, GraphExecutor, GraphProgram, Tensor, TracedTensor,
+};
 
 fn assert_close(actual: &[f64], expected: &[f64], tolerance: f64) {
     assert_eq!(actual.len(), expected.len());
@@ -34,15 +36,15 @@ fn truncated_expected(diagonal: &[f64], threshold: f64) -> Vec<f64> {
 
 fn run_case(
     executor: &mut GraphExecutor<CpuBackend>,
-    program: &tenferro_runtime::GraphProgram,
+    reconstructed_program: &GraphProgram,
+    singular_values_program: &GraphProgram,
     x: &TracedTensor,
     input: &Tensor,
     expected_rank: usize,
     expected_values: &[f64],
 ) -> Result<(), tenferro_runtime::Error> {
-    let outputs = executor.run_many_with_inputs(program, &[(x, input)])?;
-    let reconstructed = &outputs[0];
-    let singular_values = &outputs[1];
+    let reconstructed = executor.run_with_inputs(reconstructed_program, &[(x, input)])?;
+    let singular_values = executor.run_with_inputs(singular_values_program, &[(x, input)])?;
 
     assert_eq!(singular_values.shape(), &[expected_rank]);
     assert_eq!(reconstructed.shape(), &[4, 4]);
@@ -75,7 +77,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "ik,k,kj->ij",
         tenferro_einsum::EinsumOptimize::Path(vec![(0, 1), (0, 1)]),
     )?;
-    let program = compiler.compile_many(&[&reconstructed, &s_truncated])?;
+    let input_specs = [(&x, DType::F64, &[4, 4][..])];
+    let reconstructed_program = compiler.compile_with_input_specs(&reconstructed, &input_specs)?;
+    let singular_values_program = compiler.compile_with_input_specs(&s_truncated, &input_specs)?;
 
     let mut executor = GraphExecutor::new(CpuBackend::new());
     executor.register_extension(tenferro_linalg::register_runtime)?;
@@ -84,7 +88,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rank2 = diagonal_matrix(&[4.0, 3.0, 0.1, 0.01]);
     run_case(
         &mut executor,
-        &program,
+        &reconstructed_program,
+        &singular_values_program,
         &x,
         &rank2,
         2,
@@ -94,7 +99,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rank3 = diagonal_matrix(&[4.0, 3.0, 2.0, 0.01]);
     run_case(
         &mut executor,
-        &program,
+        &reconstructed_program,
+        &singular_values_program,
         &x,
         &rank3,
         3,

--- a/docs/tutorial-code/src/bin/einsum_subscripts_to_gradients.rs
+++ b/docs/tutorial-code/src/bin/einsum_subscripts_to_gradients.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     assert_close(
         auto_value.as_slice::<f64>().unwrap(),
-        &[250.0, 601.0, 372.0, 893.0],
+        &[250.0, 601.0, 372.0, 894.0],
     );
 
     let y = tenferro_einsum::traced_tensor::einsum_with(

--- a/docs/tutorial-code/tests/tutorial_binaries.rs
+++ b/docs/tutorial-code/tests/tutorial_binaries.rs
@@ -35,4 +35,12 @@ fn tutorial_binaries_run_successfully() {
         "complex_ad_convention",
         env!("CARGO_BIN_EXE_complex_ad_convention"),
     );
+    run_tutorial(
+        "einsum_subscripts_to_gradients",
+        env!("CARGO_BIN_EXE_einsum_subscripts_to_gradients"),
+    );
+    run_tutorial(
+        "dynamic_shape_truncated_svd",
+        env!("CARGO_BIN_EXE_dynamic_shape_truncated_svd"),
+    );
 }

--- a/docs/tutorials/dynamic-shape-truncated-svd.md
+++ b/docs/tutorials/dynamic-shape-truncated-svd.md
@@ -1,18 +1,20 @@
 # Dynamic Shapes: Truncated SVD
 
 Use traced dynamic-shape operations when an output size is known only after
-execution starts. This tutorial builds one compiled program that runs an SVD,
-counts singular values above a threshold, truncates `u`, `s`, and `vt` with
-`dynamic_truncate`, and reconstructs the thresholded matrix.
+execution starts. This tutorial builds compiled programs that run an SVD, count
+singular values above a threshold, truncate `u`, `s`, and `vt` with
+`dynamic_truncate`, and reconstruct the thresholded matrix.
 
-The same `GraphProgram` runs twice below: once with two singular values above
-the threshold and once with three. No re-trace or recompile is needed between
-the two executions.
+The same traced graph and explicit placeholder spec are compiled once, then the
+programs run twice below: once with two singular values above the threshold and
+once with three. No re-trace or recompile is needed between the two executions.
 
 <!-- snippet-source: docs/tutorial-code/src/bin/dynamic_shape_truncated_svd.rs -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{CompareDir, DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use tenferro_runtime::{
+    CompareDir, DType, GraphCompiler, GraphExecutor, GraphProgram, Tensor, TracedTensor,
+};
 
 fn assert_close(actual: &[f64], expected: &[f64], tolerance: f64) {
     assert_eq!(actual.len(), expected.len());
@@ -47,15 +49,15 @@ fn truncated_expected(diagonal: &[f64], threshold: f64) -> Vec<f64> {
 
 fn run_case(
     executor: &mut GraphExecutor<CpuBackend>,
-    program: &tenferro_runtime::GraphProgram,
+    reconstructed_program: &GraphProgram,
+    singular_values_program: &GraphProgram,
     x: &TracedTensor,
     input: &Tensor,
     expected_rank: usize,
     expected_values: &[f64],
 ) -> Result<(), tenferro_runtime::Error> {
-    let outputs = executor.run_many_with_inputs(program, &[(x, input)])?;
-    let reconstructed = &outputs[0];
-    let singular_values = &outputs[1];
+    let reconstructed = executor.run_with_inputs(reconstructed_program, &[(x, input)])?;
+    let singular_values = executor.run_with_inputs(singular_values_program, &[(x, input)])?;
 
     assert_eq!(singular_values.shape(), &[expected_rank]);
     assert_eq!(reconstructed.shape(), &[4, 4]);
@@ -88,7 +90,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "ik,k,kj->ij",
         tenferro_einsum::EinsumOptimize::Path(vec![(0, 1), (0, 1)]),
     )?;
-    let program = compiler.compile_many(&[&reconstructed, &s_truncated])?;
+    let input_specs = [(&x, DType::F64, &[4, 4][..])];
+    let reconstructed_program = compiler.compile_with_input_specs(&reconstructed, &input_specs)?;
+    let singular_values_program = compiler.compile_with_input_specs(&s_truncated, &input_specs)?;
 
     let mut executor = GraphExecutor::new(CpuBackend::new());
     executor.register_extension(tenferro_linalg::register_runtime)?;
@@ -97,7 +101,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rank2 = diagonal_matrix(&[4.0, 3.0, 0.1, 0.01]);
     run_case(
         &mut executor,
-        &program,
+        &reconstructed_program,
+        &singular_values_program,
         &x,
         &rank2,
         2,
@@ -107,7 +112,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rank3 = diagonal_matrix(&[4.0, 3.0, 2.0, 0.01]);
     run_case(
         &mut executor,
-        &program,
+        &reconstructed_program,
+        &singular_values_program,
         &x,
         &rank3,
         3,

--- a/docs/tutorials/einsum-subscripts-to-gradients.md
+++ b/docs/tutorials/einsum-subscripts-to-gradients.md
@@ -85,7 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     assert_close(
         auto_value.as_slice::<f64>().unwrap(),
-        &[250.0, 601.0, 372.0, 893.0],
+        &[250.0, 601.0, 372.0, 894.0],
     );
 
     let y = tenferro_einsum::traced_tensor::einsum_with(

--- a/docs/worklogs/2026-06-17-terasaki-bug-batch.md
+++ b/docs/worklogs/2026-06-17-terasaki-bug-batch.md
@@ -1,0 +1,74 @@
+# Terasaki Bug Batch
+
+## Summary
+
+Fixed a bounded batch of recent `terasakisatoshi` bug reports in one PR. The
+batch focuses on narrow public-boundary defects: unchecked shape arithmetic,
+validation order, tutorial drift, dtype promotion parity, provider registration
+status propagation, and LAPACK singular-status handling.
+
+The PR also records a general repository audit rule for this class of bugs:
+public API boundaries must validate user-derived shape, axis, dtype, padding,
+slice, gather/scatter, linalg, allocation, launch, and FFI inputs before fast
+paths, allocation, backend launch, or unchecked arithmetic.
+
+## Context Read
+
+- `REPOSITORY_RULES.md` and existing work-log guidance.
+- Open `terasakisatoshi` GitHub issues #1054 through #1084.
+- Affected modules in `tenferro-ad`, `tenferro-runtime`, `tenferro-cpu`,
+  `tenferro-gpu`, `tenferro-linalg`, and `docs/tutorial-code`.
+- Existing source-contract tests for GPU allocation and CPU/linalg behavior.
+
+## Decisions
+
+- Fixed unchecked CPU and GPU output allocation shape products with fallible
+  checked products at allocation helpers instead of relying on individual call
+  sites to remember overflow checks.
+- Kept CPU indexing validation local to each public operation: pad rejects
+  negative edge padding and shape overflow, and gather rejects collapsed
+  dimensions whose slice size is not one.
+- Made CPU `reduce_max` and `reduce_min` validate axes before the empty-axis
+  fast path. The issue's literal "empty axes plus invalid axis value" cannot be
+  represented by `&[usize]`, so the regression locks the source pattern.
+- Aligned eager owned `Clamp` dtype promotion with the existing read path by
+  promoting the input and both bounds together.
+- Made typed BLAS/LAPACK provider registration wrappers return
+  `ProviderRegistrationError` instead of discarding status codes. The BLAS
+  typed wrapper uses the status-returning LP64 C registration entry points.
+- Treated #1065 as a readability and regression-coverage fix: Rust's
+  `let _ = expr?` still propagates the error, but the source now uses direct
+  `?` propagation to make the intended validation obvious.
+- Updated tutorial source and prose together so snippet and tutorial tests
+  exercise the documented examples.
+
+## Deferred
+
+- #1054 and #1056 are not part of this PR.
+- #1073 was not closed; the existing three-way repeated-label trace test for
+  `iii` passes, so it needs a sharper reproducer before changing einsum logic.
+- #1071, #1072, #1074, #1075, #1076, and #1080 through #1084 are broader
+  safety, panic, concurrency, or overflow audits and should be split into
+  follow-up PRs.
+
+## Verification
+
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-ad --test eager_tensor context_and_promotion::clamp_promotes_all_three_operands_to_common_dtype -- --exact`
+- `cargo test -p tenferro-runtime graph::executor::tests::compile_with_input_specs_rejects_computed_placeholder_specs -- --exact`
+- `cargo test -p tenferro-cpu --lib tests::indexing_coverage::cpu_indexing_validation_covers_error_branches -- --exact`
+- `cargo test -p tenferro-cpu --lib tests::elementwise_reduction_helpers::test_reduction_helpers_cover_complex_and_error_paths -- --exact`
+- `cargo test -p tenferro-cpu --test runtime_error_tests cpu_pooled_output_allocation_uses_checked_shape_product -- --exact`
+- `cargo test -p tenferro-cpu --test runtime_error_tests cpu_reduce_max_min_validate_axes_before_empty_fast_path -- --exact`
+- `cargo test -p tenferro-cpu --features provider-inject --lib inject::tests::typed_registration_status_helpers_report_errors -- --exact`
+- `cargo test -p tenferro-cpu --features provider-inject --test inject_tests provider_inject_dot_general_uses_registered_blas -- --exact`
+- `cargo test -p tenferro-gpu --test public_surface_contract cubecl_output_allocations_use_checked_shape_products -- --exact`
+- `cargo test -p tenferro-linalg --test cpu_linalg_source_contract lapack_full_piv_lu_rejects_positive_getc2_info -- --exact`
+- `cargo test -p tenferro-linalg --features cpu-blas,blas-accelerate --test full_piv_lu full_piv_lu_blas_rejects_singular_matrix -- --exact`
+- `cargo test -p tenferro-linalg --features provider-inject --test inject_tests provider_inject_full_piv_lu_solve_uses_registered_lapack -- --exact`
+- `cargo test -p tenferro-linalg --features provider-inject --test inject_dual_abi_tests ilp64_gemm_provider_reaches_lp64_consumer -- --exact`
+- `cargo test -p tenferro-tutorial-code --release tutorial_binaries_run_successfully -- --exact`
+- `python3 scripts/check-doc-snippets.py`
+- `python3.11 scripts/check-guide-dependency-snippets.py`
+- `cargo check -p tenferro-gpu --features cuda`
+- `cargo check -p tenferro-linalg --features cuda`


### PR DESCRIPTION
## Summary

Merge policy: please merge with a merge commit; do not squash.

This PR fixes a bounded batch of recent `terasakisatoshi` bug reports around public-boundary validation, checked allocation arithmetic, tutorial drift, dtype promotion parity, provider registration status propagation, and LAPACK singular-status handling.

Work log: `docs/worklogs/2026-06-17-terasaki-bug-batch.md`

## Fixed

- CPU/GPU output allocation now uses checked shape products before allocation/byte sizing.
- CPU pad/gather validation now rejects negative edge padding, padding shape overflow, and invalid collapsed gather dimensions.
- CPU `reduce_max`/`reduce_min` validate axes before the empty-axis fast path.
- AD owned `Clamp` now promotes input/lower/upper dtypes together, matching the read path.
- Graph compiler placeholder validation is written as direct `?` propagation and has regression coverage.
- LAPACK `full_piv_lu` now rejects positive `getc2` singular info instead of silently proceeding.
- Typed BLAS/LAPACK provider registration wrappers now return registration errors.
- Dynamic SVD and einsum tutorial code/prose are synced with runnable tests.
- `REPOSITORY_RULES.md` now includes a general public-boundary safety audit rule for this class of bugs.

Fixes #1055
Fixes #1058
Fixes #1064
Fixes #1065
Fixes #1066
Fixes #1067
Fixes #1068
Fixes #1069
Fixes #1070
Fixes #1077
Fixes #1078
Fixes #1079

## Deferred

- #1073 is not closed: the existing `iii` repeated-label trace test passes, so this needs a sharper reproducer before changing einsum logic.
- #1054, #1056, #1071, #1072, #1074, #1075, #1076, and #1080 through #1084 are broader docs, AD, panic, concurrency, pool, or overflow audits and should be handled in follow-up PRs.

## Verification

- `cargo fmt --all --check`
- `cargo test -p tenferro-ad --test eager_tensor context_and_promotion::clamp_promotes_all_three_operands_to_common_dtype -- --exact`
- `cargo test -p tenferro-runtime graph::executor::tests::compile_with_input_specs_rejects_computed_placeholder_specs -- --exact`
- `cargo test -p tenferro-cpu --lib tests::indexing_coverage::cpu_indexing_validation_covers_error_branches -- --exact`
- `cargo test -p tenferro-cpu --lib tests::elementwise_reduction_helpers::test_reduction_helpers_cover_complex_and_error_paths -- --exact`
- `cargo test -p tenferro-cpu --test runtime_error_tests cpu_pooled_output_allocation_uses_checked_shape_product -- --exact`
- `cargo test -p tenferro-cpu --test runtime_error_tests cpu_reduce_max_min_validate_axes_before_empty_fast_path -- --exact`
- `cargo test -p tenferro-cpu --features provider-inject --lib inject::tests::typed_registration_status_helpers_report_errors -- --exact`
- `cargo test -p tenferro-cpu --features provider-inject --test inject_tests provider_inject_dot_general_uses_registered_blas -- --exact`
- `cargo test -p tenferro-gpu --test public_surface_contract cubecl_output_allocations_use_checked_shape_products -- --exact`
- `cargo test -p tenferro-linalg --test cpu_linalg_source_contract lapack_full_piv_lu_rejects_positive_getc2_info -- --exact`
- `cargo test -p tenferro-linalg --features cpu-blas,blas-accelerate --test full_piv_lu full_piv_lu_blas_rejects_singular_matrix -- --exact`
- `cargo test -p tenferro-linalg --features provider-inject --test inject_tests provider_inject_full_piv_lu_solve_uses_registered_lapack -- --exact`
- `cargo test -p tenferro-linalg --features provider-inject --test inject_dual_abi_tests ilp64_gemm_provider_reaches_lp64_consumer -- --exact`
- `cargo test -p tenferro-tutorial-code --release tutorial_binaries_run_successfully -- --exact`
- `python3 scripts/check-doc-snippets.py`
- `python3.11 scripts/check-guide-dependency-snippets.py`
- `cargo check -p tenferro-gpu --features cuda`
- `cargo check -p tenferro-linalg --features cuda`