### PR TITLE
[codex] Extend terasaki safety audit fixes

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -59,10 +59,23 @@ rules from `tensor4all-agent-rules`.
   `i32`, `u32`, pointer offsets, or allocation sizes. Audits should search for
   `shape.iter().product`, `* size_of`, `as usize`, `as i32`, `as u32`,
   `stride *=`, and unchecked `+`/`*` on shape-derived values.
+- Pointer-offset loops over batches, matrix blocks, tensor strides, or packed
+  FFI pointer arrays must check both the per-item stride product and the
+  `batch * stride` offset. Source-contract tests are appropriate for GPU/FFI
+  paths that cannot be exercised on every CI machine.
 - Publicly reachable library paths must not turn invalid user input into
   `panic`, `unwrap`, `expect`, unchecked indexing, poisoned-lock unwraps, or
   debug-only assertions. If an invariant is truly internal, keep it close to the
   proof; otherwise return a typed error.
+- Public cache, runtime, extension, and AD registry locks must not silently
+  ignore poison by reporting empty/default state. If the method can return a
+  `Result`, return a typed poison error; if the legacy API cannot return a
+  `Result`, provide a fallible `try_*` API and make the legacy wrapper fail
+  visibly rather than fabricating success.
+- Public traced/eager helpers must validate rank and axis counts before
+  computing output ranks or indexing shape arrays. Symbolic-shape traced values
+  must not be forced through concrete-shape helpers unless the API explicitly
+  returns a symbolic-shape error.
 - Parallel operation surfaces must keep validation and promotion semantics in
   parity across owned/read, eager/traced, CPU/GPU, and extension wrapper paths.
   A bug in one surface should trigger an audit of the corresponding surfaces

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -3,7 +3,7 @@ use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::env;
 use std::fmt;
-use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 use crate::extension_cache::{ExtensionCacheLimits, ExtensionCacheStore};
@@ -220,6 +220,18 @@ impl fmt::Debug for EagerRuntime {
 }
 
 impl EagerRuntime {
+    fn lock_backend(&self) -> Result<MutexGuard<'_, EagerBackend>> {
+        self.backend
+            .lock()
+            .map_err(|_| Error::Internal("backend lock poisoned".to_string()))
+    }
+
+    fn lock_extension_executor(&self) -> Result<MutexGuard<'_, ExtensionExecutor<EagerBackend>>> {
+        self.extension_executor
+            .lock()
+            .map_err(|_| Error::Internal("extension executor lock poisoned".to_string()))
+    }
+
     fn from_backend(backend: EagerBackend) -> Self {
         Self::from_backend_with_extension_rules(backend, None)
     }
@@ -376,7 +388,12 @@ impl EagerRuntime {
             &mut ExtensionExecutor<EagerBackend>,
         ) -> std::result::Result<(), ExtensionRuntimeRegistryError>,
     ) -> std::result::Result<(), ExtensionRuntimeRegistryError> {
-        register(&mut self.extension_executor.lock().unwrap())
+        let mut executor = self.extension_executor.lock().map_err(|_| {
+            ExtensionRuntimeRegistryError::PoisonedLock {
+                name: "extension executor lock",
+            }
+        })?;
+        register(&mut executor)
     }
 
     /// Clear generic extension runtime cache entries.
@@ -507,20 +524,16 @@ impl EagerRuntime {
     /// ctx.synchronize().unwrap();
     /// ```
     pub fn synchronize(&self) -> Result<()> {
-        self.backend
-            .lock()
-            .unwrap()
-            .synchronize()
-            .map_err(Error::from)
+        self.lock_backend()?.synchronize().map_err(Error::from)
     }
 
     pub(crate) fn exec_outputs(&self, op: &StdTensorOp, inputs: &[&Tensor]) -> Result<Vec<Tensor>> {
         let mut backend =
-            profile_eager_op_section("exec_outputs.lock_backend", || self.backend.lock().unwrap());
+            profile_eager_op_section("exec_outputs.lock_backend", || self.lock_backend())?;
         let mut extension_executor =
             profile_eager_op_section("exec_outputs.lock_extensions", || {
-                self.extension_executor.lock().unwrap()
-            });
+                self.lock_extension_executor()
+            })?;
         profile_eager_op_section("exec_outputs.exec_op", || {
             exec_op_on_tensors_with_extension_executor(
                 op,
@@ -536,13 +549,12 @@ impl EagerRuntime {
         op: &StdTensorOp,
         inputs: &[TensorRead<'_>],
     ) -> Result<Vec<Tensor>> {
-        let mut backend = profile_eager_op_section("exec_outputs_read.lock_backend", || {
-            self.backend.lock().unwrap()
-        });
+        let mut backend =
+            profile_eager_op_section("exec_outputs_read.lock_backend", || self.lock_backend())?;
         let mut extension_executor =
             profile_eager_op_section("exec_outputs_read.lock_extensions", || {
-                self.extension_executor.lock().unwrap()
-            });
+                self.lock_extension_executor()
+            })?;
         profile_eager_op_section("exec_outputs_read.exec_op", || {
             exec_op_on_tensor_reads_with_extension_executor(
                 op,
@@ -559,7 +571,7 @@ impl EagerRuntime {
         initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     ) -> Result<EagerGraphExecution> {
         let mut backend =
-            profile_eager_op_section("exec_graph.lock_backend", || self.backend.lock().unwrap());
+            profile_eager_op_section("exec_graph.lock_backend", || self.lock_backend())?;
         let mut all_values = initial_data.clone();
 
         profile_eager_op_section("exec_graph.with_backend_session", || {
@@ -721,7 +733,6 @@ impl EagerRuntime {
         backend: &mut EagerBackend,
     ) -> Result<()> {
         let mut updates = Vec::new();
-        let mut staged = Vec::new();
 
         {
             let mut slots = self.grad_slots.lock().unwrap();
@@ -739,18 +750,12 @@ impl EagerRuntime {
         }
 
         for (slot, incoming) in updates {
-            let next = {
-                let current = slot.lock().unwrap();
-                match current.as_ref() {
-                    Some(existing) => Arc::new(backend.add(existing.as_ref(), incoming.as_ref())?),
-                    None => incoming,
-                }
+            let mut current = slot.lock().unwrap();
+            let next = match current.as_ref() {
+                Some(existing) => Arc::new(backend.add(existing.as_ref(), incoming.as_ref())?),
+                None => incoming,
             };
-            staged.push((slot, next));
-        }
-
-        for (slot, next) in staged {
-            *slot.lock().unwrap() = Some(next);
+            *current = Some(next);
         }
 
         Ok(())

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -12,7 +12,7 @@ use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::SymDim;
-use tenferro_runtime::{ExtensionExecutionContext, ExtensionExecutor, ExtensionRuntime};
+use tenferro_runtime::{Error, ExtensionExecutionContext, ExtensionExecutor, ExtensionRuntime};
 use tenferro_tensor::Tensor;
 use tenferro_tensor::{DType, DotGeneralConfig, TensorBackend};
 use tenferro_tensor::{TensorFusion, TensorRead};
@@ -50,6 +50,37 @@ fn build_add_mul_reduce_graph(keys: &[TensorInputKey]) -> Arc<Graph<StdTensorOp>
     )[0];
     builder.set_outputs(vec![loss]);
     Arc::new(builder.build())
+}
+
+#[test]
+fn eager_runtime_synchronize_reports_poisoned_backend_lock() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _guard = ctx.backend.lock().unwrap();
+        panic!("poison eager backend lock");
+    }));
+    assert!(poisoned.is_err());
+
+    let err = ctx.synchronize().unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::Internal(ref message) if message.contains("backend lock poisoned")
+    ));
+}
+
+#[test]
+fn eager_runtime_register_extension_reports_poisoned_executor_lock() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _guard = ctx.extension_executor.lock().unwrap();
+        panic!("poison extension executor lock");
+    }));
+    assert!(poisoned.is_err());
+
+    let err = ctx.register_extension(|_| Ok(())).unwrap_err();
+
+    assert!(err.to_string().contains("extension executor lock poisoned"));
 }
 
 struct EagerOpProfileOverrideGuard;

--- a/crates/tenferro-ad/tests/eager_runtime_api.rs
+++ b/crates/tenferro-ad/tests/eager_runtime_api.rs
@@ -27,6 +27,16 @@ fn eager_runtime_synchronize_is_available_and_cpu_noop() {
     runtime.synchronize().unwrap();
 }
 
+#[test]
+fn eager_runtime_grad_accumulation_keeps_slot_locked_through_update() {
+    let source = include_str!("../src/eager.rs");
+
+    assert!(
+        !source.contains("let mut staged = Vec::new();"),
+        "gradient accumulation must not stage slot updates after releasing the per-slot lock"
+    );
+}
+
 #[cfg(feature = "webgpu")]
 #[test]
 fn eager_runtime_accepts_webgpu_backend_constructor() {

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -111,6 +111,34 @@ fn maybe_print_cpu_session_profile() {
     }
 }
 
+struct BufferPoolLoan<'a> {
+    target: &'a mut BufferPool,
+    buffers: Option<BufferPool>,
+}
+
+impl<'a> BufferPoolLoan<'a> {
+    fn new(target: &'a mut BufferPool) -> Self {
+        Self {
+            buffers: Some(std::mem::take(target)),
+            target,
+        }
+    }
+
+    fn get_mut(&mut self) -> &mut BufferPool {
+        self.buffers
+            .as_mut()
+            .expect("buffer pool loan already restored")
+    }
+}
+
+impl Drop for BufferPoolLoan<'_> {
+    fn drop(&mut self) {
+        if let Some(buffers) = self.buffers.take() {
+            *self.target = buffers;
+        }
+    }
+}
+
 /// CPU provider selected by a [`CpuBackend`] instance.
 ///
 /// CPU provider features are additive at compile time; this runtime selector
@@ -576,21 +604,17 @@ impl CpuBackend {
     }
 
     fn install_with_pool<R: Send>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R {
-        let mut buffers = std::mem::take(&mut self.buffers);
+        let mut buffers = BufferPoolLoan::new(&mut self.buffers);
         let ctx = Arc::clone(&self.ctx);
-        let result = ctx.install(|| op(&mut buffers));
-        self.buffers = buffers;
-        result
+        ctx.install(|| op(buffers.get_mut()))
     }
 
     // Selected when the BLAS provider is active; default Faer-only builds keep
     // it dormant.
     #[allow(dead_code)]
     fn run_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R) -> R {
-        let mut buffers = std::mem::take(&mut self.buffers);
-        let result = op(&mut buffers);
-        self.buffers = buffers;
-        result
+        let mut buffers = BufferPoolLoan::new(&mut self.buffers);
+        op(buffers.get_mut())
     }
 
     fn linalg_with_pool<R: Send>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R {
@@ -624,11 +648,9 @@ impl CpuBackend {
         gemm_analysis_cache: &mut gemm::GemmAnalysisCache,
         op: impl FnOnce(&mut BufferPool, &mut gemm::GemmAnalysisCache) -> R + Send,
     ) -> R {
-        let mut buffers = std::mem::take(&mut self.buffers);
+        let mut buffers = BufferPoolLoan::new(&mut self.buffers);
         let ctx = Arc::clone(&self.ctx);
-        let result = ctx.install(|| op(&mut buffers, gemm_analysis_cache));
-        self.buffers = buffers;
-        result
+        ctx.install(|| op(buffers.get_mut(), gemm_analysis_cache))
     }
 
     // Selected when the BLAS provider handles cached GEMM execution; default
@@ -639,10 +661,8 @@ impl CpuBackend {
         gemm_analysis_cache: &mut gemm::GemmAnalysisCache,
         op: impl FnOnce(&mut BufferPool, &mut gemm::GemmAnalysisCache) -> R,
     ) -> R {
-        let mut buffers = std::mem::take(&mut self.buffers);
-        let result = op(&mut buffers, gemm_analysis_cache);
-        self.buffers = buffers;
-        result
+        let mut buffers = BufferPoolLoan::new(&mut self.buffers);
+        op(buffers.get_mut(), gemm_analysis_cache)
     }
 }
 
@@ -1377,26 +1397,24 @@ impl BackendSessionHost for CpuBackend {
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R {
         if !cpu_session_profile_enabled() {
-            let mut buffers = std::mem::take(&mut self.buffers);
+            let mut buffers = BufferPoolLoan::new(&mut self.buffers);
             let ctx = Arc::clone(&self.ctx);
             let kind = self.kind;
-            let result = ctx.install(|| {
+            return ctx.install(|| {
                 let mut session = CpuExecSession {
                     ctx: ctx.as_ref(),
-                    buffers: &mut buffers,
+                    buffers: buffers.get_mut(),
                     gemm_analysis_cache: cache,
                     kind,
                 };
                 f(&mut session)
             });
-            self.buffers = buffers;
-            return result;
         }
 
         let total_started = Instant::now();
         let mut buffers =
             profile_cpu_session_section("with_backend_session_cached.take_buffers", || {
-                std::mem::take(&mut self.buffers)
+                BufferPoolLoan::new(&mut self.buffers)
             });
         let ctx = Arc::clone(&self.ctx);
         let kind = self.kind;
@@ -1406,7 +1424,7 @@ impl BackendSessionHost for CpuBackend {
                     let session_started = Instant::now();
                     let mut session = CpuExecSession {
                         ctx: ctx.as_ref(),
-                        buffers: &mut buffers,
+                        buffers: buffers.get_mut(),
                         gemm_analysis_cache: cache,
                         kind,
                     };
@@ -1425,7 +1443,7 @@ impl BackendSessionHost for CpuBackend {
                 })
             });
         profile_cpu_session_section("with_backend_session_cached.restore_buffers", || {
-            self.buffers = buffers;
+            drop(buffers);
         });
         record_cpu_session_profile("with_backend_session_cached.total", total_started.elapsed());
         maybe_print_cpu_session_profile();

--- a/crates/tenferro-cpu/src/buffer_pool.rs
+++ b/crates/tenferro-cpu/src/buffer_pool.rs
@@ -51,8 +51,7 @@ pub struct BufferPoolStats {
 /// Typed buffer pool keyed by element capacity and separated by scalar type.
 ///
 /// Each supported dtype has an independent best-fit pool. Acquired buffers are
-/// returned without zero-initialization so GEMM callers can avoid redundant
-/// writes when they fully overwrite the output.
+/// initialized to that dtype's zero value before they are returned.
 ///
 /// # Examples
 ///
@@ -104,15 +103,19 @@ impl fmt::Debug for BufferPool {
 /// <f64 as PoolScalar>::pool_release(&mut pool, buf);
 /// ```
 pub trait PoolScalar: Copy + Sized + Send + Sync + private::Sealed {
+    /// Zero value used to initialize acquired buffers.
+    fn pool_zero() -> Self;
+
     /// Acquire a buffer with length `len`.
     ///
-    /// The vector length is set without initializing its contents. Callers must
-    /// overwrite every element before any read.
+    /// The returned vector has length `len`, capacity at least `len`, and every
+    /// element initialized to this dtype's zero value.
     ///
     /// # Safety
     ///
-    /// The returned vector may contain uninitialized elements. Reading any
-    /// element before writing it is undefined behavior.
+    /// This method remains unsafe for API compatibility with older tenferro
+    /// releases. Implementations must return fully initialized values, and
+    /// callers do not need to uphold additional memory-safety invariants.
     ///
     /// # Examples
     ///
@@ -202,27 +205,23 @@ fn smallest_pool_candidate<T>(
 }
 
 macro_rules! impl_pool_scalar {
-    ($ty:ty, $field:ident) => {
+    ($ty:ty, $field:ident, $zero:expr) => {
         impl PoolScalar for $ty {
-            #[allow(clippy::uninit_vec)]
+            fn pool_zero() -> Self {
+                $zero
+            }
+
             unsafe fn pool_acquire(pool: &mut BufferPool, len: usize) -> Vec<Self> {
                 match take_best_fit(&mut pool.$field, len) {
                     Some(mut buf) => {
                         pool.retained_capacity_bytes = pool
                             .retained_capacity_bytes
                             .saturating_sub(buf.capacity().saturating_mul(size_of::<Self>()));
-                        // SAFETY: caller upholds that elements will be written
-                        // before any read. len <= capacity by construction.
-                        unsafe { buf.set_len(len) };
+                        buf.resize(len, Self::pool_zero());
+                        buf.fill(Self::pool_zero());
                         buf
                     }
-                    None => {
-                        let mut buf = Vec::with_capacity(len);
-                        // SAFETY: caller upholds that elements will be written
-                        // before any read. len == capacity here.
-                        unsafe { buf.set_len(len) };
-                        buf
-                    }
+                    None => vec![Self::pool_zero(); len],
                 }
             }
 
@@ -240,13 +239,13 @@ macro_rules! impl_pool_scalar {
     };
 }
 
-impl_pool_scalar!(f64, f64_pool);
-impl_pool_scalar!(f32, f32_pool);
-impl_pool_scalar!(i32, i32_pool);
-impl_pool_scalar!(i64, i64_pool);
-impl_pool_scalar!(bool, bool_pool);
-impl_pool_scalar!(Complex64, c64_pool);
-impl_pool_scalar!(Complex32, c32_pool);
+impl_pool_scalar!(f64, f64_pool, 0.0);
+impl_pool_scalar!(f32, f32_pool, 0.0);
+impl_pool_scalar!(i32, i32_pool, 0);
+impl_pool_scalar!(i64, i64_pool, 0);
+impl_pool_scalar!(bool, bool_pool, false);
+impl_pool_scalar!(Complex64, c64_pool, Complex64::new(0.0, 0.0));
+impl_pool_scalar!(Complex32, c32_pool, Complex32::new(0.0, 0.0));
 
 impl BufferPool {
     /// Create an empty typed buffer pool.
@@ -449,9 +448,7 @@ impl BufferPool {
         }
 
         let mut buf = unsafe { T::pool_acquire(self, cap) };
-        // SAFETY: shrinking the length to zero does not read the buffer. The
-        // pool only stores `PoolScalar` values, which are `Copy`.
-        unsafe { buf.set_len(0) };
+        buf.clear();
         buf
     }
 

--- a/crates/tenferro-cpu/src/buffer_pool/tests.rs
+++ b/crates/tenferro-cpu/src/buffer_pool/tests.rs
@@ -54,6 +54,18 @@ fn fresh_alloc_fallback() {
 }
 
 #[test]
+fn acquired_buffers_are_initialized_on_fresh_and_reused_paths() {
+    let mut pool = BufferPool::new();
+
+    let fresh = unsafe { <f64 as PoolScalar>::pool_acquire(&mut pool, 4) };
+    assert_eq!(fresh, vec![0.0; 4]);
+
+    <f64 as PoolScalar>::pool_release(&mut pool, vec![7.0, 8.0, 9.0, 10.0]);
+    let reused = unsafe { <f64 as PoolScalar>::pool_acquire(&mut pool, 4) };
+    assert_eq!(reused, vec![0.0; 4]);
+}
+
+#[test]
 fn zero_len_not_pooled() {
     let mut pool = BufferPool::new();
     <f64 as PoolScalar>::pool_release(&mut pool, Vec::new());

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -239,9 +239,8 @@ pub(crate) unsafe fn typed_array_uninit<T>(shape: &[usize]) -> StridedArray<T> {
 /// Create an output array from the CPU buffer pool WITHOUT initializing values.
 ///
 /// # Safety
-/// Caller must write every element before reading. The returned array contains
-/// uninitialized data acquired from `buffers`.
-#[allow(clippy::uninit_vec)]
+/// Caller should overwrite every element that is part of the operation output.
+/// The pool supplies valid zero values so accidental reads are memory-safe.
 pub(crate) unsafe fn typed_array_uninit_from_pool<T>(
     buffers: &mut BufferPool,
     shape: &[usize],

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -689,9 +689,10 @@ fn typed_triangular_mask<T: Copy + Zero + Clone>(
     k: i64,
     upper: bool,
 ) -> crate::Result<TypedTensor<T>> {
+    let op = if upper { "triu" } else { "tril" };
     if tensor.shape().len() < 2 {
         return Err(crate::Error::RankMismatch {
-            op: if upper { "triu" } else { "tril" },
+            op,
             expected: 2,
             actual: tensor.shape().len(),
         });
@@ -703,26 +704,27 @@ fn typed_triangular_mask<T: Copy + Zero + Clone>(
         return Ok(tensor.clone());
     }
 
-    let batch_count: usize = tensor.shape()[2..].iter().product();
-    let block_size = rows * cols;
+    let (batch_count, block_size) = checked_triangular_extent(op, tensor.shape(), rows, cols)?;
     let mut out = tensor.clone();
     let data = out.host_data_mut();
 
     // Intentionally sequential: triangular masks are index-dependent in the
     // innermost matrix plane and remain a dedicated CPU-kernel exception.
     for batch_idx in 0..batch_count {
-        let base = batch_idx * block_size;
         for col in 0..cols {
             let boundary = col as i128 - k as i128;
             for row in 0..rows {
-                let row = row as i128;
+                let row_idx = row;
+                let row = row_idx as i128;
                 let keep = if upper {
                     row <= boundary
                 } else {
                     row >= boundary
                 };
                 if !keep {
-                    data[base + row as usize + col * rows] = T::zero();
+                    let offset =
+                        checked_triangular_offset(op, batch_idx, block_size, col, rows, row_idx)?;
+                    data[offset] = T::zero();
                 }
             }
         }
@@ -741,9 +743,10 @@ fn typed_triangular_mask_with_fill_pool<T>(
 where
     T: Copy + Clone + PoolScalar + 'static,
 {
+    let op = if upper { "triu" } else { "tril" };
     if tensor.shape().len() < 2 {
         return Err(crate::Error::RankMismatch {
-            op: if upper { "triu" } else { "tril" },
+            op,
             expected: 2,
             actual: tensor.shape().len(),
         });
@@ -755,31 +758,81 @@ where
         return Ok(tensor.clone());
     }
 
-    let batch_count: usize = tensor.shape()[2..].iter().product();
-    let block_size = rows * cols;
-    let mut out =
-        clone_host_tensor_from_pool(buffers, if upper { "triu" } else { "tril" }, tensor)?;
+    let (batch_count, block_size) = checked_triangular_extent(op, tensor.shape(), rows, cols)?;
+    let mut out = clone_host_tensor_from_pool(buffers, op, tensor)?;
     let data = out.host_data_mut();
 
     // Intentionally sequential: triangular masks are index-dependent in the
     // innermost matrix plane and remain a dedicated CPU-kernel exception.
     for batch_idx in 0..batch_count {
-        let base = batch_idx * block_size;
         for col in 0..cols {
             let boundary = col as i128 - k as i128;
             for row in 0..rows {
-                let row = row as i128;
+                let row_idx = row;
+                let row = row_idx as i128;
                 let keep = if upper {
                     row <= boundary
                 } else {
                     row >= boundary
                 };
                 if !keep {
-                    data[base + row as usize + col * rows] = fill;
+                    let offset =
+                        checked_triangular_offset(op, batch_idx, block_size, col, rows, row_idx)?;
+                    data[offset] = fill;
                 }
             }
         }
     }
 
     Ok(out)
+}
+
+fn checked_triangular_extent(
+    op: &'static str,
+    shape: &[usize],
+    rows: usize,
+    cols: usize,
+) -> crate::Result<(usize, usize)> {
+    let batch_count = shape[2..].iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op,
+                message: format!("batch extent overflows usize: {acc} * {dim}"),
+            })
+    })?;
+    let block_size = rows
+        .checked_mul(cols)
+        .ok_or_else(|| crate::Error::InvalidConfig {
+            op,
+            message: format!("matrix block size overflows usize: {rows} * {cols}"),
+        })?;
+    Ok((batch_count, block_size))
+}
+
+fn checked_triangular_offset(
+    op: &'static str,
+    batch_idx: usize,
+    block_size: usize,
+    col: usize,
+    rows: usize,
+    row_idx: usize,
+) -> crate::Result<usize> {
+    let base = batch_idx
+        .checked_mul(block_size)
+        .ok_or_else(|| crate::Error::InvalidConfig {
+            op,
+            message: format!("batch offset overflows usize: {batch_idx} * {block_size}"),
+        })?;
+    let col_offset = col
+        .checked_mul(rows)
+        .ok_or_else(|| crate::Error::InvalidConfig {
+            op,
+            message: format!("column offset overflows usize: {col} * {rows}"),
+        })?;
+    base.checked_add(col_offset)
+        .and_then(|offset| offset.checked_add(row_idx))
+        .ok_or_else(|| crate::Error::InvalidConfig {
+            op,
+            message: "triangular mask offset overflows usize".to_string(),
+        })
 }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -280,6 +280,40 @@ fn test_install_with_pool_preserves_buffers() {
 }
 
 #[test]
+fn test_with_linalg_pool_restores_buffers_after_panic() {
+    let mut backend = CpuBackend::with_threads(1);
+    backend.reclaim_buffer(Tensor::F64(TypedTensor::from_vec_col_major(
+        vec![2],
+        vec![1.0, 2.0],
+    )));
+    assert_eq!(backend.buffer_pool_len(), 1);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_linalg_pool::<()>(|_| panic!("forced linalg panic"));
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(backend.buffer_pool_len(), 1);
+}
+
+#[test]
+fn test_backend_session_restores_buffers_after_panic() {
+    let mut backend = CpuBackend::with_threads(1);
+    backend.reclaim_buffer(Tensor::F64(TypedTensor::from_vec_col_major(
+        vec![2],
+        vec![1.0, 2.0],
+    )));
+    assert_eq!(backend.buffer_pool_len(), 1);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_backend_session::<()>(|_| panic!("forced session panic"));
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(backend.buffer_pool_len(), 1);
+}
+
+#[test]
 fn test_exec_session_read_reductions_and_reclaim_cover_typed_paths() {
     let mut backend = CpuBackend::new();
     backend.with_backend_session(|exec| {

--- a/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
@@ -435,6 +435,25 @@ fn test_tril_triu_extreme_offsets_do_not_overflow() {
 }
 
 #[test]
+fn test_triangular_masks_use_checked_index_arithmetic_contract() {
+    let source = include_str!("../../structural.rs");
+    let section_start = source
+        .find("fn typed_triangular_mask")
+        .expect("typed_triangular_mask should exist");
+    let section = &source[section_start..];
+
+    for needle in [
+        "checked_triangular_extent(op, tensor.shape(), rows, cols)?",
+        "checked_triangular_offset(op, batch_idx, block_size, col, rows, row_idx)?",
+    ] {
+        assert!(
+            section.contains(needle),
+            "triangular masks should use checked index arithmetic: missing {needle}"
+        );
+    }
+}
+
+#[test]
 fn test_neg_and_conj() {
     let t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, -7.0]));
     let n = neg(&t).unwrap();

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -315,6 +315,14 @@ impl CudaExtensionCacheInner {
 }
 
 impl CudaExtensionCache {
+    fn poisoned_lock_error() -> crate::Error {
+        crate::Error::backend_failure("cuda_extension_cache", "extension cache lock poisoned")
+    }
+
+    fn lock_inner(&self) -> crate::Result<MutexGuard<'_, CudaExtensionCacheInner>> {
+        self.inner.lock().map_err(|_| Self::poisoned_lock_error())
+    }
+
     /// Create an empty extension cache.
     ///
     /// # Examples
@@ -349,49 +357,68 @@ impl CudaExtensionCache {
     /// assert!(CudaExtensionCache::new().is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
-        self.inner
-            .lock()
-            .map(|inner| inner.entries.is_empty())
-            .unwrap_or(false)
+        self.try_is_empty()
+            .expect("CUDA extension cache lock poisoned")
+    }
+
+    /// Fallibly return whether no extension state has been initialized.
+    pub fn try_is_empty(&self) -> crate::Result<bool> {
+        Ok(self.lock_inner()?.entries.is_empty())
     }
 
     /// Remove every cached CUDA extension state value.
     pub fn clear(&self) {
-        if let Ok(mut inner) = self.inner.lock() {
-            inner.entries.clear();
-            inner.order.clear();
-            inner.retained_bytes = 0;
-        }
+        self.try_clear()
+            .expect("CUDA extension cache lock poisoned");
+    }
+
+    /// Fallibly remove every cached CUDA extension state value.
+    pub fn try_clear(&self) -> crate::Result<()> {
+        let mut inner = self.lock_inner()?;
+        inner.entries.clear();
+        inner.order.clear();
+        inner.retained_bytes = 0;
+        Ok(())
     }
 
     /// Snapshot the number of retained entries and logical retained bytes.
     pub fn stats(&self) -> CacheStats {
-        self.inner
-            .lock()
-            .map(|inner| CacheStats {
-                entries: inner.entries.len(),
-                retained_bytes: inner.retained_bytes,
-            })
-            .unwrap_or_else(|_| CacheStats::empty())
+        self.try_stats()
+            .expect("CUDA extension cache lock poisoned")
+    }
+
+    /// Fallibly snapshot the number of retained entries and logical retained bytes.
+    pub fn try_stats(&self) -> crate::Result<CacheStats> {
+        let inner = self.lock_inner()?;
+        Ok(CacheStats {
+            entries: inner.entries.len(),
+            retained_bytes: inner.retained_bytes,
+        })
     }
 
     /// Return the configured entry bound.
     pub fn max_entries(&self) -> NonZeroUsize {
-        self.inner
-            .lock()
-            .map(|inner| inner.max_entries)
-            .unwrap_or_else(|_| {
-                NonZeroUsize::new(DEFAULT_CUDA_EXTENSION_CACHE_MAX_ENTRIES)
-                    .expect("default CUDA extension cache capacity is non-zero")
-            })
+        self.try_max_entries()
+            .expect("CUDA extension cache lock poisoned")
+    }
+
+    /// Fallibly return the configured entry bound.
+    pub fn try_max_entries(&self) -> crate::Result<NonZeroUsize> {
+        Ok(self.lock_inner()?.max_entries)
     }
 
     /// Replace the entry bound and evict oldest entries if needed.
     pub fn set_max_entries(&self, max_entries: NonZeroUsize) {
-        if let Ok(mut inner) = self.inner.lock() {
-            inner.max_entries = max_entries;
-            inner.evict_to_limit();
-        }
+        self.try_set_max_entries(max_entries)
+            .expect("CUDA extension cache lock poisoned");
+    }
+
+    /// Fallibly replace the entry bound and evict oldest entries if needed.
+    pub fn try_set_max_entries(&self, max_entries: NonZeroUsize) -> crate::Result<()> {
+        let mut inner = self.lock_inner()?;
+        inner.max_entries = max_entries;
+        inner.evict_to_limit();
+        Ok(())
     }
 
     /// Get or lazily initialize one cache entry keyed by `T`.
@@ -413,9 +440,7 @@ impl CudaExtensionCache {
         T: Send + 'static,
     {
         let type_id = TypeId::of::<T>();
-        let mut inner = self.inner.lock().map_err(|_| {
-            crate::Error::backend_failure("cuda_extension_cache", "extension cache lock poisoned")
-        })?;
+        let mut inner = self.lock_inner()?;
         if !inner.entries.contains_key(&type_id) {
             inner.insert(type_id, init()?, std::mem::size_of::<T>());
         }

--- a/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
@@ -76,6 +76,22 @@ fn cuda_extension_cache_reports_stats_and_clear() {
 }
 
 #[test]
+fn cuda_extension_cache_try_methods_report_poisoned_lock() {
+    let cache = CudaExtensionCache::new();
+    let poisoned = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        let _guard = cache.inner.lock().unwrap();
+        panic!("poison cuda extension cache lock");
+    }));
+    assert!(poisoned.is_err());
+
+    assert!(cache.try_is_empty().is_err());
+    assert!(cache.try_stats().is_err());
+    assert!(cache.try_clear().is_err());
+    assert!(cache.try_max_entries().is_err());
+    assert!(cache.get_or_try_init::<usize>(|| Ok(17)).is_err());
+}
+
+#[test]
 fn cuda_extension_cache_has_configurable_entry_bound() {
     let cache = CudaExtensionCache::with_max_entries(NonZeroUsize::new(1).unwrap());
     let mut usize_initializers = 0usize;

--- a/crates/tenferro-internal-ops/src/ext_op.rs
+++ b/crates/tenferro-internal-ops/src/ext_op.rs
@@ -292,6 +292,9 @@ pub enum ExtensionRegistryError {
     /// `"<crate-name>.<op-name>.v<major>"`.
     #[error("family_id {family_id:?} does not match the namespaced format")]
     MalformedFamilyId { family_id: &'static str },
+    /// The global AD rule registry lock was poisoned by another thread.
+    #[error("extension rule registry lock poisoned")]
+    PoisonedRegistry,
 }
 
 #[cfg(feature = "autodiff")]
@@ -576,18 +579,14 @@ pub fn register_extension_rule(
     }
     let mut guard = rule_registry()
         .write()
-        .expect("extension rule registry RwLock poisoned");
+        .map_err(|_| ExtensionRegistryError::PoisonedRegistry)?;
     insert_rule(&mut guard, rule)
 }
 
 /// Look up an extension AD rule by `family_id`.
 #[cfg(feature = "autodiff")]
 pub fn lookup_extension_rule(family_id: &str) -> Option<Arc<dyn ExtensionAdRule>> {
-    rule_registry()
-        .read()
-        .expect("extension rule registry RwLock poisoned")
-        .get(family_id)
-        .cloned()
+    rule_registry().read().ok()?.get(family_id).cloned()
 }
 
 /// Emit a registered extension linearization rule.

--- a/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
@@ -22,6 +22,16 @@ use crate::std_tensor_op::StdTensorOp;
 use crate::{ExtensionFamilyId, ExtensionRuleSet, SymDim};
 use tenferro_tensor::{DType, Tensor};
 
+#[test]
+fn global_extension_rule_registry_does_not_expect_on_poison_contract() {
+    let source = include_str!("../ext_op.rs");
+
+    assert!(
+        !source.contains("extension rule registry RwLock poisoned"),
+        "global extension rule registry should return errors/None on poison instead of panicking"
+    );
+}
+
 #[derive(Debug)]
 struct CoverageRule {
     family: &'static str,

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -266,8 +266,9 @@ impl ExtensionOpTrait for LinalgExtensionOp {
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
     ) -> Vec<(DType, Vec<SymDim>)> {
-        assert_eq!(input_dtypes.len(), self.input_count());
-        assert_eq!(input_shapes.len(), self.input_count());
+        if input_dtypes.len() != self.input_count() || input_shapes.len() != self.input_count() {
+            return Vec::new();
+        }
         match self.op {
             LinalgOp::Cholesky
             | LinalgOp::FullPivLuSolve { .. }

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -34,3 +34,12 @@ fn eager_linalg_rejects_cuda_tensor_when_cuda_feature_is_disabled() {
         other => panic!("expected BackendFailure, got {other:?}"),
     }
 }
+
+#[test]
+fn infer_output_meta_returns_empty_on_input_count_mismatch() {
+    let op = LinalgExtensionOp::new(LinalgOp::Cholesky);
+
+    let metas = op.infer_output_meta(&[], &[]);
+
+    assert!(metas.is_empty());
+}

--- a/crates/tenferro-linalg/src/gpu/linalg.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg.rs
@@ -641,8 +641,8 @@ where
     };
     let rows = b.shape()[0];
     let cols = b.shape()[1];
-    let a_stride = n * n;
-    let out_stride = rows * cols;
+    let a_stride = checked_mul_usize(op, "triangular matrix stride", n, n)?;
+    let out_stride = checked_mul_usize(op, "triangular rhs stride", rows, cols)?;
     let lda = as_i32(n, op, "lda")?;
     let ldb = as_i32(rows, op, "ldb")?;
     let m = as_i32(rows, op, "m")?;
@@ -654,8 +654,12 @@ where
         let mut a_pointers = Vec::with_capacity(batch_total);
         let mut b_pointers = Vec::with_capacity(batch_total);
         for batch in 0..batch_total {
-            let batch_a = unsafe { batch_const_ptr::<T>(a_ptr.cast_const(), batch * a_stride) };
-            let batch_b = unsafe { batch_ptr::<T>(out_ptr, batch * out_stride) };
+            let a_offset =
+                checked_batch_offset(op, "triangular matrix batch offset", batch, a_stride)?;
+            let b_offset =
+                checked_batch_offset(op, "triangular rhs batch offset", batch, out_stride)?;
+            let batch_a = unsafe { batch_const_ptr::<T>(a_ptr.cast_const(), a_offset) };
+            let batch_b = unsafe { batch_ptr::<T>(out_ptr, b_offset) };
             a_pointers.push(batch_a as usize);
             b_pointers.push(batch_b as usize);
         }
@@ -1940,6 +1944,27 @@ fn has_zero_dim(shape: &[usize]) -> bool {
 
 fn batch_count(batch_shape: &[usize]) -> usize {
     batch_shape.iter().product::<usize>().max(1)
+}
+
+fn checked_mul_usize(
+    op: &'static str,
+    label: &'static str,
+    lhs: usize,
+    rhs: usize,
+) -> Result<usize> {
+    lhs.checked_mul(rhs).ok_or_else(|| Error::InvalidConfig {
+        op,
+        message: format!("{label} overflows usize: {lhs} * {rhs}"),
+    })
+}
+
+fn checked_batch_offset(
+    op: &'static str,
+    label: &'static str,
+    batch: usize,
+    stride: usize,
+) -> Result<usize> {
+    checked_mul_usize(op, label, batch, stride)
 }
 
 fn as_i32(value: usize, op: &'static str, label: &'static str) -> Result<i32> {

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -369,6 +369,7 @@ pub fn det(a: &TracedTensor) -> Result<TracedTensor> {
 /// assert_eq!(inverse.rank, 2);
 /// ```
 pub fn inv(a: &TracedTensor) -> Result<TracedTensor> {
+    ensure_min_rank("inv", a.rank, 2)?;
     let shape = a.concrete_shape();
     let eye = eye_like(a, shape[0]);
     solve(a, &eye)
@@ -494,6 +495,7 @@ pub fn norm(
     if axes.is_empty() {
         return Ok(a.clone());
     }
+    validate_axes("norm", a.rank, &axes)?;
 
     let out = match axes.len() {
         1 => vector_norm(a, axes[0], ord),
@@ -615,6 +617,28 @@ fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
             tenferro_tensor::Error::backend_failure(op, format!("unsupported dtype {dtype:?}")),
         )),
     }
+}
+
+fn ensure_min_rank(op: &'static str, actual: usize, expected: usize) -> Result<()> {
+    if actual < expected {
+        return Err(Error::TensorRuntime(tenferro_tensor::Error::RankMismatch {
+            op,
+            expected,
+            actual,
+        }));
+    }
+    Ok(())
+}
+
+fn validate_axes(op: &'static str, rank: usize, axes: &[usize]) -> Result<()> {
+    for &axis in axes {
+        if axis >= rank {
+            return Err(Error::TensorRuntime(
+                tenferro_tensor::Error::AxisOutOfBounds { op, axis, rank },
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn zero_scalar(dtype: DType) -> TracedTensor {

--- a/crates/tenferro-linalg/tests/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/eager_tensor.rs
@@ -41,6 +41,25 @@ fn assert_close_slice(actual: &[f64], expected: &[f64], tol: f64) {
     }
 }
 
+fn well_conditioned_4x4() -> Vec<f64> {
+    let n = 4;
+    let mut data: Vec<f64> = (0..n * n)
+        .map(|i| {
+            let x = (i as u64)
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(10_u64.wrapping_mul(1442695040888963407));
+            ((x % 1024) as f64 - 512.0) / 512.0
+        })
+        .collect();
+    for j in 0..n {
+        for i in 0..n {
+            data[i + n * j] *= 0.05;
+        }
+        data[j + n * j] += 1.0 + j as f64 / n as f64;
+    }
+    data
+}
+
 #[test]
 fn svd_returns_correct_shapes() {
     let a = EagerTensor::from_tensor_in(
@@ -52,6 +71,21 @@ fn svd_returns_correct_shapes() {
     assert_eq!(u.data().shape(), &[2, 2]);
     assert_eq!(s.data().shape(), &[2]);
     assert_eq!(vt.data().shape(), &[2, 2]);
+}
+
+#[test]
+fn svd_singular_value_sum_backward_does_not_panic() {
+    let ctx = ad_test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![4, 4], well_conditioned_4x4()),
+        ctx,
+    );
+    let (_, s, _) = tenferro_linalg::eager_tensor::svd(&a).unwrap();
+    let loss = s.reduce_sum(&[0]).unwrap();
+
+    loss.backward().unwrap();
+
+    assert!(a.grad().is_some());
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -120,6 +120,28 @@ fn gpu_lu_outputs_are_not_rebuilt_by_host_roundtrip() {
 }
 
 #[test]
+fn gpu_triangular_solve_batched_offsets_use_checked_arithmetic() {
+    let source = linalg_source();
+    let triangular = source_section(
+        &source,
+        "fn triangular_solve_typed_with_op",
+        "fn solve_typed",
+    );
+
+    for needle in [
+        "checked_mul_usize(op, \"triangular matrix stride\", n, n)",
+        "checked_mul_usize(op, \"triangular rhs stride\", rows, cols)",
+        "checked_batch_offset(op, \"triangular matrix batch offset\", batch, a_stride)",
+        "checked_batch_offset(op, \"triangular rhs batch offset\", batch, out_stride)",
+    ] {
+        assert!(
+            triangular.contains(needle),
+            "triangular_solve_typed_with_op should use checked arithmetic: missing {needle}"
+        );
+    }
+}
+
+#[test]
 fn gpu_zero_sized_lu_factor_parity_is_filled_on_device() {
     let source = linalg_source();
     let zero_lu = source_section(&source, "fn zero_sized_lu_factor_outputs", "fn raw_stream");

--- a/crates/tenferro-linalg/tests/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/traced_extension.rs
@@ -278,6 +278,38 @@ fn traced_norm_rejects_integer_and_bool_dtypes_before_scalar_rounding() {
 }
 
 #[test]
+fn traced_inv_rejects_rank_less_than_two_without_panicking() {
+    let scalar = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]);
+
+    let err = tenferro_linalg::inv(&scalar).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::TensorRuntime(TensorError::RankMismatch {
+            op: "inv",
+            expected: 2,
+            actual: 0,
+        })
+    ));
+}
+
+#[test]
+fn traced_norm_rejects_out_of_range_axis_without_panicking() {
+    let tensor = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+
+    let err = tenferro_linalg::norm(&tensor, Some(2.0), Some(&[5]), false).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::TensorRuntime(TensorError::AxisOutOfBounds {
+            op: "norm",
+            axis: 5,
+            rank: 1,
+        })
+    ));
+}
+
+#[test]
 fn traced_pinv_rejects_integer_and_bool_dtypes_before_scalar_rounding() {
     for dtype in [DType::I32, DType::I64, DType::Bool] {
         let tensor = traced_with_dtype(dtype, vec![2, 2]);

--- a/crates/tenferro-runtime/src/extension_runtime.rs
+++ b/crates/tenferro-runtime/src/extension_runtime.rs
@@ -22,6 +22,9 @@ pub enum ExtensionRuntimeRegistryError {
     /// `"<crate-name>.<op-name>.v<major>"`.
     #[error("family_id {family_id:?} does not match the namespaced format")]
     MalformedFamilyId { family_id: &'static str },
+    /// A registry lock was poisoned by a panic in another thread.
+    #[error("{name} poisoned")]
+    PoisonedLock { name: &'static str },
 }
 
 /// Backend and cache state passed to one extension execution.

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -115,6 +115,9 @@ pub(crate) fn broadcast_binary(a: &TracedTensor, b: &TracedTensor) -> (TracedTen
     if a.shape_hint == b.shape_hint && a.rank == b.rank {
         return (a.clone(), b.clone());
     }
+    if (try_concrete_shape(a).is_none() || try_concrete_shape(b).is_none()) && a.rank == b.rank {
+        return (a.clone(), b.clone());
+    }
     let a_shape = concrete_shape(a);
     let b_shape = concrete_shape(b);
     let target = broadcast_shape(&a_shape, &b_shape).unwrap_or_else(|_| {
@@ -1028,7 +1031,7 @@ impl TracedTensor {
                 axes: axes.to_vec(),
             },
             self,
-            self.rank - axes.len(),
+            self.rank.saturating_sub(axes.len()),
             out_shape_hint,
         )
     }
@@ -1057,7 +1060,7 @@ impl TracedTensor {
                 axes: axes.to_vec(),
             },
             self,
-            self.rank - axes.len(),
+            self.rank.saturating_sub(axes.len()),
             out_shape_hint,
         )
     }
@@ -1086,7 +1089,7 @@ impl TracedTensor {
                 axes: axes.to_vec(),
             },
             self,
-            self.rank - axes.len(),
+            self.rank.saturating_sub(axes.len()),
             out_shape_hint,
         )
     }
@@ -1112,7 +1115,7 @@ impl TracedTensor {
                 axes: axes.to_vec(),
             },
             self,
-            self.rank - axes.len(),
+            self.rank.saturating_sub(axes.len()),
             out_shape_hint,
         )
     }

--- a/crates/tenferro-runtime/tests/runtime_public_api.rs
+++ b/crates/tenferro-runtime/tests/runtime_public_api.rs
@@ -61,6 +61,34 @@ fn graph_executor_runs_elementwise_and_reduction_with_borrowed_inputs() {
 }
 
 #[test]
+fn traced_broadcast_binary_accepts_symbolic_same_rank_input() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
+    let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+
+    let z = &x + &y;
+
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(&z, &[(&x, DType::F64, &[2])])
+        .unwrap();
+    let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
+    let out = GraphExecutor::new(CpuBackend::new())
+        .run_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&input))])
+        .unwrap();
+
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+}
+
+#[test]
+fn traced_reduction_with_too_many_axes_does_not_underflow_rank() {
+    let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
+
+    let y = x.reduce_max(&[0, 1, 2]);
+
+    assert_eq!(y.rank, 0);
+}
+
+#[test]
 fn graph_executor_runs_dot_general_with_borrowed_inputs() {
     let lhs = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let rhs = TracedTensor::input_symbolic_shape(DType::F64, 2);

--- a/docs/worklogs/2026-06-17-terasaki-bug-batch.md
+++ b/docs/worklogs/2026-06-17-terasaki-bug-batch.md
@@ -3,14 +3,20 @@
 ## Summary
 
 Fixed a bounded batch of recent `terasakisatoshi` bug reports in one PR. The
-batch focuses on narrow public-boundary defects: unchecked shape arithmetic,
+batch focuses on public-boundary defects: unchecked shape arithmetic,
 validation order, tutorial drift, dtype promotion parity, provider registration
-status propagation, and LAPACK singular-status handling.
+status propagation, LAPACK singular-status handling, panic-safe CPU buffer-pool
+ownership, poisoned-lock handling, traced symbolic/rank validation, and
+selected GPU/CPU batched offset overflow checks.
 
 The PR also records a general repository audit rule for this class of bugs:
 public API boundaries must validate user-derived shape, axis, dtype, padding,
 slice, gather/scatter, linalg, allocation, launch, and FFI inputs before fast
 paths, allocation, backend launch, or unchecked arithmetic.
+
+The follow-up audit added two more durable rules: batch pointer-offset loops
+must check both stride products and `batch * stride`, and public cache/runtime
+locks must not fabricate default state after poison.
 
 ## Context Read
 
@@ -41,15 +47,39 @@ paths, allocation, backend launch, or unchecked arithmetic.
   `?` propagation to make the intended validation obvious.
 - Updated tutorial source and prose together so snippet and tutorial tests
   exercise the documented examples.
+- Made CPU buffer-pool acquisition return initialized zero values instead of
+  stale or uninitialized elements, keeping the existing unsafe signature only
+  for compatibility.
+- Replaced panic-unsafe CPU buffer-pool lending with a Drop-backed loan guard so
+  the pool is restored when a backend session or linalg pool closure panics.
+- Held eager gradient slot locks through accumulation writes to remove the
+  read-compute-write race reported in #1075.
+- Allowed traced binary operations over same-rank symbolic-shape tensors without
+  forcing `concrete_shape()`, and stopped reduction helpers from underflowing
+  output rank when too many axes are supplied.
+- Added early traced linalg rank/axis validation and removed assertion panics
+  from linalg extension metadata inference on bad input counts.
+- Added fallible poison-reporting paths for EagerRuntime locks, global
+  extension AD rule registry lookup/registration, and CUDA extension cache
+  inspection/clear methods.
+- Added checked arithmetic for CPU triangular mask indexing and GPU triangular
+  batched linalg pointer offsets.
+- Added the eager SVD singular-value-sum backward MWE as a regression test; it
+  already passes on this branch, so #1056 is covered without code changes.
 
 ## Deferred
 
-- #1054 and #1056 are not part of this PR.
+- #1054 remains outside this PR until its current reproducer and intended
+  behavior are rechecked.
 - #1073 was not closed; the existing three-way repeated-label trace test for
   `iii` passes, so it needs a sharper reproducer before changing einsum logic.
-- #1071, #1072, #1074, #1075, #1076, and #1080 through #1084 are broader
-  safety, panic, concurrency, or overflow audits and should be split into
-  follow-up PRs.
+- #1082 requires a larger design decision because `DimExpr` and shape inference
+  currently expose infallible arithmetic in several public-facing paths.
+- #1084 is a broad public-panic audit. This PR fixes representative traced,
+  linalg, poison, and buffer-pool cases and records the rule; remaining cases
+  should be handled as a follow-up sweep.
+- #1081 is partially fixed for CPU triangular masks and GPU triangular batched
+  linalg offsets. Tensor stride/accessor API changes need a separate API design.
 
 ## Verification
 
@@ -72,3 +102,21 @@ paths, allocation, backend launch, or unchecked arithmetic.
 - `python3.11 scripts/check-guide-dependency-snippets.py`
 - `cargo check -p tenferro-gpu --features cuda`
 - `cargo check -p tenferro-linalg --features cuda`
+
+Additional targeted checks after the second audit pass:
+
+- `cargo test -p tenferro-cpu acquired_buffers_are_initialized_on_fresh_and_reused_paths`
+- `cargo test -p tenferro-cpu restores_buffers_after_panic`
+- `cargo test -p tenferro-ad eager_runtime_grad_accumulation_keeps_slot_locked_through_update`
+- `cargo test -p tenferro-runtime traced_broadcast_binary_accepts_symbolic_same_rank_input`
+- `cargo test -p tenferro-runtime traced_reduction_with_too_many_axes_does_not_underflow_rank`
+- `cargo test -p tenferro-linalg without_panicking`
+- `cargo test -p tenferro-linalg infer_output_meta_returns_empty_on_input_count_mismatch`
+- `cargo test -p tenferro-ad eager_runtime_synchronize_reports_poisoned_backend_lock`
+- `cargo test -p tenferro-ad eager_runtime_register_extension_reports_poisoned_executor_lock`
+- `cargo test -p tenferro-gpu --features cuda cuda_extension_cache_try_methods_report_poisoned_lock`
+- `cargo test -p tenferro-internal-ops global_extension_rule_registry_does_not_expect_on_poison_contract --features autodiff`
+- `cargo test -p tenferro-linalg --features autodiff,cpu-faer svd_singular_value_sum_backward_does_not_panic -- --nocapture`
+- `cargo test -p tenferro-linalg gpu_triangular_solve_batched_offsets_use_checked_arithmetic`
+- `cargo test -p tenferro-cpu triu`
+- `cargo test -p tenferro-cpu test_triangular_masks_use_checked_index_arithmetic_contract`


### PR DESCRIPTION
## Summary

Merge policy: please merge with a merge commit; do not squash.

Follow-up to merged PR #1085. This continues the terasaki bug batch with the shared audit rule applied across the codebase: public/runtime boundaries must validate symbolic shape, rank, axis, lock poison, buffer ownership, and shape-derived offset arithmetic before panics, unchecked products, or fabricated default state.

Work log: `docs/worklogs/2026-06-17-terasaki-bug-batch.md`

## Fixed

- CPU buffer pool acquisition now returns initialized zero values instead of stale/uninitialized `Vec<T>` contents.
- CPU backend buffer-pool lending is panic-safe via a Drop-backed loan guard for linalg pools and backend sessions.
- Eager gradient accumulation keeps each grad slot locked through read/add/write.
- Traced same-rank symbolic binary ops no longer force `concrete_shape()`, and reductions no longer underflow output rank on too many axes.
- Linalg traced `inv`/`norm` validate rank/axes before indexing, and linalg extension metadata inference no longer asserts on wrong input counts.
- EagerRuntime, global extension AD rule registry, and CUDA extension cache now expose poison handling paths instead of panicking or fabricating empty/default state on the fallible APIs.
- CPU triangular masks and GPU triangular batched linalg pointer offsets now use checked arithmetic.
- Adds the eager SVD singular-value-sum backward MWE as a regression test; it already passes on this branch.
- `REPOSITORY_RULES.md` now records general rules for batch pointer-offset arithmetic, lock poison handling, and traced/eager rank/axis validation.

Fixes #1056
Fixes #1071
Fixes #1072
Fixes #1074
Fixes #1075
Fixes #1080
Fixes #1083

## Partial / Deferred

- #1081 is partially addressed for CPU triangular masks and GPU triangular batched linalg offsets. Tensor stride/accessor API changes need a separate design.
- #1082 requires a broader `DimExpr` / shape-inference fallibility decision.
- #1084 remains a broad public-panic audit; this PR fixes representative cases and records the durable rule.
- #1073 still needs a sharper reproducer because existing `iii` repeated-label tests pass.

## Verification

- `cargo fmt --all --check`
- `cargo test -p tenferro-cpu acquired_buffers_are_initialized_on_fresh_and_reused_paths`
- `cargo test -p tenferro-cpu restores_buffers_after_panic`
- `cargo test -p tenferro-cpu test_triangular_masks_use_checked_index_arithmetic_contract`
- `cargo test -p tenferro-ad eager_runtime`
- `cargo test -p tenferro-runtime traced_`
- `cargo test -p tenferro-linalg without_panicking`
- `cargo test -p tenferro-linalg infer_output_meta_returns_empty_on_input_count_mismatch`
- `cargo test -p tenferro-linalg gpu_triangular_solve_batched_offsets_use_checked_arithmetic`
- `cargo test -p tenferro-linalg --features autodiff,cpu-faer svd_singular_value_sum_backward_does_not_panic -- --nocapture`
- `cargo test -p tenferro-internal-ops global_extension_rule_registry_does_not_expect_on_poison_contract --features autodiff`
- `cargo test -p tenferro-gpu --features cuda cuda_extension_cache_try_methods_report_poisoned_lock`
- `cargo check -p tenferro-gpu --features cuda`
- `cargo check -p tenferro-linalg --features cuda`
