### PR TITLE
[codex] Complete terasaki audit follow-up

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -325,6 +325,22 @@ Tests follow implementation ownership.
 
 ## Performance And Layout Rules
 
+### Performance-Sensitive Safety Contracts
+
+- Potentially dangerous operations that are intentionally kept for performance,
+  such as raw scratch-buffer acquisition, unchecked indexing after validation,
+  raw pointer arithmetic, or backend-native view construction, must carry a
+  nearby one-line comment explaining the invariant that makes the operation
+  valid. This is required even when the operation is technically correct, so
+  later agents and reviewers do not "fix" a false positive by adding hidden
+  copies, repeated checks, or unconditional initialization to a hot path.
+- Buffer-pool and scratch-buffer APIs must distinguish full-overwrite callers
+  from read-before-write callers. Do not fix stale or uninitialized reads by
+  adding unconditional zero-fill to shared hot-path acquisition. Instead expose
+  an explicit zeroed/initialized acquisition path, keep raw acquisition unsafe
+  and documented for full-overwrite kernels only, and add regression coverage
+  for both contracts.
+
 ### Complexity Budget
 
 - Do not introduce accidental `O(n^2)` behavior in graph construction,

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -514,16 +514,19 @@ fn jvp_optional_result_with_rules(
         return Ok(None);
     };
     let tangent_input_key = linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1);
+    let tangent_data =
+        tangent
+            .attached_data()
+            .cloned()
+            .ok_or_else(|| Error::InvalidGraphBuild {
+                op: "jvp",
+                message: "jvp tangent must have concrete tensor data".to_string(),
+            })?;
     let metadata_scope = register_scoped_graph_metadata(
         linear.as_graph(),
         vec![(
             ValueKey::Input(tangent_input_key.clone()),
-            tensor_meta_from_tensor(
-                tangent
-                    .attached_data()
-                    .unwrap_or_else(|| panic!("jvp tangent must have concrete tensor data"))
-                    .as_ref(),
-            ),
+            tensor_meta_from_tensor(tangent_data.as_ref()),
         )],
     );
 
@@ -531,13 +534,7 @@ fn jvp_optional_result_with_rules(
     if let Some(chain) = &checkpoint_chain {
         inputs_map.extend(chain.collect_inputs());
     }
-    inputs_map.insert(
-        tangent_input_key,
-        tangent
-            .attached_data()
-            .cloned()
-            .unwrap_or_else(|| panic!("jvp tangent must have concrete tensor data")),
-    );
+    inputs_map.insert(tangent_input_key, tangent_data);
 
     let mut extra_roots = vec![Arc::clone(output.graph())];
     extra_roots.extend(checkpoint_graphs);
@@ -610,16 +607,19 @@ fn vjp_optional_result_with_rules(
         .map_err(|err| Error::Internal(err.to_string()))?;
     let cotangent_input_key =
         linear_input_key(transposed.as_graph(), transposed.tangent_inputs()[0].1);
+    let cotangent_data =
+        cotangent
+            .attached_data()
+            .cloned()
+            .ok_or_else(|| Error::InvalidGraphBuild {
+                op: "vjp",
+                message: "vjp cotangent must have concrete tensor data".to_string(),
+            })?;
     let transposed_metadata_scope = register_scoped_graph_metadata(
         transposed.as_graph(),
         vec![(
             ValueKey::Input(cotangent_input_key.clone()),
-            tensor_meta_from_tensor(
-                cotangent
-                    .attached_data()
-                    .unwrap_or_else(|| panic!("vjp cotangent must have concrete tensor data"))
-                    .as_ref(),
-            ),
+            tensor_meta_from_tensor(cotangent_data.as_ref()),
         )],
     );
     let linear_graph = Arc::new(linear.into_graph());
@@ -631,13 +631,7 @@ fn vjp_optional_result_with_rules(
     if let Some(chain) = &checkpoint_chain {
         inputs_map.extend(chain.collect_inputs());
     }
-    inputs_map.insert(
-        cotangent_input_key.clone(),
-        cotangent
-            .attached_data()
-            .cloned()
-            .unwrap_or_else(|| panic!("vjp cotangent must have concrete tensor data")),
-    );
+    inputs_map.insert(cotangent_input_key.clone(), cotangent_data);
 
     let mut extra_roots = vec![Arc::clone(output.graph()), linear_graph];
     extra_roots.extend(checkpoint_graphs);

--- a/crates/tenferro-ad/tests/fallible_api.rs
+++ b/crates/tenferro-ad/tests/fallible_api.rs
@@ -1,5 +1,7 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
 use tenferro_ad::{EagerRuntime, EagerTensor, TracedTensorAdExt};
-use tenferro_runtime::TracedTensor;
+use tenferro_runtime::{DType, TracedTensor};
 use tenferro_tensor::{Error as TensorError, Tensor};
 
 #[test]
@@ -14,6 +16,24 @@ fn traced_jvp_vjp_return_errors_for_inactive_inputs() {
     let _ = loss.vjp(&x, &cotangent).unwrap_err();
     assert!(loss.jvp_optional(&x, &tangent).unwrap().is_none());
     assert!(loss.vjp_optional(&x, &cotangent).unwrap().is_none());
+}
+
+#[test]
+fn traced_jvp_vjp_return_errors_for_symbolic_seed_tensors() {
+    let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]);
+    let loss = &x * &x;
+    let tangent = TracedTensor::input_symbolic_shape(DType::F64, 0);
+    let cotangent = TracedTensor::input_symbolic_shape(DType::F64, 0);
+
+    let jvp = catch_unwind(AssertUnwindSafe(|| loss.jvp(&x, &tangent)));
+    assert!(jvp.is_ok(), "jvp should return Err, not panic");
+    let err = jvp.unwrap().unwrap_err().to_string();
+    assert!(err.contains("jvp tangent"), "{err}");
+
+    let vjp = catch_unwind(AssertUnwindSafe(|| loss.vjp(&x, &cotangent)));
+    assert!(vjp.is_ok(), "vjp should return Err, not panic");
+    let err = vjp.unwrap().unwrap_err().to_string();
+    assert!(err.contains("vjp cotangent"), "{err}");
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/analytic.rs
+++ b/crates/tenferro-cpu/src/analytic.rs
@@ -168,6 +168,7 @@ where
     T: Copy + PoolScalar + 'static,
     R: TensorRank,
 {
+    // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) };
     map_into(&mut out.view_mut(), &typed_view_from_view(op, input)?, f)
         .map_err(|err| crate::Error::backend_failure(op, err))?;
@@ -192,6 +193,7 @@ where
             rhs: rhs.shape().to_vec(),
         });
     }
+    // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) };
     zip_map2_into(
         &mut out.view_mut(),
@@ -272,6 +274,7 @@ macro_rules! define_unary_analytic_op {
         where
             T: UnaryAnalyticElem + PoolScalar,
         {
+            // SAFETY: the following kernel overwrites every output element before any read.
             let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) };
             map_into(
                 &mut out.view_mut(),
@@ -423,6 +426,7 @@ where
             rhs: rhs.shape().to_vec(),
         });
     }
+    // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) };
     zip_map2_into(
         &mut out.view_mut(),

--- a/crates/tenferro-cpu/src/buffer_pool.rs
+++ b/crates/tenferro-cpu/src/buffer_pool.rs
@@ -51,7 +51,9 @@ pub struct BufferPoolStats {
 /// Typed buffer pool keyed by element capacity and separated by scalar type.
 ///
 /// Each supported dtype has an independent best-fit pool. Acquired buffers are
-/// initialized to that dtype's zero value before they are returned.
+/// returned without zero-initialization so kernels can avoid redundant writes
+/// when they fully overwrite the output. Use [`PoolScalar::pool_acquire_zeroed`]
+/// when the caller may read the buffer before writing every element.
 ///
 /// # Examples
 ///
@@ -108,14 +110,13 @@ pub trait PoolScalar: Copy + Sized + Send + Sync + private::Sealed {
 
     /// Acquire a buffer with length `len`.
     ///
-    /// The returned vector has length `len`, capacity at least `len`, and every
-    /// element initialized to this dtype's zero value.
+    /// The vector length is set without initializing its contents. Callers must
+    /// overwrite every element before any read.
     ///
     /// # Safety
     ///
-    /// This method remains unsafe for API compatibility with older tenferro
-    /// releases. Implementations must return fully initialized values, and
-    /// callers do not need to uphold additional memory-safety invariants.
+    /// The returned vector may contain uninitialized or stale elements. Reading
+    /// any element before writing it is undefined behavior.
     ///
     /// # Examples
     ///
@@ -128,6 +129,23 @@ pub trait PoolScalar: Copy + Sized + Send + Sync + private::Sealed {
     /// assert_eq!(buf, vec![1.0, 2.0]);
     /// ```
     unsafe fn pool_acquire(pool: &mut BufferPool, len: usize) -> Vec<Self>;
+
+    /// Acquire a buffer with length `len` and every element set to zero.
+    ///
+    /// This is the safe path for callers that may read the buffer before every
+    /// element is overwritten. Prefer [`PoolScalar::pool_acquire`] for kernels
+    /// that perform a full overwrite.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
+    ///
+    /// let mut pool = BufferPool::new();
+    /// let buf = <f64 as PoolScalar>::pool_acquire_zeroed(&mut pool, 2);
+    /// assert_eq!(buf, vec![0.0, 0.0]);
+    /// ```
+    fn pool_acquire_zeroed(pool: &mut BufferPool, len: usize) -> Vec<Self>;
 
     /// Return a buffer to the typed pool for later reuse.
     ///
@@ -211,7 +229,27 @@ macro_rules! impl_pool_scalar {
                 $zero
             }
 
+            #[allow(clippy::uninit_vec)]
             unsafe fn pool_acquire(pool: &mut BufferPool, len: usize) -> Vec<Self> {
+                match take_best_fit(&mut pool.$field, len) {
+                    Some(mut buf) => {
+                        pool.retained_capacity_bytes = pool
+                            .retained_capacity_bytes
+                            .saturating_sub(buf.capacity().saturating_mul(size_of::<Self>()));
+                        // SAFETY: raw acquire requires caller full-overwrite; len <= capacity here.
+                        unsafe { buf.set_len(len) };
+                        buf
+                    }
+                    None => {
+                        let mut buf = Vec::with_capacity(len);
+                        // SAFETY: raw acquire requires caller full-overwrite; len == capacity here.
+                        unsafe { buf.set_len(len) };
+                        buf
+                    }
+                }
+            }
+
+            fn pool_acquire_zeroed(pool: &mut BufferPool, len: usize) -> Vec<Self> {
                 match take_best_fit(&mut pool.$field, len) {
                     Some(mut buf) => {
                         pool.retained_capacity_bytes = pool
@@ -447,9 +485,30 @@ impl BufferPool {
             return Vec::new();
         }
 
+        // SAFETY: this push-only capacity helper clears length before any element can be read.
         let mut buf = unsafe { T::pool_acquire(self, cap) };
-        buf.clear();
+        // SAFETY: shrinking length to zero does not read pooled `Copy` elements.
+        unsafe { buf.set_len(0) };
         buf
+    }
+
+    /// Acquire a typed vector with length `len` initialized to zero.
+    ///
+    /// Use this only when the caller may read elements before overwriting the
+    /// entire buffer. Full-overwrite kernels should use
+    /// [`PoolScalar::pool_acquire`] to avoid the initialization cost.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::linalg_interop::BufferPool;
+    ///
+    /// let mut pool = BufferPool::new();
+    /// let buf = pool.acquire_zeroed::<f32>(3);
+    /// assert_eq!(buf, vec![0.0, 0.0, 0.0]);
+    /// ```
+    pub fn acquire_zeroed<T: PoolScalar>(&mut self, len: usize) -> Vec<T> {
+        T::pool_acquire_zeroed(self, len)
     }
 
     /// Whether all typed pools are empty.

--- a/crates/tenferro-cpu/src/buffer_pool/tests.rs
+++ b/crates/tenferro-cpu/src/buffer_pool/tests.rs
@@ -54,15 +54,25 @@ fn fresh_alloc_fallback() {
 }
 
 #[test]
-fn acquired_buffers_are_initialized_on_fresh_and_reused_paths() {
+fn zeroed_acquire_initializes_fresh_and_reused_buffers() {
     let mut pool = BufferPool::new();
 
-    let fresh = unsafe { <f64 as PoolScalar>::pool_acquire(&mut pool, 4) };
+    let fresh = <f64 as PoolScalar>::pool_acquire_zeroed(&mut pool, 4);
     assert_eq!(fresh, vec![0.0; 4]);
 
     <f64 as PoolScalar>::pool_release(&mut pool, vec![7.0, 8.0, 9.0, 10.0]);
-    let reused = unsafe { <f64 as PoolScalar>::pool_acquire(&mut pool, 4) };
+    let reused = <f64 as PoolScalar>::pool_acquire_zeroed(&mut pool, 4);
     assert_eq!(reused, vec![0.0; 4]);
+}
+
+#[test]
+fn raw_acquire_does_not_zero_initialized_reused_buffers() {
+    let mut pool = BufferPool::new();
+
+    <f64 as PoolScalar>::pool_release(&mut pool, vec![7.0, 8.0, 9.0, 10.0]);
+    let reused = unsafe { <f64 as PoolScalar>::pool_acquire(&mut pool, 4) };
+
+    assert_eq!(reused, vec![7.0, 8.0, 9.0, 10.0]);
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/elementwise.rs
+++ b/crates/tenferro-cpu/src/elementwise.rs
@@ -605,6 +605,7 @@ where
     R: TensorRank,
 {
     if lhs.shape() == rhs.shape() {
+        // SAFETY: the following kernel overwrites every output element before any read.
         let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) };
         zip_map2_into(
             &mut out.view_mut(),
@@ -616,6 +617,7 @@ where
         Ok(tensor_from_array(out))
     } else if lhs.shape().is_empty() {
         let scalar = typed_view_from_view(op, lhs)?.get(&[]);
+        // SAFETY: the following kernel overwrites every output element before any read.
         let mut out = unsafe { typed_array_uninit_from_pool(buffers, rhs.shape()) };
         map_into(&mut out.view_mut(), &typed_view_from_view(op, rhs)?, |x| {
             f(scalar, x)
@@ -624,6 +626,7 @@ where
         Ok(tensor_from_array(out))
     } else if rhs.shape().is_empty() {
         let scalar = typed_view_from_view(op, rhs)?.get(&[]);
+        // SAFETY: the following kernel overwrites every output element before any read.
         let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) };
         map_into(&mut out.view_mut(), &typed_view_from_view(op, lhs)?, |x| {
             f(x, scalar)
@@ -649,6 +652,7 @@ where
     T: Copy + PoolScalar + 'static,
     R: TensorRank,
 {
+    // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) };
     map_into(&mut out.view_mut(), &typed_view_from_view(op, input)?, f)
         .map_err(|err| crate::Error::backend_failure(op, err))?;
@@ -675,6 +679,7 @@ where
             rhs: rhs.shape().to_vec(),
         });
     }
+    // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) };
     zip_map2_into(
         &mut out.view_mut(),
@@ -712,6 +717,7 @@ where
             rhs: on_false.shape().to_vec(),
         });
     }
+    // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, pred.shape()) };
     zip_map3_into(
         &mut out.view_mut(),
@@ -750,6 +756,7 @@ where
             rhs: upper.shape().to_vec(),
         });
     }
+    // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) };
     zip_map3_into(
         &mut out.view_mut(),
@@ -2554,6 +2561,7 @@ fn typed_complex_abs_with_pool<T>(
 where
     T: num_traits::Float + PoolScalar,
 {
+    // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) };
     map_into(&mut out.view_mut(), &typed_view("abs", input)?, |x| {
         x.norm()
@@ -2570,6 +2578,7 @@ where
     T: num_traits::Float + PoolScalar + 'static,
     R: TensorRank,
 {
+    // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) };
     map_into(
         &mut out.view_mut(),

--- a/crates/tenferro-cpu/src/gemm/faer_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/faer_gemm.rs
@@ -88,6 +88,7 @@ macro_rules! impl_faer_gemm {
                     Accum::Replace
                 } else {
                     if beta != one {
+                        // SAFETY: beta != 0 callers must pass initialized C; pooled dot_general uses beta = 0.
                         let mut col_off = 0isize;
                         for _ in 0..n {
                             let mut off = col_off;

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -927,9 +927,7 @@ where
     let out_n = checked_product(&dims.out_shape)
         .ok_or_else(|| Error::backend_failure("dot_general", "output element count overflow"))?;
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
-        // SAFETY: the buffer is fully initialized immediately by fill.
-        let mut data = unsafe { T::pool_acquire(buffers, out_n) };
-        data.fill(T::zero());
+        let data = T::pool_acquire_zeroed(buffers, out_n);
         return Ok(Some(TypedTensor::from_buffer_col_major(
             dims.out_shape.into_vec(),
             Buffer::Host(data),
@@ -1250,9 +1248,7 @@ where
     let out_n = checked_product(&dims.out_shape)
         .ok_or_else(|| Error::backend_failure("dot_general", "output element count overflow"))?;
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
-        // SAFETY: the buffer is fully initialized immediately by fill.
-        let mut data = unsafe { T::pool_acquire(buffers, out_n) };
-        data.fill(T::zero());
+        let data = T::pool_acquire_zeroed(buffers, out_n);
         return Ok(Some(TypedTensor::from_buffer_col_major(
             dims.out_shape.into_vec(),
             Buffer::Host(data),
@@ -1290,8 +1286,7 @@ where
     let a_base = lhs.offset();
     let b_base = rhs.offset();
 
-    // SAFETY: each batch GEMM writes its full output block with beta = 0 when
-    // the BLAS layout can represent the requested conjugation.
+    // SAFETY: BLAS conjugation path uses beta = 0 and writes each output block fully.
     let mut out: Vec<T> = unsafe { T::pool_acquire(buffers, out_n) };
     let c_ptr = out.as_mut_ptr();
 
@@ -1356,9 +1351,7 @@ where
     let out_n = checked_product(&dims.out_shape)
         .ok_or_else(|| Error::backend_failure("dot_general", "output element count overflow"))?;
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
-        // SAFETY: the buffer is fully initialized immediately by fill.
-        let mut data = unsafe { T::pool_acquire(buffers, out_n) };
-        data.fill(T::zero());
+        let data = T::pool_acquire_zeroed(buffers, out_n);
         return Ok(Some(TypedTensor::from_buffer_col_major(
             dims.out_shape.into_vec(),
             Buffer::Host(data),

--- a/crates/tenferro-cpu/src/gemm/strided_dot.rs
+++ b/crates/tenferro-cpu/src/gemm/strided_dot.rs
@@ -77,8 +77,7 @@ where
         .map_err(map_strided_error)?;
     let out_n = checked_product(&out_shape)?;
 
-    // SAFETY: dot_general_with_backend_into is called with beta=0 and either
-    // overwrites every output element or explicitly zero-fills k=0 outputs.
+    // SAFETY: beta=0 strided dot fully overwrites outputs or explicitly zero-fills k=0.
     let mut out_data = unsafe { T::pool_acquire(buffers, out_n) };
     let out_strides = strided_einsum2::col_major_strides(&out_shape);
     let out_view = strided_einsum2::StridedViewMut::new(&mut out_data, &out_shape, &out_strides, 0)

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -460,7 +460,12 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar>(
         }
         for dim in 0..rank {
             if dim == axis {
-                axis_extent += input_shape[dim];
+                axis_extent = axis_extent.checked_add(input_shape[dim]).ok_or_else(|| {
+                    crate::Error::InvalidConfig {
+                        op: "concatenate",
+                        message: "concatenate axis extent overflows usize".to_string(),
+                    }
+                })?;
             } else if input_shape[dim] != first_shape[dim] {
                 return Err(crate::Error::ShapeMismatch {
                     op: "concatenate",
@@ -472,13 +477,17 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar>(
     }
     out_shape[axis] = axis_extent;
 
-    let segment_ends: Vec<usize> = inputs
-        .iter()
-        .scan(0usize, |sum, input| {
-            *sum += input.shape()[axis];
-            Some(*sum)
-        })
-        .collect();
+    let mut segment_ends = Vec::with_capacity(inputs.len());
+    let mut segment_end = 0usize;
+    for input in inputs {
+        segment_end = segment_end
+            .checked_add(input.shape()[axis])
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "concatenate",
+                message: "concatenate segment offset overflows usize".to_string(),
+            })?;
+        segment_ends.push(segment_end);
+    }
 
     let mut out = pooled_uninit_tensor(buffers, out_shape.clone())?;
     let mut out_idx = vec![0usize; rank];
@@ -1111,9 +1120,8 @@ where
         window_shape[window_dims[pos]] = dim;
     }
 
-    let batch_elems = checked_product("scatter", "batch shape", &batch_shape)?.max(1);
-    let window_elems =
-        checked_product("scatter", "window update shape", &window_shape_updates)?.max(1);
+    let batch_elems = checked_product("scatter", "batch shape", &batch_shape)?;
+    let window_elems = checked_product("scatter", "window update shape", &window_shape_updates)?;
     let mut out = clone_host_tensor_from_pool(buffers, "scatter", operand)?;
 
     let mut batch_idx = vec![0usize; batch_shape.len()];

--- a/crates/tenferro-cpu/src/indexing_alloc.rs
+++ b/crates/tenferro-cpu/src/indexing_alloc.rs
@@ -18,8 +18,7 @@ where
     T: Clone + PoolScalar,
 {
     let len = checked_shape_product("cpu_pooled_output", &shape)?;
-    // SAFETY: callers use this helper only for outputs that are fully written
-    // before any read.
+    // SAFETY: callers use this helper only for pooled outputs that are fully overwritten.
     let data = unsafe { T::pool_acquire(buffers, len) };
     Ok(TypedTensor::from_vec_col_major(shape, data))
 }

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -231,7 +231,7 @@ pub(crate) unsafe fn typed_array_uninit<T>(shape: &[usize]) -> StridedArray<T> {
     let total: usize = shape.iter().product();
     let strides = kernel_col_major_strides(shape);
     let mut data = Vec::with_capacity(total);
-    // SAFETY: caller guarantees every element is written before any read.
+    // SAFETY: test-only helper is used for outputs whose elements are fully overwritten.
     unsafe { data.set_len(total) };
     StridedArray::from_parts(data, shape, &strides, 0).expect("column-major output array")
 }
@@ -239,8 +239,8 @@ pub(crate) unsafe fn typed_array_uninit<T>(shape: &[usize]) -> StridedArray<T> {
 /// Create an output array from the CPU buffer pool WITHOUT initializing values.
 ///
 /// # Safety
-/// Caller should overwrite every element that is part of the operation output.
-/// The pool supplies valid zero values so accidental reads are memory-safe.
+/// Caller must write every element before reading. The returned array contains
+/// uninitialized or stale data acquired from `buffers`.
 pub(crate) unsafe fn typed_array_uninit_from_pool<T>(
     buffers: &mut BufferPool,
     shape: &[usize],
@@ -250,7 +250,7 @@ where
 {
     let total: usize = shape.iter().product();
     let strides = kernel_col_major_strides(shape);
-    // SAFETY: caller guarantees every element is written before any read.
+    // SAFETY: callers use this only for operation outputs that fully overwrite every element.
     let data = unsafe { T::pool_acquire(buffers, total) };
     StridedArray::from_parts(data, shape, &strides, 0).expect("column-major output array")
 }

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -131,26 +131,31 @@ fn copy_view_to_array<T: Copy + Clone + Send + Sync>(
     Ok(tensor_from_array(out))
 }
 
-fn zeroed_tensor_from_pool<T>(buffers: &mut BufferPool, shape: Vec<usize>) -> TypedTensor<T>
+fn zeroed_tensor_from_pool<T>(
+    buffers: &mut BufferPool,
+    op: &'static str,
+    shape: Vec<usize>,
+) -> crate::Result<TypedTensor<T>>
 where
     T: Zero + Clone + PoolScalar + 'static,
 {
-    filled_tensor_from_pool(buffers, shape, T::zero())
+    filled_tensor_from_pool(buffers, op, shape, T::zero())
 }
 
 fn filled_tensor_from_pool<T>(
     buffers: &mut BufferPool,
+    op: &'static str,
     shape: Vec<usize>,
     fill: T,
-) -> TypedTensor<T>
+) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + PoolScalar + 'static,
 {
-    let len = shape.iter().product();
+    let len = checked_shape_product(op, "output shape", &shape)?;
     // SAFETY: every pooled element is initialized with `fill` before returning.
     let mut data = unsafe { T::pool_acquire(buffers, len) };
     data.fill(fill);
-    TypedTensor::from_vec_col_major(shape, data)
+    Ok(TypedTensor::from_vec_col_major(shape, data))
 }
 
 fn clone_host_tensor_from_pool<T>(
@@ -326,7 +331,7 @@ pub(crate) fn embed_diagonal_with_pool(
         |t| typed_embed_diagonal_with_pool(buffers, t, axis_a, axis_b),
         bool | t
             | typed_embed_diagonal_impl(t, axis_a, axis_b, |shape| {
-                filled_tensor_from_pool(buffers, shape, false)
+                filled_tensor_from_pool(buffers, "embed_diagonal", shape, false)
             })
     )
 }
@@ -587,7 +592,9 @@ pub(crate) fn typed_embed_diagonal<T: Copy + Zero + Clone>(
     axis_a: usize,
     axis_b: usize,
 ) -> crate::Result<TypedTensor<T>> {
-    typed_embed_diagonal_impl(tensor, axis_a, axis_b, |shape| TypedTensor::zeros(shape))
+    typed_embed_diagonal_impl(tensor, axis_a, axis_b, |shape| {
+        Ok(TypedTensor::zeros(shape))
+    })
 }
 
 pub(crate) fn typed_embed_diagonal_with_pool<T>(
@@ -600,7 +607,7 @@ where
     T: Copy + Zero + Clone + PoolScalar + 'static,
 {
     typed_embed_diagonal_impl(tensor, axis_a, axis_b, |shape| {
-        zeroed_tensor_from_pool(buffers, shape)
+        zeroed_tensor_from_pool(buffers, "embed_diagonal", shape)
     })
 }
 
@@ -608,7 +615,7 @@ fn typed_embed_diagonal_impl<T>(
     tensor: &TypedTensor<T>,
     axis_a: usize,
     axis_b: usize,
-    make_zeroed: impl FnOnce(Vec<usize>) -> TypedTensor<T>,
+    make_zeroed: impl FnOnce(Vec<usize>) -> crate::Result<TypedTensor<T>>,
 ) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone,
@@ -625,7 +632,7 @@ where
     let n = tensor.shape()[axis_a];
     let mut out_shape = tensor.shape().to_vec();
     out_shape.insert(axis_b, n);
-    let mut out = make_zeroed(out_shape);
+    let mut out = make_zeroed(out_shape)?;
 
     let in_rank = tensor.shape().len();
     let out_rank = out.shape().len();

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -49,6 +49,20 @@ fn validate_axes_distinct(op: &'static str, axis_a: usize, axis_b: usize) -> cra
     Ok(())
 }
 
+fn checked_shape_product(
+    op: &'static str,
+    role: &'static str,
+    shape: &[usize],
+) -> crate::Result<usize> {
+    shape.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op,
+                message: format!("{role} element count overflows usize"),
+            })
+    })
+}
+
 fn validate_permutation(op: &'static str, perm: &[usize], rank: usize) -> crate::Result<()> {
     validate_rank(op, rank, perm.len())?;
     let mut seen = vec![false; rank];
@@ -133,7 +147,7 @@ where
     T: Copy + Clone + PoolScalar + 'static,
 {
     let len = shape.iter().product();
-    // SAFETY: every element is initialized with `fill` before returning.
+    // SAFETY: every pooled element is initialized with `fill` before returning.
     let mut data = unsafe { T::pool_acquire(buffers, len) };
     data.fill(fill);
     TypedTensor::from_vec_col_major(shape, data)
@@ -151,7 +165,7 @@ where
         crate::Buffer::Host(data) => data.as_slice(),
         crate::Buffer::Backend(_) => return Err(cpu_backend_buffer_error(op)),
     };
-    // SAFETY: copy_from_slice initializes every element before returning.
+    // SAFETY: copy_from_slice initializes every pooled element before returning.
     let mut data = unsafe { T::pool_acquire(buffers, input.len()) };
     data.copy_from_slice(input);
     Ok(TypedTensor::from_buffer_col_major(
@@ -404,6 +418,7 @@ where
     R: TensorRank,
 {
     typed_transpose_view_impl(view, perm, |shape| unsafe {
+        // SAFETY: transpose materialization copies every output element before returning.
         typed_array_uninit_from_pool(buffers, shape)
     })
 }
@@ -412,8 +427,8 @@ pub fn typed_reshape<T: Clone + 'static>(
     tensor: &TypedTensor<T>,
     shape: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
-    let old_n: usize = tensor.shape().iter().product();
-    let new_n: usize = shape.iter().product();
+    let old_n = checked_shape_product("reshape", "input shape", tensor.shape())?;
+    let new_n = checked_shape_product("reshape", "output shape", shape)?;
     if old_n != new_n {
         return Err(crate::Error::ShapeMismatch {
             op: "reshape",
@@ -449,6 +464,7 @@ where
     T: Copy + Clone + PoolScalar,
 {
     typed_broadcast_in_dim_impl(tensor, shape, dims, |shape| unsafe {
+        // SAFETY: broadcast materialization writes every output element before returning.
         typed_array_uninit_from_pool(buffers, shape)
     })
 }

--- a/crates/tenferro-cpu/tests/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/runtime_error_tests.rs
@@ -112,6 +112,53 @@ fn cpu_pooled_output_allocation_uses_checked_shape_product() {
 }
 
 #[test]
+fn cpu_reshape_concatenate_scatter_use_checked_boundary_arithmetic_contract() {
+    let structural = include_str!("../src/structural.rs");
+    let reshape_section = source_section(
+        structural,
+        "pub fn typed_reshape",
+        "pub(crate) fn typed_broadcast_in_dim",
+    );
+    assert!(
+        reshape_section.contains("checked_shape_product(\"reshape\", \"input shape\","),
+        "CPU reshape must check input shape products"
+    );
+    assert!(
+        reshape_section.contains("checked_shape_product(\"reshape\", \"output shape\","),
+        "CPU reshape must check output shape products"
+    );
+    assert!(
+        !reshape_section.contains("shape.iter().product"),
+        "CPU reshape must not use unchecked shape.iter().product()"
+    );
+
+    let indexing = include_str!("../src/indexing.rs");
+    let concat_section = source_section(indexing, "fn typed_concatenate", "fn typed_reverse");
+    assert!(
+        concat_section.contains("axis_extent = axis_extent.checked_add"),
+        "CPU concatenate must check output-axis extent accumulation"
+    );
+    assert!(
+        concat_section.contains("segment_end")
+            && concat_section.contains(".checked_add(input.shape()[axis])"),
+        "CPU concatenate must check segment prefix offsets"
+    );
+
+    let scatter_section = source_section(indexing, "fn typed_scatter", "fn typed_dynamic_slice");
+    assert!(
+        !scatter_section
+            .contains("checked_product(\"scatter\", \"batch shape\", &batch_shape)?.max(1)"),
+        "CPU scatter must not force a phantom iteration over zero-size batch domains"
+    );
+    assert!(
+        !scatter_section.contains(
+            "checked_product(\"scatter\", \"window update shape\", &window_shape_updates)?.max(1)"
+        ),
+        "CPU scatter must not force a phantom iteration over zero-size update windows"
+    );
+}
+
+#[test]
 fn cpu_reduce_max_min_validate_axes_before_empty_fast_path() {
     let reduction = include_str!("../src/reduction.rs");
     for (start, end, op) in [

--- a/crates/tenferro-cpu/tests/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/runtime_error_tests.rs
@@ -112,6 +112,25 @@ fn cpu_pooled_output_allocation_uses_checked_shape_product() {
 }
 
 #[test]
+fn cpu_zero_fill_pooled_outputs_use_checked_shape_product() {
+    let structural = include_str!("../src/structural.rs");
+    let filled_section = source_section(
+        structural,
+        "fn filled_tensor_from_pool",
+        "fn clone_host_tensor_from_pool",
+    );
+
+    assert!(
+        filled_section.contains("checked_shape_product(op, \"output shape\", &shape)?"),
+        "CPU zero/fill pooled output allocation must reject shape-product overflow"
+    );
+    assert!(
+        !filled_section.contains("let len = shape.iter().product();"),
+        "CPU zero/fill pooled output allocation must not use unchecked shape.iter().product()"
+    );
+}
+
+#[test]
 fn cpu_reshape_concatenate_scatter_use_checked_boundary_arithmetic_contract() {
     let structural = include_str!("../src/structural.rs");
     let reshape_section = source_section(

--- a/crates/tenferro-einsum/src/tests/eager_tests.rs
+++ b/crates/tenferro-einsum/src/tests/eager_tests.rs
@@ -79,6 +79,29 @@ fn eager_einsum_handles_higher_rank_repeated_labels() {
 }
 
 #[test]
+fn eager_einsum_handles_three_or_more_repeated_labels() {
+    let mut ctx = CpuBackend::new();
+    let cube = Tensor::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+    );
+
+    let diagonal = eager_einsum(&mut ctx, &[&cube], "iii->i").unwrap();
+    assert_f64_tensor(&diagonal, &[2], &[1.0, 8.0]);
+
+    let hypercube = Tensor::from_vec_col_major(
+        vec![2, 2, 2, 2],
+        (1..=16).map(|value| value as f64).collect(),
+    );
+    let trace = eager_einsum(&mut ctx, &[&hypercube], "iiii->").unwrap();
+    assert_f64_tensor(&trace, &[], &[17.0]);
+
+    let rhs = Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 3.0, 5.0]);
+    let mixed = eager_einsum(&mut ctx, &[&cube, &rhs], "iii,j->ij").unwrap();
+    assert_f64_tensor(&mixed, &[2, 3], &[2.0, 16.0, 3.0, 24.0, 5.0, 40.0]);
+}
+
+#[test]
 fn eager_einsum_read_views_match_owned_inputs() {
     let a_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
     let b_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];

--- a/crates/tenferro-einsum/tests/traced_correctness/ported_and_paths.rs
+++ b/crates/tenferro-einsum/tests/traced_correctness/ported_and_paths.rs
@@ -594,6 +594,45 @@ fn einsum_three_way_repeated_label_trace() {
 }
 
 #[test]
+fn einsum_three_or_more_repeated_labels_keep_and_mix() {
+    let cube = f64_tensor(vec![2, 2, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+    let hypercube = f64_tensor(
+        vec![2, 2, 2, 2],
+        (1..=16).map(|value| value as f64).collect(),
+    );
+    let rhs = f64_tensor(vec![3], vec![2.0, 3.0, 5.0]);
+
+    let mut engine = GraphExecutor::new(CpuBackend::new());
+    let tcube = TracedTensor::from_tensor_concrete_shape(cube.clone());
+    let diag = einsum(&mut engine, &[&tcube], "iii->i").unwrap();
+    let diag_result = diag.run_with(&mut engine).unwrap();
+    assert_eq!(diag_result.shape(), &[2]);
+    assert_close(get_v2(&diag_result, &[0]), 1.0, "iii_to_i[0]");
+    assert_close(get_v2(&diag_result, &[1]), 8.0, "iii_to_i[1]");
+
+    let thyper = TracedTensor::from_tensor_concrete_shape(hypercube);
+    let trace = einsum(&mut engine, &[&thyper], "iiii->").unwrap();
+    let trace_result = trace.run_with(&mut engine).unwrap();
+    assert!(trace_result.shape().is_empty());
+    assert_close(get_f64_data(&trace_result)[0], 17.0, "iiii_trace");
+
+    let tcube = TracedTensor::from_tensor_concrete_shape(cube);
+    let trhs = TracedTensor::from_tensor_concrete_shape(rhs);
+    let mixed = einsum(&mut engine, &[&tcube, &trhs], "iii,j->ij").unwrap();
+    let mixed_result = mixed.run_with(&mut engine).unwrap();
+    assert_eq!(mixed_result.shape(), &[2, 3]);
+    for (i, diag_value) in [1.0, 8.0].iter().copied().enumerate() {
+        for (j, rhs_value) in [2.0, 3.0, 5.0].iter().copied().enumerate() {
+            assert_close(
+                get_v2(&mixed_result, &[i, j]),
+                diag_value * rhs_value,
+                &format!("iii_j_to_ij[{i},{j}]"),
+            );
+        }
+    }
+}
+
+#[test]
 fn einsum_binary_diag_ii_jk_to_ijk() {
     // "ii,jk->ijk" — extract diagonal from A, outer product with B
     let a = f64_tensor(

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -2040,8 +2040,8 @@ impl TensorStructural for CubeclBackend {
     }
 
     fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
-        let old_n: usize = input.shape().iter().product();
-        let new_n: usize = shape.iter().product();
+        let old_n = checked_dim_product("reshape", "input shape", input.shape())?;
+        let new_n = checked_dim_product("reshape", "output shape", shape)?;
         if old_n != new_n {
             return Err(crate::Error::ShapeMismatch {
                 op: "reshape",
@@ -3132,7 +3132,12 @@ fn concatenate_output_shape<T>(
         ensure_rank("concatenate", rank, input.shape().len())?;
         for dim in 0..rank {
             if dim == axis {
-                axis_extent += input.shape()[dim];
+                axis_extent = axis_extent.checked_add(input.shape()[dim]).ok_or_else(|| {
+                    crate::Error::backend_failure(
+                        "concatenate",
+                        "concatenate axis extent overflows usize",
+                    )
+                })?;
             } else if input.shape()[dim] != first.shape()[dim] {
                 return Err(crate::Error::ShapeMismatch {
                     op: "concatenate",

--- a/crates/tenferro-gpu/src/kernels/reduce/launch.rs
+++ b/crates/tenferro-gpu/src/kernels/reduce/launch.rs
@@ -71,7 +71,14 @@ fn validate_reduce_problem(
         });
     }
 
-    let input_len = input_shape.iter().product::<usize>();
+    let input_len = input_shape.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| CubeclKernelError::InvalidStrategy {
+                reason: format!(
+                    "reduction input element count overflows usize for shape {input_shape:?}"
+                ),
+            })
+    })?;
     let reduce_count = input_len / reduce_len;
 
     Ok(ReduceProblem {
@@ -84,16 +91,16 @@ fn validate_reduce_problem(
 fn launch_with_unit_settings<R: Runtime>(
     client: &ComputeClient<R>,
     problem: ReduceProblem,
-) -> ResolvedReduceLaunch {
-    let settings = unit_launch_settings(client, problem);
+) -> Result<ResolvedReduceLaunch> {
+    let settings = unit_launch_settings(client, problem)?;
     let _has_idle_units = settings.blueprint.idle_units;
-    ResolvedReduceLaunch {
+    Ok(ResolvedReduceLaunch {
         kind: ResolvedReduceStrategy::Unit,
         cube_count: settings.cube_count,
         cube_dim: settings.cube_dim,
         axis: problem.axis,
         output_len: problem.reduce_count,
-    }
+    })
 }
 
 fn launch_with_plane_settings<R: Runtime>(
@@ -184,7 +191,7 @@ fn resolve_launch_settings<R: Runtime>(
 ) -> Result<ResolvedReduceLaunch> {
     match strategy {
         ReduceStrategy::Auto => match auto_reduce_strategy(client, problem)? {
-            ResolvedReduceStrategy::Unit => Ok(launch_with_unit_settings(client, problem)),
+            ResolvedReduceStrategy::Unit => launch_with_unit_settings(client, problem),
             ResolvedReduceStrategy::Plane => launch_with_plane_settings(client, problem),
         },
     }

--- a/crates/tenferro-gpu/src/kernels/reduce/launch/tests.rs
+++ b/crates/tenferro-gpu/src/kernels/reduce/launch/tests.rs
@@ -35,6 +35,21 @@ fn validate_reduce_problem_rejects_non_keepdims_output_shape() {
 }
 
 #[test]
+fn validate_reduce_problem_rejects_input_shape_product_overflow() {
+    let input_shape = [usize::MAX, 2];
+    let err = super::validate_reduce_problem(&input_shape, &[usize::MAX, 1], 1).unwrap_err();
+
+    assert_eq!(
+        err,
+        CubeclKernelError::InvalidStrategy {
+            reason: format!(
+                "reduction input element count overflows usize for shape {input_shape:?}"
+            ),
+        }
+    );
+}
+
+#[test]
 fn auto_strategy_uses_unit_only_within_bounded_axis_limit() {
     assert_eq!(
         super::auto_reduce_strategy_for_capabilities(32, 32, false).unwrap(),

--- a/crates/tenferro-gpu/src/kernels/reduce/routines.rs
+++ b/crates/tenferro-gpu/src/kernels/reduce/routines.rs
@@ -19,6 +19,8 @@
 
 use cubecl::prelude::*;
 
+use crate::kernels::{CubeclKernelError, Result};
+
 /// Validated single-axis reduction dimensions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ReduceProblem {
@@ -52,25 +54,33 @@ pub struct ReduceLaunchSettings {
 pub(crate) fn unit_launch_settings<R: Runtime>(
     client: &ComputeClient<R>,
     problem: ReduceProblem,
-) -> ReduceLaunchSettings {
+) -> Result<ReduceLaunchSettings> {
     unit_launch_settings_for_plane_size(client.properties().hardware.plane_size_max, problem)
 }
 
 fn unit_launch_settings_for_plane_size(
     plane_size: u32,
     problem: ReduceProblem,
-) -> ReduceLaunchSettings {
+) -> Result<ReduceLaunchSettings> {
     let cube_dim = CubeDim::new_1d(plane_size);
     let units_per_cube = cube_dim.num_elems() as usize;
-    let cubes = problem.reduce_count.div_ceil(units_per_cube).max(1) as u32;
+    let cubes =
+        u32::try_from(problem.reduce_count.div_ceil(units_per_cube).max(1)).map_err(|_| {
+            CubeclKernelError::InvalidStrategy {
+                reason: format!(
+                    "reduction output element count {} exceeds static CubeCL launch limit",
+                    problem.reduce_count
+                ),
+            }
+        })?;
 
-    ReduceLaunchSettings {
+    Ok(ReduceLaunchSettings {
         cube_count: CubeCount::Static(cubes, 1, 1),
         cube_dim,
         blueprint: UnitReduceBlueprint {
             idle_units: problem.reduce_count % units_per_cube != 0,
         },
-    }
+    })
 }
 
 #[cfg(test)]

--- a/crates/tenferro-gpu/src/kernels/reduce/routines/tests.rs
+++ b/crates/tenferro-gpu/src/kernels/reduce/routines/tests.rs
@@ -18,7 +18,8 @@ fn unit_launch_settings_uses_one_unit_per_output_element() {
             reduce_count: 65,
             axis: 1,
         },
-    );
+    )
+    .unwrap();
 
     assert_static_cube_count(&settings.cube_count, 3);
     assert_eq!(settings.cube_dim, CubeDim::new_1d(32));
@@ -34,7 +35,8 @@ fn unit_launch_settings_marks_full_cubes_as_non_idle() {
             reduce_count: 64,
             axis: 1,
         },
-    );
+    )
+    .unwrap();
 
     assert_static_cube_count(&settings.cube_count, 2);
     assert_eq!(settings.cube_dim, CubeDim::new_1d(32));
@@ -50,8 +52,23 @@ fn unit_launch_settings_keeps_empty_output_launch_valid() {
             reduce_count: 0,
             axis: 1,
         },
-    );
+    )
+    .unwrap();
 
     assert_static_cube_count(&settings.cube_count, 1);
     assert_eq!(settings.cube_dim, CubeDim::new_1d(32));
+}
+
+#[test]
+fn unit_launch_settings_rejects_cube_count_overflow() {
+    let settings = unit_launch_settings_for_plane_size(
+        1,
+        ReduceProblem {
+            reduce_len: 5,
+            reduce_count: u32::MAX as usize + 1,
+            axis: 1,
+        },
+    );
+
+    assert!(settings.is_err());
 }

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -252,6 +252,30 @@ fn cubecl_output_allocations_use_checked_shape_products() {
 }
 
 #[test]
+fn cubecl_structural_shape_arithmetic_is_checked() {
+    let cubecl_mod = repo_file("crates/tenferro-gpu/src/cubecl/mod.rs");
+    assert!(
+        cubecl_mod.contains("checked_dim_product(\"reshape\", \"input shape\", input.shape())?")
+            && cubecl_mod.contains("checked_dim_product(\"reshape\", \"output shape\", shape)?"),
+        "CubeCL reshape must reject shape-product overflow before reusing buffers"
+    );
+    assert!(
+        cubecl_mod.contains("axis_extent = axis_extent.checked_add(input.shape()[dim])"),
+        "CubeCL concatenate axis extent must use checked_add"
+    );
+    for banned in [
+        "let old_n: usize = input.shape().iter().product();",
+        "let new_n: usize = shape.iter().product();",
+        "axis_extent += input.shape()[dim];",
+    ] {
+        assert!(
+            !cubecl_mod.contains(banned),
+            "CubeCL structural path must not use unchecked shape arithmetic: found {banned}"
+        );
+    }
+}
+
+#[test]
 fn webgpu_allocation_uses_checked_shape_products() {
     let webgpu_mod = repo_file("crates/tenferro-gpu/src/webgpu/mod.rs");
     assert!(

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -633,9 +633,9 @@ impl LinalgBackend for CpuBackend {
                         Tensor::F64(t) => linalg::faer::eigh(ctx.as_ref(), buffers, t)
                             .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
                         Tensor::C32(t) => linalg::faer::eigh(ctx.as_ref(), buffers, t)
-                            .map(eigh_c32_outputs_to_public_tensors),
+                            .and_then(eigh_c32_outputs_to_public_tensors),
                         Tensor::C64(t) => linalg::faer::eigh(ctx.as_ref(), buffers, t)
-                            .map(eigh_c64_outputs_to_public_tensors),
+                            .and_then(eigh_c64_outputs_to_public_tensors),
                         _ => Err(unsupported_dtype("eigh", input.dtype())),
                     })
                 }
@@ -652,12 +652,10 @@ impl LinalgBackend for CpuBackend {
                             .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
                         Tensor::F64(t) => linalg::blas::eigh(buffers, t)
                             .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
-                        Tensor::C32(t) => {
-                            linalg::blas::eigh(buffers, t).map(eigh_c32_outputs_to_public_tensors)
-                        }
-                        Tensor::C64(t) => {
-                            linalg::blas::eigh(buffers, t).map(eigh_c64_outputs_to_public_tensors)
-                        }
+                        Tensor::C32(t) => linalg::blas::eigh(buffers, t)
+                            .and_then(eigh_c32_outputs_to_public_tensors),
+                        Tensor::C64(t) => linalg::blas::eigh(buffers, t)
+                            .and_then(eigh_c64_outputs_to_public_tensors),
                         _ => Err(unsupported_dtype("eigh", input.dtype())),
                     })
                 }
@@ -1034,6 +1032,10 @@ fn full_piv_lu_output_count_error(count: usize) -> Error {
     Error::backend_failure("full_piv_lu", format!("expected 5 outputs, got {count}"))
 }
 
+fn eigh_output_count_error(count: usize) -> Error {
+    Error::backend_failure("eigh", format!("expected 2 outputs, got {count}"))
+}
+
 fn full_piv_lu_c32_outputs_to_public_tensors(
     outputs: Vec<TypedTensor<Complex32>>,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -1122,24 +1124,32 @@ fn svd_c64_outputs_to_public_tensors(
     }
 }
 
-fn eigh_c32_outputs_to_public_tensors(outputs: Vec<TypedTensor<Complex32>>) -> Vec<Tensor> {
+fn eigh_c32_outputs_to_public_tensors(
+    outputs: Vec<TypedTensor<Complex32>>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    let count = outputs.len();
     let mut outputs = outputs.into_iter();
-    let values = outputs.next().expect("eigh returns eigenvalues");
-    let vectors = outputs.next().expect("eigh returns eigenvectors");
-    vec![
-        Tensor::F32(complex32_real_part_tensor(values)),
-        Tensor::C32(vectors),
-    ]
+    match (outputs.next(), outputs.next(), outputs.next()) {
+        (Some(values), Some(vectors), None) => Ok(vec![
+            Tensor::F32(complex32_real_part_tensor(values)),
+            Tensor::C32(vectors),
+        ]),
+        _ => Err(eigh_output_count_error(count)),
+    }
 }
 
-fn eigh_c64_outputs_to_public_tensors(outputs: Vec<TypedTensor<Complex64>>) -> Vec<Tensor> {
+fn eigh_c64_outputs_to_public_tensors(
+    outputs: Vec<TypedTensor<Complex64>>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    let count = outputs.len();
     let mut outputs = outputs.into_iter();
-    let values = outputs.next().expect("eigh returns eigenvalues");
-    let vectors = outputs.next().expect("eigh returns eigenvectors");
-    vec![
-        Tensor::F64(complex64_real_part_tensor(values)),
-        Tensor::C64(vectors),
-    ]
+    match (outputs.next(), outputs.next(), outputs.next()) {
+        (Some(values), Some(vectors), None) => Ok(vec![
+            Tensor::F64(complex64_real_part_tensor(values)),
+            Tensor::C64(vectors),
+        ]),
+        _ => Err(eigh_output_count_error(count)),
+    }
 }
 
 fn apply_lu_pivots_cpu(

--- a/crates/tenferro-linalg/src/gpu/linalg.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg.rs
@@ -542,10 +542,12 @@ where
     let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
     let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
     let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
-    let matrix_stride = n * n;
+    let matrix_stride = checked_mul_usize(OP, "cholesky matrix stride", n, n)?;
 
     for batch in 0..batch_total {
-        let batch_a = unsafe { batch_ptr::<T>(first_ptr, batch * matrix_stride) };
+        let a_offset =
+            checked_batch_offset(OP, "cholesky matrix batch offset", batch, matrix_stride)?;
+        let batch_a = unsafe { batch_ptr::<T>(first_ptr, a_offset) };
         let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
         unsafe {
             handles.cusolver().potrf(
@@ -772,11 +774,13 @@ where
     let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
     let pivots_ptr = typed_device_ptr(backend.runtime(), &pivots, OP)?;
     let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
-    let matrix_stride = m * n;
+    let matrix_stride = checked_mul_usize(OP, "lu matrix stride", m, n)?;
 
     for batch in 0..batch_total {
-        let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * matrix_stride) };
-        let batch_pivots = unsafe { batch_ptr::<i32>(pivots_ptr, batch * k) };
+        let a_offset = checked_batch_offset(OP, "lu matrix batch offset", batch, matrix_stride)?;
+        let pivot_offset = checked_batch_offset(OP, "lu pivot batch offset", batch, k)?;
+        let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
+        let batch_pivots = unsafe { batch_ptr::<i32>(pivots_ptr, pivot_offset) };
         let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
         unsafe {
             handles.cusolver().getrf(
@@ -1001,8 +1005,8 @@ where
     let lda = as_i32(m, OP, "lda")?;
     let ldu = as_i32(m, OP, "ldu")?;
     let batch_total = batch_count(batch_shape);
-    let a_stride = m * n;
-    let u_stride = m * k;
+    let a_stride = checked_mul_usize(OP, "svd input stride", m, n)?;
+    let u_stride = checked_mul_usize(OP, "svd u stride", m, k)?;
     let s_stride = k;
 
     match select_svd_driver(m, n) {
@@ -1040,14 +1044,24 @@ where
                 let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
                 let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
                 let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
-                let v_stride = n * k;
+                let v_stride = checked_mul_usize(OP, "svd v stride", n, k)?;
 
                 for batch in 0..batch_total {
-                    let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
+                    let a_offset =
+                        checked_batch_offset(OP, "svd input batch offset", batch, a_stride)?;
+                    let s_offset = checked_batch_offset(
+                        OP,
+                        "svd singular value batch offset",
+                        batch,
+                        s_stride,
+                    )?;
+                    let u_offset = checked_batch_offset(OP, "svd u batch offset", batch, u_stride)?;
+                    let v_offset = checked_batch_offset(OP, "svd v batch offset", batch, v_stride)?;
+                    let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
                     let batch_s =
-                        unsafe { batch_ptr::<<T as LinalgScalar>::Real>(s_ptr, batch * s_stride) };
-                    let batch_u = unsafe { batch_ptr::<T>(u_ptr, batch * u_stride) };
-                    let batch_v = unsafe { batch_ptr::<T>(v_ptr, batch * v_stride) };
+                        unsafe { batch_ptr::<<T as LinalgScalar>::Real>(s_ptr, s_offset) };
+                    let batch_u = unsafe { batch_ptr::<T>(u_ptr, u_offset) };
+                    let batch_v = unsafe { batch_ptr::<T>(v_ptr, v_offset) };
                     let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
                     unsafe {
                         handles.cusolver().gesvdj(
@@ -1094,7 +1108,11 @@ where
             let rwork = if T::NEEDS_RWORK {
                 alloc_workspace_elems::<<T as LinalgScalar>::Real>(
                     backend.runtime(),
-                    as_i32(5 * k, OP, "rwork")?,
+                    as_i32(
+                        checked_mul_usize(OP, "svd rwork length", 5, k)?,
+                        OP,
+                        "rwork",
+                    )?,
                     OP,
                 )?
             } else {
@@ -1102,15 +1120,19 @@ where
             };
             let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
             let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
-            let vt_stride = k * n;
+            let vt_stride = checked_mul_usize(OP, "svd vt stride", k, n)?;
             let job = b'S' as c_char;
 
             for batch in 0..batch_total {
-                let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
-                let batch_s =
-                    unsafe { batch_ptr::<<T as LinalgScalar>::Real>(s_ptr, batch * s_stride) };
-                let batch_u = unsafe { batch_ptr::<T>(u_ptr, batch * u_stride) };
-                let batch_vt = unsafe { batch_ptr::<T>(vt_ptr, batch * vt_stride) };
+                let a_offset = checked_batch_offset(OP, "svd input batch offset", batch, a_stride)?;
+                let s_offset =
+                    checked_batch_offset(OP, "svd singular value batch offset", batch, s_stride)?;
+                let u_offset = checked_batch_offset(OP, "svd u batch offset", batch, u_stride)?;
+                let vt_offset = checked_batch_offset(OP, "svd vt batch offset", batch, vt_stride)?;
+                let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
+                let batch_s = unsafe { batch_ptr::<<T as LinalgScalar>::Real>(s_ptr, s_offset) };
+                let batch_u = unsafe { batch_ptr::<T>(u_ptr, u_offset) };
+                let batch_vt = unsafe { batch_ptr::<T>(vt_ptr, vt_offset) };
                 let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
                 unsafe {
                     handles.cusolver().gesvd(
@@ -1166,7 +1188,7 @@ where
     let n_i32 = as_i32(n, OP, "n")?;
     let lda = as_i32(m, OP, "lda")?;
     let batch_total = batch_count(batch_shape);
-    let a_stride = m * n;
+    let a_stride = checked_mul_usize(OP, "svd_values input stride", m, n)?;
     let s_stride = k;
 
     match select_svd_driver(m, n) {
@@ -1205,14 +1227,26 @@ where
             let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
             let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
             let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
-            let u_stride = m * k;
-            let v_stride = n * k;
+            let u_stride = checked_mul_usize(OP, "svd_values u stride", m, k)?;
+            let v_stride = checked_mul_usize(OP, "svd_values v stride", n, k)?;
 
             for batch in 0..batch_total {
-                let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
-                let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, batch * s_stride) };
-                let batch_u = unsafe { batch_ptr::<T>(u_ptr, batch * u_stride) };
-                let batch_v = unsafe { batch_ptr::<T>(v_ptr, batch * v_stride) };
+                let a_offset =
+                    checked_batch_offset(OP, "svd_values input batch offset", batch, a_stride)?;
+                let s_offset = checked_batch_offset(
+                    OP,
+                    "svd_values singular value batch offset",
+                    batch,
+                    s_stride,
+                )?;
+                let u_offset =
+                    checked_batch_offset(OP, "svd_values u batch offset", batch, u_stride)?;
+                let v_offset =
+                    checked_batch_offset(OP, "svd_values v batch offset", batch, v_stride)?;
+                let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
+                let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, s_offset) };
+                let batch_u = unsafe { batch_ptr::<T>(u_ptr, u_offset) };
+                let batch_v = unsafe { batch_ptr::<T>(v_ptr, v_offset) };
                 let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
                 unsafe {
                     handles.cusolver().gesvdj(
@@ -1253,7 +1287,11 @@ where
             let rwork = if T::NEEDS_RWORK {
                 alloc_workspace_elems::<T::Real>(
                     backend.runtime(),
-                    as_i32(5 * k, OP, "rwork")?,
+                    as_i32(
+                        checked_mul_usize(OP, "svd_values rwork length", 5, k)?,
+                        OP,
+                        "rwork",
+                    )?,
                     OP,
                 )?
             } else {
@@ -1264,8 +1302,16 @@ where
             let job = b'N' as c_char;
 
             for batch in 0..batch_total {
-                let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * a_stride) };
-                let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, batch * s_stride) };
+                let a_offset =
+                    checked_batch_offset(OP, "svd_values input batch offset", batch, a_stride)?;
+                let s_offset = checked_batch_offset(
+                    OP,
+                    "svd_values singular value batch offset",
+                    batch,
+                    s_stride,
+                )?;
+                let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
+                let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, s_offset) };
                 let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
                 unsafe {
                     handles.cusolver().gesvd(
@@ -1337,7 +1383,8 @@ where
             .cusolver()
             .geqrf_buffer_size(T::DATA_TYPE, m_i32, n_i32, work_ptr, lda, OP)?;
     let geqrf_workspace = alloc_workspace_elems::<T>(backend.runtime(), geqrf_lwork, OP)?;
-    let tau = alloc_workspace_bytes(backend.runtime(), k * std::mem::size_of::<T>(), OP)?;
+    let tau_bytes = checked_mul_usize(OP, "qr tau workspace bytes", k, std::mem::size_of::<T>())?;
+    let tau = alloc_workspace_bytes(backend.runtime(), tau_bytes, OP)?;
     let orgqr_lwork = handles.cusolver().orgqr_buffer_size(
         T::DATA_TYPE,
         m_i32,
@@ -1354,12 +1401,14 @@ where
     let orgqr_info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
     let geqrf_info_ptr = typed_device_ptr(backend.runtime(), &geqrf_info, OP)?;
     let orgqr_info_ptr = typed_device_ptr(backend.runtime(), &orgqr_info, OP)?;
-    let work_stride = m * n;
-    let q_stride = m * k;
+    let work_stride = checked_mul_usize(OP, "qr work stride", m, n)?;
+    let q_stride = checked_mul_usize(OP, "qr q stride", m, k)?;
 
     for batch in 0..batch_total {
-        let batch_work = unsafe { batch_ptr::<T>(work_ptr, batch * work_stride) };
-        let batch_q = unsafe { batch_ptr::<T>(q_ptr, batch * q_stride) };
+        let work_offset = checked_batch_offset(OP, "qr work batch offset", batch, work_stride)?;
+        let q_offset = checked_batch_offset(OP, "qr q batch offset", batch, q_stride)?;
+        let batch_work = unsafe { batch_ptr::<T>(work_ptr, work_offset) };
+        let batch_q = unsafe { batch_ptr::<T>(q_ptr, q_offset) };
         let batch_geqrf_info = unsafe { batch_ptr::<i32>(geqrf_info_ptr, batch).cast::<i32>() };
         let batch_orgqr_info = unsafe { batch_ptr::<i32>(orgqr_info_ptr, batch).cast::<i32>() };
         unsafe {
@@ -1454,12 +1503,15 @@ where
     let batch_total = batch_count(batch_shape);
     let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
     let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
-    let matrix_stride = n * n;
+    let matrix_stride = checked_mul_usize(OP, "eigh matrix stride", n, n)?;
     let values_stride = n;
 
     for batch in 0..batch_total {
-        let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * matrix_stride) };
-        let batch_w = unsafe { batch_ptr::<T::Real>(values_ptr, batch * values_stride) };
+        let a_offset = checked_batch_offset(OP, "eigh matrix batch offset", batch, matrix_stride)?;
+        let values_offset =
+            checked_batch_offset(OP, "eigh values batch offset", batch, values_stride)?;
+        let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
+        let batch_w = unsafe { batch_ptr::<T::Real>(values_ptr, values_offset) };
         let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
         unsafe {
             handles.cusolver().syevd(
@@ -1525,12 +1577,16 @@ where
     let batch_total = batch_count(batch_shape);
     let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
     let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
-    let matrix_stride = n * n;
+    let matrix_stride = checked_mul_usize(OP, "eigh_values matrix stride", n, n)?;
     let values_stride = n;
 
     for batch in 0..batch_total {
-        let batch_a = unsafe { batch_ptr::<T>(a_ptr, batch * matrix_stride) };
-        let batch_w = unsafe { batch_ptr::<T::Real>(values_ptr, batch * values_stride) };
+        let a_offset =
+            checked_batch_offset(OP, "eigh_values matrix batch offset", batch, matrix_stride)?;
+        let values_offset =
+            checked_batch_offset(OP, "eigh_values values batch offset", batch, values_stride)?;
+        let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
+        let batch_w = unsafe { batch_ptr::<T::Real>(values_ptr, values_offset) };
         let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
         unsafe {
             handles.cusolver().syevd(

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -370,7 +370,7 @@ pub fn det(a: &TracedTensor) -> Result<TracedTensor> {
 /// ```
 pub fn inv(a: &TracedTensor) -> Result<TracedTensor> {
     ensure_min_rank("inv", a.rank, 2)?;
-    let shape = a.concrete_shape();
+    let shape = require_concrete_shape("inv", a)?;
     let eye = eye_like(a, shape[0]);
     solve(a, &eye)
 }
@@ -424,7 +424,7 @@ pub fn eigvals(a: &TracedTensor) -> Result<TracedTensor> {
 /// ```
 pub fn pinv(a: &TracedTensor) -> Result<TracedTensor> {
     ensure_float_or_complex("pinv", a.dtype)?;
-    let shape = a.concrete_shape();
+    let shape = require_concrete_shape("pinv", a)?;
     let max_dim = match (shape.first(), shape.get(1)) {
         (Some(&m), Some(&n)) => m.max(n),
         (Some(&m), None) => m,
@@ -450,6 +450,7 @@ pub fn pinv(a: &TracedTensor) -> Result<TracedTensor> {
 /// ```
 pub fn pinv_with_rtol(a: &TracedTensor, rtol: f64) -> Result<TracedTensor> {
     ensure_float_or_complex("pinv_with_rtol", a.dtype)?;
+    require_concrete_shape("pinv_with_rtol", a)?;
     let (u, s, vt) = svd(a)?;
     let abs_s = s.abs();
     let s_max = abs_s.reduce_max(&[0]);
@@ -491,6 +492,7 @@ pub fn norm(
     keepdim: bool,
 ) -> Result<TracedTensor> {
     ensure_float_or_complex("norm", a.dtype)?;
+    let shape = require_concrete_shape("norm", a)?;
     let axes = dim.map_or_else(|| (0..a.rank).collect::<Vec<_>>(), |dims| dims.to_vec());
     if axes.is_empty() {
         return Ok(a.clone());
@@ -511,7 +513,6 @@ pub fn norm(
             }
         }
     };
-    let shape = a.concrete_shape();
     Ok(restore_keepdim(out, &shape, &axes, keepdim))
 }
 
@@ -639,6 +640,15 @@ fn validate_axes(op: &'static str, rank: usize, axes: &[usize]) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn require_concrete_shape(op: &'static str, input: &TracedTensor) -> Result<Vec<usize>> {
+    input.try_concrete_shape().ok_or_else(|| {
+        Error::TensorRuntime(tenferro_tensor::Error::backend_failure(
+            op,
+            "symbolic shape is not supported by this traced linalg helper",
+        ))
+    })
 }
 
 fn zero_scalar(dtype: DType) -> TracedTensor {

--- a/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
@@ -24,6 +24,16 @@ fn cpu_lapack_full_piv_lu_source() -> String {
     .unwrap_or_else(|err| panic!("LAPACK full_piv_lu source should be readable: {err}"))
 }
 
+fn cpu_backend_source() -> String {
+    fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("cpu")
+            .join("backend.rs"),
+    )
+    .unwrap_or_else(|err| panic!("CPU linalg backend source should be readable: {err}"))
+}
+
 fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
     let start_idx = source
         .find(start)
@@ -84,4 +94,39 @@ fn lapack_full_piv_lu_rejects_positive_getc2_info() {
         factor.contains("matrix is singular"),
         "positive getc2 info should be reported as a singular matrix"
     );
+}
+
+#[test]
+fn cpu_eigh_complex_output_adapters_are_fallible() {
+    let source = cpu_backend_source();
+    let eigh_impl = source_section(&source, "fn eigh(&mut self", "fn eigh_values");
+    let c32_adapter = source_section(
+        &source,
+        "fn eigh_c32_outputs_to_public_tensors",
+        "fn eigh_c64_outputs_to_public_tensors",
+    );
+    let c64_adapter = source_section(
+        &source,
+        "fn eigh_c64_outputs_to_public_tensors",
+        "fn apply_lu_pivots_cpu",
+    );
+
+    assert!(
+        eigh_impl.contains(".and_then(eigh_c32_outputs_to_public_tensors)")
+            && eigh_impl.contains(".and_then(eigh_c64_outputs_to_public_tensors)"),
+        "CPU complex eigh output adapters should propagate malformed output errors"
+    );
+    for (name, adapter) in [
+        ("eigh_c32_outputs_to_public_tensors", c32_adapter),
+        ("eigh_c64_outputs_to_public_tensors", c64_adapter),
+    ] {
+        assert!(
+            adapter.contains("tenferro_tensor::Result<Vec<Tensor>>"),
+            "{name} should return a typed Result"
+        );
+        assert!(
+            !adapter.contains(".expect("),
+            "{name} should not panic on malformed backend output"
+        );
+    }
 }

--- a/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -142,6 +142,30 @@ fn gpu_triangular_solve_batched_offsets_use_checked_arithmetic() {
 }
 
 #[test]
+fn gpu_linalg_batched_pointer_offsets_use_checked_arithmetic_contract() {
+    let source = linalg_source();
+
+    assert!(
+        !source.contains("batch *"),
+        "GPU batched linalg pointer offsets must go through checked_batch_offset"
+    );
+    for banned in [
+        "let matrix_stride = n * n",
+        "let matrix_stride = m * n",
+        "let a_stride = m * n",
+        "let u_stride = m * k",
+        "let vt_stride = k * n",
+        "let v_stride = n * k",
+        "let q_stride = m * k",
+    ] {
+        assert!(
+            !source.contains(banned),
+            "GPU linalg stride products must use checked_mul_usize: found {banned}"
+        );
+    }
+}
+
+#[test]
 fn gpu_zero_sized_lu_factor_parity_is_filled_on_device() {
     let source = linalg_source();
     let zero_lu = source_section(&source, "fn zero_sized_lu_factor_outputs", "fn raw_stream");

--- a/crates/tenferro-linalg/tests/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/traced_extension.rs
@@ -294,6 +294,36 @@ fn traced_inv_rejects_rank_less_than_two_without_panicking() {
 }
 
 #[test]
+fn traced_linalg_helpers_reject_symbolic_shapes_without_panicking() {
+    let matrix = TracedTensor::input_symbolic_shape(DType::F64, 2);
+
+    for (op, result) in [
+        ("inv", tenferro_linalg::inv(&matrix)),
+        ("pinv", tenferro_linalg::pinv(&matrix)),
+        (
+            "pinv_with_rtol",
+            tenferro_linalg::pinv_with_rtol(&matrix, 1.0e-12),
+        ),
+        (
+            "norm",
+            tenferro_linalg::norm(&matrix, Some(2.0), Some(&[0, 1]), true),
+        ),
+    ] {
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::TensorRuntime(TensorError::BackendFailure {
+                    op: actual_op,
+                    ref message,
+                }) if actual_op == op && message.contains("symbolic shape")
+            ),
+            "expected symbolic-shape error for {op}, got {err:?}"
+        );
+    }
+}
+
+#[test]
 fn traced_norm_rejects_out_of_range_axis_without_panicking() {
     let tensor = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
 

--- a/crates/tenferro-tensor-core/src/lib.rs
+++ b/crates/tenferro-tensor-core/src/lib.rs
@@ -394,13 +394,8 @@ fn validate_shape_metadata(shape: &[usize]) -> Result<()> {
 }
 
 fn compact_col_major_strides(shape: &[usize]) -> StrideVec {
-    let mut strides = StrideVec::new();
-    let mut stride = 1isize;
-    for &extent in shape {
-        strides.push(stride);
-        stride *= extent as isize;
-    }
-    strides
+    // Invariant: HostTensor constructors validate shape metadata before as_view can call this.
+    col_major_strides(shape).expect("HostTensor shape metadata is validated at construction")
 }
 
 /// Return compact column-major strides for a shape.

--- a/crates/tenferro-tensor-core/tests/core.rs
+++ b/crates/tenferro-tensor-core/tests/core.rs
@@ -205,6 +205,25 @@ fn compact_layout_reports_stride_overflow() {
 }
 
 #[test]
+fn compact_host_tensor_view_reuses_checked_col_major_stride_helper() {
+    let source = include_str!("../src/lib.rs");
+    let helper = source
+        .split("fn compact_col_major_strides")
+        .nth(1)
+        .and_then(|rest| rest.split("/// Return compact column-major strides").next())
+        .expect("compact_col_major_strides helper should exist");
+
+    assert!(
+        helper.contains("col_major_strides(shape)"),
+        "compact host view strides must not duplicate unchecked stride arithmetic"
+    );
+    assert!(
+        !helper.contains("stride *= extent as isize"),
+        "compact host view strides must avoid unchecked stride multiplication"
+    );
+}
+
+#[test]
 fn layout_from_parts_preserves_offset() {
     let layout =
         TensorLayout::<DynRank>::from_parts(vec![3].into(), vec![1].into(), 7, 10).unwrap();

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 use num_complex::{Complex32, Complex64};
 
 use crate::types::{
-    col_major_strides, flat_to_multi, materialize_typed_view_col_major, Buffer, BufferHandle,
-    DType, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Rank, StridedSliceSpec,
-    Tensor, TensorBufferRef, TensorBufferRefMut, TensorLayout, TensorOwnedView, TensorRank,
-    TensorRead, TensorScalar, TensorValue, TensorView, TypedTensor, TypedTensorView,
+    col_major_strides, flat_to_multi, materialize_typed_view_col_major, try_col_major_strides,
+    Buffer, BufferHandle, DType, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Rank,
+    StridedSliceSpec, Tensor, TensorBufferRef, TensorBufferRefMut, TensorLayout, TensorOwnedView,
+    TensorRank, TensorRead, TensorScalar, TensorValue, TensorView, TypedTensor, TypedTensorView,
     TypedTensorViewMut,
 };
 use crate::{Error, SliceConfig};
@@ -221,6 +221,11 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
 fn col_major_helpers_cover_scalar_and_higher_rank_shapes() {
     assert_eq!(col_major_strides(&[]), Vec::<isize>::new());
     assert_eq!(col_major_strides(&[2, 3, 4]), vec![1, 2, 6]);
+    assert_eq!(try_col_major_strides(&[2, 3, 4]).unwrap(), vec![1, 2, 6]);
+    assert!(matches!(
+        try_col_major_strides(&[usize::MAX, 2]),
+        Err(Error::InvalidConfig { .. })
+    ));
 
     let mut scalar_idx = [];
     flat_to_multi(0, &[], &mut scalar_idx);

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -2928,19 +2928,33 @@ impl<'a> TensorRead<'a> {
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_tensor::col_major_strides;
+/// use tenferro_tensor::{col_major_strides, try_col_major_strides};
 ///
 /// assert_eq!(col_major_strides(&[2, 3]), vec![1, 2]);
+/// assert_eq!(try_col_major_strides(&[2, 3])?, vec![1, 2]);
+/// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
+pub fn try_col_major_strides(shape: &[usize]) -> crate::Result<Vec<isize>> {
+    let mut strides = Vec::with_capacity(shape.len());
+    let mut stride = 1isize;
+    for &extent in shape {
+        strides.push(stride);
+        let extent = isize::try_from(extent).map_err(|_| crate::Error::InvalidConfig {
+            op: "col_major_strides",
+            message: format!("shape extent {extent} does not fit in isize"),
+        })?;
+        stride = stride
+            .checked_mul(extent)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "col_major_strides",
+                message: format!("column-major stride overflows for shape {shape:?}"),
+            })?;
+    }
+    Ok(strides)
+}
+
 pub fn col_major_strides(shape: &[usize]) -> Vec<isize> {
-    if shape.is_empty() {
-        return vec![];
-    }
-    let mut strides = vec![1isize; shape.len()];
-    for i in 1..shape.len() {
-        strides[i] = strides[i - 1] * shape[i - 1] as isize;
-    }
-    strides
+    try_col_major_strides(shape).unwrap_or_else(|err| panic!("col_major_strides failed: {err}"))
 }
 
 fn linear_offset(shape: &[usize], indices: &[usize]) -> usize {
@@ -2949,14 +2963,28 @@ fn linear_offset(shape: &[usize], indices: &[usize]) -> usize {
     let mut stride = 1usize;
     for (&idx, &extent) in indices.iter().zip(shape) {
         assert!(idx < extent, "index out of bounds");
-        offset += idx * stride;
-        stride *= extent;
+        offset = offset
+            .checked_add(
+                idx.checked_mul(stride)
+                    .unwrap_or_else(|| panic!("linear offset multiply overflows")),
+            )
+            .unwrap_or_else(|| panic!("linear offset add overflows"));
+        stride = stride
+            .checked_mul(extent)
+            .unwrap_or_else(|| panic!("linear offset stride overflows"));
     }
     offset
 }
 
+fn checked_shape_product(shape: &[usize], op: &str) -> usize {
+    shape
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .unwrap_or_else(|| panic!("{op}: shape product overflows for shape {shape:?}"))
+}
+
 fn checked_shape_len(shape: &[usize], data_len: usize, op: &str) {
-    let n: usize = shape.iter().product();
+    let n = checked_shape_product(shape, op);
     assert_eq!(
         data_len, n,
         "{op}: data length {} does not match shape product {}",
@@ -3466,11 +3494,19 @@ fn slice_axis_specs(
 }
 
 fn row_major_offset(shape: &[usize], indices: &[usize]) -> usize {
-    let mut stride = 1;
-    let mut offset = 0;
+    let mut stride = 1usize;
+    let mut offset = 0usize;
     for (&dim, &index) in shape.iter().rev().zip(indices.iter().rev()) {
-        offset += index * stride;
-        stride *= dim;
+        offset = offset
+            .checked_add(
+                index
+                    .checked_mul(stride)
+                    .unwrap_or_else(|| panic!("row-major offset multiply overflows")),
+            )
+            .unwrap_or_else(|| panic!("row-major offset add overflows"));
+        stride = stride
+            .checked_mul(dim)
+            .unwrap_or_else(|| panic!("row-major offset stride overflows"));
     }
     offset
 }
@@ -3603,7 +3639,7 @@ fn typed_tensor_zeros<T: Clone + Zero, R: TensorRank>(
     shape: impl Into<R::Shape>,
 ) -> TypedTensor<T, R> {
     let layout = compact_layout(shape, "zeros");
-    let n: usize = layout.shape().iter().product();
+    let n = checked_shape_product(layout.shape(), "zeros");
     TypedTensor {
         buffer: Buffer::Host(vec![T::zero(); n]),
         layout,
@@ -3615,7 +3651,7 @@ fn typed_tensor_ones<T: Clone + One + Zero, R: TensorRank>(
     shape: impl Into<R::Shape>,
 ) -> TypedTensor<T, R> {
     let layout = compact_layout(shape, "ones");
-    let n: usize = layout.shape().iter().product();
+    let n = checked_shape_product(layout.shape(), "ones");
     TypedTensor {
         buffer: Buffer::Host(vec![T::one(); n]),
         layout,

--- a/crates/tenferro-tensor/src/types/accessors.rs
+++ b/crates/tenferro-tensor/src/types/accessors.rs
@@ -10,8 +10,8 @@ fn try_linear_offset(shape: &[usize], indices: &[usize]) -> Option<usize> {
         if idx >= extent {
             return None;
         }
-        offset += idx * stride;
-        stride *= extent;
+        offset = offset.checked_add(idx.checked_mul(stride)?)?;
+        stride = stride.checked_mul(extent)?;
     }
     Some(offset)
 }
@@ -28,8 +28,15 @@ fn linear_offset_unchecked(shape: &[usize], indices: &[usize]) -> usize {
     let mut offset = 0usize;
     let mut stride = 1usize;
     for (&idx, &extent) in indices.iter().zip(shape) {
-        offset += idx * stride;
-        stride *= extent;
+        offset = offset
+            .checked_add(
+                idx.checked_mul(stride)
+                    .unwrap_or_else(|| panic!("linear offset multiply overflows")),
+            )
+            .unwrap_or_else(|| panic!("linear offset add overflows"));
+        stride = stride
+            .checked_mul(extent)
+            .unwrap_or_else(|| panic!("linear offset stride overflows"));
     }
     offset
 }
@@ -45,7 +52,12 @@ fn linear_offset2_unchecked(shape: &[usize], i: usize, j: usize) -> usize {
     debug_assert_eq!(shape.len(), 2);
     debug_assert!(i < shape[0], "index out of bounds");
     debug_assert!(j < shape[1], "index out of bounds");
-    i + shape[0] * j
+    i.checked_add(
+        shape[0]
+            .checked_mul(j)
+            .unwrap_or_else(|| panic!("linear offset multiply overflows")),
+    )
+    .unwrap_or_else(|| panic!("linear offset add overflows"))
 }
 
 fn linear_offset3(shape: &[usize], i: usize, j: usize, k: usize) -> usize {
@@ -61,7 +73,19 @@ fn linear_offset3_unchecked(shape: &[usize], i: usize, j: usize, k: usize) -> us
     debug_assert!(i < shape[0], "index out of bounds");
     debug_assert!(j < shape[1], "index out of bounds");
     debug_assert!(k < shape[2], "index out of bounds");
-    i + shape[0] * (j + shape[1] * k)
+    let inner = j
+        .checked_add(
+            shape[1]
+                .checked_mul(k)
+                .unwrap_or_else(|| panic!("linear offset multiply overflows")),
+        )
+        .unwrap_or_else(|| panic!("linear offset add overflows"));
+    i.checked_add(
+        shape[0]
+            .checked_mul(inner)
+            .unwrap_or_else(|| panic!("linear offset multiply overflows")),
+    )
+    .unwrap_or_else(|| panic!("linear offset add overflows"))
 }
 
 impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
@@ -531,5 +555,20 @@ impl Tensor {
     /// ```
     pub fn iter_mut<T: TensorScalar>(&mut self) -> Option<std::slice::IterMut<'_, T>> {
         self.as_slice_mut::<T>().map(|slice| slice.iter_mut())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{linear_offset2, linear_offset3, linear_offset_unchecked, try_linear_offset};
+
+    #[test]
+    fn linear_offset_helpers_check_overflow() {
+        let shape = [usize::MAX, 3];
+
+        assert_eq!(try_linear_offset(&shape, &[0, 2]), None);
+        assert!(std::panic::catch_unwind(|| linear_offset_unchecked(&shape, &[0, 2])).is_err());
+        assert!(std::panic::catch_unwind(|| linear_offset2(&shape, 0, 2)).is_err());
+        assert!(std::panic::catch_unwind(|| linear_offset3(&[usize::MAX, 3, 2], 0, 2, 1)).is_err());
     }
 }

--- a/crates/tenferro-xla/src/lowering/program.rs
+++ b/crates/tenferro-xla/src/lowering/program.rs
@@ -294,7 +294,12 @@ fn lower_extension_instruction(
                 ),
             });
         };
-        let input_idx = *id as usize;
+        let input_idx = usize::try_from(*id).map_err(|_| Error::InvalidProgram {
+            message: format!(
+                "extension family {:?} standard-op lowering referenced oversized input id {id}",
+                op.family_id()
+            ),
+        })?;
         let Some(input_value) = input_values.get(input_idx) else {
             return Err(Error::InvalidProgram {
                 message: format!(
@@ -639,6 +644,18 @@ fn emit_transpose(
                 output_ty.shape.len()
             ),
         });
+    }
+    let mut seen = vec![false; input.ty.shape.len()];
+    for &axis in perm {
+        if axis >= input.ty.shape.len() || seen[axis] {
+            return Err(Error::InvalidProgram {
+                message: format!(
+                    "transpose permutation must be a bijection over rank {}, got {perm:?}",
+                    input.ty.shape.len()
+                ),
+            });
+        }
+        seen[axis] = true;
     }
     let name = emitter.value();
     emitter.line(format!(

--- a/crates/tenferro-xla/src/lowering/program/tests.rs
+++ b/crates/tenferro-xla/src/lowering/program/tests.rs
@@ -64,6 +64,16 @@ fn lowering_helpers_reject_invalid_internal_shapes() {
             if message.contains("transpose permutation length 2")
                 && message.contains("output rank 1")
     ));
+
+    let output_ty = f64_type(&[3, 2]);
+    for perm in [&[1, 1][..], &[2, 0][..]] {
+        let err = emit_transpose(&input, perm, &output_ty, &mut emitter).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::InvalidProgram { ref message }
+                if message.contains("transpose permutation must be a bijection")
+        ));
+    }
 }
 
 #[test]

--- a/crates/tenferro-xla/tests/source_contract.rs
+++ b/crates/tenferro-xla/tests/source_contract.rs
@@ -1,0 +1,25 @@
+use std::{fs, path::Path};
+
+fn lowering_program_source() -> String {
+    fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("lowering")
+            .join("program.rs"),
+    )
+    .unwrap_or_else(|err| panic!("XLA lowering source should be readable: {err}"))
+}
+
+#[test]
+fn extension_lowering_input_ids_are_checked_before_usize_indexing() {
+    let source = lowering_program_source();
+
+    assert!(
+        source.contains("usize::try_from(*id)"),
+        "extension lowering must reject oversized TensorInputKey ids instead of truncating them"
+    );
+    assert!(
+        !source.contains("let input_idx = *id as usize;"),
+        "extension lowering must not truncate TensorInputKey ids with `as usize`"
+    );
+}

--- a/docs/worklogs/2026-06-17-terasaki-bug-batch.md
+++ b/docs/worklogs/2026-06-17-terasaki-bug-batch.md
@@ -18,6 +18,18 @@ The follow-up audit added two more durable rules: batch pointer-offset loops
 must check both stride products and `batch * stride`, and public cache/runtime
 locks must not fabricate default state after poison.
 
+After #1086 merged, a final audit follow-up added targeted coverage/fixes for
+the remaining low-risk `terasakisatoshi` reports: repeated-label einsum
+coverage for #1073, tensor stride/accessor and CPU structural/indexing checked
+arithmetic for #1081, symbolic-shape traced linalg and AD seed error handling
+as representative #1084 cases, and tropical traced extension fallibility. It
+also corrected the #1080 buffer-pool fix to split full-overwrite raw acquisition
+from explicit zeroed acquisition instead of zero-filling every pooled buffer.
+The repository rule update was generalized: performance-sensitive operations
+that look potentially dangerous must carry a nearby invariant comment so later
+agents do not "fix" false positives with hidden initialization, copies, or
+checks.
+
 ## Context Read
 
 - `REPOSITORY_RULES.md` and existing work-log guidance.
@@ -47,9 +59,15 @@ locks must not fabricate default state after poison.
   `?` propagation to make the intended validation obvious.
 - Updated tutorial source and prose together so snippet and tutorial tests
   exercise the documented examples.
-- Made CPU buffer-pool acquisition return initialized zero values instead of
-  stale or uninitialized elements, keeping the existing unsafe signature only
-  for compatibility.
+- Corrected the CPU buffer-pool fix after review: `pool_acquire` remains the
+  unsafe full-overwrite path for hot kernels, while
+  `pool_acquire_zeroed` / `BufferPool::acquire_zeroed` are explicit safe paths
+  for callers that may read before every element is overwritten. Zero-dimension
+  GEMM returns use the zeroed path; normal BLAS/faer `beta = 0` full-overwrite
+  paths keep raw acquisition.
+- Added one-line invariant comments at raw pooled-buffer acquisition sites and
+  uninitialized pooled-output helper call sites, including the faer `beta != 0`
+  accumulation branch.
 - Replaced panic-unsafe CPU buffer-pool lending with a Drop-backed loan guard so
   the pool is restored when a backend session or linalg pool closure panics.
 - Held eager gradient slot locks through accumulation writes to remove the
@@ -66,20 +84,39 @@ locks must not fabricate default state after poison.
   batched linalg pointer offsets.
 - Added the eager SVD singular-value-sum backward MWE as a regression test; it
   already passes on this branch, so #1056 is covered without code changes.
+- Added eager and traced regression coverage for #1073 (`iii`, `iiii`, and
+  mixed repeated-label cases). These pass with the existing recursive planner
+  and eager implementation, so the issue is covered without changing einsum
+  logic.
+- Extended #1081 coverage to tensor column-major stride construction, tensor
+  offset helpers, CPU reshape/concatenate shape arithmetic, and zero-sized
+  scatter iteration. Remaining GPU/integer-cast cases are design or hardware
+  follow-ups.
+- Made traced linalg helpers return typed symbolic-shape errors instead of
+  panicking when `inv`, `pinv`, `pinv_with_rtol`, or `norm(..., keepdim=true)`
+  receive a symbolic-shape tensor.
+- Made traced `jvp`/`vjp` return typed errors for symbolic seed tensors instead
+  of panicking while registering seed metadata.
+- Switched tropical traced einsum through the fallible extension builder and
+  added symbolic-shape coverage for the standard `ij,jk->ik` path.
 
 ## Deferred
 
 - #1054 remains outside this PR until its current reproducer and intended
   behavior are rechecked.
-- #1073 was not closed; the existing three-way repeated-label trace test for
-  `iii` passes, so it needs a sharper reproducer before changing einsum logic.
 - #1082 requires a larger design decision because `DimExpr` and shape inference
   currently expose infallible arithmetic in several public-facing paths.
 - #1084 is a broad public-panic audit. This PR fixes representative traced,
   linalg, poison, and buffer-pool cases and records the rule; remaining cases
   should be handled as a follow-up sweep.
-- #1081 is partially fixed for CPU triangular masks and GPU triangular batched
-  linalg offsets. Tensor stride/accessor API changes need a separate API design.
+- #1081 is still not completely closed for every GPU launch/cast and internal
+  shape-expression path. This follow-up covers tensor stride/accessor overflow
+  and more CPU boundary arithmetic; remaining GPU and `DimExpr` cases should be
+  handled with a broader fallibility design.
+- #1084 still has broader public-panic surface in AD structural helpers, FFT,
+  and several traced shape-manipulation helpers. This follow-up fixes symbolic
+  AD seed and traced linalg representative cases, but does not attempt the
+  whole API redesign.
 
 ## Verification
 
@@ -120,3 +157,17 @@ Additional targeted checks after the second audit pass:
 - `cargo test -p tenferro-linalg gpu_triangular_solve_batched_offsets_use_checked_arithmetic`
 - `cargo test -p tenferro-cpu triu`
 - `cargo test -p tenferro-cpu test_triangular_masks_use_checked_index_arithmetic_contract`
+
+Additional targeted checks after the final audit follow-up:
+
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-einsum eager_einsum_handles_three_or_more_repeated_labels -- --nocapture`
+- `cargo test -p tenferro-einsum einsum_three_or_more_repeated_labels_keep_and_mix -- --nocapture`
+- `cargo test -p tenferro-tensor col_major_helpers_cover_scalar_and_higher_rank_shapes -- --nocapture`
+- `cargo test -p tenferro-tensor linear_offset_helpers_check_overflow -- --nocapture`
+- `cargo test -p tenferro-cpu cpu_reshape_concatenate_scatter_use_checked_boundary_arithmetic_contract -- --nocapture`
+- `cargo test -p tenferro-cpu buffer_pool -- --nocapture`
+- `cargo test -p tenferro-linalg traced_linalg_helpers_reject_symbolic_shapes_without_panicking -- --nocapture`
+- `cargo test -p tenferro-linalg without_panicking -- --nocapture`
+- `cargo test --manifest-path ext/tropical/Cargo.toml traced_einsum_accepts_symbolic_shapes_without_panicking -- --nocapture`
+- `cargo test -p tenferro-ad traced_jvp_vjp_return_errors_for_symbolic_seed_tensors -- --nocapture`

--- a/docs/worklogs/2026-06-17-terasaki-bug-batch.md
+++ b/docs/worklogs/2026-06-17-terasaki-bug-batch.md
@@ -100,6 +100,15 @@ checks.
   of panicking while registering seed metadata.
 - Switched tropical traced einsum through the fallible extension builder and
   added symbolic-shape coverage for the standard `ij,jk->ik` path.
+- Added fallible tropical fused dot-general entrypoints so callers can validate
+  rank and concrete contracting dimensions without using the legacy panic
+  wrappers.
+- Converted CPU complex `eigh` output adapters from internal `expect` calls to
+  typed output-count errors, matching the SVD/full-piv-LU adapter pattern.
+- Extended the checked-arithmetic sweep to GPU structural reshape/concatenate,
+  GPU reduction launch input-size and cube-count planning, CPU pooled zero/fill
+  allocation used by embed-diagonal, and XLA extension-lowering input-id plus
+  transpose-permutation validation.
 
 ## Deferred
 
@@ -114,6 +123,11 @@ checks.
   and several traced shape-manipulation helpers. This follow-up fixes symbolic
   AD seed and traced linalg representative cases, but does not attempt the
   whole API redesign.
+- The latest full-source audit still finds unchecked shape products or
+  infallible shape arithmetic in FFT output planning, linalg batch helpers,
+  runtime graph/ad-support internals, and `DimExpr`/shape-inference utilities.
+  Those should be grouped with the #1082/#1084 design follow-up because they
+  require either fallible shape metadata APIs or broader helper refactors.
 
 ## Verification
 
@@ -171,3 +185,14 @@ Additional targeted checks after the final audit follow-up:
 - `cargo test -p tenferro-linalg without_panicking -- --nocapture`
 - `cargo test --manifest-path ext/tropical/Cargo.toml traced_einsum_accepts_symbolic_shapes_without_panicking -- --nocapture`
 - `cargo test -p tenferro-ad traced_jvp_vjp_return_errors_for_symbolic_seed_tensors -- --nocapture`
+
+Additional targeted checks after the full-source mini-agent audit:
+
+- `cargo test -p tenferro-linalg cpu_eigh_complex_output_adapters_are_fallible --test cpu_linalg_source_contract -- --nocapture`
+- `cargo test --manifest-path ext/tropical/Cargo.toml fused_dot_general_has_fallible_validation_entrypoint -- --nocapture`
+- `cargo test -p tenferro-gpu cubecl_structural_shape_arithmetic_is_checked --test public_surface_contract -- --nocapture`
+- `cargo test -p tenferro-gpu --features cuda validate_reduce_problem_rejects_input_shape_product_overflow --lib -- --nocapture`
+- `cargo test -p tenferro-gpu --features cuda unit_launch_settings_rejects_cube_count_overflow --lib -- --nocapture`
+- `cargo test -p tenferro-xla extension_lowering_input_ids_are_checked_before_usize_indexing --test source_contract -- --nocapture`
+- `cargo test -p tenferro-xla lowering_helpers_reject_invalid_internal_shapes --lib -- --nocapture`
+- `cargo test -p tenferro-cpu cpu_zero_fill_pooled_outputs_use_checked_shape_product --test runtime_error_tests -- --nocapture`

--- a/docs/worklogs/2026-06-17-terasaki-bug-batch.md
+++ b/docs/worklogs/2026-06-17-terasaki-bug-batch.md
@@ -20,11 +20,12 @@ locks must not fabricate default state after poison.
 
 After #1086 merged, a final audit follow-up added targeted coverage/fixes for
 the remaining low-risk `terasakisatoshi` reports: repeated-label einsum
-coverage for #1073, tensor stride/accessor and CPU structural/indexing checked
-arithmetic for #1081, symbolic-shape traced linalg and AD seed error handling
-as representative #1084 cases, and tropical traced extension fallibility. It
-also corrected the #1080 buffer-pool fix to split full-overwrite raw acquisition
-from explicit zeroed acquisition instead of zero-filling every pooled buffer.
+coverage for #1073, tensor/tensor-core stride and accessor checked arithmetic
+plus CPU/GPU batched offset arithmetic for #1081, symbolic-shape traced linalg
+and AD seed error handling as representative #1084 cases, and tropical traced
+extension fallibility. It also corrected the #1080 buffer-pool fix to split
+full-overwrite raw acquisition from explicit zeroed acquisition instead of
+zero-filling every pooled buffer.
 The repository rule update was generalized: performance-sensitive operations
 that look potentially dangerous must carry a nearby invariant comment so later
 agents do not "fix" false positives with hidden initialization, copies, or
@@ -88,10 +89,10 @@ checks.
   mixed repeated-label cases). These pass with the existing recursive planner
   and eager implementation, so the issue is covered without changing einsum
   logic.
-- Extended #1081 coverage to tensor column-major stride construction, tensor
-  offset helpers, CPU reshape/concatenate shape arithmetic, and zero-sized
-  scatter iteration. Remaining GPU/integer-cast cases are design or hardware
-  follow-ups.
+- Completed #1081's listed overflow class: tensor and tensor-core column-major
+  stride construction, tensor offset helpers, CPU triangular/reshape/
+  concatenate/scatter boundary arithmetic, and GPU batched linalg stride and
+  `batch * stride` pointer offsets now use checked arithmetic.
 - Made traced linalg helpers return typed symbolic-shape errors instead of
   panicking when `inv`, `pinv`, `pinv_with_rtol`, or `norm(..., keepdim=true)`
   receive a symbolic-shape tensor.
@@ -109,10 +110,6 @@ checks.
 - #1084 is a broad public-panic audit. This PR fixes representative traced,
   linalg, poison, and buffer-pool cases and records the rule; remaining cases
   should be handled as a follow-up sweep.
-- #1081 is still not completely closed for every GPU launch/cast and internal
-  shape-expression path. This follow-up covers tensor stride/accessor overflow
-  and more CPU boundary arithmetic; remaining GPU and `DimExpr` cases should be
-  handled with a broader fallibility design.
 - #1084 still has broader public-panic surface in AD structural helpers, FFT,
   and several traced shape-manipulation helpers. This follow-up fixes symbolic
   AD seed and traced linalg representative cases, but does not attempt the
@@ -165,8 +162,11 @@ Additional targeted checks after the final audit follow-up:
 - `cargo test -p tenferro-einsum einsum_three_or_more_repeated_labels_keep_and_mix -- --nocapture`
 - `cargo test -p tenferro-tensor col_major_helpers_cover_scalar_and_higher_rank_shapes -- --nocapture`
 - `cargo test -p tenferro-tensor linear_offset_helpers_check_overflow -- --nocapture`
+- `cargo test -p tenferro-tensor-core compact_ -- --nocapture`
 - `cargo test -p tenferro-cpu cpu_reshape_concatenate_scatter_use_checked_boundary_arithmetic_contract -- --nocapture`
 - `cargo test -p tenferro-cpu buffer_pool -- --nocapture`
+- `cargo test -p tenferro-linalg gpu_ --test gpu_linalg_source_contract -- --nocapture`
+- `cargo check -p tenferro-linalg --features cuda`
 - `cargo test -p tenferro-linalg traced_linalg_helpers_reject_symbolic_shapes_without_panicking -- --nocapture`
 - `cargo test -p tenferro-linalg without_panicking -- --nocapture`
 - `cargo test --manifest-path ext/tropical/Cargo.toml traced_einsum_accepts_symbolic_shapes_without_panicking -- --nocapture`

--- a/ext/tropical/src/lib.rs
+++ b/ext/tropical/src/lib.rs
@@ -51,7 +51,8 @@ pub use extension::{register_tropical_ad_rules, tropical_ad_rules};
 pub use newtype::{MaxMul, MaxPlus, MinPlus};
 pub use traced::{
     min_plus_dot_general, min_plus_dot_general_fused, tropical_dot_general,
-    tropical_dot_general_fused, tropical_reduce_sum,
+    tropical_dot_general_fused, tropical_reduce_sum, try_min_plus_dot_general_fused,
+    try_tropical_dot_general_fused,
 };
 
 /// Tropical semiring flavor used by traced and future fused tropical ops.

--- a/ext/tropical/src/traced.rs
+++ b/ext/tropical/src/traced.rs
@@ -36,6 +36,16 @@ fn require_rank2(tensor: &TracedTensor, label: &str) {
     );
 }
 
+fn try_require_rank2(tensor: &TracedTensor, label: &str) -> Result<()> {
+    if tensor.rank != 2 {
+        return Err(Error::ContractionError(format!(
+            "{label}: tropical matrix composition requires rank-2 input, got rank {}",
+            tensor.rank
+        )));
+    }
+    Ok(())
+}
+
 fn assert_contracting_axes_compatible(a: &TracedTensor, b: &TracedTensor, label: &str) {
     if let (Some(a_shape), Some(b_shape)) = (a.try_concrete_shape(), b.try_concrete_shape()) {
         assert_eq!(
@@ -44,6 +54,22 @@ fn assert_contracting_axes_compatible(a: &TracedTensor, b: &TracedTensor, label:
             a_shape[1], b_shape[0]
         );
     }
+}
+
+fn try_require_contracting_axes_compatible(
+    a: &TracedTensor,
+    b: &TracedTensor,
+    label: &str,
+) -> Result<()> {
+    if let (Some(a_shape), Some(b_shape)) = (a.try_concrete_shape(), b.try_concrete_shape()) {
+        if a_shape[1] != b_shape[0] {
+            return Err(Error::ContractionError(format!(
+                "{label}: contracting axes must match, got a[1]={} and b[0]={}",
+                a_shape[1], b_shape[0]
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn tropical_dot_general_impl(
@@ -244,7 +270,20 @@ pub fn tropical_einsum_subscripts(
 /// ```
 #[must_use]
 pub fn tropical_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> TracedTensor {
-    fused_dot_general_impl(TropicalKind::MaxPlus, a, b, "tropical_dot_general_fused")
+    try_tropical_dot_general_fused(a, b).unwrap_or_else(|err| panic!("{err}"))
+}
+
+/// Fallible fused max-plus matrix multiplication on rank-2 traced tensors.
+///
+/// # Errors
+///
+/// Returns an error if either input is not rank 2 or if concrete contracting
+/// dimensions are known and incompatible.
+pub fn try_tropical_dot_general_fused(
+    a: &TracedTensor,
+    b: &TracedTensor,
+) -> Result<TracedTensor> {
+    try_fused_dot_general_impl(TropicalKind::MaxPlus, a, b, "tropical_dot_general_fused")
 }
 
 /// Fused min-plus matrix multiplication on rank-2 traced tensors.
@@ -277,23 +316,36 @@ pub fn tropical_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> TracedT
 /// ```
 #[must_use]
 pub fn min_plus_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> TracedTensor {
-    fused_dot_general_impl(TropicalKind::MinPlus, a, b, "min_plus_dot_general_fused")
+    try_min_plus_dot_general_fused(a, b).unwrap_or_else(|err| panic!("{err}"))
 }
 
-fn fused_dot_general_impl(
+/// Fallible fused min-plus matrix multiplication on rank-2 traced tensors.
+///
+/// # Errors
+///
+/// Returns an error if either input is not rank 2 or if concrete contracting
+/// dimensions are known and incompatible.
+pub fn try_min_plus_dot_general_fused(
+    a: &TracedTensor,
+    b: &TracedTensor,
+)-> Result<TracedTensor> {
+    try_fused_dot_general_impl(TropicalKind::MinPlus, a, b, "min_plus_dot_general_fused")
+}
+
+fn try_fused_dot_general_impl(
     kind: TropicalKind,
     a: &TracedTensor,
     b: &TracedTensor,
     label: &str,
-) -> TracedTensor {
-    require_rank2(a, &format!("{label}.a"));
-    require_rank2(b, &format!("{label}.b"));
-    assert_contracting_axes_compatible(a, b, label);
+) -> Result<TracedTensor> {
+    try_require_rank2(a, &format!("{label}.a"))?;
+    try_require_rank2(b, &format!("{label}.b"))?;
+    try_require_contracting_axes_compatible(a, b, label)?;
     let subscripts = Subscripts::new(
         &[&[b'i' as u32, b'j' as u32], &[b'j' as u32, b'k' as u32]],
         &[b'i' as u32, b'k' as u32],
     );
-    tropical_einsum_subscripts(kind, &[a, b], &subscripts).unwrap_or_else(|err| panic!("{err}"))
+    tropical_einsum_subscripts(kind, &[a, b], &subscripts)
 }
 
 fn validate_tropical_einsum_inputs(

--- a/ext/tropical/src/traced.rs
+++ b/ext/tropical/src/traced.rs
@@ -204,10 +204,10 @@ pub fn tropical_einsum_subscripts(
     subscripts: &Subscripts,
 ) -> Result<TracedTensor> {
     validate_tropical_einsum_inputs(inputs, subscripts)?;
-    let outputs = extension::apply(
+    let outputs = extension::try_apply(
         Arc::new(TropicalEinsumOp::new(kind, subscripts.clone())),
         inputs,
-    );
+    )?;
     outputs
         .into_iter()
         .next()

--- a/ext/tropical/tests/smoke.rs
+++ b/ext/tropical/tests/smoke.rs
@@ -1,7 +1,10 @@
 use tenferro_einsum::Subscripts;
-use tenferro_ext_tropical::{traced::tropical_einsum_subscripts, MaxPlus, MinPlus, TropicalKind};
-use tenferro_runtime::{DType, TracedTensor};
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use tenferro_ext_tropical::{
+    traced::{tropical_einsum_subscripts, try_tropical_dot_general_fused},
+    MaxPlus, MinPlus, TropicalKind,
+};
+use tenferro_runtime::{DType, TracedTensor};
 
 #[test]
 fn tropical_crate_exports_core_types() {
@@ -50,4 +53,15 @@ fn traced_einsum_accepts_symbolic_shapes_without_panicking() {
     let output = result.unwrap().unwrap();
     assert_eq!(output.rank, 2);
     assert!(output.sym_shape().is_none());
+}
+
+#[test]
+fn fused_dot_general_has_fallible_validation_entrypoint() {
+    let scalar = TracedTensor::input_concrete_shape(DType::F64, &[]);
+    let matrix = TracedTensor::input_concrete_shape(DType::F64, &[2, 2]);
+    let lhs = TracedTensor::input_concrete_shape(DType::F64, &[2, 3]);
+    let rhs = TracedTensor::input_concrete_shape(DType::F64, &[4, 2]);
+
+    assert!(try_tropical_dot_general_fused(&scalar, &matrix).is_err());
+    assert!(try_tropical_dot_general_fused(&lhs, &rhs).is_err());
 }

--- a/ext/tropical/tests/smoke.rs
+++ b/ext/tropical/tests/smoke.rs
@@ -1,6 +1,7 @@
 use tenferro_einsum::Subscripts;
 use tenferro_ext_tropical::{traced::tropical_einsum_subscripts, MaxPlus, MinPlus, TropicalKind};
 use tenferro_runtime::{DType, TracedTensor};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 #[test]
 fn tropical_crate_exports_core_types() {
@@ -33,4 +34,20 @@ fn traced_einsum_validation_rejects_inputs_before_extension_shape_inference() {
         &missing_output
     )
     .is_err());
+}
+
+#[test]
+fn traced_einsum_accepts_symbolic_shapes_without_panicking() {
+    let lhs = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let rhs = TracedTensor::input_symbolic_shape(DType::F64, 2);
+    let matmul = Subscripts::parse("ij,jk->ik").unwrap();
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        tropical_einsum_subscripts(TropicalKind::MaxPlus, &[&lhs, &rhs], &matmul)
+    }));
+
+    assert!(result.is_ok(), "symbolic tropical einsum should not panic");
+    let output = result.unwrap().unwrap();
+    assert_eq!(output.rank, 2);
+    assert!(output.sym_shape().is_none());
 }


### PR DESCRIPTION
## Summary

Merge policy: please merge with a merge commit; do not squash.

Follow-up to merged PR #1086. This completes the remaining low-risk terasaki audit batch by applying the repository safety rule across the remaining source surfaces, while preserving hot-path buffer-pool performance.

Work log: `docs/worklogs/2026-06-17-terasaki-bug-batch.md`

## Fixed / Covered

- Adds eager and traced regression coverage for 3+ repeated einsum labels (`iii`, `iiii`, mixed keep/reduce cases). The existing implementation already behaves correctly, so this closes the open reproducer with coverage.
- Splits CPU buffer-pool acquisition into raw full-overwrite acquisition and explicit zeroed acquisition. Zero-dimension GEMM returns use the zeroed path; normal BLAS/faer beta=0 full-overwrite paths stay raw.
- Adds one-line invariant comments around raw pooled-buffer and uninitialized pooled-output usage, including faer beta!=0 accumulation, so later audits do not replace intentional hot-path behavior with unconditional zero-fill.
- Completes #1081's listed overflow class: tensor and tensor-core column-major strides, tensor offset helpers, CPU triangular/reshape/concatenate/scatter boundary arithmetic, and GPU batched linalg stride plus `batch * stride` pointer offsets now use checked arithmetic.
- Extends the full-source audit hardening to CPU pooled zero/fill allocation, GPU structural reshape/concatenate, GPU reduction launch sizing and cube-count planning, XLA extension-lowering input ids, and XLA transpose-permutation validation.
- Converts CPU complex `eigh` output adapters from internal `expect` calls to typed output-count errors.
- Makes traced linalg helpers return typed symbolic-shape errors instead of panicking for symbolic `inv`, `pinv`, `pinv_with_rtol`, and `norm(..., keepdim=true)` inputs.
- Makes traced `jvp`/`vjp` return typed errors for symbolic seed tensors instead of panicking while registering seed metadata.
- Routes tropical traced einsum through the fallible extension builder and adds fallible fused tropical dot-general entrypoints for callers that need non-panicking validation.
- Adds `REPOSITORY_RULES.md` guidance for performance-sensitive false positives: dangerous-looking hot-path operations need nearby invariant comments.

Fixes #1073
Fixes #1081
Refs #1080
Refs #1084

## Partial / Deferred

- #1084 still has broader public-panic surface in AD structural helpers, FFT, and traced shape-manipulation helpers. This PR fixes representative AD seed/linalg/tropical/XLA boundary cases and adds rules/tests for the recurring pattern.
- #1082 remains a larger `DimExpr` / shape-inference fallibility design issue. The full-source audit still finds unchecked/infallible shape arithmetic in FFT output planning, linalg batch helpers, runtime graph/ad-support internals, and `DimExpr` utilities.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p tenferro-cpu --test runtime_error_tests -- --nocapture`
- `cargo test -p tenferro-gpu --test public_surface_contract -- --nocapture`
- `cargo test -p tenferro-gpu --features cuda kernels::reduce --lib -- --nocapture`
- `cargo check -p tenferro-gpu --features cuda --all-targets`
- `cargo test -p tenferro-linalg --test cpu_linalg_source_contract -- --nocapture`
- `cargo test --manifest-path ext/tropical/Cargo.toml -- --nocapture`
- `cargo test -p tenferro-xla -- --nocapture`
- `cargo test -p tenferro-cpu buffer_pool -- --nocapture`
- `cargo test -p tenferro-cpu cpu_reshape_concatenate_scatter_use_checked_boundary_arithmetic_contract -- --nocapture`
- `cargo test -p tenferro-tensor-core compact_ -- --nocapture`
- `cargo test -p tenferro-tensor col_major_helpers_cover_scalar_and_higher_rank_shapes -- --nocapture`
- `cargo test -p tenferro-tensor linear_offset_helpers_check_overflow -- --nocapture`
- `cargo test -p tenferro-einsum eager_einsum_handles_three_or_more_repeated_labels -- --nocapture`
- `cargo test -p tenferro-einsum einsum_three_or_more_repeated_labels_keep_and_mix -- --nocapture`
- `cargo test -p tenferro-ad traced_jvp_vjp_return_errors_for_symbolic_seed_tensors -- --nocapture`
- `cargo test -p tenferro-linalg gpu_ --test gpu_linalg_source_contract -- --nocapture`
- `cargo check -p tenferro-linalg --features cuda`
- `cargo test -p tenferro-linalg traced_linalg_helpers_reject_symbolic_shapes_without_panicking -- --nocapture`
- `cargo test -p tenferro-linalg without_panicking -- --nocapture`
- `cargo test --manifest-path ext/tropical/Cargo.toml traced_einsum_accepts_symbolic_shapes_without_panicking -- --nocapture`